### PR TITLE
[storage/qmdb/current] have current proof types implement codec

### DIFF
--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -262,6 +262,50 @@ hash = "311e78baa8209313a49f2d788d96aa880ba4b3c1c5c88f3151b665f25160fad8"
 n_cases = 200
 hash = "d6b0f89534be60d85f5754c16574536d84899fce930dfc182ef973475d3078e4"
 
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmb::Family,U64,FixedEncoding<U64>\n,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "3be28a20c912b32bc94dacedbee177f371dedae0374788062283a09198bbe8a1"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmb::Family,U64,VariableEncoding<Vec\n<u8>>,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "dec32d46d821f96fcf6795e79316dd120acbfa80c579aede1e3e1b12fa5d529b"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmr::Family,U64,FixedEncoding<U64>\n,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "ab38295608a9725a7e3ae3066d0908271f049f373beee1a266f823b8e4aa0e19"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmr::Family,U64,VariableEncoding<Vec\n<u8>>,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "8127a8b087d13a867eb02343e90b40dcc7ac1abaf1f49f205d932a7772944f94"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<KeyValueProof<mmb::Family,U64,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "bb7c2e0914c06a3cd0b64540c022cadc32ee1eafcf319a9d4fe744edf0e43428"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<KeyValueProof<mmr::Family,U64,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "a9d1bd40b8bf177389e77a4d33c9561ba5e96b12220de506bd4ce0817311d09a"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<OperationProof<mmb::Family,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "755bf9cd2a1d3e27c44472094e0b9f509b0c5f977dd63fd8df334adf860fd9b2"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<OperationProof<mmr::Family,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "d1035bc4913d84385ed906f0a44a28be3dbd0a91a3cdbf475f8a8427bd7276c8"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<OpsRootWitness<Sha256Digest>>"]
+n_cases = 65536
+hash = "10f6ff08377d0fa64e3802d5b7e14b314699a16fbd1a080d4487288a3c6048e4"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<RangeProof<mmb::Family,Sha256Digest>>"]
+n_cases = 65536
+hash = "b5e8e12fe4cefcc5cd0ba81e0bf1dabd816b6af63a2c939ad2e38c3bf2eea508"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<RangeProof<mmr::Family,Sha256Digest>>"]
+n_cases = 65536
+hash = "1385f5d8ad72ee20548a3154223208ef83b83ce34769871957c631caaf2d56f1"
+
 ["commonware_storage::qmdb::immutable::operation::fixed::tests::conformance::CodecConformance<FixedOp>"]
 n_cases = 65536
 hash = "1737c49c112fc9dfdc4dde3626d8ab08a9df8353b9a702e488d3a1fd8e9428dc"

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -47,7 +47,7 @@ impl<F: merkle::Family, K: Key, D: Digest, const N: usize> EncodeSize
 }
 
 impl<F: merkle::Family, K: Key, D: Digest, const N: usize> Read for KeyValueProof<F, K, D, N> {
-    /// `(max_digests, key_cfg)`: the per-field digest cap for the embedded operation proof and the
+    /// `(max_digests, key_cfg)`: the total digest cap for the embedded operation proof and the
     /// read configuration for the key type.
     type Cfg = (usize, <K as Read>::Cfg);
 

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -47,7 +47,7 @@ impl<F: merkle::Family, K: Key, D: Digest, const N: usize> EncodeSize
 }
 
 impl<F: merkle::Family, K: Key, D: Digest, const N: usize> Read for KeyValueProof<F, K, D, N> {
-    /// `(max_digests, key_cfg)`: the max digest count for the embedded operation proof and the
+    /// `(max_digests, key_cfg)`: the per-field digest cap for the embedded operation proof and the
     /// read configuration for the key type.
     type Cfg = (usize, <K as Read>::Cfg);
 
@@ -58,6 +58,21 @@ impl<F: merkle::Family, K: Key, D: Digest, const N: usize> Read for KeyValueProo
         let proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
         let next_key = K::read_cfg(buf, key_cfg)?;
         Ok(Self { proof, next_key })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<F: merkle::Family, K: Key, D: Digest, const N: usize> arbitrary::Arbitrary<'_>
+    for KeyValueProof<F, K, D, N>
+where
+    K: for<'a> arbitrary::Arbitrary<'a>,
+    D: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            proof: u.arbitrary()?,
+            next_key: u.arbitrary()?,
+        })
     }
 }
 

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -18,7 +18,8 @@ use crate::{
     },
     Context,
 };
-use commonware_codec::Codec;
+use bytes::{Buf, BufMut};
+use commonware_codec::{Codec, EncodeSize, Read, Write};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::{Sequential, Strategy};
 use futures::stream::Stream;
@@ -28,6 +29,36 @@ use futures::stream::Stream;
 pub struct KeyValueProof<F: merkle::Family, K: Key, D: Digest, const N: usize> {
     pub proof: OperationProof<F, D, N>,
     pub next_key: K,
+}
+
+impl<F: merkle::Family, K: Key, D: Digest, const N: usize> Write for KeyValueProof<F, K, D, N> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.proof.write(buf);
+        self.next_key.write(buf);
+    }
+}
+
+impl<F: merkle::Family, K: Key, D: Digest, const N: usize> EncodeSize
+    for KeyValueProof<F, K, D, N>
+{
+    fn encode_size(&self) -> usize {
+        self.proof.encode_size() + self.next_key.encode_size()
+    }
+}
+
+impl<F: merkle::Family, K: Key, D: Digest, const N: usize> Read for KeyValueProof<F, K, D, N> {
+    /// `(max_digests, key_cfg)`: the max digest count for the embedded operation proof and the
+    /// read configuration for the key type.
+    type Cfg = (usize, <K as Read>::Cfg);
+
+    fn read_cfg(
+        buf: &mut impl Buf,
+        (max_digests, key_cfg): &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        let proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
+        let next_key = K::read_cfg(buf, key_cfg)?;
+        Ok(Self { proof, next_key })
+    }
 }
 
 /// The generic Db type for ordered Current QMDB variants.

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -97,7 +97,7 @@ where
     D: Digest,
     Update<K, V>: Read,
 {
-    /// `(max_digests, update_cfg, value_cfg)`: per-field digest cap for the embedded operation
+    /// `(max_digests, update_cfg, value_cfg)`: total digest cap for the embedded operation
     /// proof, the read configuration for [Update], and the read configuration for the value type.
     type Cfg = (usize, <Update<K, V> as Read>::Cfg, <V::Value as Read>::Cfg);
 
@@ -956,6 +956,12 @@ pub mod tests {
         }
     }
 
+    fn op_proof_digest_count(proof: &OperationProof<mmb::Family, Digest, 32>) -> usize {
+        proof.range_proof.proof.digests.len()
+            + proof.range_proof.unfolded_prefix_peaks.len()
+            + proof.range_proof.unfolded_suffix_peaks.len()
+    }
+
     type CodecExclusionProof =
         ExclusionProof<mmb::Family, Digest, FixedEncoding<Digest>, Digest, 32>;
     type CodecKeyValueProof = db::KeyValueProof<mmb::Family, Digest, Digest, 32>;
