### PR TITLE
[utils] Optimize Bitmap Encoding

### DIFF
--- a/utils/src/bitmap/benches/bench.rs
+++ b/utils/src/bitmap/benches/bench.rs
@@ -1,5 +1,6 @@
 use criterion::criterion_main;
 
 mod count_ones;
+mod write;
 
-criterion_main!(count_ones::benches);
+criterion_main!(count_ones::benches, write::benches);

--- a/utils/src/bitmap/benches/write.rs
+++ b/utils/src/bitmap/benches/write.rs
@@ -1,0 +1,37 @@
+use bytes::BytesMut;
+use commonware_codec::{EncodeSize, Write};
+use commonware_utils::bitmap::BitMap;
+use criterion::{criterion_group, Criterion};
+use std::hint::black_box;
+
+fn bench_write<const CHUNK_SIZE: usize>(c: &mut Criterion, size: u64) {
+    let bitmap = BitMap::<CHUNK_SIZE>::ones(size);
+    let encoded_size = bitmap.encode_size();
+    let mut buf = BytesMut::with_capacity(encoded_size);
+
+    c.bench_function(
+        &format!("{}/size={size} chunk_size={CHUNK_SIZE}", module_path!()),
+        |b| {
+            b.iter(|| {
+                buf.clear();
+                black_box(&bitmap).write(&mut buf);
+                black_box(buf.len());
+            });
+        },
+    );
+}
+
+fn benchmark_write(c: &mut Criterion) {
+    for size in [64, 1 << 10, 1 << 14, 1 << 18, 1 << 22, 1 << 26] {
+        bench_write::<4>(c, size);
+        bench_write::<8>(c, size);
+        bench_write::<16>(c, size);
+        bench_write::<32>(c, size);
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_write,
+}

--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -843,12 +843,9 @@ impl<const N: usize> Write for BitMap<N> {
         // Prefix with the number of bits
         self.len().write(buf);
 
-        // Write all chunks
-        for chunk in &self.chunks {
-            for &byte in chunk {
-                byte.write(buf);
-            }
-        }
+        let (front, back) = self.chunks.as_slices();
+        buf.put_slice(front.as_flattened());
+        buf.put_slice(back.as_flattened());
     }
 }
 

--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -843,6 +843,7 @@ impl<const N: usize> Write for BitMap<N> {
         // Prefix with the number of bits
         self.len().write(buf);
 
+        // Write all chunks
         let (front, back) = self.chunks.as_slices();
         buf.put_slice(front.as_flattened());
         buf.put_slice(back.as_flattened());


### PR DESCRIPTION
  | size | speedup range | time reduction |
  |---:|---:|---:|
  | 64 | 2.5x-7.5x | 59.7%-86.8% |
  | 1,024 | 32.5x-34.1x | 96.9%-97.1% |
  | 16,384 | 165.7x-168.3x | 99.4% |
  | 262,144 | 241.7x-243.3x | 99.6% |
  | 4,194,304 | 168.9x-176.8x | 99.4% |
  | 67,108,864 | 124.0x-164.4x | 99.2%-99.4% |

  - size=1,024: main ~286-293 ns, PR ~8.6-8.8 ns
  - size=262,144: main ~74-75 us, PR ~307-309 ns
  - size=67,108,864: main ~19-20 ms, PR ~122-155 us