### PR TITLE
[consensus/marshal] Cheaper `CodedBlock::clone`

### DIFF
--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -174,7 +174,6 @@ use rand::Rng;
 use std::{
     collections::{BTreeMap, VecDeque},
     num::NonZeroUsize,
-    sync::Arc,
 };
 use thiserror::Error;
 use tracing::{debug, warn};
@@ -331,8 +330,7 @@ where
     /// An ephemeral cache of reconstructed blocks, keyed by commitment.
     ///
     /// These blocks are evicted after a durability signal from the marshal.
-    /// Wrapped in [`Arc`] to enable cheap cloning when serving multiple subscribers.
-    reconstructed_blocks: BTreeMap<Commitment, Arc<CodedBlock<B, C, H>>>,
+    reconstructed_blocks: BTreeMap<Commitment, CodedBlock<B, C, H>>,
 
     /// Open subscriptions for assigned shard verification for the keyed
     /// [`Commitment`].
@@ -350,7 +348,7 @@ where
     /// the keyed [`Commitment`].
     #[allow(clippy::type_complexity)]
     block_subscriptions:
-        BTreeMap<BlockSubscriptionKey<B::Digest>, Vec<oneshot::Sender<Arc<CodedBlock<B, C, H>>>>>,
+        BTreeMap<BlockSubscriptionKey<B::Digest>, Vec<oneshot::Sender<CodedBlock<B, C, H>>>>,
 
     /// Metrics for the shard engine.
     metrics: ShardMetrics<P>,
@@ -580,9 +578,9 @@ where
     fn try_reconstruct(
         &mut self,
         commitment: Commitment,
-    ) -> Result<Option<Arc<CodedBlock<B, C, H>>>, Error<C>> {
+    ) -> Result<Option<CodedBlock<B, C, H>>, Error<C>> {
         if let Some(block) = self.reconstructed_blocks.get(&commitment) {
-            return Ok(Some(Arc::clone(block)));
+            return Ok(Some(block.clone()));
         }
         let Some(state) = self.state.get_mut(&commitment) else {
             return Ok(None);
@@ -635,8 +633,8 @@ where
 
         // Construct a coding block with a _trusted_ commitment. `S::decode` verified the blob's
         // integrity against the commitment, so shards can be lazily re-constructed if need be.
-        let block = Arc::new(CodedBlock::new_trusted(inner, commitment));
-        self.cache_block(Arc::clone(&block));
+        let block = CodedBlock::new_trusted(inner, commitment);
+        self.cache_block(block.clone());
         self.metrics.blocks_reconstructed_total.inc();
         Ok(Some(block))
     }
@@ -744,10 +742,9 @@ where
     }
 
     /// Cache a block and notify all subscribers waiting on it.
-    fn cache_block(&mut self, block: Arc<CodedBlock<B, C, H>>) {
+    fn cache_block(&mut self, block: CodedBlock<B, C, H>) {
         let commitment = block.commitment();
-        self.reconstructed_blocks
-            .insert(commitment, Arc::clone(&block));
+        self.reconstructed_blocks.insert(commitment, block.clone());
         self.notify_block_subscribers(block);
     }
 
@@ -825,7 +822,6 @@ where
         }
 
         // Cache the block so we don't have to reconstruct it again.
-        let block = Arc::new(block);
         self.cache_block(block);
 
         // Local proposals bypass reconstruction, so shard subscribers waiting