@@ -972,6 +978,21 @@ pub mod tests {
         assert_eq!(encoded.len(), proof.encode_size());
         let decoded = CodecKeyValueProof::decode_cfg(encoded, &(MAX_DIGESTS, ())).unwrap();
         assert_eq!(decoded, proof);
+    }
+
+    #[test]
+    fn test_key_value_proof_codec_enforces_total_digest_budget() {
+        let proof = CodecKeyValueProof {
+            proof: sample_op_proof(),
+            next_key: Sha256::hash(b"next-key"),
+        };
+        let total_digests = op_proof_digest_count(&proof.proof);
+
+        let encoded = proof.encode();
+        let decoded =
+            CodecKeyValueProof::decode_cfg(encoded.clone(), &(total_digests, ())).unwrap();
+        assert_eq!(decoded, proof);
+        assert!(CodecKeyValueProof::decode_cfg(encoded, &(total_digests - 1, ())).is_err());
     }
 
     #[test]
@@ -994,6 +1015,37 @@ pub mod tests {
             assert_eq!(encoded.len(), proof.encode_size());
             let decoded = CodecExclusionProof::decode_cfg(encoded, &(MAX_DIGESTS, (), ())).unwrap();
             assert_eq!(decoded, proof);
+        }
+    }
+
+    #[test]
+    fn test_exclusion_proof_codec_enforces_total_digest_budget() {
+        let cases = [
+            CodecExclusionProof::KeyValue(
+                sample_op_proof(),
+                Update {
+                    key: Sha256::hash(b"key"),
+                    value: Sha256::hash(b"value"),
+                    next_key: Sha256::hash(b"next-key"),
+                },
+            ),
+            CodecExclusionProof::Commit(sample_op_proof(), Some(Sha256::hash(b"metadata"))),
+            CodecExclusionProof::Commit(sample_op_proof(), None),
+        ];
+
+        for proof in cases {
+            let total_digests = match &proof {
+                CodecExclusionProof::KeyValue(op_proof, _) => op_proof_digest_count(op_proof),
+                CodecExclusionProof::Commit(op_proof, _) => op_proof_digest_count(op_proof),
+            };
+
+            let encoded = proof.encode();
+            let decoded =
+                CodecExclusionProof::decode_cfg(encoded.clone(), &(total_digests, (), ())).unwrap();
+            assert_eq!(decoded, proof);
+            assert!(
+                CodecExclusionProof::decode_cfg(encoded, &(total_digests - 1, (), ())).is_err()
+            );
         }
     }
 

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -922,8 +922,8 @@ pub mod tests {
                 inactive_peaks: 0,
                 digests: vec![Sha256::hash(b"sib")],
             },
-            pre_prefix_acc: Some(Sha256::hash(b"pre")),
             unfolded_prefix_peaks: vec![Sha256::hash(b"peak")],
+            unfolded_suffix_peaks: vec![Sha256::hash(b"suf")],
             partial_chunk_digest: None,
             ops_root: Sha256::hash(b"ops"),
         };

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -54,6 +54,7 @@ where
     F: Graftable,
     K: Key,
     V: ValueEncoding,
+    Update<K, V>: Write,
     D: Digest,
 {
     fn write(&self, buf: &mut impl BufMut) {
@@ -61,17 +62,12 @@ where
             Self::KeyValue(op_proof, update) => {
                 EXCLUSION_TAG_KEY_VALUE.write(buf);
                 op_proof.write(buf);
-                update.key.write(buf);
-                update.value.write(buf);
-                update.next_key.write(buf);
+                update.write(buf);
             }
             Self::Commit(op_proof, value) => {
                 EXCLUSION_TAG_COMMIT.write(buf);
                 op_proof.write(buf);
-                value.is_some().write(buf);
-                if let Some(v) = value {
-                    v.write(buf);
-                }
+                value.write(buf);
             }
         }
     }
@@ -82,19 +78,13 @@ where
     F: Graftable,
     K: Key,
     V: ValueEncoding,
+    Update<K, V>: EncodeSize,
     D: Digest,
 {
     fn encode_size(&self) -> usize {
         1 + match self {
-            Self::KeyValue(op_proof, update) => {
-                op_proof.encode_size()
-                    + update.key.encode_size()
-                    + update.value.encode_size()
-                    + update.next_key.encode_size()
-            }
-            Self::Commit(op_proof, value) => {
-                op_proof.encode_size() + value.as_ref().map_or(1, |v| 1 + v.encode_size())
-            }
+            Self::KeyValue(op_proof, update) => op_proof.encode_size() + update.encode_size(),
+            Self::Commit(op_proof, value) => op_proof.encode_size() + value.encode_size(),
         }
     }
 }
@@ -104,43 +94,31 @@ where
     F: Graftable,
     K: Key,
     V: ValueEncoding,
