### PR TITLE
[Storage] Replace `BTreeSet`,  `HashSet`, `HashMap` with `AHashSet`, `AHashMap`

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1208,7 +1208,12 @@ where
         // Depth-1 chains skip the set entirely — a single ancestor can't shadow itself,
         // and each diff's keys are unique by construction.
         let track_shadow = m.ancestors.len() > 1;
-        let mut seen: AHashSet<&K> = AHashSet::new();
+        let seen_cap = if track_shadow {
+            m.ancestors.iter().map(|a| a.diff.len()).sum()
+        } else {
+            0
+        };
+        let mut seen: AHashSet<&K> = AHashSet::with_capacity(seen_cap);
         let mut ancestor_deleted: Vec<K> = Vec::new();
         for batch in m.ancestors.iter() {
             for (key, entry) in batch.diff.iter() {
@@ -1337,7 +1342,7 @@ where
         // Update predecessors of created and deleted keys.
         if !prev_candidates.is_empty() {
             // Safe to use a HashSet here since we don't rely on iteration order.
-            let mut rewritten_predecessors = AHashSet::new();
+            let mut rewritten_predecessors = AHashSet::with_capacity(created.len() + deleted.len());
             for key in created
                 .iter()
                 .map(|(k, _, _)| k)
@@ -1595,10 +1600,27 @@ where
         // Apply journal (handles its own partial ancestor skipping).
         self.log.apply_batch(&batch.journal_batch).await?;
 
+        // Pre-size the two hash collections used below in one pass over ancestors. Each
+        // ancestor's diff lands in exactly one of:
+        //   - `committed_locs`, if the ancestor's ops are already in the DB (`end <= db_size`)
+        //   - the `seen` set, if the ancestor's ops still need to be applied
+        let mut committed_diff_total = 0usize;
+        let mut uncommitted_diff_total = 0usize;
+        for (ancestor_diff, &ancestor_end) in
+            batch.ancestor_diffs.iter().zip(&batch.ancestor_diff_ends)
+        {
+            if ancestor_end <= db_size {
+                committed_diff_total += ancestor_diff.len();
+            } else {
+                uncommitted_diff_total += ancestor_diff.len();
+            }
+        }
+
         // Build committed_locs: for each key in a committed ancestor batch, record the nearest
         // (to child) committed ancestor's final state. Some(loc) = Active at loc, None =
         // Deleted. It's safe to use a hashmap here since we don't rely on iteration order.
-        let mut committed_locs: AHashMap<&U::Key, Option<Location<F>>> = AHashMap::new();
+        let mut committed_locs: AHashMap<&U::Key, Option<Location<F>>> =
+            AHashMap::with_capacity(committed_diff_total);
         for (i, ancestor_diff) in batch.ancestor_diffs.iter().enumerate() {
             if batch.ancestor_diff_ends[i] <= db_size {
                 for (key, entry) in ancestor_diff.iter() {
@@ -1615,7 +1637,8 @@ where
 
             // Apply child's diff (child wins via seen set). Safe to use an AHashSet here since
             // we don't rely on iteration order.
-            let mut seen = AHashSet::<&U::Key>::new();
+            let mut seen =
+                AHashSet::<&U::Key>::with_capacity(batch.diff.len() + uncommitted_diff_total);
             for (key, entry) in batch.diff.iter() {
                 seen.insert(key);
                 let base_old_loc = committed_locs

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     Context,
 };
+use ahash::{AHashMap, AHashSet};
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::{Sequential, Strategy};
@@ -28,7 +29,7 @@ use commonware_utils::bitmap;
 use core::{iter, ops::Range};
 use futures::future::try_join_all;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::BTreeMap,
     sync::{Arc, Weak},
 };
 use tracing::debug;
@@ -1198,15 +1199,16 @@ where
         // Add ancestor-diff keys that may be predecessors or successors of this batch's mutations
         // but are invisible to the base-DB-only `prev_translated_key` lookup above.
         //
-        // Walk ancestors closest-first; a BTreeSet tracks keys already seen so each key is
-        // processed only once (closest-ancestor's entry wins). BTreeSet is faster than HashMap
-        // for 32-byte Digest keys because Digest cmp (~5ns, SIMD) is cheaper than SipHash
-        // (~200ns) per op at the sizes involved.
+        // Walk ancestors closest-first; a set tracks keys already seen so each key is processed
+        // only once (closest-ancestor's entry wins). We use AHashSet (keyed per-process via
+        // runtime-rng) instead of std's default SipHash: ahash is DoS-resistant for adversarial
+        // inputs but several times faster on 32-byte Digest keys, where SipHash dominates over
+        // the actual probe.
         //
-        // Depth-1 chains skip the BTreeSet entirely — a single ancestor can't shadow itself,
+        // Depth-1 chains skip the set entirely — a single ancestor can't shadow itself,
         // and each diff's keys are unique by construction.
         let track_shadow = m.ancestors.len() > 1;
-        let mut seen: BTreeSet<&K> = BTreeSet::new();
+        let mut seen: AHashSet<&K> = AHashSet::new();
         let mut ancestor_deleted: Vec<K> = Vec::new();
         for batch in m.ancestors.iter() {
             for (key, entry) in batch.diff.iter() {
@@ -1335,7 +1337,7 @@ where
         // Update predecessors of created and deleted keys.
         if !prev_candidates.is_empty() {
             // Safe to use a HashSet here since we don't rely on iteration order.
-            let mut rewritten_predecessors = HashSet::new();
+            let mut rewritten_predecessors = AHashSet::new();
             for key in created
                 .iter()
                 .map(|(k, _, _)| k)
@@ -1596,7 +1598,7 @@ where
         // Build committed_locs: for each key in a committed ancestor batch, record the nearest
         // (to child) committed ancestor's final state. Some(loc) = Active at loc, None =
         // Deleted. It's safe to use a hashmap here since we don't rely on iteration order.
-        let mut committed_locs: HashMap<&U::Key, Option<Location<F>>> = HashMap::new();
+        let mut committed_locs: AHashMap<&U::Key, Option<Location<F>>> = AHashMap::new();
         for (i, ancestor_diff) in batch.ancestor_diffs.iter().enumerate() {
             if batch.ancestor_diff_ends[i] <= db_size {
                 for (key, entry) in ancestor_diff.iter() {
@@ -1611,9 +1613,9 @@ where
             let mut bitmap = self.bitmap.write();
             bitmap.extend_to(*batch.new_last_commit_loc + 1);
 
-            // Apply child's diff (child wins via seen set). Safe to use a HashSet here since we
-            // don't rely on iteration order.
-            let mut seen = HashSet::<&U::Key>::new();
+            // Apply child's diff (child wins via seen set). Safe to use an AHashSet here since
+            // we don't rely on iteration order.
+            let mut seen = AHashSet::<&U::Key>::new();
             for (key, entry) in batch.diff.iter() {
                 seen.insert(key);
                 let base_old_loc = committed_locs


### PR DESCRIPTION
Switch four hash-based sets/maps in `qmdb::any::batch` from std's default (SipHash) to `ahash::AHashMap`/`AHashSet`.

## Why ahash

`ahash::RandomState` seeds itself from OS entropy on process start (already enabled via `commonware-storage`'s `std` feature). Same DoS-resistance property as SipHash — an external attacker cannot predict the per-process secret — but several times faster on 32-byte digest inputs. `ahash` was already a workspace dependency, so no `Cargo.toml` change.

## Benchmarks

`qmdb::chained_growth` (`unordered` chunk=32) with params modified to `NUM_KEYS=100_000`, `UPDATES_PER_BATCH=10_000`, `PREBUILT_CHAIN=10`, `GROW_COUNTS=[10]`, sample_size=30:

| | mean | 95% CI |
|---|---|---|
| origin/main | 190.19 ms | 188.96 – 191.66 ms |
| HEAD | 176.21 ms | 175.04 – 177.68 ms |
| **Change** | **−7.35%** | −8.29% – −6.35% (p<0.001) |