@@ -937,7 +933,7 @@ where
     fn handle_block_subscription(
         &mut self,
         key: BlockSubscriptionKey<B::Digest>,
-        response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
+        response: oneshot::Sender<CodedBlock<B, C, H>>,
     ) {
         let block = match key {
             BlockSubscriptionKey::Commitment(commitment) => {
@@ -951,7 +947,7 @@ where
 
         // Answer immediately if we have the block cached.
         if let Some(block) = block {
-            response.send_lossy(Arc::clone(block));
+            response.send_lossy(block.clone());
             return;
         }
 
@@ -975,7 +971,7 @@ where
     }
 
     /// Notifies and cleans up any subscriptions for a reconstructed block.
-    fn notify_block_subscribers(&mut self, block: Arc<CodedBlock<B, C, H>>) {
+    fn notify_block_subscribers(&mut self, block: CodedBlock<B, C, H>) {
         let commitment = block.commitment();
         let digest = block.digest();
 
@@ -985,7 +981,7 @@ where
             .remove(&BlockSubscriptionKey::Commitment(commitment))
         {
             for subscriber in subscribers.drain(..) {
-                subscriber.send_lossy(Arc::clone(&block));
+                subscriber.send_lossy(block.clone());
             }
         }
 
@@ -995,7 +991,7 @@ where
             .remove(&BlockSubscriptionKey::Digest(digest))
         {
             for subscriber in subscribers.drain(..) {
-                subscriber.send_lossy(Arc::clone(&block));
+                subscriber.send_lossy(block.clone());
             }
         }
     }
@@ -1541,7 +1537,10 @@ mod tests {
         future::Future,
         marker::PhantomData,
         num::NonZeroU32,
-        sync::atomic::{AtomicIsize, Ordering},
+        sync::{
+            atomic::{AtomicIsize, Ordering},
+            Arc,
+        },
         time::Duration,
     };
 

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -8,7 +8,6 @@ use crate::{
 use commonware_coding::Scheme as CodingScheme;
 use commonware_cryptography::{Hasher, PublicKey};
 use commonware_utils::channel::{fallible::AsyncFallibleExt, mpsc, oneshot};
-use std::sync::Arc;
 
 /// A message that can be sent to the coding [`Engine`].
 ///
@@ -41,14 +40,14 @@ where
         /// The [`Commitment`] of the block to get.
         commitment: Commitment,
         /// The response channel.
-        response: oneshot::Sender<Option<Arc<CodedBlock<B, C, H>>>>,
+        response: oneshot::Sender<Option<CodedBlock<B, C, H>>>,
     },
     /// A request to get a reconstructed block by its digest, if available.
     GetByDigest {
         /// The digest of the block to get.
         digest: B::Digest,
         /// The response channel.
-        response: oneshot::Sender<Option<Arc<CodedBlock<B, C, H>>>>,
+        response: oneshot::Sender<Option<CodedBlock<B, C, H>>>,
     },
     /// A request to open a subscription for assigned shard verification.
     ///
@@ -72,7 +71,7 @@ where
         /// The block's digest.
         commitment: Commitment,
         /// The response channel.
-        response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
+        response: oneshot::Sender<CodedBlock<B, C, H>>,
     },
     /// A request to open a subscription for the reconstruction of a [`CodedBlock`]
     /// by its digest.
@@ -80,7 +79,7 @@ where
         /// The block's digest.
         digest: B::Digest,
         /// The response channel.
-        response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
+        response: oneshot::Sender<CodedBlock<B, C, H>>,
     },
     /// A request to prune all caches at and below the given commitment.
     Prune {
@@ -132,7 +131,7 @@ where
     }
 
     /// Request a reconstructed block by its [`Commitment`].
-    pub async fn get(&self, commitment: Commitment) -> Option<Arc<CodedBlock<B, C, H>>> {
+    pub async fn get(&self, commitment: Commitment) -> Option<CodedBlock<B, C, H>> {
         self.sender
             .request(|tx| Message::GetByCommitment {
                 commitment,
@@ -143,7 +142,7 @@ where
     }
 
     /// Request a reconstructed block by its digest.
-    pub async fn get_by_digest(&self, digest: B::Digest) -> Option<Arc<CodedBlock<B, C, H>>> {
+    pub async fn get_by_digest(&self, digest: B::Digest) -> Option<CodedBlock<B, C, H>> {
         self.sender
             .request(|tx| Message::GetByDigest {
                 digest,
@@ -180,7 +179,7 @@ where
     pub async fn subscribe(
         &self,
         commitment: Commitment,
-    ) -> oneshot::Receiver<Arc<CodedBlock<B, C, H>>> {
+    ) -> oneshot::Receiver<CodedBlock<B, C, H>> {
         let (responder, receiver) = oneshot::channel();
         let msg = Message::SubscribeByCommitment {
             commitment,
@@ -194,7 +193,7 @@ where
     pub async fn subscribe_by_digest(
         &self,
         digest: B::Digest,
-    ) -> oneshot::Receiver<Arc<CodedBlock<B, C, H>>> {
+    ) -> oneshot::Receiver<CodedBlock<B, C, H>> {
         let (responder, receiver) = oneshot::channel();
         let msg = Message::SubscribeByDigest {
             digest,

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -9,7 +9,7 @@ use commonware_coding::{Config as CodingConfig, Scheme};
 use commonware_cryptography::{Committable, Digestible, Hasher};
 use commonware_parallel::{Sequential, Strategy};
 use commonware_utils::{Faults, N3f1, NZU16};
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
 /// A broadcastable shard of erasure coded data, including the coding commitment and
 /// the configuration used to code the data.
@@ -142,7 +142,7 @@ where
 #[derive(Debug)]
 pub struct CodedBlock<B: Block, C: Scheme, H: Hasher> {
     /// The inner block type.
-    inner: B,
+    inner: Arc<B>,
     /// The erasure coding configuration.
     config: CodingConfig,
     /// The erasure coding commitment.
@@ -152,7 +152,7 @@ pub struct CodedBlock<B: Block, C: Scheme, H: Hasher> {
     /// These shards are optional to enable lazy construction. If the block is
     /// constructed with [`Self::new_trusted`], the shards are computed lazily
     /// via [`Self::shards`].
-    shards: Option<Vec<C::Shard>>,
+    shards: Option<Arc<[C::Shard]>>,
     /// Phantom data for the hasher.
     _hasher: PhantomData<H>,
 }
@@ -175,10 +175,10 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
     pub fn new(inner: B, config: CodingConfig, strategy: &impl Strategy) -> Self {
         let (commitment, shards) = Self::encode(&inner, config, strategy);
         Self {
-            inner,
+            inner: Arc::new(inner),
             config,
             commitment,
-            shards: Some(shards),
+            shards: Some(shards.into()),
             _hasher: PhantomData,
         }
     }
@@ -186,7 +186,7 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
     /// Create a new [`CodedBlock`] from a [`Block`] and trusted [`Commitment`].
     pub fn new_trusted(inner: B, commitment: Commitment) -> Self {
         Self {
-            inner,
+            inner: Arc::new(inner),
             config: commitment.config(),
             commitment: commitment.root(),
             shards: None,
@@ -213,7 +213,7 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
                     "coded block constructed with trusted commitment does not match commitment"
                 );
 
-                self.shards = Some(shards);
+                self.shards = Some(shards.into());
                 self.shards.as_ref().unwrap()
             }
         }
@@ -232,17 +232,17 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
     }
 
     /// Returns a reference to the inner [`Block`].
-    pub const fn inner(&self) -> &B {
+    pub fn inner(&self) -> &B {
         &self.inner
     }
 
     /// Takes the inner [`Block`].
     pub fn into_inner(self) -> B {
-        self.inner
+        Arc::unwrap_or_clone(self.inner)
     }
 }
 
-impl<B: CertifiableBlock, C: Scheme, H: Hasher> From<CodedBlock<B, C, H>>
+impl<B: CertifiableBlock + Clone, C: Scheme, H: Hasher> From<CodedBlock<B, C, H>>
     for StoredCodedBlock<B, C, H>
 {
     fn from(block: CodedBlock<B, C, H>) -> Self {
@@ -250,10 +250,10 @@ impl<B: CertifiableBlock, C: Scheme, H: Hasher> From<CodedBlock<B, C, H>>
     }
 }
 
-impl<B: Block + Clone, C: Scheme, H: Hasher> Clone for CodedBlock<B, C, H> {
+impl<B: Block, C: Scheme, H: Hasher> Clone for CodedBlock<B, C, H> {
     fn clone(&self) -> Self {
         Self {
-            inner: self.inner.clone(),
+            inner: Arc::clone(&self.inner),
             config: self.config,
             commitment: self.commitment,
             shards: self.shards.clone(),
@@ -315,10 +315,10 @@ impl<B: Block, C: Scheme, H: Hasher> Read for CodedBlock<B, C, H> {
             })?;
 
         Ok(Self {
-            inner,
+            inner: Arc::new(inner),
             config,
             commitment,
-            shards: Some(shards),
+            shards: Some(shards.into()),
             _hasher: PhantomData,
         })
     }
@@ -380,7 +380,7 @@ pub struct StoredCodedBlock<B: Block, C: Scheme, H: Hasher> {
     _scheme: PhantomData<(C, H)>,
 }
 
-impl<B: CertifiableBlock, C: Scheme, H: Hasher> StoredCodedBlock<B, C, H> {
+impl<B: CertifiableBlock + Clone, C: Scheme, H: Hasher> StoredCodedBlock<B, C, H> {
     /// Create a [`StoredCodedBlock`] from a verified [`CodedBlock`].
     ///
     /// The caller must ensure the [`CodedBlock`] has been properly verified
@@ -388,7 +388,7 @@ impl<B: CertifiableBlock, C: Scheme, H: Hasher> StoredCodedBlock<B, C, H> {
     pub fn new(block: CodedBlock<B, C, H>) -> Self {
         Self {
             commitment: block.commitment(),
-            inner: block.inner,
+            inner: block.into_inner(),
             _scheme: PhantomData,
         }
     }
@@ -619,6 +619,24 @@ mod test {
         let decoded = CodedBlock::<Block, RS, H>::decode_cfg(encoded, &()).unwrap();
 
         assert!(coded_block == decoded);
+    }
+
+    #[test]
+    fn test_coded_block_clone_shares_storage() {
+        const CONFIG: CodingConfig = CodingConfig {
+            minimum_shards: NZU16!(1),
+            extra_shards: NZU16!(2),
+        };
+
+        let block = Block::new::<Sha256>((), Sha256::hash(b"parent"), Height::new(42), 1_234_567);
+        let coded_block = CodedBlock::<Block, RS, H>::new(block, CONFIG, &Sequential);
+        let cloned = coded_block.clone();
+
+        assert!(Arc::ptr_eq(&coded_block.inner, &cloned.inner));
+        assert!(Arc::ptr_eq(
+            coded_block.shards.as_ref().unwrap(),
+            cloned.shards.as_ref().unwrap()
+        ));
     }
 
     #[test]

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -14,7 +14,6 @@ use commonware_coding::Scheme as CodingScheme;
 use commonware_cryptography::{Committable, Digestible, Hasher, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::sync::Arc;
 
 /// The coding variant of Marshal, which uses erasure coding for block dissemination.
 ///
@@ -68,7 +67,7 @@ where
     P: PublicKey,
 {
     type PublicKey = P;
-    type CachedBlock = Arc<CodedBlock<B, C, H>>;
+    type CachedBlock = CodedBlock<B, C, H>;
 
     async fn find_by_digest(
         &self,

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -67,30 +67,29 @@ where
     P: PublicKey,
 {
     type PublicKey = P;
-    type CachedBlock = CodedBlock<B, C, H>;
 
     async fn find_by_digest(
         &self,
         digest: <CodedBlock<B, C, H> as Digestible>::Digest,
-    ) -> Option<Self::CachedBlock> {
+    ) -> Option<CodedBlock<B, C, H>> {
         self.get_by_digest(digest).await
     }
 
-    async fn find_by_commitment(&self, commitment: Commitment) -> Option<Self::CachedBlock> {
+    async fn find_by_commitment(&self, commitment: Commitment) -> Option<CodedBlock<B, C, H>> {
         self.get(commitment).await
     }
 
     async fn subscribe_by_digest(
         &self,
         digest: <CodedBlock<B, C, H> as Digestible>::Digest,
-    ) -> oneshot::Receiver<Self::CachedBlock> {
+    ) -> oneshot::Receiver<CodedBlock<B, C, H>> {
         self.subscribe_by_digest(digest).await
     }
 
     async fn subscribe_by_commitment(
         &self,
         commitment: Commitment,
-    ) -> oneshot::Receiver<Self::CachedBlock> {
+    ) -> oneshot::Receiver<CodedBlock<B, C, H>> {
         self.subscribe(commitment).await
     }
 

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1,7 +1,7 @@
 use super::{
     cache,
     mailbox::{Mailbox, Message},
-    Buffer, IntoBlock, Variant,
+    Buffer, Variant,
 };
 use crate::{
     marshal::{
@@ -931,10 +931,7 @@ where
                     }
                 };
                 let waiter_key = key;
-                let aborter = waiters.push(async move {
-                    rx.await
-                        .map_or_else(|_| Err(waiter_key), |block| Ok(block.into_block()))
-                });
+                let aborter = waiters.push(async move { rx.await.map_err(|_| waiter_key) });
                 entry.insert(BlockSubscription {
                     subscribers: vec![response],
                     _aborter: aborter,
@@ -1548,7 +1545,7 @@ where
         digest: <V::Block as Digestible>::Digest,
     ) -> Option<V::Block> {
         if let Some(block) = buffer.find_by_digest(digest).await {
-            return Some(block.into_block());
+            return Some(block);
         }
         self.find_block_in_storage(digest).await
     }
@@ -1563,7 +1560,7 @@ where
         commitment: V::Commitment,
     ) -> Option<V::Block> {
         if let Some(block) = buffer.find_by_commitment(commitment).await {
-            return Some(block.into_block());
+            return Some(block);
         }
         self.find_block_in_storage(V::commitment_to_inner(commitment))
             .await

--- a/consensus/src/marshal/core/mod.rs
+++ b/consensus/src/marshal/core/mod.rs
@@ -47,4 +47,4 @@ mod mailbox;
 pub use mailbox::Mailbox;
 
 mod variant;
-pub use variant::{Buffer, IntoBlock, Variant};
+pub use variant::{Buffer, Variant};

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -17,7 +17,7 @@ use commonware_codec::{Codec, Read};
 use commonware_cryptography::{Digest, Digestible, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::{future::Future, sync::Arc};
+use std::future::Future;
 
 /// A marker trait describing the types used by a variant of Marshal.
 pub trait Variant: Clone + Send + Sync + 'static {
@@ -81,12 +81,6 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     /// The public key type used to identify peers.
     type PublicKey: PublicKey;
 
-    /// The cached block type held internally by the buffer.
-    ///
-    /// This allows buffers to use efficient internal representations (e.g., `Arc<Block>`)
-    /// while providing conversion to the underlying block type via [`IntoBlock`].
-    type CachedBlock: IntoBlock<V::Block>;
-
     /// Attempt to find a block by its digest.
     ///
     /// Returns `Some(block)` if the block is immediately available in the buffer,
@@ -96,7 +90,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn find_by_digest(
         &self,
         digest: <V::Block as Digestible>::Digest,
-    ) -> impl Future<Output = Option<Self::CachedBlock>> + Send;
+    ) -> impl Future<Output = Option<V::Block>> + Send;
 
     /// Attempt to find a block by its commitment.
     ///
@@ -109,7 +103,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn find_by_commitment(
         &self,
         commitment: V::Commitment,
-    ) -> impl Future<Output = Option<Self::CachedBlock>> + Send;
+    ) -> impl Future<Output = Option<V::Block>> + Send;
 
     /// Subscribe to a block's availability by its digest.
     ///
@@ -120,7 +114,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn subscribe_by_digest(
         &self,
         digest: <V::Block as Digestible>::Digest,
-    ) -> impl Future<Output = oneshot::Receiver<Self::CachedBlock>> + Send;
+    ) -> impl Future<Output = oneshot::Receiver<V::Block>> + Send;
 
     /// Subscribe to a block's availability by its commitment.
     ///
@@ -134,7 +128,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn subscribe_by_commitment(
         &self,
         commitment: V::Commitment,
-    ) -> impl Future<Output = oneshot::Receiver<Self::CachedBlock>> + Send;
+    ) -> impl Future<Output = oneshot::Receiver<V::Block>> + Send;
 
     /// Notify the buffer that a block has been finalized.
     ///
@@ -148,31 +142,4 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
         block: V::Block,
         recipients: Recipients<Self::PublicKey>,
     ) -> impl Future<Output = ()> + Send;
-}
-
-/// A trait for cached block types that can be converted to the underlying block.
-///
-/// This trait allows buffer implementations to use efficient internal representations
-/// (e.g., `Arc<Block>`) while providing a uniform way to extract the block.
-pub trait IntoBlock<B>: Clone + Send {
-    /// Convert this cached block into the underlying block type.
-    fn into_block(self) -> B;
-}
-
-/// Blanket implementation for any cloneable block type.
-///
-/// This covers the standard variant where `CachedBlock = B`.
-impl<B: Clone + Send> IntoBlock<B> for B {
-    fn into_block(self) -> B {
-        self
-    }
-}
-
-/// Implementation for `Arc<B>` to support shared cache implementations.
-///
-/// Uses `Arc::unwrap_or_clone` to avoid cloning when the refcount is 1.
-impl<B: Clone + Send + Sync> IntoBlock<B> for Arc<B> {
-    fn into_block(self) -> B {
-        Self::unwrap_or_clone(self)
-    }
 }

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -168,7 +168,7 @@ impl<B: Clone + Send> IntoBlock<B> for B {
     }
 }
 
-/// Implementation for `Arc<B>` to support the coding variant.
+/// Implementation for `Arc<B>` to support shared cache implementations.
 ///
 /// Uses `Arc::unwrap_or_clone` to avoid cloning when the refcount is 1.
 impl<B: Clone + Send + Sync> IntoBlock<B> for Arc<B> {

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -1615,25 +1615,21 @@ mod tests {
 
     impl crate::marshal::core::Buffer<Standard<B>> for RecordingBuffer {
         type PublicKey = PublicKey;
-        type CachedBlock = B;
 
-        async fn find_by_digest(&self, _digest: D) -> Option<Self::CachedBlock> {
+        async fn find_by_digest(&self, _digest: D) -> Option<B> {
             None
         }
 
-        async fn find_by_commitment(&self, _commitment: D) -> Option<Self::CachedBlock> {
+        async fn find_by_commitment(&self, _commitment: D) -> Option<B> {
             None
         }
 
-        async fn subscribe_by_digest(&self, _digest: D) -> oneshot::Receiver<Self::CachedBlock> {
+        async fn subscribe_by_digest(&self, _digest: D) -> oneshot::Receiver<B> {
             let (_sender, receiver) = oneshot::channel();
             receiver
         }
 
-        async fn subscribe_by_commitment(
-            &self,
-            _commitment: D,
-        ) -> oneshot::Receiver<Self::CachedBlock> {
+        async fn subscribe_by_commitment(&self, _commitment: D) -> oneshot::Receiver<B> {
             let (_sender, receiver) = oneshot::channel();
             receiver
         }
@@ -1768,8 +1764,7 @@ mod tests {
     )
     where
         R: Reporter<Activity = Update<B>>,
-        Buf: crate::marshal::core::Buffer<Standard<B>, PublicKey = PublicKey, CachedBlock = B>
-            + Clone,
+        Buf: crate::marshal::core::Buffer<Standard<B>, PublicKey = PublicKey> + Clone,
     {
         let config = Config {
             provider,

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -54,26 +54,22 @@ where
     K: PublicKey,
 {
     type PublicKey = K;
-    type CachedBlock = B;
 
-    async fn find_by_digest(&self, digest: B::Digest) -> Option<Self::CachedBlock> {
+    async fn find_by_digest(&self, digest: B::Digest) -> Option<B> {
         self.get(digest).await
     }
 
-    async fn find_by_commitment(&self, commitment: B::Digest) -> Option<Self::CachedBlock> {
+    async fn find_by_commitment(&self, commitment: B::Digest) -> Option<B> {
         self.find_by_digest(commitment).await
     }
 
-    async fn subscribe_by_digest(&self, digest: B::Digest) -> oneshot::Receiver<Self::CachedBlock> {
+    async fn subscribe_by_digest(&self, digest: B::Digest) -> oneshot::Receiver<B> {
         let (tx, rx) = oneshot::channel();
         self.subscribe_prepared(digest, tx).await;
         rx
     }
 
-    async fn subscribe_by_commitment(
-        &self,
-        commitment: B::Digest,
-    ) -> oneshot::Receiver<Self::CachedBlock> {
+    async fn subscribe_by_commitment(&self, commitment: B::Digest) -> oneshot::Receiver<B> {
         self.subscribe_by_digest(commitment).await
     }
 


### PR DESCRIPTION
## Overview

Wraps internal fields within `CodedBlock` in `Arc`, enabling cheaper clones of the type without propagating the `Arc<CodedBlock<_, _, _>>` wrapper throughout the core marshal API.

In several profiles, we've seen amplification on the core marshal loop when dealing with large blocks, particularly in fulfilling subscriptions etc. to the application. While the shard engine wraps blocks that it reconstructs in `Arc`, the same is not true for the generic marshal loop when reading data from disk or the resolver.

Profile, from a recent run, showing 25% of marshal's control loop being spent on cloning blocks: https://share.firefox.dev/4dqnmd5