+    Update<K, V>: Read,
     D: Digest,
 {
-    /// `(max_digests, key_cfg, value_cfg)`: max digest count for the embedded operation proof,
-    /// the read configuration for the key type, and the read configuration for the value type.
+    /// `(max_digests, update_cfg, value_cfg)`: max digest count for the embedded operation proof,
+    /// the read configuration for [Update], and the read configuration for the value type.
     type Cfg = (
         usize,
-        <K as Read>::Cfg,
+        <Update<K, V> as Read>::Cfg,
         <<V as ValueEncoding>::Value as Read>::Cfg,
     );
 
     fn read_cfg(
         buf: &mut impl Buf,
-        (max_digests, key_cfg, value_cfg): &Self::Cfg,
+        (max_digests, update_cfg, value_cfg): &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
         let tag = u8::read(buf)?;
         match tag {
             EXCLUSION_TAG_KEY_VALUE => {
                 let op_proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
-                let key = K::read_cfg(buf, key_cfg)?;
-                let value = V::Value::read_cfg(buf, value_cfg)?;
-                let next_key = K::read_cfg(buf, key_cfg)?;
-                Ok(Self::KeyValue(
-                    op_proof,
-                    Update {
-                        key,
-                        value,
-                        next_key,
-                    },
-                ))
+                let update = Update::<K, V>::read_cfg(buf, update_cfg)?;
+                Ok(Self::KeyValue(op_proof, update))
             }
             EXCLUSION_TAG_COMMIT => {
                 let op_proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
-                let value = if bool::read(buf)? {
-                    Some(V::Value::read_cfg(buf, value_cfg)?)
-                } else {
-                    None
-                };
+                let value = Option::<V::Value>::read_cfg(buf, value_cfg)?;
                 Ok(Self::Commit(op_proof, value))
             }
             _ => Err(commonware_codec::Error::Invalid(

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -97,8 +97,8 @@ where
     D: Digest,
     Update<K, V>: Read,
 {
-    /// `(max_digests, update_cfg, value_cfg)`: max digest count for the embedded operation proof,
-    /// the read configuration for [Update], and the read configuration for the value type.
+    /// `(max_digests, update_cfg, value_cfg)`: per-field digest cap for the embedded operation
+    /// proof, the read configuration for [Update], and the read configuration for the value type.
     type Cfg = (usize, <Update<K, V> as Read>::Cfg, <V::Value as Read>::Cfg);
 
     fn read_cfg(
@@ -117,6 +117,27 @@ where
                 Ok(Self::Commit(op_proof, value))
             }
             tag => Err(commonware_codec::Error::InvalidEnum(tag)),
+        }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<F, K, V, D, const N: usize> arbitrary::Arbitrary<'_> for ExclusionProof<F, K, V, D, N>
+where
+    F: Graftable,
+    K: Key,
+    V: ValueEncoding,
+    D: Digest,
+    K: for<'a> arbitrary::Arbitrary<'a>,
+    V::Value: for<'a> arbitrary::Arbitrary<'a>,
+    D: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let op_proof = u.arbitrary()?;
+        if u.arbitrary()? {
+            Ok(Self::KeyValue(op_proof, u.arbitrary()?))
+        } else {
+            Ok(Self::Commit(op_proof, u.arbitrary()?))
         }
     }
 }
@@ -982,5 +1003,28 @@ pub mod tests {
         bytes.extend_from_slice(&[0u8; 32]); // garbage
         let result = CodecExclusionProof::decode_cfg(bytes.as_slice(), &(MAX_DIGESTS, (), ()));
         assert!(result.is_err());
+    }
+
+    #[cfg(feature = "arbitrary")]
+    mod conformance {
+        use crate::{
+            merkle::{mmb, mmr},
+            qmdb::{
+                any::value::{FixedEncoding, VariableEncoding},
+                current::ordered::{db::KeyValueProof, ExclusionProof},
+            },
+        };
+        use commonware_codec::conformance::CodecConformance;
+        use commonware_cryptography::sha256::Digest as Sha256Digest;
+        use commonware_utils::sequence::U64;
+
+        commonware_conformance::conformance_tests! {
+            CodecConformance<KeyValueProof<mmr::Family, U64, Sha256Digest, 32>>,
+            CodecConformance<KeyValueProof<mmb::Family, U64, Sha256Digest, 32>>,
+            CodecConformance<ExclusionProof<mmr::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
+            CodecConformance<ExclusionProof<mmr::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
+            CodecConformance<ExclusionProof<mmb::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
+            CodecConformance<ExclusionProof<mmb::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
+        }
     }
 }

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -935,7 +935,8 @@ pub mod tests {
         }
     }
 
-    type CodecExclusionProof = ExclusionProof<mmb::Family, Digest, FixedEncoding<Digest>, Digest, 32>;
+    type CodecExclusionProof =
+        ExclusionProof<mmb::Family, Digest, FixedEncoding<Digest>, Digest, 32>;
     type CodecKeyValueProof = db::KeyValueProof<mmb::Family, Digest, Digest, 32>;
     const MAX_DIGESTS: usize = 64;
 
@@ -970,8 +971,7 @@ pub mod tests {
         for proof in cases {
             let encoded = proof.encode();
             assert_eq!(encoded.len(), proof.encode_size());
-            let decoded =
-                CodecExclusionProof::decode_cfg(encoded, &(MAX_DIGESTS, (), ())).unwrap();
+            let decoded = CodecExclusionProof::decode_cfg(encoded, &(MAX_DIGESTS, (), ())).unwrap();
             assert_eq!(decoded, proof);
         }
     }

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -125,25 +125,31 @@ where
 pub mod tests {
     //! Shared test utilities for ordered Current QMDB variants.
 
-    use super::db;
+    use super::{db, ExclusionProof};
     use crate::{
         index::ordered::Index,
         journal::{contiguous::Mutable, Error as JournalError},
         merkle::{Graftable, Location, Proof},
+        mmb,
         qmdb::{
             any::{
                 ordered::{Operation, Update},
                 traits::{DbAny, UnmerkleizedBatch as _},
+                value::FixedEncoding,
                 ValueEncoding,
             },
-            current::{proof::RangeProof, tests::apply_random_ops, BitmapPrunedBits},
+            current::{
+                proof::{OperationProof, RangeProof},
+                tests::apply_random_ops,
+                BitmapPrunedBits,
+            },
             store::tests::{TestKey, TestValue},
             Error,
         },
         translator::OneCap,
         Persistable,
     };
-    use commonware_codec::Codec;
+    use commonware_codec::{Codec, Decode as _, Encode as _, EncodeSize as _};
     use commonware_cryptography::{sha256::Digest, Digest as _, Hasher as _, Sha256};
     use commonware_runtime::{
         deterministic::{self, Context},
@@ -908,29 +914,10 @@ pub mod tests {
             ));
         });
     }
-}
 
