### PR TITLE
[Storage] Simplify QMDB root policy configuration

### DIFF
--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -17,7 +17,6 @@ use commonware_storage::{
             FixedConfig as Config,
         },
         operation::Committable,
-        Bagging,
     },
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -49,8 +48,6 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator> {
             page_cache,
         },
         translator: Translator::default(),
-        split_root: true,
-        root_bagging: <mmr::Family as Bagging>::BAGGING,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -91,7 +91,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(129);
 
-fn test_config<F: Bagging>(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap> {
+fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap> {
     let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(1));
     Config {
         merkle_config: MerkleConfig {
@@ -109,8 +109,6 @@ fn test_config<F: Bagging>(test_name: &str, pooler: &impl BufferPooler) -> Confi
             page_cache,
         },
         translator: TwoCap,
-        split_root: true,
-        root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -130,7 +128,7 @@ where
         Op = FixedOperation<F, Key, Value>,
     >,
 {
-    let db_config = test_config::<F>(test_name, &context);
+    let db_config = test_config(test_name, &context);
     let expected_root = target.root;
 
     let sync_config: sync::engine::Config<FixedDb<F>, R> = sync::engine::Config {
@@ -166,7 +164,7 @@ fn fuzz_family<F: MerkleFamily + Bagging>(input: &mut FuzzInput, test_name: &str
 
     let test_name = test_name.to_string();
     runner.start(|context| async move {
-        let cfg = test_config::<F>(&test_name, &context);
+        let cfg = test_config(&test_name, &context);
         let mut db: FixedDb<F> = Db::init(context.clone(), cfg)
             .await
             .expect("Failed to init source db");
@@ -263,7 +261,7 @@ fn fuzz_family<F: MerkleFamily + Bagging>(input: &mut FuzzInput, test_name: &str
                     pending_writes.clear();
                     drop(db);
 
-                    let cfg = test_config::<F>(&test_name, &context);
+                    let cfg = test_config(&test_name, &context);
                     db = Db::init(
                         context
                             .with_label("db")

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -133,7 +133,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(128);
 
-fn test_config<F: Bagging>(
+fn test_config(
     test_name: &str,
     pooler: &impl BufferPooler,
 ) -> Config<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ()))> {
@@ -156,8 +156,6 @@ fn test_config<F: Bagging>(
             page_cache,
         },
         translator: TwoCap,
-        split_root: true,
-        root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -167,7 +165,7 @@ fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput, test_name: &str) {
     let test_name = test_name.to_string();
     runner.start(|context| async move {
         let hasher = F::default_hasher::<Sha256>();
-        let cfg = test_config::<F>(&test_name, &context);
+        let cfg = test_config(&test_name, &context);
         let mut db = Db::<F, _, Key, Vec<u8>, Sha256, TwoCap>::init(context.clone(), cfg)
             .await
             .expect("Failed to init source db");
@@ -321,7 +319,7 @@ fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput, test_name: &str) {
                     historical_roots.clear();
                     drop(db);
 
-                    let cfg = test_config::<F>(&test_name, &context);
+                    let cfg = test_config(&test_name, &context);
                     db = Db::<F, _, Key, Vec<u8>, Sha256, TwoCap>::init(
                         context
                             .with_label("db")

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -105,8 +105,6 @@ fn fuzz_family<F: MerkleFamily + Bagging>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
-                split_root: true,
-                root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
             };
 
             let mut db: GenericDb<F> = commonware_storage::qmdb::any::init(context.clone(), cfg)

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -130,8 +130,6 @@ fn fuzz_family<F: MerkleFamily + Bagging>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
-                split_root: true,
-                root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -77,7 +77,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
     }
 }
 
-fn test_config<F: Bagging>(name: &str, pooler: &impl BufferPooler) -> Config<OneCap> {
+fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap> {
     let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(2));
     Config {
         merkle_config: MerkleConfig {
@@ -95,8 +95,6 @@ fn test_config<F: Bagging>(name: &str, pooler: &impl BufferPooler) -> Config<One
             page_cache,
         },
         translator: OneCap,
-        split_root: true,
-        root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -116,7 +114,7 @@ fn fuzz_family<F: MerkleFamily + Bagging>(input: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     runner.start(|context| async move {
-        let cfg = test_config::<F>(suffix, &context);
+        let cfg = test_config(suffix, &context);
         let mut db: Db<F> = Db::init(context.clone(), cfg)
             .await
             .expect("init unordered any db");

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -105,8 +105,6 @@ fn fuzz_family<F: MerkleFamily + Bagging>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
-                split_root: true,
-                root_bagging: <F as commonware_storage::qmdb::Bagging>::BAGGING,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2061,8 +2061,7 @@ mod tests {
                 OneCap,
             >;
 
-            let config =
-                fixed_db_config::<mmr::Family, OneCap>("read-locations-all-sources", &context);
+            let config = fixed_db_config::<OneCap>("read-locations-all-sources", &context);
             let mut db = TestDb::init(context, config).await.unwrap();
 
             let key_db = colliding_digest(0x30, 0);
@@ -2176,8 +2175,7 @@ mod tests {
                 OneCap,
             >;
 
-            let config =
-                fixed_db_config::<mmr::Family, OneCap>("batch-collision-regression", &context);
+            let config = fixed_db_config::<OneCap>("batch-collision-regression", &context);
             let mut db = TestDb::init(context, config).await.unwrap();
             let key_a = colliding_digest(0xAA, 1);
             let key_b = colliding_digest(0xAA, 0);
@@ -2258,7 +2256,7 @@ mod tests {
                 OneCap,
             >;
 
-            let config = fixed_db_config::<mmr::Family, OneCap>("ordered-batch-collision-regression", &context);
+            let config = fixed_db_config::<OneCap>("ordered-batch-collision-regression", &context);
             let mut db = TestDb::init(context, config).await.unwrap();
             let key_a = colliding_digest(0xAA, 1);
             let key_b = colliding_digest(0xAA, 0);
@@ -2336,7 +2334,7 @@ mod tests {
                 OneCap,
             >;
 
-            let config = fixed_db_config::<mmr::Family, OneCap>("seq-commit-basic", &context);
+            let config = fixed_db_config::<OneCap>("seq-commit-basic", &context);
             let mut db = TestDb::init(context, config).await.unwrap();
 
             // Seed an initial key.
@@ -2404,8 +2402,7 @@ mod tests {
                 OneCap,
             >;
 
-            let config =
-                fixed_db_config::<mmr::Family, OneCap>("seq-commit-base-old-loc", &context);
+            let config = fixed_db_config::<OneCap>("seq-commit-base-old-loc", &context);
             let mut db = TestDb::init(context, config).await.unwrap();
 
             // Seed an initial key so we have an existing entry.
@@ -2478,7 +2475,7 @@ mod tests {
                 OneCap,
             >;
 
-            let config = fixed_db_config::<mmr::Family, OneCap>("fork-after-commit", &context);
+            let config = fixed_db_config::<OneCap>("fork-after-commit", &context);
             let mut db = TestDb::init(context, config).await.unwrap();
 
             // Seed.
@@ -2558,7 +2555,7 @@ mod tests {
                 OneCap,
             >;
 
-            let config = fixed_db_config::<mmr::Family, OneCap>("ff-cross", &context);
+            let config = fixed_db_config::<OneCap>("ff-cross", &context);
             let mut db = TestDb::init(context, config).await.unwrap();
 
             // Grandparent: 2 keys.
@@ -2626,8 +2623,7 @@ mod tests {
                 OneCap,
             >;
 
-            let config =
-                fixed_db_config::<mmr::Family, OneCap>("recreate-deleted-collision", &context);
+            let config = fixed_db_config::<OneCap>("recreate-deleted-collision", &context);
             let mut db = TestDb::init(context, config).await.unwrap();
 
             // Two colliding keys: K0 (suffix 0) and K6 (suffix 6).
@@ -2699,7 +2695,7 @@ mod tests {
                 OneCap,
             >;
 
-            let config = fixed_db_config::<mmr::Family, OneCap>("get-many-basic", &context);
+            let config = fixed_db_config::<OneCap>("get-many-basic", &context);
             let mut db = TestDb::init(context, config).await.unwrap();
 
             let key_db = colliding_digest(0x40, 0);

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -338,14 +338,14 @@ where
     ///
     /// # Contract
     ///
-    /// When this database is configured with `split_root: true`, `historical_size` must be a
-    /// commit-boundary size: the operation at `historical_size - 1` must itself be a commit
-    /// op declaring the governing inactivity floor. With `split_root: false`, historical proof
-    /// roots do not depend on the floor and any retained `historical_size` works.
+    /// In split-root mode, `historical_size` must be a commit-boundary size: the operation at
+    /// `historical_size - 1` must itself be a commit op declaring the governing inactivity floor.
+    /// In plain-root mode, historical proof roots do not depend on the floor and any retained
+    /// `historical_size` works.
     ///
     /// # Errors
     ///
-    /// Returns [`crate::qmdb::Error::HistoricalFloorPruned`] (split_root only) if
+    /// Returns [`crate::qmdb::Error::HistoricalFloorPruned`] in split-root mode if
     /// `historical_size - 1` is retained but is not a commit op, either because the caller
     /// passed a non-commit-boundary size or because pruning removed the commit that would
     /// have governed it.

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -108,12 +108,6 @@ pub struct Config<T: Translator, J, S: Strategy = Sequential> {
 
     /// The translator used by the compressed index.
     pub translator: T,
-
-    /// Whether the operations root commits to the inactive-prefix split.
-    pub split_root: bool,
-
-    /// Bagging used by the operations root.
-    pub root_bagging: Bagging,
 }
 
 /// Configuration for an `Any` authenticated db with fixed-size values.
@@ -123,12 +117,14 @@ pub type FixedConfig<T, S = Sequential> = Config<T, FConfig, S>;
 pub type VariableConfig<T, C, S = Sequential> = Config<T, VConfig<C>, S>;
 
 /// Initialize an `Any` authenticated db from the given config.
+///
+/// The operations root uses split-root mode and the bagging policy associated with `F`.
 pub async fn init<F, E, U, H, T, I, J, S>(
     context: E,
     cfg: Config<T, J::Config, S>,
 ) -> Result<db::Db<F, E, J, I, H, U, BITMAP_CHUNK_BYTES, S>, crate::qmdb::Error<F>>
 where
-    F: Family,
+    F: crate::qmdb::Bagging,
     E: Context,
     U: Update + Send + Sync,
     H: Hasher,
@@ -138,15 +134,29 @@ where
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
 {
-    init_with_bitmap::<F, E, U, H, T, I, J, S, BITMAP_CHUNK_BYTES>(context, cfg, None).await
+    init_with_bitmap::<F, E, U, H, T, I, J, S, BITMAP_CHUNK_BYTES>(
+        context,
+        cfg,
+        None,
+        true,
+        <F as crate::qmdb::Bagging>::BAGGING,
+    )
+    .await
 }
 
 /// Like [`init`] but accepts a pre-allocated bitmap (used by `current::Db`, which sizes pruned
 /// chunks from grafted metadata). `bitmap = None` allocates internally.
+///
+/// `split_root` selects whether the operations root commits to the inactive-prefix split, and
+/// `ops_root_bagging` selects its bagging policy. Public `Any` initialization uses split roots and
+/// the QMDB family default bagging; `current::Db` passes a plain `ForwardFold` operations root
+/// because activity is committed through the grafted root instead.
 pub(crate) async fn init_with_bitmap<F, E, U, H, T, I, J, S, const N: usize>(
     context: E,
     cfg: Config<T, J::Config, S>,
     bitmap: Option<Arc<Shared<N>>>,
+    split_root: bool,
+    ops_root_bagging: Bagging,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where
     F: Family,
@@ -159,13 +169,12 @@ where
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
 {
-    let split_root = cfg.split_root;
     let mut log = J::init::<F, H, S>(
         context.with_label("log"),
         cfg.merkle_config,
         cfg.journal_config,
         Operation::is_commit,
-        cfg.root_bagging,
+        ops_root_bagging,
     )
     .await?;
 
@@ -186,10 +195,7 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
-        qmdb::{
-            self,
-            any::{FixedConfig, MerkleConfig, VariableConfig},
-        },
+        qmdb::any::{FixedConfig, MerkleConfig, VariableConfig},
         translator::OneCap,
     };
     use commonware_codec::{Codec, CodecShared};
@@ -215,7 +221,7 @@ pub(crate) mod test {
     const PAGE_SIZE: NonZeroU16 = NZU16!(101);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(11);
 
-    pub(crate) fn fixed_db_config<F: qmdb::Bagging, T: Translator + Default>(
+    pub(crate) fn fixed_db_config<T: Translator + Default>(
         suffix: &str,
         pooler: &impl BufferPooler,
     ) -> FixedConfig<T> {
@@ -236,12 +242,10 @@ pub(crate) mod test {
                 write_buffer: NZUsize!(1024),
             },
             translator: T::default(),
-            split_root: true,
-            root_bagging: <F as qmdb::Bagging>::BAGGING,
         }
     }
 
-    pub(crate) fn variable_db_config<F: qmdb::Bagging, T: Translator + Default>(
+    pub(crate) fn variable_db_config<T: Translator + Default>(
         suffix: &str,
         pooler: &impl BufferPooler,
     ) -> VariableConfig<T, ((), ())> {
@@ -264,15 +268,13 @@ pub(crate) mod test {
                 write_buffer: NZUsize!(1024),
             },
             translator: T::default(),
-            split_root: true,
-            root_bagging: <F as qmdb::Bagging>::BAGGING,
         }
     }
 
     use crate::{
         index::Unordered as UnorderedIndex,
         journal::contiguous::Mutable,
-        merkle::{mmb, mmr},
+        merkle::mmr,
         qmdb::any::{
             db::Db as AnyDb,
             operation::{update::Update as UpdateTrait, Operation as AnyOperation},
@@ -1256,7 +1258,7 @@ pub(crate) mod test {
             let p = concat!($l, "_", $sfx);
             Box::pin(async {
                 let ctx = $ctx.with_label($l);
-                let db = <$db>::init(ctx.clone(), $cfg::<$family, OneCap>(p, &ctx))
+                let db = <$db>::init(ctx.clone(), $cfg::<OneCap>(p, &ctx))
                     .await
                     .unwrap();
                 $f(
@@ -1264,7 +1266,7 @@ pub(crate) mod test {
                     db,
                     |ctx| {
                         Box::pin(async move {
-                            <$db>::init(ctx.clone(), $cfg::<$family, OneCap>(p, &ctx))
+                            <$db>::init(ctx.clone(), $cfg::<OneCap>(p, &ctx))
                                 .await
                                 .unwrap()
                         })
@@ -1282,7 +1284,7 @@ pub(crate) mod test {
             let p = concat!($l, "_", $sfx);
             Box::pin(async {
                 let ctx = $ctx.with_label($l);
-                let db = <$db>::init(ctx.clone(), $cfg::<$family, OneCap>(p, &ctx))
+                let db = <$db>::init(ctx.clone(), $cfg::<OneCap>(p, &ctx))
                     .await
                     .unwrap();
                 $f(ctx, db, to_digest).await;
@@ -1423,12 +1425,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("e", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("e", &ctx))
+                    .await
+                    .unwrap();
 
             let root_before = db.root();
             let batch = db.new_batch();
@@ -1452,12 +1452,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("m", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("m", &ctx))
+                    .await
+                    .unwrap();
 
             let metadata = val(42);
 
@@ -1482,12 +1480,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("g", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("g", &ctx))
+                    .await
+                    .unwrap();
 
             // Pre-populate with key A.
             let ka = key(0);
@@ -1529,12 +1525,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("mg", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("mg", &ctx))
+                    .await
+                    .unwrap();
 
             let ka = key(0);
             let kb = key(1);
@@ -1568,12 +1562,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("sg", &ctx),
-            )
-            .await
-            .unwrap();
+            let db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("sg", &ctx))
+                    .await
+                    .unwrap();
 
             let ka = key(0);
             let kb = key(1);
@@ -1609,12 +1601,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("dr", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("dr", &ctx))
+                    .await
+                    .unwrap();
 
             let ka = key(0);
 
@@ -1648,12 +1638,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("fr", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("fr", &ctx))
+                    .await
+                    .unwrap();
 
             // Pre-populate with 100 keys.
             let init: Vec<_> = (0..100).map(|i| (key(i), Some(val(i)))).collect();
@@ -1694,12 +1682,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("ar", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("ar", &ctx))
+                    .await
+                    .unwrap();
 
             // First batch: 5 keys.
             let writes: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
@@ -1725,12 +1711,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("dc", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("dc", &ctx))
+                    .await
+                    .unwrap();
 
             // Pre-populate with keys 0..5.
             let init: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
@@ -1793,7 +1777,7 @@ pub(crate) mod test {
             let ctx_a = ctx.with_label("a");
             let mut db_a: UnorderedVariable = UnorderedVariableDb::init(
                 ctx_a.clone(),
-                variable_db_config::<mmr::Family, OneCap>("cms-a", &ctx_a),
+                variable_db_config::<OneCap>("cms-a", &ctx_a),
             )
             .await
             .unwrap();
@@ -1802,7 +1786,7 @@ pub(crate) mod test {
             let ctx_b = ctx.with_label("b");
             let mut db_b: UnorderedVariable = UnorderedVariableDb::init(
                 ctx_b.clone(),
-                variable_db_config::<mmr::Family, OneCap>("cms-b", &ctx_b),
+                variable_db_config::<OneCap>("cms-b", &ctx_b),
             )
             .await
             .unwrap();
@@ -1856,12 +1840,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("cd", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("cd", &ctx))
+                    .await
+                    .unwrap();
 
             // Pre-populate key A.
             commit_writes(&mut db, [(key(0), Some(val(0)))], None).await;
@@ -1889,12 +1871,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("da", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("da", &ctx))
+                    .await
+                    .unwrap();
 
             // Pre-populate 5 keys.
             let init: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
@@ -1922,12 +1902,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("pf", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("pf", &ctx))
+                    .await
+                    .unwrap();
 
             // Pre-populate.
             commit_writes(&mut db, [(key(0), Some(val(0)))], None).await;
@@ -1975,12 +1953,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("frc", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("frc", &ctx))
+                    .await
+                    .unwrap();
 
             // Pre-populate with 50 keys.
             let init: Vec<_> = (0..50).map(|i| (key(i), Some(val(i)))).collect();
@@ -2031,12 +2007,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("ab", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("ab", &ctx))
+                    .await
+                    .unwrap();
 
             commit_writes(&mut db, [(key(0), Some(val(0)))], None).await;
             let root_before = db.root();
@@ -2068,7 +2042,7 @@ pub(crate) mod test {
             let ctx = context.with_label("db");
             let mut db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>(partition, &ctx),
+                variable_db_config::<OneCap>(partition, &ctx),
             )
             .await
             .unwrap();
@@ -2089,7 +2063,7 @@ pub(crate) mod test {
 
             let reopened: UnorderedVariable = UnorderedVariableDb::init(
                 context.with_label("reopen"),
-                variable_db_config::<mmr::Family, OneCap>(partition, &context),
+                variable_db_config::<OneCap>(partition, &context),
             )
             .await
             .unwrap();
@@ -2108,12 +2082,10 @@ pub(crate) mod test {
             const KEYS: u64 = 64;
 
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("rp", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("rp", &ctx))
+                    .await
+                    .unwrap();
 
             let initial: Vec<_> = (0..KEYS).map(|i| (key(i), Some(val(i)))).collect();
             let first_range = commit_writes(&mut db, initial, None).await;
@@ -2167,12 +2139,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("ri", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("ri", &ctx))
+                    .await
+                    .unwrap();
 
             let root_before = db.root();
             let size_before = db.size().await;
@@ -2218,7 +2188,7 @@ pub(crate) mod test {
 
             let ctx = context.with_label("db");
             let mut db: UnorderedVariable =
-                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<mmr::Family, OneCap>("rf", &ctx))
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("rf", &ctx))
                     .await
                     .unwrap();
 
@@ -2297,7 +2267,7 @@ pub(crate) mod test {
             const { assert!(ITEMS_PER_SECTION > BITMAP_CHUNK_BITS) };
 
             let ctx = context.with_label("db");
-            let mut cfg = variable_db_config::<mmr::Family, OneCap>("rg", &ctx);
+            let mut cfg = variable_db_config::<OneCap>("rg", &ctx);
             cfg.journal_config.items_per_section = NZU64!(ITEMS_PER_SECTION);
 
             let mut db: UnorderedVariable =
@@ -2390,7 +2360,7 @@ pub(crate) mod test {
     >;
 
     async fn open_mmb_db(context: Context, suffix: &str) -> MmbVariable {
-        let cfg = variable_db_config::<mmr::Family, OneCap>(suffix, &context);
+        let cfg = variable_db_config::<OneCap>(suffix, &context);
         super::init(context, cfg).await.unwrap()
     }
 
@@ -2530,12 +2500,10 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.with_label("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.clone(),
-                variable_db_config::<mmr::Family, OneCap>("pipe", &ctx),
-            )
-            .await
-            .unwrap();
+            let mut db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.clone(), variable_db_config::<OneCap>("pipe", &ctx))
+                    .await
+                    .unwrap();
 
             {
                 let mut batch = db.new_batch();

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -184,20 +184,20 @@ pub(crate) mod test {
     async fn open_db_generic<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> AnyTestGeneric<F> {
-        let cfg = fixed_db_config::<F, TwoCap>("partition", &context);
+        let cfg = fixed_db_config::<TwoCap>("partition", &context);
         crate::qmdb::any::init(context, cfg).await.unwrap()
     }
 
     /// Return an `Any` database initialized with a fixed config.
     async fn open_db(context: deterministic::Context) -> AnyTest {
-        let cfg = fixed_db_config::<mmr::Family, _>("partition", &context);
+        let cfg = fixed_db_config::<_>("partition", &context);
         AnyTest::init(context, cfg).await.unwrap()
     }
 
     /// Create a test database with unique partition names
     pub(crate) async fn create_test_db(mut context: Context) -> AnyTest {
         let seed = context.next_u64();
-        let cfg = fixed_db_config::<mmr::Family, TwoCap>(&seed.to_string(), &context);
+        let cfg = fixed_db_config::<TwoCap>(&seed.to_string(), &context);
         AnyTest::init(context, cfg).await.unwrap()
     }
 
@@ -267,7 +267,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let seed = context.next_u64();
-            let config = fixed_db_config::<mmr::Family, OneCap>(&seed.to_string(), &context);
+            let config = fixed_db_config::<OneCap>(&seed.to_string(), &context);
             let mut db = Db::<mmr::Family, Context, FixedBytes<2>, i32, Sha256, OneCap>::init(
                 context, config,
             )
@@ -924,7 +924,7 @@ pub(crate) mod test {
             let seed = context.next_u64();
 
             // Use a OneCap to ensure many collisions.
-            let config = fixed_db_config::<mmr::Family, OneCap>(&seed.to_string(), &context);
+            let config = fixed_db_config::<OneCap>(&seed.to_string(), &context);
             let db = Db::<mmr::Family, Context, Digest, i32, Sha256, OneCap>::init(
                 context.with_label("first"),
                 config,
@@ -935,7 +935,7 @@ pub(crate) mod test {
             db.destroy().await.unwrap();
 
             // Repeat test with TwoCap to test low/no collisions.
-            let config = fixed_db_config::<mmr::Family, TwoCap>(&seed.to_string(), &context);
+            let config = fixed_db_config::<TwoCap>(&seed.to_string(), &context);
             let db = Db::<mmr::Family, Context, Digest, i32, Sha256, TwoCap>::init(
                 context.with_label("second"),
                 config,
@@ -954,7 +954,7 @@ pub(crate) mod test {
 
     /// Return a fixed db with FixedBytes<4> keys.
     async fn open_fixed_db(context: Context) -> FixedDb {
-        let cfg = fixed_db_config::<mmr::Family, _>("fixed-bytes-partition", &context);
+        let cfg = fixed_db_config::<_>("fixed-bytes-partition", &context);
         FixedDb::init(context, cfg).await.unwrap()
     }
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -197,8 +197,6 @@ pub(crate) mod test {
                 page_cache,
             },
             translator: TwoCap,
-            split_root: true,
-            root_bagging: <mmr::Family as crate::qmdb::Bagging>::BAGGING,
         }
     }
 
@@ -281,7 +279,7 @@ pub(crate) mod test {
 
     /// Return a variable db with FixedBytes<4> keys.
     async fn open_variable_db(context: Context) -> VariableDb {
-        let cfg = variable_db_config::<mmr::Family, _>("fixed-bytes-var-partition", &context);
+        let cfg = variable_db_config::<_>("fixed-bytes-var-partition", &context);
         VariableDb::init(context, cfg).await.unwrap()
     }
 

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -96,11 +96,9 @@ async fn build_db<F, E, U, I, H, C, T, S>(
     pinned_nodes: Option<Vec<H::Digest>>,
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
-    split_root: bool,
-    root_bagging: merkle::Bagging,
 ) -> Result<Db<F, E, C, I, H, U, { crate::qmdb::any::BITMAP_CHUNK_BYTES }, S>, qmdb::Error<F>>
 where
-    F: merkle::Family,
+    F: qmdb::Bagging,
     E: Context,
     U: Update + Send + Sync + 'static,
     I: IndexFactory<T, Value = Location<F>>,
@@ -110,7 +108,7 @@ where
     S: Strategy,
     Operation<F, U>: Codec + Committable + CodecShared,
 {
-    let hasher = StandardHasher::<H>::with_bagging(root_bagging);
+    let hasher = F::default_hasher::<H>();
 
     let merkle = full::Merkle::<F, _, _, S>::init_sync(
         context.with_label("merkle"),
@@ -131,7 +129,7 @@ where
         apply_batch_size as u64,
     )
     .await?;
-    let db = Db::init_from_log(index, log, None, split_root).await?;
+    let db = Db::init_from_log(index, log, None, true).await?;
 
     Ok(db)
 }
@@ -143,7 +141,7 @@ macro_rules! impl_sync_database {
      $(; $($where_extra:tt)+)?) => {
         impl<F, E, K, V, H, T, S> qmdb::sync::Database for $db<F, E, K, V, H, T, S>
         where
-            F: merkle::Family,
+            F: qmdb::Bagging,
             E: Context,
             K: $key_bound,
             V: $value_bound + 'static,
@@ -160,6 +158,8 @@ macro_rules! impl_sync_database {
             type Config = $config;
             type Digest = H::Digest;
 
+            const ROOT_BAGGING: merkle::Bagging = <F as qmdb::Bagging>::BAGGING;
+
             async fn from_sync_result(
                 context: Self::Context,
                 config: Self::Config,
@@ -170,8 +170,6 @@ macro_rules! impl_sync_database {
             ) -> Result<Self, qmdb::Error<F>> {
                 let merkle_config = config.merkle_config.clone();
                 let translator = config.translator.clone();
-                let split_root = config.split_root;
-                let root_bagging = config.root_bagging;
                 build_db::<F, _, $update<K, V>, _, H, _, T, S>(
                     context,
                     merkle_config,
@@ -180,8 +178,6 @@ macro_rules! impl_sync_database {
                     pinned_nodes,
                     range,
                     apply_batch_size,
-                    split_root,
-                    root_bagging,
                 )
                 .await
             }
@@ -191,30 +187,22 @@ macro_rules! impl_sync_database {
                 config: &Self::Config,
                 target: &qmdb::sync::Target<Self::Family, Self::Digest>,
             ) -> bool {
-                let inactive_peaks = if config.split_root {
-                    F::inactive_peaks(
-                        F::location_to_position(target.range.end()),
-                        target.range.start(),
-                    )
-                } else {
-                    0
-                };
+                let inactive_peaks = F::inactive_peaks(
+                    F::location_to_position(target.range.end()),
+                    target.range.start(),
+                );
                 qmdb::any::sync::has_local_target_state::<F, _, H, S>(
                     context,
                     config.merkle_config.clone(),
                     target,
                     inactive_peaks,
-                    config.root_bagging,
+                    <F as qmdb::Bagging>::BAGGING,
                 )
                 .await
             }
 
             fn root(&self) -> Self::Digest {
                 crate::qmdb::any::db::Db::root(self)
-            }
-
-            fn root_bagging(config: &Self::Config) -> merkle::Bagging {
-                config.root_bagging
             }
         }
     };

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -2243,7 +2243,7 @@ mod harnesses {
             suffix: &str,
             pooler: &impl BufferPooler,
         ) -> crate::qmdb::any::FixedConfig<TwoCap> {
-            crate::qmdb::any::test::fixed_db_config::<crate::mmr::Family, _>(suffix, pooler)
+            crate::qmdb::any::test::fixed_db_config::<_>(suffix, pooler)
         }
 
         fn create_ops(
@@ -2366,7 +2366,7 @@ mod harnesses {
             suffix: &str,
             pooler: &impl BufferPooler,
         ) -> crate::qmdb::any::FixedConfig<TwoCap> {
-            crate::qmdb::any::test::fixed_db_config::<crate::mmr::Family, _>(suffix, pooler)
+            crate::qmdb::any::test::fixed_db_config::<_>(suffix, pooler)
         }
 
         fn create_ops_seeded(
@@ -2503,7 +2503,7 @@ mod harnesses {
             suffix: &str,
             pooler: &impl BufferPooler,
         ) -> crate::qmdb::any::FixedConfig<TwoCap> {
-            crate::qmdb::any::test::fixed_db_config::<crate::mmr::Family, _>(suffix, pooler)
+            crate::qmdb::any::test::fixed_db_config::<_>(suffix, pooler)
         }
 
         fn create_ops(
@@ -2521,10 +2521,7 @@ mod harnesses {
 
         async fn init_db(mut ctx: Context) -> Self::Db {
             let seed = ctx.next_u64();
-            let cfg = crate::qmdb::any::test::fixed_db_config::<crate::mmr::Family, TwoCap>(
-                &seed.to_string(),
-                &ctx,
-            );
+            let cfg = crate::qmdb::any::test::fixed_db_config::<TwoCap>(&seed.to_string(), &ctx);
             Self::Db::init(ctx, cfg).await.unwrap()
         }
 
@@ -2669,7 +2666,7 @@ mod harnesses {
             suffix: &str,
             pooler: &impl BufferPooler,
         ) -> crate::qmdb::any::FixedConfig<TwoCap> {
-            crate::qmdb::any::test::fixed_db_config::<crate::mmr::Family, _>(suffix, pooler)
+            crate::qmdb::any::test::fixed_db_config::<_>(suffix, pooler)
         }
 
         fn create_ops(
@@ -2689,10 +2686,7 @@ mod harnesses {
 
         async fn init_db(mut ctx: Context) -> Self::Db {
             let seed = ctx.next_u64();
-            let cfg = crate::qmdb::any::test::fixed_db_config::<crate::mmr::Family, TwoCap>(
-                &seed.to_string(),
-                &ctx,
-            );
+            let cfg = crate::qmdb::any::test::fixed_db_config::<TwoCap>(&seed.to_string(), &ctx);
             Self::Db::init(ctx, cfg).await.unwrap()
         }
 
@@ -3021,113 +3015,3 @@ sync_tests_for_harness!(
     harnesses::UnorderedVariableMmbHarness,
     unordered_variable_mmb
 );
-
-/// Regression: sync preserves caller-selected ops-root bagging after later commits make the
-/// inactivity floor visible in the root.
-#[commonware_macros::test_traced("WARN")]
-fn test_any_sync_preserves_non_default_policy() {
-    use crate::{
-        merkle::{mmr, Bagging, Family as _},
-        qmdb::any::{ordered::fixed::Db as OrderedFixedDb, FixedConfig},
-        translator::TwoCap,
-    };
-
-    type Db = OrderedFixedDb<
-        mmr::Family,
-        deterministic::Context,
-        Digest,
-        Digest,
-        commonware_cryptography::Sha256,
-        TwoCap,
-    >;
-
-    fn config(suffix: &str, pooler: &impl BufferPooler) -> FixedConfig<TwoCap> {
-        let mut cfg = crate::qmdb::any::test::fixed_db_config::<mmr::Family, _>(suffix, pooler);
-        // Non-default policy: full root with forward bagging (no inactive-prefix split).
-        cfg.split_root = false;
-        cfg.root_bagging = Bagging::ForwardFold;
-        cfg
-    }
-
-    /// Overwrite a small fixed key set with `version`-tagged values. Each pass retires the
-    /// previous version of the same keys, advancing the inactivity floor.
-    async fn churn(db: &mut Db, version: u64, key_count: u64) {
-        let mut batch = db.new_batch();
-        for k in 0..key_count {
-            let mut key_bytes = [0u8; 32];
-            key_bytes[..8].copy_from_slice(&k.to_be_bytes());
-            let mut value_bytes = [0u8; 32];
-            value_bytes[..8].copy_from_slice(&version.to_be_bytes());
-            value_bytes[8..16].copy_from_slice(&k.to_be_bytes());
-            batch = batch.write(Digest::from(key_bytes), Some(Digest::from(value_bytes)));
-        }
-        let merkleized = batch.merkleize(&*db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-    }
-
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Keep the initial workload small so the sync-time root has no inactive peaks.
-        let source_cfg = config("src", &context);
-        let mut source = Db::init(context.with_label("source"), source_cfg.clone())
-            .await
-            .unwrap();
-        churn(&mut source, 0, 8).await;
-
-        // Sync a replica.
-        let lower = source.sync_boundary();
-        let upper = source.bounds().await.end;
-        let sync_root = source.root();
-        let target_db = Arc::new(source);
-
-        let replica_cfg = config(&context.next_u64().to_string(), &context);
-        let engine_cfg = Config {
-            db_config: replica_cfg.clone(),
-            fetch_batch_size: NZU64!(4),
-            target: Target {
-                root: sync_root,
-                range: non_empty_range!(lower, upper),
-            },
-            context: context.with_label("client"),
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-        let mut replica: Db = sync::sync(engine_cfg).await.unwrap();
-        let mut source =
-            Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("source still shared"));
-
-        // Roots must agree at sync completion.
-        assert_eq!(replica.root(), source.root());
-
-        // Drive enough overwrites for `inactive_peaks` to grow past zero.
-        for version in 1..40u64 {
-            churn(&mut source, version, 8).await;
-            churn(&mut replica, version, 8).await;
-        }
-
-        let inactive_peaks = mmr::Family::inactive_peaks(
-            mmr::Family::location_to_position(source.bounds().await.end),
-            source.inactivity_floor_loc(),
-        );
-        assert!(
-            inactive_peaks > 0,
-            "test setup must drive inactive_peaks > 0",
-        );
-
-        // Source and replica must still agree after the inactive boundary affects the root.
-        assert_eq!(
-            replica.root(),
-            source.root(),
-            "source and replica diverged after follow-on commits",
-        );
-
-        replica.destroy().await.unwrap();
-        source.destroy().await.unwrap();
-    });
-}

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -173,14 +173,14 @@ pub(crate) mod test {
     async fn open_db_generic<F: Family + Bagging>(
         context: deterministic::Context,
     ) -> AnyTestGeneric<F> {
-        let cfg = fixed_db_config::<F, TwoCap>("partition", &context);
+        let cfg = fixed_db_config::<TwoCap>("partition", &context);
         crate::qmdb::any::init(context, cfg).await.unwrap()
     }
 
     /// Create a test database with unique partition names
     pub(crate) async fn create_test_db(mut context: Context) -> AnyTest {
         let seed = context.next_u64();
-        let cfg = fixed_db_config::<mmr::Family, TwoCap>(&seed.to_string(), &context);
+        let cfg = fixed_db_config::<TwoCap>(&seed.to_string(), &context);
         AnyTest::init(context, cfg).await.unwrap()
     }
 

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -182,8 +182,6 @@ pub(crate) mod test {
                 page_cache,
             },
             translator: TwoCap,
-            split_root: true,
-            root_bagging: <mmr::Family as crate::qmdb::Bagging>::BAGGING,
         }
     }
 

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -122,9 +122,6 @@ pub fn any_fix_cfg(ctx: &(impl BufferPooler + ThreadPooler)) -> AnyFixedConfig<E
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone()),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache),
         translator: EightCap,
-        split_root: true,
-        root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -148,9 +145,6 @@ pub fn any_var_digest_cfg(
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone()),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ())),
         translator: EightCap,
-        split_root: true,
-        root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -177,9 +171,6 @@ pub fn any_var_vec_cfg(
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone()),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ((0..=10000).into(), ()))),
         translator: EightCap,
-        split_root: true,
-        root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -328,9 +328,6 @@ fn any_fix_cfg(
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         translator: EightCap,
-        split_root: true,
-        root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -343,9 +340,6 @@ fn any_var_cfg(
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         translator: EightCap,
-        split_root: true,
-        root_bagging:
-            <commonware_storage::mmr::Family as commonware_storage::qmdb::Bagging>::BAGGING,
     }
 }
 

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -11,7 +11,6 @@ use crate::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{full::Config as MerkleConfig, mmb, mmr, Family},
     qmdb::{
-        self,
         any::{
             self,
             traits::{DbAny, UnmerkleizedBatch as _},
@@ -141,21 +140,16 @@ fn variable_log_config<C>(suffix: &str, page_cache: CacheRef, codec_config: C) -
     }
 }
 
-fn any_fixed_config<F: qmdb::Bagging>(
-    suffix: &str,
-    pooler: &impl BufferPooler,
-) -> any::FixedConfig<OneCap> {
+fn any_fixed_config(suffix: &str, pooler: &impl BufferPooler) -> any::FixedConfig<OneCap> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     any::Config {
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
-        split_root: true,
-        root_bagging: <F as crate::qmdb::Bagging>::BAGGING,
     }
 }
 
-fn any_variable_config<F: qmdb::Bagging>(
+fn any_variable_config(
     suffix: &str,
     pooler: &impl BufferPooler,
 ) -> any::VariableConfig<OneCap, ((), ())> {
@@ -164,8 +158,6 @@ fn any_variable_config<F: qmdb::Bagging>(
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
-        split_root: true,
-        root_bagging: <F as crate::qmdb::Bagging>::BAGGING,
     }
 }
 
@@ -593,42 +585,34 @@ macro_rules! immutable_compact_conformance {
 keyed_conformance!(
     AnyMmrUnorderedFixedConf,
     AnyMmrUnorderedFixed,
-    any_fixed_config::<mmr::Family>
+    any_fixed_config
 );
 keyed_conformance!(
     AnyMmrUnorderedVariableConf,
     AnyMmrUnorderedVariable,
-    any_variable_config::<mmr::Family>
+    any_variable_config
 );
-keyed_conformance!(
-    AnyMmrOrderedFixedConf,
-    AnyMmrOrderedFixed,
-    any_fixed_config::<mmr::Family>
-);
+keyed_conformance!(AnyMmrOrderedFixedConf, AnyMmrOrderedFixed, any_fixed_config);
 keyed_conformance!(
     AnyMmrOrderedVariableConf,
     AnyMmrOrderedVariable,
-    any_variable_config::<mmr::Family>
+    any_variable_config
 );
 keyed_conformance!(
     AnyMmbUnorderedFixedConf,
     AnyMmbUnorderedFixed,
-    any_fixed_config::<mmb::Family>
+    any_fixed_config
 );
 keyed_conformance!(
     AnyMmbUnorderedVariableConf,
     AnyMmbUnorderedVariable,
-    any_variable_config::<mmb::Family>
+    any_variable_config
 );
-keyed_conformance!(
-    AnyMmbOrderedFixedConf,
-    AnyMmbOrderedFixed,
-    any_fixed_config::<mmb::Family>
-);
+keyed_conformance!(AnyMmbOrderedFixedConf, AnyMmbOrderedFixed, any_fixed_config);
 keyed_conformance!(
     AnyMmbOrderedVariableConf,
     AnyMmbOrderedVariable,
-    any_variable_config::<mmb::Family>
+    any_variable_config
 );
 keyed_conformance!(
     CurrentMmrUnorderedFixedConf,
@@ -949,49 +933,49 @@ macro_rules! order_test {
 order_test!(
     test_order_any_mmr_unordered_fixed,
     AnyMmrUnorderedFixed,
-    any_fixed_config::<mmr::Family>,
+    any_fixed_config,
     |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
 );
 order_test!(
     test_order_any_mmr_unordered_variable,
     AnyMmrUnorderedVariable,
-    any_variable_config::<mmr::Family>,
+    any_variable_config,
     |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
 );
 order_test!(
     test_order_any_mmr_ordered_fixed,
     AnyMmrOrderedFixed,
-    any_fixed_config::<mmr::Family>,
+    any_fixed_config,
     |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
 );
 order_test!(
     test_order_any_mmr_ordered_variable,
     AnyMmrOrderedVariable,
-    any_variable_config::<mmr::Family>,
+    any_variable_config,
     |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
 );
 order_test!(
     test_order_any_mmb_unordered_fixed,
     AnyMmbUnorderedFixed,
-    any_fixed_config::<mmb::Family>,
+    any_fixed_config,
     |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
 );
 order_test!(
     test_order_any_mmb_unordered_variable,
     AnyMmbUnorderedVariable,
-    any_variable_config::<mmb::Family>,
+    any_variable_config,
     |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
 );
 order_test!(
     test_order_any_mmb_ordered_fixed,
     AnyMmbOrderedFixed,
-    any_fixed_config::<mmb::Family>,
+    any_fixed_config,
     |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
 );
 order_test!(
     test_order_any_mmb_ordered_variable,
     AnyMmbOrderedVariable,
-    any_variable_config::<mmb::Family>,
+    any_variable_config,
     |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
 );
 order_test!(

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -301,8 +301,6 @@ impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S>
             merkle_config: cfg.merkle_config,
             journal_config: cfg.journal_config,
             translator: cfg.translator,
-            split_root: false,
-            root_bagging: Bagging::ForwardFold,
         }
     }
 }
@@ -357,7 +355,14 @@ where
         .map_err(|_| crate::qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
     let bitmap = Arc::new(Shared::<N>::new(bitmap));
 
-    let any = any::init_with_bitmap(context.with_label("any"), config.into(), Some(bitmap)).await?;
+    let any = any::init_with_bitmap(
+        context.with_label("any"),
+        config.into(),
+        Some(bitmap),
+        false,
+        Bagging::ForwardFold,
+    )
+    .await?;
 
     // Build the grafted tree from the bitmap and ops tree.
     let hasher = StandardHasher::<H>::new();

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -256,6 +256,8 @@ macro_rules! impl_current_sync_database {
             type Config = $config;
             type Digest = H::Digest;
 
+            const ROOT_BAGGING: Bagging = Bagging::ForwardFold;
+
             async fn from_sync_result(
                 context: Self::Context,
                 config: Self::Config,
@@ -316,10 +318,6 @@ macro_rules! impl_current_sync_database {
             /// batches against the ops tree.
             fn root(&self) -> Self::Digest {
                 self.any.root()
-            }
-
-            fn root_bagging(_config: &Self::Config) -> Bagging {
-                Bagging::ForwardFold
             }
         }
     };

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -49,6 +49,8 @@ where
     type Digest = H::Digest;
     type Context = E;
 
+    const ROOT_BAGGING: merkle::Bagging = <F as FamilyBagging>::BAGGING;
+
     /// Returns an [Immutable](immutable::Immutable) initialized from data collected in the sync process.
     ///
     /// # Behavior
@@ -141,10 +143,6 @@ where
     fn root(&self) -> Self::Digest {
         self.root()
     }
-
-    fn root_bagging(_config: &Self::Config) -> merkle::Bagging {
-        <F as FamilyBagging>::BAGGING
-    }
 }
 
 impl<F, E, K, V, H, Cfg, S> sync::compact::Database for CompactDb<F, E, K, V, H, Cfg, S>
@@ -165,6 +163,8 @@ where
     type Digest = H::Digest;
     type Context = E;
     type Hasher = H;
+
+    const ROOT_BAGGING: merkle::Bagging = <F as FamilyBagging>::BAGGING;
 
     async fn from_compact_state(
         context: Self::Context,
@@ -213,10 +213,6 @@ where
 
     fn root(&self) -> Self::Digest {
         self.root()
-    }
-
-    fn root_bagging() -> merkle::Bagging {
-        <F as FamilyBagging>::BAGGING
     }
 
     async fn persist_compact_state(&self) -> Result<(), Error<F>> {

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -43,6 +43,8 @@ where
     type Digest = H::Digest;
     type Context = E;
 
+    const ROOT_BAGGING: Bagging = <F as qmdb::Bagging>::BAGGING;
+
     /// Returns a [Keyless] db initialized from data collected in the sync process.
     ///
     /// # Behavior
@@ -119,10 +121,6 @@ where
     fn root(&self) -> Self::Digest {
         self.root()
     }
-
-    fn root_bagging(_config: &Self::Config) -> Bagging {
-        <F as qmdb::Bagging>::BAGGING
-    }
 }
 
 impl<F, E, V, H, Cfg, S> sync::compact::Database for CompactDb<F, E, V, H, Cfg, S>
@@ -142,6 +140,8 @@ where
     type Digest = H::Digest;
     type Context = E;
     type Hasher = H;
+
+    const ROOT_BAGGING: Bagging = <F as qmdb::Bagging>::BAGGING;
 
     async fn from_compact_state(
         context: Self::Context,
@@ -190,10 +190,6 @@ where
 
     fn root(&self) -> Self::Digest {
         self.root()
-    }
-
-    fn root_bagging() -> Bagging {
-        <F as qmdb::Bagging>::BAGGING
     }
 
     async fn persist_compact_state(&self) -> Result<(), qmdb::Error<F>> {

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -249,6 +249,9 @@ pub trait Database: Sized + Send {
     type Context: Storage + Clock + Metrics;
     type Hasher: Hasher<Digest = Self::Digest>;
 
+    /// Bagging policy used by this database when computing roots.
+    const ROOT_BAGGING: merkle::Bagging;
+
     /// Build a database from authenticated state in memory.
     ///
     /// The caller has already verified `last_commit_proof` against the requested target root, but
@@ -263,9 +266,6 @@ pub trait Database: Sized + Send {
 
     /// Get the root digest for final verification.
     fn root(&self) -> Self::Digest;
-
-    /// Bagging policy used by this database when computing roots.
-    fn root_bagging() -> merkle::Bagging;
 
     /// Persist the compact-initialized state once the caller has verified its root.
     fn persist_compact_state(
@@ -327,7 +327,7 @@ where
         }));
     }
 
-    let hasher = StandardHasher::<DB::Hasher>::with_bagging(DB::root_bagging());
+    let hasher = StandardHasher::<DB::Hasher>::with_bagging(DB::ROOT_BAGGING);
     let last_commit_loc = Location::new(*state.leaf_count - 1);
     if !verify_proof(
         &hasher,

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -48,6 +48,9 @@ pub trait Database: Sized + Send {
         + commonware_runtime::Metrics;
     type Hasher: commonware_cryptography::Hasher<Digest = Self::Digest>;
 
+    /// Bagging policy used by this database when computing roots/proofs.
+    const ROOT_BAGGING: Bagging;
+
     /// Build a database from the journal and pinned nodes populated by the sync engine.
     fn from_sync_result(
         context: Self::Context,
@@ -75,7 +78,4 @@ pub trait Database: Sized + Send {
 
     /// Get the root digest of the database for verification
     fn root(&self) -> Self::Digest;
-
-    /// Bagging policy used by this database when computing roots/proofs.
-    fn root_bagging(config: &Self::Config) -> Bagging;
 }

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -332,7 +332,7 @@ where
             apply_batch_size: config.apply_batch_size,
             journal,
             resolver: config.resolver.clone(),
-            hasher: StandardHasher::<DB::Hasher>::with_bagging(DB::root_bagging(&config.db_config)),
+            hasher: StandardHasher::<DB::Hasher>::with_bagging(DB::ROOT_BAGGING),
             context: config.context,
             config: config.db_config,
             update_rx: config.update_rx,


### PR DESCRIPTION
Follow up to #3667

## Summary

- Remove public `AnyConfig` fields that let callers choose the operations-root shape directly.
- Make public `Any` databases use one root shape: split-root mode with the bagging policy defined by the selected family.
- Keep `Current`'s different operations-root shape as an internal implementation detail.

## Background

QMDB has an operations root over its authenticated log. Two details determine the meaning of that root:

- `split_root` decides whether the operations root also commits to the inactive-prefix boundary.
- `root_bagging` decides how Merkle peaks are folded into the root.

Those are not independent user preferences. They must agree with the database family and with the sync code that later verifies or reconstructs the database.

Before this change, `AnyConfig` exposed both fields directly. That meant a caller could choose a family, then separately choose root settings that did not belong with that family or with `Any` sync. The database might initialize, but its root semantics would no longer be the ones the type implies.

This PR makes the rule explicit: public `Any` databases always use split-root mode, and their bagging policy comes from the selected family. `Current` is the exception because its canonical root commits activity through the grafted tree, so its internal `Any` operations root stays plain. That exception now lives only in `Current`'s private initialization path instead of being exposed through `AnyConfig`.

## Changes

- Remove `split_root` and `root_bagging` from `qmdb::any::Config` and update examples, fuzz targets, benches, conformance helpers, and tests.
- Pass `split_root` and `ops_root_bagging` only through the crate-private `any::init_with_bitmap` helper used by `Current`.
- Change QMDB sync traits to expose root bagging as `ROOT_BAGGING`, since it is now fixed by the database type rather than read from config.
- Make `Any` sync reconstruct databases in split-root mode and verify target state using the family-derived inactive peak count and bagging policy.
- Simplify test helpers by removing now-unused family generic parameters from config builders.
- Remove the Any sync regression test for preserving plain-root mode, since plain-root mode is no longer public `Any` behavior.