### PR TITLE
[Storage] Move bagging onto the `Hasher`; replace `RootSpec` with `inactive_peaks: usize`

### DIFF
--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -16,7 +16,7 @@ use commonware_storage::{
             FixedConfig as Config,
         },
         operation::Committable,
-        RootSpec,
+        Bagging,
     },
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -49,7 +49,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator> {
         },
         translator: Translator::default(),
         split_root: true,
-        root_bagging: <mmr::Family as RootSpec>::root_spec(0).bagging(),
+        root_bagging: <mmr::Family as Bagging>::BAGGING,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -18,7 +18,7 @@ use commonware_storage::{
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable, Location},
     qmdb::{
         current::{unordered::variable::Db as Current, VariableConfig},
-        RootSpec,
+        Bagging,
     },
     translator::TwoCap,
 };
@@ -150,7 +150,7 @@ fn apply_pending(
 }
 
 /// Commit pending writes. Returns `true` on success, `false` on error.
-async fn commit_pending<F: Graftable + RootSpec>(
+async fn commit_pending<F: Graftable + Bagging>(
     db: &mut Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     pending: &mut HashMap<RawKey, Option<RawValue>>,
@@ -180,7 +180,7 @@ async fn commit_pending<F: Graftable + RootSpec>(
     true
 }
 
-fn fuzz_family<F: Graftable + RootSpec>(input: &FuzzInput, suffix_base: &str) {
+fn fuzz_family<F: Graftable + Bagging>(input: &FuzzInput, suffix_base: &str) {
     if input.operations.is_empty() {
         return;
     }

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -8,7 +8,7 @@ use commonware_storage::{
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable, Location},
     qmdb::{
         current::{ordered::fixed::Db as CurrentDb, FixedConfig as Config},
-        RootSpec,
+        Bagging,
     },
     translator::TwoCap,
 };
@@ -85,7 +85,7 @@ const MERKLE_ITEMS_PER_BLOB: u64 = 11;
 const LOG_ITEMS_PER_BLOB: u64 = 7;
 const WRITE_BUFFER_SIZE: usize = 1024;
 
-async fn commit_pending<F: Graftable + RootSpec>(
+async fn commit_pending<F: Graftable + Bagging>(
     db: &mut Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, RawValue>,
@@ -107,7 +107,7 @@ async fn commit_pending<F: Graftable + RootSpec>(
     committed_state.extend(pending_inserts.drain());
 }
 
-fn fuzz_family<F: Graftable + RootSpec>(data: &FuzzInput, suffix: &str) {
+fn fuzz_family<F: Graftable + Bagging>(data: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     let suffix = suffix.to_string();

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -8,7 +8,7 @@ use commonware_storage::{
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable},
     qmdb::{
         current::{unordered::fixed::Db as CurrentDb, FixedConfig as Config},
-        RootSpec,
+        Bagging,
     },
     translator::OneCap,
 };
@@ -110,7 +110,7 @@ fn value_from_bytes(bytes: [u8; 32]) -> Value {
     Value::new(bytes)
 }
 
-fn fuzz_family<F: Graftable + RootSpec>(input: &FuzzInput, test_name: &str) {
+fn fuzz_family<F: Graftable + Bagging>(input: &FuzzInput, test_name: &str) {
     let runner = deterministic::Runner::default();
 
     let test_name = test_name.to_string();

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -8,7 +8,7 @@ use commonware_storage::{
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable, Location},
     qmdb::{
         current::{unordered::fixed::Db as CurrentDb, FixedConfig as Config},
-        RootSpec,
+        Bagging,
     },
     translator::TwoCap,
 };
@@ -79,7 +79,7 @@ const MERKLE_ITEMS_PER_BLOB: u64 = 11;
 const LOG_ITEMS_PER_BLOB: u64 = 7;
 const WRITE_BUFFER_SIZE: usize = 1024;
 
-async fn commit_pending<F: Graftable + RootSpec>(
+async fn commit_pending<F: Graftable + Bagging>(
     db: &mut Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, Option<RawValue>>,
@@ -97,7 +97,7 @@ async fn commit_pending<F: Graftable + RootSpec>(
     committed_state.extend(pending_expected.drain());
 }
 
-fn fuzz_family<F: Graftable + RootSpec>(data: &FuzzInput, suffix: &str) {
+fn fuzz_family<F: Graftable + Bagging>(data: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     let suffix = suffix.to_string();

--- a/storage/fuzz/fuzz_targets/merkle_family_operations.rs
+++ b/storage/fuzz/fuzz_targets/merkle_family_operations.rs
@@ -5,7 +5,6 @@ use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_runtime::{deterministic, Runner};
 use commonware_storage::merkle::{
     hasher::Standard, mem::Mem, mmb, mmr, Error, Family as MerkleFamily, Location, Position,
-    RootSpec,
 };
 use core::any::type_name;
 use libfuzzer_sys::fuzz_target;
@@ -58,9 +57,9 @@ fn verify_element_proof<F: MerkleFamily>(
     loc: Location<F>,
     element: &[u8],
 ) -> Result<bool, Error<F>> {
-    let proof = merkle.proof(hasher, loc, RootSpec::FULL_FORWARD)?;
-    let root = merkle.root(hasher, RootSpec::FULL_FORWARD)?;
-    Ok(proof.verify_element_inclusion(hasher, element, loc, &root, RootSpec::FULL_FORWARD))
+    let proof = merkle.proof(hasher, loc, 0)?;
+    let root = merkle.root(hasher, 0)?;
+    Ok(proof.verify_element_inclusion(hasher, element, loc, &root, 0))
 }
 
 struct ReferenceMerkle<F: MerkleFamily> {
@@ -177,7 +176,7 @@ fn fuzz_family<F: MerkleFamily>(operations: &[MerkleOperation]) {
                     }
 
                     let size_before = merkle.size();
-                    let root_before = merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+                    let root_before = merkle.root(&hasher, 0).unwrap();
                     let root_should_change = reference.leaf_data[idx].as_slice() != limited;
 
                     update_leaf(&mut merkle, &hasher, leaf_loc, limited).unwrap();
@@ -192,7 +191,7 @@ fn fuzz_family<F: MerkleFamily>(operations: &[MerkleOperation]) {
 
                     if root_should_change {
                         assert_ne!(
-                            merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
+                            merkle.root(&hasher, 0).unwrap(),
                             root_before,
                             "{} op {op_idx}: root should change after updating a leaf to different data",
                             type_name::<F>()
@@ -270,7 +269,7 @@ fn fuzz_family<F: MerkleFamily>(operations: &[MerkleOperation]) {
                         type_name::<F>()
                     );
 
-                    let _ = merkle.root(&hasher, RootSpec::FULL_FORWARD);
+                    let _ = merkle.root(&hasher, 0);
                 }
 
                 MerkleOperation::PruneToPos { pos_idx } => {
@@ -310,7 +309,7 @@ fn fuzz_family<F: MerkleFamily>(operations: &[MerkleOperation]) {
                         type_name::<F>()
                     );
 
-                    let _ = merkle.root(&hasher, RootSpec::FULL_FORWARD);
+                    let _ = merkle.root(&hasher, 0);
                 }
             }
         }

--- a/storage/fuzz/fuzz_targets/merkle_full.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::Sha256;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner};
 use commonware_storage::merkle::{
     full::Config, hasher::Standard, mem::Mem, mmb, mmr, Error, Family as MerkleFamily, Location,
-    LocationRangeExt as _, Position, RootSpec,
+    LocationRangeExt as _, Position,
 };
 use commonware_utils::{non_empty_range, NZUsize, NZU16, NZU64};
 use libfuzzer_sys::fuzz_target;
@@ -101,7 +101,7 @@ fn historical_root<F: MerkleFamily>(
         batch.merkleize(&mem, &hasher)
     };
     mem.apply_batch(&batch).unwrap();
-    mem.root(&hasher, RootSpec::FULL_FORWARD).unwrap()
+    mem.root(&hasher, 0).unwrap()
 }
 
 fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
@@ -203,18 +203,10 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             if bounds.contains(&location) {
                                 let element = leaves.get(location.as_u64() as usize).unwrap();
 
-                                if let Ok(proof) = merkle
-                                    .proof(&hasher, location, RootSpec::FULL_FORWARD)
-                                    .await
-                                {
-                                    let root =
-                                        merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+                                if let Ok(proof) = merkle.proof(&hasher, location, 0).await {
+                                    let root = merkle.root(&hasher, 0).unwrap();
                                     assert!(proof.verify_element_inclusion(
-                                        &hasher,
-                                        element,
-                                        location,
-                                        &root,
-                                        RootSpec::FULL_FORWARD,
+                                        &hasher, element, location, &root, 0,
                                     ));
                                 }
                             }
@@ -232,18 +224,16 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                                 && end_loc < merkle.leaves()
                                 && merkle.bounds().contains(&range.start)
                             {
-                                if let Ok(proof) = merkle
-                                    .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-                                    .await
+                                if let Ok(proof) =
+                                    merkle.range_proof(&hasher, range.clone(), 0).await
                                 {
-                                    let root =
-                                        merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+                                    let root = merkle.root(&hasher, 0).unwrap();
                                     assert!(proof.verify_range_inclusion(
                                         &hasher,
                                         &leaves[range.to_usize_range()],
                                         Location::<F>::new(start_loc),
                                         &root,
-                                        RootSpec::FULL_FORWARD,
+                                        0,
                                     ));
                                 }
                             }
@@ -264,12 +254,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         let expected_root = historical_root::<F>(&leaves, requested_leaves);
 
                         let result = merkle
-                            .historical_range_proof(
-                                &hasher,
-                                requested_leaves,
-                                range.clone(),
-                                RootSpec::FULL_FORWARD,
-                            )
+                            .historical_range_proof(&hasher, requested_leaves, range.clone(), 0)
                             .await;
                         match result {
                             Ok(historical_proof) => {
@@ -279,7 +264,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                                     &leaves[range.to_usize_range()],
                                     range.start,
                                     &expected_root,
-                                    RootSpec::FULL_FORWARD,
+                                    0,
                                 ));
                             }
                             Err(Error::RangeOutOfBounds(_)) => {
@@ -314,7 +299,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                     }
 
                     Operation::GetRoot => {
-                        let _ = merkle.root(&hasher, RootSpec::FULL_FORWARD);
+                        let _ = merkle.root(&hasher, 0);
                     }
 
                     Operation::GetSize => {

--- a/storage/fuzz/fuzz_targets/proof_store.rs
+++ b/storage/fuzz/fuzz_targets/proof_store.rs
@@ -8,7 +8,7 @@ use commonware_storage::{
         hasher::Standard, mmb, mmr, verification::ProofStore, Family as MerkleFamily, Location,
         Position, Proof,
     },
-    qmdb::RootSpec as QmdbRootSpec,
+    qmdb::Bagging as QmdbBagging,
 };
 use libfuzzer_sys::fuzz_target;
 use std::ops::Range;
@@ -60,7 +60,7 @@ impl<'a, F: MerkleFamily> Arbitrary<'a> for FuzzInput<F> {
     }
 }
 
-fn fuzz_family<F: MerkleFamily + QmdbRootSpec>(input: &FuzzInput<F>) {
+fn fuzz_family<F: MerkleFamily + QmdbBagging>(input: &FuzzInput<F>) {
     let hasher = Standard::<Sha256>::new();
     let proof = Proof::<F, Digest> {
         leaves: input.proof_leaves,
@@ -75,7 +75,7 @@ fn fuzz_family<F: MerkleFamily + QmdbRootSpec>(input: &FuzzInput<F>) {
     let start_loc = Location::<F>::new(input.start_loc);
     let root = Digest::from(input.root);
     let range = Location::<F>::new(input.range.start)..Location::<F>::new(input.range.end);
-    let root_spec = F::root_spec(proof.inactive_peaks);
+    let root_spec = proof.inactive_peaks;
 
     let Ok(proof_store) = ProofStore::new(
         &hasher,

--- a/storage/fuzz/fuzz_targets/proof_store.rs
+++ b/storage/fuzz/fuzz_targets/proof_store.rs
@@ -5,8 +5,7 @@ use commonware_codec::Encode as _;
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_storage::{
     merkle::{
-        hasher::Standard, mmb, mmr, verification::ProofStore, Family as MerkleFamily, Location,
-        Position, Proof,
+        mmb, mmr, verification::ProofStore, Family as MerkleFamily, Location, Position, Proof,
     },
     qmdb::Bagging as QmdbBagging,
 };
@@ -61,7 +60,7 @@ impl<'a, F: MerkleFamily> Arbitrary<'a> for FuzzInput<F> {
 }
 
 fn fuzz_family<F: MerkleFamily + QmdbBagging>(input: &FuzzInput<F>) {
-    let hasher = Standard::<Sha256>::new();
+    let hasher = F::default_hasher::<Sha256>();
     let proof = Proof::<F, Digest> {
         leaves: input.proof_leaves,
         inactive_peaks: input.inactive_peaks,

--- a/storage/fuzz/fuzz_targets/proofs_malleability.rs
+++ b/storage/fuzz/fuzz_targets/proofs_malleability.rs
@@ -7,7 +7,7 @@ use commonware_storage::{
     bmt::Builder as BmtBuilder,
     merkle::{
         hasher::Standard, mem::Mem, mmb, mmr, verification, Bagging, Family as MerkleFamily,
-        Location, RootSpec,
+        Location,
     },
 };
 use futures::executor::block_on;
@@ -127,57 +127,69 @@ where
     }
 }
 
-fn supported_root_specs<F: MerkleFamily>(merkle: &Mem<F, Digest>) -> Vec<RootSpec> {
+fn supported_root_specs<F: MerkleFamily>(merkle: &Mem<F, Digest>) -> Vec<(Bagging, usize)> {
     let peak_count = F::peaks(merkle.size()).count();
-    let mut specs = Vec::with_capacity(2 + 2 * (peak_count + 1));
+    let mut specs = Vec::with_capacity(2 * (peak_count + 1));
     let mut push_unique = |spec| {
         if !specs.contains(&spec) {
             specs.push(spec);
         }
     };
-
-    push_unique(RootSpec::FULL_FORWARD);
-    push_unique(RootSpec::Full {
-        bagging: Bagging::BackwardFold,
-    });
     for inactive_peaks in 0..=peak_count {
-        push_unique(RootSpec::split_forward(inactive_peaks));
-        push_unique(RootSpec::split_backward(inactive_peaks));
+        push_unique((Bagging::ForwardFold, inactive_peaks));
+        push_unique((Bagging::BackwardFold, inactive_peaks));
     }
     specs
 }
 
 fn fuzz_element_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
-    let hasher = Standard::<Sha256>::new();
+    let build_hasher = Standard::<Sha256>::new();
     let mut merkle = Mem::<F, Digest>::new();
     let batch = {
         let mut batch = merkle.new_batch();
         for digest in digests {
-            batch = batch.add(&hasher, digest);
+            batch = batch.add(&build_hasher, digest);
         }
-        batch.merkleize(&merkle, &hasher)
+        batch.merkleize(&merkle, &build_hasher)
     };
     merkle.apply_batch(&batch).unwrap();
 
-    for spec in supported_root_specs(&merkle) {
-        let root = merkle.root(&hasher, spec).unwrap();
+    for (bagging, inactive_peaks) in supported_root_specs(&merkle) {
+        let hasher = Standard::<Sha256>::with_bagging(bagging);
+        let root = merkle.root(&hasher, inactive_peaks).unwrap();
         for (leaf, element) in digests.iter().enumerate() {
             let loc = Location::<F>::new(leaf as u64);
-            let original_proof = merkle.proof(&hasher, loc, spec).unwrap();
-            assert!(original_proof.verify_element_inclusion(&hasher, element, loc, &root, spec));
+            let original_proof = merkle.proof(&hasher, loc, inactive_peaks).unwrap();
+            assert!(original_proof.verify_element_inclusion(
+                &hasher,
+                element,
+                loc,
+                &root,
+                inactive_peaks
+            ));
 
             let mut mutated_proof = original_proof.clone();
             mutated_proof.inactive_peaks ^= input.inactive_peaks_mask.get();
             assert_ne!(mutated_proof, original_proof);
-            assert!(!mutated_proof.verify_element_inclusion(&hasher, element, loc, &root, spec));
+            assert!(!mutated_proof.verify_element_inclusion(
+                &hasher,
+                element,
+                loc,
+                &root,
+                inactive_peaks
+            ));
 
             for mutation in &input.mutations {
                 let mut mutated_proof = original_proof.clone();
                 mutate_proof_bytes(&mut mutated_proof, mutation, &256);
                 if mutated_proof != original_proof {
-                    assert!(
-                        !mutated_proof.verify_element_inclusion(&hasher, element, loc, &root, spec)
-                    );
+                    assert!(!mutated_proof.verify_element_inclusion(
+                        &hasher,
+                        element,
+                        loc,
+                        &root,
+                        inactive_peaks
+                    ));
                 }
             }
         }
@@ -195,7 +207,7 @@ fn fuzz_range_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
         batch.merkleize(&merkle, &hasher)
     };
     merkle.apply_batch(&batch).unwrap();
-    let root = merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+    let root = merkle.root(&hasher, 0).unwrap();
 
     let (start_idx, range_len) = if digests.is_empty() || input.positions.is_empty() {
         (0, 0)
@@ -208,32 +220,18 @@ fn fuzz_range_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
         (i1.min(i2), i1.abs_diff(i2) + 1)
     };
     let start_loc = Location::<F>::new(start_idx as u64);
-    let Ok(original_proof) = merkle.range_proof(
-        &hasher,
-        start_loc..start_loc + range_len as u64,
-        RootSpec::FULL_FORWARD,
-    ) else {
+    let Ok(original_proof) =
+        merkle.range_proof(&hasher, start_loc..start_loc + range_len as u64, 0)
+    else {
         return;
     };
     let range_elements: Vec<Digest> = digests[start_idx..start_idx + range_len].to_vec();
-    assert!(original_proof.verify_range_inclusion(
-        &hasher,
-        &range_elements,
-        start_loc,
-        &root,
-        RootSpec::FULL_FORWARD
-    ));
+    assert!(original_proof.verify_range_inclusion(&hasher, &range_elements, start_loc, &root, 0));
 
     let mut mutated_proof = original_proof.clone();
     mutated_proof.inactive_peaks ^= input.inactive_peaks_mask.get();
     assert_ne!(mutated_proof, original_proof);
-    assert!(!mutated_proof.verify_range_inclusion(
-        &hasher,
-        &range_elements,
-        start_loc,
-        &root,
-        RootSpec::FULL_FORWARD
-    ));
+    assert!(!mutated_proof.verify_range_inclusion(&hasher, &range_elements, start_loc, &root, 0));
 
     for mutation in &input.mutations {
         let mut mutated_proof = original_proof.clone();
@@ -244,19 +242,20 @@ fn fuzz_range_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
                 &range_elements,
                 start_loc,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             ));
         }
     }
 
-    for spec in supported_root_specs(&merkle) {
-        let root = merkle.root(&hasher, spec).unwrap();
+    for (bagging, inactive_peaks) in supported_root_specs(&merkle) {
+        let hasher = Standard::<Sha256>::with_bagging(bagging);
+        let root = merkle.root(&hasher, inactive_peaks).unwrap();
         let Ok(original_proof) = block_on(verification::historical_range_proof(
             &hasher,
             &merkle,
             merkle.leaves(),
             start_loc..start_loc + range_len as u64,
-            spec,
+            inactive_peaks,
         )) else {
             continue;
         };
@@ -265,7 +264,7 @@ fn fuzz_range_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
             &range_elements,
             start_loc,
             &root,
-            spec,
+            inactive_peaks,
         ));
 
         let mut mutated_proof = original_proof.clone();
@@ -276,7 +275,7 @@ fn fuzz_range_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
             &range_elements,
             start_loc,
             &root,
-            spec,
+            inactive_peaks,
         ));
 
         for mutation in &input.mutations {
@@ -288,7 +287,7 @@ fn fuzz_range_proof<F: MerkleFamily>(input: &FuzzInput, digests: &[Digest]) {
                     &range_elements,
                     start_loc,
                     &root,
-                    spec,
+                    inactive_peaks,
                 ));
             }
         }

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -11,7 +11,7 @@ use commonware_storage::{
             unordered::fixed::{Db, Operation as FixedOperation},
             FixedConfig as Config,
         },
-        sync, RootSpec,
+        sync, Bagging,
     },
     translator::TwoCap,
 };
@@ -90,7 +90,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(129);
 
-fn test_config<F: RootSpec>(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap> {
+fn test_config<F: Bagging>(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap> {
     let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(1));
     Config {
         merkle_config: MerkleConfig {
@@ -109,7 +109,7 @@ fn test_config<F: RootSpec>(test_name: &str, pooler: &impl BufferPooler) -> Conf
         },
         translator: TwoCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -122,7 +122,7 @@ async fn test_sync<F, R>(
     sync_id: usize,
 ) -> bool
 where
-    F: MerkleFamily + RootSpec,
+    F: MerkleFamily + Bagging,
     R: sync::resolver::Resolver<
         Family = F,
         Digest = commonware_cryptography::sha256::Digest,
@@ -159,7 +159,7 @@ where
     }
 }
 
-fn fuzz_family<F: MerkleFamily + RootSpec>(input: &mut FuzzInput, test_name: &str) {
+fn fuzz_family<F: MerkleFamily + Bagging>(input: &mut FuzzInput, test_name: &str) {
     input.commit_counter = 0;
     let runner = deterministic::Runner::default();
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -10,7 +10,7 @@ use commonware_storage::{
     },
     qmdb::{
         any::{unordered::variable::Db, VariableConfig as Config},
-        verify_proof, RootSpec,
+        verify_proof, Bagging,
     },
     translator::TwoCap,
 };
@@ -134,7 +134,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(128);
 
-fn test_config<F: RootSpec>(
+fn test_config<F: Bagging>(
     test_name: &str,
     pooler: &impl BufferPooler,
 ) -> Config<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ()))> {
@@ -158,11 +158,11 @@ fn test_config<F: RootSpec>(
         },
         translator: TwoCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
-fn fuzz_family<F: MerkleFamily + RootSpec>(input: &FuzzInput, test_name: &str) {
+fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput, test_name: &str) {
     let runner = deterministic::Runner::default();
 
     let test_name = test_name.to_string();
@@ -236,7 +236,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(input: &FuzzInput, test_name: &str) {
                     if start_loc >= oldest_retained_loc && start_loc < op_count {
                         if let Ok((proof, log)) = db.proof(start_loc, *max_ops).await {
                             let root = db.root();
-                            let spec = F::root_spec(proof.inactive_peaks);
+                            let spec = proof.inactive_peaks;
                             assert!(verify_proof(&hasher, &proof, start_loc, &log, &root, spec,));
                         }
                     }
@@ -277,7 +277,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(input: &FuzzInput, test_name: &str) {
                         let root = historical_roots
                             .get(&op_count)
                             .expect("historical root missing for known commit point");
-                        let spec = F::root_spec(proof.inactive_peaks);
+                        let spec = proof.inactive_peaks;
                         assert!(verify_proof(&hasher, &proof, start_loc, &log, root, spec));
                     }
                 }

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -5,9 +5,7 @@ use commonware_cryptography::Sha256;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner};
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::{
-        full::Config as MerkleConfig, hasher::Standard, mmb, mmr, Family as MerkleFamily, Location,
-    },
+    merkle::{full::Config as MerkleConfig, mmb, mmr, Family as MerkleFamily, Location},
     qmdb::{
         any::{unordered::variable::Db, VariableConfig as Config},
         verify_proof, Bagging,
@@ -167,7 +165,7 @@ fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput, test_name: &str) {
 
     let test_name = test_name.to_string();
     runner.start(|context| async move {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
         let cfg = test_config::<F>(&test_name, &context);
         let mut db = Db::<F, _, Key, Vec<u8>, Sha256, TwoCap>::init(context.clone(), cfg)
             .await

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -6,7 +6,7 @@ use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Runner};
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::{hasher::Standard, mmb, mmr, Family as MerkleFamily, Location},
+    merkle::{mmb, mmr, Family as MerkleFamily, Location},
     mmr::full::Config as MerkleConfig,
     qmdb::{
         immutable::{variable::Db as Immutable, Config},
@@ -150,7 +150,7 @@ fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput, suffix: &str) {
                 .await
                 .unwrap();
 
-            let hasher = Standard::<Sha256>::new();
+            let hasher = F::default_hasher::<Sha256>();
             let mut keys_set: Vec<(Digest, Location<F>)> = Vec::new();
             let mut set_locations: Vec<(Digest, Location<F>)> = Vec::new();
             let mut last_commit_loc: Option<Location<F>> = None;

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -10,7 +10,7 @@ use commonware_storage::{
     mmr::full::Config as MerkleConfig,
     qmdb::{
         immutable::{variable::Db as Immutable, Config},
-        verify_proof, RootSpec,
+        verify_proof, Bagging,
     },
     translator::TwoCap,
 };
@@ -122,7 +122,7 @@ fn db_config(
 
 /// Assign locations to pending keys based on sorted order (matching BTreeMap
 /// iteration in `merkleize()`).
-fn assign_pending_locations<F: MerkleFamily + RootSpec>(
+fn assign_pending_locations<F: MerkleFamily + Bagging>(
     pending: &[(Digest, Vec<u8>)],
     base: Location<F>,
     keys_set: &mut Vec<(Digest, Location<F>)>,
@@ -137,7 +137,7 @@ fn assign_pending_locations<F: MerkleFamily + RootSpec>(
     }
 }
 
-fn fuzz_family<F: MerkleFamily + RootSpec>(input: &FuzzInput, suffix: &str) {
+fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::seeded(input.seed);
 
     runner.start(|context| {
@@ -275,7 +275,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(input: &FuzzInput, suffix: &str) {
                                     safe_start,
                                     &ops,
                                     &root,
-                                    F::root_spec(proof.inactive_peaks),
+                                    proof.inactive_peaks,
                                 );
                             }
                         }

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::Sha256;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner};
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::{full::Config as MerkleConfig, hasher::Standard, mmb, mmr, Family, Location},
+    merkle::{full::Config as MerkleConfig, mmb, mmr, Family, Location},
     qmdb::{
         keyless::variable::{Config, Db as Keyless},
         verify_proof, Bagging, Error,
@@ -215,7 +215,7 @@ fn fuzz_family<F: Family + Bagging>(input: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     runner.start(|context| async move {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
         let cfg = test_config(suffix, &context);
         let mut db: Db<F> = Db::init(context.clone(), cfg)
             .await

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -8,7 +8,7 @@ use commonware_storage::{
     merkle::{full::Config as MerkleConfig, hasher::Standard, mmb, mmr, Family, Location},
     qmdb::{
         keyless::variable::{Config, Db as Keyless},
-        verify_proof, Error, RootSpec,
+        verify_proof, Bagging, Error,
     },
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -25,7 +25,7 @@ enum BadFloorExpect {
     BeyondSize,
 }
 
-fn assert_bad_floor_error<F: Family + RootSpec>(err: &Error<F>, kind: BadFloorExpect) {
+fn assert_bad_floor_error<F: Family + Bagging>(err: &Error<F>, kind: BadFloorExpect) {
     match (err, kind) {
         (Error::FloorRegressed(_, _), BadFloorExpect::Regression) => {}
         (Error::FloorBeyondSize(_, _), BadFloorExpect::BeyondSize) => {}
@@ -211,7 +211,7 @@ fn test_config(
     }
 }
 
-fn fuzz_family<F: Family + RootSpec>(input: &FuzzInput, suffix: &str) {
+fn fuzz_family<F: Family + Bagging>(input: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     runner.start(|context| async move {
@@ -425,7 +425,7 @@ fn fuzz_family<F: Family + RootSpec>(input: &FuzzInput, suffix: &str) {
                                     start_loc,
                                     &ops,
                                     &root,
-                                    F::root_spec(proof.inactive_peaks),
+                                    proof.inactive_peaks,
                                 ),
                                 "Failed to verify proof for start loc{start_loc} with ops {max_ops} ops",
                             );
@@ -466,7 +466,7 @@ fn fuzz_family<F: Family + RootSpec>(input: &FuzzInput, suffix: &str) {
                                     start_loc,
                                     &ops,
                                     &root,
-                                    F::root_spec(proof.inactive_peaks),
+                                    proof.inactive_peaks,
                                 ),
                                 "Failed to verify historical proof for start loc{start_loc} with max ops {max_ops}",
                             );

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -15,7 +15,7 @@ use commonware_storage::{
             value::FixedEncoding,
             FixedConfig as Config,
         },
-        RootSpec,
+        Bagging,
     },
     translator::EightCap,
 };
@@ -58,7 +58,7 @@ struct FuzzInput {
 const PAGE_SIZE: NonZeroU16 = NZU16!(111);
 const PAGE_CACHE_SIZE: usize = 100;
 
-async fn commit_pending<F: MerkleFamily + RootSpec>(
+async fn commit_pending<F: MerkleFamily + Bagging>(
     db: &mut GenericDb<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut BTreeMap<RawKey, RawValue>,
@@ -81,7 +81,7 @@ async fn commit_pending<F: MerkleFamily + RootSpec>(
     committed_state.extend(pending_inserts.drain());
 }
 
-fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
+fn fuzz_family<F: MerkleFamily + Bagging>(data: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     runner.start(|context| {
@@ -105,7 +105,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 split_root: true,
-                root_bagging: F::root_spec(0).bagging(),
+                root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
             };
 
             let mut db: GenericDb<F> = commonware_storage::qmdb::any::init(context.clone(), cfg)

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -15,7 +15,7 @@ use commonware_storage::{
             value::FixedEncoding,
             FixedConfig as Config,
         },
-        verify_proof, RootSpec,
+        verify_proof, Bagging,
     },
     translator::EightCap,
 };
@@ -79,7 +79,7 @@ struct FuzzInput {
 const PAGE_SIZE: NonZeroU16 = NZU16!(555);
 const PAGE_CACHE_SIZE: usize = 100;
 
-async fn commit_pending<F: MerkleFamily + RootSpec>(
+async fn commit_pending<F: MerkleFamily + Bagging>(
     db: &mut GenericDb<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, RawValue>,
@@ -101,7 +101,7 @@ async fn commit_pending<F: MerkleFamily + RootSpec>(
     committed_state.extend(pending_inserts.drain());
 }
 
-fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
+fn fuzz_family<F: MerkleFamily + Bagging>(data: &FuzzInput, suffix: &str) {
     let hasher = Standard::<Sha256>::new();
     let runner = deterministic::Runner::default();
 
@@ -130,7 +130,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 split_root: true,
-                root_bagging: F::root_spec(0).bagging(),
+                root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
             };
 
             let mut db: GenericDb<F> =
@@ -206,7 +206,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
                                     adjusted_start,
                                     &log,
                                     &current_root,
-                                    F::root_spec(proof.inactive_peaks),
+                                    proof.inactive_peaks,
                                 ),
                                 "Proof verification failed for start_loc={adjusted_start}, max_ops={max_ops}",
                             );
@@ -239,7 +239,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
                                         adjusted_start,
                                         &res.1,
                                         &current_root,
-                                        F::root_spec(proof.inactive_peaks),
+                                        proof.inactive_peaks,
                                     );
 
                             }

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -6,7 +6,7 @@ use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner};
 use commonware_storage::{
     index::ordered::Index,
     journal::contiguous::fixed::{Config as FConfig, Journal},
-    merkle::{hasher::Standard, mmb, mmr, Family as MerkleFamily, Location, Proof},
+    merkle::{mmb, mmr, Family as MerkleFamily, Location, Proof},
     mmr::full::Config as MerkleConfig,
     qmdb::{
         any::{
@@ -102,7 +102,7 @@ async fn commit_pending<F: MerkleFamily + Bagging>(
 }
 
 fn fuzz_family<F: MerkleFamily + Bagging>(data: &FuzzInput, suffix: &str) {
-    let hasher = Standard::<Sha256>::new();
+    let hasher = F::default_hasher::<Sha256>();
     let runner = deterministic::Runner::default();
 
     runner.start(|context| {

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -8,7 +8,7 @@ use commonware_storage::{
     merkle::{full::Config as MerkleConfig, mmb, mmr, Family as MerkleFamily},
     qmdb::{
         any::{unordered::fixed::Db as AnyDb, FixedConfig as Config},
-        RootSpec,
+        Bagging,
     },
     translator::OneCap,
 };
@@ -76,7 +76,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
     }
 }
 
-fn test_config<F: RootSpec>(name: &str, pooler: &impl BufferPooler) -> Config<OneCap> {
+fn test_config<F: Bagging>(name: &str, pooler: &impl BufferPooler) -> Config<OneCap> {
     let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(2));
     Config {
         merkle_config: MerkleConfig {
@@ -95,7 +95,7 @@ fn test_config<F: RootSpec>(name: &str, pooler: &impl BufferPooler) -> Config<On
         },
         translator: OneCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -111,7 +111,7 @@ fn value_from_bytes(bytes: [u8; 32]) -> Value {
     Value::new(bytes)
 }
 
-fn fuzz_family<F: MerkleFamily + RootSpec>(input: &FuzzInput, suffix: &str) {
+fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     runner.start(|context| async move {

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -15,7 +15,7 @@ use commonware_storage::{
             value::FixedEncoding,
             FixedConfig as Config,
         },
-        verify_proof, RootSpec,
+        verify_proof, Bagging,
     },
     translator::EightCap,
 };
@@ -58,7 +58,7 @@ struct FuzzInput {
 const PAGE_SIZE: NonZeroU16 = NZU16!(223);
 const PAGE_CACHE_SIZE: usize = 100;
 
-async fn commit_pending<F: MerkleFamily + RootSpec>(
+async fn commit_pending<F: MerkleFamily + Bagging>(
     db: &mut GenericDb<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, Option<RawValue>>,
@@ -76,7 +76,7 @@ async fn commit_pending<F: MerkleFamily + RootSpec>(
     committed_state.extend(pending_expected.drain());
 }
 
-fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
+fn fuzz_family<F: MerkleFamily + Bagging>(data: &FuzzInput, suffix: &str) {
     let hasher = Standard::<Sha256>::new();
     let runner = deterministic::Runner::default();
 
@@ -105,7 +105,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 split_root: true,
-                root_bagging: F::root_spec(0).bagging(),
+                root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
             };
 
             let mut db: GenericDb<F> =
@@ -181,7 +181,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(data: &FuzzInput, suffix: &str) {
                                 adjusted_start,
                                 &log,
                                 &current_root,
-                                F::root_spec(proof.inactive_peaks),
+                                proof.inactive_peaks,
                             ),
                             "Proof verification failed for start_loc={adjusted_start}, max_ops={adjusted_max_ops}",
                         );

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -6,7 +6,7 @@ use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner};
 use commonware_storage::{
     index::unordered::Index,
     journal::contiguous::fixed::{Config as FConfig, Journal},
-    merkle::{hasher::Standard, mmb, mmr, Family as MerkleFamily, Location},
+    merkle::{mmb, mmr, Family as MerkleFamily, Location},
     mmr::full::Config as MerkleConfig,
     qmdb::{
         any::{
@@ -77,7 +77,7 @@ async fn commit_pending<F: MerkleFamily + Bagging>(
 }
 
 fn fuzz_family<F: MerkleFamily + Bagging>(data: &FuzzInput, suffix: &str) {
-    let hasher = Standard::<Sha256>::new();
+    let hasher = F::default_hasher::<Sha256>();
     let runner = deterministic::Runner::default();
 
     runner.start(|context| {

--- a/storage/fuzz/fuzz_targets/range_proof.rs
+++ b/storage/fuzz/fuzz_targets/range_proof.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_storage::merkle::{
     hasher::Standard,
     mem::{Config, Mem},
-    mmb, mmr, Bagging, Family as MerkleFamily, Location, RootSpec,
+    mmb, mmr, Bagging, Family as MerkleFamily, Location,
 };
 use libfuzzer_sys::fuzz_target;
 
@@ -19,24 +19,19 @@ struct FuzzInput {
     range_start: u64,
 }
 
-/// All `RootSpec` shapes a range proof may legitimately be requested for: both `Full` baggings
-/// plus every `Split` count from 0 up to the number of peaks. Mirrors the helper in
-/// `proofs_malleability.rs`.
-fn supported_root_specs<F: MerkleFamily>(merkle: &Mem<F, Digest>) -> Vec<RootSpec> {
+/// All `(bagging, inactive_peaks)` shapes a range proof may legitimately be requested for: both
+/// baggings plus every count from 0 up to the number of peaks.
+fn supported_root_specs<F: MerkleFamily>(merkle: &Mem<F, Digest>) -> Vec<(Bagging, usize)> {
     let peak_count = F::peaks(merkle.size()).count();
-    let mut specs = Vec::with_capacity(2 + 2 * (peak_count + 1));
+    let mut specs = Vec::with_capacity(2 * (peak_count + 1));
     let mut push_unique = |spec| {
         if !specs.contains(&spec) {
             specs.push(spec);
         }
     };
-    push_unique(RootSpec::FULL_FORWARD);
-    push_unique(RootSpec::Full {
-        bagging: Bagging::BackwardFold,
-    });
     for inactive_peaks in 0..=peak_count {
-        push_unique(RootSpec::split_forward(inactive_peaks));
-        push_unique(RootSpec::split_backward(inactive_peaks));
+        push_unique((Bagging::ForwardFold, inactive_peaks));
+        push_unique((Bagging::BackwardFold, inactive_peaks));
     }
     specs
 }
@@ -56,7 +51,6 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput) {
         pinned_nodes,
     };
 
-    let hasher = Standard::<Sha256>::new();
     let Ok(merkle) = Mem::<F, Digest>::init(config) else {
         return;
     };
@@ -70,8 +64,9 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput) {
         return;
     }
     let start = Location::<F>::new(input.range_start % *leaves);
-    for spec in supported_root_specs::<F>(&merkle) {
-        let _ = merkle.range_proof(&hasher, start..leaves, spec);
+    for (bagging, inactive_peaks) in supported_root_specs::<F>(&merkle) {
+        let hasher = Standard::<Sha256>::with_bagging(bagging);
+        let _ = merkle.range_proof(&hasher, start..leaves, inactive_peaks);
     }
 }
 

--- a/storage/fuzz/fuzz_targets/verify_proof.rs
+++ b/storage/fuzz/fuzz_targets/verify_proof.rs
@@ -3,7 +3,7 @@
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_storage::{
-    merkle::{hasher::Standard, mmb, mmr, Family as MerkleFamily, Location, Proof},
+    merkle::{mmb, mmr, Family as MerkleFamily, Location, Proof},
     qmdb::{verify::verify_multi_proof, Bagging},
 };
 use libfuzzer_sys::fuzz_target;
@@ -43,7 +43,7 @@ impl<'a, F: MerkleFamily + Bagging> Arbitrary<'a> for FuzzInput<F> {
 }
 
 fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput<F>) {
-    let hasher = Standard::<Sha256>::new();
+    let hasher = F::default_hasher::<Sha256>();
 
     let digests: Vec<Digest> = input
         .digests

--- a/storage/fuzz/fuzz_targets/verify_proof.rs
+++ b/storage/fuzz/fuzz_targets/verify_proof.rs
@@ -4,7 +4,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_storage::{
     merkle::{hasher::Standard, mmb, mmr, Family as MerkleFamily, Location, Proof},
-    qmdb::{verify::verify_multi_proof, RootSpec},
+    qmdb::{verify::verify_multi_proof, Bagging},
 };
 use libfuzzer_sys::fuzz_target;
 
@@ -22,7 +22,7 @@ struct OperationInput {
 // `proof_leaves` is typed `Location<F>` so that `Arbitrary` bounds it to `F::MAX_LEAVES`;
 // otherwise `verify_multi_proof` would reject on overflow before exercising its inner logic.
 #[derive(Debug)]
-struct FuzzInput<F: MerkleFamily + RootSpec> {
+struct FuzzInput<F: MerkleFamily + Bagging> {
     proof_leaves: Location<F>,
     inactive_peaks: usize,
     digests: Vec<[u8; 32]>,
@@ -30,7 +30,7 @@ struct FuzzInput<F: MerkleFamily + RootSpec> {
     root: [u8; 32],
 }
 
-impl<'a, F: MerkleFamily + RootSpec> Arbitrary<'a> for FuzzInput<F> {
+impl<'a, F: MerkleFamily + Bagging> Arbitrary<'a> for FuzzInput<F> {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             proof_leaves: u.arbitrary()?,
@@ -42,7 +42,7 @@ impl<'a, F: MerkleFamily + RootSpec> Arbitrary<'a> for FuzzInput<F> {
     }
 }
 
-fn fuzz_family<F: MerkleFamily + RootSpec>(input: &FuzzInput<F>) {
+fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput<F>) {
     let hasher = Standard::<Sha256>::new();
 
     let digests: Vec<Digest> = input
@@ -77,7 +77,7 @@ fn fuzz_family<F: MerkleFamily + RootSpec>(input: &FuzzInput<F>) {
         &proof,
         operations.as_slice(),
         &root,
-        F::root_spec(proof.inactive_peaks),
+        proof.inactive_peaks,
     );
 }
 

--- a/storage/src/bitmap/authenticated.rs
+++ b/storage/src/bitmap/authenticated.rs
@@ -20,7 +20,7 @@ use crate::{
             verification, Error, Location, Position, Proof,
         },
         storage::Storage,
-        Family as _, RootSpec,
+        Family as _,
     },
     metadata::{Config as MConfig, Metadata},
     Context,
@@ -251,13 +251,7 @@ impl<E: Context, D: Digest, const N: usize, S: State<D>> BitMap<E, D, N, S> {
 
         let loc = Location::new(PrunableBitMap::<N>::to_chunk_index(bit) as u64);
         if bit_len.is_multiple_of(Self::CHUNK_SIZE_BITS) {
-            return mmr_proof.verify_element_inclusion(
-                hasher,
-                chunk,
-                loc,
-                root,
-                RootSpec::FULL_FORWARD,
-            );
+            return mmr_proof.verify_element_inclusion(hasher, chunk, loc, root, 0);
         }
 
         if proof.digests.is_empty() {
@@ -286,14 +280,13 @@ impl<E: Context, D: Digest, const N: usize, S: State<D>> BitMap<E, D, N, S> {
 
         // For the case where the proof is over a bit in a full chunk, `last_digest` contains the
         // digest of that chunk.
-        let mmr_root =
-            match mmr_proof.reconstruct_root(hasher, &[chunk], loc, RootSpec::FULL_FORWARD) {
-                Ok(root) => root,
-                Err(error) => {
-                    debug!(error = ?error, "invalid proof input");
-                    return false;
-                }
-            };
+        let mmr_root = match mmr_proof.reconstruct_root(hasher, &[chunk], loc, 0) {
+            Ok(root) => root,
+            Err(error) => {
+                debug!(error = ?error, "invalid proof input");
+                return false;
+            }
+        };
 
         let next_bit = bit_len % Self::CHUNK_SIZE_BITS;
         let reconstructed_root =
@@ -336,7 +329,7 @@ impl<E: Context, D: Digest, const N: usize> MerkleizedBitMap<E, D, N> {
         } as usize;
         if pruned_chunks == 0 {
             let mmr = Mmr::new();
-            let cached_root = mmr.root(hasher, RootSpec::FULL_FORWARD)?;
+            let cached_root = mmr.root(hasher, 0)?;
             return Ok(Self {
                 bitmap: PrunableBitMap::new(),
                 authenticated_len: 0,
@@ -373,7 +366,7 @@ impl<E: Context, D: Digest, const N: usize> MerkleizedBitMap<E, D, N> {
 
         let bitmap = PrunableBitMap::new_with_pruned_chunks(pruned_chunks)
             .expect("pruned_chunks should never overflow");
-        let cached_root = mmr.root(hasher, RootSpec::FULL_FORWARD)?;
+        let cached_root = mmr.root(hasher, 0)?;
         Ok(Self {
             bitmap,
             // Pruned chunks are already authenticated in the MMR
@@ -490,15 +483,14 @@ impl<E: Context, D: Digest, const N: usize> MerkleizedBitMap<E, D, N> {
                 Proof {
                     leaves: Location::new(self.len()),
                     inactive_peaks: 0,
-                    digests: vec![self.mmr.root(hasher, RootSpec::FULL_FORWARD)?],
+                    digests: vec![self.mmr.root(hasher, 0)?],
                 },
                 chunk,
             ));
         }
 
         let range = chunk_loc..chunk_loc + 1;
-        let mut proof =
-            verification::range_proof(hasher, &self.mmr, range, RootSpec::FULL_FORWARD).await?;
+        let mut proof = verification::range_proof(hasher, &self.mmr, range, 0).await?;
         proof.leaves = Location::new(self.len());
         if next_bit == Self::CHUNK_SIZE_BITS {
             // Bitmap is chunk aligned.
@@ -626,7 +618,7 @@ impl<E: Context, D: Digest, const N: usize> UnmerkleizedBitMap<E, D, N> {
         self.mmr.apply_batch(&batch)?;
 
         // Compute the bitmap root.
-        let mmr_root = self.mmr.root(hasher, RootSpec::FULL_FORWARD)?;
+        let mmr_root = self.mmr.root(hasher, 0)?;
         let cached_root = if self.bitmap.is_chunk_aligned() {
             mmr_root
         } else {
@@ -874,7 +866,7 @@ mod tests {
 
             let bitmap = dirty.merkleize(&hasher).unwrap();
             let root = bitmap.root();
-            let inner_root = bitmap.mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let inner_root = bitmap.mmr.root(&hasher, 0).unwrap();
             assert_eq!(root, inner_root);
 
             {

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -15,7 +15,7 @@ use crate::{
         full::Merkle,
         hasher::{Hasher as _, Standard as StandardHasher},
         mem::Mem,
-        Family, Location, Position, Proof, Readable, RootSpec,
+        Family, Location, Position, Proof, Readable,
     },
     Context, Persistable,
 };
@@ -192,37 +192,37 @@ impl<F: Family, D: Digest, Item: Send + Sync> MerkleizedBatch<F, D, Item> {
         *self.inner.leaves()
     }
 
-    /// Compute the root digest after this batch is applied using `spec`.
+    /// Compute the root digest after this batch is applied using `inactive_peaks` and the bagging
+    /// carried by `hasher`.
     ///
-    /// This recomputes the root rather than reading a cache. Callers that need repeated cheap root
-    /// access should compute it once and cache the digest at the layer that owns the root spec.
+    /// This recomputes the root rather than reading a cache.
     pub fn root(
         &self,
         base: &Mem<F, D>,
         hasher: &impl merkle::hasher::Hasher<F, Digest = D>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<D, merkle::Error<F>> {
-        self.inner.root(base, hasher, spec)
+        self.inner.root(base, hasher, inactive_peaks)
     }
 
-    /// Inclusion proof for the element at `loc` using an explicit root spec.
+    /// Inclusion proof for the element at `loc`.
     pub fn proof(
         &self,
         hasher: &impl merkle::hasher::Hasher<F, Digest = D>,
         loc: Location<F>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, merkle::Error<F>> {
-        self.inner.proof(hasher, loc, spec)
+        self.inner.proof(hasher, loc, inactive_peaks)
     }
 
-    /// Inclusion proof for all elements in `range` using an explicit root spec.
+    /// Inclusion proof for all elements in `range`.
     pub fn range_proof(
         &self,
         hasher: &impl merkle::hasher::Hasher<F, Digest = D>,
         range: core::ops::Range<Location<F>>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, merkle::Error<F>> {
-        self.inner.range_proof(hasher, range, spec)
+        self.inner.range_proof(hasher, range, inactive_peaks)
     }
 
     /// The items added in this batch.
@@ -299,9 +299,12 @@ where
         Location::new(self.journal.size().await)
     }
 
-    /// Compute the root of the Merkle structure using `spec`.
-    pub fn root(&self, spec: RootSpec) -> Result<H::Digest, Error<F>> {
-        self.merkle.root(&self.hasher, spec).map_err(Into::into)
+    /// Compute the root of the Merkle structure using `inactive_peaks` and the bagging carried by
+    /// the journal's hasher.
+    pub fn root(&self, inactive_peaks: usize) -> Result<H::Digest, Error<F>> {
+        self.merkle
+            .root(&self.hasher, inactive_peaks)
+            .map_err(Into::into)
     }
 
     /// Convert authenticated-journal errors to the contiguous journal trait error type.
@@ -592,9 +595,9 @@ where
         &self,
         start_loc: Location<F>,
         max_ops: NonZeroU64,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<(Proof<F, H::Digest>, Vec<C::Item>), Error<F>> {
-        self.historical_proof(self.size().await, start_loc, max_ops, spec)
+        self.historical_proof(self.size().await, start_loc, max_ops, inactive_peaks)
             .await
     }
 
@@ -615,7 +618,7 @@ where
         historical_leaves: Location<F>,
         start_loc: Location<F>,
         max_ops: NonZeroU64,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<(Proof<F, H::Digest>, Vec<C::Item>), Error<F>> {
         let reader = self.journal.reader().await;
         let bounds = reader.bounds();
@@ -632,7 +635,12 @@ where
         let hasher = self.hasher.clone();
         let proof = self
             .merkle
-            .historical_range_proof(&hasher, historical_leaves, start_loc..end_loc, spec)
+            .historical_range_proof(
+                &hasher,
+                historical_leaves,
+                start_loc..end_loc,
+                inactive_peaks,
+            )
             .await?;
 
         let futures = (*start_loc..*end_loc)
@@ -695,12 +703,13 @@ macro_rules! impl_journal_new {
                 merkle_cfg: merkle::full::Config,
                 journal_cfg: $cfg_ty,
                 rewind_predicate: fn(&O) -> bool,
+                bagging: merkle::Bagging,
             ) -> Result<Self, Error<F>> {
                 let mut journal =
                     $journal_mod::Journal::init(context.with_label("journal"), journal_cfg).await?;
                 journal.rewind_to(rewind_predicate).await?;
 
-                let hasher = StandardHasher::<H>::new();
+                let hasher = StandardHasher::<H>::with_bagging(bagging);
                 let mut merkle =
                     Merkle::init(context.with_label("merkle"), &hasher, merkle_cfg).await?;
                 Self::align(&mut merkle, &journal, &hasher, APPLY_BATCH_SIZE).await?;
@@ -782,6 +791,7 @@ pub trait Inner<E: Context>: Mutable + Persistable<Error = JournalError> {
         merkle_cfg: merkle::full::Config,
         journal_cfg: Self::Config,
         rewind_predicate: fn(&Self::Item) -> bool,
+        bagging: merkle::Bagging,
     ) -> impl core::future::Future<Output = Result<Journal<F, E, Self, H>, Error<F>>> + Send
     where
         Self: Sized,
@@ -873,7 +883,7 @@ mod tests {
     >;
 
     fn journal_root<F: Family>(journal: &TestJournal<F>) -> Digest {
-        journal.root(RootSpec::FULL_FORWARD).unwrap()
+        journal.root(0).unwrap()
     }
 
     fn batch_root<F: Family>(
@@ -882,7 +892,7 @@ mod tests {
     ) -> Digest {
         journal
             .merkle
-            .with_mem(|mem| batch.root(mem, &journal.hasher, RootSpec::FULL_FORWARD))
+            .with_mem(|mem| batch.root(mem, &journal.hasher, 0))
             .unwrap()
     }
 
@@ -915,9 +925,13 @@ mod tests {
     ) -> TestJournal<F> {
         let merkle_cfg = merkle_config(suffix, &context);
         let journal_cfg = journal_config(suffix, &context);
-        TestJournal::<F>::new(context, merkle_cfg, journal_cfg, |op: &TestOp<F>| {
-            op.is_commit()
-        })
+        TestJournal::<F>::new(
+            context,
+            merkle_cfg,
+            journal_cfg,
+            |op: &TestOp<F>| op.is_commit(),
+            crate::merkle::Bagging::ForwardFold,
+        )
         .await
         .unwrap()
     }
@@ -990,13 +1004,7 @@ mod tests {
         hasher: &StandardHasher<Sha256>,
     ) -> bool {
         let encoded_ops: Vec<_> = operations.iter().map(|op| op.encode()).collect();
-        proof.verify_range_inclusion(
-            hasher,
-            &encoded_ops,
-            start_loc,
-            root,
-            RootSpec::FULL_FORWARD,
-        )
+        proof.verify_range_inclusion(hasher, &encoded_ops, start_loc, root, 0)
     }
 
     /// Verify that new() creates an empty authenticated journal.
@@ -1361,10 +1369,15 @@ mod tests {
         {
             let merkle_cfg = merkle_config("rewind", &context);
             let journal_cfg = journal_config("rewind", &context);
-            let mut journal =
-                TestJournal::<F>::new(context, merkle_cfg, journal_cfg, |op| op.is_commit())
-                    .await
-                    .unwrap();
+            let mut journal = TestJournal::<F>::new(
+                context,
+                merkle_cfg,
+                journal_cfg,
+                |op| op.is_commit(),
+                crate::merkle::Bagging::ForwardFold,
+            )
+            .await
+            .unwrap();
 
             // Add operations with a commit at position 5 (in section 0: 0-6)
             for i in 0..5 {
@@ -1931,7 +1944,7 @@ mod tests {
         let journal = create_journal_with_ops::<F>(context, "proof_multi", 50).await;
 
         let (proof, ops) = journal
-            .proof(Location::<F>::new(0), NZU64!(50), RootSpec::FULL_FORWARD)
+            .proof(Location::<F>::new(0), NZU64!(50), 0)
             .await
             .unwrap();
 
@@ -1972,12 +1985,7 @@ mod tests {
 
         let size = journal.size().await;
         let (proof, ops) = journal
-            .historical_proof(
-                size,
-                Location::<F>::new(0),
-                NZU64!(20),
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_proof(size, Location::<F>::new(0), NZU64!(20), 0)
             .await
             .unwrap();
 
@@ -2024,12 +2032,7 @@ mod tests {
         let size = journal.size().await;
         // Request proof starting near the end
         let (proof, ops) = journal
-            .historical_proof(
-                size,
-                Location::<F>::new(40),
-                NZU64!(20),
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_proof(size, Location::<F>::new(40), NZU64!(20), 0)
             .await
             .unwrap();
 
@@ -2071,12 +2074,7 @@ mod tests {
 
         // Request proof with size > actual journal size
         let result = journal
-            .historical_proof(
-                Location::<F>::new(10),
-                Location::<F>::new(0),
-                NZU64!(1),
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_proof(Location::<F>::new(10), Location::<F>::new(0), NZU64!(1), 0)
             .await;
 
         assert!(matches!(
@@ -2109,9 +2107,7 @@ mod tests {
 
         let size = journal.size().await;
         // Request proof starting at size (should fail)
-        let result = journal
-            .historical_proof(size, size, NZU64!(1), RootSpec::FULL_FORWARD)
-            .await;
+        let result = journal.historical_proof(size, size, NZU64!(1), 0).await;
 
         assert!(matches!(
             result,
@@ -2156,12 +2152,7 @@ mod tests {
 
         // Generate proof for the historical state
         let (proof, ops) = journal
-            .historical_proof(
-                historical_size,
-                Location::<F>::new(0),
-                NZU64!(50),
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_proof(historical_size, Location::<F>::new(0), NZU64!(50), 0)
             .await
             .unwrap();
 
@@ -2211,7 +2202,7 @@ mod tests {
         let start_loc = Location::<F>::new(0);
         if start_loc < pruned_boundary {
             let result = journal
-                .historical_proof(size, start_loc, NZU64!(1), RootSpec::FULL_FORWARD)
+                .historical_proof(size, start_loc, NZU64!(1), 0)
                 .await;
 
             // Should fail when trying to read pruned operations
@@ -2464,7 +2455,7 @@ mod tests {
         assert_eq!(journal_root(&journal), expected_root);
         assert_eq!(journal.size().await, expected_size);
         let (_, ops) = journal
-            .proof(Location::<F>::new(0), NZU64!(1), RootSpec::FULL_FORWARD)
+            .proof(Location::<F>::new(0), NZU64!(1), 0)
             .await
             .unwrap();
         assert_eq!(ops, vec![op_a]);
@@ -2609,7 +2600,7 @@ mod tests {
 
         // Verify all items are present.
         let (_, ops) = journal
-            .proof(Location::<F>::new(3), NZU64!(5), RootSpec::FULL_FORWARD)
+            .proof(Location::<F>::new(3), NZU64!(5), 0)
             .await
             .unwrap();
         assert_eq!(ops.len(), 5);
@@ -2666,7 +2657,7 @@ mod tests {
 
         // Verify the actual items at each location.
         let (_, ops) = journal
-            .proof(Location::<F>::new(2), NZU64!(6), RootSpec::FULL_FORWARD)
+            .proof(Location::<F>::new(2), NZU64!(6), 0)
             .await
             .unwrap();
         for (i, op) in ops.iter().enumerate() {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1025,6 +1025,7 @@ impl<E: Context, A: CodecFixedShared> crate::journal::authenticated::Inner<E> fo
         merkle_cfg: crate::merkle::full::Config,
         journal_cfg: Self::Config,
         rewind_predicate: fn(&A) -> bool,
+        bagging: crate::merkle::Bagging,
     ) -> Result<
         crate::journal::authenticated::Journal<F, E, Self, H>,
         crate::journal::authenticated::Error<F>,
@@ -1034,6 +1035,7 @@ impl<E: Context, A: CodecFixedShared> crate::journal::authenticated::Inner<E> fo
             merkle_cfg,
             journal_cfg,
             rewind_predicate,
+            bagging,
         )
         .await
     }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -999,6 +999,7 @@ impl<E: Context, V: CodecShared> crate::journal::authenticated::Inner<E> for Jou
         merkle_cfg: crate::merkle::full::Config,
         journal_cfg: Self::Config,
         rewind_predicate: fn(&V) -> bool,
+        bagging: crate::merkle::Bagging,
     ) -> Result<
         crate::journal::authenticated::Journal<F, E, Self, H>,
         crate::journal::authenticated::Error<F>,
@@ -1008,6 +1009,7 @@ impl<E: Context, V: CodecShared> crate::journal::authenticated::Inner<E> for Jou
             merkle_cfg,
             journal_cfg,
             rewind_predicate,
+            bagging,
         )
         .await
     }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -82,7 +82,6 @@
 
 use crate::merkle::{
     hasher::Hasher, mem::Mem, path, proof::Proof, Error, Family, Location, Position, Readable,
-    RootSpec,
 };
 use alloc::{
     collections::BTreeMap,
@@ -568,12 +567,13 @@ impl<F: Family, D: Digest> MerkleizedBatch<F, D> {
         None
     }
 
-    /// Compute the root digest after this batch's mutations using `spec`.
+    /// Compute the root digest after this batch's mutations using `inactive_peaks` and the bagging
+    /// carried by `hasher`.
     pub fn root(
         &self,
         base: &Mem<F, D>,
         hasher: &impl Hasher<F, Digest = D>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<D, Error<F>> {
         let leaves = self.leaves();
         let peaks: Vec<D> = F::peaks(self.size())
@@ -583,37 +583,39 @@ impl<F: Family, D: Digest> MerkleizedBatch<F, D> {
                     .expect("peak missing")
             })
             .collect();
-        hasher.root(leaves, spec, peaks.iter())
+        hasher.root(leaves, inactive_peaks, peaks.iter())
     }
 
-    /// Inclusion proof for the element at `loc` using an explicit root spec.
+    /// Inclusion proof for the element at `loc` using `inactive_peaks` and the bagging carried by
+    /// `hasher`.
     pub fn proof(
         &self,
         hasher: &impl Hasher<F, Digest = D>,
         loc: Location<F>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, Error<F>> {
         if !loc.is_valid_index() {
             return Err(Error::LocationOverflow(loc));
         }
-        self.range_proof(hasher, loc..loc + 1, spec)
+        self.range_proof(hasher, loc..loc + 1, inactive_peaks)
             .map_err(|e| match e {
                 Error::RangeOutOfBounds(_) => Error::LeafOutOfBounds(loc),
                 _ => e,
             })
     }
 
-    /// Inclusion proof for all elements in `range` using an explicit root spec.
+    /// Inclusion proof for all elements in `range` using `inactive_peaks` and the bagging carried
+    /// by `hasher`.
     pub fn range_proof(
         &self,
         hasher: &impl Hasher<F, Digest = D>,
         range: Range<Location<F>>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, Error<F>> {
         crate::merkle::proof::build_range_proof(
             hasher,
             self.leaves(),
-            spec,
+            inactive_peaks,
             range,
             |pos| Self::get_node(self, pos),
             Error::ElementPruned,
@@ -672,7 +674,7 @@ impl<F: Family, D: Digest> Readable for MerkleizedBatch<F, D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::{hasher::Standard, mem::Mem, RootSpec};
+    use crate::merkle::{hasher::Standard, mem::Mem};
     use commonware_cryptography::{sha256, Sha256};
     use commonware_runtime::{deterministic, Runner as _};
 
@@ -680,11 +682,11 @@ mod tests {
     type H = Standard<Sha256>;
 
     fn mem_root<F: Family>(mem: &Mem<F, D>, hasher: &H) -> D {
-        mem.root(hasher, RootSpec::FULL_FORWARD).unwrap()
+        mem.root(hasher, 0).unwrap()
     }
 
     fn batch_root<F: Family>(base: &Mem<F, D>, batch: &MerkleizedBatch<F, D>, hasher: &H) -> D {
-        batch.root(base, hasher, RootSpec::FULL_FORWARD).unwrap()
+        batch.root(base, hasher, 0).unwrap()
     }
 
     fn build_reference<F: Family>(hasher: &H, n: u64) -> Mem<F, D> {
@@ -744,13 +746,13 @@ mod tests {
             applied.apply_batch(&merkleized).unwrap();
             let loc = Location::<F>::new(55);
             let element = hasher.digest(&55u64.to_be_bytes());
-            let proof = applied.proof(&hasher, loc, RootSpec::FULL_FORWARD).unwrap();
+            let proof = applied.proof(&hasher, loc, 0).unwrap();
             assert!(proof.verify_element_inclusion(
                 &hasher,
                 &element,
                 loc,
                 &batch_root(&applied, &merkleized, &hasher),
-                RootSpec::FULL_FORWARD,
+                0,
             ));
         });
     }
@@ -830,13 +832,13 @@ mod tests {
             for i in [0u64, 25, 55, 65, 69] {
                 let loc = Location::<F>::new(i);
                 let element = hasher.digest(&i.to_be_bytes());
-                let proof = applied.proof(&hasher, loc, RootSpec::FULL_FORWARD).unwrap();
+                let proof = applied.proof(&hasher, loc, 0).unwrap();
                 assert!(proof.verify_element_inclusion(
                     &hasher,
                     &element,
                     loc,
                     &batch_root(&applied, &mb, &hasher),
-                    RootSpec::FULL_FORWARD,
+                    0,
                 ));
             }
         });
@@ -936,18 +938,16 @@ mod tests {
             applied.apply_batch(&m).unwrap();
             let loc = Location::<F>::new(55);
             let element = hasher.digest(&55u64.to_be_bytes());
-            let proof = applied.proof(&hasher, loc, RootSpec::FULL_FORWARD).unwrap();
+            let proof = applied.proof(&hasher, loc, 0).unwrap();
             assert!(proof.verify_element_inclusion(
                 &hasher,
                 &element,
                 loc,
                 &batch_root(&applied, &m, &hasher),
-                RootSpec::FULL_FORWARD,
+                0,
             ));
             let range = Location::<F>::new(50)..Location::new(55);
-            let rp = applied
-                .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-                .unwrap();
+            let rp = applied.range_proof(&hasher, range.clone(), 0).unwrap();
             let elements: Vec<D> = (50u64..55)
                 .map(|i| hasher.digest(&i.to_be_bytes()))
                 .collect();
@@ -956,7 +956,7 @@ mod tests {
                 &elements,
                 range.start,
                 &batch_root(&applied, &m, &hasher),
-                RootSpec::FULL_FORWARD,
+                0,
             ));
         });
     }
@@ -1038,16 +1038,10 @@ mod tests {
             applied.apply_batch(&m).unwrap();
             let loc = Location::<F>::new(80);
             let element = hasher.digest(&80u64.to_be_bytes());
-            let proof = applied.proof(&hasher, loc, RootSpec::FULL_FORWARD).unwrap();
-            assert!(proof.verify_element_inclusion(
-                &hasher,
-                &element,
-                loc,
-                &expected_root,
-                RootSpec::FULL_FORWARD
-            ));
+            let proof = applied.proof(&hasher, loc, 0).unwrap();
+            assert!(proof.verify_element_inclusion(&hasher, &element, loc, &expected_root, 0));
             assert!(matches!(
-                applied.proof(&hasher, Location::new(0), RootSpec::FULL_FORWARD),
+                applied.proof(&hasher, Location::new(0), 0),
                 Err(Error::ElementPruned(_))
             ));
         });

--- a/storage/src/merkle/benches/prove_many_elements.rs
+++ b/storage/src/merkle/benches/prove_many_elements.rs
@@ -1,8 +1,6 @@
 use commonware_cryptography::{sha256, Sha256};
 use commonware_math::algebra::Random as _;
-use commonware_storage::merkle::{
-    self, mem::Mem, Family, Location, LocationRangeExt as _, RootSpec,
-};
+use commonware_storage::merkle::{self, mem::Mem, Family, Location, LocationRangeExt as _};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -35,7 +33,7 @@ fn bench_prove_many_elements_family<F: Family>(c: &mut Criterion, family: &str) 
             };
             mem.apply_batch(&batch).unwrap();
         });
-        let root = mem.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mem.root(&hasher, 0).unwrap();
 
         // Generate SAMPLE_SIZE random starts without replacement and create/verify range proofs
         for range in [2, 5, 10, 25, 50, 100, 250, 500, 1_000, 5_000] {
@@ -66,15 +64,13 @@ fn bench_prove_many_elements_family<F: Family>(c: &mut Criterion, family: &str) 
                             let hasher = StandardHasher::<Sha256>::new();
                             block_on(async {
                                 for range in samples {
-                                    let proof = mem
-                                        .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-                                        .unwrap();
+                                    let proof = mem.range_proof(&hasher, range.clone(), 0).unwrap();
                                     assert!(proof.verify_range_inclusion(
                                         &hasher,
                                         &elements[range.to_usize_range()],
                                         range.start,
                                         &root,
-                                        RootSpec::FULL_FORWARD,
+                                        0,
                                     ));
                                 }
                             })

--- a/storage/src/merkle/benches/prove_single_element.rs
+++ b/storage/src/merkle/benches/prove_single_element.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::{sha256, Sha256};
 use commonware_math::algebra::Random as _;
-use commonware_storage::merkle::{self, mem::Mem, Family, Location, RootSpec};
+use commonware_storage::merkle::{self, mem::Mem, Family, Location};
 use criterion::{criterion_group, Criterion};
 use futures::executor::block_on;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -32,7 +32,7 @@ fn bench_prove_single_element_family<F: Family>(c: &mut Criterion, family: &str)
             };
             mem.apply_batch(&batch).unwrap();
         });
-        let root = mem.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mem.root(&hasher, 0).unwrap();
 
         // Select SAMPLE_SIZE random elements without replacement and create/verify proofs
         c.bench_function(
@@ -53,15 +53,9 @@ fn bench_prove_single_element_family<F: Family>(c: &mut Criterion, family: &str)
                         block_on(async {
                             let hasher = StandardHasher::<Sha256>::new();
                             for (loc, element) in samples {
-                                let proof =
-                                    mem.proof(&hasher, loc, RootSpec::FULL_FORWARD).unwrap();
-                                assert!(proof.verify_element_inclusion(
-                                    &hasher,
-                                    &element,
-                                    loc,
-                                    &root,
-                                    RootSpec::FULL_FORWARD
-                                ));
+                                let proof = mem.proof(&hasher, loc, 0).unwrap();
+                                assert!(proof
+                                    .verify_element_inclusion(&hasher, &element, loc, &root, 0));
                             }
                         });
                     },

--- a/storage/src/merkle/conformance.rs
+++ b/storage/src/merkle/conformance.rs
@@ -1,6 +1,6 @@
 //! Shared conformance test utilities and stability tests for Merkle-family structures.
 
-use crate::merkle::{hasher::Hasher, mem::Mem, Family, RootSpec};
+use crate::merkle::{hasher::Hasher, mem::Mem, Family};
 use commonware_conformance::{conformance_tests, Conformance};
 use commonware_cryptography::{sha256, Sha256};
 
@@ -58,7 +58,7 @@ impl Conformance for MmrRootStability {
         let hasher = Standard::new();
         let mmr = crate::mmr::mem::Mmr::new();
         build_test_mem(&hasher, mmr, seed)
-            .root(&hasher, RootSpec::FULL_FORWARD)
+            .root(&hasher, 0)
             .unwrap()
             .to_vec()
     }
@@ -75,7 +75,7 @@ impl Conformance for MmbRootStability {
         let hasher = Standard::new();
         let mmb = crate::mmb::mem::Mmb::new();
         build_test_mem(&hasher, mmb, seed)
-            .root(&hasher, RootSpec::FULL_FORWARD)
+            .root(&hasher, 0)
             .unwrap()
             .to_vec()
     }

--- a/storage/src/merkle/hasher.rs
+++ b/storage/src/merkle/hasher.rs
@@ -1,6 +1,6 @@
 //! Shared hasher trait and standard implementation for Merkle-family data structures.
 
-use crate::merkle::{Bagging, Error, Family, Location, Position, RootSpec};
+use crate::merkle::{Bagging, Error, Family, Location, Position};
 use alloc::vec::Vec;
 use commonware_cryptography::{Digest, Hasher as CHasher};
 use core::marker::PhantomData;
@@ -18,6 +18,10 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
     /// The parts are concatenated before hashing (i.e. there is no domain separation between
     /// parts).
     fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> Self::Digest;
+
+    /// The bagging policy applied when this hasher folds peaks into a root. Only affects root peak
+    /// aggregation; `hash`, `leaf_digest`, and `node_digest` are unaffected.
+    fn root_bagging(&self) -> Bagging;
 
     /// Computes the digest for a node given its position and the digests of its children.
     fn node_digest(
@@ -48,32 +52,16 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
         self.hash([acc.as_ref(), peak.as_ref()])
     }
 
-    /// Computes a root according to the supplied [`RootSpec`].
-    fn root<'a, I>(
-        &self,
-        leaves: Location<F>,
-        spec: RootSpec,
-        peak_digests: I,
-    ) -> Result<Self::Digest, Error<F>>
-    where
-        I: IntoIterator<Item = &'a Self::Digest>,
-        I::IntoIter: ExactSizeIterator,
-    {
-        self.root_with_inactive_prefix(leaves, spec.inactive_peaks(), spec.bagging(), peak_digests)
-    }
-
-    /// Computes a root where the oldest `inactive_peaks` are forward-bagged into a single
-    /// accumulator and the remaining peaks are folded with the strategy indicated by `bagging`.
+    /// Computes a root using `inactive_peaks` and the bagging policy carried by `self`.
     ///
     /// # Errors
     ///
     /// Returns [`Error::InvalidInactivePeaks`] if `inactive_peaks` exceeds the number of
     /// provided peak digests.
-    fn root_with_inactive_prefix<'a, I>(
+    fn root<'a, I>(
         &self,
         leaves: Location<F>,
         inactive_peaks: usize,
-        bagging: Bagging,
         peak_digests: I,
     ) -> Result<Self::Digest, Error<F>>
     where
@@ -82,7 +70,7 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
     {
         let iter = peak_digests.into_iter();
         let peaks = iter.len();
-        self.root_with_folded_peaks(leaves, inactive_peaks, inactive_peaks, bagging, iter)
+        self.root_with_folded_peaks(leaves, inactive_peaks, inactive_peaks, iter)
             .ok_or(Error::InvalidInactivePeaks {
                 requested: inactive_peaks,
                 peaks,
@@ -90,7 +78,7 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
     }
 
     /// Computes a root from a peak list that may already contain a forward-folded prefix
-    /// accumulator.
+    /// accumulator. The bagging policy is read from `self.root_bagging()`.
     ///
     /// `inactive_peaks_to_fold` is how many leading entries of `peak_digests` to fold before the
     /// root bagging step. `committed_inactive_peaks` is the boundary committed into the root. They
@@ -106,7 +94,6 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
         leaves: Location<F>,
         inactive_peaks_to_fold: usize,
         committed_inactive_peaks: usize,
-        bagging: Bagging,
         peak_digests: impl IntoIterator<Item = &'a Self::Digest>,
     ) -> Option<Self::Digest> {
         let mut peak_digests = peak_digests.into_iter();
@@ -121,7 +108,7 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
             acc = self.fold(&acc, peak);
         }
 
-        let folded_peaks = match bagging {
+        let folded_peaks = match self.root_bagging() {
             Bagging::ForwardFold => {
                 for peak in peak_digests {
                     acc = self.fold(&acc, peak);
@@ -158,16 +145,36 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
 ///
 /// A single `Standard<H>` implements `Hasher<F>` for every Merkle family `F`, so
 /// one instance can be used with MMR, MMB, or any future family.
+///
+/// The `bagging` field selects how peaks are folded into the root; pick at construction time and
+/// keep the same hasher for the lifetime of any structure or proof that depends on root identity.
 #[derive(Clone)]
 pub struct Standard<H: CHasher> {
     _hasher: PhantomData<H>,
+    bagging: Bagging,
 }
 
 impl<H: CHasher> Standard<H> {
-    /// Creates a new [Standard] hasher.
+    /// Creates a new [Standard] hasher with the default forward-fold bagging.
     pub const fn new() -> Self {
+        Self::forward()
+    }
+
+    /// Creates a new [Standard] hasher with forward-fold bagging.
+    pub const fn forward() -> Self {
+        Self::with_bagging(Bagging::ForwardFold)
+    }
+
+    /// Creates a new [Standard] hasher with backward-fold bagging.
+    pub const fn backward() -> Self {
+        Self::with_bagging(Bagging::BackwardFold)
+    }
+
+    /// Creates a new [Standard] hasher with the given bagging policy.
+    pub const fn with_bagging(bagging: Bagging) -> Self {
         Self {
             _hasher: PhantomData,
+            bagging,
         }
     }
 
@@ -198,15 +205,24 @@ impl<F: Family, H: CHasher> Hasher<F> for Standard<H> {
     fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> H::Digest {
         Self::hash(self, parts)
     }
+
+    fn root_bagging(&self) -> Bagging {
+        self.bagging
+    }
 }
 
-// This intentionally forwards only `hash`: the default `Hasher` methods are all expressed in terms
-// of `hash`. If a future hasher specializes other methods, forward those here as well.
+// This intentionally forwards only `hash` and `root_bagging`: the default `Hasher` methods are all
+// expressed in terms of `hash`. If a future hasher specializes other methods, forward those here as
+// well.
 impl<F: Family, T: Hasher<F>> Hasher<F> for &T {
     type Digest = T::Digest;
 
     fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> Self::Digest {
         (**self).hash(parts)
+    }
+
+    fn root_bagging(&self) -> Bagging {
+        (**self).root_bagging()
     }
 }
 
@@ -234,16 +250,16 @@ mod tests {
 
     #[test]
     fn test_invalid_inactive_prefix_returns_err() {
-        let mmr_hasher: Standard<Sha256> = Standard::new();
+        let mmr_hasher: Standard<Sha256> = Standard::backward();
         let d1 = test_digest::<Sha256>(1);
         let d2 = test_digest::<Sha256>(2);
         let digests = [d1, d2];
 
         assert!(matches!(
-            mmr_hasher.root_with_inactive_prefix(
+            <Standard<Sha256> as Hasher<crate::merkle::mmr::Family>>::root(
+                &mmr_hasher,
                 Location::new(2),
                 3,
-                Bagging::BackwardFold,
                 digests.iter()
             ),
             Err(crate::merkle::Error::InvalidInactivePeaks {
@@ -251,20 +267,21 @@ mod tests {
                 peaks: 2
             })
         ));
-        assert!(mmr_hasher
-            .root_with_folded_peaks(
+        assert!(
+            <Standard<Sha256> as Hasher<crate::merkle::mmr::Family>>::root_with_folded_peaks(
+                &mmr_hasher,
                 Location::new(2),
                 3,
                 3,
-                Bagging::BackwardFold,
                 digests.iter()
             )
-            .is_none());
+            .is_none()
+        );
         assert!(matches!(
-            mmr_hasher.root_with_inactive_prefix(
+            <Standard<Sha256> as Hasher<crate::merkle::mmr::Family>>::root(
+                &mmr_hasher,
                 Location::new(0),
                 1,
-                Bagging::BackwardFold,
                 Vec::<sha256::Digest>::new().iter()
             ),
             Err(crate::merkle::Error::InvalidInactivePeaks {
@@ -340,7 +357,7 @@ mod tests {
 
         let empty_vec: Vec<H::Digest> = Vec::new();
         let empty_out = mmr_hasher
-            .root(Location::new(0), RootSpec::FULL_FORWARD, empty_vec.iter())
+            .root(Location::new(0), 0, empty_vec.iter())
             .expect("zero inactive peaks is always valid");
         assert_ne!(
             empty_out,
@@ -351,36 +368,36 @@ mod tests {
         assert_eq!(
             empty_out,
             mmr_hasher
-                .root(Location::new(0), RootSpec::FULL_FORWARD, empty_vec.iter())
+                .root(Location::new(0), 0, empty_vec.iter())
                 .expect("zero inactive peaks is always valid")
         );
 
         let digests = [d1, d2, d3, d4];
         let out = mmr_hasher
-            .root(Location::new(10), RootSpec::FULL_FORWARD, digests.iter())
+            .root(Location::new(10), 0, digests.iter())
             .expect("zero inactive peaks is always valid");
         assert_ne!(out, test_digest::<H>(0), "root should be non-zero");
         assert_ne!(out, empty_out, "root should differ from empty MMR");
 
         let mut out2 = mmr_hasher
-            .root(Location::new(10), RootSpec::FULL_FORWARD, digests.iter())
+            .root(Location::new(10), 0, digests.iter())
             .expect("zero inactive peaks is always valid");
         assert_eq!(out, out2, "root should be computed consistently");
 
         out2 = mmr_hasher
-            .root(Location::new(11), RootSpec::FULL_FORWARD, digests.iter())
+            .root(Location::new(11), 0, digests.iter())
             .expect("zero inactive peaks is always valid");
         assert_ne!(out, out2, "root should change with different position");
 
         let digests = [d1, d2, d4, d3];
         out2 = mmr_hasher
-            .root(Location::new(10), RootSpec::FULL_FORWARD, digests.iter())
+            .root(Location::new(10), 0, digests.iter())
             .expect("zero inactive peaks is always valid");
         assert_ne!(out, out2, "root should change with different digest order");
 
         let digests = [d1, d2, d3];
         out2 = mmr_hasher
-            .root(Location::new(10), RootSpec::FULL_FORWARD, digests.iter())
+            .root(Location::new(10), 0, digests.iter())
             .expect("zero inactive peaks is always valid");
         assert_ne!(
             out, out2,

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -6,7 +6,7 @@
 
 use crate::merkle::{
     batch, hasher::Hasher, proof as merkle_proof, Error, Family, Location, Position, Proof,
-    Readable, RootSpec,
+    Readable,
 };
 use alloc::{
     collections::{BTreeMap, VecDeque},
@@ -36,7 +36,8 @@ pub struct Config<F: Family, D: Digest> {
 /// Mutations go through the batch API: create an
 /// [`UnmerkleizedBatch`](batch::UnmerkleizedBatch) via [`Self::new_batch`], accumulate changes,
 /// merkleize, then apply the result via [`Self::apply_batch`]. Roots are computed explicitly with
-/// [`Self::root`] from a caller-supplied [`RootSpec`].
+/// [`Self::root`] from a caller-supplied `inactive_peaks` count, with the bagging policy carried
+/// by the supplied [`Hasher`].
 #[derive(Clone, Debug)]
 pub struct Mem<F: Family, D: Digest> {
     /// The retained nodes, starting at `pruning_boundary`.
@@ -142,14 +143,19 @@ impl<F: Family, D: Digest> Mem<F, D> {
         }
     }
 
-    /// Compute the root digest for this structure using `spec`.
-    pub fn root(&self, hasher: &impl Hasher<F, Digest = D>, spec: RootSpec) -> Result<D, Error<F>> {
+    /// Compute the root digest for this structure using `inactive_peaks` and the bagging carried by
+    /// `hasher`.
+    pub fn root(
+        &self,
+        hasher: &impl Hasher<F, Digest = D>,
+        inactive_peaks: usize,
+    ) -> Result<D, Error<F>> {
         let size = self.size();
         let leaves = Location::try_from(size).expect("invalid merkle size");
         let peaks: Vec<&D> = F::peaks(size)
             .map(|(p, _)| self.get_node_unchecked(p))
             .collect();
-        hasher.root(leaves, spec, peaks)
+        hasher.root(leaves, inactive_peaks, peaks)
     }
 
     /// Return the total number of nodes, irrespective of any pruning.
@@ -268,12 +274,12 @@ impl<F: Family, D: Digest> Mem<F, D> {
         &self,
         hasher: &impl Hasher<F, Digest = D>,
         loc: Location<F>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, Error<F>> {
         if !loc.is_valid_index() {
             return Err(Error::LocationOverflow(loc));
         }
-        self.range_proof(hasher, loc..loc + 1, spec)
+        self.range_proof(hasher, loc..loc + 1, inactive_peaks)
             .map_err(|e| match e {
                 Error::RangeOutOfBounds(_) => Error::LeafOutOfBounds(loc),
                 _ => e,
@@ -293,12 +299,12 @@ impl<F: Family, D: Digest> Mem<F, D> {
         &self,
         hasher: &impl Hasher<F, Digest = D>,
         range: Range<Location<F>>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, Error<F>> {
         merkle_proof::build_range_proof(
             hasher,
             self.leaves(),
-            spec,
+            inactive_peaks,
             range,
             |pos| self.get_node(pos),
             Error::ElementPruned,
@@ -441,7 +447,7 @@ impl<F: Family, D: Digest> Readable for Mem<F, D> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::{hasher::Standard, Bagging, Error, Location, Position, RootSpec};
+    use crate::merkle::{hasher::Standard, Bagging, Error, Location, Position};
     use commonware_cryptography::{sha256, Sha256};
     use commonware_runtime::{deterministic, Runner as _, ThreadPooler};
     use commonware_utils::NZUsize;
@@ -450,7 +456,7 @@ mod tests {
     type H = Standard<Sha256>;
 
     fn plain_root<F: Family>(mem: &Mem<F, D>, hasher: &H) -> D {
-        mem.root(hasher, RootSpec::FULL_FORWARD).unwrap()
+        mem.root(hasher, 0).unwrap()
     }
 
     fn build<F: Family>(hasher: &H, n: u64) -> Mem<F, D> {
@@ -536,28 +542,16 @@ mod tests {
             let hasher: H = Standard::new();
             let mem = Mem::<F, D>::new();
             assert!(matches!(
-                mem.range_proof(
-                    &hasher,
-                    Location::new(0)..Location::new(1),
-                    RootSpec::FULL_FORWARD
-                ),
+                mem.range_proof(&hasher, Location::new(0)..Location::new(1), 0),
                 Err(Error::RangeOutOfBounds(_))
             ));
             let mem = build::<F>(&hasher, 10);
             assert!(matches!(
-                mem.range_proof(
-                    &hasher,
-                    Location::new(5)..Location::new(11),
-                    RootSpec::FULL_FORWARD
-                ),
+                mem.range_proof(&hasher, Location::new(5)..Location::new(11), 0),
                 Err(Error::RangeOutOfBounds(_))
             ));
             assert!(mem
-                .range_proof(
-                    &hasher,
-                    Location::new(5)..Location::new(10),
-                    RootSpec::FULL_FORWARD
-                )
+                .range_proof(&hasher, Location::new(5)..Location::new(10), 0)
                 .is_ok());
         });
     }
@@ -568,17 +562,15 @@ mod tests {
             let hasher: H = Standard::new();
             let mem = Mem::<F, D>::new();
             assert!(matches!(
-                mem.proof(&hasher, Location::new(0), RootSpec::FULL_FORWARD),
+                mem.proof(&hasher, Location::new(0), 0),
                 Err(Error::LeafOutOfBounds(_))
             ));
             let mem = build::<F>(&hasher, 10);
             assert!(matches!(
-                mem.proof(&hasher, Location::new(10), RootSpec::FULL_FORWARD),
+                mem.proof(&hasher, Location::new(10), 0),
                 Err(Error::LeafOutOfBounds(_))
             ));
-            assert!(mem
-                .proof(&hasher, Location::new(9), RootSpec::FULL_FORWARD)
-                .is_ok());
+            assert!(mem.proof(&hasher, Location::new(9), 0).is_ok());
         });
     }
 
@@ -733,7 +725,7 @@ mod tests {
         let root = plain_root(&mem, &hasher);
         for i in 0u64..16 {
             let proof = mem
-                .proof(&hasher, Location::new(i), RootSpec::FULL_FORWARD)
+                .proof(&hasher, Location::new(i), 0)
                 .unwrap_or_else(|e| panic!("loc={i}: {e:?}"));
             assert!(
                 proof.verify_element_inclusion(
@@ -741,7 +733,7 @@ mod tests {
                     &i.to_be_bytes(),
                     Location::new(i),
                     &root,
-                    RootSpec::FULL_FORWARD
+                    0
                 ),
                 "loc={i}: proof should verify"
             );
@@ -758,18 +750,12 @@ mod tests {
                 for end in start + 1..=n {
                     let range = Location::new(start)..Location::new(end);
                     let proof = mem
-                        .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
+                        .range_proof(&hasher, range.clone(), 0)
                         .unwrap_or_else(|e| panic!("n={n}, range={start}..{end}: {e:?}"));
                     let elements: Vec<_> = (start..end).map(|i| i.to_be_bytes()).collect();
 
                     assert!(
-                        proof.verify_range_inclusion(
-                            &hasher,
-                            &elements,
-                            range.start,
-                            &root,
-                            RootSpec::FULL_FORWARD
-                        ),
+                        proof.verify_range_inclusion(&hasher, &elements, range.start, &root, 0),
                         "n={n}, range={start}..{end}: range proof should verify"
                     );
                 }
@@ -792,13 +778,11 @@ mod tests {
             );
             assert_eq!(mem.bounds().start, prune_loc);
             assert!(
-                mem.proof(&hasher, prune_loc, RootSpec::FULL_FORWARD)
-                    .is_ok(),
+                mem.proof(&hasher, prune_loc, 0).is_ok(),
                 "boundary leaf {prune_loc} should remain provable"
             );
             assert!(
-                mem.proof(&hasher, mem.leaves() - 1, RootSpec::FULL_FORWARD)
-                    .is_ok(),
+                mem.proof(&hasher, mem.leaves() - 1, 0).is_ok(),
                 "latest leaf should remain provable after pruning to {prune_loc}"
             );
         }
@@ -829,7 +813,7 @@ mod tests {
         let root = plain_root(&mem, &hasher);
         for loc in *mem.bounds().start..*mem.leaves() {
             let proof = mem
-                .proof(&hasher, Location::new(loc), RootSpec::FULL_FORWARD)
+                .proof(&hasher, Location::new(loc), 0)
                 .unwrap_or_else(|e| panic!("loc={loc}: {e:?}"));
             assert!(
                 proof.verify_element_inclusion(
@@ -837,7 +821,7 @@ mod tests {
                     &loc.to_be_bytes(),
                     Location::new(loc),
                     &root,
-                    RootSpec::FULL_FORWARD,
+                    0,
                 ),
                 "loc={loc}: proof should verify after append on pruned structure"
             );
@@ -865,16 +849,14 @@ mod tests {
         );
         assert_eq!(*mem.leaves(), 11);
 
-        let proof = mem
-            .proof(&hasher, Location::new(5), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let proof = mem.proof(&hasher, Location::new(5), 0).unwrap();
         assert!(
             proof.verify_element_inclusion(
                 &hasher,
                 b"updated-5",
                 Location::new(5),
                 &plain_root(&mem, &hasher),
-                RootSpec::FULL_FORWARD,
+                0,
             ),
             "updated leaf should verify with new data"
         );
@@ -885,22 +867,20 @@ mod tests {
                 &5u64.to_be_bytes(),
                 Location::new(5),
                 &plain_root(&mem, &hasher),
-                RootSpec::FULL_FORWARD,
+                0,
             ),
             "old data should not verify"
         );
 
         for i in [0u64, 3, 7, 10] {
-            let p = mem
-                .proof(&hasher, Location::new(i), RootSpec::FULL_FORWARD)
-                .unwrap();
+            let p = mem.proof(&hasher, Location::new(i), 0).unwrap();
             assert!(
                 p.verify_element_inclusion(
                     &hasher,
                     &i.to_be_bytes(),
                     Location::new(i),
                     &plain_root(&mem, &hasher),
-                    RootSpec::FULL_FORWARD,
+                    0,
                 ),
                 "leaf {i} should still verify with original data"
             );
@@ -922,16 +902,14 @@ mod tests {
             };
             mem.apply_batch(&batch).unwrap();
 
-            let proof = mem
-                .proof(&hasher, Location::new(update_loc), RootSpec::FULL_FORWARD)
-                .unwrap();
+            let proof = mem.proof(&hasher, Location::new(update_loc), 0).unwrap();
             assert!(
                 proof.verify_element_inclusion(
                     &hasher,
                     b"new-value",
                     Location::new(update_loc),
                     &plain_root(&mem, &hasher),
-                    RootSpec::FULL_FORWARD,
+                    0,
                 ),
                 "update at {update_loc} should verify"
             );
@@ -979,26 +957,22 @@ mod tests {
 
         assert_eq!(*mem.leaves(), 10);
 
-        let proof = mem
-            .proof(&hasher, Location::new(3), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let proof = mem.proof(&hasher, Location::new(3), 0).unwrap();
         assert!(proof.verify_element_inclusion(
             &hasher,
             b"updated-3",
             Location::new(3),
             &plain_root(&mem, &hasher),
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
-        let proof = mem
-            .proof(&hasher, Location::new(8), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let proof = mem.proof(&hasher, Location::new(8), 0).unwrap();
         assert!(proof.verify_element_inclusion(
             &hasher,
             &100u64.to_be_bytes(),
             Location::new(8),
             &plain_root(&mem, &hasher),
-            RootSpec::FULL_FORWARD,
+            0,
         ));
     }
 
@@ -1038,16 +1012,14 @@ mod tests {
             "roots must match"
         );
 
-        let proof = mem
-            .proof(&hasher, Location::new(0), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let proof = mem.proof(&hasher, Location::new(0), 0).unwrap();
         assert!(
             proof.verify_element_inclusion(
                 &hasher,
                 b"updated-0",
                 Location::new(0),
                 &plain_root(&mem, &hasher),
-                RootSpec::FULL_FORWARD,
+                0,
             ),
             "updated leaf should verify"
         );
@@ -1076,16 +1048,14 @@ mod tests {
                     };
                     m.apply_batch(&batch).unwrap();
 
-                    let proof = m
-                        .proof(&hasher, Location::new(update_loc), RootSpec::FULL_FORWARD)
-                        .unwrap();
+                    let proof = m.proof(&hasher, Location::new(update_loc), 0).unwrap();
                     assert!(
                         proof.verify_element_inclusion(
                             &hasher,
                             b"new",
                             Location::new(update_loc),
                             &plain_root(&m, &hasher),
-                            RootSpec::FULL_FORWARD,
+                            0,
                         ),
                         "n={n} prune={prune_to} update={update_loc}: proof should verify"
                     );
@@ -1194,21 +1164,16 @@ mod tests {
         let peaks: Vec<_> = F::peaks(plain.size())
             .map(|(pos, _)| plain.get_node(pos).expect("peak should be present"))
             .collect();
-        let expected = crate::merkle::hasher::Hasher::root_with_inactive_prefix(
+        let expected = <crate::merkle::hasher::Standard<commonware_cryptography::Sha256> as crate::merkle::hasher::Hasher<F>>::root(
             &hasher,
             plain.leaves(),
             inactive_peaks,
-            Bagging::ForwardFold,
             peaks.iter(),
         )
         .unwrap();
 
-        assert_eq!(
-            plain
-                .root(&hasher, RootSpec::split_forward(inactive_peaks))
-                .unwrap(),
-            expected
-        );
+        assert_eq!(plain.root(&hasher, inactive_peaks).unwrap(), expected);
+        let _ = Bagging::ForwardFold;
     }
 
     // --- MMR tests ---

--- a/storage/src/merkle/mmb/mem.rs
+++ b/storage/src/merkle/mmb/mem.rs
@@ -12,7 +12,6 @@ mod tests {
     use crate::merkle::{
         hasher::{Hasher as _, Standard},
         mmb::{Error, Location, Position},
-        RootSpec,
     };
     use commonware_cryptography::Sha256;
 
@@ -113,14 +112,10 @@ mod tests {
         assert_eq!(mmb.get_node(Position::new(12)).unwrap(), digest12);
 
         let expected_root = hasher
-            .root(
-                Location::new(8),
-                RootSpec::FULL_FORWARD,
-                [digest7, digest9, digest12].iter(),
-            )
+            .root(Location::new(8), 0, [digest7, digest9, digest12].iter())
             .expect("zero inactive peaks is always valid");
         assert_eq!(
-            mmb.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
+            mmb.root(&hasher, 0).unwrap(),
             expected_root,
             "incorrect root"
         );
@@ -130,21 +125,20 @@ mod tests {
     fn test_prune_and_reinit() {
         let (hasher, mut mmb) = build_mmb(24);
 
-        let root = mmb.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mmb.root(&hasher, 0).unwrap();
         let prune_loc = Location::new(9);
         mmb.prune(prune_loc).unwrap();
 
         assert_eq!(mmb.bounds().start, prune_loc);
-        assert_eq!(mmb.root(&hasher, RootSpec::FULL_FORWARD).unwrap(), root);
+        assert_eq!(mmb.root(&hasher, 0).unwrap(), root);
         assert!(matches!(
-            mmb.proof(&hasher, Location::new(0), RootSpec::FULL_FORWARD),
+            mmb.proof(&hasher, Location::new(0), 0),
             Err(Error::ElementPruned(_))
         ));
 
         for loc in *prune_loc..*mmb.leaves() {
             assert!(
-                mmb.proof(&hasher, Location::new(loc), RootSpec::FULL_FORWARD)
-                    .is_ok(),
+                mmb.proof(&hasher, Location::new(loc), 0).is_ok(),
                 "loc={loc} should remain provable after pruning"
             );
         }
@@ -161,13 +155,8 @@ mod tests {
         assert_eq!(mmb_copy.size(), mmb.size());
         assert_eq!(mmb_copy.leaves(), mmb.leaves());
         assert_eq!(mmb_copy.bounds(), mmb.bounds());
-        assert_eq!(
-            mmb_copy.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            root
-        );
-        assert!(mmb_copy
-            .proof(&hasher, Location::new(17), RootSpec::FULL_FORWARD)
-            .is_ok());
+        assert_eq!(mmb_copy.root(&hasher, 0).unwrap(), root);
+        assert!(mmb_copy.proof(&hasher, Location::new(17), 0).is_ok());
     }
 
     #[test]

--- a/storage/src/merkle/mmb/proof.rs
+++ b/storage/src/merkle/mmb/proof.rs
@@ -5,7 +5,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        merkle::{hasher::Standard, mmb::mem::Mmb, proof::Blueprint, Family, RootSpec},
+        merkle::{hasher::Standard, mmb::mem::Mmb, proof::Blueprint, Bagging, Family},
         mmb::Location,
     };
     use commonware_cryptography::Sha256;
@@ -34,7 +34,7 @@ mod tests {
     #[test]
     fn test_verify_proof_and_pinned_nodes_recursive_fold_prefix_regression() {
         let (hasher, mmb) = make_mmb(5);
-        let root = mmb.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mmb.root(&hasher, 0).unwrap();
         let start = 4;
 
         let pinned: Vec<D> = crate::merkle::mmb::Family::nodes_to_pin(Location::new(start))
@@ -42,11 +42,7 @@ mod tests {
             .collect();
 
         let proof = mmb
-            .range_proof(
-                &hasher,
-                Location::new(start)..Location::new(start + 1),
-                RootSpec::FULL_FORWARD,
-            )
+            .range_proof(&hasher, Location::new(start)..Location::new(start + 1), 0)
             .unwrap();
 
         assert!(proof.verify_proof_and_pinned_nodes(
@@ -55,7 +51,7 @@ mod tests {
             Location::new(start),
             &pinned,
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
     }
 
@@ -69,13 +65,18 @@ mod tests {
 
         while n <= 5000 {
             let leaves = mmb.leaves();
-            let root = mmb.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root = mmb.root(&hasher, 0).unwrap();
 
             let loc = n - 1;
             let inactive_peaks =
                 crate::merkle::mmb::Family::inactive_peaks(mmb.size(), Location::new(0));
-            let bp = Blueprint::new(leaves, inactive_peaks, Location::new(loc)..Location::new(n))
-                .unwrap();
+            let bp = Blueprint::new(
+                leaves,
+                inactive_peaks,
+                Bagging::ForwardFold,
+                Location::new(loc)..Location::new(n),
+            )
+            .unwrap();
 
             let total_digests = usize::from(!bp.fold_prefix.is_empty()) + bp.fetch_nodes.len();
             assert!(
@@ -87,16 +88,14 @@ mod tests {
             );
 
             // Verify the proof actually works.
-            let proof = mmb
-                .proof(&hasher, Location::new(loc), RootSpec::FULL_FORWARD)
-                .unwrap();
+            let proof = mmb.proof(&hasher, Location::new(loc), 0).unwrap();
             assert!(
                 proof.verify_element_inclusion(
                     &hasher,
                     &loc.to_be_bytes(),
                     Location::new(loc),
                     &root,
-                    RootSpec::FULL_FORWARD,
+                    0,
                 ),
                 "n={n}: verification failed"
             );

--- a/storage/src/merkle/mmr/full.rs
+++ b/storage/src/merkle/mmr/full.rs
@@ -25,7 +25,7 @@ pub type Mmr<E, D> = crate::merkle::full::Merkle<Family, E, D>;
 mod tests {
     use super::*;
     use crate::{
-        merkle::{conformance::build_test_mmr, Family as _, RootSpec},
+        merkle::{conformance::build_test_mmr, Family as _},
         mmr::{mem, Error, Location, Position, StandardHasher as Standard},
     };
     use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
@@ -63,7 +63,7 @@ mod tests {
             let hasher: Standard<Sha256> = Standard::new();
             let test_mmr = mem::Mmr::new();
             let test_mmr = build_test_mmr(&hasher, test_mmr, NUM_ELEMENTS);
-            let expected_root = test_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let expected_root = test_mmr.root(&hasher, 0).unwrap();
 
             let mut mmr = Mmr::init(
                 context.clone(),
@@ -80,10 +80,7 @@ mod tests {
             }
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
             mmr.apply_batch(&batch).unwrap();
-            assert_eq!(
-                mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                expected_root
-            );
+            assert_eq!(mmr.root(&hasher, 0).unwrap(), expected_root);
 
             mmr.destroy().await.unwrap();
         });
@@ -94,18 +91,12 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let hasher: Standard<Sha256> = Standard::new();
-            let peek = Mmr::<_, Digest>::peek_root(
-                context.clone(),
-                test_config(&context),
-                &hasher,
-                RootSpec::FULL_FORWARD,
-            )
-            .await
-            .unwrap();
+            let peek =
+                Mmr::<_, Digest>::peek_root(context.clone(), test_config(&context), &hasher, 0)
+                    .await
+                    .unwrap();
 
-            let empty_root = mem::Mmr::new()
-                .root(&hasher, RootSpec::FULL_FORWARD)
-                .unwrap();
+            let empty_root = mem::Mmr::new().root(&hasher, 0).unwrap();
             assert_eq!(peek, Some((Location::new(0), Location::new(0), empty_root)));
         });
     }
@@ -133,7 +124,7 @@ mod tests {
             // Rewind one node at a time without syncing until empty, confirming the root matches.
             for i in (0..NUM_ELEMENTS).rev() {
                 assert!(mmr.rewind(1).await.is_ok());
-                let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+                let root = mmr.root(&hasher, 0).unwrap();
                 let mut reference_mmr = mem::Mmr::new();
                 let batch = {
                     let mut batch = reference_mmr.new_batch();
@@ -147,7 +138,7 @@ mod tests {
                 reference_mmr.apply_batch(&batch).unwrap();
                 assert_eq!(
                     root,
-                    reference_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
+                    reference_mmr.root(&hasher, 0).unwrap(),
                     "root mismatch after rewind at {i}"
                 );
             }
@@ -183,12 +174,12 @@ mod tests {
 
             for i in (0..NUM_ELEMENTS - 1).rev().step_by(2) {
                 assert!(mmr.rewind(2).await.is_ok(), "at position {i:?}");
-                let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+                let root = mmr.root(&hasher, 0).unwrap();
                 let reference_mmr = mem::Mmr::new();
                 let reference_mmr = build_test_mmr(&hasher, reference_mmr, i);
                 assert_eq!(
                     root,
-                    reference_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
+                    reference_mmr.root(&hasher, 0).unwrap(),
                     "root mismatch at position {i:?}"
                 );
             }
@@ -220,9 +211,7 @@ mod tests {
             // Rewind enough nodes to cause the mem-mmr to be completely emptied, and then some.
             mmr.rewind(80).await.unwrap();
             // Make sure the pinned node boundary is valid by generating a proof for the oldest item.
-            mmr.proof(&hasher, prune_loc, RootSpec::FULL_FORWARD)
-                .await
-                .unwrap();
+            mmr.proof(&hasher, prune_loc, 0).await.unwrap();
             // prune all remaining leaves 1 at a time.
             while mmr.size() > prune_pos {
                 assert!(mmr.rewind(1).await.is_ok());
@@ -279,22 +268,19 @@ mod tests {
             }
             let merkleized_b = mmr.with_mem(|mem| batch_b.merkleize(mem, &hasher));
             let expected_root = mmr
-                .with_mem(|mem| merkleized_b.root(mem, &hasher, RootSpec::FULL_FORWARD))
+                .with_mem(|mem| merkleized_b.root(mem, &hasher, 0))
                 .unwrap();
 
             // Apply.
             mmr.apply_batch(&merkleized_b).unwrap();
-            assert_eq!(
-                mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                expected_root
-            );
+            assert_eq!(mmr.root(&hasher, 0).unwrap(), expected_root);
 
             // Build a reference in-memory MMR with 20 elements to verify.
             let empty = mem::Mmr::new();
             let reference = build_test_mmr(&hasher, empty, 20);
             assert_eq!(
-                mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                reference.root(&hasher, RootSpec::FULL_FORWARD).unwrap()
+                mmr.root(&hasher, 0).unwrap(),
+                reference.root(&hasher, 0).unwrap()
             );
 
             mmr.destroy().await.unwrap();

--- a/storage/src/merkle/mmr/mem.rs
+++ b/storage/src/merkle/mmr/mem.rs
@@ -10,7 +10,7 @@ pub type Config<D> = crate::merkle::mem::Config<super::Family, D>;
 mod tests {
     use super::*;
     use crate::{
-        merkle::{conformance::build_test_mmr, hasher::Hasher as _, RootSpec},
+        merkle::{conformance::build_test_mmr, hasher::Hasher as _},
         mmr::{Error, Location, Position, StandardHasher as Standard},
     };
     use commonware_cryptography::{sha256, Hasher, Sha256};
@@ -69,44 +69,32 @@ mod tests {
                 assert_eq!(mmr.get_node(pos).unwrap(), digest);
             }
 
-            let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root = mmr.root(&hasher, 0).unwrap();
 
             // pruning tests
             mmr.prune(Location::new(8)).unwrap();
             assert_eq!(mmr.bounds().start, Location::new(8));
 
             assert!(matches!(
-                mmr.proof(&hasher, Location::new(0), RootSpec::FULL_FORWARD),
+                mmr.proof(&hasher, Location::new(0), 0),
                 Err(Error::ElementPruned(_))
             ));
             assert!(matches!(
-                mmr.proof(&hasher, Location::new(6), RootSpec::FULL_FORWARD),
+                mmr.proof(&hasher, Location::new(6), 0),
                 Err(Error::ElementPruned(_))
             ));
 
-            assert!(mmr
-                .proof(&hasher, Location::new(8), RootSpec::FULL_FORWARD)
-                .is_ok());
-            assert!(mmr
-                .proof(&hasher, Location::new(10), RootSpec::FULL_FORWARD)
-                .is_ok());
+            assert!(mmr.proof(&hasher, Location::new(8), 0).is_ok());
+            assert!(mmr.proof(&hasher, Location::new(10), 0).is_ok());
 
-            let root_after_prune = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root_after_prune = mmr.root(&hasher, 0).unwrap();
             assert_eq!(root, root_after_prune, "root changed after pruning");
 
             assert!(mmr
-                .range_proof(
-                    &hasher,
-                    Location::new(5)..Location::new(9),
-                    RootSpec::FULL_FORWARD
-                )
+                .range_proof(&hasher, Location::new(5)..Location::new(9), 0)
                 .is_err(),);
             assert!(mmr
-                .range_proof(
-                    &hasher,
-                    Location::new(8)..mmr.leaves(),
-                    RootSpec::FULL_FORWARD
-                )
+                .range_proof(&hasher, Location::new(8)..mmr.leaves(), 0)
                 .is_ok(),);
 
             // Test that we can initialize a new MMR from another's elements.
@@ -123,10 +111,7 @@ mod tests {
             assert_eq!(mmr_copy.size(), 19);
             assert_eq!(mmr_copy.leaves(), mmr.leaves());
             assert_eq!(mmr_copy.bounds().start, mmr.bounds().start);
-            assert_eq!(
-                mmr_copy.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                root
-            );
+            assert_eq!(mmr_copy.root(&hasher, 0).unwrap(), root);
         });
     }
 
@@ -139,7 +124,7 @@ mod tests {
             const NUM_ELEMENTS: u64 = 199;
             let mut test_mmr = Mmr::new();
             test_mmr = build_test_mmr(&hasher, test_mmr, NUM_ELEMENTS);
-            let expected_root = test_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let expected_root = test_mmr.root(&hasher, 0).unwrap();
 
             let mut batched_mmr = Mmr::new();
 
@@ -154,7 +139,7 @@ mod tests {
             batched_mmr.apply_batch(&batch).unwrap();
 
             assert_eq!(
-                batched_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
+                batched_mmr.root(&hasher, 0).unwrap(),
                 expected_root,
                 "Batched MMR root should match reference"
             );
@@ -170,7 +155,7 @@ mod tests {
             const NUM_ELEMENTS: u64 = 199;
             let test_mmr = Mmr::new();
             let test_mmr = build_test_mmr(&hasher, test_mmr, NUM_ELEMENTS);
-            let expected_root = test_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let expected_root = test_mmr.root(&hasher, 0).unwrap();
 
             let pool = context.create_thread_pool(NZUsize!(4)).unwrap();
             let hasher: Standard<Sha256> = Standard::new();
@@ -192,7 +177,7 @@ mod tests {
             };
             mmr.apply_batch(&batch).unwrap();
             assert_eq!(
-                mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
+                mmr.root(&hasher, 0).unwrap(),
                 expected_root,
                 "Batched MMR root should match reference"
             );

--- a/storage/src/merkle/mmr/proof.rs
+++ b/storage/src/merkle/mmr/proof.rs
@@ -9,7 +9,7 @@ mod tests {
             StandardHasher as Standard,
         },
         proof::{nodes_required_for_multi_proof, Blueprint},
-        Bagging, Family as _, LocationRangeExt as _, RootSpec,
+        Bagging, Family as _, LocationRangeExt as _,
     };
     use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
 
@@ -31,16 +31,12 @@ mod tests {
             batch.merkleize(&mmr, &hasher)
         };
         mmr.apply_batch(&batch).unwrap();
-        let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mmr.root(&hasher, 0).unwrap();
 
         // Test 1: compute_digests over the entire range should contain a digest for every node
         // in the tree.
         let proof = mmr
-            .range_proof(
-                &hasher,
-                Location::new(0)..mmr.leaves(),
-                RootSpec::FULL_FORWARD,
-            )
+            .range_proof(&hasher, Location::new(0)..mmr.leaves(), 0)
             .unwrap();
         let mut node_digests = proof
             .verify_range_inclusion_and_extract_digests(
@@ -48,7 +44,7 @@ mod tests {
                 &elements,
                 Location::new(0),
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .unwrap();
         assert_eq!(node_digests.len() as u64, mmr.size());
@@ -65,16 +61,14 @@ mod tests {
                 &elements,
                 Location::new(0),
                 &wrong_root,
-                RootSpec::FULL_FORWARD,
+                0,
             ),
             Err(Error::RootMismatch)
         ));
 
         // Test 2: Single element range (first element)
         let range = Location::new(0)..Location::new(1);
-        let single_proof = mmr
-            .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let single_proof = mmr.range_proof(&hasher, range.clone(), 0).unwrap();
         let range_start = range.start;
         let single_digests = single_proof
             .verify_range_inclusion_and_extract_digests(
@@ -82,7 +76,7 @@ mod tests {
                 &elements[range.to_usize_range()],
                 range_start,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .unwrap();
         assert!(single_digests.len() > 1);
@@ -91,16 +85,14 @@ mod tests {
         let mid_idx = 24;
         let range = Location::new(mid_idx)..Location::new(mid_idx + 1);
         let range_start = range.start;
-        let mid_proof = mmr
-            .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let mid_proof = mmr.range_proof(&hasher, range.clone(), 0).unwrap();
         let mid_digests = mid_proof
             .verify_range_inclusion_and_extract_digests(
                 &hasher,
                 &elements[range.to_usize_range()],
                 range_start,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .unwrap();
         assert!(mid_digests.len() > 1);
@@ -109,16 +101,14 @@ mod tests {
         let last_idx = elements.len() as u64 - 1;
         let range = Location::new(last_idx)..Location::new(last_idx + 1);
         let range_start = range.start;
-        let last_proof = mmr
-            .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let last_proof = mmr.range_proof(&hasher, range.clone(), 0).unwrap();
         let last_digests = last_proof
             .verify_range_inclusion_and_extract_digests(
                 &hasher,
                 &elements[range.to_usize_range()],
                 range_start,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .unwrap();
         assert!(!last_digests.is_empty());
@@ -126,16 +116,14 @@ mod tests {
         // Test 5: Small range at the beginning
         let range = Location::new(0)..Location::new(5);
         let range_start = range.start;
-        let small_proof = mmr
-            .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let small_proof = mmr.range_proof(&hasher, range.clone(), 0).unwrap();
         let small_digests = small_proof
             .verify_range_inclusion_and_extract_digests(
                 &hasher,
                 &elements[range.to_usize_range()],
                 range_start,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .unwrap();
         // Verify that we get digests for the range elements and their ancestors
@@ -144,16 +132,14 @@ mod tests {
         // Test 6: Medium range in the middle
         let range = Location::new(10)..Location::new(31);
         let range_start = range.start;
-        let mid_range_proof = mmr
-            .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let mid_range_proof = mmr.range_proof(&hasher, range.clone(), 0).unwrap();
         let mid_range_digests = mid_range_proof
             .verify_range_inclusion_and_extract_digests(
                 &hasher,
                 &elements[range.to_usize_range()],
                 range_start,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .unwrap();
         let num_elements = range.end - range.start;
@@ -166,14 +152,19 @@ mod tests {
         let max_loc = Family::MAX_LEAVES;
         let max_loc_plus_1 = Location::new(*max_loc + 1);
 
-        let result = Blueprint::new(max_loc, 0, max_loc - 1..max_loc);
+        let result = Blueprint::new(max_loc, 0, Bagging::ForwardFold, max_loc - 1..max_loc);
         assert!(
             result.is_ok(),
             "Should be able to prove with MAX_LEAVES leaves"
         );
 
         // MAX_LEAVES + 1 should be rejected.
-        let result_overflow = Blueprint::new(max_loc_plus_1, 0, max_loc..max_loc_plus_1);
+        let result_overflow = Blueprint::new(
+            max_loc_plus_1,
+            0,
+            Bagging::ForwardFold,
+            max_loc..max_loc_plus_1,
+        );
         assert!(
             result_overflow.is_err(),
             "Should reject location > MAX_LEAVES"
@@ -257,7 +248,7 @@ mod tests {
         // Expected: 61 path siblings + 61 other peaks = 122 digests
         let leaves = Location::try_from(many_peaks_size).unwrap();
         let loc = Location::new(0);
-        let bp = Blueprint::new(leaves, 0, loc..loc + 1)
+        let bp = Blueprint::new(leaves, 0, Bagging::ForwardFold, loc..loc + 1)
             .expect("should compute blueprint for location 0");
         let total_nodes = bp.fold_prefix.len() + bp.fetch_nodes.len();
 
@@ -270,8 +261,13 @@ mod tests {
         // Test the rightmost leaf (in smallest tree of height 0, which is itself a peak)
         // Expected: 0 path siblings + 61 other peaks = 61 digests
         let last_leaf_loc = leaves - 1;
-        let bp = Blueprint::new(leaves, 0, last_leaf_loc..last_leaf_loc + 1)
-            .expect("should compute blueprint for last leaf");
+        let bp = Blueprint::new(
+            leaves,
+            0,
+            Bagging::ForwardFold,
+            last_leaf_loc..last_leaf_loc + 1,
+        )
+        .expect("should compute blueprint for last leaf");
         let total_nodes = bp.fold_prefix.len() + bp.fetch_nodes.len();
 
         let expected_last_leaf = NUM_PEAKS - 1;
@@ -324,12 +320,12 @@ mod tests {
             batch.merkleize(&mmr, &hasher)
         };
         mmr.apply_batch(&batch).unwrap();
-        let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mmr.root(&hasher, 0).unwrap();
 
         // Proof for range [1, 3) -- fold prefix is empty, pinned node at position 0 is a sibling.
         let start_loc = Location::new(1);
         let proof = mmr
-            .range_proof(&hasher, start_loc..Location::new(3), RootSpec::FULL_FORWARD)
+            .range_proof(&hasher, start_loc..Location::new(3), 0)
             .unwrap();
 
         let pinned: Vec<Digest> = mmr.nodes_to_pin(start_loc).into_values().collect();
@@ -343,7 +339,7 @@ mod tests {
                 start_loc,
                 &pinned,
                 &root,
-                RootSpec::FULL_FORWARD
+                0
             ),
             "valid pinned nodes should verify"
         );
@@ -357,7 +353,7 @@ mod tests {
                 start_loc,
                 &bad_pinned,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             ),
             "wrong pinned digest should fail"
         );
@@ -371,21 +367,14 @@ mod tests {
                 start_loc,
                 &extra_pinned,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             ),
             "extra pinned node should fail"
         );
 
         // Empty pinned nodes must fail (start_loc > 0 requires at least one).
         assert!(
-            !proof.verify_proof_and_pinned_nodes(
-                &hasher,
-                &elements[1..],
-                start_loc,
-                &[],
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !proof.verify_proof_and_pinned_nodes(&hasher, &elements[1..], start_loc, &[], &root, 0),
             "missing pinned nodes should fail"
         );
     }
@@ -406,15 +395,11 @@ mod tests {
             batch.merkleize(&mmr, &hasher)
         };
         mmr.apply_batch(&batch).unwrap();
-        let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mmr.root(&hasher, 0).unwrap();
 
         let start_loc = Location::new(8);
         let proof = mmr
-            .range_proof(
-                &hasher,
-                start_loc..Location::new(10),
-                RootSpec::FULL_FORWARD,
-            )
+            .range_proof(&hasher, start_loc..Location::new(10), 0)
             .unwrap();
 
         let pinned: Vec<Digest> = mmr.nodes_to_pin(start_loc).into_values().collect();
@@ -427,7 +412,7 @@ mod tests {
                 start_loc,
                 &pinned,
                 &root,
-                RootSpec::FULL_FORWARD
+                0
             ),
             "valid fold-prefix pinned nodes should verify"
         );
@@ -440,7 +425,7 @@ mod tests {
                 start_loc,
                 &[test_digest(99)],
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             ),
             "wrong fold-prefix digest should fail"
         );

--- a/storage/src/merkle/mmr/verification.rs
+++ b/storage/src/merkle/mmr/verification.rs
@@ -4,7 +4,7 @@ use crate::merkle::{
     hasher::Hasher,
     mmr::{Error, Family, Location, Proof},
     storage::Storage,
-    RootSpec,
+    Bagging,
 };
 use commonware_cryptography::Digest;
 use core::ops::Range;
@@ -13,9 +13,6 @@ use core::ops::Range;
 pub type ProofStore<D> = crate::merkle::verification::ProofStore<Family, D>;
 
 /// Return a range proof for the nodes corresponding to the given location range.
-///
-/// This is a thin wrapper around the generic
-/// [range_proof](crate::merkle::verification::range_proof), specialized for the MMR family.
 pub async fn range_proof<
     D: Digest,
     H: Hasher<Family, Digest = D>,
@@ -24,16 +21,12 @@ pub async fn range_proof<
     hasher: &H,
     mmr: &S,
     range: Range<Location>,
-    spec: RootSpec,
+    inactive_peaks: usize,
 ) -> Result<Proof<D>, Error> {
-    crate::merkle::verification::range_proof(hasher, mmr, range, spec).await
+    crate::merkle::verification::range_proof(hasher, mmr, range, inactive_peaks).await
 }
 
 /// Analogous to [range_proof] but for a previous database state.
-///
-/// This is a thin wrapper around the generic
-/// [historical_range_proof](crate::merkle::verification::historical_range_proof), specialized for
-/// the MMR family.
 pub async fn historical_range_proof<
     D: Digest,
     H: Hasher<Family, Digest = D>,
@@ -43,19 +36,18 @@ pub async fn historical_range_proof<
     mmr: &S,
     leaves: Location,
     range: Range<Location>,
-    spec: RootSpec,
+    inactive_peaks: usize,
 ) -> Result<Proof<D>, Error> {
-    crate::merkle::verification::historical_range_proof(hasher, mmr, leaves, range, spec).await
+    crate::merkle::verification::historical_range_proof(hasher, mmr, leaves, range, inactive_peaks)
+        .await
 }
 
 /// Return an inclusion proof for the elements at the specified locations.
-///
-/// This is a thin wrapper around the generic
-/// [multi_proof](crate::merkle::verification::multi_proof), specialized for the MMR family.
 pub async fn multi_proof<D: Digest, S: Storage<Family, Digest = D>>(
     mmr: &S,
-    spec: RootSpec,
+    inactive_peaks: usize,
+    bagging: Bagging,
     locations: &[Location],
 ) -> Result<Proof<D>, Error> {
-    crate::merkle::verification::multi_proof(mmr, spec, locations).await
+    crate::merkle::verification::multi_proof(mmr, inactive_peaks, bagging, locations).await
 }

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -45,100 +45,11 @@ pub enum Bagging {
     BackwardFold,
 }
 
-/// Fully specifies how to compute a Merkle root from the current peak set.
-///
-/// Generic Merkle storage does not cache roots or remember this value. Callers choose a
-/// concrete spec whenever they compute a root or construct a proof.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum RootSpec {
-    /// Bag every peak with `bagging`. No inactive prefix.
-    Full {
-        /// Bagging applied to the full peak list.
-        bagging: Bagging,
-    },
-    /// Forward-fold the inactive prefix, then bag the remaining peaks with `bagging`.
-    ///
-    /// The inactive prefix bagging is not configurable: it always uses forward bagging
-    /// (left-folded) into a single accumulator. Only the remaining peak bagging is selectable.
-    /// The inactive boundary is committed into the root.
-    ///
-    /// When `inactive_peaks == 0`, no boundary is committed. For an empty inactive prefix, a
-    /// split root is byte-equivalent to the corresponding full root with the same bagging.
-    Split {
-        /// Number of oldest peaks included in the inactive prefix.
-        inactive_peaks: usize,
-        /// Bagging applied to the remaining peaks after the inactive prefix has been folded.
-        bagging: Bagging,
-    },
-}
-
-impl RootSpec {
-    /// `Full { bagging: ForwardFold }`: the default for plain Merkle structures.
-    pub const FULL_FORWARD: Self = Self::Full {
-        bagging: Bagging::ForwardFold,
-    };
-
-    /// `Split { inactive_peaks, bagging: ForwardFold }`.
-    pub const fn split_forward(inactive_peaks: usize) -> Self {
-        Self::Split {
-            inactive_peaks,
-            bagging: Bagging::ForwardFold,
-        }
-    }
-
-    /// `Split { inactive_peaks, bagging: BackwardFold }`.
-    pub const fn split_backward(inactive_peaks: usize) -> Self {
-        Self::Split {
-            inactive_peaks,
-            bagging: Bagging::BackwardFold,
-        }
-    }
-
-    /// Build a spec from a `(split_root, bagging)` policy plus the runtime `inactive_peaks` count.
-    /// `inactive_peaks` is ignored when `split_root` is false.
-    pub const fn from_split_policy(
-        split_root: bool,
-        bagging: Bagging,
-        inactive_peaks: usize,
-    ) -> Self {
-        if split_root {
-            Self::Split {
-                inactive_peaks,
-                bagging,
-            }
-        } else {
-            Self::Full { bagging }
-        }
-    }
-
-    /// True if this spec splits an inactive prefix off from the remaining peaks.
-    pub const fn has_inactive_prefix(self) -> bool {
-        matches!(self, Self::Split { .. })
-    }
-
-    /// Number of inactive peaks committed into the root.
-    pub const fn inactive_peaks(self) -> usize {
-        match self {
-            Self::Full { .. } => 0,
-            Self::Split { inactive_peaks, .. } => inactive_peaks,
-        }
-    }
-
-    /// The bagging policy applied to the bag step. For `Full`, this bags every peak; for
-    /// `Split`, this bags only the remaining peaks (the inactive prefix uses forward bagging
-    /// separately and unconditionally).
-    pub const fn bagging(self) -> Bagging {
-        match self {
-            Self::Full { bagging } | Self::Split { bagging, .. } => bagging,
-        }
-    }
-}
-
 /// Marker trait for Merkle-family data structures.
 ///
 /// Provides the per-family constants and conversion functions that differentiate
 /// MMR from MMB (or other future Merkle structures). Families capture structural topology
-/// only; bagging is owned by [`RootSpec`] and supplied by the consumer.
+/// only; bagging is owned by the [`hasher::Hasher`] instance and supplied by the consumer.
 pub trait Family: Copy + Clone + Debug + Default + Send + Sync + 'static {
     /// Maximum valid node count / size.
     const MAX_NODES: Position<Self>;
@@ -387,15 +298,6 @@ pub enum Error<F: Family> {
     /// The root does not match the computed root.
     #[error("root mismatch")]
     RootMismatch,
-
-    /// A proof or cached value was used with a different root spec than expected.
-    #[error("root spec mismatch: expected {expected:?}, actual {actual:?}")]
-    RootSpecMismatch {
-        /// Expected root spec.
-        expected: RootSpec,
-        /// Actual root spec.
-        actual: RootSpec,
-    },
 
     /// A required digest is missing.
     #[error("missing digest: {0}")]

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -24,7 +24,7 @@ use crate::{
         batch,
         hasher::Hasher,
         mem::{Config as MemConfig, Mem},
-        Error, Family, Location, Position, RootSpec,
+        Error, Family, Location, Position,
     },
     metadata::{Config as MConfig, Metadata},
     Context,
@@ -287,8 +287,12 @@ impl<F: Family, E: Context, D: Digest> Merkle<F, E, D> {
     }
 
     /// Return the root digest of the current committed state.
-    pub fn root(&self, hasher: &impl Hasher<F, Digest = D>, spec: RootSpec) -> Result<D, Error<F>> {
-        self.inner.read().root(hasher, spec)
+    pub fn root(
+        &self,
+        hasher: &impl Hasher<F, Digest = D>,
+        inactive_peaks: usize,
+    ) -> Result<D, Error<F>> {
+        self.inner.read().root(hasher, inactive_peaks)
     }
 
     /// Return the total number of nodes (MMR position count, not leaf count).
@@ -543,7 +547,7 @@ mod tests {
             merkle.with_mem(|mem| batch.merkleize(mem, &hasher))
         };
         merkle.apply_batch(&batch).unwrap();
-        let root_before = merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root_before = merkle.root(&hasher, 0).unwrap();
         let leaves_before = merkle.leaves();
         merkle.sync().await.unwrap();
         drop(merkle);
@@ -551,10 +555,7 @@ mod tests {
         let mut reopened = TestMerkle::<F>::init(context.with_label("second"), cfg)
             .await
             .unwrap();
-        assert_eq!(
-            reopened.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            root_before
-        );
+        assert_eq!(reopened.root(&hasher, 0).unwrap(), root_before);
         assert_eq!(reopened.leaves(), leaves_before);
 
         let batch = {
@@ -587,20 +588,14 @@ mod tests {
         let mut merkle = open::<F>(context, partition).await;
 
         append_and_sync(&mut merkle, &[b"a", b"b"]).await;
-        let root_after_first = merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root_after_first = merkle.root(&hasher, 0).unwrap();
         let leaves_after_first = merkle.leaves();
 
         append_and_sync(&mut merkle, &[b"c"]).await;
-        assert_ne!(
-            merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            root_after_first
-        );
+        assert_ne!(merkle.root(&hasher, 0).unwrap(), root_after_first);
 
         merkle.rewind().await.unwrap();
-        assert_eq!(
-            merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            root_after_first
-        );
+        assert_eq!(merkle.root(&hasher, 0).unwrap(), root_after_first);
         assert_eq!(merkle.leaves(), leaves_after_first);
 
         merkle.destroy().await.unwrap();
@@ -648,7 +643,7 @@ mod tests {
 
             append_and_sync(&mut merkle, &[b"a"]).await;
             append_and_sync(&mut merkle, &[b"b"]).await;
-            let root_after_two = merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root_after_two = merkle.root(&hasher, 0).unwrap();
             let leaves_after_two = merkle.leaves();
 
             // Apply a batch but do not sync. State is ahead of the last persisted slot.
@@ -657,18 +652,12 @@ mod tests {
                 merkle.with_mem(|mem| b.merkleize(mem, &hasher))
             };
             merkle.apply_batch(&batch).unwrap();
-            assert_ne!(
-                merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                root_after_two
-            );
+            assert_ne!(merkle.root(&hasher, 0).unwrap(), root_after_two);
 
             // Rewind reverts to the state as of the sync before the most recent sync, discarding
             // both the uncommitted append and the most recent sync.
             merkle.rewind().await.unwrap();
-            assert_ne!(
-                merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                root_after_two
-            );
+            assert_ne!(merkle.root(&hasher, 0).unwrap(), root_after_two);
             assert_ne!(merkle.leaves(), leaves_after_two);
 
             merkle.destroy().await.unwrap();
@@ -687,7 +676,7 @@ mod tests {
 
             let mut merkle = open::<mmr::Family>(context.with_label("first"), partition).await;
             append_and_sync(&mut merkle, &[b"a"]).await;
-            let root_after_first = merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root_after_first = merkle.root(&hasher, 0).unwrap();
             append_and_sync(&mut merkle, &[b"b"]).await;
             merkle.rewind().await.unwrap();
             drop(merkle);
@@ -696,10 +685,7 @@ mod tests {
                 Merkle::<mmr::Family, _, _>::init(context.with_label("second"), cfg)
                     .await
                     .unwrap();
-            assert_eq!(
-                reopened.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                root_after_first
-            );
+            assert_eq!(reopened.root(&hasher, 0).unwrap(), root_after_first);
             reopened.destroy().await.unwrap();
         });
     }
@@ -726,23 +712,17 @@ mod tests {
             let mut merkle = open::<mmr::Family>(context, "rewind-resumable").await;
 
             append_and_sync(&mut merkle, &[b"a"]).await;
-            let root_after_first = merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root_after_first = merkle.root(&hasher, 0).unwrap();
             append_and_sync(&mut merkle, &[b"b"]).await;
             merkle.rewind().await.unwrap();
-            assert_eq!(
-                merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                root_after_first
-            );
+            assert_eq!(merkle.root(&hasher, 0).unwrap(), root_after_first);
 
             // Now sync a different branch. Rewind should restore `root_after_first` again.
             append_and_sync(&mut merkle, &[b"c"]).await;
-            let root_abc = merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root_abc = merkle.root(&hasher, 0).unwrap();
             assert_ne!(root_abc, root_after_first);
             merkle.rewind().await.unwrap();
-            assert_eq!(
-                merkle.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                root_after_first
-            );
+            assert_eq!(merkle.root(&hasher, 0).unwrap(), root_after_first);
 
             merkle.destroy().await.unwrap();
         });

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -18,7 +18,7 @@ use crate::{
         batch,
         hasher::Hasher,
         mem::{Config as MemConfig, Mem},
-        Error, Family, Location, Position, Proof, Readable, RootSpec,
+        Error, Family, Location, Position, Proof, Readable,
     },
     metadata::{Config as MConfig, Metadata},
 };
@@ -256,7 +256,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Merkle<F, E, D> {
         context: E,
         cfg: Config,
         hasher: &impl Hasher<F, Digest = D>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Option<(Location<F>, Location<F>, D)>, Error<F>> {
         let journal_cfg = JConfig {
             partition: cfg.journal_partition,
@@ -274,7 +274,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Merkle<F, E, D> {
                 pruning_boundary: Location::new(0),
                 pinned_nodes: vec![],
             })?;
-            let empty_root = mem.root(hasher, spec)?;
+            let empty_root = mem.root(hasher, inactive_peaks)?;
             return Ok(Some((Location::new(0), Location::new(0), empty_root)));
         }
 
@@ -325,7 +325,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Merkle<F, E, D> {
             Self::add_extra_pinned_nodes(&mut mem, &metadata, &journal, prune_pos).await?;
         }
 
-        let root = mem.root(hasher, spec)?;
+        let root = mem.root(hasher, inactive_peaks)?;
         Ok(Some((prune_loc, journal_leaves, root)))
     }
 
@@ -765,9 +765,13 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Merkle<F, E, D> {
         Ok(())
     }
 
-    /// Compute the root of the structure using `spec`.
-    pub fn root(&self, hasher: &impl Hasher<F, Digest = D>, spec: RootSpec) -> Result<D, Error<F>> {
-        self.inner.read().mem.root(hasher, spec)
+    /// Compute the root of the structure using `inactive_peaks` and the bagging carried by `hasher`.
+    pub fn root(
+        &self,
+        hasher: &impl Hasher<F, Digest = D>,
+        inactive_peaks: usize,
+    ) -> Result<D, Error<F>> {
+        self.inner.read().mem.root(hasher, inactive_peaks)
     }
 
     /// Prune as many nodes as possible, leaving behind at most items_per_blob nodes in the current
@@ -1013,13 +1017,13 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Merkle<F, E, D> {
         hasher: &impl Hasher<F, Digest = D>,
         leaves: Location<F>,
         loc: Location<F>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, Error<F>> {
         if !loc.is_valid_index() {
             return Err(Error::LocationOverflow(loc));
         }
         // loc is valid so it won't overflow from + 1
-        self.historical_range_proof(hasher, leaves, loc..loc + 1, spec)
+        self.historical_range_proof(hasher, leaves, loc..loc + 1, inactive_peaks)
             .await
     }
 
@@ -1039,12 +1043,19 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Merkle<F, E, D> {
         hasher: &impl Hasher<F, Digest = D>,
         leaves: Location<F>,
         range: core::ops::Range<Location<F>>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, Error<F>> {
         if leaves > self.leaves() {
             return Err(Error::RangeOutOfBounds(leaves));
         }
-        crate::merkle::verification::historical_range_proof(hasher, self, leaves, range, spec).await
+        crate::merkle::verification::historical_range_proof(
+            hasher,
+            self,
+            leaves,
+            range,
+            inactive_peaks,
+        )
+        .await
     }
 
     /// Return an inclusion proof for the element at the location `loc` that can be verified against
@@ -1063,13 +1074,13 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Merkle<F, E, D> {
         &self,
         hasher: &impl Hasher<F, Digest = D>,
         loc: Location<F>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, Error<F>> {
         if !loc.is_valid_index() {
             return Err(Error::LocationOverflow(loc));
         }
         // loc is valid so it won't overflow from + 1
-        self.range_proof(hasher, loc..loc + 1, spec).await
+        self.range_proof(hasher, loc..loc + 1, inactive_peaks).await
     }
 
     /// Return an inclusion proof for the elements within the specified location range, using
@@ -1088,9 +1099,9 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest> Merkle<F, E, D> {
         &self,
         hasher: &impl Hasher<F, Digest = D>,
         range: core::ops::Range<Location<F>>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Proof<F, D>, Error<F>> {
-        self.historical_range_proof(hasher, self.leaves(), range, spec)
+        self.historical_range_proof(hasher, self.leaves(), range, inactive_peaks)
             .await
     }
 }
@@ -1100,9 +1111,7 @@ mod tests {
     use super::*;
     use crate::{
         journal::contiguous::fixed::{Config as JConfig, Journal},
-        merkle::{
-            hasher::Standard, mmb, mmr, Location, LocationRangeExt as _, Position, Proof, RootSpec,
-        },
+        merkle::{hasher::Standard, mmb, mmr, Location, LocationRangeExt as _, Position, Proof},
         metadata::{Config as MConfig, Metadata},
     };
     use commonware_cryptography::{
@@ -1175,38 +1184,38 @@ mod tests {
 
         let empty_proof = Proof::<F, Digest>::default();
         let hasher: Standard<Sha256> = Standard::new();
-        let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mmr.root(&hasher, 0).unwrap();
         assert!(empty_proof.verify_range_inclusion(
             &hasher,
             &[] as &[Digest],
             Location::<F>::new(0),
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
         assert!(empty_proof.verify_multi_inclusion(
             &hasher,
             &[] as &[(Digest, Location<F>)],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Confirm empty proof no longer verifies after adding an element.
         let batch = mmr.new_batch().add(&hasher, &test_digest(0));
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
         mmr.apply_batch(&batch).unwrap();
-        let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mmr.root(&hasher, 0).unwrap();
         assert!(!empty_proof.verify_range_inclusion(
             &hasher,
             &[] as &[Digest],
             Location::<F>::new(0),
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
         assert!(!empty_proof.verify_multi_inclusion(
             &hasher,
             &[] as &[(Digest, Location<F>)],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         mmr.destroy().await.unwrap();
@@ -1346,17 +1355,14 @@ mod tests {
         const TEST_ELEMENT: usize = 133;
         let test_element_loc: Location<F> = Location::new(TEST_ELEMENT as u64);
 
-        let proof = mmr
-            .proof(&hasher, test_element_loc, RootSpec::FULL_FORWARD)
-            .await
-            .unwrap();
-        let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let proof = mmr.proof(&hasher, test_element_loc, 0).await.unwrap();
+        let root = mmr.root(&hasher, 0).unwrap();
         assert!(proof.verify_element_inclusion(
             &hasher,
             &leaves[TEST_ELEMENT],
             test_element_loc,
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Sync the structure, make sure it flushes the in-mem structure as expected.
@@ -1364,24 +1370,18 @@ mod tests {
 
         // Now that the element is flushed from the in-mem structure, confirm its proof is still
         // generated correctly.
-        let proof2 = mmr
-            .proof(&hasher, test_element_loc, RootSpec::FULL_FORWARD)
-            .await
-            .unwrap();
+        let proof2 = mmr.proof(&hasher, test_element_loc, 0).await.unwrap();
         assert_eq!(proof, proof2);
 
         // Generate & verify a proof that spans flushed elements and the last element.
         let range = Location::<F>::new(TEST_ELEMENT as u64)..Location::<F>::new(LEAF_COUNT as u64);
-        let proof = mmr
-            .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-            .await
-            .unwrap();
+        let proof = mmr.range_proof(&hasher, range.clone(), 0).await.unwrap();
         assert!(proof.verify_range_inclusion(
             &hasher,
             &leaves[range.to_usize_range()],
             test_element_loc,
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         mmr.destroy().await.unwrap();
@@ -1548,16 +1548,16 @@ mod tests {
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
             mmr.apply_batch(&batch).unwrap();
             assert_eq!(
-                pruned_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-                mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap()
+                pruned_mmr.root(&hasher, 0).unwrap(),
+                mmr.root(&hasher, 0).unwrap()
             );
         }
 
         // Sync the structures.
         pruned_mmr.sync().await.unwrap();
         assert_eq!(
-            pruned_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap()
+            pruned_mmr.root(&hasher, 0).unwrap(),
+            mmr.root(&hasher, 0).unwrap()
         );
 
         // Sync the structure & reopen.
@@ -1571,16 +1571,16 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            pruned_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap()
+            pruned_mmr.root(&hasher, 0).unwrap(),
+            mmr.root(&hasher, 0).unwrap()
         );
 
         // Prune everything.
         let size = pruned_mmr.size();
         pruned_mmr.prune_all().await.unwrap();
         assert_eq!(
-            pruned_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap()
+            pruned_mmr.root(&hasher, 0).unwrap(),
+            mmr.root(&hasher, 0).unwrap()
         );
         let bounds = pruned_mmr.bounds();
         assert!(bounds.is_empty());
@@ -1607,8 +1607,8 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            pruned_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap()
+            pruned_mmr.root(&hasher, 0).unwrap(),
+            mmr.root(&hasher, 0).unwrap()
         );
         let bounds = pruned_mmr.bounds();
         assert!(!bounds.is_empty());
@@ -1772,25 +1772,21 @@ mod tests {
                 &hasher,
                 original_leaves,
                 Location::<F>::new(2)..Location::<F>::new(6),
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .await
             .unwrap();
         assert_eq!(historical_proof.leaves, original_leaves);
-        let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mmr.root(&hasher, 0).unwrap();
         assert!(historical_proof.verify_range_inclusion(
             &hasher,
             &elements[2..6],
             Location::<F>::new(2),
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
         let regular_proof = mmr
-            .range_proof(
-                &hasher,
-                Location::<F>::new(2)..Location::<F>::new(6),
-                RootSpec::FULL_FORWARD,
-            )
+            .range_proof(&hasher, Location::<F>::new(2)..Location::<F>::new(6), 0)
             .await
             .unwrap();
         assert_eq!(regular_proof.leaves, historical_proof.leaves);
@@ -1811,7 +1807,7 @@ mod tests {
                 &hasher,
                 original_leaves,
                 Location::<F>::new(2)..Location::<F>::new(6),
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .await
             .unwrap();
@@ -1882,7 +1878,7 @@ mod tests {
         let batch = ref_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
         ref_mmr.apply_batch(&batch).unwrap();
         let historical_leaves = ref_mmr.leaves();
-        let historical_root = ref_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let historical_root = ref_mmr.root(&hasher, 0).unwrap();
 
         // Test proof at historical position after pruning
         let historical_proof = mmr
@@ -1890,7 +1886,7 @@ mod tests {
                 &hasher,
                 historical_leaves,
                 Location::<F>::new(35)..Location::<F>::new(39),
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .await
             .unwrap();
@@ -1903,7 +1899,7 @@ mod tests {
             &elements[35..39],
             Location::<F>::new(35),
             &historical_root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         ref_mmr.destroy().await.unwrap();
@@ -1977,16 +1973,11 @@ mod tests {
         let batch = ref_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
         ref_mmr.apply_batch(&batch).unwrap();
         let historical_leaves = ref_mmr.leaves();
-        let expected_root = ref_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let expected_root = ref_mmr.root(&hasher, 0).unwrap();
 
         // Generate proof from full structure
         let proof = mmr
-            .historical_range_proof(
-                &hasher,
-                historical_leaves,
-                range.clone(),
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, historical_leaves, range.clone(), 0)
             .await
             .unwrap();
 
@@ -1995,7 +1986,7 @@ mod tests {
             &elements[range.to_usize_range()],
             range.start,
             &expected_root, // Compare to historical (reference) root
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         ref_mmr.destroy().await.unwrap();
@@ -2032,18 +2023,18 @@ mod tests {
                 &hasher,
                 Location::<F>::new(1),
                 Location::<F>::new(0)..Location::<F>::new(1),
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .await
             .unwrap();
 
-        let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let root = mmr.root(&hasher, 0).unwrap();
         assert!(single_proof.verify_range_inclusion(
             &hasher,
             &[element],
             Location::<F>::new(0),
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         mmr.destroy().await.unwrap();
@@ -2089,7 +2080,7 @@ mod tests {
         sync_mmr.apply_batch(&batch).unwrap();
 
         // Root should be computable
-        let _root = sync_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let _root = sync_mmr.root(&hasher, 0).unwrap();
 
         sync_mmr.destroy().await.unwrap();
     }
@@ -2127,7 +2118,7 @@ mod tests {
         mmr.sync().await.unwrap();
         let original_size = mmr.size();
         let original_leaves = mmr.leaves();
-        let original_root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let original_root = mmr.root(&hasher, 0).unwrap();
 
         // Sync with range.start <= existing_size <= range.end should reuse data
         let lower_bound_loc = mmr.bounds().start;
@@ -2160,10 +2151,7 @@ mod tests {
         let bounds = sync_mmr.bounds();
         assert_eq!(bounds.start, lower_bound_loc);
         assert!(!bounds.is_empty());
-        assert_eq!(
-            sync_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            original_root
-        );
+        assert_eq!(sync_mmr.root(&hasher, 0).unwrap(), original_root);
         for pos in *lower_bound_pos..*upper_bound_pos {
             let pos = Position::<F>::new(pos);
             assert_eq!(
@@ -2211,7 +2199,7 @@ mod tests {
 
         let original_size = mmr.size();
         let original_leaves = mmr.leaves();
-        let original_root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let original_root = mmr.root(&hasher, 0).unwrap();
         let original_pruning_boundary = mmr.bounds().start;
         let original_pruning_pos = Position::<F>::try_from(original_pruning_boundary).unwrap();
 
@@ -2243,10 +2231,7 @@ mod tests {
         let bounds = sync_mmr.bounds();
         assert_eq!(bounds.start, lower_bound_loc);
         assert!(!bounds.is_empty());
-        assert_eq!(
-            sync_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            original_root
-        );
+        assert_eq!(sync_mmr.root(&hasher, 0).unwrap(), original_root);
 
         // Check that existing nodes are preserved in the overlapping range.
         for i in *original_pruning_pos..*original_size {
@@ -2401,7 +2386,7 @@ mod tests {
         // Prune to position 30 (this stores pinned nodes and updates metadata)
         let prune_loc = Location::<F>::new(16);
         mmr.prune(prune_loc).await.unwrap();
-        let expected_root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let expected_root = mmr.root(&hasher, 0).unwrap();
         let expected_size = mmr.size();
         drop(mmr);
 
@@ -2417,10 +2402,7 @@ mod tests {
 
         assert_eq!(mmr.bounds().start, prune_loc);
         assert_eq!(mmr.size(), expected_size);
-        assert_eq!(
-            mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            expected_root
-        );
+        assert_eq!(mmr.root(&hasher, 0).unwrap(), expected_root);
 
         mmr.destroy().await.unwrap();
     }
@@ -2474,7 +2456,7 @@ mod tests {
         // Don't prune - this ensures metadata has no pinned nodes. init_sync will need to
         // read pinned nodes from the journal.
         let original_size = mmr.size();
-        let original_root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let original_root = mmr.root(&hasher, 0).unwrap();
         drop(mmr);
 
         // Reopen via init_sync with range.start > 0. This will prune the journal, so
@@ -2492,10 +2474,7 @@ mod tests {
 
         // Verify the structure state is correct.
         assert_eq!(sync_mmr.size(), original_size);
-        assert_eq!(
-            sync_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            original_root
-        );
+        assert_eq!(sync_mmr.root(&hasher, 0).unwrap(), original_root);
         assert_eq!(sync_mmr.bounds().start, prune_loc);
 
         sync_mmr.destroy().await.unwrap();
@@ -2541,12 +2520,7 @@ mod tests {
         for loc_u64 in 0..*historical_leaves {
             let loc = Location::<F>::new(loc_u64);
             let result = mmr
-                .historical_range_proof(
-                    &hasher,
-                    historical_leaves,
-                    loc..loc + 1,
-                    RootSpec::FULL_FORWARD,
-                )
+                .historical_range_proof(&hasher, historical_leaves, loc..loc + 1, 0)
                 .await;
             if matches!(result, Err(Error::ElementPruned(_))) {
                 pruned_loc = Some(loc);
@@ -2565,12 +2539,7 @@ mod tests {
 
         let requested = mmr.leaves();
         let result = mmr
-            .historical_range_proof(
-                &hasher,
-                requested,
-                pruned_loc..pruned_loc + 1,
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, requested, pruned_loc..pruned_loc + 1, 0)
             .await;
         assert!(matches!(result, Err(Error::ElementPruned(_))));
 
@@ -2620,17 +2589,12 @@ mod tests {
         mmr.apply_batch(&batch).unwrap();
 
         let proof = mmr
-            .historical_range_proof(
-                &hasher,
-                historical_leaves,
-                range.clone(),
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, historical_leaves, range.clone(), 0)
             .await
             .unwrap();
 
         let expected = mmr
-            .historical_range_proof(&hasher, historical_leaves, range, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, historical_leaves, range, 0)
             .await
             .unwrap();
         assert_eq!(proof, expected);
@@ -2673,17 +2637,12 @@ mod tests {
         let historical_leaves = Location::<F>::new(20);
         let range = Location::<F>::new(5)..Location::<F>::new(15);
         let expected = mmr
-            .historical_range_proof(
-                &hasher,
-                historical_leaves,
-                range.clone(),
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, historical_leaves, range.clone(), 0)
             .await
             .unwrap();
 
         let actual = mmr
-            .historical_range_proof(&hasher, historical_leaves, range, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, historical_leaves, range, 0)
             .await
             .unwrap();
         assert_eq!(actual, expected);
@@ -2726,7 +2685,7 @@ mod tests {
         let requested = Location::<F>::new(20);
         let range = prune_loc..requested;
         let proof = mmr
-            .historical_range_proof(&hasher, requested, range, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, requested, range, 0)
             .await
             .unwrap();
         assert!(proof.leaves > Location::<F>::new(0));
@@ -2759,21 +2718,11 @@ mod tests {
         .unwrap();
         let empty_end = Location::<F>::new(0);
         let empty_result = mmr
-            .historical_range_proof(
-                &hasher,
-                empty_end,
-                empty_end..empty_end,
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, empty_end, empty_end..empty_end, 0)
             .await;
         assert!(matches!(empty_result, Err(Error::Empty)));
         let oob_result = mmr
-            .historical_range_proof(
-                &hasher,
-                empty_end + 1,
-                empty_end..empty_end + 1,
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, empty_end + 1, empty_end..empty_end + 1, 0)
             .await;
         assert!(matches!(
             oob_result,
@@ -2799,11 +2748,11 @@ mod tests {
         mmr.prune_all().await.unwrap();
         assert!(mmr.bounds().is_empty());
         let pruned_result = mmr
-            .historical_range_proof(&hasher, end, end - 1..end, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, end, end - 1..end, 0)
             .await;
         assert!(matches!(pruned_result, Err(Error::ElementPruned(_))));
         let oob_result = mmr
-            .historical_range_proof(&hasher, end + 1, end - 1..end, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, end + 1, end - 1..end, 0)
             .await;
         assert!(matches!(
             oob_result,
@@ -2829,23 +2778,18 @@ mod tests {
         let keep_loc = end - 1;
         mmr.prune(keep_loc).await.unwrap();
         let ok_result = mmr
-            .historical_range_proof(&hasher, end, keep_loc..end, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, end, keep_loc..end, 0)
             .await;
         assert!(ok_result.is_ok());
         let pruned_end = keep_loc - 1;
         // make sure this is in a pruned range, considering blob boundaries.
         let start_loc = Location::<F>::new(1);
         let pruned_result = mmr
-            .historical_range_proof(
-                &hasher,
-                end,
-                start_loc..pruned_end + 1,
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, end, start_loc..pruned_end + 1, 0)
             .await;
         assert!(matches!(pruned_result, Err(Error::ElementPruned(_))));
         let oob_result = mmr
-            .historical_range_proof(&hasher, end + 1, keep_loc..end, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, end + 1, keep_loc..end, 0)
             .await;
         assert!(matches!(oob_result, Err(Error::RangeOutOfBounds(_))));
         mmr.destroy().await.unwrap();
@@ -2879,12 +2823,7 @@ mod tests {
         let requested = mmr.leaves() + 1;
 
         let result = mmr
-            .historical_range_proof(
-                &hasher,
-                requested,
-                Location::<F>::new(0)..requested,
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, requested, Location::<F>::new(0)..requested, 0)
             .await;
         assert!(matches!(
             result,
@@ -2931,19 +2870,14 @@ mod tests {
         let requested = Location::<F>::new(5);
         let empty_range = requested..requested;
         let empty_result = mmr
-            .historical_range_proof(&hasher, requested, empty_range, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, requested, empty_range, 0)
             .await;
         assert!(matches!(empty_result, Err(Error::Empty)));
 
         // Requested historical size is out of bounds.
         let leaves_oob = mmr.leaves() + 1;
         let result = mmr
-            .historical_range_proof(
-                &hasher,
-                leaves_oob,
-                valid_range.clone(),
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, leaves_oob, valid_range.clone(), 0)
             .await;
         assert!(matches!(
             result,
@@ -2954,7 +2888,7 @@ mod tests {
         let end_oob = mmr.leaves() + 1;
         let range_oob = Location::<F>::new(0)..end_oob;
         let result = mmr
-            .historical_range_proof(&hasher, requested, range_oob, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, requested, range_oob, 0)
             .await;
         assert!(matches!(
             result,
@@ -2966,12 +2900,7 @@ mod tests {
         let range_oob_at_requested = Location::<F>::new(0)..range_end_gt_requested;
         assert!(range_end_gt_requested <= mmr.leaves());
         let result = mmr
-            .historical_range_proof(
-                &hasher,
-                requested,
-                range_oob_at_requested,
-                RootSpec::FULL_FORWARD,
-            )
+            .historical_range_proof(&hasher, requested, range_oob_at_requested, 0)
             .await;
         assert!(matches!(
             result,
@@ -2983,7 +2912,7 @@ mod tests {
         let overflow_loc = Location::<F>::new(u64::MAX);
         let overflow_range = Location::<F>::new(0)..overflow_loc;
         let result = mmr
-            .historical_range_proof(&hasher, requested, overflow_range, RootSpec::FULL_FORWARD)
+            .historical_range_proof(&hasher, requested, overflow_range, 0)
             .await;
         assert!(matches!(
             result,
@@ -3032,7 +2961,7 @@ mod tests {
             for loc_u64 in 0..*end {
                 let loc = Location::<F>::new(loc_u64);
                 let range_includes_pruned_leaf = loc < prune_loc;
-                match mmr.historical_proof(&hasher, end, loc, RootSpec::FULL_FORWARD).await {
+                match mmr.historical_proof(&hasher, end, loc, 0).await {
                     Ok(_) => {}
                     Err(Error::ElementPruned(_)) if range_includes_pruned_leaf => {}
                     Err(Error::ElementPruned(_)) => failures.push(format!(
@@ -3090,7 +3019,7 @@ mod tests {
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
         mmr.apply_batch(&batch).unwrap();
         let valid_size = mmr.size();
-        let valid_root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+        let valid_root = mmr.root(&hasher, 0).unwrap();
         mmr.sync().await.unwrap();
         drop(mmr);
 
@@ -3126,10 +3055,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(sync_mmr.size(), valid_size);
-        assert_eq!(
-            sync_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap(),
-            valid_root
-        );
+        assert_eq!(sync_mmr.root(&hasher, 0).unwrap(), valid_root);
 
         sync_mmr.destroy().await.unwrap();
     }

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -4,7 +4,7 @@
 //! family (MMR, MMB, etc.) reuses the shared verification and reconstruction logic in this module,
 //! while retaining any family-specific proof helpers in its submodule.
 
-use crate::merkle::{hasher::Hasher, Bagging, Error, Family, Location, Position, RootSpec};
+use crate::merkle::{hasher::Hasher, Bagging, Error, Family, Location, Position};
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec,
@@ -136,58 +136,39 @@ impl<F: Family, D: Digest> Default for Proof<F, D> {
 
 impl<F: Family, D: Digest> Proof<F, D> {
     /// Return true if this proof proves that `element` appears at location `loc` within the
-    /// structure with root digest `root`, using `spec` to determine peak bagging.
+    /// structure with root digest `root`, using the bagging carried by `hasher`.
     pub fn verify_element_inclusion<H>(
         &self,
         hasher: &H,
         element: &[u8],
         loc: Location<F>,
         root: &D,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> bool
     where
         H: Hasher<F, Digest = D>,
     {
-        self.verify_range_inclusion(hasher, &[element], loc, root, spec)
+        self.verify_range_inclusion(hasher, &[element], loc, root, inactive_peaks)
     }
 
-    /// Return true if this proof verifies against the supplied root using `spec`.
+    /// Return true if this proof verifies against the supplied root, using the bagging carried by
+    /// `hasher`.
     pub fn verify_range_inclusion<H, E>(
         &self,
         hasher: &H,
         elements: &[E],
         start_loc: Location<F>,
         root: &D,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> bool
     where
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if self.inactive_peaks != spec.inactive_peaks() {
+        if self.inactive_peaks != inactive_peaks {
             return false;
         }
-        self.verify_range_inclusion_using_policy(hasher, elements, start_loc, root, spec.bagging())
-    }
-
-    /// Verify a range proof using a decomposed bagging policy supplied by the caller.
-    ///
-    /// Internal callers use this after they have already validated `inactive_peaks` against the
-    /// proof; prefer [`verify_range_inclusion`](Self::verify_range_inclusion) when the full root
-    /// spec is available.
-    pub(crate) fn verify_range_inclusion_using_policy<H, E>(
-        &self,
-        hasher: &H,
-        elements: &[E],
-        start_loc: Location<F>,
-        root: &D,
-        bagging: Bagging,
-    ) -> bool
-    where
-        H: Hasher<F, Digest = D>,
-        E: AsRef<[u8]>,
-    {
-        match self.reconstruct_root_using_policy(hasher, elements, start_loc, bagging) {
+        match self.reconstruct_root_inner(hasher, elements, start_loc, None) {
             Ok(reconstructed_root) => *root == reconstructed_root,
             Err(_error) => {
                 #[cfg(feature = "std")]
@@ -197,21 +178,25 @@ impl<F: Family, D: Digest> Proof<F, D> {
         }
     }
 
-    /// Verify a position-keyed multi-proof using a decomposed bagging policy.
+    /// Verify a position-keyed multi-proof using the bagging carried by `hasher`.
     ///
     /// Multi-proofs keep every witness tied to a concrete node position, so this path may include
     /// extra backward-bagged suffix peaks that range proofs can collapse into a suffix accumulator.
-    pub(crate) fn verify_multi_inclusion_using_policy<H, E>(
+    pub fn verify_multi_inclusion<H, E>(
         &self,
         hasher: &H,
         elements: &[(E, Location<F>)],
         root: &D,
-        bagging: Bagging,
+        inactive_peaks: usize,
     ) -> bool
     where
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
+        if self.inactive_peaks != inactive_peaks {
+            return false;
+        }
+        let bagging = hasher.root_bagging();
         // Empty proof is valid only for an empty tree with no extra digest data.
         if elements.is_empty() {
             return self.digests.is_empty()
@@ -219,11 +204,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
                 && self.inactive_peaks == 0
                 && *root
                     == hasher
-                        .root(
-                            Location::new(0),
-                            RootSpec::FULL_FORWARD,
-                            core::iter::empty(),
-                        )
+                        .root(Location::new(0), 0, core::iter::empty())
                         .expect("zero inactive peaks is always valid");
         }
 
@@ -236,12 +217,8 @@ impl<F: Family, D: Digest> Proof<F, D> {
                 return false;
             }
             // `loc` is valid so it won't overflow from +1
-            let Ok(bp) = Blueprint::new_using_policy(
-                self.leaves,
-                self.inactive_peaks,
-                bagging,
-                *loc..*loc + 1,
-            ) else {
+            let Ok(bp) = Blueprint::new(self.leaves, self.inactive_peaks, bagging, *loc..*loc + 1)
+            else {
                 return false;
             };
             node_positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
@@ -313,13 +290,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
                 digests,
             };
 
-            match proof.reconstruct_root_collecting_using_policy(
-                hasher,
-                &[element.as_ref()],
-                *loc,
-                None,
-                bagging,
-            ) {
+            match proof.reconstruct_root_inner(hasher, &[element.as_ref()], *loc, None) {
                 Ok(reconstructed_root) if &reconstructed_root == root => {}
                 Ok(_) | Err(_) => return false,
             }
@@ -328,96 +299,27 @@ impl<F: Family, D: Digest> Proof<F, D> {
         true
     }
 
-    /// Return true if this multi-proof verifies against `root` using `spec`.
-    pub fn verify_multi_inclusion<H, E>(
-        &self,
-        hasher: &H,
-        elements: &[(E, Location<F>)],
-        root: &D,
-        spec: RootSpec,
-    ) -> bool
-    where
-        H: Hasher<F, Digest = D>,
-        E: AsRef<[u8]>,
-    {
-        if self.inactive_peaks != spec.inactive_peaks() {
-            return false;
-        }
-        self.verify_multi_inclusion_using_policy(hasher, elements, root, spec.bagging())
-    }
-
-    /// Reconstruct the root digest from this proof and the given consecutive elements using `spec`,
-    /// or return a `ReconstructionError` if the input data is invalid.
+    /// Reconstruct the root digest from this proof and the given consecutive elements using
+    /// `inactive_peaks` and the bagging carried by `hasher`, or return a `ReconstructionError` if
+    /// the input data is invalid.
     pub fn reconstruct_root<H, E>(
         &self,
         hasher: &H,
         elements: &[E],
         start_loc: Location<F>,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<D, ReconstructionError>
     where
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if self.inactive_peaks != spec.inactive_peaks() {
+        if self.inactive_peaks != inactive_peaks {
             return Err(ReconstructionError::InvalidProof);
         }
-        self.reconstruct_root_using_policy(hasher, elements, start_loc, spec.bagging())
+        self.reconstruct_root_inner(hasher, elements, start_loc, None)
     }
 
-    /// Reconstruct a root from a range proof using a decomposed bagging policy.
-    ///
-    /// Internal callers use this after deriving the policy from their canonical root spec or from a
-    /// higher-level proof format.
-    pub(crate) fn reconstruct_root_using_policy<H, E>(
-        &self,
-        hasher: &H,
-        elements: &[E],
-        start_loc: Location<F>,
-        bagging: Bagging,
-    ) -> Result<D, ReconstructionError>
-    where
-        H: Hasher<F, Digest = D>,
-        E: AsRef<[u8]>,
-    {
-        self.reconstruct_root_collecting_using_policy(hasher, elements, start_loc, None, bagging)
-    }
-
-    /// Verify a range proof with decomposed bagging and return authenticated internal digests.
-    ///
-    /// The extracted digests are used by callers that need to validate pinned nodes in addition to
-    /// the range elements.
-    pub(crate) fn verify_range_inclusion_and_extract_digests_using_policy<H, E>(
-        &self,
-        hasher: &H,
-        elements: &[E],
-        start_loc: Location<F>,
-        root: &D,
-        bagging: Bagging,
-    ) -> Result<Vec<(Position<F>, D)>, Error<F>>
-    where
-        H: Hasher<F, Digest = D>,
-        E: AsRef<[u8]>,
-    {
-        let mut collected_digests = Vec::new();
-        let Ok(reconstructed_root) = self.reconstruct_root_collecting_using_policy(
-            hasher,
-            elements,
-            start_loc,
-            Some(&mut collected_digests),
-            bagging,
-        ) else {
-            return Err(Error::InvalidProof);
-        };
-
-        if reconstructed_root != *root {
-            return Err(Error::RootMismatch);
-        }
-
-        Ok(collected_digests)
-    }
-
-    /// Verify this proof against `root` using `spec` and extract all authenticated digests.
+    /// Verify this proof against `root` using `inactive_peaks` and extract all authenticated digests.
     ///
     /// Reconstructs the root from the proof and provided elements and returns every
     /// `(position, digest)` required by that reconstruction, including the proof's own digests.
@@ -429,22 +331,27 @@ impl<F: Family, D: Digest> Proof<F, D> {
         elements: &[E],
         start_loc: Location<F>,
         root: &D,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Vec<(Position<F>, D)>, Error<F>>
     where
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if self.inactive_peaks != spec.inactive_peaks() {
+        if self.inactive_peaks != inactive_peaks {
             return Err(Error::InvalidProof);
         }
-        self.verify_range_inclusion_and_extract_digests_using_policy(
-            hasher,
-            elements,
-            start_loc,
-            root,
-            spec.bagging(),
-        )
+        let mut collected_digests = Vec::new();
+        let Ok(reconstructed_root) =
+            self.reconstruct_root_inner(hasher, elements, start_loc, Some(&mut collected_digests))
+        else {
+            return Err(Error::InvalidProof);
+        };
+
+        if reconstructed_root != *root {
+            return Err(Error::RootMismatch);
+        }
+
+        Ok(collected_digests)
     }
 
     /// Verify this proof and the pinned nodes against `root` using `spec`.
@@ -486,51 +393,17 @@ impl<F: Family, D: Digest> Proof<F, D> {
         start_loc: Location<F>,
         pinned_nodes: &[D],
         root: &D,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> bool
     where
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if self.inactive_peaks != spec.inactive_peaks() {
+        if self.inactive_peaks != inactive_peaks {
             return false;
         }
-        self.verify_proof_and_pinned_nodes_using_policy(
-            hasher,
-            elements,
-            start_loc,
-            pinned_nodes,
-            root,
-            spec.bagging(),
-        )
-    }
-
-    /// Verify a proof and pinned nodes using a decomposed bagging policy.
-    ///
-    /// This is the internal counterpart to
-    /// [`verify_proof_and_pinned_nodes`](Self::verify_proof_and_pinned_nodes).
-    pub(crate) fn verify_proof_and_pinned_nodes_using_policy<H, E>(
-        &self,
-        hasher: &H,
-        elements: &[E],
-        start_loc: Location<F>,
-        pinned_nodes: &[D],
-        root: &D,
-        bagging: Bagging,
-    ) -> bool
-    where
-        H: Hasher<F, Digest = D>,
-        E: AsRef<[u8]>,
-    {
-        self.try_verify_proof_and_pinned_nodes(
-            hasher,
-            elements,
-            start_loc,
-            pinned_nodes,
-            root,
-            bagging,
-        )
-        .is_some()
+        self.try_verify_proof_and_pinned_nodes(hasher, elements, start_loc, pinned_nodes, root)
+            .is_some()
     }
 
     /// Fallible implementation of [`verify_proof_and_pinned_nodes`](Self::verify_proof_and_pinned_nodes).
@@ -545,15 +418,19 @@ impl<F: Family, D: Digest> Proof<F, D> {
         start_loc: Location<F>,
         pinned_nodes: &[D],
         root: &D,
-        bagging: Bagging,
     ) -> Option<()>
     where
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
+        let bagging = hasher.root_bagging();
         let collected = self
-            .verify_range_inclusion_and_extract_digests_using_policy(
-                hasher, elements, start_loc, root, bagging,
+            .verify_range_inclusion_and_extract_digests(
+                hasher,
+                elements,
+                start_loc,
+                root,
+                self.inactive_peaks,
             )
             .ok()?;
 
@@ -571,7 +448,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
         }
 
         let end_loc = start_loc.checked_add(elements.len() as u64)?;
-        let bp = Blueprint::new_using_policy(
+        let bp = Blueprint::new(
             self.leaves,
             self.inactive_peaks,
             bagging,
@@ -627,21 +504,20 @@ impl<F: Family, D: Digest> Proof<F, D> {
 
     /// Reconstruct a root from range-proof digests and optionally collect authenticated nodes.
     ///
-    /// `bagging` describes the root bagging step after the inactive prefix has been handled. When
-    /// `collected` is supplied, the verifier records the intermediate node digests it authenticates
-    /// while reconstructing the range.
-    pub(crate) fn reconstruct_root_collecting_using_policy<H, E>(
+    /// Reads the bagging policy from `hasher`. When `collected` is supplied, the verifier records
+    /// the intermediate node digests it authenticates while reconstructing the range.
+    pub(crate) fn reconstruct_root_inner<H, E>(
         &self,
         hasher: &H,
         elements: &[E],
         start_loc: Location<F>,
         collected: Option<&mut Vec<(Position<F>, D)>>,
-        bagging: Bagging,
     ) -> Result<D, ReconstructionError>
     where
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
+        let bagging = hasher.root_bagging();
         let mut collected = collected;
         if elements.is_empty() {
             if start_loc == 0 {
@@ -670,7 +546,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
         }
         let range = start_loc..end_loc;
 
-        let bp = Blueprint::new_using_policy(self.leaves, self.inactive_peaks, bagging, range)
+        let bp = Blueprint::new(self.leaves, self.inactive_peaks, bagging, range)
             .map_err(|_| ReconstructionError::InvalidSize)?;
 
         let proof_digests = bp.split_proof_digests(&self.digests)?;
@@ -733,7 +609,6 @@ impl<F: Family, D: Digest> Proof<F, D> {
                 self.leaves,
                 bp.inactive_peaks_after_prefix_fold(self.inactive_peaks),
                 self.inactive_peaks,
-                bagging,
                 peak_digests.iter(),
             )
             .ok_or(ReconstructionError::InvalidProof)
@@ -952,22 +827,12 @@ pub(crate) struct ProofDigestLayout<'a, D> {
 }
 
 impl<F: Family> Blueprint<F> {
-    /// Test-only convenience for the default forward-fold policy.
-    #[cfg(test)]
-    pub(crate) fn new(
-        leaves: Location<F>,
-        inactive_peaks: usize,
-        range: Range<Location<F>>,
-    ) -> Result<Self, super::Error<F>> {
-        Self::new_using_policy(leaves, inactive_peaks, Bagging::ForwardFold, range)
-    }
-
     /// Build a range-proof blueprint for a caller-supplied bagging policy.
     ///
     /// Forward bagging folds peaks before the range into one prefix accumulator. Backward bagging
     /// also collapses active peaks after the range into one suffix accumulator while leaving inactive
     /// after-peaks position-keyed.
-    pub(crate) fn new_using_policy(
+    pub(crate) fn new(
         leaves: Location<F>,
         inactive_peaks: usize,
         bagging: Bagging,
@@ -1197,13 +1062,13 @@ impl<F: Family> Blueprint<F> {
 /// and 61 peak digests.
 pub const MAX_PROOF_DIGESTS_PER_ELEMENT: usize = 122;
 
-/// Build a range proof from a node-fetching closure using `spec`. This is the generic
-/// implementation shared by all Merkle families. The `element_pruned` closure is called when
-/// `get_node` returns `None` for a required position.
+/// Build a range proof from a node-fetching closure. The bagging policy is read from `hasher`.
+/// This is the generic implementation shared by all Merkle families. The `element_pruned` closure
+/// is called when `get_node` returns `None` for a required position.
 pub(crate) fn build_range_proof<F, D, H, E>(
     hasher: &H,
     leaves: Location<F>,
-    spec: RootSpec,
+    inactive_peaks: usize,
     range: Range<Location<F>>,
     get_node: impl Fn(Position<F>) -> Option<D>,
     element_pruned: impl Fn(Position<F>) -> E,
@@ -1214,9 +1079,9 @@ where
     H: Hasher<F, Digest = D>,
     E: From<super::Error<F>>,
 {
-    Blueprint::new_using_policy(leaves, spec.inactive_peaks(), spec.bagging(), range)?.build_proof(
+    Blueprint::new(leaves, inactive_peaks, hasher.root_bagging(), range)?.build_proof(
         hasher,
-        spec.inactive_peaks(),
+        inactive_peaks,
         get_node,
         element_pruned,
     )
@@ -1238,7 +1103,7 @@ pub(crate) fn nodes_required_for_multi_proof<F: Family>(
         if !loc.is_valid_index() {
             return Err(super::Error::LocationOverflow(*loc));
         }
-        let bp = Blueprint::new_using_policy(leaves, inactive_peaks, bagging, *loc..*loc + 1)?;
+        let bp = Blueprint::new(leaves, inactive_peaks, bagging, *loc..*loc + 1)?;
         if let Some(suffix_peaks) = bp.suffix_peaks() {
             acc.extend(suffix_peaks);
         }
@@ -1270,7 +1135,7 @@ mod tests {
         mem::Mem,
         mmb, mmr,
         proof::{nodes_required_for_multi_proof, Blueprint, Proof},
-        Family, Location, LocationRangeExt as _, RootSpec,
+        Family, Location, LocationRangeExt as _,
     };
     use alloc::vec;
     use commonware_codec::{Decode, Encode, EncodeSize};
@@ -1306,9 +1171,7 @@ mod tests {
                 batch = batch.add(hasher, &i.to_be_bytes());
             }
             let batch = batch.merkleize(&mem, hasher);
-            batch
-                .root(&mem, hasher, RootSpec::split_forward(inactive_peaks))
-                .unwrap();
+            batch.root(&mem, hasher, inactive_peaks).unwrap();
             batch
         };
         mem.apply_batch(&batch).unwrap();
@@ -1316,34 +1179,34 @@ mod tests {
     }
 
     fn plain_root<F: Family>(mem: &Mem<F, D>, hasher: &H) -> D {
-        mem.root(hasher, RootSpec::FULL_FORWARD).unwrap()
+        mem.root(hasher, 0).unwrap()
     }
 
-    fn split_root<F: Family>(mem: &Mem<F, D>, hasher: &H, inactive_peaks: usize) -> D {
-        mem.root(hasher, RootSpec::split_backward(inactive_peaks))
-            .unwrap()
+    fn split_root<F: Family>(mem: &Mem<F, D>, inactive_peaks: usize) -> D {
+        let backward_hasher: H = Standard::backward();
+        mem.root(&backward_hasher, inactive_peaks).unwrap()
     }
 
-    fn push_unique_spec(specs: &mut Vec<RootSpec>, spec: RootSpec) {
+    /// Hasher tuned for `bagging` so callers can mix forward/backward and full/split policies.
+    fn hasher_for_bagging(bagging: Bagging) -> H {
+        Standard::with_bagging(bagging)
+    }
+
+    fn push_unique_spec(specs: &mut Vec<(Bagging, usize)>, spec: (Bagging, usize)) {
         if !specs.contains(&spec) {
             specs.push(spec);
         }
     }
 
-    fn supported_root_specs<F: Family>(leaves: Location<F>) -> Vec<RootSpec> {
+    fn supported_root_specs<F: Family>(leaves: Location<F>) -> Vec<(Bagging, usize)> {
         let peak_count = F::peaks(F::location_to_position(leaves)).count();
         let mut specs = Vec::new();
 
-        push_unique_spec(&mut specs, RootSpec::FULL_FORWARD);
-        push_unique_spec(
-            &mut specs,
-            RootSpec::Full {
-                bagging: Bagging::BackwardFold,
-            },
-        );
+        push_unique_spec(&mut specs, (Bagging::ForwardFold, 0));
+        push_unique_spec(&mut specs, (Bagging::BackwardFold, 0));
         for inactive_peaks in 0..=peak_count {
-            push_unique_spec(&mut specs, RootSpec::split_forward(inactive_peaks));
-            push_unique_spec(&mut specs, RootSpec::split_backward(inactive_peaks));
+            push_unique_spec(&mut specs, (Bagging::ForwardFold, inactive_peaks));
+            push_unique_spec(&mut specs, (Bagging::BackwardFold, inactive_peaks));
         }
 
         specs
@@ -1358,10 +1221,10 @@ mod tests {
 
     fn active_start_for_spec<F: Family>(
         leaves: Location<F>,
-        spec: RootSpec,
+        inactive_peaks: usize,
         width: u64,
     ) -> Location<F> {
-        let start = inactive_leaf_floor::<F>(leaves, spec.inactive_peaks());
+        let start = inactive_leaf_floor::<F>(leaves, inactive_peaks);
         if start + width <= *leaves {
             return Location::new(start);
         }
@@ -1369,44 +1232,50 @@ mod tests {
     }
 
     fn range_proofs_verify_for_supported_root_specs<F: Family>() {
-        let hasher = H::new();
-        let mem = build_raw::<F>(&hasher, 123);
+        let mem = build_raw::<F>(&H::new(), 123);
         let leaves = mem.leaves();
 
-        for spec in supported_root_specs::<F>(leaves) {
-            let range_start = active_start_for_spec::<F>(leaves, spec, 3);
+        for (bagging, inactive_peaks) in supported_root_specs::<F>(leaves) {
+            let hasher = hasher_for_bagging(bagging);
+            let range_start = active_start_for_spec::<F>(leaves, inactive_peaks, 3);
             let range = range_start..range_start + 3;
-            let root = mem.root(&hasher, spec).unwrap();
+            let root = mem.root(&hasher, inactive_peaks).unwrap();
             let elements: Vec<_> = (*range.start..*range.end)
                 .map(|i| i.to_be_bytes())
                 .collect();
             let proof: Proof<F, D> = build_range_proof(
                 &hasher,
                 leaves,
-                spec,
+                inactive_peaks,
                 range.clone(),
                 |pos| mem.get_node(pos),
                 Error::ElementPruned,
             )
             .unwrap();
 
-            assert_eq!(proof.inactive_peaks, spec.inactive_peaks());
+            assert_eq!(proof.inactive_peaks, inactive_peaks);
             assert!(
-                proof.verify_range_inclusion(&hasher, &elements, range.start, &root, spec,),
-                "range proof should verify for {spec:?}",
+                proof.verify_range_inclusion(
+                    &hasher,
+                    &elements,
+                    range.start,
+                    &root,
+                    inactive_peaks,
+                ),
+                "range proof should verify for ({bagging:?}, {inactive_peaks})",
             );
 
             let mut tampered_boundary = proof.clone();
-            tampered_boundary.inactive_peaks = if spec.inactive_peaks() == 0 { 1 } else { 0 };
+            tampered_boundary.inactive_peaks = if inactive_peaks == 0 { 1 } else { 0 };
             assert!(
                 !tampered_boundary.verify_range_inclusion(
                     &hasher,
                     &elements,
                     range.start,
                     &root,
-                    spec,
+                    inactive_peaks,
                 ),
-                "inactive_peaks mutation should fail for {spec:?}",
+                "inactive_peaks mutation should fail for ({bagging:?}, {inactive_peaks})",
             );
 
             if !proof.digests.is_empty() {
@@ -1418,82 +1287,83 @@ mod tests {
                         &elements,
                         range.start,
                         &root,
-                        spec,
+                        inactive_peaks,
                     ),
-                    "digest mutation should fail for {spec:?}",
+                    "digest mutation should fail for ({bagging:?}, {inactive_peaks})",
                 );
             }
         }
     }
 
     fn multi_proofs_verify_for_supported_root_specs<F: Family>() {
-        let hasher = H::new();
-        let mem = build_raw::<F>(&hasher, 123);
+        let mem = build_raw::<F>(&H::new(), 123);
         let leaves = mem.leaves();
 
-        for spec in supported_root_specs::<F>(leaves) {
-            let first = active_start_for_spec::<F>(leaves, spec, 12);
+        for (bagging, inactive_peaks) in supported_root_specs::<F>(leaves) {
+            let hasher = hasher_for_bagging(bagging);
+            let first = active_start_for_spec::<F>(leaves, inactive_peaks, 12);
             let locations = [first, first + 5, first + 11];
-            let nodes = nodes_required_for_multi_proof(
-                leaves,
-                spec.inactive_peaks(),
-                spec.bagging(),
-                &locations,
-            )
-            .expect("test locations valid");
+            let nodes = nodes_required_for_multi_proof(leaves, inactive_peaks, bagging, &locations)
+                .expect("test locations valid");
             let proof = Proof {
                 leaves,
-                inactive_peaks: spec.inactive_peaks(),
+                inactive_peaks,
                 digests: nodes
                     .into_iter()
                     .map(|pos| mem.get_node(pos).unwrap())
                     .collect(),
             };
-            let root = mem.root(&hasher, spec).unwrap();
+            let root = mem.root(&hasher, inactive_peaks).unwrap();
             let elements: Vec<_> = locations
                 .iter()
                 .map(|loc| ((*loc).to_be_bytes(), *loc))
                 .collect();
 
             assert!(
-                proof.verify_multi_inclusion(&hasher, &elements, &root, spec),
-                "multi-proof should verify for {spec:?}",
+                proof.verify_multi_inclusion(&hasher, &elements, &root, inactive_peaks),
+                "multi-proof should verify for ({bagging:?}, {inactive_peaks})",
             );
 
             let mut tampered_boundary = proof.clone();
-            tampered_boundary.inactive_peaks = if spec.inactive_peaks() == 0 { 1 } else { 0 };
+            tampered_boundary.inactive_peaks = if inactive_peaks == 0 { 1 } else { 0 };
             assert!(
-                !tampered_boundary.verify_multi_inclusion(&hasher, &elements, &root, spec,),
-                "inactive_peaks mutation should fail for {spec:?}",
+                !tampered_boundary.verify_multi_inclusion(
+                    &hasher,
+                    &elements,
+                    &root,
+                    inactive_peaks
+                ),
+                "inactive_peaks mutation should fail for ({bagging:?}, {inactive_peaks})",
             );
 
             if !proof.digests.is_empty() {
                 let mut tampered_digest = proof.clone();
                 tampered_digest.digests[0].0[0] ^= 1;
                 assert!(
-                    !tampered_digest.verify_multi_inclusion(&hasher, &elements, &root, spec,),
-                    "digest mutation should fail for {spec:?}",
+                    !tampered_digest.verify_multi_inclusion(
+                        &hasher,
+                        &elements,
+                        &root,
+                        inactive_peaks
+                    ),
+                    "digest mutation should fail for ({bagging:?}, {inactive_peaks})",
                 );
             }
         }
     }
 
     fn backward_fold_proof_optimization_inner(inactive_peaks: usize) {
-        let hasher = H::new();
+        let hasher: H = Standard::backward();
         let mem = build_inactive_prefix::<mmb::Family>(&hasher, 123, inactive_peaks);
         let leaves = mem.leaves();
-        let root = split_root(&mem, &hasher, inactive_peaks);
+        let root = split_root(&mem, inactive_peaks);
 
         let mut selected = None;
         for loc in 0..*leaves {
             let range = Location::new(loc)..Location::new(loc + 1);
-            let optimized = Blueprint::new_using_policy(
-                leaves,
-                inactive_peaks,
-                Bagging::BackwardFold,
-                range.clone(),
-            )
-            .unwrap();
+            let optimized =
+                Blueprint::new(leaves, inactive_peaks, Bagging::BackwardFold, range.clone())
+                    .unwrap();
             if optimized.suffix_peaks.len() > 1 {
                 selected = Some((range, optimized));
                 break;
@@ -1518,51 +1388,48 @@ mod tests {
             .unwrap();
 
         assert_eq!(position_keyed_len - proof.digests.len(), suffix_len - 1);
-        assert!(proof.verify_range_inclusion_using_policy(
+        assert!(proof.verify_range_inclusion(
             &hasher,
             &[range.start.to_be_bytes()],
             range.start,
             &root,
-            Bagging::BackwardFold,
+            inactive_peaks,
         ));
 
         let mut tampered = proof;
         tampered.digests[suffix_idx].0[0] ^= 1;
-        assert!(!tampered.verify_range_inclusion_using_policy(
+        assert!(!tampered.verify_range_inclusion(
             &hasher,
             &[range.start.to_be_bytes()],
             range.start,
             &root,
-            Bagging::BackwardFold,
+            inactive_peaks,
         ));
     }
 
     #[test]
     fn full_backward_root_spec_proves_like_split_zero() {
-        let hasher = H::new();
+        let hasher: H = Standard::backward();
         let mem = build_raw::<mmb::Family>(&hasher, 123);
-        let full_backward = RootSpec::Full {
-            bagging: Bagging::BackwardFold,
-        };
         let range = Location::new(2)..Location::new(3);
 
         let generated: Result<Proof<mmb::Family, D>, Error<mmb::Family>> = build_range_proof(
             &hasher,
             mem.leaves(),
-            full_backward,
+            0,
             range.clone(),
             |pos| mem.get_node(pos),
             Error::ElementPruned,
         );
         let generated = generated.unwrap();
 
-        let full_backward_root = mem.root(&hasher, full_backward).unwrap();
+        let full_backward_root = mem.root(&hasher, 0).unwrap();
         assert!(generated.verify_range_inclusion(
             &hasher,
             &[range.start.to_be_bytes()],
             range.start,
             &full_backward_root,
-            full_backward,
+            0,
         ));
 
         let locations = &[Location::new(0), Location::new(5), Location::new(10)];
@@ -1585,16 +1452,16 @@ mod tests {
                 (10u64.to_be_bytes(), Location::new(10)),
             ],
             &full_backward_root,
-            full_backward,
+            0,
         ));
 
-        let split_zero = RootSpec::split_backward(0);
-        let split_root = mem.root(&hasher, split_zero).unwrap();
-        assert_eq!(full_backward_root, split_root);
+        // Split { inactive_peaks: 0 } is byte-identical to Full when inactive_peaks == 0.
+        let split_root_value = mem.root(&hasher, 0).unwrap();
+        assert_eq!(full_backward_root, split_root_value);
         let split_proof: Result<Proof<mmb::Family, D>, Error<mmb::Family>> = build_range_proof(
             &hasher,
             mem.leaves(),
-            split_zero,
+            0,
             range.clone(),
             |pos| mem.get_node(pos),
             Error::ElementPruned,
@@ -1604,8 +1471,8 @@ mod tests {
             &hasher,
             &[range.start.to_be_bytes()],
             range.start,
-            &split_root,
-            split_zero,
+            &split_root_value,
+            0,
         ));
     }
 
@@ -1615,19 +1482,8 @@ mod tests {
         let mem = Mem::<F, D>::new();
         let root = plain_root(&mem, &hasher);
         let proof: Proof<F, D> = Proof::default();
-        assert!(proof.verify_range_inclusion(
-            &hasher,
-            &[] as &[D],
-            Location::new(0),
-            &root,
-            RootSpec::FULL_FORWARD
-        ));
-        assert!(proof.verify_multi_inclusion(
-            &hasher,
-            &[] as &[(D, Location<F>)],
-            &root,
-            RootSpec::FULL_FORWARD
-        ));
+        assert!(proof.verify_range_inclusion(&hasher, &[] as &[D], Location::new(0), &root, 0));
+        assert!(proof.verify_multi_inclusion(&hasher, &[] as &[(D, Location<F>)], &root, 0));
 
         let mut inactive_proof = proof.clone();
         inactive_proof.inactive_peaks = 1;
@@ -1636,66 +1492,28 @@ mod tests {
             &[] as &[D],
             Location::new(0),
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
         assert!(!inactive_proof.verify_multi_inclusion(
             &hasher,
             &[] as &[(D, Location<F>)],
             &root,
-            RootSpec::FULL_FORWARD
-        ));
-        assert!(!inactive_proof.verify_multi_inclusion_using_policy(
-            &hasher,
-            &[] as &[(D, Location<F>)],
-            &root,
-            Bagging::ForwardFold,
+            0
         ));
         assert!(matches!(
-            inactive_proof.reconstruct_root(
-                &hasher,
-                &[] as &[D],
-                Location::new(0),
-                RootSpec::FULL_FORWARD
-            ),
-            Err(ReconstructionError::InvalidProof)
-        ));
-        assert!(matches!(
-            inactive_proof.reconstruct_root_using_policy(
-                &hasher,
-                &[] as &[D],
-                Location::new(0),
-                Bagging::ForwardFold,
-            ),
+            inactive_proof.reconstruct_root(&hasher, &[] as &[D], Location::new(0), 0),
             Err(ReconstructionError::InvalidProof)
         ));
 
         // Any starting position other than 0 should fail to verify.
-        assert!(!proof.verify_range_inclusion(
-            &hasher,
-            &[] as &[D],
-            Location::new(1),
-            &root,
-            RootSpec::FULL_FORWARD
-        ));
+        assert!(!proof.verify_range_inclusion(&hasher, &[] as &[D], Location::new(1), &root, 0));
 
         // Invalid root should fail to verify.
         let td = test_digest(0);
-        assert!(!proof.verify_range_inclusion(
-            &hasher,
-            &[] as &[D],
-            Location::new(0),
-            &td,
-            RootSpec::FULL_FORWARD
-        ));
+        assert!(!proof.verify_range_inclusion(&hasher, &[] as &[D], Location::new(0), &td, 0));
 
         // Non-empty elements list should fail to verify.
-        assert!(!proof.verify_range_inclusion(
-            &hasher,
-            &[td],
-            Location::new(0),
-            &root,
-            RootSpec::FULL_FORWARD
-        ));
+        assert!(!proof.verify_range_inclusion(&hasher, &[td], Location::new(0), &root, 0));
     }
 
     fn verify_element<F: Family>() {
@@ -1716,15 +1534,9 @@ mod tests {
         // Confirm the proof of inclusion for each leaf verifies.
         for leaf in 0u64..11 {
             let leaf = Location::new(leaf);
-            let proof: Proof<F, D> = mem.proof(&hasher, leaf, RootSpec::FULL_FORWARD).unwrap();
+            let proof: Proof<F, D> = mem.proof(&hasher, leaf, 0).unwrap();
             assert!(
-                proof.verify_element_inclusion(
-                    &hasher,
-                    &element,
-                    leaf,
-                    &root,
-                    RootSpec::FULL_FORWARD
-                ),
+                proof.verify_element_inclusion(&hasher, &element, leaf, &root, 0),
                 "valid proof should verify successfully"
             );
         }
@@ -1732,99 +1544,51 @@ mod tests {
         // Create a valid proof, then confirm various mangling of the proof or proof args results in
         // verification failure.
         let leaf = Location::<F>::new(10);
-        let proof = mem.proof(&hasher, leaf, RootSpec::FULL_FORWARD).unwrap();
+        let proof = mem.proof(&hasher, leaf, 0).unwrap();
         assert!(
-            proof.verify_element_inclusion(&hasher, &element, leaf, &root, RootSpec::FULL_FORWARD),
+            proof.verify_element_inclusion(&hasher, &element, leaf, &root, 0),
             "proof verification should be successful"
         );
         assert!(
-            !proof.verify_element_inclusion(
-                &hasher,
-                &element,
-                leaf + 1,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !proof.verify_element_inclusion(&hasher, &element, leaf + 1, &root, 0),
             "proof verification should fail with incorrect element position"
         );
         assert!(
-            !proof.verify_element_inclusion(
-                &hasher,
-                &element,
-                leaf - 1,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !proof.verify_element_inclusion(&hasher, &element, leaf - 1, &root, 0),
             "proof verification should fail with incorrect element position 2"
         );
         assert!(
-            !proof.verify_element_inclusion(
-                &hasher,
-                &test_digest(0),
-                leaf,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !proof.verify_element_inclusion(&hasher, &test_digest(0), leaf, &root, 0),
             "proof verification should fail with mangled element"
         );
         let root2 = test_digest(0);
         assert!(
-            !proof.verify_element_inclusion(
-                &hasher,
-                &element,
-                leaf,
-                &root2,
-                RootSpec::FULL_FORWARD
-            ),
+            !proof.verify_element_inclusion(&hasher, &element, leaf, &root2, 0),
             "proof verification should fail with mangled root"
         );
         let mut proof2 = proof.clone();
         proof2.digests[0] = test_digest(0);
         assert!(
-            !proof2.verify_element_inclusion(
-                &hasher,
-                &element,
-                leaf,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !proof2.verify_element_inclusion(&hasher, &element, leaf, &root, 0),
             "proof verification should fail with mangled proof hash"
         );
         proof2 = proof.clone();
         proof2.leaves = Location::new(10);
         assert!(
-            !proof2.verify_element_inclusion(
-                &hasher,
-                &element,
-                leaf,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !proof2.verify_element_inclusion(&hasher, &element, leaf, &root, 0),
             "proof verification should fail with incorrect leaves"
         );
         proof2 = proof.clone();
         proof2.digests.push(test_digest(0));
         assert!(
-            !proof2.verify_element_inclusion(
-                &hasher,
-                &element,
-                leaf,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !proof2.verify_element_inclusion(&hasher, &element, leaf, &root, 0),
             "proof verification should fail with extra hash"
         );
         proof2 = proof.clone();
         while !proof2.digests.is_empty() {
             proof2.digests.pop();
             assert!(
-                !proof2.verify_element_inclusion(
-                    &hasher,
-                    &element,
-                    leaf,
-                    &root,
-                    RootSpec::FULL_FORWARD
-                ),
+                !proof2.verify_element_inclusion(&hasher, &element, leaf, &root, 0),
                 "proof verification should fail with missing digests"
             );
         }
@@ -1836,7 +1600,7 @@ mod tests {
             proof2.digests.push(test_digest(0));
             proof2.digests.extend(proof.digests[1..].iter().cloned());
             assert!(
-                !proof2.verify_element_inclusion(&hasher, &element, leaf, &root, RootSpec::FULL_FORWARD),
+                !proof2.verify_element_inclusion(&hasher, &element, leaf, &root, 0),
                 "proof verification should fail with extra hash even if it's unused by the computation"
             );
         }
@@ -1861,16 +1625,14 @@ mod tests {
         for i in 0..elements.len() {
             for j in i + 1..elements.len() {
                 let range = Location::new(i as u64)..Location::new(j as u64);
-                let range_proof = mem
-                    .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-                    .unwrap();
+                let range_proof = mem.range_proof(&hasher, range.clone(), 0).unwrap();
                 assert!(
                     range_proof.verify_range_inclusion(
                         &hasher,
                         &elements[range.to_usize_range()],
                         range.start,
                         &root,
-                        RootSpec::FULL_FORWARD,
+                        0,
                     ),
                     "valid range proof should verify successfully {i}:{j}",
                 );
@@ -1879,30 +1641,16 @@ mod tests {
 
         // Create a proof over a range, confirm it verifies, then mangle it in various ways.
         let range = Location::new(33)..Location::new(40);
-        let range_proof = mem
-            .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let range_proof = mem.range_proof(&hasher, range.clone(), 0).unwrap();
         let valid_elements = &elements[range.to_usize_range()];
         assert!(
-            range_proof.verify_range_inclusion(
-                &hasher,
-                valid_elements,
-                range.start,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            range_proof.verify_range_inclusion(&hasher, valid_elements, range.start, &root, 0),
             "valid range proof should verify successfully"
         );
         let mut invalid_proof = range_proof.clone();
         invalid_proof.inactive_peaks = 1;
         assert!(
-            !invalid_proof.verify_range_inclusion(
-                &hasher,
-                valid_elements,
-                range.start,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !invalid_proof.verify_range_inclusion(&hasher, valid_elements, range.start, &root, 0),
             "plain range proof with inactive peaks must fail verification"
         );
         // Remove digests from the proof until it's empty.
@@ -1915,7 +1663,7 @@ mod tests {
                     valid_elements,
                     range.start,
                     &root,
-                    RootSpec::FULL_FORWARD
+                    0
                 ),
                 "range proof with removed elements should fail"
             );
@@ -1933,7 +1681,7 @@ mod tests {
                         &elements[i..j],
                         range.start,
                         &root,
-                        RootSpec::FULL_FORWARD,
+                        0,
                     ),
                     "range proof with invalid element range should fail {i}:{j}",
                 );
@@ -1947,7 +1695,7 @@ mod tests {
                 valid_elements,
                 range.start,
                 &invalid_root,
-                RootSpec::FULL_FORWARD,
+                0,
             ),
             "range proof with invalid root should fail"
         );
@@ -1961,7 +1709,7 @@ mod tests {
                     valid_elements,
                     range.start,
                     &root,
-                    RootSpec::FULL_FORWARD
+                    0
                 ),
                 "mangled range proof should fail verification"
             );
@@ -1976,7 +1724,7 @@ mod tests {
                     valid_elements,
                     range.start,
                     &root,
-                    RootSpec::FULL_FORWARD
+                    0
                 ),
                 "mangled range proof should fail verification. inserted element at: {i}",
             );
@@ -1988,13 +1736,7 @@ mod tests {
                 continue;
             }
             assert!(
-                !range_proof.verify_range_inclusion(
-                    &hasher,
-                    valid_elements,
-                    loc,
-                    &root,
-                    RootSpec::FULL_FORWARD
-                ),
+                !range_proof.verify_range_inclusion(&hasher, valid_elements, loc, &root, 0),
                 "bad start_loc should fail verification {loc}",
             );
         }
@@ -2023,7 +1765,7 @@ mod tests {
             assert_eq!(root, pruned_root);
             for loc in 0..elements.len() {
                 let loc = Location::new(loc as u64);
-                let proof = mem.proof(&hasher, loc, RootSpec::FULL_FORWARD);
+                let proof = mem.proof(&hasher, loc, 0);
                 if loc < prune_loc {
                     continue;
                 }
@@ -2033,7 +1775,7 @@ mod tests {
                     &elements[*loc as usize],
                     loc,
                     &root,
-                    RootSpec::FULL_FORWARD,
+                    0,
                 ));
             }
         }
@@ -2066,16 +1808,14 @@ mod tests {
             }
             for j in (i + 2)..elements.len() {
                 let range = Location::new(i as u64)..Location::new(j as u64);
-                let range_proof = mem
-                    .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-                    .unwrap();
+                let range_proof = mem.range_proof(&hasher, range.clone(), 0).unwrap();
                 assert!(
                     range_proof.verify_range_inclusion(
                         &hasher,
                         &elements[range.to_usize_range()],
                         range.start,
                         &root,
-                        RootSpec::FULL_FORWARD,
+                        0,
                     ),
                     "valid range proof over remaining elements should verify successfully",
                 );
@@ -2098,16 +1838,14 @@ mod tests {
 
         let updated_root = plain_root(&mem, &hasher);
         let range = Location::new(elements.len() as u64 - 10)..Location::new(elements.len() as u64);
-        let range_proof = mem
-            .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let range_proof = mem.range_proof(&hasher, range.clone(), 0).unwrap();
         assert!(
             range_proof.verify_range_inclusion(
                 &hasher,
                 &elements[range.to_usize_range()],
                 range.start,
                 &updated_root,
-                RootSpec::FULL_FORWARD,
+                0,
             ),
             "valid range proof over remaining elements after 2 pruning rounds should verify",
         );
@@ -2132,9 +1870,7 @@ mod tests {
         for i in 0..elements.len() {
             for j in i + 1..elements.len() {
                 let range = Location::new(i as u64)..Location::new(j as u64);
-                let proof = mem
-                    .range_proof(&hasher, range, RootSpec::FULL_FORWARD)
-                    .unwrap();
+                let proof = mem.range_proof(&hasher, range, 0).unwrap();
 
                 let expected_size = proof.encode_size();
                 let serialized_proof = proof.encode();
@@ -2224,7 +1960,7 @@ mod tests {
                 (elements[10], Location::new(10)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Verify in different order.
@@ -2236,7 +1972,7 @@ mod tests {
                 (elements[0], Location::new(0)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         let mut invalid_proof = multi_proof.clone();
@@ -2249,7 +1985,7 @@ mod tests {
                 (elements[10], Location::new(10)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Verify with duplicate items.
@@ -2262,7 +1998,7 @@ mod tests {
                 (elements[5], Location::new(5)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Verify mangling the location to something invalid should fail.
@@ -2276,7 +2012,7 @@ mod tests {
                 (elements[10], Location::new(10)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Verify with wrong positions.
@@ -2288,7 +2024,7 @@ mod tests {
                 (elements[10], Location::new(11)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Verify with wrong elements.
@@ -2305,7 +2041,7 @@ mod tests {
                 (wrong_elements[2].as_slice(), Location::new(10)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         );
         assert!(!wrong_verification, "Should fail with wrong elements");
 
@@ -2318,7 +2054,7 @@ mod tests {
                 (elements[10], Location::new(1000)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         );
         assert!(
             !wrong_verification,
@@ -2335,7 +2071,7 @@ mod tests {
                 (elements[10], Location::new(10)),
             ],
             &wrong_root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Empty multi-proof.
@@ -2347,7 +2083,7 @@ mod tests {
             &hasher,
             &[] as &[(D, Location<F>)],
             &empty_root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Malformed empty proof with extra digests must be rejected.
@@ -2360,7 +2096,7 @@ mod tests {
             &hasher,
             &[] as &[(D, Location<F>)],
             &empty_root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
     }
 
@@ -2378,12 +2114,8 @@ mod tests {
         mem.apply_batch(&batch).unwrap();
 
         // Get individual proofs that will share some digests (elements in same subtree).
-        let proof1 = mem
-            .proof(&hasher, Location::new(0), RootSpec::FULL_FORWARD)
-            .unwrap();
-        let proof2 = mem
-            .proof(&hasher, Location::new(1), RootSpec::FULL_FORWARD)
-            .unwrap();
+        let proof1 = mem.proof(&hasher, Location::new(0), 0).unwrap();
+        let proof2 = mem.proof(&hasher, Location::new(1), 0).unwrap();
         let total_digests_separate = proof1.digests.len() + proof2.digests.len();
 
         // Generate multi-proof for the same positions.
@@ -2413,7 +2145,7 @@ mod tests {
                 (elements[1], Location::new(1))
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
     }
 
@@ -2436,27 +2168,15 @@ mod tests {
         let root = plain_root(&mem, &hasher);
 
         let loc = Location::new(240);
-        let proof = mem.proof(&hasher, loc, RootSpec::FULL_FORWARD).unwrap();
-        assert!(proof.verify_element_inclusion(
-            &hasher,
-            &elements[240],
-            loc,
-            &root,
-            RootSpec::FULL_FORWARD
-        ));
+        let proof = mem.proof(&hasher, loc, 0).unwrap();
+        assert!(proof.verify_element_inclusion(&hasher, &elements[240], loc, &root, 0));
 
         // Tamper with the leaves field (249 has the same peak layout for leaf 240).
         let mut tampered = proof.clone();
         tampered.leaves = Location::new(249);
         assert_ne!(tampered, proof);
         assert!(
-            !tampered.verify_element_inclusion(
-                &hasher,
-                &elements[240],
-                loc,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !tampered.verify_element_inclusion(&hasher, &elements[240], loc, &root, 0),
             "proof with tampered leaves field must not verify"
         );
 
@@ -2465,17 +2185,11 @@ mod tests {
         tampered.inactive_peaks = 1;
         assert_ne!(tampered, proof);
         assert!(
-            !tampered.verify_element_inclusion(
-                &hasher,
-                &elements[240],
-                loc,
-                &root,
-                RootSpec::FULL_FORWARD
-            ),
+            !tampered.verify_element_inclusion(&hasher, &elements[240], loc, &root, 0),
             "plain proof with tampered inactive_peaks must not verify"
         );
         assert!(matches!(
-            tampered.reconstruct_root(&hasher, &[elements[240]], loc, RootSpec::FULL_FORWARD),
+            tampered.reconstruct_root(&hasher, &[elements[240]], loc, 0),
             Err(ReconstructionError::InvalidProof)
         ));
     }
@@ -2485,20 +2199,35 @@ mod tests {
 
         // Empty range.
         assert!(matches!(
-            Blueprint::<F>::new(leaves, 0, Location::new(3)..Location::new(3)),
+            Blueprint::<F>::new(
+                leaves,
+                0,
+                Bagging::ForwardFold,
+                Location::new(3)..Location::new(3)
+            ),
             Err(crate::merkle::Error::Empty)
         ));
 
         // Out of bounds.
         assert!(matches!(
-            Blueprint::<F>::new(leaves, 0, Location::new(0)..Location::new(11)),
+            Blueprint::<F>::new(
+                leaves,
+                0,
+                Bagging::ForwardFold,
+                Location::new(0)..Location::new(11)
+            ),
             Err(crate::merkle::Error::RangeOutOfBounds(_))
         ));
 
         // Inactive prefix cannot exceed the number of peaks.
         let peak_count = F::peaks(Position::try_from(leaves).unwrap()).count();
         assert!(matches!(
-            Blueprint::<F>::new(leaves, peak_count + 1, Location::new(0)..Location::new(1)),
+            Blueprint::<F>::new(
+                leaves,
+                peak_count + 1,
+                Bagging::ForwardFold,
+                Location::new(0)..Location::new(1)
+            ),
             Err(crate::merkle::Error::InvalidProof)
         ));
 
@@ -2517,14 +2246,14 @@ mod tests {
 
             for loc_idx in 0..n {
                 let proof = mem
-                    .proof(&hasher, Location::new(loc_idx), RootSpec::FULL_FORWARD)
+                    .proof(&hasher, Location::new(loc_idx), 0)
                     .unwrap_or_else(|e| panic!("n={n}, loc={loc_idx}: build failed: {e:?}"));
 
                 let elements = [loc_idx.to_be_bytes()];
                 let start_loc = Location::new(loc_idx);
 
                 let reconstructed = proof
-                    .reconstruct_root(&hasher, &elements, start_loc, RootSpec::FULL_FORWARD)
+                    .reconstruct_root(&hasher, &elements, start_loc, 0)
                     .unwrap_or_else(|e| panic!("n={n}, loc={loc_idx}: reconstruct failed: {e:?}"));
                 assert_eq!(reconstructed, root, "n={n}, loc={loc_idx}: root mismatch");
             }
@@ -2550,17 +2279,13 @@ mod tests {
                     continue;
                 }
                 let proof = mem
-                    .range_proof(
-                        &hasher,
-                        Location::new(start)..Location::new(end),
-                        RootSpec::FULL_FORWARD,
-                    )
+                    .range_proof(&hasher, Location::new(start)..Location::new(end), 0)
                     .unwrap_or_else(|e| panic!("n={n}, range={start}..{end}: build failed: {e:?}"));
                 let elements: Vec<_> = (start..end).map(|i| i.to_be_bytes()).collect();
                 let start_loc = Location::new(start);
 
                 let reconstructed = proof
-                    .reconstruct_root(&hasher, &elements, start_loc, RootSpec::FULL_FORWARD)
+                    .reconstruct_root(&hasher, &elements, start_loc, 0)
                     .unwrap_or_else(|e| {
                         panic!("n={n}, range={start}..{end}: reconstruct failed: {e}")
                     });
@@ -2579,19 +2304,11 @@ mod tests {
             let root = plain_root(&mem, &hasher);
 
             for loc_idx in 0..n {
-                let proof = mem
-                    .proof(&hasher, Location::new(loc_idx), RootSpec::FULL_FORWARD)
-                    .unwrap();
+                let proof = mem.proof(&hasher, Location::new(loc_idx), 0).unwrap();
                 let loc = Location::new(loc_idx);
 
                 assert!(
-                    proof.verify_element_inclusion(
-                        &hasher,
-                        &loc_idx.to_be_bytes(),
-                        loc,
-                        &root,
-                        RootSpec::FULL_FORWARD
-                    ),
+                    proof.verify_element_inclusion(&hasher, &loc_idx.to_be_bytes(), loc, &root, 0),
                     "n={n}, loc={loc_idx}: verification failed"
                 );
 
@@ -2602,7 +2319,7 @@ mod tests {
                         &(loc_idx + 1000).to_be_bytes(),
                         loc,
                         &root,
-                        RootSpec::FULL_FORWARD,
+                        0,
                     ),
                     "n={n}, loc={loc_idx}: wrong element should not verify"
                 );
@@ -2617,15 +2334,11 @@ mod tests {
             let root = plain_root(&mem, &hasher);
 
             let proof = mem
-                .range_proof(
-                    &hasher,
-                    Location::new(0)..Location::new(n),
-                    RootSpec::FULL_FORWARD,
-                )
+                .range_proof(&hasher, Location::new(0)..Location::new(n), 0)
                 .unwrap();
             let elements: Vec<_> = (0..n).map(|i| i.to_be_bytes()).collect();
             let reconstructed = proof
-                .reconstruct_root(&hasher, &elements, Location::new(0), RootSpec::FULL_FORWARD)
+                .reconstruct_root(&hasher, &elements, Location::new(0), 0)
                 .unwrap();
             assert_eq!(reconstructed, root, "n={n}: full range failed");
 
@@ -2645,13 +2358,7 @@ mod tests {
         let proof = Proof::<F, D>::default();
 
         // Empty proof should verify against the empty root.
-        assert!(proof.verify_range_inclusion(
-            &hasher,
-            &[] as &[&[u8]],
-            Location::new(0),
-            &root,
-            RootSpec::FULL_FORWARD
-        ));
+        assert!(proof.verify_range_inclusion(&hasher, &[] as &[&[u8]], Location::new(0), &root, 0));
 
         let mut inactive_proof = proof.clone();
         inactive_proof.inactive_peaks = 1;
@@ -2660,13 +2367,13 @@ mod tests {
             &[] as &[&[u8]],
             Location::new(0),
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
         assert!(!inactive_proof.verify_multi_inclusion(
             &hasher,
             &[] as &[(&[u8], Location<F>)],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Non-zero start_loc with empty elements should fail.
@@ -2675,7 +2382,7 @@ mod tests {
             &[] as &[&[u8]],
             Location::new(1),
             &root,
-            RootSpec::FULL_FORWARD
+            0
         ));
     }
 
@@ -2688,23 +2395,13 @@ mod tests {
             let start = 1;
             let end = n - 1;
             let proof = mem
-                .range_proof(
-                    &hasher,
-                    Location::new(start)..Location::new(end),
-                    RootSpec::FULL_FORWARD,
-                )
+                .range_proof(&hasher, Location::new(start)..Location::new(end), 0)
                 .unwrap();
             let elements: Vec<_> = (start..end).map(|i| i.to_be_bytes()).collect();
 
             // Valid elements verify.
             assert!(
-                proof.verify_range_inclusion(
-                    &hasher,
-                    &elements,
-                    Location::new(start),
-                    &root,
-                    RootSpec::FULL_FORWARD
-                ),
+                proof.verify_range_inclusion(&hasher, &elements, Location::new(start), &root, 0),
                 "n={n}: valid range should verify"
             );
 
@@ -2718,7 +2415,7 @@ mod tests {
                         &tampered,
                         Location::new(start),
                         &root,
-                        RootSpec::FULL_FORWARD
+                        0
                     ),
                     "n={n}: tampered element at index {flip_idx} should not verify"
                 );
@@ -2754,7 +2451,7 @@ mod tests {
                 (10u64.to_be_bytes(), Location::new(10)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Different order should also verify.
@@ -2766,7 +2463,7 @@ mod tests {
                 (0u64.to_be_bytes(), Location::new(0)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Wrong elements should fail.
@@ -2778,7 +2475,7 @@ mod tests {
                 (10u64.to_be_bytes(), Location::new(10)),
             ],
             &root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Wrong root should fail.
@@ -2791,7 +2488,7 @@ mod tests {
                 (10u64.to_be_bytes(), Location::new(10)),
             ],
             &wrong_root,
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Empty multi-proof on empty tree.
@@ -2802,7 +2499,7 @@ mod tests {
             &hasher2,
             &[] as &[([u8; 8], Location<F>)],
             &plain_root(&empty_mem, &hasher2),
-            RootSpec::FULL_FORWARD,
+            0,
         ));
 
         // Malformed empty proof with extra digests must be rejected.
@@ -2815,7 +2512,7 @@ mod tests {
             &hasher2,
             &[] as &[([u8; 8], Location<F>)],
             &plain_root(&empty_mem, &hasher2),
-            RootSpec::FULL_FORWARD,
+            0,
         ));
     }
 
@@ -2826,31 +2523,17 @@ mod tests {
             let root = plain_root(&mem, &hasher);
 
             for loc_idx in [0, n / 2, n - 1] {
-                let proof = mem
-                    .proof(&hasher, Location::new(loc_idx), RootSpec::FULL_FORWARD)
-                    .unwrap();
+                let proof = mem.proof(&hasher, Location::new(loc_idx), 0).unwrap();
                 let element = loc_idx.to_be_bytes();
                 let loc = Location::new(loc_idx);
 
-                assert!(proof.verify_element_inclusion(
-                    &hasher,
-                    &element,
-                    loc,
-                    &root,
-                    RootSpec::FULL_FORWARD
-                ));
+                assert!(proof.verify_element_inclusion(&hasher, &element, loc, &root, 0));
 
                 for digest_idx in 0..proof.digests.len() {
                     let mut tampered = proof.clone();
                     tampered.digests[digest_idx].0[0] ^= 1;
                     assert!(
-                        !tampered.verify_element_inclusion(
-                            &hasher,
-                            &element,
-                            loc,
-                            &root,
-                            RootSpec::FULL_FORWARD
-                        ),
+                        !tampered.verify_element_inclusion(&hasher, &element, loc, &root, 0),
                         "n={n}, loc={loc_idx}: tampered digest[{digest_idx}] should not verify"
                     );
                 }
@@ -2866,7 +2549,8 @@ mod tests {
             let leaves = mem.leaves();
             for loc in 0..n {
                 let loc = Location::new(loc);
-                let bp = Blueprint::<F>::new(leaves, 0, loc..loc + 1).unwrap();
+                let bp =
+                    Blueprint::<F>::new(leaves, 0, Bagging::ForwardFold, loc..loc + 1).unwrap();
                 let mut positions: Vec<Position<F>> = Vec::new();
                 positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
                 positions.extend(&bp.fetch_nodes);
@@ -2921,7 +2605,7 @@ mod tests {
                 .range_proof(
                     &hasher,
                     Location::<F>::new(start)..Location::<F>::new(start + 1),
-                    RootSpec::FULL_FORWARD,
+                    0,
                 )
                 .unwrap();
 
@@ -2932,7 +2616,7 @@ mod tests {
                     Location::<F>::new(start),
                     &pinned,
                     &root,
-                    RootSpec::FULL_FORWARD,
+                    0,
                 ),
                 "verify_proof_and_pinned_nodes failed: leaves={n}, start={start}"
             );

--- a/storage/src/merkle/read.rs
+++ b/storage/src/merkle/read.rs
@@ -9,9 +9,9 @@ use core::ops::Range;
 ///
 /// This trait covers structural reads (size, leaves, retained nodes, pruning boundary). Proof
 /// construction is intentionally *not* part of the trait: every concrete implementation exposes
-/// inherent `proof` / `range_proof` methods that take an explicit [`crate::merkle::RootSpec`], so
-/// callers cannot accidentally pair a split-spec root with a forward-fold proof from the same
-/// state.
+/// inherent `proof` / `range_proof` methods that take an explicit `inactive_peaks` count and read
+/// the bagging policy from the supplied [`crate::merkle::hasher::Hasher`], so callers cannot
+/// accidentally pair a split-spec root with a forward-fold proof from the same state.
 pub trait Readable: Send + Sync {
     /// The Merkle family implemented by this structure.
     type Family: Family;

--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -15,7 +15,7 @@ use crate::merkle::{
     hasher::Hasher,
     proof::{self as merkle_proof, Blueprint},
     storage::Storage,
-    Bagging, Error, Family, Location, Position, Proof, RootSpec,
+    Bagging, Error, Family, Location, Position, Proof,
 };
 use commonware_cryptography::Digest;
 use core::ops::Range;
@@ -56,32 +56,22 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
         elements: &[E],
         start_loc: Location<F>,
         root: &D,
-        spec: RootSpec,
+        inactive_peaks: usize,
     ) -> Result<Self, Error<F>>
     where
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
     {
-        if proof.inactive_peaks != spec.inactive_peaks() {
+        if proof.inactive_peaks != inactive_peaks {
             return Err(Error::InvalidProof);
         }
-        Self::new_using_policy(hasher, proof, elements, start_loc, root, spec.bagging())
-    }
-
-    pub(crate) fn new_using_policy<H, E>(
-        hasher: &H,
-        proof: &Proof<F, D>,
-        elements: &[E],
-        start_loc: Location<F>,
-        root: &D,
-        bagging: Bagging,
-    ) -> Result<Self, Error<F>>
-    where
-        H: Hasher<F, Digest = D>,
-        E: AsRef<[u8]>,
-    {
-        let digests = proof.verify_range_inclusion_and_extract_digests_using_policy(
-            hasher, elements, start_loc, root, bagging,
+        let bagging = hasher.root_bagging();
+        let digests = proof.verify_range_inclusion_and_extract_digests(
+            hasher,
+            elements,
+            start_loc,
+            root,
+            inactive_peaks,
         )?;
         let map: HashMap<Position<F>, D> = digests.into_iter().collect();
 
@@ -92,7 +82,7 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
         let end_loc = start_loc
             .checked_add(elements.len() as u64)
             .ok_or(Error::LocationOverflow(F::MAX_LEAVES))?;
-        let bp = Blueprint::<F>::new_using_policy(
+        let bp = Blueprint::<F>::new(
             proof.leaves,
             proof.inactive_peaks,
             bagging,
@@ -136,7 +126,7 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
         range: Range<Location<F>>,
     ) -> Result<Proof<F, D>, Error<F>> {
         let leaves = Location::try_from(self.size)?;
-        let bp = Blueprint::new_using_policy(leaves, self.inactive_peaks, self.bagging, range)?;
+        let bp = Blueprint::new(leaves, self.inactive_peaks, self.bagging, range)?;
 
         let mut digests: Vec<D> = Vec::new();
         if !bp.fold_prefix.is_empty() {
@@ -310,10 +300,10 @@ pub async fn range_proof<
     hasher: &H,
     merkle: &S,
     range: Range<Location<F>>,
-    spec: RootSpec,
+    inactive_peaks: usize,
 ) -> Result<Proof<F, D>, Error<F>> {
     let leaves = Location::try_from(merkle.size().await)?;
-    historical_range_proof(hasher, merkle, leaves, range, spec).await
+    historical_range_proof(hasher, merkle, leaves, range, inactive_peaks).await
 }
 
 /// Analogous to range_proof but for a previous database state. Specifically, the state when the
@@ -335,35 +325,9 @@ pub async fn historical_range_proof<
     merkle: &S,
     leaves: Location<F>,
     range: Range<Location<F>>,
-    spec: RootSpec,
-) -> Result<Proof<F, D>, Error<F>> {
-    historical_range_proof_using_policy(
-        hasher,
-        merkle,
-        leaves,
-        spec.inactive_peaks(),
-        spec.bagging(),
-        range,
-    )
-    .await
-}
-
-/// Analogous to [`historical_range_proof`] but lets internal callers select the decomposed root
-/// bagging pieces. Prefer [`historical_range_proof`] when a complete root spec is available.
-pub(crate) async fn historical_range_proof_using_policy<
-    F: Family,
-    D: Digest,
-    H: Hasher<F, Digest = D>,
-    S: Storage<F, Digest = D>,
->(
-    hasher: &H,
-    merkle: &S,
-    leaves: Location<F>,
     inactive_peaks: usize,
-    bagging: Bagging,
-    range: Range<Location<F>>,
 ) -> Result<Proof<F, D>, Error<F>> {
-    let bp = Blueprint::new_using_policy(leaves, inactive_peaks, bagging, range)?;
+    let bp = Blueprint::new(leaves, inactive_peaks, hasher.root_bagging(), range)?;
 
     let mut all_positions = BTreeSet::new();
     all_positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
@@ -403,17 +367,6 @@ pub(crate) async fn historical_range_proof_using_policy<
 /// Returns [Error::Empty] if locations is empty
 pub async fn multi_proof<F: Family, D: Digest, S: Storage<F, Digest = D>>(
     merkle: &S,
-    spec: RootSpec,
-    locations: &[Location<F>],
-) -> Result<Proof<F, D>, Error<F>> {
-    multi_proof_using_policy(merkle, spec.inactive_peaks(), spec.bagging(), locations).await
-}
-
-/// Return a multi proof for the elements at the specified locations using decomposed root bagging
-/// pieces. Multi-proofs stay position-keyed, so backward-bagged split proofs may include active
-/// peaks that range proofs can collapse into a suffix accumulator.
-pub(crate) async fn multi_proof_using_policy<F: Family, D: Digest, S: Storage<F, Digest = D>>(
-    merkle: &S,
     inactive_peaks: usize,
     bagging: Bagging,
     locations: &[Location<F>],
@@ -452,7 +405,7 @@ pub(crate) async fn multi_proof_using_policy<F: Family, D: Digest, S: Storage<F,
 mod tests {
     use super::*;
     use crate::{
-        merkle::{LocationRangeExt as _, RootSpec},
+        merkle::LocationRangeExt as _,
         mmb::{mem::Mmb, Location as MmbLocation},
         mmr::{mem::Mmr, StandardHasher as Standard},
     };
@@ -480,18 +433,17 @@ mod tests {
                 batch.merkleize(&mmr, &hasher)
             };
             mmr.apply_batch(&batch).unwrap();
-            let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root = mmr.root(&hasher, 0).unwrap();
 
-            let inactive_peaks = 1;
-            let inactive_spec = RootSpec::split_forward(inactive_peaks);
-            let inactive_root = mmr.root(&hasher, inactive_spec).unwrap();
+            let inactive_peaks = 1usize;
+            let inactive_root = mmr.root(&hasher, inactive_peaks).unwrap();
             let inactive_range = Location::new(32)..Location::new(49);
             let inactive_proof = historical_range_proof(
                 &hasher,
                 &mmr,
                 mmr.leaves(),
                 inactive_range.clone(),
-                inactive_spec,
+                inactive_peaks,
             )
             .await
             .unwrap();
@@ -501,7 +453,7 @@ mod tests {
                 &elements[inactive_range.to_usize_range()],
                 inactive_range.start,
                 &inactive_root,
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .is_err());
             assert!(ProofStore::new(
@@ -510,7 +462,7 @@ mod tests {
                 &elements[inactive_range.to_usize_range()],
                 inactive_range.start,
                 &inactive_root,
-                inactive_spec,
+                inactive_peaks,
             )
             .is_ok());
 
@@ -520,16 +472,14 @@ mod tests {
             let mut range_end = Location::new(49);
             while range_start < range_end {
                 let range = range_start..range_end;
-                let range_proof = mmr
-                    .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-                    .unwrap();
+                let range_proof = mmr.range_proof(&hasher, range.clone(), 0).unwrap();
                 let proof_store = ProofStore::new(
                     &hasher,
                     &range_proof,
                     &elements[range.to_usize_range()],
                     range_start,
                     &root,
-                    RootSpec::FULL_FORWARD,
+                    0,
                 )
                 .unwrap();
 
@@ -548,7 +498,7 @@ mod tests {
                         &elements[sub_range.to_usize_range()],
                         sub_range.start,
                         &root,
-                        RootSpec::FULL_FORWARD,
+                        0,
                     ));
                     subrange_start += 1;
                     subrange_end -= 1;
@@ -576,22 +526,20 @@ mod tests {
                 batch.merkleize(&mmr, &hasher)
             };
             mmr.apply_batch(&batch).unwrap();
-            let root = mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root = mmr.root(&hasher, 0).unwrap();
 
             // Proof for range 32..49 has a non-empty fold prefix (the 32-leaf peak).
             // The ProofStore derives the fold accumulator from the proof itself, so
             // sub-proofs should succeed for all sub-ranges without needing peaks.
             let range = Location::new(32)..Location::new(49);
-            let range_proof = mmr
-                .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-                .unwrap();
+            let range_proof = mmr.range_proof(&hasher, range.clone(), 0).unwrap();
             let proof_store = ProofStore::new(
                 &hasher,
                 &range_proof,
                 &elements[range.to_usize_range()],
                 range.start,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .unwrap();
 
@@ -606,7 +554,7 @@ mod tests {
                             &elements[sub_range.to_usize_range()],
                             sub_range.start,
                             &root,
-                            RootSpec::FULL_FORWARD,
+                            0,
                         ),
                         "sub-proof should verify for range {start}..{end}"
                     );
@@ -630,22 +578,20 @@ mod tests {
                 batch.merkleize(&mmb, &hasher)
             };
             mmb.apply_batch(&batch).unwrap();
-            let root = mmb.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let root = mmb.root(&hasher, 0).unwrap();
 
             // With 8 leaves, the oldest MMB peak covers locations 0..4 but sits at position 7,
             // while the first leaf in the proven range (location 4) sits at position 6.
             // A position-based peak comparison therefore misclassifies the fold prefix.
             let range = MmbLocation::new(4)..MmbLocation::new(8);
-            let range_proof = mmb
-                .range_proof(&hasher, range.clone(), RootSpec::FULL_FORWARD)
-                .unwrap();
+            let range_proof = mmb.range_proof(&hasher, range.clone(), 0).unwrap();
             let proof_store = ProofStore::new(
                 &hasher,
                 &range_proof,
                 &elements[range.to_usize_range()],
                 range.start,
                 &root,
-                RootSpec::FULL_FORWARD,
+                0,
             )
             .unwrap();
 
@@ -659,7 +605,7 @@ mod tests {
                             &elements[sub_range.to_usize_range()],
                             sub_range.start,
                             &root,
-                            RootSpec::FULL_FORWARD,
+                            0,
                         ),
                         "sub-proof should verify for MMB range {start}..{end}"
                     );
@@ -684,20 +630,21 @@ mod tests {
                 batch.merkleize(&mmb, &hasher)
             };
             mmb.apply_batch(&batch).unwrap();
-            let spec = RootSpec::split_backward(inactive_peaks);
-            let root = mmb.root(&hasher, spec).unwrap();
+            let hasher: Standard<Sha256> = Standard::backward();
+            let root = mmb.root(&hasher, inactive_peaks).unwrap();
 
             let range = MmbLocation::new(0)..MmbLocation::new(1);
-            let proof = historical_range_proof(&hasher, &mmb, mmb.leaves(), range.clone(), spec)
-                .await
-                .unwrap();
+            let proof =
+                historical_range_proof(&hasher, &mmb, mmb.leaves(), range.clone(), inactive_peaks)
+                    .await
+                    .unwrap();
             let proof_store = ProofStore::new(
                 &hasher,
                 &proof,
                 &elements[range.to_usize_range()],
                 range.start,
                 &root,
-                spec,
+                inactive_peaks,
             )
             .unwrap();
 
@@ -707,7 +654,7 @@ mod tests {
                 &elements[range.to_usize_range()],
                 range.start,
                 &root,
-                spec,
+                inactive_peaks,
             ));
             assert!(matches!(
                 proof_store.range_proof(&hasher, MmbLocation::new(64)..MmbLocation::new(65)),
@@ -749,12 +696,12 @@ mod tests {
             let total_leaves = *mmb.leaves();
             assert!(active_start > 0 && active_start < total_leaves);
 
-            let spec = RootSpec::split_backward(inactive_peaks);
-            let root = mmb.root(&hasher, spec).unwrap();
+            let hasher: Standard<Sha256> = Standard::backward();
+            let root = mmb.root(&hasher, inactive_peaks).unwrap();
 
             let range = MmbLocation::new(active_start)..MmbLocation::new(total_leaves);
             let range_proof =
-                historical_range_proof(&hasher, &mmb, mmb.leaves(), range.clone(), spec)
+                historical_range_proof(&hasher, &mmb, mmb.leaves(), range.clone(), inactive_peaks)
                     .await
                     .unwrap();
             let proof_store = ProofStore::new(
@@ -763,7 +710,7 @@ mod tests {
                 &elements[range.to_usize_range()],
                 range.start,
                 &root,
-                spec,
+                inactive_peaks,
             )
             .unwrap();
 
@@ -778,7 +725,7 @@ mod tests {
                             &elements[sub_range.to_usize_range()],
                             sub_range.start,
                             &root,
-                            spec,
+                            inactive_peaks,
                         ),
                         "sub-proof should verify for MMB range {start}..{end} with split_backward({inactive_peaks})"
                     );
@@ -817,8 +764,9 @@ mod tests {
                 batch.merkleize(&mmb, &hasher)
             };
             mmb.apply_batch(&batch).unwrap();
-            let spec = RootSpec::split_backward(0);
-            let root = mmb.root(&hasher, spec).unwrap();
+            let hasher: Standard<Sha256> = Standard::backward();
+            let inactive_peaks = 0usize;
+            let root = mmb.root(&hasher, inactive_peaks).unwrap();
 
             let target = vec![MmbLocation::new(0)];
             let selected: Vec<_> = target
@@ -827,14 +775,16 @@ mod tests {
                 .collect();
 
             // Case 1: multi-proof built from the source structure with the full witness verifies.
-            let direct = multi_proof(&mmb, spec, &target).await.unwrap();
-            assert!(direct.verify_multi_inclusion(&hasher, &selected, &root, spec));
+            let direct = multi_proof(&mmb, inactive_peaks, Bagging::BackwardFold, &target)
+                .await
+                .unwrap();
+            assert!(direct.verify_multi_inclusion(&hasher, &selected, &root, inactive_peaks));
 
             // Build a ProofStore from a backward-folded range proof over a single leaf.
             // The other ~6 active peaks are folded into one synthetic suffix accumulator.
             let range = MmbLocation::new(0)..MmbLocation::new(1);
             let range_proof =
-                historical_range_proof(&hasher, &mmb, mmb.leaves(), range.clone(), spec)
+                historical_range_proof(&hasher, &mmb, mmb.leaves(), range.clone(), inactive_peaks)
                     .await
                     .unwrap();
             let proof_store = ProofStore::new(
@@ -843,7 +793,7 @@ mod tests {
                 &elements[range.to_usize_range()],
                 range.start,
                 &root,
-                spec,
+                inactive_peaks,
             )
             .unwrap();
 
@@ -877,7 +827,7 @@ mod tests {
                 .map(|&pos| (pos, mmb.get_node(pos).unwrap()))
                 .collect();
             let derived = proof_store.multi_proof(&target, &peaks).unwrap();
-            assert!(derived.verify_multi_inclusion(&hasher, &selected, &root, spec));
+            assert!(derived.verify_multi_inclusion(&hasher, &selected, &root, inactive_peaks));
         });
     }
 }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -707,13 +707,13 @@ where
         // re-encoded, or re-hashed.
         let ops = Arc::new(ops);
         let leaves = Location::new(self.base_size + ops.len() as u64);
-        let spec = db.root_spec(leaves, floor);
+        let inactive_peaks = db.inactive_peaks(leaves, floor);
         let journal = db
             .log
             .with_mem(|base| self.journal_batch.merkleize_with(base, ops));
         let root = db
             .log
-            .with_mem(|base| journal.root(base, &db.log.hasher, spec))?;
+            .with_mem(|base| journal.root(base, &db.log.hasher, inactive_peaks))?;
 
         let ancestor_diffs: Vec<_> = self.ancestors.iter().map(|a| Arc::clone(&a.diff)).collect();
         let ancestor_diff_ends: Vec<_> = self.ancestors.iter().map(|a| a.total_size).collect();

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -13,7 +13,7 @@ use crate::{
         contiguous::{Contiguous, Mutable, Reader},
         Error as JournalError,
     },
-    merkle::{Bagging, Family, Location, Proof, RootSpec},
+    merkle::{Bagging, Family, Location, Proof},
     qmdb::{
         bitmap::Shared, build_snapshot_from_log, delete_known_loc,
         operation::Operation as OperationTrait, update_known_loc, Error,
@@ -80,6 +80,7 @@ pub struct Db<
     pub(crate) split_root: bool,
 
     /// Bagging used by the operations root.
+    #[allow(dead_code)]
     pub(crate) root_bagging: Bagging,
 
     /// A location before which all operations are "inactive" (that is, operations before this point
@@ -159,10 +160,18 @@ where
         self.root
     }
 
-    /// Return the operations-root spec for the given leaf count and inactivity floor.
-    pub(crate) fn root_spec(&self, leaves: Location<F>, inactivity_floor: Location<F>) -> RootSpec {
-        let inactive_peaks = F::inactive_peaks(F::location_to_position(leaves), inactivity_floor);
-        RootSpec::from_split_policy(self.split_root, self.root_bagging, inactive_peaks)
+    /// Return the inactive_peaks count for the given leaf count and inactivity floor.
+    ///
+    /// Returns 0 when `split_root` is false (the boundary is not committed in that case).
+    pub(crate) fn inactive_peaks(
+        &self,
+        leaves: Location<F>,
+        inactivity_floor: Location<F>,
+    ) -> usize {
+        if !self.split_root {
+            return 0;
+        }
+        F::inactive_peaks(F::location_to_position(leaves), inactivity_floor)
     }
 
     /// Get the value of `key` in the db, or None if it has no value.
@@ -355,9 +364,9 @@ where
         } else {
             Location::new(0)
         };
-        let spec = self.root_spec(historical_size, inactivity_floor);
+        let inactive_peaks = self.inactive_peaks(historical_size, inactivity_floor);
         self.log
-            .historical_proof(historical_size, start_loc, max_ops, spec)
+            .historical_proof(historical_size, start_loc, max_ops, inactive_peaks)
             .await
             .map_err(Into::into)
     }
@@ -534,7 +543,7 @@ where
         self.inactivity_floor_loc = rewind_floor;
         self.root = self
             .log
-            .root(self.root_spec(Location::new(rewind_size), rewind_floor))?;
+            .root(self.inactive_peaks(Location::new(rewind_size), rewind_floor))?;
 
         Ok(())
     }
@@ -643,15 +652,15 @@ where
             ));
         }
 
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(log.merkle.leaves()),
-            inactivity_floor_loc,
-        );
-        let root = log.root(RootSpec::from_split_policy(
-            split_root,
-            root_bagging,
-            inactive_peaks,
-        ))?;
+        let inactive_peaks = if split_root {
+            F::inactive_peaks(
+                F::location_to_position(log.merkle.leaves()),
+                inactivity_floor_loc,
+            )
+        } else {
+            0
+        };
+        let root = log.root(inactive_peaks)?;
 
         Ok(Self {
             log,

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -156,11 +156,14 @@ where
     J: Inner<E, Item = Operation<F, U>>,
     Operation<F, U>: Committable + CodecShared,
 {
+    let split_root = cfg.split_root;
+    let root_bagging = cfg.root_bagging;
     let mut log = J::init::<F, H>(
         context.with_label("log"),
         cfg.merkle_config,
         cfg.journal_config,
         Operation::is_commit,
+        root_bagging,
     )
     .await?;
 
@@ -171,8 +174,6 @@ where
         log.sync().await?;
     }
 
-    let split_root = cfg.split_root;
-    let root_bagging = cfg.root_bagging;
     let index = I::new(context.with_label("index"), cfg.translator);
     db::Db::init_from_log(index, log, bitmap, split_root, root_bagging).await
 }
@@ -212,7 +213,7 @@ pub(crate) mod test {
     const PAGE_SIZE: NonZeroU16 = NZU16!(101);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(11);
 
-    pub(crate) fn fixed_db_config<F: qmdb::RootSpec, T: Translator + Default>(
+    pub(crate) fn fixed_db_config<F: qmdb::Bagging, T: Translator + Default>(
         suffix: &str,
         pooler: &impl BufferPooler,
     ) -> FixedConfig<T> {
@@ -234,11 +235,11 @@ pub(crate) mod test {
             },
             translator: T::default(),
             split_root: true,
-            root_bagging: F::root_spec(0).bagging(),
+            root_bagging: <F as qmdb::Bagging>::BAGGING,
         }
     }
 
-    pub(crate) fn variable_db_config<F: qmdb::RootSpec, T: Translator + Default>(
+    pub(crate) fn variable_db_config<F: qmdb::Bagging, T: Translator + Default>(
         suffix: &str,
         pooler: &impl BufferPooler,
     ) -> VariableConfig<T, ((), ())> {
@@ -262,7 +263,7 @@ pub(crate) mod test {
             },
             translator: T::default(),
             split_root: true,
-            root_bagging: F::root_spec(0).bagging(),
+            root_bagging: <F as qmdb::Bagging>::BAGGING,
         }
     }
 
@@ -638,10 +639,7 @@ pub(crate) mod test {
         V: CodecShared + Clone + Eq + std::hash::Hash + std::fmt::Debug,
         <D as Provable<mmr::Family>>::Operation: Codec,
     {
-        use crate::{
-            mmr::StandardHasher,
-            qmdb::{verify_proof, RootSpec as _},
-        };
+        use crate::{mmr::StandardHasher, qmdb::verify_proof};
 
         const ELEMENTS: u64 = 1000;
 
@@ -709,7 +707,7 @@ pub(crate) mod test {
         for loc in *inactivity_floor..*bounds.end {
             let loc = Location::new(loc);
             let (proof, ops) = db.proof(loc, NZU64!(10)).await.unwrap();
-            let spec = mmr::Family::root_spec(proof.inactive_peaks);
+            let spec = proof.inactive_peaks;
             assert!(verify_proof(&hasher, &proof, loc, &ops, &root, spec));
         }
 
@@ -764,10 +762,7 @@ pub(crate) mod test {
         D: DbAny<mmr::Family, Key = Digest, Value = V, Digest = Digest> + Provable<mmr::Family>,
         <D as Provable<mmr::Family>>::Operation: Codec + PartialEq + std::fmt::Debug,
     {
-        use crate::{
-            mmr::StandardHasher,
-            qmdb::{verify_proof, RootSpec as _},
-        };
+        use crate::{mmr::StandardHasher, qmdb::verify_proof};
         use commonware_utils::NZU64;
 
         // Add some operations
@@ -804,7 +799,7 @@ pub(crate) mod test {
             start_loc,
             &historical_ops,
             &root_hash,
-            mmr::Family::root_spec(historical_proof.inactive_peaks),
+            historical_proof.inactive_peaks,
         ));
 
         // Add more operations to the database
@@ -833,7 +828,7 @@ pub(crate) mod test {
             start_loc,
             &historical_ops2,
             &root_hash,
-            mmr::Family::root_spec(historical_proof2.inactive_peaks),
+            historical_proof2.inactive_peaks,
         ));
 
         db.destroy().await.unwrap();
@@ -848,10 +843,7 @@ pub(crate) mod test {
         D: DbAny<mmr::Family, Key = Digest, Value = V, Digest = Digest> + Provable<mmr::Family>,
         <D as Provable<mmr::Family>>::Operation: Codec + PartialEq + std::fmt::Debug + Clone,
     {
-        use crate::{
-            mmr::StandardHasher,
-            qmdb::{verify_proof, RootSpec as _},
-        };
+        use crate::{mmr::StandardHasher, qmdb::verify_proof};
         use commonware_utils::NZU64;
 
         // Apply two single-write batches and capture the commit-boundary size after the
@@ -882,8 +874,7 @@ pub(crate) mod test {
         assert_eq!(ops.len(), expected_ops_len);
 
         let hasher = StandardHasher::<Sha256>::new();
-
-        let spec = mmr::Family::root_spec(proof.inactive_peaks);
+        let inactive_peaks = proof.inactive_peaks;
 
         // Changing the proof digests should cause verification to fail
         {
@@ -896,7 +887,7 @@ pub(crate) mod test {
                 Location::new(1),
                 &ops,
                 &root_hash,
-                spec,
+                inactive_peaks,
             ));
         }
 
@@ -911,7 +902,7 @@ pub(crate) mod test {
                 Location::new(1),
                 &ops,
                 &root_hash,
-                spec,
+                inactive_peaks,
             ));
         }
 
@@ -928,7 +919,7 @@ pub(crate) mod test {
                     Location::new(1),
                     &tampered_ops,
                     &root_hash,
-                    spec,
+                    inactive_peaks,
                 ));
             }
         }
@@ -944,7 +935,7 @@ pub(crate) mod test {
                 Location::new(1),
                 &tampered_ops,
                 &root_hash,
-                spec,
+                inactive_peaks,
             ));
         }
 
@@ -957,7 +948,7 @@ pub(crate) mod test {
                 Location::new(2),
                 &ops,
                 &root_hash,
-                spec,
+                inactive_peaks,
             ));
         }
 
@@ -970,7 +961,7 @@ pub(crate) mod test {
                 Location::new(1),
                 &ops,
                 &invalid_root,
-                spec,
+                inactive_peaks,
             ));
         }
 
@@ -985,7 +976,7 @@ pub(crate) mod test {
                 Location::new(1),
                 &ops,
                 &root_hash,
-                spec,
+                inactive_peaks,
             ));
         }
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -10,7 +10,7 @@ use crate::{
     merkle::{Family, Location},
     qmdb::{
         any::{ordered, value::FixedEncoding, FixedConfig as Config, FixedValue},
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context,
@@ -26,7 +26,7 @@ pub type Operation<F, K, V> = ordered::Operation<F, K, FixedEncoding<V>>;
 pub type Db<F, E, K, V, H, T> =
     super::Db<F, E, Journal<E, Operation<F, K, V>>, Index<T, Location<F>>, H, Update<K, V>>;
 
-impl<F: Family + RootSpec, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator>
+impl<F: Family + Bagging, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator>
     Db<F, E, K, V, H, T>
 {
     /// Returns a [Db] qmdb initialized from `cfg`. Any uncommitted log operations will be
@@ -49,7 +49,7 @@ pub mod partitioned {
         merkle::{Family, Location},
         qmdb::{
             any::{FixedConfig as Config, FixedValue},
-            Error, RootSpec,
+            Bagging, Error,
         },
         translator::Translator,
         Context,
@@ -76,7 +76,7 @@ pub mod partitioned {
     >;
 
     impl<
-            F: Family + RootSpec,
+            F: Family + Bagging,
             E: Context,
             K: Array,
             V: FixedValue,
@@ -125,7 +125,7 @@ pub(crate) mod test {
                 },
                 test::fixed_db_config,
             },
-            verify_proof, RootSpec,
+            verify_proof, Bagging,
         },
         translator::{OneCap, TwoCap},
     };
@@ -159,7 +159,7 @@ pub(crate) mod test {
         Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap>;
 
     /// Return an `Any` database initialized with a fixed config, generic over merkle family.
-    async fn open_db_generic<F: Family + RootSpec>(
+    async fn open_db_generic<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> AnyTestGeneric<F> {
         let cfg = fixed_db_config::<mmr::Family, TwoCap>("partition", &context);
@@ -434,7 +434,7 @@ pub(crate) mod test {
             for i in start_loc.as_u64()..end_loc.as_u64() {
                 let loc = Location::from(i);
                 let (proof, log) = db.proof(loc, max_ops).await.unwrap();
-                let spec = mmr::Family::root_spec(proof.inactive_peaks);
+                let spec = proof.inactive_peaks;
                 assert!(verify_proof(&hasher, &proof, loc, &log, &root, spec));
             }
 
@@ -684,7 +684,7 @@ pub(crate) mod test {
                 Location::new(5),
                 &historical_ops,
                 &root_hash,
-                mmr::Family::root_spec(historical_proof.inactive_peaks),
+                historical_proof.inactive_peaks,
             ));
 
             // Add more operations to the database
@@ -708,7 +708,7 @@ pub(crate) mod test {
                 Location::new(5),
                 &historical_ops,
                 &root_hash,
-                mmr::Family::root_spec(historical_proof.inactive_peaks),
+                historical_proof.inactive_peaks,
             ));
 
             db.destroy().await.unwrap();
@@ -743,7 +743,7 @@ pub(crate) mod test {
                 Location::new(1),
                 &proof_ops,
                 &root,
-                mmr::Family::root_spec(proof.inactive_peaks),
+                proof.inactive_peaks,
             ));
 
             // historical_proof at full size should match proof.
@@ -822,7 +822,7 @@ pub(crate) mod test {
                     start_loc,
                     &historical_ops,
                     &root,
-                    mmr::Family::root_spec(historical_proof.inactive_peaks),
+                    historical_proof.inactive_peaks,
                 ));
             }
 
@@ -1204,7 +1204,7 @@ pub(crate) mod test {
     }
 
     /// Helper: commit a batch of key-value writes and return the applied range (generic).
-    async fn commit_writes_generic<F: Family + RootSpec>(
+    async fn commit_writes_generic<F: Family + Bagging>(
         db: &mut AnyTestGeneric<F>,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
         metadata: Option<Digest>,
@@ -1221,7 +1221,7 @@ pub(crate) mod test {
 
     // -- Generic inner functions for parameterized batch tests --
 
-    async fn batch_empty_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_empty_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
         let root_before = db.root();
 
@@ -1235,7 +1235,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_metadata_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_metadata_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
         let metadata = val(42);
 
@@ -1249,7 +1249,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_get_read_through_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_get_read_through_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
 
         let ka = key(0);
@@ -1277,7 +1277,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_get_on_merkleized_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_get_on_merkleized_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
 
         let ka = key(0);
@@ -1303,7 +1303,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_stacked_get_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_stacked_get_inner<F: Family + Bagging>(context: deterministic::Context) {
         let db = open_db_generic::<F>(context.with_label("db")).await;
 
         let ka = key(0);
@@ -1330,7 +1330,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_stacked_delete_recreate_inner<F: Family + RootSpec>(
+    async fn batch_stacked_delete_recreate_inner<F: Family + Bagging>(
         context: deterministic::Context,
     ) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
@@ -1360,9 +1360,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_apply_returns_range_inner<F: Family + RootSpec>(
-        context: deterministic::Context,
-    ) {
+    async fn batch_apply_returns_range_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
 
         let writes: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
@@ -1378,7 +1376,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_speculative_root_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_speculative_root_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
 
         let mut batch = db.new_batch();
@@ -1394,7 +1392,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn log_replay_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn log_replay_inner<F: Family + Bagging>(context: deterministic::Context) {
         let db_context = context.with_label("db");
         let mut db = open_db_generic::<F>(db_context.clone()).await;
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -12,7 +12,7 @@ use crate::{
     qmdb::{
         any::{ordered, value::VariableEncoding, VariableConfig, VariableValue},
         operation::Key,
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context,
@@ -28,7 +28,7 @@ pub type Operation<F, K, V> = ordered::Operation<F, K, VariableEncoding<V>>;
 pub type Db<F, E, K, V, H, T> =
     super::Db<F, E, Journal<E, Operation<F, K, V>>, Index<T, Location<F>>, H, Update<K, V>>;
 
-impl<F: Family + RootSpec, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator>
+impl<F: Family + Bagging, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator>
     Db<F, E, K, V, H, T>
 where
     Operation<F, K, V>: Codec,
@@ -57,7 +57,7 @@ pub mod partitioned {
         qmdb::{
             any::{VariableConfig, VariableValue},
             operation::Key,
-            Error, RootSpec,
+            Bagging, Error,
         },
         translator::Translator,
         Context,
@@ -84,7 +84,7 @@ pub mod partitioned {
     >;
 
     impl<
-            F: Family + RootSpec,
+            F: Family + Bagging,
             E: Context,
             K: Key,
             V: VariableValue,
@@ -175,7 +175,7 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             split_root: true,
-            root_bagging: <mmr::Family as crate::qmdb::RootSpec>::root_spec(0).bagging(),
+            root_bagging: <mmr::Family as crate::qmdb::Bagging>::BAGGING,
         }
     }
 

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         authenticated,
         contiguous::{fixed, variable, Mutable},
     },
-    merkle::{self, full, hasher::Standard as StandardHasher, Location, RootSpec},
+    merkle::{self, full, hasher::Standard as StandardHasher, Location, Proof},
     qmdb::{
         self,
         any::{
@@ -59,19 +59,20 @@ pub async fn has_local_target_state<F, E, H>(
     context: E,
     merkle_config: full::Config,
     target: &qmdb::sync::Target<F, H::Digest>,
-    spec: RootSpec,
+    inactive_peaks: usize,
+    bagging: merkle::Bagging,
 ) -> bool
 where
     F: merkle::Family,
     E: Context,
     H: Hasher,
 {
-    let hasher = StandardHasher::<H>::new();
+    let hasher = StandardHasher::<H>::with_bagging(bagging);
     let peek = full::Merkle::<F, _, _>::peek_root(
         context.with_label("local_target_probe"),
         merkle_config,
         &hasher,
-        spec,
+        inactive_peaks,
     )
     .await;
     // Size + root identify a unique state, so if they match the target's we can reuse
@@ -106,7 +107,7 @@ where
     C: Mutable<Item = Operation<F, U>> + Persistable<Error = crate::journal::Error>,
     Operation<F, U>: Codec + Committable + CodecShared,
 {
-    let hasher = StandardHasher::<H>::new();
+    let hasher = StandardHasher::<H>::with_bagging(root_bagging);
 
     let merkle = full::Merkle::<F, _, _>::init_sync(
         context.with_label("merkle"),
@@ -186,19 +187,20 @@ macro_rules! impl_sync_database {
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Family, Self::Digest>,
             ) -> bool {
-                let inactive_peaks = F::inactive_peaks(
-                    F::location_to_position(target.range.end()),
-                    target.range.start(),
-                );
+                let inactive_peaks = if config.split_root {
+                    F::inactive_peaks(
+                        F::location_to_position(target.range.end()),
+                        target.range.start(),
+                    )
+                } else {
+                    0
+                };
                 qmdb::any::sync::has_local_target_state::<F, _, H>(
                     context,
                     config.merkle_config.clone(),
                     target,
-                    RootSpec::from_split_policy(
-                        config.split_root,
-                        config.root_bagging,
-                        inactive_peaks,
-                    ),
+                    inactive_peaks,
+                    config.root_bagging,
                 )
                 .await
             }
@@ -207,15 +209,15 @@ macro_rules! impl_sync_database {
                 crate::qmdb::any::db::Db::root(self)
             }
 
-            fn proof_spec(
-                config: &Self::Config,
-                proof: &crate::merkle::Proof<Self::Family, Self::Digest>,
-            ) -> RootSpec {
-                RootSpec::from_split_policy(
-                    config.split_root,
-                    config.root_bagging,
-                    proof.inactive_peaks,
-                )
+            fn proof_inactive_peaks(
+                _config: &Self::Config,
+                proof: &Proof<Self::Family, Self::Digest>,
+            ) -> usize {
+                proof.inactive_peaks
+            }
+
+            fn root_bagging(config: &Self::Config) -> merkle::Bagging {
+                config.root_bagging
             }
         }
     };

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -55,7 +55,7 @@ pub(crate) type JournalOf<H> = <DbOf<H> as qmdb::sync::Database>::Journal;
 
 /// Trait for cleanup operations in tests.
 pub(crate) trait Destructible {
-    type Family: merkle::Family + qmdb::RootSpec;
+    type Family: merkle::Family + qmdb::Bagging;
 
     fn destroy(
         self,
@@ -64,7 +64,7 @@ pub(crate) trait Destructible {
 
 // Implement Destructible once for the generic full Merkle type used in tests.
 // This is here (rather than in fixed/variable modules) to avoid duplicate implementations.
-impl<F: merkle::Family + qmdb::RootSpec> Destructible
+impl<F: merkle::Family + qmdb::Bagging> Destructible
     for crate::merkle::full::Merkle<F, deterministic::Context, Digest>
 {
     type Family = F;
@@ -3027,7 +3027,7 @@ sync_tests_for_harness!(
 /// after follow-on commits push `inactive_peaks` past zero.
 ///
 /// Pre-fix, `qmdb::any::sync::build_db` hardcoded `split_root=true` and family-canonical bagging,
-/// and `proof_spec` derived the spec from `F::root_spec(...)` rather than the caller's policy. As
+/// and `proof_spec` derived the spec from `...` rather than the caller's policy. As
 /// long as `inactive_peaks==0` at sync time, `Split { inactive_peaks: 0, .. }` is byte-equivalent
 /// to the corresponding `Full { .. }` root, so the mismatch was silent. Once subsequent commits
 /// grew the inactive prefix the source and replica would diverge.

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -6,7 +6,7 @@ use crate::{
     merkle::{Family, Location},
     qmdb::{
         any::{unordered, value::FixedEncoding, FixedConfig as Config, FixedValue},
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context,
@@ -22,7 +22,7 @@ pub type Operation<F, K, V> = unordered::Operation<F, K, FixedEncoding<V>>;
 pub type Db<F, E, K, V, H, T> =
     super::Db<F, E, Journal<E, Operation<F, K, V>>, Index<T, Location<F>>, H, Update<K, V>>;
 
-impl<F: Family + RootSpec, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator>
+impl<F: Family + Bagging, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator>
     Db<F, E, K, V, H, T>
 {
     /// Returns a [Db] QMDB initialized from `cfg`. Uncommitted log operations will be
@@ -45,7 +45,7 @@ pub mod partitioned {
         merkle::{Family, Location},
         qmdb::{
             any::{FixedConfig as Config, FixedValue},
-            Error, RootSpec,
+            Bagging, Error,
         },
         translator::Translator,
         Context,
@@ -72,7 +72,7 @@ pub mod partitioned {
     >;
 
     impl<
-            F: Family + RootSpec,
+            F: Family + Bagging,
             E: Context,
             K: Array,
             V: FixedValue,
@@ -116,7 +116,7 @@ pub(crate) mod test {
                 test::fixed_db_config,
                 unordered::{fixed::Operation, Update},
             },
-            verify_proof, RootSpec,
+            verify_proof, Bagging,
         },
         translator::TwoCap,
     };
@@ -148,7 +148,7 @@ pub(crate) mod test {
         Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap>;
 
     /// Return an `Any` database initialized with a fixed config, generic over merkle family.
-    async fn open_db_generic<F: Family + RootSpec>(
+    async fn open_db_generic<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> AnyTestGeneric<F> {
         let cfg = fixed_db_config::<mmr::Family, TwoCap>("partition", &context);
@@ -215,7 +215,7 @@ pub(crate) mod test {
     }
 
     /// Helper: commit a batch of key-value writes and return the applied range (generic).
-    async fn commit_writes_generic<F: Family + RootSpec>(
+    async fn commit_writes_generic<F: Family + Bagging>(
         db: &mut AnyTestGeneric<F>,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
         metadata: Option<Digest>,
@@ -240,7 +240,7 @@ pub(crate) mod test {
 
     // -- Generic inner functions for parameterized batch tests --
 
-    async fn batch_empty_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_empty_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
         let root_before = db.root();
 
@@ -255,7 +255,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_metadata_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_metadata_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
         let metadata = val(42);
 
@@ -269,7 +269,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_get_read_through_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_get_read_through_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
 
         let ka = key(0);
@@ -297,7 +297,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_get_on_merkleized_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_get_on_merkleized_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
 
         let ka = key(0);
@@ -326,7 +326,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_stacked_get_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_stacked_get_inner<F: Family + Bagging>(context: deterministic::Context) {
         let db = open_db_generic::<F>(context.with_label("db")).await;
 
         let ka = key(0);
@@ -356,7 +356,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_stacked_delete_recreate_inner<F: Family + RootSpec>(
+    async fn batch_stacked_delete_recreate_inner<F: Family + Bagging>(
         context: deterministic::Context,
     ) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
@@ -386,9 +386,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_apply_returns_range_inner<F: Family + RootSpec>(
-        context: deterministic::Context,
-    ) {
+    async fn batch_apply_returns_range_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
 
         let writes: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
@@ -404,7 +402,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn batch_speculative_root_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn batch_speculative_root_inner<F: Family + Bagging>(context: deterministic::Context) {
         let mut db = open_db_generic::<F>(context.with_label("db")).await;
 
         let mut batch = db.new_batch();
@@ -420,7 +418,7 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn log_replay_inner<F: Family + RootSpec>(context: deterministic::Context) {
+    async fn log_replay_inner<F: Family + Bagging>(context: deterministic::Context) {
         let db_context = context.with_label("db");
         let mut db = open_db_generic::<F>(db_context.clone()).await;
 
@@ -589,7 +587,7 @@ pub(crate) mod test {
                 Location::new(6),
                 &historical_ops,
                 &root_hash,
-                mmr::Family::root_spec(historical_proof.inactive_peaks),
+                historical_proof.inactive_peaks,
             ));
 
             // Add more operations to the database
@@ -613,7 +611,7 @@ pub(crate) mod test {
                 Location::new(6),
                 &historical_ops,
                 &root_hash,
-                mmr::Family::root_spec(historical_proof.inactive_peaks),
+                historical_proof.inactive_peaks,
             ));
 
             // Try to get historical proof with op_count > number of operations and confirm it
@@ -656,7 +654,7 @@ pub(crate) mod test {
                 Location::new(1),
                 &proof_ops,
                 &root,
-                mmr::Family::root_spec(proof.inactive_peaks),
+                proof.inactive_peaks,
             ));
 
             // historical_proof at full size should match proof.
@@ -738,7 +736,7 @@ pub(crate) mod test {
                     start_loc,
                     &historical_ops,
                     &root,
-                    mmr::Family::root_spec(historical_proof.inactive_peaks),
+                    historical_proof.inactive_peaks,
                 ));
             }
 
@@ -751,7 +749,7 @@ pub(crate) mod test {
                 start_loc,
                 &full_ops,
                 &full_root,
-                mmr::Family::root_spec(full_proof.inactive_peaks),
+                full_proof.inactive_peaks,
             ));
 
             db.destroy().await.unwrap();

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -11,7 +11,7 @@ use crate::{
     qmdb::{
         any::{unordered, value::VariableEncoding, VariableConfig, VariableValue},
         operation::Key,
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context,
@@ -27,7 +27,7 @@ pub type Operation<F, K, V> = unordered::Operation<F, K, VariableEncoding<V>>;
 pub type Db<F, E, K, V, H, T> =
     super::Db<F, E, Journal<E, Operation<F, K, V>>, Index<T, Location<F>>, H, Update<K, V>>;
 
-impl<F: Family + RootSpec, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator>
+impl<F: Family + Bagging, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator>
     Db<F, E, K, V, H, T>
 where
     Operation<F, K, V>: Codec,
@@ -56,7 +56,7 @@ pub mod partitioned {
         qmdb::{
             any::{VariableConfig, VariableValue},
             operation::Key,
-            Error, RootSpec,
+            Bagging, Error,
         },
         translator::Translator,
         Context,
@@ -83,7 +83,7 @@ pub mod partitioned {
     >;
 
     impl<
-            F: Family + RootSpec,
+            F: Family + Bagging,
             E: Context,
             K: Key,
             V: VariableValue,
@@ -160,7 +160,7 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             split_root: true,
-            root_bagging: <mmr::Family as crate::qmdb::RootSpec>::root_spec(0).bagging(),
+            root_bagging: <mmr::Family as crate::qmdb::Bagging>::BAGGING,
         }
     }
 

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -19,7 +19,7 @@ use commonware_storage::{
             FixedConfig as CurrentFixedConfig, VariableConfig as CurrentVariableConfig,
         },
         keyless::variable::{Config as KeylessConfig, Db as Keyless},
-        RootSpec,
+        Bagging,
     },
     translator::EightCap,
 };
@@ -65,7 +65,7 @@ pub type CurOVarVecDb<F> = OCVariable<F, Context, Digest, Vec<u8>, Sha256, Eight
 pub type KeylessDb<F> = Keyless<F, Context, Vec<u8>, Sha256>;
 
 /// Open a keyless benchmark database using the shared benchmark configuration.
-pub async fn open_keyless_db<F: Family + RootSpec>(ctx: Context) -> KeylessDb<F> {
+pub async fn open_keyless_db<F: Family + Bagging>(ctx: Context) -> KeylessDb<F> {
     let cfg = keyless_cfg(&ctx);
     KeylessDb::<F>::init(ctx, cfg).await.unwrap()
 }
@@ -119,8 +119,7 @@ pub fn any_fix_cfg(ctx: &(impl BufferPooler + ThreadPooler)) -> AnyFixedConfig<E
         translator: EightCap,
         split_root: true,
         root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -144,8 +143,7 @@ pub fn any_var_digest_cfg(
         translator: EightCap,
         split_root: true,
         root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -171,8 +169,7 @@ pub fn any_var_vec_cfg(
         translator: EightCap,
         split_root: true,
         root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -305,8 +305,7 @@ fn any_fix_cfg(
         translator: EightCap,
         split_root: true,
         root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -321,8 +320,7 @@ fn any_var_cfg(
         translator: EightCap,
         split_root: true,
         root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::RootSpec>::root_spec(0)
-                .bagging(),
+            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 

--- a/storage/src/qmdb/compact_witness.rs
+++ b/storage/src/qmdb/compact_witness.rs
@@ -23,9 +23,9 @@
 //!    its proof on every serve.
 
 use crate::{
-    merkle::{compact, hasher::Standard as StandardHasher, Family, Location, Proof},
+    merkle::{compact, Family, Location, Proof},
     metadata::Metadata,
-    qmdb::{sync::compact::Target, Error, RootSpec},
+    qmdb::{sync::compact::Target, Bagging, Error},
     Context,
 };
 use commonware_codec::{Decode as _, Encode as _, FixedSize};
@@ -200,7 +200,7 @@ pub(crate) async fn load_serve_state<F, E, H, C, M, DecodeCommitOp>(
     decode_commit_op: DecodeCommitOp,
 ) -> Result<(CachedServeState<F, H::Digest>, M, Location<F>), Error<F>>
 where
-    F: Family + RootSpec,
+    F: Family + Bagging,
     E: Context,
     H: Hasher,
     DecodeCommitOp: FnOnce(&[u8], &C) -> Result<(M, Location<F>), Error<F>>,
@@ -233,16 +233,16 @@ where
 
     let inactive_peaks =
         F::inactive_peaks(F::location_to_position(leaf_count), inactivity_floor_loc);
-    let hasher = StandardHasher::<H>::new();
+    let hasher = F::default_hasher::<H>();
     let root = merkle
-        .root(&hasher, F::root_spec(inactive_peaks))
+        .root(&hasher, inactive_peaks)
         .map_err(|_| Error::DataCorrupted("failed to compute compact witness root"))?;
     if !commit_proof.verify_range_inclusion(
         &hasher,
         &[commit_op_bytes.as_slice()],
         last_commit_loc,
         &root,
-        F::root_spec(inactive_peaks),
+        inactive_peaks,
     ) {
         return Err(Error::DataCorrupted("invalid compact witness"));
     }
@@ -272,11 +272,11 @@ pub(crate) async fn bootstrap_initial_commit<F, E, H>(
     commit_op_bytes: Vec<u8>,
 ) -> Result<(), Error<F>>
 where
-    F: Family + RootSpec,
+    F: Family + Bagging,
     E: Context,
     H: Hasher,
 {
-    let hasher = StandardHasher::<H>::new();
+    let hasher = F::default_hasher::<H>();
     let batch = {
         let batch = merkle.new_batch().add(&hasher, &commit_op_bytes);
         merkle.with_mem(|mem| batch.merkleize(mem, &hasher))
@@ -289,8 +289,8 @@ where
     merkle
         .sync_with_witness(
             |mem| {
-                let root = mem.root(&hasher, F::root_spec(inactive_peaks))?;
-                let proof = mem.proof(&hasher, Location::new(0), F::root_spec(inactive_peaks))?;
+                let root = mem.root(&hasher, inactive_peaks)?;
+                let proof = mem.proof(&hasher, Location::new(0), inactive_peaks)?;
                 Ok(CachedServeState {
                     root,
                     leaf_count: Location::new(1),
@@ -356,11 +356,11 @@ where
 pub(crate) async fn persist_witness<S, F, E, H>(source: &S) -> Result<(), Error<F>>
 where
     S: WitnessSource<F, E, H>,
-    F: Family + RootSpec,
+    F: Family + Bagging,
     E: Context,
     H: Hasher,
 {
-    let hasher = StandardHasher::<H>::new();
+    let hasher = F::default_hasher::<H>();
     let last_commit_loc = source.last_commit_loc();
     let inactivity_floor_loc = source.inactivity_floor_loc();
     let commit_op_bytes = source.encode_current_commit_op();
@@ -375,12 +375,11 @@ where
                 }
                 let inactive_peaks =
                     F::inactive_peaks(F::location_to_position(mem_leaves), inactivity_floor_loc);
-                let mem_root = mem.root(&hasher, F::root_spec(inactive_peaks))?;
+                let mem_root = mem.root(&hasher, inactive_peaks)?;
                 let pinned_nodes = F::nodes_to_pin(mem_leaves)
                     .map(|pos| *mem.get_node_unchecked(pos))
                     .collect::<Vec<_>>();
-                let commit_proof =
-                    mem.proof(&hasher, last_commit_loc, F::root_spec(inactive_peaks))?;
+                let commit_proof = mem.proof(&hasher, last_commit_loc, inactive_peaks)?;
                 Ok(CachedServeState {
                     root: mem_root,
                     leaf_count: mem_leaves,

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -140,7 +140,7 @@ fn variable_log_config<C>(suffix: &str, page_cache: CacheRef, codec_config: C) -
     }
 }
 
-fn any_fixed_config<F: qmdb::RootSpec>(
+fn any_fixed_config<F: qmdb::Bagging>(
     suffix: &str,
     pooler: &impl BufferPooler,
 ) -> any::FixedConfig<OneCap> {
@@ -150,11 +150,11 @@ fn any_fixed_config<F: qmdb::RootSpec>(
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: <F as crate::qmdb::Bagging>::BAGGING,
     }
 }
 
-fn any_variable_config<F: qmdb::RootSpec>(
+fn any_variable_config<F: qmdb::Bagging>(
     suffix: &str,
     pooler: &impl BufferPooler,
 ) -> any::VariableConfig<OneCap, ((), ())> {
@@ -164,7 +164,7 @@ fn any_variable_config<F: qmdb::RootSpec>(
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
         split_root: true,
-        root_bagging: F::root_spec(0).bagging(),
+        root_bagging: <F as crate::qmdb::Bagging>::BAGGING,
     }
 }
 

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -140,7 +140,7 @@ pub(super) fn fold_grafted_peaks<
 
 /// Compute the grafted root by folding peak digests with multi-peak chunk grafting.
 ///
-/// For MMR this produces the same result as `hasher.root(leaves, RootSpec::FULL_FORWARD, peaks).expect("zero inactive peaks is always valid")` because every chunk has a
+/// For MMR this produces the same result as `hasher.root(leaves, 0, peaks).expect("zero inactive peaks is always valid")` because every chunk has a
 /// single peak at the grafting height. For MMB, chunks that span multiple sub-grafting-height peaks
 /// are folded together and combined with the bitmap chunk.
 ///
@@ -271,6 +271,10 @@ impl<F: Graftable, H: HasherTrait<F>> HasherTrait<F> for GraftedHasher<F, H> {
         self.inner.hash(parts)
     }
 
+    fn root_bagging(&self) -> merkle::Bagging {
+        self.inner.root_bagging()
+    }
+
     fn node_digest(
         &self,
         pos: Position<F>,
@@ -331,6 +335,10 @@ impl<F: Graftable, H: CHasher> HasherTrait<F> for Verifier<'_, F, H> {
 
     fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> H::Digest {
         self.hasher.hash(parts)
+    }
+
+    fn root_bagging(&self) -> merkle::Bagging {
+        <merkle::hasher::Standard<H> as HasherTrait<F>>::root_bagging(&self.hasher)
     }
 
     fn node_digest(
@@ -488,7 +496,6 @@ mod tests {
         merkle::{
             conformance::{build_test_mem, build_test_mmr},
             mem::Mem,
-            RootSpec,
         },
         mmb, mmr,
         mmr::{
@@ -804,7 +811,7 @@ mod tests {
             // yield 2 grafted leaves.
             let grafted = build_test_grafted_mmr(&hasher, &ops_mmr, &[c1, c2], GRAFTING_HEIGHT);
 
-            let ops_root = ops_mmr.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let ops_root = ops_mmr.root(&hasher, 0).unwrap();
 
             {
                 let combined = Storage::new(&grafted, GRAFTING_HEIGHT, &ops_mmr, hasher.clone());
@@ -824,7 +831,7 @@ mod tests {
                         }
                     }
                     hasher
-                        .root(ops_leaves, RootSpec::FULL_FORWARD, peaks.iter())
+                        .root(ops_leaves, 0, peaks.iter())
                         .expect("zero inactive peaks is always valid")
                 };
                 assert_ne!(grafted_root, ops_root);
@@ -832,117 +839,50 @@ mod tests {
                 // Verify inclusion proofs for each of the 4 ops leaves.
                 {
                     let loc = Location::new(0);
-                    let proof = verification::range_proof(
-                        &hasher,
-                        &combined,
-                        loc..loc + 1,
-                        RootSpec::FULL_FORWARD,
-                    )
-                    .await
-                    .unwrap();
+                    let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
+                        .await
+                        .unwrap();
 
                     let verifier =
                         Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![&c1]);
-                    assert!(proof.verify_element_inclusion(
-                        &verifier,
-                        &b1,
-                        loc,
-                        &grafted_root,
-                        RootSpec::FULL_FORWARD
-                    ));
+                    assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root, 0));
 
                     let loc = Location::new(1);
-                    let proof = verification::range_proof(
-                        &hasher,
-                        &combined,
-                        loc..loc + 1,
-                        RootSpec::FULL_FORWARD,
-                    )
-                    .await
-                    .unwrap();
-                    assert!(proof.verify_element_inclusion(
-                        &verifier,
-                        &b2,
-                        loc,
-                        &grafted_root,
-                        RootSpec::FULL_FORWARD
-                    ));
+                    let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
+                        .await
+                        .unwrap();
+                    assert!(proof.verify_element_inclusion(&verifier, &b2, loc, &grafted_root, 0));
 
                     let loc = Location::new(2);
-                    let proof = verification::range_proof(
-                        &hasher,
-                        &combined,
-                        loc..loc + 1,
-                        RootSpec::FULL_FORWARD,
-                    )
-                    .await
-                    .unwrap();
+                    let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
+                        .await
+                        .unwrap();
                     let verifier =
                         Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 1, vec![&c2]);
-                    assert!(proof.verify_element_inclusion(
-                        &verifier,
-                        &b3,
-                        loc,
-                        &grafted_root,
-                        RootSpec::FULL_FORWARD
-                    ));
+                    assert!(proof.verify_element_inclusion(&verifier, &b3, loc, &grafted_root, 0));
 
                     let loc = Location::new(3);
-                    let proof = verification::range_proof(
-                        &hasher,
-                        &combined,
-                        loc..loc + 1,
-                        RootSpec::FULL_FORWARD,
-                    )
-                    .await
-                    .unwrap();
-                    assert!(proof.verify_element_inclusion(
-                        &verifier,
-                        &b4,
-                        loc,
-                        &grafted_root,
-                        RootSpec::FULL_FORWARD
-                    ));
+                    let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
+                        .await
+                        .unwrap();
+                    assert!(proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root, 0));
                 }
 
                 // Verify that manipulated inputs cause proof verification to fail.
                 {
                     let loc = Location::new(3);
-                    let proof = verification::range_proof(
-                        &hasher,
-                        &combined,
-                        loc..loc + 1,
-                        RootSpec::FULL_FORWARD,
-                    )
-                    .await
-                    .unwrap();
+                    let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
+                        .await
+                        .unwrap();
                     let verifier =
                         Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 1, vec![&c2]);
-                    assert!(proof.verify_element_inclusion(
-                        &verifier,
-                        &b4,
-                        loc,
-                        &grafted_root,
-                        RootSpec::FULL_FORWARD
-                    ));
+                    assert!(proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root, 0));
 
                     // Wrong leaf element.
-                    assert!(!proof.verify_element_inclusion(
-                        &verifier,
-                        &b3,
-                        loc,
-                        &grafted_root,
-                        RootSpec::FULL_FORWARD
-                    ));
+                    assert!(!proof.verify_element_inclusion(&verifier, &b3, loc, &grafted_root, 0));
 
                     // Wrong root.
-                    assert!(!proof.verify_element_inclusion(
-                        &verifier,
-                        &b4,
-                        loc,
-                        &ops_root,
-                        RootSpec::FULL_FORWARD
-                    ));
+                    assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &ops_root, 0));
 
                     // Wrong position.
                     assert!(!proof.verify_element_inclusion(
@@ -950,30 +890,18 @@ mod tests {
                         &b4,
                         loc + 1,
                         &grafted_root,
-                        RootSpec::FULL_FORWARD,
+                        0,
                     ));
 
                     // Wrong chunk element in the verifier.
                     let verifier =
                         Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![&c1]);
-                    assert!(!proof.verify_element_inclusion(
-                        &verifier,
-                        &b4,
-                        loc,
-                        &grafted_root,
-                        RootSpec::FULL_FORWARD
-                    ));
+                    assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root, 0));
 
                     // Wrong chunk index in the verifier.
                     let verifier =
                         Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 2, vec![&c2]);
-                    assert!(!proof.verify_element_inclusion(
-                        &verifier,
-                        &b4,
-                        loc,
-                        &grafted_root,
-                        RootSpec::FULL_FORWARD
-                    ));
+                    assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root, 0));
                 }
 
                 // Verify range proofs.
@@ -982,7 +910,7 @@ mod tests {
                         &hasher,
                         &combined,
                         Location::new(0)..Location::new(4),
-                        RootSpec::FULL_FORWARD,
+                        0,
                     )
                     .await
                     .unwrap();
@@ -994,7 +922,7 @@ mod tests {
                         &range,
                         Location::new(0),
                         &grafted_root,
-                        RootSpec::FULL_FORWARD,
+                        0,
                     ));
 
                     // Fails with incomplete chunk elements.
@@ -1005,7 +933,7 @@ mod tests {
                         &range,
                         Location::new(0),
                         &grafted_root,
-                        RootSpec::FULL_FORWARD,
+                        0,
                     ));
                 }
             }
@@ -1038,47 +966,25 @@ mod tests {
                     }
                 }
                 hasher
-                    .root(ops_leaves, RootSpec::FULL_FORWARD, peaks.iter())
+                    .root(ops_leaves, 0, peaks.iter())
                     .expect("zero inactive peaks is always valid")
             };
 
             // Verify inclusion proofs still work for both covered and uncovered ops leaves.
             let loc = Location::new(0);
-            let proof = merkle::verification::range_proof(
-                &hasher,
-                &combined,
-                loc..loc + 1,
-                RootSpec::FULL_FORWARD,
-            )
-            .await
-            .unwrap();
+            let proof = merkle::verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
+                .await
+                .unwrap();
 
             let verifier = Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![&c1]);
-            assert!(proof.verify_element_inclusion(
-                &verifier,
-                &b1,
-                loc,
-                &grafted_root,
-                RootSpec::FULL_FORWARD
-            ));
+            assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root, 0));
 
             let verifier = Verifier::<mmr::Family, Sha256>::new(GRAFTING_HEIGHT, 0, vec![]);
             let loc = Location::new(4);
-            let proof = merkle::verification::range_proof(
-                &hasher,
-                &combined,
-                loc..loc + 1,
-                RootSpec::FULL_FORWARD,
-            )
-            .await
-            .unwrap();
-            assert!(proof.verify_element_inclusion(
-                &verifier,
-                &b5,
-                loc,
-                &grafted_root,
-                RootSpec::FULL_FORWARD
-            ));
+            let proof = merkle::verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
+                .await
+                .unwrap();
+            assert!(proof.verify_element_inclusion(&verifier, &b5, loc, &grafted_root, 0));
         });
     }
 
@@ -1198,7 +1104,7 @@ mod tests {
 
                 // A naive peak fold does not regroup sub-grafting-height peaks within a chunk.
                 let naive_root = hasher
-                    .root(leaves, RootSpec::FULL_FORWARD, peaks.iter())
+                    .root(leaves, 0, peaks.iter())
                     .expect("zero inactive peaks is always valid");
                 assert_ne!(
                     grafted_root, naive_root,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -3637,4 +3637,58 @@ pub mod tests {
             db.destroy().await.unwrap();
         });
     }
+
+    /// Regression: a `current::Db` over `mmb::Family` commits its ops root with full-forward
+    /// bagging, so `verify_proof` must be invoked with a forward hasher (not the family-default
+    /// backward hasher) to accept proofs returned by `ops_historical_proof`.
+    #[test_traced("INFO")]
+    fn test_current_mmb_ops_historical_proof_verifies_with_full_forward_spec() {
+        use crate::{merkle::hasher::Standard, qmdb::verify_proof};
+        use commonware_utils::NZU64;
+
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let ctx = context.with_label("db");
+            let mut db: UnorderedFixedMmbDb = UnorderedFixedMmbDb::init(
+                ctx.clone(),
+                fixed_config::<OneCap>("mmb-ops-proof", &ctx),
+            )
+            .await
+            .unwrap();
+
+            let writes: Vec<(Digest, Option<Digest>)> =
+                (0u64..16).map(|i| (key(i), Some(val(i)))).collect();
+            commit_writes(&mut db, writes).await.unwrap();
+
+            let ops_root = db.ops_root();
+            let historical_size = db.bounds().await.end;
+            let (proof, ops) = db
+                .ops_historical_proof(historical_size, Location::new(0), NZU64!(32))
+                .await
+                .unwrap();
+
+            let hasher = Standard::<Sha256>::new();
+            let hasher_backward = Standard::<Sha256>::backward();
+
+            assert!(verify_proof(
+                &hasher,
+                &proof,
+                Location::new(0),
+                &ops,
+                &ops_root,
+                proof.inactive_peaks,
+            ));
+
+            assert!(!verify_proof(
+                &hasher_backward,
+                &proof,
+                Location::new(0),
+                &ops,
+                &ops_root,
+                proof.inactive_peaks,
+            ));
+
+            db.destroy().await.unwrap();
+        });
+    }
 }

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         current::proof::OperationProof,
         operation::Key,
-        Error, RootSpec,
+        Bagging, Error,
     },
     Context,
 };
@@ -38,7 +38,7 @@ pub type Db<F, E, C, K, V, I, H, const N: usize> =
 
 // Shared read-only functionality.
 impl<
-        F: merkle::Graftable + RootSpec,
+        F: merkle::Graftable + Bagging,
         E: Context,
         C: Contiguous<Item = Operation<F, K, V>>,
         K: Key,
@@ -134,7 +134,7 @@ where
 }
 
 impl<
-        F: merkle::Graftable + RootSpec,
+        F: merkle::Graftable + Bagging,
         E: Context,
         C: Mutable<Item = Operation<F, K, V>>,
         K: Key,

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -15,7 +15,7 @@ use crate::{
     qmdb::{
         any::{ordered::fixed::Operation, value::FixedEncoding, FixedValue},
         current::FixedConfig as Config,
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context,
@@ -35,7 +35,7 @@ pub type Db<F, E, K, V, H, T, const N: usize> = super::db::Db<
 >;
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: FixedValue,
@@ -76,7 +76,7 @@ pub mod partitioned {
         >;
 
     impl<
-            F: Graftable + RootSpec,
+            F: Graftable + Bagging,
             E: Context,
             K: Array,
             V: FixedValue,

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -14,7 +14,7 @@ use crate::{
         any::{ordered::Update, ValueEncoding},
         current::proof::OperationProof,
         operation::Key,
-        RootSpec,
+        Bagging,
     },
 };
 use commonware_cryptography::Digest;
@@ -33,13 +33,8 @@ pub mod variable;
 ///
 /// Verify using [Db::verify_exclusion_proof](fixed::Db::verify_exclusion_proof).
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub enum ExclusionProof<
-    F: Graftable + RootSpec,
-    K: Key,
-    V: ValueEncoding,
-    D: Digest,
-    const N: usize,
-> {
+pub enum ExclusionProof<F: Graftable + Bagging, K: Key, V: ValueEncoding, D: Digest, const N: usize>
+{
     /// Proves that two keys are active in the database and adjacent to each other in the key
     /// ordering. Any key falling between them (non-inclusively) can be proven excluded.
     KeyValue(OperationProof<F, D, N>, Update<K, V>),
@@ -68,7 +63,7 @@ pub mod tests {
             },
             current::{proof::RangeProof, tests::apply_random_ops, BitmapPrunedBits},
             store::tests::{TestKey, TestValue},
-            Error, RootSpec,
+            Bagging, Error,
         },
         translator::OneCap,
         Persistable,
@@ -97,7 +92,7 @@ pub mod tests {
     /// and verifies state is preserved across close/reopen cycles.
     pub fn test_build_small_close_reopen<F, C, Fn, Fut>(mut open_db: Fn)
     where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: DbAny<F> + BitmapPrunedBits,
         C::Key: TestKey,
         <C as DbAny<F>>::Value: TestValue,
@@ -195,7 +190,7 @@ pub mod tests {
     pub(super) fn test_verify_proof_over_bits_in_uncommitted_chunk<F, C, V, Fn, Fut>(
         mut open_db: Fn,
     ) where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
@@ -381,7 +376,7 @@ pub mod tests {
     /// proof, and that adding extra chunks causes verification to fail.
     pub(super) fn test_range_proofs<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
@@ -466,7 +461,7 @@ pub mod tests {
     /// wrong keys, wrong values, wrong roots, and wrong next-keys.
     pub(super) fn test_key_value_proof<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
@@ -565,7 +560,7 @@ pub mod tests {
     /// value's proof fails.
     pub(super) fn test_proving_repeated_updates<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
@@ -625,7 +620,7 @@ pub mod tests {
     /// wrong roots are rejected.
     pub(super) fn test_exclusion_proofs<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
-        F: Graftable + RootSpec + PartialEq,
+        F: Graftable + Bagging + PartialEq,
         C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
         V: ValueEncoding<Value = Digest> + PartialEq + core::fmt::Debug + 'static,
         Operation<F, Digest, V>: Codec,

--- a/storage/src/qmdb/current/ordered/test_trait_impls.rs
+++ b/storage/src/qmdb/current/ordered/test_trait_impls.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         current::BitmapPrunedBits,
         operation::Key,
-        RootSpec,
+        Bagging,
     },
     translator::Translator,
     Context,
@@ -28,7 +28,7 @@ use commonware_utils::Array;
 crate::qmdb::any::traits::impl_db_any! {
     [F, E, K, V, H, T, const N: usize] fixed::Db<F, E, K, V, H, T, N>
     where {
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: FixedValue + 'static,
@@ -46,7 +46,7 @@ crate::qmdb::any::traits::impl_db_any! {
 crate::qmdb::any::traits::impl_db_any! {
     [F, E, K, V, H, T, const N: usize] variable::Db<F, E, K, V, H, T, N>
     where {
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Key,
         V: VariableValue + 'static,
@@ -62,7 +62,7 @@ crate::qmdb::any::traits::impl_db_any! {
 // =============================================================================
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: FixedValue,
@@ -85,7 +85,7 @@ impl<
 }
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Key,
         V: VariableValue,
@@ -117,7 +117,7 @@ crate::qmdb::any::traits::impl_db_any! {
     [F, E, K, V, H, T, const P: usize, const N: usize]
     fixed::partitioned::Db<F, E, K, V, H, T, P, N>
     where {
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: FixedValue + 'static,
@@ -129,7 +129,7 @@ crate::qmdb::any::traits::impl_db_any! {
 }
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: FixedValue,
@@ -160,7 +160,7 @@ crate::qmdb::any::traits::impl_db_any! {
     [F, E, K, V, H, T, const P: usize, const N: usize]
     variable::partitioned::Db<F, E, K, V, H, T, P, N>
     where {
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Key,
         V: VariableValue + 'static,

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -15,7 +15,7 @@ use crate::{
         any::{ordered::variable::Operation, value::VariableEncoding, VariableValue},
         current::VariableConfig as Config,
         operation::Key,
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context,
@@ -35,7 +35,7 @@ pub type Db<F, E, K, V, H, T, const N: usize> = super::db::Db<
 >;
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Key,
         V: VariableValue,
@@ -81,7 +81,7 @@ pub mod partitioned {
         >;
 
     impl<
-            F: Graftable + RootSpec,
+            F: Graftable + Bagging,
             E: Context,
             K: Key,
             V: VariableValue,

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -338,15 +338,9 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let size = Position::<F>::try_from(leaves)?;
         let needs_grafted_peak_fold =
             proof_needs_grafted_peak_fold(&layout, size, grafting_height, complete_chunks);
-        let proof = merkle::verification::historical_range_proof_using_policy(
-            &std_hasher,
-            storage,
-            leaves,
-            0,
-            merkle::Bagging::ForwardFold,
-            range,
-        )
-        .await?;
+        let proof =
+            merkle::verification::historical_range_proof(&std_hasher, storage, leaves, range, 0)
+                .await?;
         let mut pre_prefix_acc: Option<D> = None;
         let mut unfolded_prefix_peaks = Vec::new();
         if needs_grafted_peak_fold {
@@ -576,12 +570,10 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
                 debug!("verification failed, unexpected grafted prefix metadata");
                 return false;
             }
-            match self.proof.reconstruct_root_using_policy(
-                &verifier,
-                &elements,
-                start_loc,
-                merkle::Bagging::ForwardFold,
-            ) {
+            match self
+                .proof
+                .reconstruct_root(&verifier, &elements, start_loc, 0)
+            {
                 Ok(root) => root,
                 Err(error) => {
                     debug!(?error, "invalid proof input");
@@ -590,12 +582,11 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             }
         } else {
             let mut collected = Vec::new();
-            if let Err(error) = self.proof.reconstruct_root_collecting_using_policy(
+            if let Err(error) = self.proof.reconstruct_root_inner(
                 &verifier,
                 &elements,
                 start_loc,
                 Some(&mut collected),
-                merkle::Bagging::ForwardFold,
             ) {
                 debug!(?error, "invalid proof input");
                 return false;
@@ -708,7 +699,7 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
 mod tests {
     use super::*;
     use crate::{
-        merkle::{conformance::build_test_mem, mem::Mem, RootSpec},
+        merkle::{conformance::build_test_mem, mem::Mem},
         mmb,
         mmr::StandardHasher,
         qmdb::current::{db, grafting},
@@ -759,7 +750,7 @@ mod tests {
                 status.push(true);
             }
             let ops = build_test_mem(&hasher, mmb::mem::Mmb::new(), leaf_count);
-            let ops_root = ops.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let ops_root = ops.root(&hasher, 0).unwrap();
 
             let chunk_inputs: Vec<_> =
                 (0..<BitMap<N> as BitmapReadable<N>>::complete_chunks(&status))
@@ -860,7 +851,7 @@ mod tests {
                 status.push(true);
             }
             let ops = build_test_mem(&hasher, mmb::mem::Mmb::new(), leaf_count);
-            let ops_root = ops.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let ops_root = ops.root(&hasher, 0).unwrap();
 
             let chunk_inputs: Vec<_> =
                 (0..<BitMap<N> as BitmapReadable<N>>::complete_chunks(&status))
@@ -965,7 +956,7 @@ mod tests {
                 status.push(true);
             }
             let ops = build_test_mem(&hasher, mmb::mem::Mmb::new(), leaf_count);
-            let ops_root = ops.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let ops_root = ops.root(&hasher, 0).unwrap();
 
             let chunk_inputs: Vec<_> =
                 (0..<BitMap<N> as BitmapReadable<N>>::complete_chunks(&status))
@@ -1047,7 +1038,7 @@ mod tests {
                 status.push(true);
             }
             let ops = build_test_mem(&hasher, mmb::mem::Mmb::new(), leaf_count);
-            let ops_root = ops.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let ops_root = ops.root(&hasher, 0).unwrap();
 
             let chunk_inputs: Vec<_> =
                 (0..<BitMap<N> as BitmapReadable<N>>::complete_chunks(&status))
@@ -1155,7 +1146,7 @@ mod tests {
                 status.push(true);
             }
             let ops = build_test_mem(&hasher, mmb::mem::Mmb::new(), leaf_count);
-            let ops_root = ops.root(&hasher, RootSpec::FULL_FORWARD).unwrap();
+            let ops_root = ops.root(&hasher, 0).unwrap();
 
             let chunk_inputs: Vec<_> =
                 (0..<BitMap<N> as BitmapReadable<N>>::complete_chunks(&status))

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     merkle::{
         full::{self, Merkle},
         hasher::Standard as StandardHasher,
-        Bagging, Graftable, Location, Proof, RootSpec,
+        Bagging, Graftable, Location, Proof,
     },
     qmdb::{
         self,
@@ -288,7 +288,8 @@ macro_rules! impl_current_sync_database {
                     context.with_label("local_target_merkle_probe"),
                     config.merkle_config.clone(),
                     target,
-                    RootSpec::FULL_FORWARD,
+                    0,
+                    Bagging::ForwardFold,
                 )
                 .await
                 {
@@ -314,11 +315,15 @@ macro_rules! impl_current_sync_database {
                 self.any.root()
             }
 
-            fn proof_spec(
+            fn proof_inactive_peaks(
                 _config: &Self::Config,
                 _proof: &Proof<Self::Family, Self::Digest>,
-            ) -> RootSpec {
-                RootSpec::FULL_FORWARD
+            ) -> usize {
+                0
+            }
+
+            fn root_bagging(_config: &Self::Config) -> Bagging {
+                Bagging::ForwardFold
             }
         }
     };

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -17,7 +17,7 @@ use crate::qmdb::{
     any::sync::tests::{ConfigOf, SyncTestHarness},
     current::tests::{fixed_config, variable_config},
     sync::Database as SyncDatabase,
-    RootSpec,
+    Bagging,
 };
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_macros::test_traced;
@@ -269,7 +269,7 @@ mod harnesses {
 
     pub struct UnorderedFixedHarness<F>(std::marker::PhantomData<F>);
 
-    impl<F: merkle::Graftable + RootSpec> SyncTestHarness for UnorderedFixedHarness<F> {
+    impl<F: merkle::Graftable + Bagging> SyncTestHarness for UnorderedFixedHarness<F> {
         type Family = F;
         type Db = UnorderedFixedDb<F>;
 
@@ -316,7 +316,7 @@ mod harnesses {
 
     pub struct UnorderedVariableHarness<F>(std::marker::PhantomData<F>);
 
-    impl<F: merkle::Graftable + RootSpec> SyncTestHarness for UnorderedVariableHarness<F> {
+    impl<F: merkle::Graftable + Bagging> SyncTestHarness for UnorderedVariableHarness<F> {
         type Family = F;
         type Db = UnorderedVariableDb<F>;
 
@@ -363,7 +363,7 @@ mod harnesses {
 
     pub struct OrderedFixedHarness<F>(std::marker::PhantomData<F>);
 
-    impl<F: merkle::Graftable + RootSpec> SyncTestHarness for OrderedFixedHarness<F> {
+    impl<F: merkle::Graftable + Bagging> SyncTestHarness for OrderedFixedHarness<F> {
         type Family = F;
         type Db = OrderedFixedDb<F>;
 
@@ -410,7 +410,7 @@ mod harnesses {
 
     pub struct OrderedVariableHarness<F>(std::marker::PhantomData<F>);
 
-    impl<F: merkle::Graftable + RootSpec> SyncTestHarness for OrderedVariableHarness<F> {
+    impl<F: merkle::Graftable + Bagging> SyncTestHarness for OrderedVariableHarness<F> {
         type Family = F;
         type Db = OrderedVariableDb<F>;
 

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -14,7 +14,7 @@ use crate::{
     qmdb::{
         any::{unordered::fixed::Operation, value::FixedEncoding, FixedValue},
         current::FixedConfig as Config,
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context,
@@ -35,7 +35,7 @@ pub type Db<F, E, K, V, H, T, const N: usize> = super::db::Db<
 >;
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: FixedValue,
@@ -79,7 +79,7 @@ pub mod partitioned {
         >;
 
     impl<
-            F: Graftable + RootSpec,
+            F: Graftable + Bagging,
             E: Context,
             K: Array,
             V: FixedValue,

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -31,7 +31,7 @@ pub mod tests {
             },
             current::{proof::RangeProof, tests::apply_random_ops, BitmapPrunedBits},
             store::tests::{TestKey, TestValue},
-            Error, RootSpec,
+            Bagging, Error,
         },
         translator::TwoCap,
         Persistable,
@@ -60,7 +60,7 @@ pub mod tests {
     /// and verifies state is preserved across close/reopen cycles.
     pub fn test_build_small_close_reopen<F, C, Fn, Fut>(mut open_db: Fn)
     where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: DbAny<F> + BitmapPrunedBits,
         C::Key: TestKey,
         <C as DbAny<F>>::Value: TestValue,
@@ -160,7 +160,7 @@ pub mod tests {
     pub(super) fn test_verify_proof_over_bits_in_uncommitted_chunk<F, C, V, Fn, Fut>(
         mut open_db: Fn,
     ) where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
@@ -329,7 +329,7 @@ pub mod tests {
     /// proof, and that adding extra chunks causes verification to fail.
     pub(super) fn test_range_proofs<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
@@ -415,7 +415,7 @@ pub mod tests {
     /// wrong keys, wrong values, and wrong roots.
     pub(super) fn test_key_value_proof<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
@@ -505,7 +505,7 @@ pub mod tests {
     /// value's proof fails.
     pub(super) fn test_proving_repeated_updates<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,

--- a/storage/src/qmdb/current/unordered/test_trait_impls.rs
+++ b/storage/src/qmdb/current/unordered/test_trait_impls.rs
@@ -11,7 +11,7 @@ use crate::{
             FixedValue, VariableValue,
         },
         current::BitmapPrunedBits,
-        RootSpec,
+        Bagging,
     },
     translator::Translator,
     Context,
@@ -27,7 +27,7 @@ use commonware_utils::Array;
 crate::qmdb::any::traits::impl_db_any! {
     [F, E, K, V, H, T, const N: usize] fixed::Db<F, E, K, V, H, T, N>
     where {
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: FixedValue + 'static,
@@ -45,7 +45,7 @@ crate::qmdb::any::traits::impl_db_any! {
 crate::qmdb::any::traits::impl_db_any! {
     [F, E, K, V, H, T, const N: usize] variable::Db<F, E, K, V, H, T, N>
     where {
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: VariableValue + 'static,
@@ -61,7 +61,7 @@ crate::qmdb::any::traits::impl_db_any! {
 // =============================================================================
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: FixedValue,
@@ -84,7 +84,7 @@ impl<
 }
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: VariableValue,
@@ -127,7 +127,7 @@ crate::qmdb::any::traits::impl_db_any! {
 }
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: FixedValue,
@@ -158,7 +158,7 @@ crate::qmdb::any::traits::impl_db_any! {
     [F, E, K, V, H, T, const P: usize, const N: usize]
     variable::partitioned::Db<F, E, K, V, H, T, P, N>
     where {
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: VariableValue + 'static,
@@ -170,7 +170,7 @@ crate::qmdb::any::traits::impl_db_any! {
 }
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: VariableValue,

--- a/storage/src/qmdb/current/unordered/variable.rs
+++ b/storage/src/qmdb/current/unordered/variable.rs
@@ -14,7 +14,7 @@ use crate::{
     qmdb::{
         any::{unordered::variable::Operation, value::VariableEncoding, VariableValue},
         current::VariableConfig as Config,
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context,
@@ -35,7 +35,7 @@ pub type Db<F, E, K, V, H, T, const N: usize> = super::db::Db<
 >;
 
 impl<
-        F: Graftable + RootSpec,
+        F: Graftable + Bagging,
         E: Context,
         K: Array,
         V: VariableValue,
@@ -81,7 +81,7 @@ pub mod partitioned {
         >;
 
     impl<
-            F: Graftable + RootSpec,
+            F: Graftable + Bagging,
             E: Context,
             K: Array,
             V: VariableValue,

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -8,7 +8,7 @@ use crate::{
         any::{batch::lookup_sorted, ValueEncoding},
         immutable::operation::Operation,
         operation::Key,
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context, Persistable,
@@ -25,7 +25,7 @@ type DiffVec<K, F, V> = Vec<(K, DiffEntry<F, V>)>;
 
 /// What happened to a key in this batch.
 #[derive(Clone)]
-pub(crate) struct DiffEntry<F: Family + RootSpec, V> {
+pub(crate) struct DiffEntry<F: Family + Bagging, V> {
     pub(crate) value: V,
     pub(crate) loc: Location<F>,
 }
@@ -38,7 +38,7 @@ pub(crate) struct DiffEntry<F: Family + RootSpec, V> {
 #[allow(clippy::type_complexity)]
 pub struct UnmerkleizedBatch<F, H, K, V>
 where
-    F: Family + RootSpec,
+    F: Family + Bagging,
     K: Key,
     V: ValueEncoding,
     H: CHasher,
@@ -63,7 +63,7 @@ where
 /// A speculative batch of operations whose root digest has been computed,
 /// in contrast to [`UnmerkleizedBatch`].
 #[derive(Clone)]
-pub struct MerkleizedBatch<F: Family + RootSpec, D: Digest, K: Key, V: ValueEncoding> {
+pub struct MerkleizedBatch<F: Family + Bagging, D: Digest, K: Key, V: ValueEncoding> {
     /// Authenticated journal batch (Merkle state + local items).
     pub(super) journal_batch: Arc<authenticated::MerkleizedBatch<F, D, Operation<F, K, V>>>,
 
@@ -106,7 +106,7 @@ pub struct MerkleizedBatch<F: Family + RootSpec, D: Digest, K: Key, V: ValueEnco
 
 impl<F, H, K, V> UnmerkleizedBatch<F, H, K, V>
 where
-    F: Family + RootSpec,
+    F: Family + Bagging,
     K: Key,
     V: ValueEncoding,
     H: CHasher,
@@ -286,9 +286,7 @@ where
         let journal_merkleized = db.journal.with_mem(|mem| journal_batch.merkleize(mem));
         let root = db
             .journal
-            .with_mem(|mem| {
-                journal_merkleized.root(mem, &db.journal.hasher, F::root_spec(inactive_peaks))
-            })
+            .with_mem(|mem| journal_merkleized.root(mem, &db.journal.hasher, inactive_peaks))
             .expect("inactive_peaks computed from batch size");
 
         let mut ancestor_diffs = Vec::new();
@@ -321,7 +319,7 @@ where
     }
 }
 
-impl<F: Family + RootSpec, D: Digest, K: Key, V: ValueEncoding> MerkleizedBatch<F, D, K, V>
+impl<F: Family + Bagging, D: Digest, K: Key, V: ValueEncoding> MerkleizedBatch<F, D, K, V>
 where
     Operation<F, K, V>: EncodeShared,
 {
@@ -445,7 +443,7 @@ where
 
 impl<F, E, K, V, C, H, T> Immutable<F, E, K, V, C, H, T>
 where
-    F: Family + RootSpec,
+    F: Family + Bagging,
     E: Context,
     K: Key,
     V: ValueEncoding,

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -22,16 +22,13 @@
 
 use super::operation::Operation;
 use crate::{
-    merkle::{
-        batch, compact as compact_merkle, hasher::Standard as StandardHasher, Family, Location,
-        Proof,
-    },
+    merkle::{batch, compact as compact_merkle, Family, Location, Proof},
     qmdb::{
         any::value::ValueEncoding,
         compact_witness::{self, CachedServeState, WitnessSource},
         operation::Key,
         sync::compact as compact_sync,
-        Error, RootSpec,
+        Bagging, Error,
     },
     Context,
 };
@@ -197,12 +194,12 @@ where
         inactivity_floor: Location<F>,
     ) -> Arc<MerkleizedBatch<F, H::Digest, K, V>>
     where
-        F: RootSpec,
+        F: Bagging,
         E: Context,
         C: Clone + Send + Sync + 'static,
         Operation<F, K, V>: Read<Cfg = C>,
     {
-        let hasher = StandardHasher::<H>::new();
+        let hasher = F::default_hasher::<H>();
         let mut ops: Vec<Operation<F, K, V>> = Vec::with_capacity(self.mutations.len() + 1);
         for (key, value) in self.mutations {
             ops.push(Operation::Set(key, value));
@@ -224,7 +221,7 @@ where
         );
         let root = db
             .merkle
-            .with_mem(|mem| merkle.root(mem, &hasher, F::root_spec(inactive_peaks)))
+            .with_mem(|mem| merkle.root(mem, &hasher, inactive_peaks))
             .expect("inactive_peaks computed from batch size");
 
         let mut ancestor_batch_ends = Vec::new();
@@ -300,7 +297,7 @@ where
         Error<F>,
     >
     where
-        F: RootSpec,
+        F: Bagging,
     {
         compact_witness::load_serve_state::<F, E, H, _, _, _>(
             merkle,
@@ -361,7 +358,7 @@ where
         commit_codec_config: C,
     ) -> Result<Self, Error<F>>
     where
-        F: RootSpec,
+        F: Bagging,
         Operation<F, K, V>: Read<Cfg = C>,
     {
         // Bootstrap: append an initial Commit(None, 0) on first open. This establishes the
@@ -399,15 +396,15 @@ where
     /// Return the root of the db.
     pub fn root(&self) -> H::Digest
     where
-        F: RootSpec,
+        F: Bagging,
     {
-        let hasher = StandardHasher::<H>::new();
+        let hasher = F::default_hasher::<H>();
         let inactive_peaks = F::inactive_peaks(
             F::location_to_position(Location::new(*self.last_commit_loc + 1)),
             self.inactivity_floor_loc,
         );
         self.merkle
-            .root(&hasher, F::root_spec(inactive_peaks))
+            .root(&hasher, inactive_peaks)
             .expect("compact Merkle root should not fail")
     }
 
@@ -494,7 +491,7 @@ where
     /// intentionally not consulted here.
     pub fn to_batch(&self) -> Arc<MerkleizedBatch<F, H::Digest, K, V>>
     where
-        F: RootSpec,
+        F: Bagging,
     {
         let committed_size = *self.last_commit_loc + 1;
         Arc::new(MerkleizedBatch {
@@ -566,7 +563,7 @@ where
     /// witness when the current state has already been persisted.
     pub async fn sync(&self) -> Result<(), Error<F>>
     where
-        F: RootSpec,
+        F: Bagging,
     {
         compact_witness::persist_witness(self).await
     }
@@ -574,7 +571,7 @@ where
     /// Durably persist the current db state to disk (alias for [`Self::sync`]).
     pub async fn commit(&self) -> Result<(), Error<F>>
     where
-        F: RootSpec,
+        F: Bagging,
     {
         self.sync().await
     }
@@ -605,7 +602,7 @@ where
     /// after any `Err` from `rewind` and reopen from storage.
     pub async fn rewind(&mut self) -> Result<(), Error<F>>
     where
-        F: RootSpec,
+        F: Bagging,
     {
         self.merkle.rewind().await?;
         // Reload the witness from the reverted slot as well, so compact serving stays aligned with
@@ -663,7 +660,7 @@ mod tests {
     use crate::{
         merkle::mmr,
         metadata::{Config as MConfig, Metadata},
-        qmdb::{any::value::FixedEncoding, RootSpec},
+        qmdb::{any::value::FixedEncoding, Bagging},
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
@@ -672,7 +669,7 @@ mod tests {
 
     type TestDb<F> = Db<F, deterministic::Context, Digest, FixedEncoding<Digest>, Sha256>;
 
-    async fn open_db<F: Family + RootSpec>(
+    async fn open_db<F: Family + Bagging>(
         context: deterministic::Context,
         partition: &str,
     ) -> TestDb<F> {

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -11,7 +11,7 @@ use crate::{
     merkle::Family,
     qmdb::{
         any::{value::FixedEncoding, FixedValue},
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
 };
@@ -39,7 +39,7 @@ pub type Config<T> = BaseConfig<T, JournalConfig>;
 pub type CompactConfig = super::CompactConfig<()>;
 
 impl<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         E: Storage + Clock + Metrics,
         K: Array,
         V: FixedValue,
@@ -55,13 +55,14 @@ impl<
             cfg.merkle_config,
             cfg.log,
             Operation::<F, K, V>::is_commit,
+            <F as Bagging>::BAGGING,
         )
         .await?;
         Self::init_from_journal(journal, context, cfg.translator).await
     }
 }
 
-impl<F: Family + RootSpec, E: Storage + Clock + Metrics, K: Array, V: FixedValue, H: Hasher>
+impl<F: Family + Bagging, E: Storage + Clock + Metrics, K: Array, V: FixedValue, H: Hasher>
     CompactDb<F, E, K, V, H>
 {
     /// Returns a [CompactDb] initialized from `cfg`.
@@ -110,14 +111,14 @@ mod tests {
         }
     }
 
-    async fn open_db<F: Family + RootSpec>(
+    async fn open_db<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> Db<F, deterministic::Context, Digest, Digest, Sha256, TwoCap> {
         let cfg = config("partition", &context);
         Db::init(context, cfg).await.unwrap()
     }
 
-    async fn open_compact<F: Family + RootSpec>(
+    async fn open_compact<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> CompactDb<F, deterministic::Context, Digest, Digest, Sha256> {
         let cfg = CompactConfig {
@@ -131,7 +132,7 @@ mod tests {
     }
 
     #[allow(clippy::type_complexity)]
-    fn open<F: Family + RootSpec>(
+    fn open<F: Family + Bagging>(
         ctx: deterministic::Context,
     ) -> Pin<
         Box<
@@ -163,7 +164,7 @@ mod tests {
         cfg
     }
 
-    async fn open_small_sections_db<F: Family + RootSpec>(
+    async fn open_small_sections_db<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> Db<F, deterministic::Context, Digest, Digest, Sha256, TwoCap> {
         let cfg = small_sections_config("partition", &context);
@@ -171,7 +172,7 @@ mod tests {
     }
 
     #[allow(clippy::type_complexity)]
-    fn open_small_sections<F: Family + RootSpec>(
+    fn open_small_sections<F: Family + Bagging>(
         ctx: deterministic::Context,
     ) -> Pin<
         Box<
@@ -294,7 +295,7 @@ mod tests {
         });
     }
 
-    async fn assert_compact_root_compatibility<F: Family + RootSpec>(ctx: deterministic::Context) {
+    async fn assert_compact_root_compatibility<F: Family + Bagging>(ctx: deterministic::Context) {
         let mut db = open_db::<F>(ctx.with_label("db")).await;
         let mut compact = open_compact::<F>(ctx.with_label("compact")).await;
         assert_eq!(db.root(), compact.root());

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -89,7 +89,7 @@ use crate::{
         any::ValueEncoding,
         build_snapshot_from_log, compact_witness,
         operation::{Key, Operation as _},
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
     Context, Persistable,
@@ -169,7 +169,7 @@ pub struct Immutable<
 // Shared read-only functionality.
 impl<F, E, K, V, C, H, T> Immutable<F, E, K, V, C, H, T>
 where
-    F: Family + RootSpec,
+    F: Family + Bagging,
     E: Context,
     K: Key,
     V: ValueEncoding,
@@ -227,7 +227,7 @@ where
             F::location_to_position(Location::new(*last_commit_loc + 1)),
             inactivity_floor_loc,
         );
-        let root = journal.root(F::root_spec(inactive_peaks))?;
+        let root = journal.root(inactive_peaks)?;
 
         Ok(Self {
             journal,
@@ -411,7 +411,7 @@ where
 
         Ok(self
             .journal
-            .historical_proof(op_count, start_loc, max_ops, F::root_spec(inactive_peaks))
+            .historical_proof(op_count, start_loc, max_ops, inactive_peaks)
             .await?)
     }
 
@@ -545,7 +545,7 @@ where
         self.last_commit_loc = rewind_last_loc;
         self.inactivity_floor_loc = rewind_floor;
         let inactive_peaks = F::inactive_peaks(F::location_to_position(size), rewind_floor);
-        self.root = self.journal.root(F::root_spec(inactive_peaks))?;
+        self.root = self.journal.root(inactive_peaks)?;
 
         Ok(())
     }
@@ -686,7 +686,7 @@ pub(super) mod test {
     use super::*;
     use crate::{
         merkle::{Family, Location},
-        qmdb::{verify_proof, RootSpec},
+        qmdb::verify_proof,
         translator::TwoCap,
     };
     use commonware_codec::EncodeShared;
@@ -696,13 +696,11 @@ pub(super) mod test {
     use core::{future::Future, pin::Pin};
     use std::ops::Range;
 
-    type StandardHasher<H> = crate::merkle::hasher::Standard<H>;
-
     const ITEMS_PER_SECTION: u64 = 5;
 
     type TestDb<F, V, C> = Immutable<F, deterministic::Context, Digest, V, C, Sha256, TwoCap>;
 
-    pub(crate) async fn test_immutable_empty<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_empty<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -747,7 +745,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_build_basic<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_build_basic<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -822,7 +820,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_proof_verify<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_proof_verify<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -847,20 +845,20 @@ pub(super) mod test {
 
         let (proof, ops) = db.proof(Location::new(0), NZU64!(100)).await.unwrap();
         let root = db.root();
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
         assert!(verify_proof(
             &hasher,
             &proof,
             Location::new(0),
             &ops,
             &root,
-            F::root_spec(proof.inactive_peaks),
+            proof.inactive_peaks,
         ));
 
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_prune<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_prune<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -902,7 +900,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_batch_chain<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_chain<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -953,7 +951,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_build_and_authenticate<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_build_and_authenticate<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -964,7 +962,7 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         // Build a db with `ELEMENTS` key/value pairs and prove ranges over them.
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
         let mut db = open_db(context.with_label("first")).await;
 
         let mut batch = db.new_batch();
@@ -1002,18 +1000,14 @@ pub(super) mod test {
                 Location::new(i),
                 &log,
                 &root,
-                F::root_spec(proof.inactive_peaks),
+                proof.inactive_peaks,
             ));
         }
 
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_recovery_from_failed_merkle_sync<
-        F: Family + RootSpec,
-        V,
-        C,
-    >(
+    pub(crate) async fn test_immutable_recovery_from_failed_merkle_sync<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1068,7 +1062,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_recovery_from_failed_log_sync<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_recovery_from_failed_log_sync<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1106,7 +1100,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_pruning<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_pruning<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1214,7 +1208,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_prune_beyond_floor<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_prune_beyond_floor<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1277,7 +1271,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    async fn commit_sets<F: Family + RootSpec, V, C>(
+    async fn commit_sets<F: Family + Bagging, V, C>(
         db: &mut TestDb<F, V, C>,
         sets: impl IntoIterator<Item = (Digest, V::Value)>,
         metadata: Option<V::Value>,
@@ -1290,7 +1284,7 @@ pub(super) mod test {
         commit_sets_with_floor(db, sets, metadata, Location::new(0)).await
     }
 
-    async fn commit_sets_with_floor<F: Family + RootSpec, V, C>(
+    async fn commit_sets_with_floor<F: Family + Bagging, V, C>(
         db: &mut TestDb<F, V, C>,
         sets: impl IntoIterator<Item = (Digest, V::Value)>,
         metadata: Option<V::Value>,
@@ -1313,7 +1307,7 @@ pub(super) mod test {
         range
     }
 
-    pub(crate) async fn test_immutable_rewind_recovery<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_rewind_recovery<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1381,7 +1375,7 @@ pub(super) mod test {
     /// rewound suffix must survive rewind. Earlier the snapshot remove pruned the entire translated
     /// bucket and dropped the retained key.
     pub(crate) async fn test_immutable_rewind_preserves_collision_bucket<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -1426,7 +1420,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_rewind_pruned_target_errors<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_rewind_pruned_target_errors<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_small_sections_db: impl Fn(
             deterministic::Context,
@@ -1494,7 +1488,7 @@ pub(super) mod test {
     }
 
     /// batch.get() reads pending mutations and falls through to base DB.
-    pub(crate) async fn test_immutable_batch_get_read_through<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_get_read_through<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1535,7 +1529,7 @@ pub(super) mod test {
     }
 
     /// Child batch reads parent diff and adds its own mutations.
-    pub(crate) async fn test_immutable_batch_stacked_get<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_stacked_get<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1571,7 +1565,7 @@ pub(super) mod test {
     }
 
     /// Two-level stacked batch apply works end-to-end.
-    pub(crate) async fn test_immutable_batch_stacked_apply<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_stacked_apply<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1621,7 +1615,7 @@ pub(super) mod test {
     }
 
     /// MerkleizedBatch::root() matches db.root() after apply_batch().
-    pub(crate) async fn test_immutable_batch_speculative_root<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_speculative_root<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1658,7 +1652,7 @@ pub(super) mod test {
     }
 
     /// MerkleizedBatch::get() reads from diff and base DB.
-    pub(crate) async fn test_immutable_merkleized_batch_get<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_merkleized_batch_get<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1703,7 +1697,7 @@ pub(super) mod test {
     }
 
     /// Independent sequential batches applied one at a time.
-    pub(crate) async fn test_immutable_batch_sequential_apply<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_sequential_apply<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1744,7 +1738,7 @@ pub(super) mod test {
     }
 
     /// Many sequential batches accumulate correctly.
-    pub(crate) async fn test_immutable_batch_many_sequential<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_many_sequential<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1755,7 +1749,7 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.with_label("db")).await;
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
 
         const BATCHES: u64 = 20;
         const KEYS_PER_BATCH: u64 = 5;
@@ -1789,7 +1783,7 @@ pub(super) mod test {
             Location::new(0),
             &ops,
             &root,
-            F::root_spec(proof.inactive_peaks),
+            proof.inactive_peaks,
         ));
 
         // Expected: 1 initial commit + BATCHES * (KEYS_PER_BATCH + 1 commit).
@@ -1800,7 +1794,7 @@ pub(super) mod test {
     }
 
     /// Empty batch (zero mutations) produces correct speculative root.
-    pub(crate) async fn test_immutable_batch_empty_batch<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_empty_batch<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1839,7 +1833,7 @@ pub(super) mod test {
     }
 
     /// MerkleizedBatch::get() works on a chained child's merkleized batch.
-    pub(crate) async fn test_immutable_batch_chained_merkleized_get<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_chained_merkleized_get<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1894,7 +1888,7 @@ pub(super) mod test {
     }
 
     /// Large single batch, verifying all values and proof.
-    pub(crate) async fn test_immutable_batch_large<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_large<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1905,7 +1899,7 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.with_label("db")).await;
-        let hasher = StandardHasher::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
 
         const N: u64 = 500;
         let mut kvs: Vec<(Digest, Digest)> = Vec::new();
@@ -1934,7 +1928,7 @@ pub(super) mod test {
             Location::new(0),
             &ops,
             &root,
-            F::root_spec(proof.inactive_peaks),
+            proof.inactive_peaks,
         ));
 
         // Expected: 1 initial commit + N sets + 1 commit.
@@ -1944,7 +1938,7 @@ pub(super) mod test {
     }
 
     /// Child batch overrides same key set by parent.
-    pub(crate) async fn test_immutable_batch_chained_key_override<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_chained_key_override<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -1991,7 +1985,7 @@ pub(super) mod test {
     ///
     /// `open_db_small_sections` must return a DB whose log has `items_per_section=1`
     /// so pruning is per-item.
-    pub(crate) async fn test_immutable_batch_sequential_key_override<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_sequential_key_override<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db_small_sections: impl Fn(
             deterministic::Context,
@@ -2042,7 +2036,7 @@ pub(super) mod test {
     }
 
     /// Metadata propagates through merkleize and clears with None.
-    pub(crate) async fn test_immutable_batch_metadata<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_batch_metadata<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2075,7 +2069,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_stale_batch_rejected<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_stale_batch_rejected<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2125,7 +2119,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_stale_batch_chained<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_stale_batch_chained<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2170,7 +2164,7 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_immutable_partial_ancestor_commit<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_partial_ancestor_commit<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2218,7 +2212,7 @@ pub(super) mod test {
     }
 
     pub(crate) async fn test_immutable_sequential_commit_parent_then_child<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -2263,7 +2257,7 @@ pub(super) mod test {
     }
 
     pub(crate) async fn test_immutable_child_root_matches_pending_and_committed<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -2307,7 +2301,7 @@ pub(super) mod test {
     }
 
     pub(crate) async fn test_immutable_stale_batch_child_applied_before_parent<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -2352,7 +2346,7 @@ pub(super) mod test {
 
     /// to_batch() creates an owned snapshot whose root matches the committed DB.
     /// A child batch chained from it can be applied.
-    pub(crate) async fn test_immutable_to_batch<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_to_batch<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2397,7 +2391,7 @@ pub(super) mod test {
 
     /// Regression: applying a batch after its ancestor Arc is dropped (without
     /// committing) must still apply the ancestor's snapshot diffs.
-    pub(crate) async fn test_immutable_apply_after_ancestor_dropped<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_apply_after_ancestor_dropped<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2447,7 +2441,7 @@ pub(super) mod test {
 
     /// Verify the inactivity floor is zero for a fresh empty database and is
     /// correctly set after applying batches with specific floor values.
-    pub(crate) async fn test_immutable_inactivity_floor_tracking<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_inactivity_floor_tracking<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2498,7 +2492,7 @@ pub(super) mod test {
 
     /// Verify that applying a batch with a floor equal to the current floor succeeds,
     /// and that a higher floor also succeeds.
-    pub(crate) async fn test_immutable_floor_monotonicity<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_floor_monotonicity<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2551,7 +2545,7 @@ pub(super) mod test {
     }
 
     /// Verify that the inactivity floor is correctly restored after a rewind.
-    pub(crate) async fn test_immutable_rewind_restores_floor<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_rewind_restores_floor<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2599,7 +2593,7 @@ pub(super) mod test {
 
     /// Verify that applying a batch with a floor lower than the current floor
     /// returns an error.
-    pub(crate) async fn test_immutable_floor_monotonicity_violation<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_floor_monotonicity_violation<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2640,7 +2634,7 @@ pub(super) mod test {
 
     /// Verify that applying a batch with a floor beyond the total operation
     /// count returns an error.
-    pub(crate) async fn test_immutable_floor_beyond_size<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_floor_beyond_size<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -2699,7 +2693,7 @@ pub(super) mod test {
     /// commit's floor at or above the previous commit's floor) from the simpler "every
     /// commit's floor at or above the live floor" rule.
     pub(crate) async fn test_immutable_chained_ancestor_floor_regression<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -2757,7 +2751,7 @@ pub(super) mod test {
     /// dangerous variant: monotonicity can still be satisfied while the floor poisons future
     /// `historical_proof` and rewind.
     pub(crate) async fn test_immutable_chained_ancestor_floor_beyond_size<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -2810,7 +2804,7 @@ pub(super) mod test {
     /// all keys that were live at the rewind target -- not just the ones that
     /// happened to be in the rebuilt snapshot.
     pub(crate) async fn test_immutable_rewind_after_reopen_with_floor_change<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -2874,7 +2868,7 @@ pub(super) mod test {
     /// immediate predecessor. This ensures the snapshot gap fill only covers
     /// [rewind_floor, old_floor) and does not re-insert keys already present.
     pub(crate) async fn test_immutable_rewind_after_reopen_partial_floor_gap<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -2944,7 +2938,7 @@ pub(super) mod test {
     /// - Reopen reconstructs `inactivity_floor_loc` from the sole surviving commit op, and the
     ///   in-memory snapshot is empty (all Sets were below the floor).
     /// - A follow-on batch applies cleanly on top from the floor-at-max state.
-    pub(crate) async fn test_immutable_single_commit_live_set<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_single_commit_live_set<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -3055,7 +3049,7 @@ pub(super) mod test {
 
     /// `get_many` on the DB and on unmerkleized/merkleized batches returns results
     /// that match individual `get` calls.
-    pub(crate) async fn test_immutable_get_many<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_get_many<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,
@@ -3117,7 +3111,7 @@ pub(super) mod test {
     }
 
     /// `get_many` reports unexpected data when the snapshot points at a non-`Set` operation.
-    pub(crate) async fn test_immutable_get_many_unexpected_data<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_immutable_get_many_unexpected_data<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(
             deterministic::Context,

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -6,8 +6,9 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
+        self,
         full::{self, Merkle},
-        Family, Location, Proof, RootSpec as MerkleRootSpec,
+        Family, Location, Proof,
     },
     qmdb::{
         any::ValueEncoding,
@@ -15,7 +16,7 @@ use crate::{
         immutable::{self, CompactDb, Operation},
         operation::{Key, Operation as _},
         sync::{self},
-        Error, RootSpec,
+        Bagging as FamilyBagging, Error,
     },
     translator::Translator,
     Context, Persistable,
@@ -24,11 +25,9 @@ use commonware_codec::{Encode, EncodeShared, Read};
 use commonware_cryptography::Hasher;
 use commonware_utils::range::NonEmptyRange;
 
-type StandardHasher<H> = crate::merkle::hasher::Standard<H>;
-
 impl<F, E, K, V, C, H, T> sync::Database for immutable::Immutable<F, E, K, V, C, H, T>
 where
-    F: Family + RootSpec,
+    F: Family + FamilyBagging,
     E: Context,
     K: Key,
     V: ValueEncoding,
@@ -72,7 +71,7 @@ where
         range: NonEmptyRange<Location<F>>,
         apply_batch_size: usize,
     ) -> Result<Self, Error<F>> {
-        let hasher = StandardHasher::new();
+        let hasher = F::default_hasher();
 
         // Initialize Merkle structure for sync
         let merkle = Merkle::init_sync(
@@ -123,7 +122,7 @@ where
             F::location_to_position(Location::new(*last_commit_loc + 1)),
             inactivity_floor_loc,
         );
-        let root = journal.root(F::root_spec(inactive_peaks))?;
+        let root = journal.root(inactive_peaks)?;
 
         let db = Self {
             journal,
@@ -141,17 +140,21 @@ where
         self.root()
     }
 
-    fn proof_spec(
+    fn proof_inactive_peaks(
         _config: &Self::Config,
         proof: &Proof<Self::Family, Self::Digest>,
-    ) -> MerkleRootSpec {
-        F::root_spec(proof.inactive_peaks)
+    ) -> usize {
+        proof.inactive_peaks
+    }
+
+    fn root_bagging(_config: &Self::Config) -> merkle::Bagging {
+        <F as FamilyBagging>::BAGGING
     }
 }
 
 impl<F, E, K, V, H, Cfg> sync::compact::Database for CompactDb<F, E, K, V, H, Cfg>
 where
-    F: Family + RootSpec,
+    F: Family + FamilyBagging,
     E: Context,
     K: Key,
     V: ValueEncoding,
@@ -187,7 +190,7 @@ where
             Operation::<F, K, V>::Commit(last_commit_metadata.clone(), inactivity_floor_loc)
                 .encode()
                 .to_vec();
-        let hasher = StandardHasher::<H>::new();
+        let hasher = F::default_hasher::<H>();
         let merkle = crate::merkle::compact::Merkle::init_from_compact_state(
             context.with_label("merkle"),
             config.merkle,
@@ -198,7 +201,7 @@ where
         let inactive_peaks =
             F::inactive_peaks(F::location_to_position(leaf_count), inactivity_floor_loc);
         let root = merkle
-            .root(&hasher, F::root_spec(inactive_peaks))
+            .root(&hasher, inactive_peaks)
             .map_err(|_| Error::DataCorrupted("failed to compute compact state root"))?;
         Self::init_from_verified_state(
             merkle,
@@ -216,8 +219,12 @@ where
         self.root()
     }
 
-    fn proof_spec(proof: &Proof<Self::Family, Self::Digest>) -> MerkleRootSpec {
-        F::root_spec(proof.inactive_peaks)
+    fn proof_inactive_peaks(proof: &Proof<Self::Family, Self::Digest>) -> usize {
+        proof.inactive_peaks
+    }
+
+    fn root_bagging() -> merkle::Bagging {
+        <F as FamilyBagging>::BAGGING
     }
 
     async fn persist_compact_state(&self) -> Result<(), Error<F>> {

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -46,7 +46,7 @@ const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
 /// Harness that abstracts per-family details so the generic tests below can operate on
 /// any immutable database.
 pub(crate) trait SyncTestHarness: Sized + 'static {
-    type Family: merkle::Family + qmdb::RootSpec;
+    type Family: merkle::Family + qmdb::Bagging;
     type Db: qmdb::sync::Database<
             Family = Self::Family,
             Context = deterministic::Context,
@@ -894,7 +894,7 @@ pub(crate) mod harnesses {
         }
     }
 
-    fn variable_create_ops_seeded<F: Family + qmdb::RootSpec>(
+    fn variable_create_ops_seeded<F: Family + qmdb::Bagging>(
         n: usize,
         seed: u64,
     ) -> Vec<Operation<F, sha256::Digest, sha256::Digest>> {
@@ -908,7 +908,7 @@ pub(crate) mod harnesses {
         ops
     }
 
-    async fn variable_apply_ops<F: Family + qmdb::RootSpec>(
+    async fn variable_apply_ops<F: Family + qmdb::Bagging>(
         db: VariableDb<F>,
         ops: Vec<Operation<F, sha256::Digest, sha256::Digest>>,
         metadata: Option<sha256::Digest>,
@@ -920,7 +920,7 @@ pub(crate) mod harnesses {
         variable_apply_ops_with_floor::<F>(db, ops, metadata, floor).await
     }
 
-    async fn variable_apply_ops_with_floor<F: Family + qmdb::RootSpec>(
+    async fn variable_apply_ops_with_floor<F: Family + qmdb::Bagging>(
         mut db: VariableDb<F>,
         ops: Vec<Operation<F, sha256::Digest, sha256::Digest>>,
         metadata: Option<sha256::Digest>,
@@ -947,7 +947,7 @@ pub(crate) mod harnesses {
 
     pub(crate) struct VariableHarness<F>(std::marker::PhantomData<F>);
 
-    impl<F: Family + qmdb::RootSpec> SyncTestHarness for VariableHarness<F> {
+    impl<F: Family + qmdb::Bagging> SyncTestHarness for VariableHarness<F> {
         type Family = F;
         type Db = VariableDb<F>;
         type Key = sha256::Digest;

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -12,7 +12,7 @@ use crate::{
     qmdb::{
         any::{value::VariableEncoding, VariableValue},
         operation::Key,
-        Error, RootSpec,
+        Bagging, Error,
     },
     translator::Translator,
 };
@@ -40,7 +40,7 @@ pub type Config<T, C> = BaseConfig<T, JournalConfig<C>>;
 pub type CompactConfig<C> = super::CompactConfig<C>;
 
 impl<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         E: Storage + Clock + Metrics,
         K: Key,
         V: VariableValue,
@@ -59,6 +59,7 @@ impl<
             cfg.merkle_config,
             cfg.log,
             Operation::<F, K, V>::is_commit,
+            <F as Bagging>::BAGGING,
         )
         .await?;
         Self::init_from_journal(journal, context, cfg.translator).await
@@ -66,7 +67,7 @@ impl<
 }
 
 impl<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         E: Storage + Clock + Metrics,
         K: Key,
         V: VariableValue,
@@ -125,14 +126,14 @@ mod tests {
         }
     }
 
-    async fn open_db<F: Family + RootSpec>(
+    async fn open_db<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> Db<F, deterministic::Context, Digest, Digest, Sha256, TwoCap> {
         let cfg = config("partition", &context);
         Db::init(context, cfg).await.unwrap()
     }
 
-    async fn open_compact<F: Family + RootSpec>(
+    async fn open_compact<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> CompactDb<F, deterministic::Context, Digest, Digest, Sha256, ((), ())> {
         let cfg = CompactConfig {
@@ -146,7 +147,7 @@ mod tests {
     }
 
     #[allow(clippy::type_complexity)]
-    fn open<F: Family + RootSpec>(
+    fn open<F: Family + Bagging>(
         ctx: deterministic::Context,
     ) -> Pin<
         Box<
@@ -178,7 +179,7 @@ mod tests {
         cfg
     }
 
-    async fn open_small_sections_db<F: Family + RootSpec>(
+    async fn open_small_sections_db<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> Db<F, deterministic::Context, Digest, Digest, Sha256, TwoCap> {
         let cfg = small_sections_config("partition", &context);
@@ -186,7 +187,7 @@ mod tests {
     }
 
     #[allow(clippy::type_complexity)]
-    fn open_small_sections<F: Family + RootSpec>(
+    fn open_small_sections<F: Family + Bagging>(
         ctx: deterministic::Context,
     ) -> Pin<
         Box<
@@ -277,7 +278,7 @@ mod tests {
         });
     }
 
-    async fn assert_compact_root_compatibility<F: Family + RootSpec>(ctx: deterministic::Context) {
+    async fn assert_compact_root_compatibility<F: Family + Bagging>(ctx: deterministic::Context) {
         let mut db = open_db::<F>(ctx.with_label("db")).await;
         let mut compact = open_compact::<F>(ctx.with_label("compact")).await;
         assert_eq!(db.root(), compact.root());

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -4,7 +4,7 @@ use super::{operation::Operation, Keyless};
 use crate::{
     journal::{authenticated, contiguous::Mutable, Error as JournalError},
     merkle::{Family, Location},
-    qmdb::{any::value::ValueEncoding, Error, RootSpec},
+    qmdb::{any::value::ValueEncoding, Bagging, Error},
     Context, Persistable,
 };
 use commonware_codec::EncodeShared;
@@ -18,7 +18,7 @@ use std::sync::{Arc, Weak};
 /// Consuming [`UnmerkleizedBatch::merkleize`] produces an `Arc<MerkleizedBatch>`.
 pub struct UnmerkleizedBatch<F, H, V>
 where
-    F: Family + RootSpec,
+    F: Family + Bagging,
     V: ValueEncoding,
     H: Hasher,
     Operation<F, V>: EncodeShared,
@@ -43,7 +43,7 @@ where
 /// A speculative batch of operations whose root digest has been computed,
 /// in contrast to [`UnmerkleizedBatch`].
 #[derive(Clone)]
-pub struct MerkleizedBatch<F: Family + RootSpec, D: Digest, V: ValueEncoding>
+pub struct MerkleizedBatch<F: Family + Bagging, D: Digest, V: ValueEncoding>
 where
     Operation<F, V>: EncodeShared,
 {
@@ -78,7 +78,7 @@ where
     pub(super) new_inactivity_floor_loc: Location<F>,
 }
 
-impl<F: Family + RootSpec, D: Digest, V: ValueEncoding> MerkleizedBatch<F, D, V>
+impl<F: Family + Bagging, D: Digest, V: ValueEncoding> MerkleizedBatch<F, D, V>
 where
     Operation<F, V>: EncodeShared,
 {
@@ -98,7 +98,7 @@ where
 /// Returns `None` if the location cannot be found in the live parent chain (e.g. the
 /// owning ancestor was committed and freed). Callers should fall through to the committed
 /// DB in that case.
-fn read_chain_op<F: Family + RootSpec, D: Digest, V: ValueEncoding>(
+fn read_chain_op<F: Family + Bagging, D: Digest, V: ValueEncoding>(
     batch: &MerkleizedBatch<F, D, V>,
     loc: u64,
 ) -> Option<Operation<F, V>>
@@ -125,7 +125,7 @@ where
 
 impl<F, H, V> UnmerkleizedBatch<F, H, V>
 where
-    F: Family + RootSpec,
+    F: Family + Bagging,
     V: ValueEncoding,
     H: Hasher,
     Operation<F, V>: EncodeShared,
@@ -297,7 +297,7 @@ where
         let journal = db.journal.with_mem(|mem| journal_batch.merkleize(mem));
         let root = db
             .journal
-            .with_mem(|mem| journal.root(mem, &db.journal.hasher, F::root_spec(inactive_peaks)))
+            .with_mem(|mem| journal.root(mem, &db.journal.hasher, inactive_peaks))
             .expect("inactive_peaks computed from batch size");
 
         let mut ancestor_batch_ends = Vec::new();
@@ -325,7 +325,7 @@ where
     }
 }
 
-impl<F: Family + RootSpec, D: Digest, V: ValueEncoding> MerkleizedBatch<F, D, V>
+impl<F: Family + Bagging, D: Digest, V: ValueEncoding> MerkleizedBatch<F, D, V>
 where
     Operation<F, V>: EncodeShared,
 {

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -22,15 +22,12 @@
 
 use super::operation::Operation;
 use crate::{
-    merkle::{
-        batch, compact as compact_merkle, hasher::Standard as StandardHasher, Family, Location,
-        Proof,
-    },
+    merkle::{batch, compact as compact_merkle, Family, Location, Proof},
     qmdb::{
         any::value::ValueEncoding,
         compact_witness::{self, CachedServeState, WitnessSource},
         sync::compact as compact_sync,
-        Error, RootSpec,
+        Bagging, Error,
     },
     Context,
 };
@@ -187,12 +184,12 @@ where
         inactivity_floor: Location<F>,
     ) -> Arc<MerkleizedBatch<F, H::Digest, V>>
     where
-        F: RootSpec,
+        F: Bagging,
         E: Context,
         C: Clone + Send + Sync + 'static,
         Operation<F, V>: Read<Cfg = C>,
     {
-        let hasher = StandardHasher::<H>::new();
+        let hasher = F::default_hasher::<H>();
         let mut ops: Vec<Operation<F, V>> = Vec::with_capacity(self.appends.len() + 1);
         for value in self.appends {
             ops.push(Operation::Append(value));
@@ -214,7 +211,7 @@ where
         );
         let root = db
             .merkle
-            .with_mem(|mem| merkle.root(mem, &hasher, F::root_spec(inactive_peaks)))
+            .with_mem(|mem| merkle.root(mem, &hasher, inactive_peaks))
             .expect("inactive_peaks computed from batch size");
 
         let mut ancestor_batch_ends = Vec::new();
@@ -288,7 +285,7 @@ where
         Error<F>,
     >
     where
-        F: RootSpec,
+        F: Bagging,
     {
         compact_witness::load_serve_state::<F, E, H, _, _, _>(
             merkle,
@@ -348,7 +345,7 @@ where
         commit_codec_config: C,
     ) -> Result<Self, Error<F>>
     where
-        F: RootSpec,
+        F: Bagging,
         Operation<F, V>: Read<Cfg = C>,
     {
         // Bootstrap: append an initial Commit(None, 0) on first open. This establishes the
@@ -386,15 +383,15 @@ where
     /// Return the root of the db.
     pub fn root(&self) -> H::Digest
     where
-        F: RootSpec,
+        F: Bagging,
     {
-        let hasher = StandardHasher::<H>::new();
+        let hasher = F::default_hasher::<H>();
         let inactive_peaks = F::inactive_peaks(
             F::location_to_position(Location::new(*self.last_commit_loc + 1)),
             self.inactivity_floor_loc,
         );
         self.merkle
-            .root(&hasher, F::root_spec(inactive_peaks))
+            .root(&hasher, inactive_peaks)
             .expect("compact Merkle root should not fail")
     }
 
@@ -481,7 +478,7 @@ where
     /// intentionally not consulted here.
     pub fn to_batch(&self) -> Arc<MerkleizedBatch<F, H::Digest, V>>
     where
-        F: RootSpec,
+        F: Bagging,
     {
         let committed_size = *self.last_commit_loc + 1;
         Arc::new(MerkleizedBatch {
@@ -552,7 +549,7 @@ where
     /// witness when the current state has already been persisted.
     pub async fn sync(&self) -> Result<(), Error<F>>
     where
-        F: RootSpec,
+        F: Bagging,
     {
         compact_witness::persist_witness(self).await
     }
@@ -560,7 +557,7 @@ where
     /// Durably persist the current db state to disk (alias for [`Self::sync`]).
     pub async fn commit(&self) -> Result<(), Error<F>>
     where
-        F: RootSpec,
+        F: Bagging,
     {
         self.sync().await
     }
@@ -591,7 +588,7 @@ where
     /// after any `Err` from `rewind` and reopen from storage.
     pub async fn rewind(&mut self) -> Result<(), Error<F>>
     where
-        F: RootSpec,
+        F: Bagging,
     {
         self.merkle.rewind().await?;
         // Reload the witness from the reverted slot as well, so compact serving stays aligned with
@@ -648,7 +645,7 @@ mod tests {
     use crate::{
         merkle::mmr,
         metadata::{Config as MConfig, Metadata},
-        qmdb::{any::value::FixedEncoding, RootSpec},
+        qmdb::{any::value::FixedEncoding, Bagging},
     };
     use commonware_cryptography::Sha256;
     use commonware_macros::test_traced;
@@ -657,7 +654,7 @@ mod tests {
 
     type TestDb<F> = Db<F, deterministic::Context, FixedEncoding<U64>, Sha256>;
 
-    async fn open_db<F: Family + RootSpec>(
+    async fn open_db<F: Family + Bagging>(
         context: deterministic::Context,
         partition: &str,
     ) -> TestDb<F> {

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -12,7 +12,7 @@ use crate::{
         any::value::{FixedEncoding, FixedValue},
         keyless::operation::Operation as BaseOperation,
         operation::Committable,
-        Error, RootSpec,
+        Bagging, Error,
     },
 };
 use commonware_cryptography::Hasher;
@@ -36,17 +36,23 @@ pub type Config = super::Config<JournalConfig>;
 /// Configuration for a fixed-size [keyless](super) compact db.
 pub type CompactConfig = super::CompactConfig<()>;
 
-impl<F: Family + RootSpec, E: Storage + Clock + Metrics, V: FixedValue, H: Hasher> Db<F, E, V, H> {
+impl<F: Family + Bagging, E: Storage + Clock + Metrics, V: FixedValue, H: Hasher> Db<F, E, V, H> {
     /// Returns a [Db] initialized from `cfg`. Any uncommitted operations will be
     /// discarded and the state of the db will be as of the last committed operation.
     pub async fn init(context: E, cfg: Config) -> Result<Self, Error<F>> {
-        let journal: Journal<F, E, V, H> =
-            Journal::new(context, cfg.merkle, cfg.log, Operation::<F, V>::is_commit).await?;
+        let journal: Journal<F, E, V, H> = Journal::new(
+            context,
+            cfg.merkle,
+            cfg.log,
+            Operation::<F, V>::is_commit,
+            <F as Bagging>::BAGGING,
+        )
+        .await?;
         Self::init_from_journal(journal).await
     }
 }
 
-impl<F: Family + RootSpec, E: Storage + Clock + Metrics, V: FixedValue, H: Hasher>
+impl<F: Family + Bagging, E: Storage + Clock + Metrics, V: FixedValue, H: Hasher>
     CompactDb<F, E, V, H>
 {
     /// Returns a [CompactDb] initialized from `cfg`.
@@ -98,11 +104,11 @@ mod test {
     type TestCompactDb<F> =
         CompactDb<F, deterministic::Context, commonware_utils::sequence::U64, Sha256>;
 
-    async fn open_db<F: Family + RootSpec>(context: deterministic::Context) -> TestDb<F> {
+    async fn open_db<F: Family + Bagging>(context: deterministic::Context) -> TestDb<F> {
         open_db_with_suffix("partition", context).await
     }
 
-    async fn open_db_with_suffix<F: Family + RootSpec>(
+    async fn open_db_with_suffix<F: Family + Bagging>(
         suffix: &str,
         context: deterministic::Context,
     ) -> TestDb<F> {
@@ -110,7 +116,7 @@ mod test {
         TestDb::init(context, cfg).await.unwrap()
     }
 
-    async fn open_compact<F: crate::merkle::Family + RootSpec>(
+    async fn open_compact<F: crate::merkle::Family + Bagging>(
         context: deterministic::Context,
     ) -> TestCompactDb<F> {
         let cfg = CompactConfig {
@@ -123,7 +129,7 @@ mod test {
         TestCompactDb::init(context, cfg).await.unwrap()
     }
 
-    fn reopen<F: Family + RootSpec>() -> tests::Reopen<TestDb<F>> {
+    fn reopen<F: Family + Bagging>() -> tests::Reopen<TestDb<F>> {
         Box::new(|ctx| Box::pin(open_db(ctx)))
     }
 
@@ -216,7 +222,7 @@ mod test {
         });
     }
 
-    async fn assert_compact_root_compatibility<F: crate::merkle::Family + RootSpec>(
+    async fn assert_compact_root_compatibility<F: crate::merkle::Family + Bagging>(
         ctx: deterministic::Context,
     ) {
         let mut db = open_db::<F>(ctx.with_label("db")).await;

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -50,7 +50,7 @@ use crate::{
         Error as JournalError,
     },
     merkle::{full::Config as MerkleConfig, Family, Location, Proof},
-    qmdb::{any::value::ValueEncoding, Error, RootSpec},
+    qmdb::{any::value::ValueEncoding, Bagging, Error},
     Context, Persistable,
 };
 use commonware_codec::EncodeShared;
@@ -106,7 +106,7 @@ where
 
 impl<F, E, V, C, H> Keyless<F, E, V, C, H>
 where
-    F: Family + RootSpec,
+    F: Family + Bagging,
     E: Context,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
@@ -140,7 +140,7 @@ where
             F::location_to_position(Location::new(*last_commit_loc + 1)),
             inactivity_floor_loc,
         );
-        let root = journal.root(F::root_spec(inactive_peaks))?;
+        let root = journal.root(inactive_peaks)?;
 
         Ok(Self {
             journal,
@@ -290,7 +290,7 @@ where
 
         Ok(self
             .journal
-            .historical_proof(op_count, start_loc, max_ops, F::root_spec(inactive_peaks))
+            .historical_proof(op_count, start_loc, max_ops, inactive_peaks)
             .await?)
     }
 
@@ -383,7 +383,7 @@ where
         self.last_commit_loc = rewind_last_loc;
         self.inactivity_floor_loc = rewind_floor;
         let inactive_peaks = F::inactive_peaks(F::location_to_position(size), rewind_floor);
-        self.root = self.journal.root(F::root_spec(inactive_peaks))?;
+        self.root = self.journal.root(inactive_peaks)?;
         Ok(())
     }
 
@@ -520,8 +520,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::{
         journal::{contiguous::Mutable, Error as JournalError},
-        merkle::hasher::Standard,
-        qmdb::{verify_proof, RootSpec},
+        qmdb::verify_proof,
         Persistable,
     };
     use commonware_cryptography::Sha256;
@@ -549,7 +548,7 @@ pub(crate) mod tests {
         }
     }
 
-    pub(crate) async fn test_keyless_db_empty<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_empty<F: Family + Bagging, V, C, H>(
         context: deterministic::Context,
         db: Keyless<F, deterministic::Context, V, C, H>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, H>>,
@@ -603,7 +602,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_build_basic<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_build_basic<F: Family + Bagging, V, C, H>(
         context: deterministic::Context,
         mut db: Keyless<F, deterministic::Context, V, C, H>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, H>>,
@@ -653,7 +652,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_recovery<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_recovery<F: Family + Bagging, V, C, H>(
         context: deterministic::Context,
         db: Keyless<F, deterministic::Context, V, C, H>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, H>>,
@@ -727,14 +726,14 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_proof<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_db_proof<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
         const ELEMENTS: u64 = 50;
 
         {
@@ -755,7 +754,7 @@ pub(crate) mod tests {
             Location::new(0),
             &ops,
             &root,
-            F::root_spec(proof.inactive_peaks),
+            proof.inactive_peaks,
         ));
         assert_eq!(ops.len() as u64, 1 + ELEMENTS + 1);
 
@@ -766,14 +765,14 @@ pub(crate) mod tests {
             Location::new(10),
             &ops,
             &root,
-            F::root_spec(proof.inactive_peaks),
+            proof.inactive_peaks,
         ));
         assert_eq!(ops.len(), 5);
 
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_metadata<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_metadata<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -799,7 +798,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_pruning<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_pruning<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -851,7 +850,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_empty_db_recovery<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_empty_db_recovery<F: Family + Bagging, V, C, H>(
         context: deterministic::Context,
         db: Keyless<F, deterministic::Context, V, C, H>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, H>>,
@@ -927,12 +926,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_replay_with_trailing_appends<
-        F: Family + RootSpec,
-        V,
-        C,
-        H,
-    >(
+    pub(crate) async fn test_keyless_db_replay_with_trailing_appends<F: Family + Bagging, V, C, H>(
         context: deterministic::Context,
         mut db: Keyless<F, deterministic::Context, V, C, H>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, H>>,
@@ -1031,7 +1025,7 @@ pub(crate) mod tests {
 
     /// `get_many` on the DB and on unmerkleized/merkleized batches returns
     /// results consistent with individual `get` calls.
-    pub(crate) async fn test_keyless_get_many<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_get_many<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1080,7 +1074,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_batch_chained<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_batch_chained<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1115,7 +1109,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_stale_batch<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_stale_batch<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1142,7 +1136,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_partial_ancestor_commit<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_partial_ancestor_commit<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1179,7 +1173,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_to_batch<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_to_batch<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1209,7 +1203,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_non_empty_recovery<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_non_empty_recovery<F: Family + Bagging, V, C, H>(
         context: deterministic::Context,
         mut db: Keyless<F, deterministic::Context, V, C, H>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, H>>,
@@ -1300,14 +1294,14 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_proof_comprehensive<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_db_proof_comprehensive<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
 
         // Build a db with some values.
         const ELEMENTS: u64 = 100;
@@ -1345,7 +1339,7 @@ pub(crate) mod tests {
                 .proof(Location::new(start_loc), NZU64!(max_ops))
                 .await
                 .unwrap();
-            let spec = F::root_spec(proof.inactive_peaks);
+            let spec = proof.inactive_peaks;
             assert!(
                 verify_proof(&hasher, &proof, Location::new(start_loc), &ops, &root, spec,),
                 "Failed to verify proof for range starting at {start_loc} with max {max_ops} ops",
@@ -1377,7 +1371,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_proof_with_pruning<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_db_proof_with_pruning<F: Family + Bagging, V, C>(
         context: deterministic::Context,
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, Sha256>>,
@@ -1386,7 +1380,7 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
 
         const ELEMENTS: u64 = 100;
         {
@@ -1438,7 +1432,7 @@ pub(crate) mod tests {
                 start_loc,
                 &ops,
                 &root,
-                F::root_spec(proof.inactive_peaks),
+                proof.inactive_peaks,
             ));
         }
 
@@ -1453,7 +1447,7 @@ pub(crate) mod tests {
             new_oldest,
             &ops,
             &root,
-            F::root_spec(proof.inactive_peaks),
+            proof.inactive_peaks,
         ));
 
         let almost_all = db.bounds().await.end - 5;
@@ -1467,14 +1461,14 @@ pub(crate) mod tests {
                 final_oldest,
                 &final_ops,
                 &root,
-                F::root_spec(final_proof.inactive_peaks),
+                final_proof.inactive_peaks,
             ));
         }
 
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_get_out_of_bounds<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_get_out_of_bounds<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1505,7 +1499,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_batch_get<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_batch_get<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1547,7 +1541,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_batch_stacked_get<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_batch_stacked_get<F: Family + Bagging, V, C>(
         db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1573,7 +1567,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_batch_speculative_root<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_batch_speculative_root<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1602,7 +1596,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_merkleized_batch_get<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_merkleized_batch_get<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1635,7 +1629,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_batch_chained_apply_sequential<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_batch_chained_apply_sequential<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1668,14 +1662,14 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_batch_many_sequential<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_batch_many_sequential<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
 
         const BATCHES: u64 = 20;
         const APPENDS_PER_BATCH: u64 = 5;
@@ -1707,14 +1701,14 @@ pub(crate) mod tests {
             Location::new(0),
             &ops,
             &root,
-            F::root_spec(proof.inactive_peaks),
+            proof.inactive_peaks,
         ));
         assert_eq!(db.bounds().await.end, 1 + BATCHES * (APPENDS_PER_BATCH + 1));
 
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_batch_empty<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_batch_empty<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1744,7 +1738,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_batch_chained_merkleized_get<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_batch_chained_merkleized_get<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1785,14 +1779,14 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_batch_large<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_batch_large<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = Standard::<Sha256>::new();
+        let hasher = F::default_hasher::<Sha256>();
         const N: u64 = 500;
         let mut values = Vec::new();
         let mut locs = Vec::new();
@@ -1819,14 +1813,14 @@ pub(crate) mod tests {
             Location::new(0),
             &ops,
             &root,
-            F::root_spec(proof.inactive_peaks),
+            proof.inactive_peaks,
         ));
         assert_eq!(db.bounds().await.end, 1 + N + 1);
 
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_stale_batch_chained<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_stale_batch_chained<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1857,7 +1851,7 @@ pub(crate) mod tests {
     }
 
     pub(crate) async fn test_keyless_sequential_commit_parent_then_child<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -1883,7 +1877,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_stale_batch_child_before_parent<F: Family + RootSpec, V, C>(
+    pub(crate) async fn test_keyless_stale_batch_child_before_parent<F: Family + Bagging, V, C>(
         mut db: Keyless<F, deterministic::Context, V, C, Sha256>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -1910,7 +1904,7 @@ pub(crate) mod tests {
     }
 
     pub(crate) async fn test_keyless_child_root_matches_pending_and_committed<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
     >(
@@ -1947,7 +1941,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    async fn commit_appends<F: Family + RootSpec, V, C, H>(
+    async fn commit_appends<F: Family + Bagging, V, C, H>(
         db: &mut Keyless<F, deterministic::Context, V, C, H>,
         values: impl IntoIterator<Item = V::Value>,
         metadata: Option<V::Value>,
@@ -1976,7 +1970,7 @@ pub(crate) mod tests {
         range
     }
 
-    pub(crate) async fn test_keyless_db_rewind_recovery<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_rewind_recovery<F: Family + Bagging, V, C, H>(
         context: deterministic::Context,
         mut db: Keyless<F, deterministic::Context, V, C, H>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, H>>,
@@ -2076,7 +2070,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_rewind_pruned_target_errors<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_rewind_pruned_target_errors<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -2126,7 +2120,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_floor_tracking<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_floor_tracking<F: Family + Bagging, V, C, H>(
         context: deterministic::Context,
         mut db: Keyless<F, deterministic::Context, V, C, H>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, H>>,
@@ -2175,7 +2169,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_floor_regression_rejected<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_floor_regression_rejected<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -2214,7 +2208,7 @@ pub(crate) mod tests {
     }
 
     pub(crate) async fn test_keyless_db_floor_beyond_commit_loc_rejected<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
         H,
@@ -2255,7 +2249,7 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
-    pub(crate) async fn test_keyless_db_rewind_restores_floor<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_rewind_restores_floor<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -2302,7 +2296,7 @@ pub(crate) mod tests {
 
     /// Floor is embedded in the Commit operation and therefore in the Merkle root: two databases
     /// with identical appends but different floors must produce different roots.
-    pub(crate) async fn test_keyless_db_floor_changes_root<F: Family + RootSpec, V, C, H>(
+    pub(crate) async fn test_keyless_db_floor_changes_root<F: Family + Bagging, V, C, H>(
         mut db_a: Keyless<F, deterministic::Context, V, C, H>,
         mut db_b: Keyless<F, deterministic::Context, V, C, H>,
     ) where
@@ -2338,12 +2332,7 @@ pub(crate) mod tests {
     }
 
     /// A floor equal to the commit operation's location is on the tight boundary of acceptance.
-    pub(crate) async fn test_keyless_db_floor_at_commit_loc_accepted<
-        F: Family + RootSpec,
-        V,
-        C,
-        H,
-    >(
+    pub(crate) async fn test_keyless_db_floor_at_commit_loc_accepted<F: Family + Bagging, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -2369,7 +2358,7 @@ pub(crate) mod tests {
 
     /// End-to-end: commit → drop → reopen → rewind → verify floor restored after a crash.
     pub(crate) async fn test_keyless_db_rewind_after_reopen_with_floor<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V,
         C,
         H,
@@ -2434,7 +2423,7 @@ pub(crate) mod tests {
     pub(crate) async fn test_keyless_db_ancestor_floor_regression_rejected<F, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         H: Hasher,
@@ -2475,7 +2464,7 @@ pub(crate) mod tests {
     pub(crate) async fn test_keyless_db_ancestor_floor_beyond_commit_loc_rejected<F, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         H: Hasher,
@@ -2513,7 +2502,7 @@ pub(crate) mod tests {
         mut db: Keyless<F, deterministic::Context, V, C, H>,
         reopen: Reopen<Keyless<F, deterministic::Context, V, C, H>>,
     ) where
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         H: Hasher,
@@ -2605,7 +2594,7 @@ pub(crate) mod tests {
     pub(crate) async fn test_keyless_db_chained_apply_with_valid_floors_succeeds<F, V, C, H>(
         mut db: Keyless<F, deterministic::Context, V, C, H>,
     ) where
-        F: Family + RootSpec,
+        F: Family + Bagging,
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
         H: Hasher,

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -6,8 +6,7 @@ use crate::{
     },
     merkle::{
         full::{self, Merkle},
-        hasher::Standard as StandardHasher,
-        Family, Location, Proof, RootSpec,
+        Bagging, Family, Location, Proof,
     },
     qmdb::{
         self,
@@ -24,7 +23,7 @@ use commonware_utils::range::NonEmptyRange;
 
 impl<F, E, V, C, H> sync::Database for Keyless<F, E, V, C, H>
 where
-    F: Family + qmdb::RootSpec,
+    F: Family + qmdb::Bagging,
     E: Context,
     V: ValueEncoding + Codec,
     C: Mutable<Item = Operation<F, V>>
@@ -65,7 +64,7 @@ where
         range: NonEmptyRange<Location<F>>,
         apply_batch_size: usize,
     ) -> Result<Self, qmdb::Error<F>> {
-        let hasher = StandardHasher::<H>::new();
+        let hasher = F::default_hasher::<H>();
 
         let merkle = Merkle::init_sync(
             context.with_label("merkle"),
@@ -102,7 +101,7 @@ where
             F::location_to_position(Location::new(*last_commit_loc + 1)),
             inactivity_floor_loc,
         );
-        let root = journal.root(F::root_spec(inactive_peaks))?;
+        let root = journal.root(inactive_peaks)?;
 
         let db = Self {
             journal,
@@ -119,14 +118,21 @@ where
         self.root()
     }
 
-    fn proof_spec(_config: &Self::Config, proof: &Proof<Self::Family, Self::Digest>) -> RootSpec {
-        F::root_spec(proof.inactive_peaks)
+    fn proof_inactive_peaks(
+        _config: &Self::Config,
+        proof: &Proof<Self::Family, Self::Digest>,
+    ) -> usize {
+        proof.inactive_peaks
+    }
+
+    fn root_bagging(_config: &Self::Config) -> Bagging {
+        <F as qmdb::Bagging>::BAGGING
     }
 }
 
 impl<F, E, V, H, Cfg> sync::compact::Database for CompactDb<F, E, V, H, Cfg>
 where
-    F: Family + qmdb::RootSpec,
+    F: Family + qmdb::Bagging,
     E: Context,
     V: ValueEncoding + Codec,
     H: Hasher,
@@ -161,7 +167,7 @@ where
             Operation::<F, V>::Commit(last_commit_metadata.clone(), inactivity_floor_loc)
                 .encode()
                 .to_vec();
-        let hasher = StandardHasher::<H>::new();
+        let hasher = F::default_hasher::<H>();
         let merkle = crate::merkle::compact::Merkle::init_from_compact_state(
             context.with_label("merkle"),
             config.merkle,
@@ -172,7 +178,7 @@ where
         let inactive_peaks =
             F::inactive_peaks(F::location_to_position(leaf_count), inactivity_floor_loc);
         let root = merkle
-            .root(&hasher, F::root_spec(inactive_peaks))
+            .root(&hasher, inactive_peaks)
             .map_err(|_| qmdb::Error::DataCorrupted("failed to compute compact state root"))?;
         Self::init_from_verified_state(
             merkle,
@@ -190,8 +196,12 @@ where
         self.root()
     }
 
-    fn proof_spec(proof: &Proof<Self::Family, Self::Digest>) -> RootSpec {
-        F::root_spec(proof.inactive_peaks)
+    fn proof_inactive_peaks(proof: &Proof<Self::Family, Self::Digest>) -> usize {
+        proof.inactive_peaks
+    }
+
+    fn root_bagging() -> Bagging {
+        <F as qmdb::Bagging>::BAGGING
     }
 
     async fn persist_compact_state(&self) -> Result<(), qmdb::Error<F>> {

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -43,7 +43,7 @@ const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
 /// Harness that abstracts per-family/per-variant details so the generic tests below
 /// can operate on any keyless database.
 pub(crate) trait SyncTestHarness: Sized + 'static {
-    type Family: merkle::Family + qmdb::RootSpec;
+    type Family: merkle::Family + qmdb::Bagging;
     type Db: qmdb::sync::Database<
             Family = Self::Family,
             Context = deterministic::Context,
@@ -812,7 +812,7 @@ pub(crate) mod harnesses {
         }
     }
 
-    fn variable_create_ops_seeded<F: Family + qmdb::RootSpec>(
+    fn variable_create_ops_seeded<F: Family + qmdb::Bagging>(
         n: usize,
         seed: u64,
     ) -> Vec<VariableOp<F>> {
@@ -829,7 +829,7 @@ pub(crate) mod harnesses {
 
     /// Applies the given operations and commits the database, advancing the inactivity floor to
     /// the new commit location so sync tests that exercise pruning can do so freely.
-    async fn variable_apply_ops<F: Family + qmdb::RootSpec>(
+    async fn variable_apply_ops<F: Family + qmdb::Bagging>(
         mut db: VariableDb<F>,
         ops: Vec<VariableOp<F>>,
         metadata: Option<Vec<u8>>,
@@ -857,7 +857,7 @@ pub(crate) mod harnesses {
 
     pub(crate) struct VariableHarness<F>(std::marker::PhantomData<F>);
 
-    impl<F: Family + qmdb::RootSpec> SyncTestHarness for VariableHarness<F> {
+    impl<F: Family + qmdb::Bagging> SyncTestHarness for VariableHarness<F> {
         type Family = F;
         type Db = VariableDb<F>;
         type Value = Vec<u8>;

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -12,7 +12,7 @@ use crate::{
         any::value::{VariableEncoding, VariableValue},
         keyless::operation::Operation as BaseOperation,
         operation::Committable,
-        Error, RootSpec,
+        Bagging, Error,
     },
 };
 use commonware_codec::Read;
@@ -37,7 +37,7 @@ pub type Config<C> = super::Config<JournalConfig<C>>;
 /// Configuration for a variable-size [keyless](super) compact db.
 pub type CompactConfig<C> = super::CompactConfig<C>;
 
-impl<F: Family + RootSpec, E: Storage + Clock + Metrics, V: VariableValue, H: Hasher>
+impl<F: Family + Bagging, E: Storage + Clock + Metrics, V: VariableValue, H: Hasher>
     Db<F, E, V, H>
 {
     /// Returns a [Db] initialized from `cfg`. Any uncommitted operations will be
@@ -46,14 +46,20 @@ impl<F: Family + RootSpec, E: Storage + Clock + Metrics, V: VariableValue, H: Ha
         context: E,
         cfg: Config<<Operation<F, V> as Read>::Cfg>,
     ) -> Result<Self, Error<F>> {
-        let journal: Journal<F, E, V, H> =
-            Journal::new(context, cfg.merkle, cfg.log, Operation::<F, V>::is_commit).await?;
+        let journal: Journal<F, E, V, H> = Journal::new(
+            context,
+            cfg.merkle,
+            cfg.log,
+            Operation::<F, V>::is_commit,
+            <F as Bagging>::BAGGING,
+        )
+        .await?;
         Self::init_from_journal(journal).await
     }
 }
 
 impl<
-        F: Family + RootSpec,
+        F: Family + Bagging,
         E: Storage + Clock + Metrics,
         V: VariableValue,
         H: Hasher,
@@ -123,11 +129,11 @@ mod test {
     >;
 
     /// Return a [Db] database initialized with a fixed config.
-    async fn open_db<F: Family + RootSpec>(context: deterministic::Context) -> TestDb<F> {
+    async fn open_db<F: Family + Bagging>(context: deterministic::Context) -> TestDb<F> {
         open_db_with_suffix("partition", context).await
     }
 
-    async fn open_db_with_suffix<F: Family + RootSpec>(
+    async fn open_db_with_suffix<F: Family + Bagging>(
         suffix: &str,
         context: deterministic::Context,
     ) -> TestDb<F> {
@@ -135,7 +141,7 @@ mod test {
         TestDb::init(context, cfg).await.unwrap()
     }
 
-    async fn open_compact<F: crate::merkle::Family + RootSpec>(
+    async fn open_compact<F: crate::merkle::Family + Bagging>(
         context: deterministic::Context,
     ) -> TestCompactDb<F> {
         let cfg = CompactConfig {
@@ -148,7 +154,7 @@ mod test {
         TestCompactDb::init(context, cfg).await.unwrap()
     }
 
-    fn reopen<F: Family + RootSpec>() -> tests::Reopen<TestDb<F>> {
+    fn reopen<F: Family + Bagging>() -> tests::Reopen<TestDb<F>> {
         Box::new(|ctx| Box::pin(open_db(ctx)))
     }
 
@@ -303,7 +309,7 @@ mod test {
         });
     }
 
-    async fn assert_compact_root_compatibility<F: crate::merkle::Family + RootSpec>(
+    async fn assert_compact_root_compatibility<F: crate::merkle::Family + Bagging>(
         ctx: deterministic::Context,
     ) {
         let mut db = open_db::<F>(ctx.with_label("db")).await;

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -48,7 +48,7 @@ use crate::{
         contiguous::{Mutable, Reader},
         Error as JournalError,
     },
-    merkle::{self, Family, Location, RootSpec as MerkleRootSpec},
+    merkle::{self, Family, Location},
     qmdb::operation::Operation,
 };
 use commonware_utils::NZUsize;
@@ -69,7 +69,7 @@ pub mod store;
 pub mod sync;
 pub mod verify;
 
-/// Per-family root spec used by QMDB databases.
+/// Per-family default bagging policy used by QMDB databases.
 ///
 /// QMDB chooses different active-region bagging per family: MMR uses forward bagging and MMB uses
 /// backward bagging (so the active suffix can collapse into a single accumulator under MMB's
@@ -77,20 +77,23 @@ pub mod verify;
 ///
 /// This trait isolates that consumer choice from the family's structural topology — `Family` itself
 /// stays bagging-agnostic.
-pub trait RootSpec: Family {
-    fn root_spec(inactive_peaks: usize) -> MerkleRootSpec;
-}
+pub trait Bagging: Family {
+    /// The default bagging policy for this family in QMDB databases.
+    const BAGGING: merkle::Bagging;
 
-impl RootSpec for merkle::mmr::Family {
-    fn root_spec(inactive_peaks: usize) -> MerkleRootSpec {
-        MerkleRootSpec::split_forward(inactive_peaks)
+    /// Construct a [`merkle::hasher::Standard`] hasher pre-configured with this family's default
+    /// bagging.
+    fn default_hasher<H: commonware_cryptography::Hasher>() -> merkle::hasher::Standard<H> {
+        merkle::hasher::Standard::with_bagging(Self::BAGGING)
     }
 }
 
-impl RootSpec for merkle::mmb::Family {
-    fn root_spec(inactive_peaks: usize) -> MerkleRootSpec {
-        MerkleRootSpec::split_backward(inactive_peaks)
-    }
+impl Bagging for merkle::mmr::Family {
+    const BAGGING: merkle::Bagging = merkle::Bagging::ForwardFold;
+}
+
+impl Bagging for merkle::mmb::Family {
+    const BAGGING: merkle::Bagging = merkle::Bagging::BackwardFold;
 }
 pub use verify::{
     create_multi_proof, create_proof_store, verify_multi_proof, verify_proof,

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -264,8 +264,11 @@ pub trait Database: Sized + Send {
     /// Get the root digest for final verification.
     fn root(&self) -> Self::Digest;
 
-    /// Return the root spec used to verify the final commit proof against the target root.
-    fn proof_spec(proof: &Proof<Self::Family, Self::Digest>) -> merkle::RootSpec;
+    /// Return the inactive_peaks count for verifying the final commit proof.
+    fn proof_inactive_peaks(proof: &Proof<Self::Family, Self::Digest>) -> usize;
+
+    /// Bagging policy used by this database when computing roots.
+    fn root_bagging() -> merkle::Bagging;
 
     /// Persist the compact-initialized state once the caller has verified its root.
     fn persist_compact_state(
@@ -327,7 +330,7 @@ where
         }));
     }
 
-    let hasher = StandardHasher::<DB::Hasher>::new();
+    let hasher = StandardHasher::<DB::Hasher>::with_bagging(DB::root_bagging());
     let last_commit_loc = Location::new(*state.leaf_count - 1);
     if !verify_proof(
         &hasher,
@@ -335,7 +338,7 @@ where
         last_commit_loc,
         std::slice::from_ref(&state.last_commit_op),
         &target.root,
-        DB::proof_spec(&state.last_commit_proof),
+        DB::proof_inactive_peaks(&state.last_commit_proof),
     ) {
         return Err(Error::Engine(EngineError::InvalidProof));
     }
@@ -407,7 +410,7 @@ macro_rules! impl_compact_resolver_keyless {
     ($db:ident, $op:ident, $val_bound:ident) => {
         impl<F, E, V, H> Resolver for Arc<$db<F, E, V, H>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: crate::Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
@@ -444,7 +447,7 @@ macro_rules! impl_compact_resolver_keyless {
 
         impl<F, E, V, H> Resolver for Arc<AsyncRwLock<$db<F, E, V, H>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: crate::Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
@@ -482,7 +485,7 @@ macro_rules! impl_compact_resolver_keyless {
 
         impl<F, E, V, H> Resolver for Arc<AsyncRwLock<Option<$db<F, E, V, H>>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: crate::Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
@@ -527,7 +530,7 @@ macro_rules! impl_compact_resolver_immutable {
     ($db:ident, $op:ident, $val_bound:ident, $key_bound:path) => {
         impl<F, E, K, V, H, T> Resolver for Arc<$db<F, E, K, V, H, T>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: crate::Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -567,7 +570,7 @@ macro_rules! impl_compact_resolver_immutable {
 
         impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: crate::Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -608,7 +611,7 @@ macro_rules! impl_compact_resolver_immutable {
 
         impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T>>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: crate::Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -1,5 +1,5 @@
 use crate::{
-    merkle::{Family, Location, Proof, RootSpec},
+    merkle::{Bagging, Family, Location, Proof},
     qmdb::sync::Journal,
     translator::Translator,
 };
@@ -75,6 +75,13 @@ pub trait Database: Sized + Send {
     /// Get the root digest of the database for verification
     fn root(&self) -> Self::Digest;
 
-    /// Return the root spec for verifying an ops proof against this database's configured policy.
-    fn proof_spec(config: &Self::Config, proof: &Proof<Self::Family, Self::Digest>) -> RootSpec;
+    /// Return the inactive_peaks count for verifying an ops proof against this database's
+    /// configured policy. The bagging is supplied via the hasher passed to verification.
+    fn proof_inactive_peaks(
+        config: &Self::Config,
+        proof: &Proof<Self::Family, Self::Digest>,
+    ) -> usize;
+
+    /// Bagging policy used by this database when computing roots/proofs.
+    fn root_bagging(config: &Self::Config) -> Bagging;
 }

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -332,7 +332,7 @@ where
             apply_batch_size: config.apply_batch_size,
             journal,
             resolver: config.resolver.clone(),
-            hasher: StandardHasher::<DB::Hasher>::new(),
+            hasher: StandardHasher::<DB::Hasher>::with_bagging(DB::root_bagging(&config.db_config)),
             context: config.context,
             config: config.db_config,
             update_rx: config.update_rx,
@@ -702,7 +702,7 @@ where
             && self.pinned_nodes.is_none()
             && !self.local_target_state_available
             && start_loc == self.target.range.start();
-        let proof_spec = DB::proof_spec(&self.config, &proof);
+        let inactive_peaks = DB::proof_inactive_peaks(&self.config, &proof);
         let elements = operations.iter().map(|op| op.encode()).collect::<Vec<_>>();
         let valid = if need_pinned {
             let nodes = pinned_nodes.as_deref().unwrap_or(&[]);
@@ -712,7 +712,7 @@ where
                 start_loc,
                 nodes,
                 target_root,
-                proof_spec,
+                inactive_peaks,
             )
         } else {
             proof.verify_range_inclusion(
@@ -720,7 +720,7 @@ where
                 &elements,
                 start_loc,
                 target_root,
-                proof_spec,
+                inactive_peaks,
             )
         };
 

--- a/storage/src/qmdb/sync/resolver.rs
+++ b/storage/src/qmdb/sync/resolver.rs
@@ -92,7 +92,7 @@ macro_rules! impl_resolver {
     ($db:ident, $op:ident, $val_bound:ident) => {
         impl<F, E, K, V, H, T> Resolver for Arc<$db<F, E, K, V, H, T>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: Context,
             K: Array,
             V: $val_bound + Send + Sync + 'static,
@@ -131,7 +131,7 @@ macro_rules! impl_resolver {
 
         impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: Context,
             K: Array,
             V: $val_bound + Send + Sync + 'static,
@@ -170,7 +170,7 @@ macro_rules! impl_resolver {
 
         impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T>>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: Context,
             K: Array,
             V: $val_bound + Send + Sync + 'static,
@@ -229,7 +229,7 @@ macro_rules! impl_resolver_immutable {
     ($db:ident, $op:ident, $val_bound:ident, $key_bound:path) => {
         impl<F, E, K, V, H, T> Resolver for Arc<$db<F, E, K, V, H, T>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -268,7 +268,7 @@ macro_rules! impl_resolver_immutable {
 
         impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -307,7 +307,7 @@ macro_rules! impl_resolver_immutable {
 
         impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T>>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: Context,
             K: $key_bound,
             V: $val_bound + Send + Sync + 'static,
@@ -358,7 +358,7 @@ macro_rules! impl_resolver_keyless {
     ($db:ident, $op:ident, $val_bound:ident) => {
         impl<F, E, V, H> Resolver for Arc<$db<F, E, V, H>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
@@ -394,7 +394,7 @@ macro_rules! impl_resolver_keyless {
 
         impl<F, E, V, H> Resolver for Arc<AsyncRwLock<$db<F, E, V, H>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
@@ -430,7 +430,7 @@ macro_rules! impl_resolver_keyless {
 
         impl<F, E, V, H> Resolver for Arc<AsyncRwLock<Option<$db<F, E, V, H>>>>
         where
-            F: Family + qmdb::RootSpec,
+            F: Family + qmdb::Bagging,
             E: Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,

--- a/storage/src/qmdb/verify.rs
+++ b/storage/src/qmdb/verify.rs
@@ -1,19 +1,20 @@
 use crate::merkle::{
-    hasher::Standard, verification::ProofStore, Error, Family, Location, Position, Proof, RootSpec,
+    hasher::Standard, verification::ProofStore, Error, Family, Location, Position, Proof,
 };
 use commonware_codec::Encode;
 use commonware_cryptography::{Digest, Hasher};
 
 /// Verify that a [Proof] is valid for a range of operations and a target root.
 ///
-/// `root_spec` must match the spec used to compute `target_root` for verification to succeed.
+/// `inactive_peaks` and the bagging carried by `hasher` must match those used to compute
+/// `target_root`.
 pub fn verify_proof<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,
     start_loc: Location<F>,
     operations: &[Op],
     target_root: &D,
-    root_spec: RootSpec,
+    inactive_peaks: usize,
 ) -> bool
 where
     F: Family,
@@ -22,18 +23,10 @@ where
     D: Digest,
 {
     let elements = operations.iter().map(|op| op.encode()).collect::<Vec<_>>();
-    proof.verify_range_inclusion(hasher, &elements, start_loc, target_root, root_spec)
+    proof.verify_range_inclusion(hasher, &elements, start_loc, target_root, inactive_peaks)
 }
 
 /// Verify that both a [Proof] and a set of pinned nodes are valid with respect to a target root.
-///
-/// The `pinned_nodes` are the pruning-boundary peaks at `start_loc` (as returned by
-/// `nodes_to_pin`). When the larger tree has merged smaller subtrees into a bigger parent, the
-/// pins sit below the prefix subtrees authenticated by the proof; the verifier hashes pairs of
-/// pins up to each authenticated subtree's root and compares. When `start_loc` is 0,
-/// `pinned_nodes` must be empty.
-///
-/// `root_spec` must match the spec used to compute `target_root`.
 pub fn verify_proof_and_pinned_nodes<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,
@@ -41,7 +34,7 @@ pub fn verify_proof_and_pinned_nodes<F, Op, H, D>(
     operations: &[Op],
     pinned_nodes: &[D],
     target_root: &D,
-    root_spec: RootSpec,
+    inactive_peaks: usize,
 ) -> bool
 where
     F: Family,
@@ -56,21 +49,19 @@ where
         start_loc,
         pinned_nodes,
         target_root,
-        root_spec,
+        inactive_peaks,
     )
 }
 
 /// Verify that a [Proof] is valid for a range of operations and extract all digests (and their
 /// positions) in the range of the [Proof].
-///
-/// `root_spec` must match the spec used to compute `target_root`.
 pub fn verify_proof_and_extract_digests<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,
     start_loc: Location<F>,
     operations: &[Op],
     target_root: &D,
-    root_spec: RootSpec,
+    inactive_peaks: usize,
 ) -> Result<Vec<(Position<F>, D)>, Error<F>>
 where
     F: Family,
@@ -84,20 +75,18 @@ where
         &elements,
         start_loc,
         target_root,
-        root_spec,
+        inactive_peaks,
     )
 }
 
 /// Verify a [Proof] and convert it into a [ProofStore].
-///
-/// `root_spec` must match the spec used to compute `root`.
 pub fn create_proof_store<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,
     start_loc: Location<F>,
     operations: &[Op],
     root: &D,
-    root_spec: RootSpec,
+    inactive_peaks: usize,
 ) -> Result<ProofStore<F, D>, Error<F>>
 where
     F: Family,
@@ -106,7 +95,7 @@ where
     D: Digest,
 {
     let elements = operations.iter().map(|op| op.encode()).collect::<Vec<_>>();
-    ProofStore::new(hasher, proof, &elements, start_loc, root, root_spec)
+    ProofStore::new(hasher, proof, &elements, start_loc, root, inactive_peaks)
 }
 
 /// Create a Multi-Proof for specific operations (identified by location) from a [ProofStore].
@@ -131,14 +120,12 @@ where
 }
 
 /// Verify a Multi-Proof for operations at specific locations.
-///
-/// `root_spec` must match the spec used to compute `target_root`.
 pub fn verify_multi_proof<F, Op, H, D>(
     hasher: &Standard<H>,
     proof: &Proof<F, D>,
     operations: &[(Location<F>, Op)],
     target_root: &D,
-    root_spec: RootSpec,
+    inactive_peaks: usize,
 ) -> bool
 where
     F: Family,
@@ -150,7 +137,7 @@ where
         .iter()
         .map(|(loc, op)| (op.encode(), *loc))
         .collect::<Vec<_>>();
-    proof.verify_multi_inclusion(hasher, &elements, target_root, root_spec)
+    proof.verify_multi_inclusion(hasher, &elements, target_root, inactive_peaks)
 }
 
 #[cfg(test)]
@@ -159,7 +146,7 @@ mod tests {
     use crate::{
         merkle::{build_range_proof, mem::Mem, LocationRangeExt as _},
         mmb, mmr,
-        qmdb::RootSpec,
+        qmdb::Bagging,
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
@@ -174,15 +161,15 @@ mod tests {
         Standard::new()
     }
 
-    fn qmdb_root<F: Family + RootSpec>(
+    fn qmdb_root<F: Family + Bagging>(
         merkle: &Mem<F, Digest>,
         hasher: &Standard<Sha256>,
         inactive_peaks: usize,
     ) -> Digest {
-        merkle.root(hasher, F::root_spec(inactive_peaks)).unwrap()
+        merkle.root(hasher, inactive_peaks).unwrap()
     }
 
-    fn qmdb_range_proof<F: Family + RootSpec>(
+    fn qmdb_range_proof<F: Family + Bagging>(
         hasher: &Standard<Sha256>,
         merkle: &Mem<F, Digest>,
         inactive_peaks: usize,
@@ -191,7 +178,7 @@ mod tests {
         build_range_proof(
             hasher,
             merkle.leaves(),
-            F::root_spec(inactive_peaks),
+            inactive_peaks,
             range,
             |pos| merkle.get_node(pos),
             crate::merkle::Error::ElementPruned,
@@ -201,7 +188,7 @@ mod tests {
 
     // ---- Generic inner functions for tests that work on both MMR and MMB ----
 
-    fn verify_proof_inner<F: Family + RootSpec>() {
+    fn verify_proof_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
         let mut merkle = Mem::<F, Digest>::new();
 
@@ -216,7 +203,7 @@ mod tests {
             let batch = batch.merkleize(&merkle, &hasher);
             merkle.apply_batch(&batch).unwrap();
         }
-        let spec = F::root_spec(0);
+        let spec = 0;
         let root = qmdb_root(&merkle, &hasher, 0);
 
         // Generate proof for all operations
@@ -272,7 +259,7 @@ mod tests {
         executor.start(|_| async move { verify_proof_inner::<mmb::Family>() });
     }
 
-    fn verify_proof_with_offset_inner<F: Family + RootSpec>() {
+    fn verify_proof_with_offset_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
         let mut merkle = Mem::<F, Digest>::new();
 
@@ -292,7 +279,7 @@ mod tests {
             let batch = batch.merkleize(&merkle, &hasher);
             merkle.apply_batch(&batch).unwrap();
         }
-        let spec = F::root_spec(0);
+        let spec = 0;
         let start_loc = Location::<F>::new(5u64);
         let root = qmdb_root(&merkle, &hasher, 0);
         let proof = qmdb_range_proof(
@@ -335,7 +322,7 @@ mod tests {
         executor.start(|_| async move { verify_proof_with_offset_inner::<mmb::Family>() });
     }
 
-    fn verify_proof_and_extract_digests_inner<F: Family + RootSpec>() {
+    fn verify_proof_and_extract_digests_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
         let mut merkle = Mem::<F, Digest>::new();
 
@@ -350,7 +337,7 @@ mod tests {
             let batch = batch.merkleize(&merkle, &hasher);
             merkle.apply_batch(&batch).unwrap();
         }
-        let spec = F::root_spec(0);
+        let spec = 0;
         let root = qmdb_root(&merkle, &hasher, 0);
         let range = Location::<F>::new(1)..Location::<F>::new(4);
         let proof = qmdb_range_proof(&hasher, &merkle, 0, range.clone());
@@ -393,7 +380,7 @@ mod tests {
         executor.start(|_| async move { verify_proof_and_extract_digests_inner::<mmb::Family>() });
     }
 
-    fn create_proof_store_inner<F: Family + RootSpec>() {
+    fn create_proof_store_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
         let mut merkle = Mem::<F, Digest>::new();
 
@@ -409,7 +396,7 @@ mod tests {
             let batch = batch.merkleize(&merkle, &hasher);
             merkle.apply_batch(&batch).unwrap();
         }
-        let spec = F::root_spec(0);
+        let spec = 0;
         let root = qmdb_root(&merkle, &hasher, 0);
         let range = Location::<F>::new(0)..Location::<F>::new(3);
         let proof = qmdb_range_proof(&hasher, &merkle, 0, range.clone());
@@ -453,7 +440,7 @@ mod tests {
         executor.start(|_| async move { create_proof_store_inner::<mmb::Family>() });
     }
 
-    fn create_proof_store_invalid_proof_inner<F: Family + RootSpec>() {
+    fn create_proof_store_invalid_proof_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
         let mut merkle = Mem::<F, Digest>::new();
 
@@ -479,7 +466,7 @@ mod tests {
             Location::<F>::new(0),
             &operations,
             &wrong_root,
-            F::root_spec(0),
+            0,
         )
         .is_err());
     }
@@ -496,7 +483,7 @@ mod tests {
         executor.start(|_| async move { create_proof_store_invalid_proof_inner::<mmb::Family>() });
     }
 
-    fn create_multi_proof_inner<F: Family + RootSpec>() {
+    fn create_multi_proof_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
         let mut merkle = Mem::<F, Digest>::new();
 
@@ -511,7 +498,7 @@ mod tests {
             let batch = batch.merkleize(&merkle, &hasher);
             merkle.apply_batch(&batch).unwrap();
         }
-        let spec = F::root_spec(0);
+        let spec = 0;
         let root = qmdb_root(&merkle, &hasher, 0);
 
         // Create proof for full range
@@ -571,7 +558,7 @@ mod tests {
         executor.start(|_| async move { create_multi_proof_inner::<mmb::Family>() });
     }
 
-    fn create_multi_proof_with_fold_prefix_peaks_inner<F: Family + RootSpec>() {
+    fn create_multi_proof_with_fold_prefix_peaks_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
         let mut merkle = Mem::<F, Digest>::new();
 
@@ -586,7 +573,7 @@ mod tests {
             merkle.apply_batch(&batch).unwrap();
         }
         let inactive_peaks = 1;
-        let spec = F::root_spec(inactive_peaks);
+        let spec = inactive_peaks;
         let root = qmdb_root(&merkle, &hasher, inactive_peaks);
 
         // Proof store starts at 32, so the first peak is folded into the proof prefix.
@@ -709,7 +696,7 @@ mod tests {
         });
     }
 
-    fn verify_multi_proof_inner<F: Family + RootSpec>() {
+    fn verify_multi_proof_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
         let mut merkle = Mem::<F, Digest>::new();
 
@@ -724,7 +711,7 @@ mod tests {
             let batch = batch.merkleize(&merkle, &hasher);
             merkle.apply_batch(&batch).unwrap();
         }
-        let spec = F::root_spec(0);
+        let spec = 0;
         let root = qmdb_root(&merkle, &hasher, 0);
 
         // Generate multi-proof via range proof -> proof store -> multi-proof
@@ -800,9 +787,9 @@ mod tests {
         executor.start(|_| async move { verify_multi_proof_inner::<mmb::Family>() });
     }
 
-    fn multi_proof_empty_inner<F: Family + RootSpec>() {
+    fn multi_proof_empty_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
-        let spec = F::root_spec(0);
+        let spec = 0;
         let empty_merkle = Mem::<F, Digest>::new();
         let empty_root = qmdb_root(&empty_merkle, &hasher, 0);
 
@@ -856,7 +843,7 @@ mod tests {
         executor.start(|_| async move { multi_proof_empty_inner::<mmb::Family>() });
     }
 
-    fn multi_proof_single_element_inner<F: Family + RootSpec>() {
+    fn multi_proof_single_element_inner<F: Family + Bagging>() {
         let hasher = test_hasher();
         let mut merkle = Mem::<F, Digest>::new();
 
@@ -871,7 +858,7 @@ mod tests {
             let batch = batch.merkleize(&merkle, &hasher);
             merkle.apply_batch(&batch).unwrap();
         }
-        let spec = F::root_spec(0);
+        let spec = 0;
         let root = qmdb_root(&merkle, &hasher, 0);
 
         // Create proof store for all elements


### PR DESCRIPTION
Suggested changes on #3667.

## Summary

Threading `RootSpec` through every `root()` and `verify()` call site is the largest source of churn in the pyramid-MMB work. This PR moves the `Bagging` choice onto the `Hasher` instance — where it actually lives operationally — and drops `RootSpec` entirely. The per-call value becomes a single `inactive_peaks: usize`.

## Why

`Bagging` is chosen at `Db` construction time and never changes for the lifetime of any structure or proof from that `Db`. Threading it through every call as part of `RootSpec` was costly:

- Seven `_using_policy` siblings in `proof.rs` existed only to decompose `RootSpec` into `(inactive_peaks, bagging)` and dispatch.
- `RootSpec::Full { F }` and `RootSpec::Split { 0, F }` produced byte-identical roots — two encodings of the same value.
- A `qmdb::RootSpec::root_spec(n) -> RootSpec` trait existed solely so callers could read `.bagging()` off the result.
- `from_split_policy(split_root, bagging, n)` papered over a bool→variant conversion at every call site.

`inactive_peaks` is genuinely runtime data (changes as the inactivity floor moves) and stays a per-call `usize`. `Bagging` is per-instance and moves onto the `Hasher`.

## The change

### `Hasher` trait gains `fn root_bagging(&self) -> Bagging`

```rust
pub trait Hasher<F: Family>: Clone + Send + Sync {
    type Digest: Digest;
    fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> Self::Digest;
    fn root_bagging(&self) -> Bagging;   // new
    // default root_*, fold, leaf_digest, node_digest unchanged
}
```

The name is deliberate: the policy only affects root peak aggregation; `hash`, `leaf_digest`, `node_digest` are unaffected. The `&T` blanket impl forwards `root_bagging`. `GraftedHasher` and `Verifier` (in `qmdb/current/grafting.rs`) likewise forward to their inner hasher.

### `Standard<H>` carries `bagging` as a runtime field

```rust
pub struct Standard<H: CHasher> {
    _hasher: PhantomData<H>,
    bagging: Bagging,
}
impl<H: CHasher> Standard<H> {
    pub const fn new() -> Self { Self::forward() }
    pub const fn forward() -> Self { Self::with_bagging(Bagging::ForwardFold) }
    pub const fn backward() -> Self { Self::with_bagging(Bagging::BackwardFold) }
    pub const fn with_bagging(b: Bagging) -> Self { ... }
}
```

Runtime field rather than a generic — adding `Standard<H, B>` would thread through every `Hasher<F>` impl site. `forward()` / `backward()` shortcuts replace `with_bagging(Bagging::BackwardFold)` at every site that statically knows the choice; `with_bagging(b)` stays for callers passing a runtime value.

### Public method signatures lose `RootSpec`, gain `inactive_peaks: usize`

```rust
// Before:
fn verify_range_inclusion(&self, hasher, elements, start, root, spec: RootSpec) -> bool

// After:
fn verify_range_inclusion(&self, hasher, elements, start, root, inactive_peaks: usize) -> bool
```

Same shape across `Hasher::root`, `Mem::root`, `MerkleizedBatch::root`, `persisted::full` / `compact`, `journal::authenticated::{root, proof, range_proof, historical_proof}`, every `Proof::verify_*`, `qmdb::{verify_proof, verify_multi_proof, verify_proof_and_extract_digests, verify_proof_and_pinned_nodes}`, and the family proof modules.

The proof's own `Proof.inactive_peaks: usize` field is unchanged. Verification still asserts `proof.inactive_peaks == caller_supplied_inactive_peaks`.

### `authenticated::Journal` threads `Bagging` into hasher construction

The journal owns `pub(crate) hasher: StandardHasher<H>`. `Inner::init` now takes a `Bagging` parameter and constructs the field via `StandardHasher::with_bagging(bagging)`. `from_components` already accepted a configured hasher; sync paths in `qmdb/{any,current}/sync/mod.rs` were updated to construct hashers with the right bagging.

This is the load-bearing plumbing: every QMDB root computation goes through the journal's owned hasher, so getting this wrong silently produces wrong roots.

### `qmdb::RootSpec` trait renamed to `qmdb::Bagging`

```rust
// Before:
pub trait RootSpec: Family {
    fn root_spec(inactive_peaks: usize) -> MerkleRootSpec;
}

// After:
pub trait Bagging: Family {
    const BAGGING: merkle::Bagging;
    fn default_hasher<H: CHasher>() -> Standard<H> {
        Standard::with_bagging(Self::BAGGING)
    }
}
```

Two changes:
1. **Renamed** because the trait no longer returns a `RootSpec`; it carries the family's default bagging. The new name is honest. One file (`qmdb/immutable/sync/mod.rs`) imports both `merkle::Bagging` (enum) and `qmdb::Bagging` (trait) — the trait is aliased there as `FamilyBagging` to avoid namespace collision.
2. **`default_hasher::<H>()` method** so callers say `F::default_hasher::<Sha256>()` instead of `Standard::<Sha256>::with_bagging(F::BAGGING)`.

### `qmdb::sync::Database` trait splits one method into two

```rust
// Before:
fn proof_spec(config, proof) -> RootSpec;

// After:
fn proof_inactive_peaks(config, proof) -> usize;
fn root_bagging(config) -> Bagging;
```

### Seven `_using_policy` siblings in `proof.rs` collapsed into their primaries

`verify_range_inclusion_using_policy`, `verify_multi_inclusion_using_policy`, `reconstruct_root_using_policy`, `reconstruct_root_collecting_using_policy`, `verify_range_inclusion_and_extract_digests_using_policy`, `verify_proof_and_pinned_nodes_using_policy`, `Blueprint::new_using_policy` — each existed only to take `Bagging` directly when the spec wasn't yet decomposed. With bagging on the hasher, no decomposition needed; primaries handle everything.

### Tests reformulated to iterate `(Bagging, inactive_peaks)`

Multi-spec tests in `proof.rs` and `verification.rs` previously iterated `Vec<RootSpec>`. They now iterate `Vec<(Bagging, usize)>`, constructing `Standard::with_bagging(b)` per iteration. Same coverage; same byte outputs.

## What's preserved

- **Wire format unchanged.**
- **All existing roots.** Pyramid-MMB short proofs work via `Standard::backward()` (or `F::default_hasher::<H>()` when MMB) for MMB QMDBs.
- **`current::Db<mmb::Family>` keeps using `ForwardFold`** (the cross-family case). Its hasher is constructed at init with that choice — now visible at one call site instead of buried in helper signatures.
- **`split_root: bool` Db config field** for boundary commitment toggling.