-#[cfg(test)]
-mod codec_tests {
-    use super::{db::KeyValueProof, ExclusionProof};
-    use crate::{
-        merkle::Proof,
-        mmb,
-        qmdb::{
-            any::{ordered::Update, value::FixedEncoding},
-            current::proof::{OperationProof, RangeProof},
-        },
-    };
-    use commonware_codec::{Decode as _, Encode as _, EncodeSize as _};
-    use commonware_cryptography::{sha256::Digest, Hasher as _, Sha256};
-
-    type F = mmb::Family;
-    const N: usize = 32;
-    const MAX_DIGESTS: usize = 64;
-
-    fn sample_op_proof() -> OperationProof<F, Digest, N> {
+    fn sample_op_proof() -> OperationProof<mmb::Family, Digest, 32> {
         let range_proof = RangeProof {
-            proof: Proof::<F, Digest> {
+            proof: Proof::<mmb::Family, Digest> {
                 leaves: mmb::Location::new(7),
                 inactive_peaks: 0,
                 digests: vec![Sha256::hash(b"sib")],
@@ -940,7 +927,7 @@ mod codec_tests {
             partial_chunk_digest: None,
             ops_root: Sha256::hash(b"ops"),
         };
-        let chunk: [u8; N] = core::array::from_fn(|i| i as u8);
+        let chunk: [u8; 32] = core::array::from_fn(|i| i as u8);
         OperationProof {
             loc: mmb::Location::new(5),
             chunk,
@@ -948,24 +935,27 @@ mod codec_tests {
         }
     }
 
+    type CodecExclusionProof = ExclusionProof<mmb::Family, Digest, FixedEncoding<Digest>, Digest, 32>;
+    type CodecKeyValueProof = db::KeyValueProof<mmb::Family, Digest, Digest, 32>;
+    const MAX_DIGESTS: usize = 64;
+
     #[test]
     fn test_key_value_proof_codec_roundtrip() {
-        let proof = KeyValueProof::<F, Digest, Digest, N> {
+        let proof = CodecKeyValueProof {
             proof: sample_op_proof(),
             next_key: Sha256::hash(b"next-key"),
         };
 
         let encoded = proof.encode();
         assert_eq!(encoded.len(), proof.encode_size());
-        let decoded =
-            KeyValueProof::<F, Digest, Digest, N>::decode_cfg(encoded, &(MAX_DIGESTS, ())).unwrap();
+        let decoded = CodecKeyValueProof::decode_cfg(encoded, &(MAX_DIGESTS, ())).unwrap();
         assert_eq!(decoded, proof);
     }
 
     #[test]
     fn test_exclusion_proof_codec_roundtrip() {
         let cases = [
-            ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::KeyValue(
+            CodecExclusionProof::KeyValue(
                 sample_op_proof(),
                 Update {
                     key: Sha256::hash(b"key"),
@@ -973,25 +963,15 @@ mod codec_tests {
                     next_key: Sha256::hash(b"next-key"),
                 },
             ),
-            ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::Commit(
-                sample_op_proof(),
-                Some(Sha256::hash(b"metadata")),
-            ),
-            ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::Commit(
-                sample_op_proof(),
-                None,
-            ),
+            CodecExclusionProof::Commit(sample_op_proof(), Some(Sha256::hash(b"metadata"))),
+            CodecExclusionProof::Commit(sample_op_proof(), None),
         ];
 
         for proof in cases {
             let encoded = proof.encode();
             assert_eq!(encoded.len(), proof.encode_size());
             let decoded =
-                ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::decode_cfg(
-                    encoded,
-                    &(MAX_DIGESTS, (), ()),
-                )
-                .unwrap();
+                CodecExclusionProof::decode_cfg(encoded, &(MAX_DIGESTS, (), ())).unwrap();
             assert_eq!(decoded, proof);
         }
     }
@@ -1000,10 +980,7 @@ mod codec_tests {
     fn test_exclusion_proof_rejects_unknown_tag() {
         let mut bytes = vec![42u8]; // unknown tag
         bytes.extend_from_slice(&[0u8; 32]); // garbage
-        let result = ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::decode_cfg(
-            bytes.as_slice(),
-            &(MAX_DIGESTS, (), ()),
-        );
+        let result = CodecExclusionProof::decode_cfg(bytes.as_slice(), &(MAX_DIGESTS, (), ()));
         assert!(result.is_err());
     }
 }

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -46,26 +46,26 @@ pub enum ExclusionProof<F: Graftable, K: Key, V: ValueEncoding, D: Digest, const
     Commit(OperationProof<F, D, N>, Option<V::Value>),
 }
 
-const EXCLUSION_TAG_KEY_VALUE: u8 = 0;
-const EXCLUSION_TAG_COMMIT: u8 = 1;
+const KEY_VALUE_CONTEXT: u8 = 0;
+const COMMIT_CONTEXT: u8 = 1;
 
 impl<F, K, V, D, const N: usize> Write for ExclusionProof<F, K, V, D, N>
 where
     F: Graftable,
     K: Key,
     V: ValueEncoding,
-    Update<K, V>: Write,
     D: Digest,
+    Update<K, V>: Write,
 {
     fn write(&self, buf: &mut impl BufMut) {
         match self {
             Self::KeyValue(op_proof, update) => {
-                EXCLUSION_TAG_KEY_VALUE.write(buf);
+                KEY_VALUE_CONTEXT.write(buf);
                 op_proof.write(buf);
                 update.write(buf);
             }
             Self::Commit(op_proof, value) => {
-                EXCLUSION_TAG_COMMIT.write(buf);
+                COMMIT_CONTEXT.write(buf);
                 op_proof.write(buf);
                 value.write(buf);
             }
@@ -78,8 +78,8 @@ where
     F: Graftable,
     K: Key,
     V: ValueEncoding,
-    Update<K, V>: EncodeSize,
     D: Digest,
+    Update<K, V>: EncodeSize,
 {
     fn encode_size(&self) -> usize {
         1 + match self {
@@ -94,37 +94,29 @@ where
     F: Graftable,
     K: Key,
     V: ValueEncoding,
-    Update<K, V>: Read,
     D: Digest,
+    Update<K, V>: Read,
 {
     /// `(max_digests, update_cfg, value_cfg)`: max digest count for the embedded operation proof,
     /// the read configuration for [Update], and the read configuration for the value type.
-    type Cfg = (
-        usize,
-        <Update<K, V> as Read>::Cfg,
-        <<V as ValueEncoding>::Value as Read>::Cfg,
-    );
+    type Cfg = (usize, <Update<K, V> as Read>::Cfg, <V::Value as Read>::Cfg);
 
     fn read_cfg(
         buf: &mut impl Buf,
         (max_digests, update_cfg, value_cfg): &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
-        let tag = u8::read(buf)?;
-        match tag {
-            EXCLUSION_TAG_KEY_VALUE => {
+        match u8::read(buf)? {
+            KEY_VALUE_CONTEXT => {
                 let op_proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
                 let update = Update::<K, V>::read_cfg(buf, update_cfg)?;
                 Ok(Self::KeyValue(op_proof, update))
             }
-            EXCLUSION_TAG_COMMIT => {
+            COMMIT_CONTEXT => {
                 let op_proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
                 let value = Option::<V::Value>::read_cfg(buf, value_cfg)?;
                 Ok(Self::Commit(op_proof, value))
             }
-            _ => Err(commonware_codec::Error::Invalid(
-                "ExclusionProof",
-                "unknown variant tag",
-            )),
+            tag => Err(commonware_codec::Error::InvalidEnum(tag)),
         }
     }
 }
@@ -948,10 +940,7 @@ mod codec_tests {
             partial_chunk_digest: None,
             ops_root: Sha256::hash(b"ops"),
         };
-        let mut chunk = [0u8; N];
-        for (i, byte) in chunk.iter_mut().enumerate() {
-            *byte = i as u8;
-        }
+        let chunk: [u8; N] = core::array::from_fn(|i| i as u8);
         OperationProof {
             loc: mmb::Location::new(5),
             chunk,

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -16,6 +16,8 @@ use crate::{
         operation::Key,
     },
 };
+use bytes::{Buf, BufMut};
+use commonware_codec::{EncodeSize, Read, ReadExt as _, Write};
 use commonware_cryptography::Digest;
 
 pub mod db;
@@ -42,6 +44,111 @@ pub enum ExclusionProof<F: Graftable, K: Key, V: ValueEncoding, D: Digest, const
     /// equal to its own location, which is a necessary and sufficient condition for an empty
     /// database.
     Commit(OperationProof<F, D, N>, Option<V::Value>),
+}
+
+const EXCLUSION_TAG_KEY_VALUE: u8 = 0;
+const EXCLUSION_TAG_COMMIT: u8 = 1;
+
+impl<F, K, V, D, const N: usize> Write for ExclusionProof<F, K, V, D, N>
+where
+    F: Graftable,
+    K: Key,
+    V: ValueEncoding,
+    D: Digest,
+{
+    fn write(&self, buf: &mut impl BufMut) {
+        match self {
+            Self::KeyValue(op_proof, update) => {
+                EXCLUSION_TAG_KEY_VALUE.write(buf);
+                op_proof.write(buf);
+                update.key.write(buf);
+                update.value.write(buf);
+                update.next_key.write(buf);
+            }
+            Self::Commit(op_proof, value) => {
+                EXCLUSION_TAG_COMMIT.write(buf);
+                op_proof.write(buf);
+                value.is_some().write(buf);
+                if let Some(v) = value {
+                    v.write(buf);
+                }
+            }
+        }
+    }
+}
+
+impl<F, K, V, D, const N: usize> EncodeSize for ExclusionProof<F, K, V, D, N>
+where
+    F: Graftable,
+    K: Key,
+    V: ValueEncoding,
+    D: Digest,
+{
+    fn encode_size(&self) -> usize {
+        1 + match self {
+            Self::KeyValue(op_proof, update) => {
+                op_proof.encode_size()
+                    + update.key.encode_size()
+                    + update.value.encode_size()
+                    + update.next_key.encode_size()
+            }
+            Self::Commit(op_proof, value) => {
+                op_proof.encode_size() + value.as_ref().map_or(1, |v| 1 + v.encode_size())
+            }
+        }
+    }
+}
+
+impl<F, K, V, D, const N: usize> Read for ExclusionProof<F, K, V, D, N>
+where
+    F: Graftable,
+    K: Key,
+    V: ValueEncoding,
+    D: Digest,
+{
+    /// `(max_digests, key_cfg, value_cfg)`: max digest count for the embedded operation proof,
+    /// the read configuration for the key type, and the read configuration for the value type.
+    type Cfg = (
+        usize,
+        <K as Read>::Cfg,
+        <<V as ValueEncoding>::Value as Read>::Cfg,
+    );
+
+    fn read_cfg(
+        buf: &mut impl Buf,
+        (max_digests, key_cfg, value_cfg): &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        let tag = u8::read(buf)?;
+        match tag {
+            EXCLUSION_TAG_KEY_VALUE => {
+                let op_proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
+                let key = K::read_cfg(buf, key_cfg)?;
+                let value = V::Value::read_cfg(buf, value_cfg)?;
+                let next_key = K::read_cfg(buf, key_cfg)?;
+                Ok(Self::KeyValue(
+                    op_proof,
+                    Update {
+                        key,
+                        value,
+                        next_key,
+                    },
+                ))
+            }
+            EXCLUSION_TAG_COMMIT => {
+                let op_proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
+                let value = if bool::read(buf)? {
+                    Some(V::Value::read_cfg(buf, value_cfg)?)
+                } else {
+                    None
+                };
+                Ok(Self::Commit(op_proof, value))
+            }
+            _ => Err(commonware_codec::Error::Invalid(
+                "ExclusionProof",
+                "unknown variant tag",
+            )),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -830,5 +937,106 @@ pub mod tests {
                 &empty_root, // wrong root
             ));
         });
+    }
+}
+
+#[cfg(test)]
+mod codec_tests {
+    use super::{db::KeyValueProof, ExclusionProof};
+    use crate::{
+        merkle::Proof,
+        mmb,
+        qmdb::{
+            any::{ordered::Update, value::FixedEncoding},
+            current::proof::{OperationProof, RangeProof},
+        },
+    };
+    use commonware_codec::{Decode as _, Encode as _, EncodeSize as _};
+    use commonware_cryptography::{sha256::Digest, Hasher as _, Sha256};
+
+    type F = mmb::Family;
+    const N: usize = 32;
+    const MAX_DIGESTS: usize = 64;
+
+    fn sample_op_proof() -> OperationProof<F, Digest, N> {
+        let range_proof = RangeProof {
+            proof: Proof::<F, Digest> {
+                leaves: mmb::Location::new(7),
+                inactive_peaks: 0,
+                digests: vec![Sha256::hash(b"sib")],
+            },
+            pre_prefix_acc: Some(Sha256::hash(b"pre")),
+            unfolded_prefix_peaks: vec![Sha256::hash(b"peak")],
+            partial_chunk_digest: None,
+            ops_root: Sha256::hash(b"ops"),
+        };
+        let mut chunk = [0u8; N];
+        for (i, byte) in chunk.iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+        OperationProof {
+            loc: mmb::Location::new(5),
+            chunk,
+            range_proof,
+        }
+    }
+
+    #[test]
+    fn test_key_value_proof_codec_roundtrip() {
+        let proof = KeyValueProof::<F, Digest, Digest, N> {
+            proof: sample_op_proof(),
+            next_key: Sha256::hash(b"next-key"),
+        };
+
+        let encoded = proof.encode();
+        assert_eq!(encoded.len(), proof.encode_size());
+        let decoded =
+            KeyValueProof::<F, Digest, Digest, N>::decode_cfg(encoded, &(MAX_DIGESTS, ())).unwrap();
+        assert_eq!(decoded, proof);
+    }
+
+    #[test]
+    fn test_exclusion_proof_codec_roundtrip() {
+        let cases = [
+            ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::KeyValue(
+                sample_op_proof(),
+                Update {
+                    key: Sha256::hash(b"key"),
+                    value: Sha256::hash(b"value"),
+                    next_key: Sha256::hash(b"next-key"),
+                },
+            ),
+            ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::Commit(
+                sample_op_proof(),
+                Some(Sha256::hash(b"metadata")),
+            ),
+            ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::Commit(
+                sample_op_proof(),
+                None,
+            ),
+        ];
+
+        for proof in cases {
+            let encoded = proof.encode();
+            assert_eq!(encoded.len(), proof.encode_size());
+            let decoded =
+                ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::decode_cfg(
+                    encoded,
+                    &(MAX_DIGESTS, (), ()),
+                )
+                .unwrap();
+            assert_eq!(decoded, proof);
+        }
+    }
+
+    #[test]
+    fn test_exclusion_proof_rejects_unknown_tag() {
+        let mut bytes = vec![42u8]; // unknown tag
+        bytes.extend_from_slice(&[0u8; 32]); // garbage
+        let result = ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, N>::decode_cfg(
+            bytes.as_slice(),
+            &(MAX_DIGESTS, (), ()),
+        );
+        assert!(result.is_err());
     }
 }

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -909,15 +909,9 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
 impl<F: Family, D: Digest> Write for RangeProof<F, D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.proof.write(buf);
-        self.pre_prefix_acc.is_some().write(buf);
-        if let Some(digest) = &self.pre_prefix_acc {
-            digest.write(buf);
-        }
+        self.pre_prefix_acc.write(buf);
         self.unfolded_prefix_peaks.write(buf);
-        self.partial_chunk_digest.is_some().write(buf);
-        if let Some(digest) = &self.partial_chunk_digest {
-            digest.write(buf);
-        }
+        self.partial_chunk_digest.write(buf);
         self.ops_root.write(buf);
     }
 }
@@ -925,15 +919,9 @@ impl<F: Family, D: Digest> Write for RangeProof<F, D> {
 impl<F: Family, D: Digest> EncodeSize for RangeProof<F, D> {
     fn encode_size(&self) -> usize {
         self.proof.encode_size()
-            + self
-                .pre_prefix_acc
-                .as_ref()
-                .map_or(1, |d| 1 + d.encode_size())
+            + self.pre_prefix_acc.encode_size()
             + self.unfolded_prefix_peaks.encode_size()
-            + self
-                .partial_chunk_digest
-                .as_ref()
-                .map_or(1, |d| 1 + d.encode_size())
+            + self.partial_chunk_digest.encode_size()
             + self.ops_root.encode_size()
     }
 }
@@ -948,17 +936,9 @@ impl<F: Family, D: Digest> Read for RangeProof<F, D> {
         max_digests: &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
         let proof = Proof::<F, D>::read_cfg(buf, max_digests)?;
-        let pre_prefix_acc = if bool::read(buf)? {
-            Some(D::read(buf)?)
-        } else {
-            None
-        };
+        let pre_prefix_acc = Option::<D>::read(buf)?;
         let unfolded_prefix_peaks = Vec::<D>::read_range(buf, ..=*max_digests)?;
-        let partial_chunk_digest = if bool::read(buf)? {
-            Some(D::read(buf)?)
-        } else {
-            None
-        };
+        let partial_chunk_digest = Option::<D>::read(buf)?;
         let ops_root = D::read(buf)?;
         Ok(Self {
             proof,

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -909,8 +909,8 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
 impl<F: Family, D: Digest> Write for RangeProof<F, D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.proof.write(buf);
-        self.pre_prefix_acc.write(buf);
         self.unfolded_prefix_peaks.write(buf);
+        self.unfolded_suffix_peaks.write(buf);
         self.partial_chunk_digest.write(buf);
         self.ops_root.write(buf);
     }
@@ -919,8 +919,8 @@ impl<F: Family, D: Digest> Write for RangeProof<F, D> {
 impl<F: Family, D: Digest> EncodeSize for RangeProof<F, D> {
     fn encode_size(&self) -> usize {
         self.proof.encode_size()
-            + self.pre_prefix_acc.encode_size()
             + self.unfolded_prefix_peaks.encode_size()
+            + self.unfolded_suffix_peaks.encode_size()
             + self.partial_chunk_digest.encode_size()
             + self.ops_root.encode_size()
     }
@@ -928,7 +928,8 @@ impl<F: Family, D: Digest> EncodeSize for RangeProof<F, D> {
 
 impl<F: Family, D: Digest> Read for RangeProof<F, D> {
     /// The maximum number of digests in the proof, also used as the upper bound on the
-    /// number of unfolded prefix peaks (which is itself bounded by the structural peak count).
+    /// number of unfolded prefix and suffix peaks (each itself bounded by the structural peak
+    /// count).
     type Cfg = usize;
 
     fn read_cfg(
@@ -936,14 +937,14 @@ impl<F: Family, D: Digest> Read for RangeProof<F, D> {
         max_digests: &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
         let proof = Proof::<F, D>::read_cfg(buf, max_digests)?;
-        let pre_prefix_acc = Option::<D>::read(buf)?;
         let unfolded_prefix_peaks = Vec::<D>::read_range(buf, ..=*max_digests)?;
+        let unfolded_suffix_peaks = Vec::<D>::read_range(buf, ..=*max_digests)?;
         let partial_chunk_digest = Option::<D>::read(buf)?;
         let ops_root = D::read(buf)?;
         Ok(Self {
             proof,
-            pre_prefix_acc,
             unfolded_prefix_peaks,
+            unfolded_suffix_peaks,
             partial_chunk_digest,
             ops_root,
         })
@@ -1110,24 +1111,24 @@ mod tests {
             // Minimal: no optional fields, no unfolded peaks.
             RangeProof {
                 proof: proof.clone(),
-                pre_prefix_acc: None,
                 unfolded_prefix_peaks: vec![],
+                unfolded_suffix_peaks: vec![],
                 partial_chunk_digest: None,
                 ops_root,
             },
-            // All optional fields populated, with unfolded peaks.
+            // All optional fields populated, with unfolded peaks on both sides.
             RangeProof {
                 proof,
-                pre_prefix_acc: Some(Sha256::hash(b"pre-prefix")),
                 unfolded_prefix_peaks: vec![Sha256::hash(b"u0"), Sha256::hash(b"u1")],
+                unfolded_suffix_peaks: vec![Sha256::hash(b"s0"), Sha256::hash(b"s1")],
                 partial_chunk_digest: Some(Sha256::hash(b"partial")),
                 ops_root,
             },
             // Default proof with only partial chunk digest.
             RangeProof {
                 proof: Proof::<F, sha256::Digest>::default(),
-                pre_prefix_acc: None,
                 unfolded_prefix_peaks: vec![],
+                unfolded_suffix_peaks: vec![],
                 partial_chunk_digest: Some(Sha256::hash(b"only-partial")),
                 ops_root,
             },
@@ -1154,8 +1155,8 @@ mod tests {
                 inactive_peaks: 0,
                 digests: vec![Sha256::hash(b"sib")],
             },
-            pre_prefix_acc: Some(Sha256::hash(b"pre")),
             unfolded_prefix_peaks: vec![Sha256::hash(b"peak")],
+            unfolded_suffix_peaks: vec![Sha256::hash(b"suf")],
             partial_chunk_digest: None,
             ops_root: Sha256::hash(b"ops"),
         };

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -1160,10 +1160,7 @@ mod tests {
             ops_root: Sha256::hash(b"ops"),
         };
 
-        let mut chunk = [0u8; N];
-        for (i, byte) in chunk.iter_mut().enumerate() {
-            *byte = i as u8;
-        }
+        let chunk: [u8; N] = core::array::from_fn(|i| i as u8);
 
         let proof = OperationProof::<F, sha256::Digest, N> {
             loc: mmb::Location::new(5),

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -940,10 +940,7 @@ impl<F: Family, D: Digest> EncodeSize for RangeProof<F, D> {
 }
 
 impl<F: Family, D: Digest> Read for RangeProof<F, D> {
-    /// The maximum number of digests allowed in each digest vector.
-    ///
-    /// This is a per-field cap, not a total allocation budget across the whole range proof. It
-    /// bounds `proof.digests`, `unfolded_prefix_peaks`, and `unfolded_suffix_peaks` separately.
+    /// The maximum number of digests allowed across all digest vectors in the range proof.
     type Cfg = usize;
 
     fn read_cfg(
@@ -951,8 +948,12 @@ impl<F: Family, D: Digest> Read for RangeProof<F, D> {
         max_digests: &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
         let proof = Proof::<F, D>::read_cfg(buf, max_digests)?;
-        let unfolded_prefix_peaks = Vec::<D>::read_range(buf, ..=*max_digests)?;
-        let unfolded_suffix_peaks = Vec::<D>::read_range(buf, ..=*max_digests)?;
+        let remaining = max_digests.checked_sub(proof.digests.len()).ok_or(
+            commonware_codec::Error::Invalid("RangeProof", "digest budget exceeded"),
+        )?;
+        let unfolded_prefix_peaks = Vec::<D>::read_range(buf, ..=remaining)?;
+        let remaining = remaining - unfolded_prefix_peaks.len();
+        let unfolded_suffix_peaks = Vec::<D>::read_range(buf, ..=remaining)?;
         let partial_chunk_digest = Option::<D>::read(buf)?;
         let ops_root = D::read(buf)?;
         Ok(Self {
@@ -1070,7 +1071,7 @@ impl<F: Family, D: Digest, const N: usize> EncodeSize for OperationProof<F, D, N
 }
 
 impl<F: Family, D: Digest, const N: usize> Read for OperationProof<F, D, N> {
-    /// The per-field digest cap forwarded to the embedded range proof.
+    /// The total digest cap forwarded to the embedded range proof.
     type Cfg = usize;
 
     fn read_cfg(
@@ -1135,6 +1136,12 @@ mod tests {
         }
     }
 
+    fn range_proof_digest_count<F: Family, D: Digest>(proof: &RangeProof<F, D>) -> usize {
+        proof.proof.digests.len()
+            + proof.unfolded_prefix_peaks.len()
+            + proof.unfolded_suffix_peaks.len()
+    }
+
     #[test]
     fn test_range_proof_codec_roundtrip() {
         type F = mmb::Family;
@@ -1188,6 +1195,33 @@ mod tests {
     }
 
     #[test]
+    fn test_range_proof_codec_enforces_total_digest_budget() {
+        type F = mmb::Family;
+
+        let proof = RangeProof {
+            proof: Proof::<F, sha256::Digest> {
+                leaves: mmb::Location::new(42),
+                inactive_peaks: 0,
+                digests: vec![Sha256::hash(b"d0")],
+            },
+            unfolded_prefix_peaks: vec![Sha256::hash(b"u0")],
+            unfolded_suffix_peaks: vec![Sha256::hash(b"s0")],
+            partial_chunk_digest: None,
+            ops_root: Sha256::hash(b"ops-root"),
+        };
+
+        let encoded = proof.encode();
+        let total_digests = range_proof_digest_count(&proof);
+
+        let decoded =
+            RangeProof::<F, sha256::Digest>::decode_cfg(encoded.clone(), &total_digests).unwrap();
+        assert_eq!(decoded, proof);
+        assert!(
+            RangeProof::<F, sha256::Digest>::decode_cfg(encoded, &(total_digests - 1)).is_err()
+        );
+    }
+
+    #[test]
     fn test_operation_proof_codec_roundtrip() {
         type F = mmb::Family;
         const N: usize = 32;
@@ -1218,6 +1252,40 @@ mod tests {
         let decoded =
             OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded, &MAX_DIGESTS).unwrap();
         assert_eq!(decoded, proof);
+    }
+
+    #[test]
+    fn test_operation_proof_codec_enforces_total_digest_budget() {
+        type F = mmb::Family;
+        const N: usize = 32;
+
+        let range_proof = RangeProof {
+            proof: Proof::<F, sha256::Digest> {
+                leaves: mmb::Location::new(7),
+                inactive_peaks: 0,
+                digests: vec![Sha256::hash(b"sib")],
+            },
+            unfolded_prefix_peaks: vec![Sha256::hash(b"peak")],
+            unfolded_suffix_peaks: vec![Sha256::hash(b"suf")],
+            partial_chunk_digest: None,
+            ops_root: Sha256::hash(b"ops"),
+        };
+        let total_digests = range_proof_digest_count(&range_proof);
+        let proof = OperationProof::<F, sha256::Digest, N> {
+            loc: mmb::Location::new(5),
+            chunk: core::array::from_fn(|i| i as u8),
+            range_proof,
+        };
+
+        let encoded = proof.encode();
+        let decoded =
+            OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded.clone(), &total_digests)
+                .unwrap();
+        assert_eq!(decoded, proof);
+        assert!(
+            OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded, &(total_digests - 1))
+                .is_err()
+        );
     }
 
     #[test_traced]

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -20,7 +20,9 @@ use crate::{
     },
 };
 use bytes::{Buf, BufMut};
-use commonware_codec::{varint::UInt, Codec, EncodeSize, Read, ReadExt as _, Write};
+use commonware_codec::{
+    varint::UInt, Codec, EncodeSize, Read, ReadExt as _, ReadRangeExt as _, Write,
+};
 use commonware_cryptography::{Digest, Hasher as CHasher};
 use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
 use core::ops::Range;
@@ -904,6 +906,70 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
     }
 }
 
+impl<F: Family, D: Digest> Write for RangeProof<F, D> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.proof.write(buf);
+        self.pre_prefix_acc.is_some().write(buf);
+        if let Some(digest) = &self.pre_prefix_acc {
+            digest.write(buf);
+        }
+        self.unfolded_prefix_peaks.write(buf);
+        self.partial_chunk_digest.is_some().write(buf);
+        if let Some(digest) = &self.partial_chunk_digest {
+            digest.write(buf);
+        }
+        self.ops_root.write(buf);
+    }
+}
+
+impl<F: Family, D: Digest> EncodeSize for RangeProof<F, D> {
+    fn encode_size(&self) -> usize {
+        self.proof.encode_size()
+            + self
+                .pre_prefix_acc
+                .as_ref()
+                .map_or(1, |d| 1 + d.encode_size())
+            + self.unfolded_prefix_peaks.encode_size()
+            + self
+                .partial_chunk_digest
+                .as_ref()
+                .map_or(1, |d| 1 + d.encode_size())
+            + self.ops_root.encode_size()
+    }
+}
+
+impl<F: Family, D: Digest> Read for RangeProof<F, D> {
+    /// The maximum number of digests in the proof, also used as the upper bound on the
+    /// number of unfolded prefix peaks (which is itself bounded by the structural peak count).
+    type Cfg = usize;
+
+    fn read_cfg(
+        buf: &mut impl Buf,
+        max_digests: &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        let proof = Proof::<F, D>::read_cfg(buf, max_digests)?;
+        let pre_prefix_acc = if bool::read(buf)? {
+            Some(D::read(buf)?)
+        } else {
+            None
+        };
+        let unfolded_prefix_peaks = Vec::<D>::read_range(buf, ..=*max_digests)?;
+        let partial_chunk_digest = if bool::read(buf)? {
+            Some(D::read(buf)?)
+        } else {
+            None
+        };
+        let ops_root = D::read(buf)?;
+        Ok(Self {
+            proof,
+            pre_prefix_acc,
+            unfolded_prefix_peaks,
+            partial_chunk_digest,
+            ops_root,
+        })
+    }
+}
+
 /// A proof that a specific operation is currently active in the database.
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct OperationProof<F: Family, D: Digest, const N: usize> {
@@ -978,6 +1044,39 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
     }
 }
 
+impl<F: Family, D: Digest, const N: usize> Write for OperationProof<F, D, N> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.loc.write(buf);
+        self.chunk.write(buf);
+        self.range_proof.write(buf);
+    }
+}
+
+impl<F: Family, D: Digest, const N: usize> EncodeSize for OperationProof<F, D, N> {
+    fn encode_size(&self) -> usize {
+        self.loc.encode_size() + self.chunk.encode_size() + self.range_proof.encode_size()
+    }
+}
+
+impl<F: Family, D: Digest, const N: usize> Read for OperationProof<F, D, N> {
+    /// The maximum number of digests in the embedded range proof.
+    type Cfg = usize;
+
+    fn read_cfg(
+        buf: &mut impl Buf,
+        max_digests: &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        let loc = Location::<F>::read(buf)?;
+        let chunk = <[u8; N]>::read(buf)?;
+        let range_proof = RangeProof::<F, D>::read_cfg(buf, max_digests)?;
+        Ok(Self {
+            loc,
+            chunk,
+            range_proof,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -986,7 +1085,7 @@ mod tests {
         mmb,
         qmdb::current::{db, grafting},
     };
-    use commonware_codec::{DecodeExt as _, Encode as _};
+    use commonware_codec::{Decode as _, DecodeExt as _, Encode as _};
     use commonware_cryptography::{sha256, Sha256};
     use commonware_macros::test_traced;
     use commonware_parallel::Sequential;
@@ -1009,6 +1108,94 @@ mod tests {
             let decoded = OpsRootWitness::<sha256::Digest>::decode(encoded).unwrap();
             assert_eq!(decoded, witness);
         }
+    }
+
+    #[test]
+    fn test_range_proof_codec_roundtrip() {
+        type F = mmb::Family;
+        const MAX_DIGESTS: usize = 64;
+
+        let proof = Proof::<F, sha256::Digest> {
+            leaves: mmb::Location::new(42),
+            inactive_peaks: 0,
+            digests: vec![
+                Sha256::hash(b"d0"),
+                Sha256::hash(b"d1"),
+                Sha256::hash(b"d2"),
+            ],
+        };
+        let ops_root = Sha256::hash(b"ops-root");
+
+        let cases = [
+            // Minimal: no optional fields, no unfolded peaks.
+            RangeProof {
+                proof: proof.clone(),
+                pre_prefix_acc: None,
+                unfolded_prefix_peaks: vec![],
+                partial_chunk_digest: None,
+                ops_root,
+            },
+            // All optional fields populated, with unfolded peaks.
+            RangeProof {
+                proof,
+                pre_prefix_acc: Some(Sha256::hash(b"pre-prefix")),
+                unfolded_prefix_peaks: vec![Sha256::hash(b"u0"), Sha256::hash(b"u1")],
+                partial_chunk_digest: Some(Sha256::hash(b"partial")),
+                ops_root,
+            },
+            // Default proof with only partial chunk digest.
+            RangeProof {
+                proof: Proof::<F, sha256::Digest>::default(),
+                pre_prefix_acc: None,
+                unfolded_prefix_peaks: vec![],
+                partial_chunk_digest: Some(Sha256::hash(b"only-partial")),
+                ops_root,
+            },
+        ];
+
+        for proof in cases {
+            let encoded = proof.encode();
+            assert_eq!(encoded.len(), proof.encode_size());
+            let decoded =
+                RangeProof::<F, sha256::Digest>::decode_cfg(encoded, &MAX_DIGESTS).unwrap();
+            assert_eq!(decoded, proof);
+        }
+    }
+
+    #[test]
+    fn test_operation_proof_codec_roundtrip() {
+        type F = mmb::Family;
+        const N: usize = 32;
+        const MAX_DIGESTS: usize = 64;
+
+        let range_proof = RangeProof {
+            proof: Proof::<F, sha256::Digest> {
+                leaves: mmb::Location::new(7),
+                inactive_peaks: 0,
+                digests: vec![Sha256::hash(b"sib")],
+            },
+            pre_prefix_acc: Some(Sha256::hash(b"pre")),
+            unfolded_prefix_peaks: vec![Sha256::hash(b"peak")],
+            partial_chunk_digest: None,
+            ops_root: Sha256::hash(b"ops"),
+        };
+
+        let mut chunk = [0u8; N];
+        for (i, byte) in chunk.iter_mut().enumerate() {
+            *byte = i as u8;
+        }
+
+        let proof = OperationProof::<F, sha256::Digest, N> {
+            loc: mmb::Location::new(5),
+            chunk,
+            range_proof,
+        };
+
+        let encoded = proof.encode();
+        assert_eq!(encoded.len(), proof.encode_size());
+        let decoded =
+            OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded, &MAX_DIGESTS).unwrap();
+        assert_eq!(decoded, proof);
     }
 
     #[test_traced]

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -96,6 +96,19 @@ impl<D: Digest> Read for OpsRootWitness<D> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<D: Digest> arbitrary::Arbitrary<'_> for OpsRootWitness<D>
+where
+    D: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            grafted_root: u.arbitrary()?,
+            partial_chunk: u.arbitrary()?,
+        })
+    }
+}
+
 /// An inventory of all structural peaks for a Merkle-family tree, mapped linearly top-to-bottom
 /// relative to the bounds of a verified range proof.
 ///
@@ -927,9 +940,10 @@ impl<F: Family, D: Digest> EncodeSize for RangeProof<F, D> {
 }
 
 impl<F: Family, D: Digest> Read for RangeProof<F, D> {
-    /// The maximum number of digests in the proof, also used as the upper bound on the
-    /// number of unfolded prefix and suffix peaks (each itself bounded by the structural peak
-    /// count).
+    /// The maximum number of digests allowed in each digest vector.
+    ///
+    /// This is a per-field cap, not a total allocation budget across the whole range proof. It
+    /// bounds `proof.digests`, `unfolded_prefix_peaks`, and `unfolded_suffix_peaks` separately.
     type Cfg = usize;
 
     fn read_cfg(
@@ -947,6 +961,22 @@ impl<F: Family, D: Digest> Read for RangeProof<F, D> {
             unfolded_suffix_peaks,
             partial_chunk_digest,
             ops_root,
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<F: Family, D: Digest> arbitrary::Arbitrary<'_> for RangeProof<F, D>
+where
+    D: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            proof: u.arbitrary()?,
+            unfolded_prefix_peaks: u.arbitrary()?,
+            unfolded_suffix_peaks: u.arbitrary()?,
+            partial_chunk_digest: u.arbitrary()?,
+            ops_root: u.arbitrary()?,
         })
     }
 }
@@ -1040,7 +1070,7 @@ impl<F: Family, D: Digest, const N: usize> EncodeSize for OperationProof<F, D, N
 }
 
 impl<F: Family, D: Digest, const N: usize> Read for OperationProof<F, D, N> {
-    /// The maximum number of digests in the embedded range proof.
+    /// The per-field digest cap forwarded to the embedded range proof.
     type Cfg = usize;
 
     fn read_cfg(
@@ -1054,6 +1084,20 @@ impl<F: Family, D: Digest, const N: usize> Read for OperationProof<F, D, N> {
             loc,
             chunk,
             range_proof,
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<F: Family, D: Digest, const N: usize> arbitrary::Arbitrary<'_> for OperationProof<F, D, N>
+where
+    D: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            loc: u.arbitrary()?,
+            chunk: u.arbitrary()?,
+            range_proof: u.arbitrary()?,
         })
     }
 }
@@ -1862,5 +1906,21 @@ mod tests {
             let mut verify_hasher = Sha256::new();
             assert!(proof.verify(&mut verify_hasher, loc, &[element], &[chunk], &root));
         });
+    }
+
+    #[cfg(feature = "arbitrary")]
+    mod conformance {
+        use super::super::{OperationProof, OpsRootWitness, RangeProof};
+        use crate::merkle::{mmb, mmr};
+        use commonware_codec::conformance::CodecConformance;
+        use commonware_cryptography::sha256::Digest as Sha256Digest;
+
+        commonware_conformance::conformance_tests! {
+            CodecConformance<OpsRootWitness<Sha256Digest>>,
+            CodecConformance<RangeProof<mmr::Family, Sha256Digest>>,
+            CodecConformance<RangeProof<mmb::Family, Sha256Digest>>,
+            CodecConformance<OperationProof<mmr::Family, Sha256Digest, 32>>,
+            CodecConformance<OperationProof<mmb::Family, Sha256Digest, 32>>,
+        }
     }
 }

--- a/storage/src/qmdb/current/proof.rs
+++ b/storage/src/qmdb/current/proof.rs
@@ -948,9 +948,7 @@ impl<F: Family, D: Digest> Read for RangeProof<F, D> {
         max_digests: &Self::Cfg,
     ) -> Result<Self, commonware_codec::Error> {
         let proof = Proof::<F, D>::read_cfg(buf, max_digests)?;
-        let remaining = max_digests.checked_sub(proof.digests.len()).ok_or(
-            commonware_codec::Error::Invalid("RangeProof", "digest budget exceeded"),
-        )?;
+        let remaining = max_digests - proof.digests.len();
         let unfolded_prefix_peaks = Vec::<D>::read_range(buf, ..=remaining)?;
         let remaining = remaining - unfolded_prefix_peaks.len();
         let unfolded_suffix_peaks = Vec::<D>::read_range(buf, ..=remaining)?;


### PR DESCRIPTION
Resolves: https://github.com/commonwarexyz/monorepo/issues/3705