### PR TITLE
qmdb/sync/gaps: clamp checked_add to range.end instead of unwrap-panic

### DIFF
--- a/storage/src/qmdb/sync/gaps.rs
+++ b/storage/src/qmdb/sync/gaps.rs
@@ -40,7 +40,7 @@ pub fn find_next<'a, F: Family>(
     let mut fetched_ops_iter = fetched_operations
         .iter()
         .map(|(&start_loc, &operation_count)| {
-            let end_loc = start_loc.checked_add(operation_count).unwrap();
+            let end_loc = start_loc.checked_add(operation_count).unwrap_or(range.end);
             start_loc..end_loc
         })
         .peekable();
@@ -48,7 +48,7 @@ pub fn find_next<'a, F: Family>(
     let mut outstanding_reqs_iter = outstanding_requests
         .into_iter()
         .map(|&start_loc| {
-            let end_loc = start_loc.checked_add(fetch_batch_size.get()).unwrap();
+            let end_loc = start_loc.checked_add(fetch_batch_size.get()).unwrap_or(range.end);
             start_loc..end_loc
         })
         .peekable();

--- a/storage/src/qmdb/sync/gaps.rs
+++ b/storage/src/qmdb/sync/gaps.rs
@@ -37,7 +37,7 @@ pub fn find_next<F: Family>(
     let mut fetched_ops_iter = fetched_operations
         .iter()
         .map(|(&start_loc, &operation_count)| {
-            let end_loc = start_loc.checked_add(operation_count).unwrap();
+            let end_loc = start_loc.checked_add(operation_count).unwrap_or(range.end);
             start_loc..end_loc
         })
         .peekable();


### PR DESCRIPTION
Fixes #2068.

`Location::checked_add` returns `None` on overflow OR when the result exceeds `Family::MAX_LEAVES`. The two callsites in `gaps::find_next` unconditionally `.unwrap()`'d the result, so fuzzer inputs with `start_loc` near the family ceiling panicked the sync engine.

Clamp to `range.end` on `None` so the merge loop terminates on the next iteration as expected, instead of crashing.