### PR TITLE
[storage/journal] batch read/append journal optimizations

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -27,7 +27,7 @@ use commonware_codec::{CodecFixedShared, CodecShared, Encode, EncodeShared};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::{Sequential, Strategy};
 use core::num::NonZeroU64;
-use futures::{future::try_join_all, try_join, TryFutureExt as _};
+use futures::{try_join, TryFutureExt as _};
 use thiserror::Error;
 use tracing::{debug, warn};
 
@@ -646,10 +646,8 @@ where
             )
             .await?;
 
-        let futures = (*start_loc..*end_loc)
-            .map(|i| reader.read(i))
-            .collect::<Vec<_>>();
-        let ops = try_join_all(futures).await?;
+        let positions: Vec<u64> = (*start_loc..*end_loc).collect();
+        let ops = reader.read_many(&positions).await?;
 
         Ok((proof, ops))
     }

--- a/storage/src/journal/benches/bench.rs
+++ b/storage/src/journal/benches/bench.rs
@@ -19,6 +19,7 @@ mod fixed_append;
 mod fixed_read_random;
 mod fixed_read_sequential;
 mod fixed_replay;
+mod variable_read_random;
 mod variable_replay;
 
 criterion_main!(
@@ -26,6 +27,7 @@ criterion_main!(
     fixed_read_random::benches,
     fixed_read_sequential::benches,
     fixed_replay::benches,
+    variable_read_random::benches,
     variable_replay::benches,
 );
 

--- a/storage/src/journal/benches/variable_read_random.rs
+++ b/storage/src/journal/benches/variable_read_random.rs
@@ -102,9 +102,12 @@ fn bench_variable_read_random(c: &mut Criterion) {
                     // Benchmark: measure read time.
                     b.to_async(&runner).iter_custom(|iters| async move {
                         let ctx = context::get::<commonware_runtime::tokio::Context>();
-                        let j =
-                            get_variable_journal(ctx.child("storage"), PARTITION, ITEMS_PER_SECTION)
-                                .await;
+                        let j = get_variable_journal(
+                            ctx.child("storage"),
+                            PARTITION,
+                            ITEMS_PER_SECTION,
+                        )
+                        .await;
                         let mut duration = Duration::ZERO;
                         for _ in 0..iters {
                             let start = Instant::now();

--- a/storage/src/journal/benches/variable_read_random.rs
+++ b/storage/src/journal/benches/variable_read_random.rs
@@ -1,0 +1,139 @@
+use crate::{append_fixed_random_data, get_variable_journal};
+use commonware_runtime::{
+    benchmarks::{context, tokio},
+    tokio::{Config, Context, Runner},
+    Runner as _, Supervisor as _,
+};
+use commonware_storage::journal::contiguous::{variable::Journal, Reader as _};
+use commonware_utils::{sequence::FixedBytes, NZU64};
+use criterion::{criterion_group, Criterion};
+use futures::future::try_join_all;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::{
+    hint::black_box,
+    num::NonZeroU64,
+    time::{Duration, Instant},
+};
+
+/// Partition name to use in the journal config.
+const PARTITION: &str = "variable-random-test-partition";
+
+/// Value of items_per_section to use in the journal config.
+const ITEMS_PER_SECTION: NonZeroU64 = NZU64!(10_000);
+
+/// Number of items to write to the journal we will be reading from.
+const ITEMS_TO_WRITE: u64 = 5_000_000;
+
+/// Size of each journal item in bytes.
+const ITEM_SIZE: usize = 32;
+
+/// Read `items_to_read` random items from the given `journal`, awaiting each
+/// result before continuing.
+async fn bench_run_serial(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, items_to_read: usize) {
+    let reader = journal.reader().await;
+    let mut rng = StdRng::seed_from_u64(0);
+    for _ in 0..items_to_read {
+        let pos = rng.gen_range(0..ITEMS_TO_WRITE);
+        black_box(reader.read(pos).await.expect("failed to read data"));
+    }
+}
+
+/// Concurrently read (via try_join_all) `items_to_read` random items from the given `journal`.
+async fn bench_run_concurrent(
+    journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
+    items_to_read: usize,
+) {
+    let reader = journal.reader().await;
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut futures = Vec::with_capacity(items_to_read);
+    for _ in 0..items_to_read {
+        let pos = rng.gen_range(0..ITEMS_TO_WRITE);
+        futures.push(reader.read(pos));
+    }
+    try_join_all(futures).await.expect("failed to read data");
+}
+
+/// Batch-read `items_to_read` random items via `read_many`.
+async fn bench_run_read_many(
+    journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
+    items_to_read: usize,
+) {
+    let reader = journal.reader().await;
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut positions: Vec<u64> = (0..items_to_read)
+        .map(|_| rng.gen_range(0..ITEMS_TO_WRITE))
+        .collect();
+    positions.sort_unstable();
+    positions.dedup();
+    black_box(
+        reader
+            .read_many(&positions)
+            .await
+            .expect("failed to read data"),
+    );
+}
+
+fn bench_variable_read_random(c: &mut Criterion) {
+    let cfg = Config::default();
+    let mut initialized = false;
+    let runner = tokio::Runner::new(cfg.clone());
+    for mode in ["serial", "concurrent", "read_many"] {
+        for items_to_read in [100, 1_000, 10_000, 100_000] {
+            c.bench_function(
+                &format!(
+                    "{}/mode={} items={} size={}",
+                    module_path!(),
+                    mode,
+                    items_to_read,
+                    ITEM_SIZE
+                ),
+                |b| {
+                    // Setup: populate journal (once, on first sample).
+                    if !initialized {
+                        Runner::new(cfg.clone()).start(|ctx| async move {
+                            let mut j =
+                                get_variable_journal(ctx, PARTITION, ITEMS_PER_SECTION).await;
+                            append_fixed_random_data::<_, ITEM_SIZE>(&mut j, ITEMS_TO_WRITE).await;
+                            j.sync().await.unwrap();
+                        });
+                        initialized = true;
+                    }
+
+                    // Benchmark: measure read time.
+                    b.to_async(&runner).iter_custom(|iters| async move {
+                        let ctx = context::get::<commonware_runtime::tokio::Context>();
+                        let j =
+                            get_variable_journal(ctx.child("storage"), PARTITION, ITEMS_PER_SECTION)
+                                .await;
+                        let mut duration = Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = Instant::now();
+                            match mode {
+                                "serial" => bench_run_serial(&j, items_to_read).await,
+                                "concurrent" => bench_run_concurrent(&j, items_to_read).await,
+                                "read_many" => bench_run_read_many(&j, items_to_read).await,
+                                _ => unreachable!(),
+                            }
+                            duration += start.elapsed();
+                        }
+                        duration
+                    });
+                },
+            );
+        }
+    }
+
+    // Cleanup: destroy journal.
+    if initialized {
+        Runner::new(cfg).start(|context| async move {
+            let j = get_variable_journal::<ITEM_SIZE>(context, PARTITION, ITEMS_PER_SECTION).await;
+            j.destroy().await.unwrap();
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_variable_read_random
+}

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -162,7 +162,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         self.try_read_sync_into(pos, items_per_blob, &mut buf)
     }
 
-    /// Read an item synchronously using caller-provided scratch space.
+    /// Read an item synchronously using caller-provided buffer.
     fn try_read_sync_into(&self, pos: u64, items_per_blob: u64, buf: &mut [u8]) -> Option<A> {
         if pos >= self.size || pos < self.pruning_boundary {
             return None;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -158,6 +158,12 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
 
     /// Read an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
     fn try_read_sync(&self, pos: u64, items_per_blob: u64) -> Option<A> {
+        let mut buf = vec![0u8; SegmentedJournal::<E, A>::CHUNK_SIZE];
+        self.try_read_sync_into(pos, items_per_blob, &mut buf)
+    }
+
+    /// Read an item synchronously using caller-provided scratch space.
+    fn try_read_sync_into(&self, pos: u64, items_per_blob: u64, buf: &mut [u8]) -> Option<A> {
         if pos >= self.size || pos < self.pruning_boundary {
             return None;
         }
@@ -165,7 +171,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         let section_start = section * items_per_blob;
         let first_in_section = self.pruning_boundary.max(section_start);
         let pos_in_section = pos - first_in_section;
-        self.journal.try_get_sync(section, pos_in_section)
+        self.journal.try_get_sync_into(section, pos_in_section, buf)
     }
 }
 
@@ -238,8 +244,12 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         let mut miss_indices: Vec<usize> = Vec::new();
         let mut miss_positions: Vec<u64> = Vec::new();
 
+        let mut sync_buf = vec![0u8; chunk_size];
         for (i, &pos) in positions.iter().enumerate() {
-            if let Some(item) = self.guard.try_read_sync(pos, items_per_blob) {
+            if let Some(item) = self
+                .guard
+                .try_read_sync_into(pos, items_per_blob, &mut sync_buf)
+            {
                 result.push(Some(item));
             } else {
                 result.push(None);

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -35,11 +35,11 @@ pub trait Reader: Send + Sync {
     /// Guaranteed not to return [Error::ItemPruned] for positions within `bounds()`.
     fn read(&self, position: u64) -> impl Future<Output = Result<Self::Item, Error>> + Send;
 
-    /// Read multiple items at the given positions, which must be sorted in ascending order.
+    /// Read multiple items at the given positions. `positions` must be sorted in strictly ascending
+    /// order (sorted and unique).
     ///
-    /// The default implementation calls [`read`](Self::read) in a loop.
-    /// Fixed-size journal implementations override this to amortize lock
-    /// acquisition and avoid per-item buffer allocation.
+    /// The default implementation calls [`read`](Self::read) in a loop. Concrete journal
+    /// implementations override this to amortize lock acquisition and batch I/O.
     fn read_many(
         &self,
         positions: &[u64],
@@ -111,6 +111,14 @@ pub enum Many<'a, T> {
 }
 
 impl<T> Many<'_, T> {
+    /// Returns the total number of items across all segments.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Flat(items) => items.len(),
+            Self::Nested(nested_items) => nested_items.iter().map(|items| items.len()).sum(),
+        }
+    }
+
     /// Returns `true` if there are no items across all segments.
     pub fn is_empty(&self) -> bool {
         match self {

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -68,6 +68,7 @@ where
     test_persistence_basic(&indexed_factory).await;
     test_persistence_after_prune(&indexed_factory).await;
     test_read_by_position(&indexed_factory).await;
+    test_read_many(&indexed_factory).await;
     test_read_out_of_range(&indexed_factory).await;
     test_read_after_prune(&indexed_factory).await;
     test_rewind_to_middle(&indexed_factory).await;
@@ -728,6 +729,26 @@ where
     for i in 0..1000u64 {
         assert_eq!(read_item(&journal, i).await.unwrap(), i * 100);
     }
+
+    journal.destroy().await.unwrap();
+}
+
+/// Test reading multiple items by position.
+pub(super) async fn test_read_many<F, J>(factory: &F)
+where
+    F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
+    J: PersistableContiguous,
+{
+    let mut journal = factory("read-many".into()).await.unwrap();
+
+    for i in 0..15u64 {
+        journal.append(&(i * 100)).await.unwrap();
+    }
+
+    let reader = journal.reader().await;
+    let items = reader.read_many(&[1, 4, 12]).await.unwrap();
+    assert_eq!(items, vec![100, 400, 1200]);
+    drop(reader);
 
     journal.destroy().await.unwrap();
 }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -153,12 +153,24 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         items_per_section: u64,
         offsets: &impl super::Reader<Item = u64>,
     ) -> Option<V> {
+        let mut scratch = Vec::new();
+        self.try_read_sync_into(position, items_per_section, offsets, &mut scratch)
+    }
+
+    /// Read an item synchronously using caller-provided scratch space.
+    fn try_read_sync_into(
+        &self,
+        position: u64,
+        items_per_section: u64,
+        offsets: &impl super::Reader<Item = u64>,
+        scratch: &mut Vec<u8>,
+    ) -> Option<V> {
         if position >= self.size || position < self.pruning_boundary {
             return None;
         }
         let offset = offsets.try_read_sync(position)?;
         let section = position_to_section(position, items_per_section);
-        self.data.try_get_sync(section, offset)
+        self.data.try_get_sync_into(section, offset, scratch)
     }
 }
 
@@ -240,6 +252,98 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<'_, E, V> {
         self.guard
             .read(position, self.items_per_section, &self.offsets)
             .await
+    }
+
+    async fn read_many(&self, positions: &[u64]) -> Result<Vec<V>, Error> {
+        // Sanity check the input.
+        if positions.is_empty() {
+            return Ok(Vec::new());
+        }
+        debug_assert!(
+            positions.windows(2).all(|w| w[0] < w[1]),
+            "positions must be sorted and unique"
+        );
+        for &position in positions {
+            if position >= self.guard.size {
+                return Err(Error::ItemOutOfRange(position));
+            }
+            if position < self.guard.pruning_boundary {
+                return Err(Error::ItemPruned(position));
+            }
+        }
+
+        // Read the items from cache if possible.
+        let mut result: Vec<Option<V>> = Vec::with_capacity(positions.len());
+        let mut miss_indices = Vec::with_capacity(positions.len());
+        let mut miss_positions = Vec::with_capacity(positions.len());
+        let mut scratch = Vec::new();
+        for (i, &position) in positions.iter().enumerate() {
+            if let Some(item) = self.guard.try_read_sync_into(
+                position,
+                self.items_per_section,
+                &self.offsets,
+                &mut scratch,
+            ) {
+                result.push(Some(item));
+            } else {
+                result.push(None);
+                miss_indices.push(i);
+                miss_positions.push(position);
+            }
+        }
+
+        if miss_positions.is_empty() {
+            return Ok(result.into_iter().map(|r| r.unwrap()).collect());
+        }
+
+        // Read the offsets of all items that were not found in the cache.
+        let miss_offsets = self
+            .offsets
+            .read_many(&miss_positions)
+            .await
+            .map_err(|e| match e {
+                Error::ItemOutOfRange(e) | Error::ItemPruned(e) => {
+                    Error::Corruption(format!("section/item should be found, but got: {e}"))
+                }
+                other => other,
+            })?;
+
+        // Group runs of consecutive positions that fall into the same section and perform a
+        // consecutive read for each run.
+        let mut group_start = 0;
+        while group_start < miss_positions.len() {
+            let section = position_to_section(miss_positions[group_start], self.items_per_section);
+            let mut group_end = group_start + 1;
+            while group_end < miss_positions.len()
+                && position_to_section(miss_positions[group_end], self.items_per_section) == section
+            {
+                group_end += 1;
+            }
+
+            let mut run_start = group_start;
+            while run_start < group_end {
+                let mut run_end = run_start + 1;
+                while run_end < group_end
+                    && miss_positions[run_end - 1].checked_add(1) == Some(miss_positions[run_end])
+                {
+                    run_end += 1;
+                }
+
+                let items = self
+                    .guard
+                    .data
+                    .get_many_consecutive(section, &miss_offsets[run_start..run_end])
+                    .await?;
+
+                for (item, &miss_idx) in items.into_iter().zip(&miss_indices[run_start..run_end]) {
+                    result[miss_idx] = Some(item);
+                }
+                run_start = run_end;
+            }
+            group_start = group_end;
+        }
+
+        Ok(result.into_iter().map(|r| r.unwrap()).collect())
     }
 
     fn try_read_sync(&self, position: u64) -> Option<V> {
@@ -546,50 +650,84 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         if items.is_empty() {
             return Err(Error::EmptyAppend);
         }
+        let items_count = items.len();
 
-        // Encode before grabbing write guard.
-        let encode = |item: &V| variable::Journal::<E, V>::encode_item(self.compression, item);
-        let encoded: Vec<_> = match &items {
-            Many::Flat(s) => s.iter().map(encode).collect::<Result<Vec<_>, _>>()?,
-            Many::Nested(nested_items) => nested_items
-                .iter()
-                .flat_map(|items| items.iter())
-                .map(encode)
-                .collect::<Result<Vec<_>, _>>()?,
+        // Encode every item into a single buffer for bulk-writing before grabbing write guard.
+        let mut encoded = Vec::new();
+        let mut item_starts = Vec::with_capacity(items_count);
+        let mut encode = |item: &V| {
+            item_starts.push(encoded.len());
+            variable::Journal::<E, V>::encode_item_into(self.compression, item, &mut encoded)
         };
+        match &items {
+            Many::Flat(items) => {
+                for item in *items {
+                    encode(item)?;
+                }
+            }
+            Many::Nested(nested_items) => {
+                for items in *nested_items {
+                    for item in *items {
+                        encode(item)?;
+                    }
+                }
+            }
+        }
 
         // Mutating operations are serialized by taking the write guard.
         let mut inner = self.inner.write().await;
 
-        let mut last_position = 0;
-        for (index, (buf, _item_len)) in encoded.iter().enumerate() {
-            // Calculate which section this position belongs to.
+        let mut written = 0;
+        while written < items_count {
             let section = position_to_section(inner.size, self.items_per_section);
+            let pos_in_section = inner.size % self.items_per_section;
+            let remaining_space = (self.items_per_section - pos_in_section) as usize;
+            let batch_count = remaining_space.min(items_count - written);
+            let batch_start = item_starts[written];
+            let batch_end = item_starts
+                .get(written + batch_count)
+                .copied()
+                .unwrap_or(encoded.len());
 
-            // Append pre-encoded data to the data journal, get offset.
-            let offset = inner.data.append_raw(section, buf).await?;
+            // Append pre-encoded data to the data journal, then convert relative item starts
+            // into absolute offsets.
+            let base_offset = inner
+                .data
+                .append_raw(section, &encoded[batch_start..batch_end])
+                .await?;
 
-            // Append offset to offsets journal.
-            let offsets_pos = self.offsets.append(&offset).await?;
-            assert_eq!(offsets_pos, inner.size);
+            let absolute_offsets = item_starts[written..written + batch_count]
+                .iter()
+                .map(|&start| {
+                    base_offset
+                        .checked_add((start - batch_start) as u64)
+                        .ok_or(Error::OffsetOverflow)
+                })
+                .collect::<Result<Vec<u64>, _>>()?;
 
-            // Return the current position.
-            last_position = inner.size;
-            inner.size += 1;
+            // Persist the offsets for this section batch in the offsets journal.
+            let last_offsets_pos = self
+                .offsets
+                .append_many(Many::Flat(&absolute_offsets))
+                .await?;
+            assert_eq!(last_offsets_pos, inner.size + batch_count as u64 - 1);
+
+            inner.size += batch_count as u64;
+            written += batch_count;
 
             // The section was filled and must be synced. Downgrade so readers can continue
             // during the sync while mutators remain blocked.
             if inner.size.is_multiple_of(self.items_per_section) {
                 let inner_ref = inner.downgrade_to_upgradable();
                 futures::try_join!(inner_ref.data.sync(section), self.offsets.sync())?;
-                if index + 1 == encoded.len() {
-                    return Ok(last_position);
+                if written == items_count {
+                    return Ok(inner_ref.size - 1);
                 }
                 inner = inner_ref.upgrade().await;
             }
         }
 
-        Ok(last_position)
+        Ok(inner.size - 1)
     }
 
     /// Acquire a reader guard that holds a consistent view of the journal.
@@ -1080,7 +1218,7 @@ mod tests {
     use commonware_runtime::{
         buffer::paged::CacheRef, deterministic, Runner, Storage, Supervisor as _,
     };
-    use commonware_utils::{NZUsize, NZU16, NZU64};
+    use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
     use futures::FutureExt as _;
     use std::num::NonZeroU16;
 
@@ -1090,6 +1228,116 @@ mod tests {
     // Larger page sizes for tests that need more buffer space.
     const LARGE_PAGE_SIZE: NonZeroU16 = NZU16!(1024);
     const SMALL_PAGE_SIZE: NonZeroU16 = NZU16!(512);
+
+    #[test_traced]
+    fn test_variable_append_many_compressed() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "append-many-compressed".into(),
+                items_per_section: NZU64!(3),
+                compression: Some(1),
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+            let journal = Journal::<_, FixedBytes<32>>::init(context.child("journal"), cfg)
+                .await
+                .unwrap();
+            let items = [
+                FixedBytes::new([0; 32]),
+                FixedBytes::new([1; 32]),
+                FixedBytes::new([2; 32]),
+                FixedBytes::new([3; 32]),
+                FixedBytes::new([4; 32]),
+            ];
+
+            let last = journal.append_many(Many::Flat(&items)).await.unwrap();
+            assert_eq!(last, 4);
+            for (pos, item) in items.iter().enumerate() {
+                assert_eq!(journal.read(pos as u64).await.unwrap(), *item);
+            }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_read_many_after_reopen() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "read-many-after-reopen".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let cfg = Config {
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                ..cfg
+            };
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            let reader = journal.reader().await;
+            let items = reader.read_many(&[1, 2, 3, 7, 8, 12, 18]).await.unwrap();
+            assert_eq!(items, vec![100, 200, 300, 700, 800, 1200, 1800]);
+            drop(reader);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_read_many_consecutive_after_reopen() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "read-many-consecutive-after-reopen".into(),
+                items_per_section: NZU64!(20),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let cfg = Config {
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                ..cfg
+            };
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            let reader = journal.reader().await;
+            let positions: Vec<u64> = (3..10).collect();
+            let items = reader.read_many(&positions).await.unwrap();
+            assert_eq!(items, vec![300, 400, 500, 600, 700, 800, 900]);
+            drop(reader);
+
+            journal.destroy().await.unwrap();
+        });
+    }
 
     /// Test that complete offsets partition loss after pruning is detected as unrecoverable.
     ///

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -153,8 +153,8 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         items_per_section: u64,
         offsets: &impl super::Reader<Item = u64>,
     ) -> Option<V> {
-        let mut scratch = Vec::new();
-        self.try_read_sync_into(position, items_per_section, offsets, &mut scratch)
+        let mut buf = Vec::new();
+        self.try_read_sync_into(position, items_per_section, offsets, &mut buf)
     }
 
     /// Read an item synchronously using caller-provided scratch space.
@@ -163,14 +163,14 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         position: u64,
         items_per_section: u64,
         offsets: &impl super::Reader<Item = u64>,
-        scratch: &mut Vec<u8>,
+        buf: &mut Vec<u8>,
     ) -> Option<V> {
         if position >= self.size || position < self.pruning_boundary {
             return None;
         }
         let offset = offsets.try_read_sync(position)?;
         let section = position_to_section(position, items_per_section);
-        self.data.try_get_sync_into(section, offset, scratch)
+        self.data.try_get_sync_into(section, offset, buf)
     }
 }
 
@@ -263,26 +263,25 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<'_, E, V> {
             positions.windows(2).all(|w| w[0] < w[1]),
             "positions must be sorted and unique"
         );
-        for &position in positions {
-            if position >= self.guard.size {
-                return Err(Error::ItemOutOfRange(position));
-            }
-            if position < self.guard.pruning_boundary {
-                return Err(Error::ItemPruned(position));
-            }
+        if positions[0] < self.guard.pruning_boundary {
+            return Err(Error::ItemPruned(positions[0]));
+        }
+        let last_position = *positions.last().expect("positions is not empty");
+        if last_position >= self.guard.size {
+            return Err(Error::ItemOutOfRange(last_position));
         }
 
         // Read the items from cache if possible.
         let mut result: Vec<Option<V>> = Vec::with_capacity(positions.len());
         let mut miss_indices = Vec::with_capacity(positions.len());
         let mut miss_positions = Vec::with_capacity(positions.len());
-        let mut scratch = Vec::new();
+        let mut buf = Vec::new();
         for (i, &position) in positions.iter().enumerate() {
             if let Some(item) = self.guard.try_read_sync_into(
                 position,
                 self.items_per_section,
                 &self.offsets,
-                &mut scratch,
+                &mut buf,
             ) {
                 result.push(Some(item));
             } else {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -157,7 +157,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         self.try_read_sync_into(position, items_per_section, offsets, &mut buf)
     }
 
-    /// Read an item synchronously using caller-provided scratch space.
+    /// Read an item synchronously using caller-provided buffer.
     fn try_read_sync_into(
         &self,
         position: u64,

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -59,6 +59,15 @@ pub enum Error {
     ValueTooLarge,
     #[error("corruption detected: {0}")]
     Corruption(String),
+    /// The offsets journal and the data journal disagree about an item's layout. Either the
+    /// on-disk state is corrupted, or the caller passed offsets that aren't byte-adjacent on disk.
+    #[error("offset/data layout mismatch in section {section} at offset {offset}: offsets journal expected {expected_len}, data varint reports {actual_len}")]
+    OffsetDataMismatch {
+        section: u64,
+        offset: u64,
+        expected_len: usize,
+        actual_len: usize,
+    },
     #[error("invalid configuration: {0}")]
     InvalidConfiguration(String),
     #[error("checksum mismatch: expected={0}, found={1}")]

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -219,14 +219,30 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
 
     /// Get an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
     pub fn try_get_sync(&self, section: u64, position: u64) -> Option<A> {
+        let mut buf = vec![0u8; Self::CHUNK_SIZE];
+        self.try_get_sync_into(section, position, &mut buf)
+    }
+
+    /// Get an item synchronously using caller-provided scratch space.
+    ///
+    /// `buf` must be at least [Self::CHUNK_SIZE] bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `buf` is smaller than [Self::CHUNK_SIZE].
+    pub fn try_get_sync_into(&self, section: u64, position: u64, buf: &mut [u8]) -> Option<A> {
+        assert!(
+            buf.len() >= Self::CHUNK_SIZE,
+            "try_get_sync_into requires buf.len() >= CHUNK_SIZE"
+        );
         let blob = self.manager.get(section).ok()??;
         let offset = position.checked_mul(Self::CHUNK_SIZE_U64)?;
         let remaining = blob.try_size()?.checked_sub(offset)?;
         if remaining < Self::CHUNK_SIZE_U64 {
             return None;
         }
-        let mut buf = vec![0u8; Self::CHUNK_SIZE];
-        if !blob.try_read_sync(offset, &mut buf) {
+        let buf = &mut buf[..Self::CHUNK_SIZE];
+        if !blob.try_read_sync(offset, buf) {
             return None;
         }
         A::decode(&buf[..]).ok()

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -223,7 +223,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         self.try_get_sync_into(section, position, &mut buf)
     }
 
-    /// Get an item synchronously using caller-provided scratch space.
+    /// Get an item synchronously using caller-provided buffer.
     ///
     /// `buf` must be at least [Self::CHUNK_SIZE] bytes.
     ///

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -600,10 +600,6 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     ///
     /// Offsets should be sorted in ascending order.
     pub async fn get_many(&self, section: u64, offsets: &[u64]) -> Result<Vec<V>, Error> {
-        self.get_many_sequential(section, offsets).await
-    }
-
-    async fn get_many_sequential(&self, section: u64, offsets: &[u64]) -> Result<Vec<V>, Error> {
         if offsets.is_empty() {
             return Ok(Vec::new());
         }
@@ -640,7 +636,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         offsets: &[u64],
     ) -> Result<Vec<V>, Error> {
         if offsets.len() <= 1 {
-            return self.get_many_sequential(section, offsets).await;
+            return self.get_many(section, offsets).await;
         }
         let blob = self
             .manager
@@ -650,7 +646,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         let start = offsets[0];
         let end = offsets[offsets.len() - 1];
         if end <= start {
-            return self.get_many_sequential(section, offsets).await;
+            return self.get_many(section, offsets).await;
         }
         let range_len = usize::try_from(end - start).map_err(|_| Error::OffsetOverflow)?;
         let bytes = blob.read_at(start, range_len).await?.coalesce();

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -88,7 +88,7 @@ use commonware_codec::{
 };
 use commonware_runtime::{
     buffer::paged::{Append, CacheRef, Replay},
-    Blob, Buf, BufMut, IoBuf, IoBufMut, Metrics, Storage,
+    Blob, Buf, IoBuf, IoBufMut, Metrics, Storage,
 };
 use futures::stream::{self, Stream, StreamExt};
 use std::{io::Cursor, num::NonZeroUsize};
@@ -496,6 +496,22 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// Returns `(buf, item_len)` where `item_len` is the length of the encoded (and
     /// possibly compressed) payload, excluding the size prefix.
     pub(crate) fn encode_item(compression: Option<u8>, item: &V) -> Result<(Vec<u8>, u32), Error> {
+        let mut buf = Vec::new();
+        let item_len = Self::encode_item_into(compression, item, &mut buf)?;
+        Ok((buf, item_len))
+    }
+
+    /// Encode an item with its length prefix, appending the encoded bytes to `buf`.
+    ///
+    /// Existing contents of `buf` are preserved; this allows callers to accumulate
+    /// multiple encoded items into a single buffer.
+    ///
+    /// Returns the payload length, excluding the size prefix.
+    pub(crate) fn encode_item_into(
+        compression: Option<u8>,
+        item: &V,
+        buf: &mut Vec<u8>,
+    ) -> Result<u32, Error> {
         if let Some(compression) = compression {
             // Compressed: encode first, then compress
             let encoded = item.encode();
@@ -511,11 +527,11 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
                 .checked_add(item_len)
                 .ok_or(Error::OffsetOverflow)?;
 
-            let mut buf = Vec::with_capacity(entry_len);
-            UInt(item_len_u32).write(&mut buf);
-            buf.put_slice(&compressed);
+            buf.reserve(entry_len);
+            UInt(item_len_u32).write(buf);
+            buf.extend_from_slice(&compressed);
 
-            Ok((buf, item_len_u32))
+            Ok(item_len_u32)
         } else {
             // Uncompressed: pre-allocate exact size to avoid copying
             let item_len = item.encode_size();
@@ -528,11 +544,11 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
                 .checked_add(item_len)
                 .ok_or(Error::OffsetOverflow)?;
 
-            let mut buf = Vec::with_capacity(entry_len);
-            UInt(item_len_u32).write(&mut buf);
-            item.write(&mut buf);
+            buf.reserve(entry_len);
+            UInt(item_len_u32).write(buf);
+            item.write(buf);
 
-            Ok((buf, item_len_u32))
+            Ok(item_len_u32)
         }
     }
 
@@ -580,8 +596,120 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         Ok(item)
     }
 
+    /// Read multiple items from the same section.
+    ///
+    /// Offsets should be sorted in ascending order.
+    pub async fn get_many(&self, section: u64, offsets: &[u64]) -> Result<Vec<V>, Error> {
+        self.get_many_sequential(section, offsets).await
+    }
+
+    async fn get_many_sequential(&self, section: u64, offsets: &[u64]) -> Result<Vec<V>, Error> {
+        if offsets.is_empty() {
+            return Ok(Vec::new());
+        }
+        let blob = self
+            .manager
+            .get(section)?
+            .ok_or(Error::SectionOutOfRange(section))?;
+
+        let compressed = self.compression.is_some();
+        let cfg = &self.codec_config;
+        let mut items = Vec::with_capacity(offsets.len());
+        for &offset in offsets {
+            let (_, _, item) = Self::read(compressed, cfg, blob, offset).await?;
+            items.push(item);
+        }
+        Ok(items)
+    }
+
+    /// Read consecutive items from the same section. `offsets` must be sorted in strictly
+    /// ascending order and identify items that are adjacent in the section.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::OffsetDataMismatch`] if the on-disk varint at any offset reports a size
+    /// inconsistent with the gap to the next offset. This indicates either on-disk corruption or a
+    /// caller violation of the byte-adjacency precondition.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `offsets` is not strictly increasing.
+    pub(crate) async fn get_many_consecutive(
+        &self,
+        section: u64,
+        offsets: &[u64],
+    ) -> Result<Vec<V>, Error> {
+        if offsets.len() <= 1 {
+            return self.get_many_sequential(section, offsets).await;
+        }
+        let blob = self
+            .manager
+            .get(section)?
+            .ok_or(Error::SectionOutOfRange(section))?;
+
+        let start = offsets[0];
+        let end = offsets[offsets.len() - 1];
+        if end <= start {
+            return self.get_many_sequential(section, offsets).await;
+        }
+        let range_len = usize::try_from(end - start).map_err(|_| Error::OffsetOverflow)?;
+        let bytes = blob.read_at(start, range_len).await?.coalesce();
+        let bytes = bytes.as_ref();
+
+        let compressed = self.compression.is_some();
+        let cfg = &self.codec_config;
+        let mut items = Vec::with_capacity(offsets.len());
+        let mut local_offset = 0usize;
+
+        for window in offsets.windows(2) {
+            let offset = window[0];
+            let next_offset = window[1];
+            assert!(offset < next_offset, "offsets must be strictly increasing");
+
+            let item_len =
+                usize::try_from(next_offset - offset).map_err(|_| Error::OffsetOverflow)?;
+
+            let mut cursor = Cursor::new(&bytes[local_offset..]);
+            let (size, varint_len) = decode_length_prefix(&mut cursor)?;
+            let actual_len = size + varint_len;
+            if actual_len != item_len {
+                return Err(Error::OffsetDataMismatch {
+                    section,
+                    offset,
+                    expected_len: item_len,
+                    actual_len,
+                });
+            }
+
+            let data_start = local_offset
+                .checked_add(varint_len)
+                .ok_or(Error::OffsetOverflow)?;
+            let data_end = local_offset
+                .checked_add(item_len)
+                .ok_or(Error::OffsetOverflow)?;
+
+            items.push(decode_item::<V>(
+                &bytes[data_start..data_end],
+                cfg,
+                compressed,
+            )?);
+
+            local_offset = data_end;
+        }
+
+        let (_, _, item) = Self::read(compressed, cfg, blob, end).await?;
+        items.push(item);
+        Ok(items)
+    }
+
     /// Get an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
     pub fn try_get_sync(&self, section: u64, offset: u64) -> Option<V> {
+        let mut scratch = Vec::new();
+        self.try_get_sync_into(section, offset, &mut scratch)
+    }
+
+    /// Get an item synchronously using caller-provided scratch space.
+    pub fn try_get_sync_into(&self, section: u64, offset: u64, scratch: &mut Vec<u8>) -> Option<V> {
         let blob = self.manager.get(section).ok()??;
         let remaining = blob.try_size()?.checked_sub(offset)?;
         let header_len = usize::try_from(remaining.min(MAX_U32_VARINT_SIZE as u64)).ok()?;
@@ -624,12 +752,12 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         }
 
         // Otherwise try reading the full item from cache.
-        let mut full = vec![0u8; item_len];
-        if !blob.try_read_sync(offset, &mut full) {
+        scratch.resize(item_len, 0);
+        if !blob.try_read_sync(offset, scratch) {
             return None;
         }
         decode_item::<V>(
-            &full[varint_len..varint_len + data_len],
+            &scratch[varint_len..varint_len + data_len],
             &self.codec_config,
             self.compression.is_some(),
         )

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -700,12 +700,12 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
 
     /// Get an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
     pub fn try_get_sync(&self, section: u64, offset: u64) -> Option<V> {
-        let mut scratch = Vec::new();
-        self.try_get_sync_into(section, offset, &mut scratch)
+        let mut buf = Vec::new();
+        self.try_get_sync_into(section, offset, &mut buf)
     }
 
-    /// Get an item synchronously using caller-provided scratch space.
-    pub fn try_get_sync_into(&self, section: u64, offset: u64, scratch: &mut Vec<u8>) -> Option<V> {
+    /// Get an item synchronously using caller-provided buffer.
+    pub fn try_get_sync_into(&self, section: u64, offset: u64, buf: &mut Vec<u8>) -> Option<V> {
         let blob = self.manager.get(section).ok()??;
         let remaining = blob.try_size()?.checked_sub(offset)?;
         let header_len = usize::try_from(remaining.min(MAX_U32_VARINT_SIZE as u64)).ok()?;
@@ -748,12 +748,12 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         }
 
         // Otherwise try reading the full item from cache.
-        scratch.resize(item_len, 0);
-        if !blob.try_read_sync(offset, scratch) {
+        buf.resize(item_len, 0);
+        if !blob.try_read_sync(offset, buf) {
             return None;
         }
         decode_item::<V>(
-            &scratch[varint_len..varint_len + data_len],
+            &buf[varint_len..varint_len + data_len],
             &self.codec_config,
             self.compression.is_some(),
         )

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -126,6 +126,137 @@ struct PeakLayout<F: Family> {
     after: Vec<(Position<F>, u32)>,
 }
 
+#[derive(Clone, Copy)]
+struct GraftingInfo {
+    height: u32,
+    complete_chunks: u64,
+}
+
+impl GraftingInfo {
+    fn from_status<const N: usize>(status: &impl BitmapReadable<N>) -> Self {
+        Self {
+            height: grafting::height::<N>(),
+            complete_chunks: status.complete_chunks() as u64,
+        }
+    }
+}
+
+struct BitmapGrafting<'a, B, const N: usize> {
+    status: &'a B,
+    info: GraftingInfo,
+    pruned_chunks: u64,
+}
+
+impl<'a, B: BitmapReadable<N>, const N: usize> BitmapGrafting<'a, B, N> {
+    fn new(status: &'a B) -> Self {
+        Self {
+            status,
+            info: GraftingInfo::from_status(status),
+            pruned_chunks: status.pruned_chunks() as u64,
+        }
+    }
+
+    fn chunk(&self, idx: u64) -> Option<[u8; N]> {
+        if idx >= self.info.complete_chunks {
+            None
+        } else if idx < self.pruned_chunks {
+            Some([0u8; N])
+        } else {
+            Some(self.status.get_chunk(idx as usize))
+        }
+    }
+}
+
+struct ProofPlan<F: Family> {
+    leaves: Location<F>,
+    range: Range<Location<F>>,
+    layout: PeakLayout<F>,
+    inactive_peaks: usize,
+    start_chunk: u64,
+    end_chunk: u64,
+    grafting: GraftingInfo,
+}
+
+impl<F: Family> ProofPlan<F> {
+    fn new(
+        leaves: Location<F>,
+        range: Range<Location<F>>,
+        inactive_peaks: usize,
+        grafting: GraftingInfo,
+    ) -> Result<Self, merkle::Error<F>> {
+        let layout = peak_layout(leaves, range.clone())?;
+        let end_loc = range.end.checked_sub(1).expect("range is non-empty");
+        let start_chunk = *range.start >> grafting.height;
+        let end_chunk = *end_loc >> grafting.height;
+
+        Ok(Self {
+            leaves,
+            range,
+            layout,
+            inactive_peaks,
+            start_chunk,
+            end_chunk,
+            grafting,
+        })
+    }
+
+    fn range_start(&self) -> u64 {
+        peaks_leaf_len(&self.layout.prefix)
+    }
+
+    fn after_start(&self) -> u64 {
+        self.range_start() + peaks_leaf_len(&self.layout.range)
+    }
+
+    fn prefix_raw_start(&self) -> usize {
+        prefix_raw_start_idx(
+            &self.layout.prefix,
+            self.start_chunk,
+            self.grafting.height,
+        )
+    }
+
+    fn after_raw_end(&self) -> usize {
+        after_raw_end_idx(
+            &self.layout.after,
+            self.after_start(),
+            self.end_chunk,
+            self.grafting.height,
+        )
+    }
+
+    const fn chunk_available(&self, idx: u64) -> bool {
+        idx < self.grafting.complete_chunks
+    }
+
+    const fn total_peaks(&self) -> usize {
+        self.layout.prefix.len() + self.layout.range.len() + self.layout.after.len()
+    }
+}
+
+impl<F: Graftable> ProofPlan<F> {
+    fn from_inactivity_floor(
+        leaves: Location<F>,
+        range: Range<Location<F>>,
+        inactivity_floor: Location<F>,
+        grafting: GraftingInfo,
+    ) -> Result<Self, merkle::Error<F>> {
+        let inactive_peaks =
+            grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting.height)?;
+        Self::new(leaves, range, inactive_peaks, grafting)
+    }
+
+    fn needs_grafted_peak_fold(&self) -> Result<bool, merkle::Error<F>> {
+        let size = Position::<F>::try_from(self.leaves)?;
+        Ok(proof_needs_grafted_peak_fold(
+            &self.layout,
+            size,
+            self.grafting.height,
+            self.grafting.complete_chunks,
+        ))
+    }
+}
+
 /// Helper to bucket a tree's current peaks into prefix, range, and after sub-vectors.
 ///
 /// Traverses all structural peaks left-to-right (from largest/leftmost to smallest/rightmost)
@@ -304,40 +435,33 @@ fn transformed_peak_counts<F: Graftable>(
 
 // Reconstructs the canonical grafted root from the combination of generic proof boundaries,
 // operation elements, and grafted prefix/suffix witnesses provided by the prover.
-#[allow(clippy::too_many_arguments)]
 fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     verifier: &grafting::Verifier<'_, F, H>,
     proof: &RangeProof<F, H::Digest>,
-    layout: &PeakLayout<F>,
-    leaves: Location<F>,
-    range: Range<Location<F>>,
+    plan: &ProofPlan<F>,
     collected: &BTreeMap<Position<F>, H::Digest>,
-    grafting_height: u32,
     get_chunk: impl Fn(u64) -> Option<C>,
 ) -> Option<H::Digest> {
     let prefix_start = 0;
-    let range_start = peaks_leaf_len(&layout.prefix);
-    let after_start = range_start + peaks_leaf_len(&layout.range);
-    let chunk_available = |idx| idx < (*leaves >> grafting_height);
-    let start_chunk = *range.start >> grafting_height;
-    let end_chunk = *range.end.checked_sub(1)? >> grafting_height;
-    let prefix_raw_start = prefix_raw_start_idx(&layout.prefix, start_chunk, grafting_height);
-    let after_raw_end = after_raw_end_idx(&layout.after, after_start, end_chunk, grafting_height);
+    let range_start = plan.range_start();
+    let after_start = plan.after_start();
+    let prefix_raw_start = plan.prefix_raw_start();
+    let after_raw_end = plan.after_raw_end();
 
     let prefix_counts = transformed_peak_counts(
-        &layout.prefix[..prefix_raw_start],
+        &plan.layout.prefix[..prefix_raw_start],
         prefix_start,
-        grafting_height,
-        chunk_available,
+        plan.grafting.height,
+        |idx| plan.chunk_available(idx),
     );
     let suffix_counts = transformed_peak_counts(
-        &layout.after[after_raw_end..],
-        after_start + peaks_leaf_len(&layout.after[..after_raw_end]),
-        grafting_height,
-        chunk_available,
+        &plan.layout.after[after_raw_end..],
+        after_start + peaks_leaf_len(&plan.layout.after[..after_raw_end]),
+        plan.grafting.height,
+        |idx| plan.chunk_available(idx),
     );
-    let prefix_witness_len = prefix_counts.len() + layout.prefix[prefix_raw_start..].len();
-    let suffix_witness_len = layout.after[..after_raw_end].len() + suffix_counts.len();
+    let prefix_witness_len = prefix_counts.len() + plan.layout.prefix[prefix_raw_start..].len();
+    let suffix_witness_len = plan.layout.after[..after_raw_end].len() + suffix_counts.len();
     if proof.unfolded_prefix_peaks.len() != prefix_witness_len
         || proof.unfolded_suffix_peaks.len() != suffix_witness_len
     {
@@ -345,36 +469,38 @@ fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     }
 
     let mut transformed = Vec::with_capacity(
-        proof.unfolded_prefix_peaks.len() + layout.range.len() + proof.unfolded_suffix_peaks.len(),
+        proof.unfolded_prefix_peaks.len()
+            + plan.layout.range.len()
+            + proof.unfolded_suffix_peaks.len(),
     );
     let (prefix_transformed, prefix_raw) =
         proof.unfolded_prefix_peaks.split_at(prefix_counts.len());
     transformed.extend(prefix_transformed.iter().copied().zip(prefix_counts));
-    let mut range_digests = Vec::with_capacity(layout.range.len());
-    for (pos, _) in &layout.range {
+    let mut range_digests = Vec::with_capacity(plan.layout.range.len());
+    for (pos, _) in &plan.layout.range {
         range_digests.push(*collected.get(pos)?);
     }
     let (suffix_raw, suffix_transformed) = proof
         .unfolded_suffix_peaks
-        .split_at(layout.after[..after_raw_end].len());
+        .split_at(plan.layout.after[..after_raw_end].len());
 
     // The transformed list has three regions: entries before the range-adjacent chunks, the
     // middle chunks that may combine raw prefix/range/suffix peaks, and entries after that middle
     // region. `middle_peaks` covers exactly the chunk span from the first raw prefix peak through
     // the last raw suffix peak that can share a grafted chunk with the proven range.
-    let middle_iter = layout.prefix[prefix_raw_start..]
+    let middle_iter = plan.layout.prefix[prefix_raw_start..]
         .iter()
         .map(|(_, h)| *h)
         .zip(prefix_raw.iter().copied())
         .chain(
-            layout
+            plan.layout
                 .range
                 .iter()
                 .map(|(_, h)| *h)
                 .zip(range_digests.iter().copied()),
         )
         .chain(
-            layout.after[..after_raw_end]
+            plan.layout.after[..after_raw_end]
                 .iter()
                 .map(|(_, h)| *h)
                 .zip(suffix_raw.iter().copied()),
@@ -382,8 +508,8 @@ fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     transformed.extend(grafting::transform_peak_digests::<F, _, _, _>(
         verifier,
         middle_iter,
-        range_start - peaks_leaf_len(&layout.prefix[prefix_raw_start..]),
-        grafting_height,
+        range_start - peaks_leaf_len(&plan.layout.prefix[prefix_raw_start..]),
+        plan.grafting.height,
         get_chunk,
     ));
     transformed.extend(suffix_transformed.iter().copied().zip(suffix_counts));
@@ -392,32 +518,17 @@ fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     let inactive_to_fold = grafting::transformed_inactive_peaks::<F, _>(
         &transformed,
         inactive_peaks,
-        layout.prefix.len() + layout.range.len() + layout.after.len(),
+        plan.total_peaks(),
     )
     .ok()?;
     let digests = transformed.iter().map(|(digest, _count)| digest);
-    verifier.root_with_folded_peaks(leaves, inactive_to_fold, inactive_peaks, digests)
+    verifier.root_with_folded_peaks(plan.leaves, inactive_to_fold, inactive_peaks, digests)
 }
 
 struct GraftedProofParts<F: Family, D: Digest> {
     proof: Proof<F, D>,
     unfolded_prefix_peaks: Vec<D>,
     unfolded_suffix_peaks: Vec<D>,
-}
-
-fn grafted_chunk<const N: usize>(
-    status: &impl BitmapReadable<N>,
-    complete_chunks: u64,
-    pruned_chunks: u64,
-    idx: u64,
-) -> Option<[u8; N]> {
-    if idx >= complete_chunks {
-        None
-    } else if idx < pruned_chunks {
-        Some([0u8; N])
-    } else {
-        Some(status.get_chunk(idx as usize))
-    }
 }
 
 fn peak_digests<F: Family, D: Digest>(
@@ -435,16 +546,18 @@ fn peak_digests<F: Family, D: Digest>(
         .collect()
 }
 
-#[allow(clippy::too_many_arguments)]
-fn prefix_witness<F: Graftable, D: Digest, H: CHasher<Digest = D>, const N: usize>(
+fn prefix_witness<
+    F: Graftable,
+    D: Digest,
+    H: CHasher<Digest = D>,
+    B: BitmapReadable<N>,
+    const N: usize,
+>(
     hasher: &StandardHasher<H>,
-    status: &impl BitmapReadable<N>,
+    bitmap: &BitmapGrafting<'_, B, N>,
     peaks: &[(Position<F>, u32)],
     raw_digests: &[D],
     raw_start: usize,
-    grafting_height: u32,
-    complete_chunks: u64,
-    pruned_chunks: u64,
 ) -> Vec<D> {
     let mut witness = grafting::transform_peak_digests::<F, _, _, _>(
         hasher,
@@ -453,8 +566,8 @@ fn prefix_witness<F: Graftable, D: Digest, H: CHasher<Digest = D>, const N: usiz
             .map(|(_, h)| *h)
             .zip(raw_digests[..raw_start].iter().copied()),
         0,
-        grafting_height,
-        |idx| grafted_chunk(status, complete_chunks, pruned_chunks, idx),
+        bitmap.info.height,
+        |idx| bitmap.chunk(idx),
     )
     .into_iter()
     .map(|(digest, _count)| digest)
@@ -463,17 +576,19 @@ fn prefix_witness<F: Graftable, D: Digest, H: CHasher<Digest = D>, const N: usiz
     witness
 }
 
-#[allow(clippy::too_many_arguments)]
-fn suffix_witness<F: Graftable, D: Digest, H: CHasher<Digest = D>, const N: usize>(
+fn suffix_witness<
+    F: Graftable,
+    D: Digest,
+    H: CHasher<Digest = D>,
+    B: BitmapReadable<N>,
+    const N: usize,
+>(
     hasher: &StandardHasher<H>,
-    status: &impl BitmapReadable<N>,
+    bitmap: &BitmapGrafting<'_, B, N>,
     peaks: &[(Position<F>, u32)],
     raw_digests: &[D],
     suffix_start: u64,
     raw_end: usize,
-    grafting_height: u32,
-    complete_chunks: u64,
-    pruned_chunks: u64,
 ) -> Vec<D> {
     let mut witness = raw_digests[..raw_end].to_vec();
     witness.extend(
@@ -484,8 +599,8 @@ fn suffix_witness<F: Graftable, D: Digest, H: CHasher<Digest = D>, const N: usiz
                 .map(|(_, h)| *h)
                 .zip(raw_digests[raw_end..].iter().copied()),
             suffix_start + peaks_leaf_len(&peaks[..raw_end]),
-            grafting_height,
-            |idx| grafted_chunk(status, complete_chunks, pruned_chunks, idx),
+            bitmap.info.height,
+            |idx| bitmap.chunk(idx),
         )
         .into_iter()
         .map(|(digest, _count)| digest),
@@ -493,32 +608,24 @@ fn suffix_witness<F: Graftable, D: Digest, H: CHasher<Digest = D>, const N: usiz
     witness
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn build_grafted_range_proof<
     F: Graftable,
     D: Digest,
     H: CHasher<Digest = D>,
     S: Storage<F, Digest = D>,
+    B: BitmapReadable<N>,
     const N: usize,
 >(
     hasher: &StandardHasher<H>,
-    status: &impl BitmapReadable<N>,
+    bitmap: &BitmapGrafting<'_, B, N>,
     storage: &S,
-    layout: &PeakLayout<F>,
-    leaves: Location<F>,
-    inactive_peaks: usize,
-    range: Range<Location<F>>,
-    grafting_height: u32,
-    complete_chunks: u64,
-    pruned_chunks: u64,
+    plan: &ProofPlan<F>,
 ) -> Result<GraftedProofParts<F, D>, Error<F>> {
-    let proof_start_chunk = *range.start >> grafting_height;
-    let proof_end_chunk = *range.end.checked_sub(1).ok_or(merkle::Error::Empty)? >> grafting_height;
-
-    let proof_positions = merkle::range_collection_nodes(leaves, inactive_peaks, range)?;
+    let proof_positions =
+        merkle::range_collection_nodes(plan.leaves, plan.inactive_peaks, plan.range.clone())?;
     let mut fetch_positions = proof_positions.clone();
-    fetch_positions.extend(layout.prefix.iter().map(|&(pos, _)| pos));
-    fetch_positions.extend(layout.after.iter().map(|&(pos, _)| pos));
+    fetch_positions.extend(plan.layout.prefix.iter().map(|&(pos, _)| pos));
+    fetch_positions.extend(plan.layout.after.iter().map(|&(pos, _)| pos));
     fetch_positions.sort_unstable();
     debug_assert!(
         fetch_positions
@@ -542,44 +649,31 @@ async fn build_grafted_range_proof<
         .collect::<Result<_, Error<F>>>()?;
 
     let proof = merkle::build_range_collection_proof::<F, D, Error<F>>(
-        leaves,
-        inactive_peaks,
+        plan.leaves,
+        plan.inactive_peaks,
         &proof_positions,
         |pos| fetched.get(&pos).copied(),
         |pos| Error::from(merkle::Error::<F>::MissingNode(pos)),
     )?;
 
-    let prefix_raw = peak_digests(&layout.prefix, &fetched)?;
-    let prefix_raw_start = prefix_raw_start_idx(&layout.prefix, proof_start_chunk, grafting_height);
-    let unfolded_prefix_peaks = prefix_witness::<F, D, H, N>(
+    let prefix_raw = peak_digests(&plan.layout.prefix, &fetched)?;
+    let unfolded_prefix_peaks = prefix_witness::<F, D, H, B, N>(
         hasher,
-        status,
-        &layout.prefix,
+        bitmap,
+        &plan.layout.prefix,
         &prefix_raw,
-        prefix_raw_start,
-        grafting_height,
-        complete_chunks,
-        pruned_chunks,
+        plan.prefix_raw_start(),
     );
 
-    let suffix_raw = peak_digests(&layout.after, &fetched)?;
-    let suffix_start = peaks_leaf_len(&layout.prefix) + peaks_leaf_len(&layout.range);
-    let suffix_raw_end = after_raw_end_idx(
-        &layout.after,
-        suffix_start,
-        proof_end_chunk,
-        grafting_height,
-    );
-    let unfolded_suffix_peaks = suffix_witness::<F, D, H, N>(
+    let suffix_raw = peak_digests(&plan.layout.after, &fetched)?;
+    let suffix_start = plan.after_start();
+    let unfolded_suffix_peaks = suffix_witness::<F, D, H, B, N>(
         hasher,
-        status,
-        &layout.after,
+        bitmap,
+        &plan.layout.after,
         &suffix_raw,
         suffix_start,
-        suffix_raw_end,
-        grafting_height,
-        complete_chunks,
-        pruned_chunks,
+        plan.after_raw_end(),
     );
 
     Ok(GraftedProofParts {
@@ -632,18 +726,12 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         ops_root: D,
     ) -> Result<Self, Error<F>> {
         let std_hasher = qmdb::hasher::<H>();
-        let range_for_layout = range.clone();
-        let complete_chunks = status.complete_chunks() as u64;
-        let pruned_chunks = status.pruned_chunks() as u64;
+        let bitmap = BitmapGrafting::new(status);
         let leaves = Location::try_from(storage.size().await)?;
-        let layout = peak_layout(leaves, range_for_layout)?;
-        let grafting_height = grafting::height::<N>();
-        let inactive_peaks =
-            grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting_height)?;
+        let plan =
+            ProofPlan::from_inactivity_floor(leaves, range, inactivity_floor, bitmap.info)?;
 
-        let size = Position::<F>::try_from(leaves)?;
-        let needs_grafted_peak_fold =
-            proof_needs_grafted_peak_fold(&layout, size, grafting_height, complete_chunks);
+        let needs_grafted_peak_fold = plan.needs_grafted_peak_fold()?;
         let GraftedProofParts {
             proof,
             unfolded_prefix_peaks,
@@ -651,15 +739,9 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         } = if needs_grafted_peak_fold {
             build_grafted_range_proof(
                 &std_hasher,
-                status,
+                &bitmap,
                 storage,
-                &layout,
-                leaves,
-                inactive_peaks,
-                range.clone(),
-                grafting_height,
-                complete_chunks,
-                pruned_chunks,
+                &plan,
             )
             .await?
         } else {
@@ -667,9 +749,9 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
                 proof: merkle::verification::historical_range_proof(
                     &std_hasher,
                     storage,
-                    leaves,
-                    range.clone(),
-                    inactive_peaks,
+                    plan.leaves,
+                    plan.range.clone(),
+                    plan.inactive_peaks,
                 )
                 .await?,
                 unfolded_prefix_peaks: Vec::new(),
@@ -812,6 +894,10 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let elements = ops.iter().map(|op| op.encode()).collect::<Vec<_>>();
         let chunk_vec = chunks.iter().map(|c| c.as_ref()).collect::<Vec<_>>();
         let grafting_height = grafting::height::<N>();
+        let grafting = GraftingInfo {
+            height: grafting_height,
+            complete_chunks,
+        };
         let verifier = grafting::Verifier::<F, H>::new(
             grafting_height,
             start_chunk,
@@ -840,22 +926,25 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             return false;
         }
 
-        let layout = match peak_layout(leaves, start_loc..end_loc) {
-            Ok(layout) => layout,
+        let plan = match ProofPlan::new(
+            leaves,
+            start_loc..end_loc,
+            self.proof.inactive_peaks,
+            grafting,
+        ) {
+            Ok(plan) => plan,
             Err(error) => {
                 debug!(?error, "verification failed, invalid peak layout");
                 return false;
             }
         };
-        let size = match Position::<F>::try_from(leaves) {
-            Ok(size) => size,
+        let needs_grafted_peak_fold = match plan.needs_grafted_peak_fold() {
+            Ok(needs_grafted_peak_fold) => needs_grafted_peak_fold,
             Err(error) => {
                 debug!(?error, "verification failed, invalid size");
                 return false;
             }
         };
-        let needs_grafted_peak_fold =
-            proof_needs_grafted_peak_fold(&layout, size, grafting_height, complete_chunks);
         let merkle_root = if !needs_grafted_peak_fold {
             if !self.unfolded_prefix_peaks.is_empty() || !self.unfolded_suffix_peaks.is_empty() {
                 debug!("verification failed, unexpected grafted metadata");
@@ -893,11 +982,8 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             let Some(root) = reconstruct_grafted_root(
                 &verifier,
                 self,
-                &layout,
-                leaves,
-                start_loc..end_loc,
+                &plan,
                 &collected,
-                grafting_height,
                 get_chunk,
             ) else {
                 debug!("verification failed, could not reconstruct grafted root");

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -209,11 +209,7 @@ impl<F: Family> ProofPlan<F> {
     }
 
     fn prefix_raw_start(&self) -> usize {
-        prefix_raw_start_idx(
-            &self.layout.prefix,
-            self.start_chunk,
-            self.grafting.height,
-        )
+        prefix_raw_start_idx(&self.layout.prefix, self.start_chunk, self.grafting.height)
     }
 
     fn after_raw_end(&self) -> usize {
@@ -728,8 +724,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let std_hasher = qmdb::hasher::<H>();
         let bitmap = BitmapGrafting::new(status);
         let leaves = Location::try_from(storage.size().await)?;
-        let plan =
-            ProofPlan::from_inactivity_floor(leaves, range, inactivity_floor, bitmap.info)?;
+        let plan = ProofPlan::from_inactivity_floor(leaves, range, inactivity_floor, bitmap.info)?;
 
         let needs_grafted_peak_fold = plan.needs_grafted_peak_fold()?;
         let GraftedProofParts {
@@ -737,13 +732,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             unfolded_prefix_peaks,
             unfolded_suffix_peaks,
         } = if needs_grafted_peak_fold {
-            build_grafted_range_proof(
-                &std_hasher,
-                &bitmap,
-                storage,
-                &plan,
-            )
-            .await?
+            build_grafted_range_proof(&std_hasher, &bitmap, storage, &plan).await?
         } else {
             GraftedProofParts {
                 proof: merkle::verification::historical_range_proof(
@@ -979,13 +968,9 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
                     .filter(|&idx| idx < chunks.len() as u64)
                     .map(|idx| chunks[idx as usize].as_ref())
             };
-            let Some(root) = reconstruct_grafted_root(
-                &verifier,
-                self,
-                &plan,
-                &collected,
-                get_chunk,
-            ) else {
+            let Some(root) =
+                reconstruct_grafted_root(&verifier, self, &plan, &collected, get_chunk)
+            else {
                 debug!("verification failed, could not reconstruct grafted root");
                 return false;
             };

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -200,7 +200,7 @@ where
 
     /// Batch read values at multiple locations.
     ///
-    /// Locations must be sorted in ascending order.
+    /// Locations must be sorted in strictly ascending order (sorted and unique).
     /// Returns results in the same order as the input locations.
     pub async fn get_many<E, C>(
         &self,
@@ -215,8 +215,8 @@ where
             return Ok(Vec::new());
         }
         debug_assert!(
-            locs.is_sorted(),
-            "locations must be sorted in ascending order"
+            locs.windows(2).all(|window| window[0] < window[1]),
+            "locations must be sorted and unique"
         );
         let mut results = Vec::with_capacity(locs.len());
         let mut db_indices = Vec::new();
@@ -365,7 +365,7 @@ where
 
     /// Batch read values at multiple locations.
     ///
-    /// Locations must be sorted in ascending order.
+    /// Locations must be sorted in strictly ascending order (sorted and unique).
     /// Returns results in the same order as the input locations.
     pub async fn get_many<E, H, C>(
         &self,
@@ -381,8 +381,8 @@ where
             return Ok(Vec::new());
         }
         debug_assert!(
-            locs.is_sorted(),
-            "locations must be sorted in ascending order"
+            locs.windows(2).all(|window| window[0] < window[1]),
+            "locations must be sorted and unique"
         );
         let mut results = Vec::with_capacity(locs.len());
         let mut db_indices = Vec::new();

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -172,7 +172,7 @@ where
 
     /// Batch read values at multiple locations.
     ///
-    /// Locations must be sorted in ascending order.
+    /// Locations must be sorted in strictly ascending order (sorted and unique).
     /// Returns results in the same order as the input locations.
     ///
     /// # Errors
@@ -183,8 +183,8 @@ where
             return Ok(Vec::new());
         }
         debug_assert!(
-            locs.is_sorted(),
-            "locations must be sorted in ascending order"
+            locs.windows(2).all(|window| window[0] < window[1]),
+            "locations must be sorted and unique"
         );
         let reader = self.journal.reader().await;
         let op_count = reader.bounds().end;


### PR DESCRIPTION
## Summary

Optimizes journal batch read paths and variable journal batch appends.

## Changes

- Adds allocation-free sync read helpers for segmented fixed and variable journals.
- Updates contiguous fixed and variable `read_many` to reuse scratch buffers for sync hits.
- Improves contiguous variable `read_many` by batching offset reads, grouping data misses by section, and using a bounded consecutive-read fast path.
- Optimizes contiguous variable `append_many` by encoding items into one buffer, batching data appends by section, and appending offsets with `append_many`.
- Adds a variable random-read benchmark analogous to the fixed random-read benchmark.

### Benchmark Impact

| Benchmark | Workload | Improvement |
|---|---:|---:|
| `journal::fixed_read_random/mode=read_many` | `items=100` | ~17.3% |
| `journal::fixed_read_random/mode=read_many` | `items=1_000` | ~18.7% |
| `journal::fixed_read_random/mode=read_many` | `items=10_000` | ~18.0% |
| `journal::variable_read_random/mode=read_many` | `items=100` | ~66.9% |
| `journal::variable_read_random/mode=read_many` | `items=1_000` | ~62.8% |
| `journal::variable_read_random/mode=read_many` | `items=10_000` | ~66.6% |
| `journal::variable_read_random/mode=read_many` | `items=100_000` | ~7.4% |
| `qmdb::generate/variant=any::unordered::variable::*` | `elements=10_000 operations=100_000` | ~7.8% |
| `qmdb::generate/variant=any::ordered::variable::*` | `elements=10_000 operations=100_000` | ~6.4% |
| `qmdb::generate/variant=current::unordered::variable::*` | `elements=10_000 operations=100_000` | ~7.3% |
| `qmdb::generate/variant=current::ordered::variable::*` | `elements=10_000 operations=100_000` | ~8% |
| `qmdb::generate/variant=*::variable-vec::*` | larger write-heavy workloads | ~4.4-9.2% |