### PR TITLE
[storage/qmdb/current] Refactor current range proof planning

### DIFF
--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -7,7 +7,7 @@
 //! checkpoint and verifies that `init()` succeeds and the DB is usable.
 
 use arbitrary::{Arbitrary, Result, Unstructured};
-use commonware_cryptography::{Hasher as _, Sha256};
+use commonware_cryptography::Sha256;
 use commonware_parallel::Sequential;
 use commonware_runtime::{
     buffer::paged::CacheRef,
@@ -17,7 +17,10 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable, Location},
-    qmdb::current::{unordered::variable::Db as Current, VariableConfig},
+    qmdb::{
+        self,
+        current::{unordered::variable::Db as Current, VariableConfig},
+    },
     translator::TwoCap,
 };
 use commonware_utils::{sequence::FixedBytes, NZU64};
@@ -299,7 +302,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
             .await
             .expect("recovery must succeed");
 
-            let mut hasher = Sha256::new();
+            let hasher = qmdb::hasher::<Sha256>();
 
             // Verify all committed KV pairs survived the crash and are provable.
             let root = db.root();
@@ -315,11 +318,11 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 );
 
                 let proof = db
-                    .key_value_proof(&mut hasher, k.clone())
+                    .key_value_proof(&hasher, k.clone())
                     .await
                     .expect("proof generation should not fail for committed key");
                 assert!(
-                    Db::<F>::verify_key_value_proof(&mut hasher, k, v, &proof, &root),
+                    Db::<F>::verify_key_value_proof(&hasher, k, v, &proof, &root),
                     "key value proof failed to verify after crash recovery"
                 );
             }
@@ -330,11 +333,11 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
             for i in floor..size {
                 let loc = Location::<F>::new(i);
                 let (proof, ops, chunks) = db
-                    .range_proof(&mut hasher, loc, NZU64!(4))
+                    .range_proof(&hasher, loc, NZU64!(4))
                     .await
                     .expect("range proof should not fail after recovery");
                 assert!(
-                    Db::<F>::verify_range_proof(&mut hasher, &proof, loc, &ops, &chunks, &root),
+                    Db::<F>::verify_range_proof(&hasher, &proof, loc, &ops, &chunks, &root),
                     "range proof failed to verify after crash recovery at loc {loc}"
                 );
             }

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -1,13 +1,16 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
+use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_parallel::Sequential;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervisor as _};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable, Location},
-    qmdb::current::{ordered::fixed::Db as CurrentDb, FixedConfig as Config},
+    qmdb::{
+        self,
+        current::{ordered::fixed::Db as CurrentDb, FixedConfig as Config},
+    },
     translator::TwoCap,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
@@ -113,7 +116,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let suffix = suffix.to_string();
     let operations = data.operations.clone();
     runner.start(|context| async move {
-        let mut hasher = Sha256::new();
+        let hasher = qmdb::hasher::<Sha256>();
         let page_cache = CacheRef::from_pooler(
             &context,
             PAGE_SIZE,
@@ -251,13 +254,13 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     let oldest_loc = db.sync_boundary();
                     if start_loc >= oldest_loc {
                         let (proof, ops, chunks) = db
-                            .range_proof(&mut hasher, start_loc, *max_ops)
+                            .range_proof(&hasher, start_loc, *max_ops)
                             .await
                             .expect("Range proof should not fail");
 
                         assert!(
                             Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &proof,
                                 start_loc,
                                 &ops,
@@ -292,7 +295,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     let root = db.root();
 
                     if let Ok((range_proof, ops, chunks)) = db
-                        .range_proof(&mut hasher, start_loc, *max_ops)
+                        .range_proof(&hasher, start_loc, *max_ops)
                         .await {
                         // Try to verify the proof when providing bad proof digests.
                         let bad_digests = bad_digests.iter().map(|d| Digest::from(*d)).collect();
@@ -300,7 +303,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_proof = range_proof.clone();
                             bad_proof.proof.digests = bad_digests;
                             assert!(!Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &bad_proof,
                                 start_loc,
                                 &ops,
@@ -312,7 +315,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         // Try to verify the proof when providing bad input chunks.
                         if &chunks != bad_chunks {
                             assert!(!Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &range_proof,
                                 start_loc,
                                 &ops,
@@ -323,11 +326,11 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
 
                         let bad_prefix_peaks =
                             bad_prefix_peaks.iter().map(|d| Digest::from(*d)).collect();
-                        if range_proof.unfolded_prefix_peaks != bad_prefix_peaks {
+                        if range_proof.prefix_witnesses != bad_prefix_peaks {
                             let mut bad_proof = range_proof.clone();
-                            bad_proof.unfolded_prefix_peaks = bad_prefix_peaks;
+                            bad_proof.prefix_witnesses = bad_prefix_peaks;
                             assert!(!Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &bad_proof,
                                 start_loc,
                                 &ops,
@@ -338,11 +341,11 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
 
                         let bad_suffix_peaks =
                             bad_suffix_peaks.iter().map(|d| Digest::from(*d)).collect();
-                        if range_proof.unfolded_suffix_peaks != bad_suffix_peaks {
+                        if range_proof.suffix_witnesses != bad_suffix_peaks {
                             let mut bad_proof = range_proof.clone();
-                            bad_proof.unfolded_suffix_peaks = bad_suffix_peaks;
+                            bad_proof.suffix_witnesses = bad_suffix_peaks;
                             assert!(!Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &bad_proof,
                                 start_loc,
                                 &ops,
@@ -363,11 +366,11 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     committed_op_count = db.bounds().await.end;
                     let current_root = db.root();
 
-                    match db.key_value_proof(&mut hasher, k.clone()).await {
+                    match db.key_value_proof(&hasher, k.clone()).await {
                         Ok(proof) => {
                             let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
                             let verification_result = Db::<F>::verify_key_value_proof(
-                                &mut hasher,
+                                &hasher,
                                 k,
                                 value,
                                 &proof,
@@ -394,10 +397,10 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     committed_op_count = db.bounds().await.end;
                     let current_root = db.root();
 
-                    match db.exclusion_proof(&mut hasher, &k).await {
+                    match db.exclusion_proof(&hasher, &k).await {
                         Ok(proof) => {
                             let verification_result = Db::<F>::verify_exclusion_proof(
-                                &mut hasher,
+                                &hasher,
                                 &k,
                                 &proof,
                                 &current_root,

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -1,13 +1,16 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
+use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_parallel::Sequential;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervisor as _};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable, Location},
-    qmdb::current::{unordered::fixed::Db as CurrentDb, FixedConfig as Config},
+    qmdb::{
+        self,
+        current::{unordered::fixed::Db as CurrentDb, FixedConfig as Config},
+    },
     translator::TwoCap,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
@@ -103,7 +106,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let suffix = suffix.to_string();
     let operations = data.operations.clone();
     runner.start(|context| async move {
-        let mut hasher = Sha256::new();
+        let hasher = qmdb::hasher::<Sha256>();
         let page_cache = CacheRef::from_pooler(
             &context,
             PAGE_SIZE,
@@ -226,13 +229,13 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     let oldest_loc = db.sync_boundary();
                     if start_loc >= oldest_loc {
                         let (proof, ops, chunks) = db
-                            .range_proof(&mut hasher, start_loc, *max_ops)
+                            .range_proof(&hasher, start_loc, *max_ops)
                             .await
                             .expect("Range proof should not fail");
 
                         assert!(
                             Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &proof,
                                 start_loc,
                                 &ops,
@@ -264,7 +267,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     let root = db.root();
 
                     if let Ok((range_proof, ops, chunks)) = db
-                        .range_proof(&mut hasher, start_loc, *max_ops)
+                        .range_proof(&hasher, start_loc, *max_ops)
                         .await {
                         // Try to verify the proof when providing bad proof digests.
                         let bad_digests = bad_digests.iter().map(|d| Digest::from(*d)).collect();
@@ -272,7 +275,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_proof = range_proof.clone();
                             bad_proof.proof.digests = bad_digests;
                             assert!(!Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &bad_proof,
                                 start_loc,
                                 &ops,
@@ -284,7 +287,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         // Try to verify the proof when providing bad input chunks.
                         if &chunks != bad_chunks {
                             assert!(!Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &range_proof,
                                 start_loc,
                                 &ops,
@@ -295,11 +298,11 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
 
                         let bad_prefix_peaks =
                             bad_prefix_peaks.iter().map(|d| Digest::from(*d)).collect();
-                        if range_proof.unfolded_prefix_peaks != bad_prefix_peaks {
+                        if range_proof.prefix_witnesses != bad_prefix_peaks {
                             let mut bad_proof = range_proof.clone();
-                            bad_proof.unfolded_prefix_peaks = bad_prefix_peaks;
+                            bad_proof.prefix_witnesses = bad_prefix_peaks;
                             assert!(!Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &bad_proof,
                                 start_loc,
                                 &ops,
@@ -310,11 +313,11 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
 
                         let bad_suffix_peaks =
                             bad_suffix_peaks.iter().map(|d| Digest::from(*d)).collect();
-                        if range_proof.unfolded_suffix_peaks != bad_suffix_peaks {
+                        if range_proof.suffix_witnesses != bad_suffix_peaks {
                             let mut bad_proof = range_proof.clone();
-                            bad_proof.unfolded_suffix_peaks = bad_suffix_peaks;
+                            bad_proof.suffix_witnesses = bad_suffix_peaks;
                             assert!(!Db::<F>::verify_range_proof(
-                                &mut hasher,
+                                &hasher,
                                 &bad_proof,
                                 start_loc,
                                 &ops,
@@ -332,11 +335,11 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     committed_op_count = db.bounds().await.end;
                     let current_root = db.root();
 
-                    match db.key_value_proof(&mut hasher, k.clone()).await {
+                    match db.key_value_proof(&hasher, k.clone()).await {
                         Ok(proof) => {
                             let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
                             let verification_result = Db::<F>::verify_key_value_proof(
-                                &mut hasher,
+                                &hasher,
                                 k,
                                 value,
                                 &proof,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -123,7 +123,7 @@ where
     /// Return true if the given sequence of `ops` were applied starting at location `start_loc`
     /// in the log with the provided `root`, having the activity status described by `chunks`.
     pub fn verify_range_proof(
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         proof: &RangeProof<F, H::Digest>,
         start_loc: Location<F>,
         ops: &[Operation<F, U>],
@@ -188,7 +188,7 @@ where
     /// This can be used to authenticate an ops root against a trusted canonical `current` root.
     pub async fn ops_root_witness(
         &self,
-        hasher: &mut StandardHasher<H>,
+        hasher: &StandardHasher<H>,
     ) -> Result<OpsRootWitness<H::Digest>, Error<F>> {
         let storage = self.grafted_storage();
         let grafted_root = compute_grafted_root::<F, H, _, _, N>(
@@ -226,7 +226,7 @@ where
     /// Returns a proof for the operation at `loc`.
     pub(super) async fn operation_proof(
         &self,
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         loc: Location<F>,
     ) -> Result<OperationProof<F, H::Digest, N>, Error<F>> {
         let storage = self.grafted_storage();
@@ -255,7 +255,7 @@ where
     /// `start_loc` >= number of leaves in the tree.
     pub async fn range_proof(
         &self,
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         start_loc: Location<F>,
         max_ops: NonZeroU64,
     ) -> Result<(RangeProof<F, H::Digest>, Vec<Operation<F, U>>, Vec<[u8; N]>), Error<F>> {
@@ -1166,23 +1166,23 @@ mod tests {
                 next_idx += 1;
             }
 
-            let mut hasher = qmdb::hasher::<Sha256>();
-            let witness = db.ops_root_witness(&mut hasher).await.unwrap();
+            let hasher = qmdb::hasher::<Sha256>();
+            let witness = db.ops_root_witness(&hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
 
             assert!(witness.partial_chunk.is_none());
-            assert!(witness.verify(&mut hasher, &ops_root, &canonical_root));
+            assert!(witness.verify(&hasher, &ops_root, &canonical_root));
 
             let wrong_ops_root = Sha256::hash(b"wrong ops root");
-            assert!(!witness.verify(&mut hasher, &wrong_ops_root, &canonical_root));
+            assert!(!witness.verify(&hasher, &wrong_ops_root, &canonical_root));
 
             let wrong_canonical_root = Sha256::hash(b"wrong canonical root");
-            assert!(!witness.verify(&mut hasher, &ops_root, &wrong_canonical_root));
+            assert!(!witness.verify(&hasher, &ops_root, &wrong_canonical_root));
 
             let mut tampered = witness;
             tampered.grafted_root = Sha256::hash(b"wrong grafted root");
-            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
         });
     }
 
@@ -1198,31 +1198,31 @@ mod tests {
             .unwrap();
             populate_fixed_db::<mmb::Family, _>(&mut db, 0, 260).await;
 
-            let mut hasher = qmdb::hasher::<Sha256>();
-            let witness = db.ops_root_witness(&mut hasher).await.unwrap();
+            let hasher = qmdb::hasher::<Sha256>();
+            let witness = db.ops_root_witness(&hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
 
             assert!(witness.partial_chunk.is_some());
-            assert!(witness.verify(&mut hasher, &ops_root, &canonical_root));
+            assert!(witness.verify(&hasher, &ops_root, &canonical_root));
 
             let wrong_ops_root = Sha256::hash(b"wrong ops root");
-            assert!(!witness.verify(&mut hasher, &wrong_ops_root, &canonical_root));
+            assert!(!witness.verify(&hasher, &wrong_ops_root, &canonical_root));
 
             let wrong_canonical_root = Sha256::hash(b"wrong canonical root");
-            assert!(!witness.verify(&mut hasher, &ops_root, &wrong_canonical_root));
+            assert!(!witness.verify(&hasher, &ops_root, &wrong_canonical_root));
 
             let mut tampered = witness.clone();
             tampered.grafted_root = Sha256::hash(b"wrong grafted root");
-            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
 
             let mut tampered = witness.clone();
             tampered.partial_chunk.as_mut().unwrap().0 += 1;
-            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
 
             let mut tampered = witness;
             tampered.partial_chunk.as_mut().unwrap().1 = Sha256::hash(b"wrong partial chunk");
-            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
         });
     }
 
@@ -1247,19 +1247,19 @@ mod tests {
                 "test requires at least one pruned chunk to exercise the zero-chunk path"
             );
 
-            let mut hasher = qmdb::hasher::<Sha256>();
-            let witness = db.ops_root_witness(&mut hasher).await.unwrap();
+            let hasher = qmdb::hasher::<Sha256>();
+            let witness = db.ops_root_witness(&hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
 
-            assert!(witness.verify(&mut hasher, &ops_root, &canonical_root));
+            assert!(witness.verify(&hasher, &ops_root, &canonical_root));
 
             let wrong_canonical_root = Sha256::hash(b"wrong canonical root");
-            assert!(!witness.verify(&mut hasher, &ops_root, &wrong_canonical_root));
+            assert!(!witness.verify(&hasher, &ops_root, &wrong_canonical_root));
 
             let mut tampered = witness;
             tampered.grafted_root = Sha256::hash(b"wrong grafted root");
-            assert!(!tampered.verify(&mut hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
         });
     }
 
@@ -1274,12 +1274,12 @@ mod tests {
             .await
             .unwrap();
 
-            let mut hasher = qmdb::hasher::<Sha256>();
-            let witness = db.ops_root_witness(&mut hasher).await.unwrap();
+            let hasher = qmdb::hasher::<Sha256>();
+            let witness = db.ops_root_witness(&hasher).await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
 
-            assert!(witness.verify(&mut hasher, &ops_root, &canonical_root));
+            assert!(witness.verify(&hasher, &ops_root, &canonical_root));
         });
     }
 }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -22,7 +22,7 @@ use crate::{
         current::{
             batch::BitmapBatch,
             grafting,
-            proof::{OperationProof, OpsRootWitness, RangeProof},
+            proof::{OperationProof, OpsRootWitness, RangeProof, RangeProofSpec},
         },
         operation::Operation as _,
         Error,
@@ -265,11 +265,13 @@ where
             hasher,
             self.any.bitmap.as_ref(),
             &storage,
-            self.any.inactivity_floor_loc,
             &self.any.log,
-            start_loc,
-            max_ops,
-            ops_root,
+            RangeProofSpec {
+                start_loc,
+                max_ops,
+                inactivity_floor: self.any.inactivity_floor_loc,
+                ops_root,
+            },
         )
         .await
     }

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1743,8 +1743,8 @@ pub mod tests {
             assert_eq!(reopened.get(&k).await.unwrap(), expected);
 
             // key_value_proof: RangeProof::new must also handle pruned chunk 0.
-            let mut hasher = commonware_cryptography::Sha256::new();
-            let _proof = reopened.key_value_proof(&mut hasher, k).await.unwrap();
+            let hasher = crate::qmdb::hasher::<Sha256>();
+            let _proof = reopened.key_value_proof(&hasher, k).await.unwrap();
 
             reopened.destroy().await.unwrap();
         });
@@ -1984,10 +1984,10 @@ pub mod tests {
                 mmb_commit(&mut db, [(key(1), Some(val(round)))]).await;
             }
 
-            let mut hasher = commonware_cryptography::Sha256::new();
-            let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+            let hasher = crate::qmdb::hasher::<Sha256>();
+            let proof = db.key_value_proof(&hasher, k).await.unwrap();
             assert!(UnorderedVariableMmbDb::verify_key_value_proof(
-                &mut hasher,
+                &hasher,
                 k,
                 val(60_000 + 199),
                 &proof,
@@ -2007,10 +2007,10 @@ pub mod tests {
 
             assert_eq!(reopened.root(), target_root);
 
-            let mut hasher = commonware_cryptography::Sha256::new();
-            let proof = reopened.key_value_proof(&mut hasher, k).await.unwrap();
+            let hasher = crate::qmdb::hasher::<Sha256>();
+            let proof = reopened.key_value_proof(&hasher, k).await.unwrap();
             assert!(UnorderedVariableMmbDb::verify_key_value_proof(
-                &mut hasher,
+                &hasher,
                 k,
                 val(60_000 + 199),
                 &proof,
@@ -2234,11 +2234,11 @@ pub mod tests {
                     "root mismatch after prune at round {round}"
                 );
 
-                let mut hasher = commonware_cryptography::Sha256::new();
-                let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+                let hasher = crate::qmdb::hasher::<Sha256>();
+                let proof = db.key_value_proof(&hasher, k).await.unwrap();
                 assert!(
                     UnorderedVariableMmbDb::verify_key_value_proof(
-                        &mut hasher,
+                        &hasher,
                         k,
                         expected.expect("value should exist"),
                         &proof,
@@ -2267,11 +2267,11 @@ pub mod tests {
                     "value mismatch after reopen at round {round}"
                 );
 
-                let mut hasher = commonware_cryptography::Sha256::new();
-                let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+                let hasher = crate::qmdb::hasher::<Sha256>();
+                let proof = db.key_value_proof(&hasher, k).await.unwrap();
                 assert!(
                     UnorderedVariableMmbDb::verify_key_value_proof(
-                        &mut hasher,
+                        &hasher,
                         k,
                         expected.expect("value should exist"),
                         &proof,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1743,7 +1743,7 @@ pub mod tests {
             assert_eq!(reopened.get(&k).await.unwrap(), expected);
 
             // key_value_proof: RangeProof::new must also handle pruned chunk 0.
-            let hasher = crate::qmdb::hasher::<Sha256>();
+            let hasher = qmdb::hasher::<Sha256>();
             let _proof = reopened.key_value_proof(&hasher, k).await.unwrap();
 
             reopened.destroy().await.unwrap();
@@ -1984,7 +1984,7 @@ pub mod tests {
                 mmb_commit(&mut db, [(key(1), Some(val(round)))]).await;
             }
 
-            let hasher = crate::qmdb::hasher::<Sha256>();
+            let hasher = qmdb::hasher::<Sha256>();
             let proof = db.key_value_proof(&hasher, k).await.unwrap();
             assert!(UnorderedVariableMmbDb::verify_key_value_proof(
                 &hasher,
@@ -2007,7 +2007,7 @@ pub mod tests {
 
             assert_eq!(reopened.root(), target_root);
 
-            let hasher = crate::qmdb::hasher::<Sha256>();
+            let hasher = qmdb::hasher::<Sha256>();
             let proof = reopened.key_value_proof(&hasher, k).await.unwrap();
             assert!(UnorderedVariableMmbDb::verify_key_value_proof(
                 &hasher,
@@ -2234,7 +2234,7 @@ pub mod tests {
                     "root mismatch after prune at round {round}"
                 );
 
-                let hasher = crate::qmdb::hasher::<Sha256>();
+                let hasher = qmdb::hasher::<Sha256>();
                 let proof = db.key_value_proof(&hasher, k).await.unwrap();
                 assert!(
                     UnorderedVariableMmbDb::verify_key_value_proof(
@@ -2267,7 +2267,7 @@ pub mod tests {
                     "value mismatch after reopen at round {round}"
                 );
 
-                let hasher = crate::qmdb::hasher::<Sha256>();
+                let hasher = qmdb::hasher::<Sha256>();
                 let proof = db.key_value_proof(&hasher, k).await.unwrap();
                 assert!(
                     UnorderedVariableMmbDb::verify_key_value_proof(

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -6,7 +6,7 @@
 use crate::{
     index::Ordered as OrderedIndex,
     journal::contiguous::{Contiguous, Mutable, Reader},
-    merkle::{self, Location},
+    merkle::{self, hasher::Standard as StandardHasher, Location},
     qmdb::{
         any::{
             ordered::{Operation, Update},
@@ -106,7 +106,7 @@ where
     /// Return true if the proof authenticates that `key` currently has value `value` in the db with
     /// the provided `root`.
     pub fn verify_key_value_proof(
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         key: K,
         value: V::Value,
         proof: &KeyValueProof<F, K, H::Digest, N>,
@@ -142,7 +142,7 @@ where
     /// Return true if the proof authenticates that `key` does _not_ exist in the db with the
     /// provided `root`.
     pub fn verify_exclusion_proof(
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         key: &K,
         proof: &super::ExclusionProof<F, K, V, H::Digest, N>,
         root: &H::Digest,
@@ -204,7 +204,7 @@ where
     /// Returns [Error::KeyNotFound] if the key is not currently assigned any value.
     pub async fn key_value_proof(
         &self,
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         key: K,
     ) -> Result<KeyValueProof<F, K, H::Digest, N>, Error<F>> {
         let op_loc = self.any.get_with_loc(&key).await?;
@@ -226,7 +226,7 @@ where
     /// Returns [Error::KeyExists] if the key exists in the db.
     pub async fn exclusion_proof(
         &self,
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         key: &K,
     ) -> Result<super::ExclusionProof<F, K, V, H::Digest, N>, Error<F>> {
         match self.any.get_span(key).await? {

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -144,7 +144,7 @@ pub mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let partition = "range-proofs-pruned".to_string();
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let mut db = open_db(context.child("db"), partition).await;
 
             let chunk_bits = BitMap::<32>::CHUNK_SIZE_BITS;
@@ -173,9 +173,7 @@ pub mod test {
 
             // Requesting a range proof at location 0 (in the pruned range) should return
             // OperationPruned, not panic.
-            let result = db
-                .range_proof(&mut hasher, Location::new(0), NZU64!(1))
-                .await;
+            let result = db.range_proof(&hasher, Location::new(0), NZU64!(1)).await;
             assert!(
                 matches!(result, Err(Error::OperationPruned(_))),
                 "expected OperationPruned, got {result:?}"

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -302,7 +302,7 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "build-small".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -318,32 +318,24 @@ pub mod tests {
             db.apply_batch(merkleized).await.unwrap();
 
             let (_, op_loc) = db.any.get_with_loc(&k).await.unwrap().unwrap();
-            let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+            let proof = db.key_value_proof(&hasher, k).await.unwrap();
 
             // Proof should be verifiable against current root.
             let root = db.root();
             assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v1,
-                &proof,
-                &root,
+                &hasher, k, v1, &proof, &root,
             ));
 
             let v2 = Sha256::fill(0xA2);
             // Proof should not verify against a different value.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v2,
-                &proof,
-                &root,
+                &hasher, k, v2, &proof, &root,
             ));
             // Proof should not verify against a mangled next_key.
             let mut mangled_proof = proof.clone();
             mangled_proof.next_key = Sha256::fill(0xFF);
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
+                &hasher,
                 k,
                 v1,
                 &mangled_proof,
@@ -362,38 +354,23 @@ pub mod tests {
 
             // New value should not be verifiable against the old proof.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v2,
-                &proof,
-                &root,
+                &hasher, k, v2, &proof, &root,
             ));
 
             // But the new value should verify against a new proof.
-            let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+            let proof = db.key_value_proof(&hasher, k).await.unwrap();
             assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v2,
-                &proof,
-                &root,
+                &hasher, k, v2, &proof, &root,
             ));
 
             // Old value will not verify against new proof.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v1,
-                &proof,
-                &root,
+                &hasher, k, v1, &proof, &root,
             ));
 
             // Create a proof of the now-inactive update operation assigning v1 to k against the
             // current root.
-            let (p, _, chunks) = db
-                .range_proof(&mut hasher, op_loc, NZU64!(1))
-                .await
-                .unwrap();
+            let (p, _, chunks) = db.range_proof(&hasher, op_loc, NZU64!(1)).await.unwrap();
             let proof_inactive = db::KeyValueProof {
                 proof: crate::qmdb::current::proof::OperationProof {
                     loc: op_loc,
@@ -410,7 +387,7 @@ pub mod tests {
                 next_key: k,
             });
             assert!(TestDb::<F, C, V>::verify_range_proof(
-                &mut hasher,
+                &hasher,
                 &proof_inactive.proof.range_proof,
                 proof_inactive.proof.loc,
                 &[op],
@@ -421,7 +398,7 @@ pub mod tests {
             // But this proof should *not* verify as a key value proof, since verification will see
             // that the operation is inactive.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
+                &hasher,
                 k,
                 v1,
                 &proof_inactive,
@@ -441,7 +418,7 @@ pub mod tests {
             let mut fake_proof = proof_inactive.clone();
             fake_proof.proof.loc = active_loc;
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
+                &hasher,
                 k,
                 v1,
                 &fake_proof,
@@ -461,7 +438,7 @@ pub mod tests {
             let mut fake_proof = proof_inactive.clone();
             fake_proof.proof.chunk = modified_chunk;
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
+                &hasher,
                 k,
                 v1,
                 &fake_proof,
@@ -489,20 +466,20 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let db = open_db(context.child("db"), partition.clone()).await;
             let root = db.root();
 
             // Empty range proof should not crash or verify, since even an empty db has a single
             let proof = RangeProof {
                 proof: Proof::default(),
-                unfolded_prefix_peaks: vec![],
-                unfolded_suffix_peaks: vec![],
+                prefix_witnesses: vec![],
+                suffix_witnesses: vec![],
                 partial_chunk_digest: None,
                 ops_root: Digest::EMPTY,
             };
             assert!(!TestDb::<F, C, V>::verify_range_proof(
-                &mut hasher,
+                &hasher,
                 &proof,
                 Location::<F>::new(0),
                 &[],
@@ -525,18 +502,11 @@ pub mod tests {
 
             for loc in *start_loc..*end_loc {
                 let loc = Location::<F>::new(loc);
-                let (proof, ops, chunks) = db
-                    .range_proof(&mut hasher, loc, NZU64!(max_ops))
-                    .await
-                    .unwrap();
+                let (proof, ops, chunks) =
+                    db.range_proof(&hasher, loc, NZU64!(max_ops)).await.unwrap();
                 assert!(
                     TestDb::<F, C, V>::verify_range_proof(
-                        &mut hasher,
-                        &proof,
-                        loc,
-                        &ops,
-                        &chunks,
-                        &root
+                        &hasher, &proof, loc, &ops, &chunks, &root
                     ),
                     "failed to verify range at start_loc {start_loc}",
                 );
@@ -544,7 +514,7 @@ pub mod tests {
                 let mut chunks_with_extra = chunks.clone();
                 chunks_with_extra.push(chunks[chunks.len() - 1]);
                 assert!(!TestDb::<F, C, V>::verify_range_proof(
-                    &mut hasher,
+                    &hasher,
                     &proof,
                     loc,
                     &ops,
@@ -574,7 +544,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let db = open_db(context.child("db"), partition.clone()).await;
             let mut db = apply_random_ops::<F, TestDb<F, C, V>>(500, true, context.next_u64(), db)
                 .await
@@ -585,7 +555,7 @@ pub mod tests {
 
             // Confirm bad keys produce the expected error.
             let bad_key = Sha256::fill(0xAA);
-            let res = db.key_value_proof(&mut hasher, bad_key).await;
+            let res = db.key_value_proof(&hasher, bad_key).await;
             assert!(matches!(res, Err(Error::KeyNotFound)));
 
             let start = *db.inactivity_floor_loc();
@@ -601,40 +571,28 @@ pub mod tests {
                     Operation::CommitFloor(_, _) => continue,
                     _ => unreachable!("expected update or commit floor operation"),
                 };
-                let proof = db.key_value_proof(&mut hasher, key).await.unwrap();
+                let proof = db.key_value_proof(&hasher, key).await.unwrap();
 
                 // Proof should validate against the current value and correct root.
                 assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                    &mut hasher,
-                    key,
-                    value,
-                    &proof,
-                    &root
+                    &hasher, key, value, &proof, &root
                 ));
                 // Proof should fail against the wrong value. Use hash instead of fill to ensure
                 // the value differs from any key/value created by TestKey::from_seed (which uses
                 // fill patterns).
                 let wrong_val = Sha256::hash(&[0xFF]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &mut hasher,
-                    key,
-                    wrong_val,
-                    &proof,
-                    &root
+                    &hasher, key, wrong_val, &proof, &root
                 ));
                 // Proof should fail against the wrong key.
                 let wrong_key = Sha256::hash(&[0xEE]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &mut hasher,
-                    wrong_key,
-                    value,
-                    &proof,
-                    &root
+                    &hasher, wrong_key, value, &proof, &root
                 ));
                 // Proof should fail against the wrong root.
                 let wrong_root = Sha256::hash(&[0xDD]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &mut hasher,
+                    &hasher,
                     key,
                     value,
                     &proof,
@@ -644,11 +602,7 @@ pub mod tests {
                 let mut bad_proof = proof.clone();
                 bad_proof.next_key = wrong_key;
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &mut hasher,
-                    key,
-                    value,
-                    &bad_proof,
-                    &root,
+                    &hasher, key, value, &bad_proof, &root,
                 ));
             }
 
@@ -672,7 +626,7 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "build-small".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -692,20 +646,14 @@ pub mod tests {
                 let root = db.root();
 
                 // Create a proof for the current value of k.
-                let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+                let proof = db.key_value_proof(&hasher, k).await.unwrap();
                 assert!(
-                    TestDb::<F, C, V>::verify_key_value_proof(&mut hasher, k, v, &proof, &root),
+                    TestDb::<F, C, V>::verify_key_value_proof(&hasher, k, v, &proof, &root),
                     "proof of update {i} failed to verify"
                 );
                 // Ensure the proof does NOT verify if we use the previous value.
                 assert!(
-                    !TestDb::<F, C, V>::verify_key_value_proof(
-                        &mut hasher,
-                        k,
-                        old_val,
-                        &proof,
-                        &root,
-                    ),
+                    !TestDb::<F, C, V>::verify_key_value_proof(&hasher, k, old_val, &proof, &root,),
                     "proof of update {i} verified when it should not have"
                 );
                 old_val = v;
@@ -732,7 +680,7 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "exclusion-proofs".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -740,12 +688,9 @@ pub mod tests {
 
             // We should be able to prove exclusion for any key against an empty db.
             let empty_root = db.root();
-            let empty_proof = db
-                .exclusion_proof(&mut hasher, &key_exists_1)
-                .await
-                .unwrap();
+            let empty_proof = db.exclusion_proof(&hasher, &key_exists_1).await.unwrap();
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &key_exists_1,
                 &empty_proof,
                 &empty_root,
@@ -763,34 +708,34 @@ pub mod tests {
             let root = db.root();
 
             // We shouldn't be able to generate an exclusion proof for a key already in the db.
-            let result = db.exclusion_proof(&mut hasher, &key_exists_1).await;
+            let result = db.exclusion_proof(&hasher, &key_exists_1).await;
             assert!(matches!(result, Err(Error::KeyExists)));
 
             // Generate some valid exclusion proofs for keys on either side.
             let greater_key = Sha256::fill(0xFF);
             let lesser_key = Sha256::fill(0x00);
-            let proof = db.exclusion_proof(&mut hasher, &greater_key).await.unwrap();
-            let proof2 = db.exclusion_proof(&mut hasher, &lesser_key).await.unwrap();
+            let proof = db.exclusion_proof(&hasher, &greater_key).await.unwrap();
+            let proof2 = db.exclusion_proof(&hasher, &lesser_key).await.unwrap();
 
             // Since there's only one span in the DB, the two exclusion proofs should be identical,
             // and the proof should verify any key but the one that exists in the db.
             assert_eq!(proof, proof2);
             // Any key except the one that exists should verify against this proof.
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &greater_key,
                 &proof,
                 &root,
             ));
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &lesser_key,
                 &proof,
                 &root,
             ));
             // Exclusion should fail if we test it on a key that exists.
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &key_exists_1,
                 &proof,
                 &root,
@@ -814,50 +759,50 @@ pub mod tests {
             let lesser_key = Sha256::fill(0x0F); // < k1=0x10
             let greater_key = Sha256::fill(0x31); // > k2=0x30
             let middle_key = Sha256::fill(0x20); // between k1=0x10 and k2=0x30
-            let proof = db.exclusion_proof(&mut hasher, &greater_key).await.unwrap();
+            let proof = db.exclusion_proof(&hasher, &greater_key).await.unwrap();
             // Test the "cycle around" span. This should prove exclusion of greater_key & lesser
             // key, but fail on middle_key.
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &greater_key,
                 &proof,
                 &root,
             ));
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &lesser_key,
                 &proof,
                 &root,
             ));
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &middle_key,
                 &proof,
                 &root,
             ));
 
             // Due to the cycle, lesser & greater keys should produce the same proof.
-            let new_proof = db.exclusion_proof(&mut hasher, &lesser_key).await.unwrap();
+            let new_proof = db.exclusion_proof(&hasher, &lesser_key).await.unwrap();
             assert_eq!(proof, new_proof);
 
             // Test the inner span [k, k2).
-            let proof = db.exclusion_proof(&mut hasher, &middle_key).await.unwrap();
+            let proof = db.exclusion_proof(&hasher, &middle_key).await.unwrap();
             // `k` should fail since it's in the db.
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &key_exists_1,
                 &proof,
                 &root,
             ));
             // `middle_key` should succeed since it's in range.
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &middle_key,
                 &proof,
                 &root,
             ));
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &key_exists_2,
                 &proof,
                 &root,
@@ -865,7 +810,7 @@ pub mod tests {
 
             let conflicting_middle_key = Sha256::fill(0x11); // between k1=0x10 and k2=0x30
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &conflicting_middle_key,
                 &proof,
                 &root,
@@ -873,13 +818,13 @@ pub mod tests {
 
             // Using lesser/greater keys for the middle-proof should fail.
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &greater_key,
                 &proof,
                 &root,
             ));
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &lesser_key,
                 &proof,
                 &root,
@@ -903,18 +848,15 @@ pub mod tests {
             assert_ne!(db.bounds().await.end, 0);
             assert_ne!(root, empty_root);
 
-            let proof = db
-                .exclusion_proof(&mut hasher, &key_exists_1)
-                .await
-                .unwrap();
+            let proof = db.exclusion_proof(&hasher, &key_exists_1).await.unwrap();
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &key_exists_1,
                 &proof,
                 &root,
             ));
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &key_exists_2,
                 &proof,
                 &root,
@@ -922,13 +864,13 @@ pub mod tests {
 
             // Try fooling the verifier with improper values.
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &key_exists_1,
                 &empty_proof, // wrong proof
                 &root,
             ));
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &mut hasher,
+                &hasher,
                 &key_exists_1,
                 &proof,
                 &empty_root, // wrong root
@@ -943,8 +885,8 @@ pub mod tests {
                 inactive_peaks: 0,
                 digests: vec![Sha256::hash(b"sib")],
             },
-            unfolded_prefix_peaks: vec![Sha256::hash(b"peak")],
-            unfolded_suffix_peaks: vec![Sha256::hash(b"suf")],
+            prefix_witnesses: vec![Sha256::hash(b"peak")],
+            suffix_witnesses: vec![Sha256::hash(b"suf")],
             partial_chunk_digest: None,
             ops_root: Sha256::hash(b"ops"),
         };
@@ -958,8 +900,8 @@ pub mod tests {
 
     fn op_proof_digest_count(proof: &OperationProof<mmb::Family, Digest, 32>) -> usize {
         proof.range_proof.proof.digests.len()
-            + proof.range_proof.unfolded_prefix_peaks.len()
-            + proof.range_proof.unfolded_suffix_peaks.len()
+            + proof.range_proof.prefix_witnesses.len()
+            + proof.range_proof.suffix_witnesses.len()
     }
 
     type CodecExclusionProof =

--- a/storage/src/qmdb/current/proof/geometry.rs
+++ b/storage/src/qmdb/current/proof/geometry.rs
@@ -1,0 +1,261 @@
+//! Geometry helpers for range proofs over grafted current trees.
+//!
+//! The proof format starts from ops-tree peaks, but the current root commits to bitmap chunks
+//! grafted onto those ops-tree digests. This module keeps track of where the proven operation range
+//! falls among the ops-tree peaks and which boundary peaks must stay unfolded so verification can
+//! regroup them by complete grafted chunk.
+
+use crate::merkle::{self, Family, Graftable, Location, Position};
+use core::ops::Range;
+
+/// An inventory of current ops-tree peaks, paired with their heights, from oldest to youngest
+/// relative to the bounds of a range proof. Every peak is assigned to exactly one of three
+/// sequential layout regions: before the operation range, overlapping the operation range, or
+/// after the operation range.
+struct PeakLayout<F: Family> {
+    /// Ops-tree peaks whose leaves all precede the operation range's starting location.
+    prefix: Vec<(Position<F>, u32)>,
+    /// Ops-tree peaks whose leaves intersect the operation range.
+    range: Vec<(Position<F>, u32)>,
+    /// Ops-tree peaks whose leaves all follow the operation range's ending location.
+    after: Vec<(Position<F>, u32)>,
+}
+
+/// Return the number of leaves covered by `peaks`.
+pub(super) fn covered_leaves<F: Family>(peaks: &[(Position<F>, u32)]) -> u64 {
+    peaks
+        .iter()
+        .fold(0u64, |acc, (_pos, height)| acc + (1u64 << *height))
+}
+
+impl<F: Family> PeakLayout<F> {
+    /// Bucket an ops tree's current peaks into prefix, range, and after sub-vectors.
+    fn new(leaves: Location<F>, range: Range<Location<F>>) -> Result<Self, merkle::Error<F>> {
+        if range.is_empty() {
+            return Err(merkle::Error::Empty);
+        }
+        let end_minus_one = range.end.checked_sub(1).expect("range is non-empty");
+        if end_minus_one >= leaves {
+            return Err(merkle::Error::RangeOutOfBounds(range.end));
+        }
+
+        let size = Position::<F>::try_from(leaves)?;
+        let mut prefix = Vec::new();
+        let mut range_peaks = Vec::new();
+        let mut after = Vec::new();
+        let mut leaf_cursor = 0u64;
+
+        for (peak_pos, height) in F::peaks(size) {
+            let leaf_end = leaf_cursor + (1u64 << height);
+            if leaf_end <= *range.start {
+                prefix.push((peak_pos, height));
+            } else if leaf_cursor >= *range.end {
+                after.push((peak_pos, height));
+            } else {
+                range_peaks.push((peak_pos, height));
+            }
+            leaf_cursor = leaf_end;
+        }
+
+        Ok(Self {
+            prefix,
+            range: range_peaks,
+            after,
+        })
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &(Position<F>, u32)> {
+        self.prefix
+            .iter()
+            .chain(self.range.iter())
+            .chain(self.after.iter())
+    }
+
+    const fn total_peaks(&self) -> usize {
+        self.prefix.len() + self.range.len() + self.after.len()
+    }
+}
+
+/// Merkle-family geometry for building or verifying a range proof. This collects the proven
+/// operation range, the ops-tree peak layout around that range, the inactive peak prefix, and the
+/// bitmap chunks touched by the range.
+pub(super) struct RangeProofGeometry<F: Graftable> {
+    leaves: Location<F>,
+    range: Range<Location<F>>,
+    layout: PeakLayout<F>,
+    inactive_peaks: usize,
+    start_chunk: u64,
+    end_chunk: u64,
+    grafting_height: u32,
+    complete_chunks: u64,
+}
+
+impl<F: Graftable> RangeProofGeometry<F> {
+    pub(super) fn new(
+        leaves: Location<F>,
+        range: Range<Location<F>>,
+        inactive_peaks: usize,
+        grafting_height: u32,
+        complete_chunks: u64,
+    ) -> Result<Self, merkle::Error<F>> {
+        let layout = PeakLayout::new(leaves, range.clone())?;
+        let end_loc = range.end.checked_sub(1).expect("range is non-empty");
+        let start_chunk = *range.start >> grafting_height;
+        let end_chunk = *end_loc >> grafting_height;
+
+        Ok(Self {
+            leaves,
+            range,
+            layout,
+            inactive_peaks,
+            start_chunk,
+            end_chunk,
+            grafting_height,
+            complete_chunks,
+        })
+    }
+
+    pub(super) const fn leaves(&self) -> Location<F> {
+        self.leaves
+    }
+
+    pub(super) fn range(&self) -> Range<Location<F>> {
+        self.range.clone()
+    }
+
+    pub(super) const fn inactive_peaks(&self) -> usize {
+        self.inactive_peaks
+    }
+
+    pub(super) const fn grafting_height(&self) -> u32 {
+        self.grafting_height
+    }
+
+    pub(super) fn prefix_peaks(&self) -> &[(Position<F>, u32)] {
+        &self.layout.prefix
+    }
+
+    pub(super) fn range_peaks(&self) -> &[(Position<F>, u32)] {
+        &self.layout.range
+    }
+
+    pub(super) fn after_peaks(&self) -> &[(Position<F>, u32)] {
+        &self.layout.after
+    }
+
+    pub(super) const fn total_peaks(&self) -> usize {
+        self.layout.total_peaks()
+    }
+
+    /// Return how many input ops-tree peaks each unfolded witness digest covers.
+    ///
+    /// `peaks` is a contiguous slice from one [`PeakLayout`] region, in left-to-right leaf order.
+    /// Each returned count corresponds to one digest in the unfolded prefix/suffix witness. Most
+    /// ops-tree peaks stay one-for-one and produce count `1`.
+    ///
+    /// Adjacent sub-grafting-height peaks are grouped when they belong to the same complete bitmap
+    /// chunk. `complete_chunks` is the number of grafted-tree leaves, so chunk indexes at or above
+    /// this boundary are incomplete and cannot be grouped here.
+    ///
+    /// For example, if `p1` and `p2` are adjacent sub-grafting-height peaks in complete chunk `7`,
+    /// input peaks `[p0, p1, p2, p3]` produce counts `[1, 2, 1]`. If chunk `7` is incomplete,
+    /// the same input produces `[1, 1, 1, 1]`.
+    ///
+    /// For MMRs this always returns one `1` per input peak. The grouping only matters for families
+    /// such as MMB, where a complete chunk can be represented by multiple smaller ops-tree peaks.
+    pub(super) fn witness_peak_counts(
+        &self,
+        peaks: &[(Position<F>, u32)],
+        start_leaf: u64,
+    ) -> Vec<usize> {
+        let mut leaf_cursor = start_leaf;
+        let mut counts = Vec::with_capacity(peaks.len());
+        let mut current_chunk = None;
+
+        for (_pos, height) in peaks {
+            let peak_start = leaf_cursor;
+            leaf_cursor += 1u64 << *height;
+
+            let chunk_idx = peak_start >> self.grafting_height;
+            if *height < self.grafting_height && chunk_idx < self.complete_chunks {
+                if current_chunk == Some(chunk_idx) {
+                    *counts.last_mut().unwrap() += 1;
+                } else {
+                    counts.push(1);
+                    current_chunk = Some(chunk_idx);
+                }
+            } else {
+                counts.push(1);
+                current_chunk = None;
+            }
+        }
+
+        counts
+    }
+
+    /// First leaf covered by the peaks that follow the proven operation range.
+    pub(super) fn after_start(&self) -> u64 {
+        covered_leaves(&self.layout.prefix) + covered_leaves(&self.layout.range)
+    }
+
+    /// Index in `layout.prefix` where prefix peaks stop being pre-grouped as grafted witnesses.
+    ///
+    /// Prefix peaks before this index are fully before the range's first bitmap chunk and can stay
+    /// in grafted form. Peaks at or after this index may share a complete grafted chunk with the
+    /// proven range, so reconstruction needs their ops-tree digests.
+    pub(super) fn prefix_regroup_start(&self) -> usize {
+        let chunk_start = self.start_chunk << self.grafting_height;
+        let mut leaf_cursor = 0u64;
+        for (idx, (_pos, height)) in self.layout.prefix.iter().enumerate() {
+            leaf_cursor += 1u64 << *height;
+            if leaf_cursor > chunk_start {
+                return idx;
+            }
+        }
+        self.layout.prefix.len()
+    }
+
+    /// Index in `layout.after` where after peaks start being pre-grouped as grafted witnesses.
+    ///
+    /// After peaks before this index may share a complete grafted chunk with the proven range, so
+    /// reconstruction needs their ops-tree digests. Peaks at or after this index are fully after
+    /// the range's last bitmap chunk and can stay in grafted form.
+    pub(super) fn after_regroup_end(&self) -> usize {
+        let chunk_end = (self.end_chunk + 1) << self.grafting_height;
+        let mut leaf_cursor = self.after_start();
+        for (idx, (_pos, height)) in self.layout.after.iter().enumerate() {
+            if leaf_cursor >= chunk_end {
+                return idx;
+            }
+            leaf_cursor += 1u64 << *height;
+        }
+        self.layout.after.len()
+    }
+
+    /// Return true when a generic range proof would hide boundary peaks needed for grafting.
+    ///
+    /// This happens when some ops-tree peak is smaller than a grafted chunk and belongs to a
+    /// complete bitmap chunk represented by multiple ops-tree peaks. In that case the proof must
+    /// include unfolded prefix/suffix peak digests so verification can regroup the complete chunk
+    /// correctly.
+    pub(super) fn needs_unfolded_boundary_peaks(&self) -> Result<bool, merkle::Error<F>> {
+        let size = Position::<F>::try_from(self.leaves)?;
+        let mut leaf_cursor = 0u64;
+
+        Ok(self.layout.iter().any(|(_pos, height)| {
+            let peak_start = leaf_cursor;
+            leaf_cursor += 1u64 << *height;
+
+            *height < self.grafting_height
+                && self.has_multiple_ops_peaks(size, peak_start >> self.grafting_height)
+        }))
+    }
+
+    /// Return true when `chunk_idx` is complete and spans more than one ops-tree peak.
+    fn has_multiple_ops_peaks(&self, size: Position<F>, chunk_idx: u64) -> bool {
+        chunk_idx < self.complete_chunks
+            && F::chunk_peaks(size, chunk_idx, self.grafting_height)
+                .nth(1)
+                .is_some()
+    }
+}

--- a/storage/src/qmdb/current/proof/geometry.rs
+++ b/storage/src/qmdb/current/proof/geometry.rs
@@ -1,17 +1,23 @@
-//! Geometry helpers for range proofs over grafted current trees.
+//! Geometry for current range proofs.
 //!
-//! The proof format starts from ops-tree peaks, but the current root commits to bitmap chunks
-//! grafted onto those ops-tree digests. This module keeps track of where the proven operation range
-//! falls among the ops-tree peaks and which boundary peaks must stay unfolded so verification can
-//! regroup them by complete grafted chunk.
+//! Current proofs combine two views of the operation log. The range proof is collected from the ops
+//! tree, while the current root commits to activity bitmap chunks grafted onto that tree. This
+//! module records how the requested operation range lines up with the ops-tree peaks so proof
+//! generation and verification can translate between those two views.
+//!
+//! For MMR, each bitmap chunk corresponds to one ops-tree peak, so this translation is one-for-one.
+//! For MMB-like families, one bitmap chunk can span multiple sub-grafting-height ops-tree peaks.
+//! If the requested range covers only part of such a chunk, a standard range proof may fold the
+//! out-of-range peaks into its prefix or suffix witnesses. This module identifies those peaks so
+//! the proof can carry their digests explicitly and verification can rebuild the bitmap chunk root.
 
 use crate::merkle::{self, Family, Graftable, Location, Position};
 use core::ops::Range;
 
-/// An inventory of current ops-tree peaks, paired with their heights, from oldest to youngest
-/// relative to the bounds of a range proof. Every peak is assigned to exactly one of three
-/// sequential layout regions: before the operation range, overlapping the operation range, or
-/// after the operation range.
+/// An inventory of ops-tree peaks, paired with their heights, from oldest to youngest relative to
+/// the bounds of a range proof. Every peak is assigned to exactly one of three sequential layout
+/// regions: before the operation range, overlapping the operation range, or after the operation
+/// range.
 struct PeakLayout<F: Family> {
     /// Ops-tree peaks whose leaves all precede the operation range's starting location.
     prefix: Vec<(Position<F>, u32)>,
@@ -29,7 +35,7 @@ pub(super) fn covered_leaves<F: Family>(peaks: &[(Position<F>, u32)]) -> u64 {
 }
 
 impl<F: Family> PeakLayout<F> {
-    /// Bucket an ops tree's current peaks into prefix, range, and after sub-vectors.
+    /// Bucket the ops-tree peaks into prefix, range, and after sub-vectors.
     fn new(leaves: Location<F>, range: Range<Location<F>>) -> Result<Self, merkle::Error<F>> {
         if range.is_empty() {
             return Err(merkle::Error::Empty);
@@ -153,16 +159,15 @@ impl<F: Graftable> RangeProofGeometry<F> {
     /// Each returned count corresponds to one digest in the unfolded prefix/suffix witness. Most
     /// ops-tree peaks stay one-for-one and produce count `1`.
     ///
-    /// Adjacent sub-grafting-height peaks are grouped when they belong to the same complete bitmap
-    /// chunk. `complete_chunks` is the number of grafted-tree leaves, so chunk indexes at or above
-    /// this boundary are incomplete and cannot be grouped here.
+    /// Adjacent sub-grafting-height peaks are grouped when they belong to the same bitmap chunk.
+    /// `complete_chunks` is the number of peak-tree leaves, not counting the partial chunk if any.
     ///
-    /// For example, if `p1` and `p2` are adjacent sub-grafting-height peaks in complete chunk `7`,
-    /// input peaks `[p0, p1, p2, p3]` produce counts `[1, 2, 1]`. If chunk `7` is incomplete,
-    /// the same input produces `[1, 1, 1, 1]`.
+    /// For example, if `p1` and `p2` are adjacent sub-grafting-height peaks covered by chunk `7`,
+    /// input peaks `[p0, p1, p2, p3]` produce counts `[1, 2, 1]`.
     ///
     /// For MMRs this always returns one `1` per input peak. The grouping only matters for families
-    /// such as MMB, where a complete chunk can be represented by multiple smaller ops-tree peaks.
+    /// such as MMB, where a chunk can be represented by multiple
+    /// sub-grafting-height ops-tree peaks.
     pub(super) fn witness_peak_counts(
         &self,
         peaks: &[(Position<F>, u32)],
@@ -198,11 +203,11 @@ impl<F: Graftable> RangeProofGeometry<F> {
         covered_leaves(&self.layout.prefix) + covered_leaves(&self.layout.range)
     }
 
-    /// Index in `layout.prefix` where prefix peaks stop being pre-grouped as grafted witnesses.
+    /// Index in `layout.prefix` where prefix peaks stop being pre-grouped as bitmap chunk witnesses.
     ///
     /// Prefix peaks before this index are fully before the range's first bitmap chunk and can stay
-    /// in grafted form. Peaks at or after this index may share a complete grafted chunk with the
-    /// proven range, so reconstruction needs their ops-tree digests.
+    /// pre-grouped. Peaks at or after this index may share a bitmap chunk with the proven
+    /// range, so reconstruction needs their ops-tree digests.
     pub(super) fn prefix_regroup_start(&self) -> usize {
         let chunk_start = self.start_chunk << self.grafting_height;
         let mut leaf_cursor = 0u64;
@@ -215,11 +220,11 @@ impl<F: Graftable> RangeProofGeometry<F> {
         self.layout.prefix.len()
     }
 
-    /// Index in `layout.after` where after peaks start being pre-grouped as grafted witnesses.
+    /// Index in `layout.after` where after peaks start being pre-grouped as bitmap chunk witnesses.
     ///
-    /// After peaks before this index may share a complete grafted chunk with the proven range, so
+    /// After peaks before this index may share a bitmap chunk with the proven range, so
     /// reconstruction needs their ops-tree digests. Peaks at or after this index are fully after
-    /// the range's last bitmap chunk and can stay in grafted form.
+    /// the range's last bitmap chunk and can stay pre-grouped.
     pub(super) fn after_regroup_end(&self) -> usize {
         let chunk_end = (self.end_chunk + 1) << self.grafting_height;
         let mut leaf_cursor = self.after_start();
@@ -232,12 +237,14 @@ impl<F: Graftable> RangeProofGeometry<F> {
         self.layout.after.len()
     }
 
-    /// Return true when a generic range proof would hide boundary peaks needed for grafting.
+    /// Return true when proof verification needs extra prefix/suffix ops-tree peak digests.
     ///
-    /// This happens when some ops-tree peak is smaller than a grafted chunk and belongs to a
-    /// complete bitmap chunk represented by multiple ops-tree peaks. In that case the proof must
-    /// include unfolded prefix/suffix peak digests so verification can regroup the complete chunk
-    /// correctly.
+    /// For MMB, a bitmap chunk may be represented by several sub-grafting-height ops-tree peaks. If
+    /// one of those peaks is outside the proven operation range, the generic range proof can hide
+    /// it behind a prefix or suffix accumulator. Verification then needs the hidden peak digest so
+    /// it can rebuild the bitmap chunk root.
+    ///
+    /// MMR chunks are already single ops-tree peaks, so this returns false for MMR layouts.
     pub(super) fn needs_unfolded_boundary_peaks(&self) -> Result<bool, merkle::Error<F>> {
         let size = Position::<F>::try_from(self.leaves)?;
         let mut leaf_cursor = 0u64;
@@ -246,16 +253,12 @@ impl<F: Graftable> RangeProofGeometry<F> {
             let peak_start = leaf_cursor;
             leaf_cursor += 1u64 << *height;
 
+            let chunk_idx = peak_start >> self.grafting_height;
             *height < self.grafting_height
-                && self.has_multiple_ops_peaks(size, peak_start >> self.grafting_height)
+                && chunk_idx < self.complete_chunks
+                && F::chunk_peaks(size, chunk_idx, self.grafting_height)
+                    .nth(1)
+                    .is_some()
         }))
-    }
-
-    /// Return true when `chunk_idx` is complete and spans more than one ops-tree peak.
-    fn has_multiple_ops_peaks(&self, size: Position<F>, chunk_idx: u64) -> bool {
-        chunk_idx < self.complete_chunks
-            && F::chunk_peaks(size, chunk_idx, self.grafting_height)
-                .nth(1)
-                .is_some()
     }
 }

--- a/storage/src/qmdb/current/proof/geometry.rs
+++ b/storage/src/qmdb/current/proof/geometry.rs
@@ -7,91 +7,75 @@
 //!
 //! For MMR, each bitmap chunk corresponds to one ops-tree peak, so this translation is one-for-one.
 //! For MMB-like families, one bitmap chunk can span multiple sub-grafting-height ops-tree peaks.
-//! If the requested range covers only part of such a chunk, a standard range proof may fold the
-//! out-of-range peaks into its prefix or suffix witnesses. This module identifies those peaks so
+//! If the requested range covers only part of such a chunk, the ops-tree range proof may fold
+//! the out-of-range peaks into its prefix or suffix witnesses. This module identifies those peaks so
 //! the proof can carry their digests explicitly and verification can rebuild the bitmap chunk root.
+//!
+//! The grafting view splits the ops-tree peaks into five ordered segments:
+//! pure prefix, prefix boundary, range, suffix boundary, and pure suffix. The pure prefix/suffix
+//! segments are already grouped as bitmap chunk witnesses. The boundary segments stay as individual
+//! ops-tree digests because they may need to be combined with the range segment to reconstruct a
+//! bitmap chunk.
 
 use crate::merkle::{self, Family, Graftable, Location, Position};
 use core::ops::Range;
 
-/// An inventory of ops-tree peaks, paired with their heights, from oldest to youngest relative to
-/// the bounds of a range proof. Every peak is assigned to exactly one of three sequential layout
-/// regions: before the operation range, overlapping the operation range, or after the operation
-/// range.
-struct PeakLayout<F: Family> {
-    /// Ops-tree peaks whose leaves all precede the operation range's starting location.
-    prefix: Vec<(Position<F>, u32)>,
-    /// Ops-tree peaks whose leaves intersect the operation range.
-    range: Vec<(Position<F>, u32)>,
-    /// Ops-tree peaks whose leaves all follow the operation range's ending location.
-    after: Vec<(Position<F>, u32)>,
+/// A contiguous segment of ops-tree peaks, along with the first leaf covered by the segment.
+pub(super) struct PeakSegment<F: Family> {
+    peaks: Vec<(Position<F>, u32)>,
+    start_leaf: u64,
+}
+
+impl<F: Family> PeakSegment<F> {
+    pub(super) const fn len(&self) -> usize {
+        self.peaks.len()
+    }
+
+    pub(super) const fn start_leaf(&self) -> u64 {
+        self.start_leaf
+    }
+
+    pub(super) fn positions(&self) -> impl Iterator<Item = Position<F>> + '_ {
+        self.peaks.iter().map(|&(pos, _height)| pos)
+    }
+
+    pub(super) fn heights_with_digests<'a, D: Copy>(
+        &'a self,
+        digests: &'a [D],
+    ) -> impl Iterator<Item = (u32, D)> + 'a {
+        self.peaks
+            .iter()
+            .map(|(_pos, height)| *height)
+            .zip(digests.iter().copied())
+    }
+
+    fn peak_starts_with_heights(&self) -> impl Iterator<Item = (u64, u32)> + '_ {
+        let mut leaf_cursor = self.start_leaf;
+        self.peaks.iter().map(move |(_pos, height)| {
+            let peak_start = leaf_cursor;
+            leaf_cursor += 1u64 << *height;
+            (peak_start, *height)
+        })
+    }
 }
 
 /// Return the number of leaves covered by `peaks`.
-pub(super) fn covered_leaves<F: Family>(peaks: &[(Position<F>, u32)]) -> u64 {
+fn covered_leaves<F: Family>(peaks: &[(Position<F>, u32)]) -> u64 {
     peaks
         .iter()
         .fold(0u64, |acc, (_pos, height)| acc + (1u64 << *height))
 }
 
-impl<F: Family> PeakLayout<F> {
-    /// Bucket the ops-tree peaks into prefix, range, and after sub-vectors.
-    fn new(leaves: Location<F>, range: Range<Location<F>>) -> Result<Self, merkle::Error<F>> {
-        if range.is_empty() {
-            return Err(merkle::Error::Empty);
-        }
-        let end_minus_one = range.end.checked_sub(1).expect("range is non-empty");
-        if end_minus_one >= leaves {
-            return Err(merkle::Error::RangeOutOfBounds(range.end));
-        }
-
-        let size = Position::<F>::try_from(leaves)?;
-        let mut prefix = Vec::new();
-        let mut range_peaks = Vec::new();
-        let mut after = Vec::new();
-        let mut leaf_cursor = 0u64;
-
-        for (peak_pos, height) in F::peaks(size) {
-            let leaf_end = leaf_cursor + (1u64 << height);
-            if leaf_end <= *range.start {
-                prefix.push((peak_pos, height));
-            } else if leaf_cursor >= *range.end {
-                after.push((peak_pos, height));
-            } else {
-                range_peaks.push((peak_pos, height));
-            }
-            leaf_cursor = leaf_end;
-        }
-
-        Ok(Self {
-            prefix,
-            range: range_peaks,
-            after,
-        })
-    }
-
-    fn iter(&self) -> impl Iterator<Item = &(Position<F>, u32)> {
-        self.prefix
-            .iter()
-            .chain(self.range.iter())
-            .chain(self.after.iter())
-    }
-
-    const fn total_peaks(&self) -> usize {
-        self.prefix.len() + self.range.len() + self.after.len()
-    }
-}
-
-/// Merkle-family geometry for building or verifying a range proof. This collects the proven
-/// operation range, the ops-tree peak layout around that range, the inactive peak prefix, and the
-/// bitmap chunks touched by the range.
+/// Grafting-aware geometry for building or verifying a current range proof.
 pub(super) struct RangeProofGeometry<F: Graftable> {
     leaves: Location<F>,
     range: Range<Location<F>>,
-    layout: PeakLayout<F>,
+    pure_prefix: PeakSegment<F>,
+    prefix_boundary: PeakSegment<F>,
+    range_peaks: PeakSegment<F>,
+    suffix_boundary: PeakSegment<F>,
+    pure_suffix: PeakSegment<F>,
     inactive_peaks: usize,
-    start_chunk: u64,
-    end_chunk: u64,
     grafting_height: u32,
     complete_chunks: u64,
 }
@@ -104,18 +88,77 @@ impl<F: Graftable> RangeProofGeometry<F> {
         grafting_height: u32,
         complete_chunks: u64,
     ) -> Result<Self, merkle::Error<F>> {
-        let layout = PeakLayout::new(leaves, range.clone())?;
+        if range.is_empty() {
+            return Err(merkle::Error::Empty);
+        }
         let end_loc = range.end.checked_sub(1).expect("range is non-empty");
+        if end_loc >= leaves {
+            return Err(merkle::Error::RangeOutOfBounds(range.end));
+        }
+
+        let size = Position::<F>::try_from(leaves)?;
+        let mut prefix_peaks = Vec::new();
+        let mut range_peaks = Vec::new();
+        let mut after_peaks = Vec::new();
+        let mut leaf_cursor = 0u64;
+
+        for (peak_pos, height) in F::peaks(size) {
+            let leaf_end = leaf_cursor + (1u64 << height);
+            if leaf_end <= *range.start {
+                prefix_peaks.push((peak_pos, height));
+            } else if leaf_cursor >= *range.end {
+                after_peaks.push((peak_pos, height));
+            } else {
+                range_peaks.push((peak_pos, height));
+            }
+            leaf_cursor = leaf_end;
+        }
+
         let start_chunk = *range.start >> grafting_height;
         let end_chunk = *end_loc >> grafting_height;
+        let prefix_boundary_start =
+            Self::prefix_boundary_start(&prefix_peaks, start_chunk, grafting_height);
+        let range_start_leaf = covered_leaves(&prefix_peaks);
+        let suffix_boundary_start_leaf = range_start_leaf + covered_leaves(&range_peaks);
+        let suffix_boundary_end = Self::suffix_boundary_end(
+            &after_peaks,
+            suffix_boundary_start_leaf,
+            end_chunk,
+            grafting_height,
+        );
+
+        let prefix_boundary_start_leaf = covered_leaves(&prefix_peaks[..prefix_boundary_start]);
+        let pure_suffix_start_leaf =
+            suffix_boundary_start_leaf + covered_leaves(&after_peaks[..suffix_boundary_end]);
+        let prefix_boundary = prefix_peaks.split_off(prefix_boundary_start);
+        let pure_prefix = prefix_peaks;
+        let pure_suffix = after_peaks.split_off(suffix_boundary_end);
+        let suffix_boundary = after_peaks;
 
         Ok(Self {
             leaves,
             range,
-            layout,
+            pure_prefix: PeakSegment {
+                peaks: pure_prefix,
+                start_leaf: 0,
+            },
+            prefix_boundary: PeakSegment {
+                peaks: prefix_boundary,
+                start_leaf: prefix_boundary_start_leaf,
+            },
+            range_peaks: PeakSegment {
+                peaks: range_peaks,
+                start_leaf: range_start_leaf,
+            },
+            suffix_boundary: PeakSegment {
+                peaks: suffix_boundary,
+                start_leaf: suffix_boundary_start_leaf,
+            },
+            pure_suffix: PeakSegment {
+                peaks: pure_suffix,
+                start_leaf: pure_suffix_start_leaf,
+            },
             inactive_peaks,
-            start_chunk,
-            end_chunk,
             grafting_height,
             complete_chunks,
         })
@@ -137,30 +180,102 @@ impl<F: Graftable> RangeProofGeometry<F> {
         self.grafting_height
     }
 
-    pub(super) fn prefix_peaks(&self) -> &[(Position<F>, u32)] {
-        &self.layout.prefix
+    /// Peaks fully before the first bitmap chunk touched by the range.
+    pub(super) const fn pure_prefix(&self) -> &PeakSegment<F> {
+        &self.pure_prefix
     }
 
-    pub(super) fn range_peaks(&self) -> &[(Position<F>, u32)] {
-        &self.layout.range
+    /// Prefix peaks that may share a bitmap chunk with the range.
+    pub(super) const fn prefix_boundary(&self) -> &PeakSegment<F> {
+        &self.prefix_boundary
     }
 
-    pub(super) fn after_peaks(&self) -> &[(Position<F>, u32)] {
-        &self.layout.after
+    /// Peaks intersecting the proven operation range.
+    pub(super) const fn range_peaks(&self) -> &PeakSegment<F> {
+        &self.range_peaks
+    }
+
+    /// After peaks that may share a bitmap chunk with the range.
+    pub(super) const fn suffix_boundary(&self) -> &PeakSegment<F> {
+        &self.suffix_boundary
+    }
+
+    /// Peaks fully after the last bitmap chunk touched by the range.
+    pub(super) const fn pure_suffix(&self) -> &PeakSegment<F> {
+        &self.pure_suffix
     }
 
     pub(super) const fn total_peaks(&self) -> usize {
-        self.layout.total_peaks()
+        self.pure_prefix.len()
+            + self.prefix_boundary.len()
+            + self.range_peaks.len()
+            + self.suffix_boundary.len()
+            + self.pure_suffix.len()
     }
 
-    /// Return how many input ops-tree peaks each unfolded witness digest covers.
+    /// Positions of all peaks before the range, in proof witness order.
+    pub(super) fn prefix_positions(&self) -> impl Iterator<Item = Position<F>> + '_ {
+        self.pure_prefix
+            .positions()
+            .chain(self.prefix_boundary.positions())
+    }
+
+    /// Positions of all peaks after the range, in proof witness order.
+    pub(super) fn after_positions(&self) -> impl Iterator<Item = Position<F>> + '_ {
+        self.suffix_boundary
+            .positions()
+            .chain(self.pure_suffix.positions())
+    }
+
+    pub(super) fn prefix_witness_len(&self) -> usize {
+        self.bitmap_witness_counts(&self.pure_prefix).len() + self.prefix_boundary.len()
+    }
+
+    pub(super) fn suffix_witness_len(&self) -> usize {
+        self.suffix_boundary.len() + self.bitmap_witness_counts(&self.pure_suffix).len()
+    }
+
+    /// Split prefix witnesses into bitmap witnesses for the pure prefix and ops-tree digests for
+    /// the prefix boundary.
+    pub(super) fn split_prefix_witnesses<'a, D>(
+        &self,
+        witnesses: &'a [D],
+    ) -> Option<(Vec<usize>, &'a [D], &'a [D])> {
+        let counts = self.bitmap_witness_counts(&self.pure_prefix);
+        let expected_len = counts.len() + self.prefix_boundary.len();
+        debug_assert_eq!(expected_len, self.prefix_witness_len());
+        if witnesses.len() != expected_len {
+            return None;
+        }
+        let (bitmap_witnesses, boundary_digests) = witnesses.split_at(counts.len());
+        Some((counts, bitmap_witnesses, boundary_digests))
+    }
+
+    /// Split suffix witnesses into ops-tree digests for the suffix boundary and bitmap witnesses
+    /// for the pure suffix.
+    pub(super) fn split_suffix_witnesses<'a, D>(
+        &self,
+        witnesses: &'a [D],
+    ) -> Option<(&'a [D], &'a [D], Vec<usize>)> {
+        let counts = self.bitmap_witness_counts(&self.pure_suffix);
+        let expected_len = self.suffix_boundary.len() + counts.len();
+        debug_assert_eq!(expected_len, self.suffix_witness_len());
+        if witnesses.len() != expected_len {
+            return None;
+        }
+        let (boundary_digests, bitmap_witnesses) = witnesses.split_at(self.suffix_boundary.len());
+        Some((boundary_digests, bitmap_witnesses, counts))
+    }
+
+    /// Return how many input ops-tree peaks each already-grouped witness digest covers.
     ///
-    /// `peaks` is a contiguous slice from one [`PeakLayout`] region, in left-to-right leaf order.
-    /// Each returned count corresponds to one digest in the unfolded prefix/suffix witness. Most
-    /// ops-tree peaks stay one-for-one and produce count `1`.
+    /// `segment` should be the pure prefix or pure suffix segment. Each returned count corresponds
+    /// to one bitmap chunk witness digest. Most ops-tree peaks stay one-for-one and produce
+    /// count `1`.
     ///
-    /// Adjacent sub-grafting-height peaks are grouped when they belong to the same bitmap chunk.
-    /// `complete_chunks` is the number of peak-tree leaves, not counting the partial chunk if any.
+    /// Adjacent sub-grafting-height peaks are grouped when they belong to the same complete bitmap
+    /// chunk. Peaks in a trailing partial chunk, which can appear in the pure suffix, stay
+    /// one-for-one because that chunk is not part of the grafted bitmap root yet.
     ///
     /// For example, if `p1` and `p2` are adjacent sub-grafting-height peaks covered by chunk `7`,
     /// input peaks `[p0, p1, p2, p3]` produce counts `[1, 2, 1]`.
@@ -168,21 +283,13 @@ impl<F: Graftable> RangeProofGeometry<F> {
     /// For MMRs this always returns one `1` per input peak. The grouping only matters for families
     /// such as MMB, where a chunk can be represented by multiple
     /// sub-grafting-height ops-tree peaks.
-    pub(super) fn witness_peak_counts(
-        &self,
-        peaks: &[(Position<F>, u32)],
-        start_leaf: u64,
-    ) -> Vec<usize> {
-        let mut leaf_cursor = start_leaf;
-        let mut counts = Vec::with_capacity(peaks.len());
+    fn bitmap_witness_counts(&self, segment: &PeakSegment<F>) -> Vec<usize> {
+        let mut counts = Vec::with_capacity(segment.peaks.len());
         let mut current_chunk = None;
 
-        for (_pos, height) in peaks {
-            let peak_start = leaf_cursor;
-            leaf_cursor += 1u64 << *height;
-
+        for (peak_start, height) in segment.peak_starts_with_heights() {
             let chunk_idx = peak_start >> self.grafting_height;
-            if *height < self.grafting_height && chunk_idx < self.complete_chunks {
+            if height < self.grafting_height && chunk_idx < self.complete_chunks {
                 if current_chunk == Some(chunk_idx) {
                     *counts.last_mut().unwrap() += 1;
                 } else {
@@ -198,64 +305,59 @@ impl<F: Graftable> RangeProofGeometry<F> {
         counts
     }
 
-    /// First leaf covered by the peaks that follow the proven operation range.
-    pub(super) fn after_start(&self) -> u64 {
-        covered_leaves(&self.layout.prefix) + covered_leaves(&self.layout.range)
-    }
-
-    /// Index in `layout.prefix` where prefix peaks stop being pre-grouped as bitmap chunk witnesses.
-    ///
-    /// Prefix peaks before this index are fully before the range's first bitmap chunk and can stay
-    /// pre-grouped. Peaks at or after this index may share a bitmap chunk with the proven
-    /// range, so reconstruction needs their ops-tree digests.
-    pub(super) fn prefix_regroup_start(&self) -> usize {
-        let chunk_start = self.start_chunk << self.grafting_height;
+    fn prefix_boundary_start(
+        prefix_peaks: &[(Position<F>, u32)],
+        start_chunk: u64,
+        grafting_height: u32,
+    ) -> usize {
+        let chunk_start = start_chunk << grafting_height;
         let mut leaf_cursor = 0u64;
-        for (idx, (_pos, height)) in self.layout.prefix.iter().enumerate() {
+        for (idx, (_pos, height)) in prefix_peaks.iter().enumerate() {
             leaf_cursor += 1u64 << *height;
             if leaf_cursor > chunk_start {
                 return idx;
             }
         }
-        self.layout.prefix.len()
+        prefix_peaks.len()
     }
 
-    /// Index in `layout.after` where after peaks start being pre-grouped as bitmap chunk witnesses.
-    ///
-    /// After peaks before this index may share a bitmap chunk with the proven range, so
-    /// reconstruction needs their ops-tree digests. Peaks at or after this index are fully after
-    /// the range's last bitmap chunk and can stay pre-grouped.
-    pub(super) fn after_regroup_end(&self) -> usize {
-        let chunk_end = (self.end_chunk + 1) << self.grafting_height;
-        let mut leaf_cursor = self.after_start();
-        for (idx, (_pos, height)) in self.layout.after.iter().enumerate() {
+    fn suffix_boundary_end(
+        after_peaks: &[(Position<F>, u32)],
+        after_start_leaf: u64,
+        end_chunk: u64,
+        grafting_height: u32,
+    ) -> usize {
+        let chunk_end = (end_chunk + 1) << grafting_height;
+        let mut leaf_cursor = after_start_leaf;
+        for (idx, (_pos, height)) in after_peaks.iter().enumerate() {
             if leaf_cursor >= chunk_end {
                 return idx;
             }
             leaf_cursor += 1u64 << *height;
         }
-        self.layout.after.len()
+        after_peaks.len()
     }
 
-    /// Return true when proof verification needs extra prefix/suffix ops-tree peak digests.
-    ///
-    /// For MMB, a bitmap chunk may be represented by several sub-grafting-height ops-tree peaks. If
-    /// one of those peaks is outside the proven operation range, the generic range proof can hide
-    /// it behind a prefix or suffix accumulator. Verification then needs the hidden peak digest so
-    /// it can rebuild the bitmap chunk root.
-    ///
-    /// MMR chunks are already single ops-tree peaks, so this returns false for MMR layouts.
-    pub(super) fn needs_unfolded_boundary_peaks(&self) -> Result<bool, merkle::Error<F>> {
+    /// Return true when verification needs the grafted reconstruction path.
+    pub(super) fn requires_grafted_reconstruction(&self) -> Result<bool, merkle::Error<F>> {
         let size = Position::<F>::try_from(self.leaves)?;
-        let mut leaf_cursor = 0u64;
 
-        Ok(self.layout.iter().any(|(_pos, height)| {
-            let peak_start = leaf_cursor;
-            leaf_cursor += 1u64 << *height;
+        Ok([
+            &self.pure_prefix,
+            &self.prefix_boundary,
+            &self.range_peaks,
+            &self.suffix_boundary,
+            &self.pure_suffix,
+        ]
+        .into_iter()
+        .flat_map(|segment| segment.peak_starts_with_heights())
+        .any(|(peak_start, height)| {
+            if height >= self.grafting_height {
+                return false;
+            }
 
             let chunk_idx = peak_start >> self.grafting_height;
-            *height < self.grafting_height
-                && chunk_idx < self.complete_chunks
+            chunk_idx < self.complete_chunks
                 && F::chunk_peaks(size, chunk_idx, self.grafting_height)
                     .nth(1)
                     .is_some()

--- a/storage/src/qmdb/current/proof/geometry.rs
+++ b/storage/src/qmdb/current/proof/geometry.rs
@@ -22,7 +22,10 @@ use core::ops::Range;
 
 /// A contiguous segment of ops-tree peaks, along with the first leaf covered by the segment.
 pub(super) struct PeakSegment<F: Family> {
+    /// Ops-tree peaks in oldest-to-youngest order, stored as `(position, height)`.
     peaks: Vec<(Position<F>, u32)>,
+
+    /// Leaf index covered by the first peak in `peaks`.
     start_leaf: u64,
 }
 
@@ -35,10 +38,15 @@ impl<F: Family> PeakSegment<F> {
         self.start_leaf
     }
 
+    /// Return the ops-tree positions in this segment.
     pub(super) fn positions(&self) -> impl Iterator<Item = Position<F>> + '_ {
         self.peaks.iter().map(|&(pos, _height)| pos)
     }
 
+    /// Pair each peak height with the corresponding digest from `digests`.
+    ///
+    /// The caller is responsible for passing digests in the same order as this segment's peaks.
+    /// Extra digests are ignored and missing digests truncate the iterator.
     pub(super) fn heights_with_digests<'a, D: Copy>(
         &'a self,
         digests: &'a [D],
@@ -49,6 +57,7 @@ impl<F: Family> PeakSegment<F> {
             .zip(digests.iter().copied())
     }
 
+    /// Return each peak's starting leaf and height.
     fn peak_starts_with_heights(&self) -> impl Iterator<Item = (u64, u32)> + '_ {
         let mut leaf_cursor = self.start_leaf;
         self.peaks.iter().map(move |(_pos, height)| {
@@ -68,15 +77,34 @@ fn covered_leaves<F: Family>(peaks: &[(Position<F>, u32)]) -> u64 {
 
 /// Grafting-aware geometry for building or verifying a current range proof.
 pub(super) struct RangeProofGeometry<F: Graftable> {
+    /// Total number of ops-tree leaves committed by the proof.
     leaves: Location<F>,
+
+    /// Requested operation range, in leaf locations.
     range: Range<Location<F>>,
+
+    /// Peaks fully before the first bitmap chunk touched by `range`.
     pure_prefix: PeakSegment<F>,
+
+    /// Prefix peaks that may share a bitmap chunk with `range`.
     prefix_boundary: PeakSegment<F>,
+
+    /// Peaks that intersect `range`.
     range_peaks: PeakSegment<F>,
+
+    /// Suffix peaks that may share a bitmap chunk with `range`.
     suffix_boundary: PeakSegment<F>,
+
+    /// Peaks fully after the last bitmap chunk touched by `range`.
     pure_suffix: PeakSegment<F>,
+
+    /// Number of inactive peaks hidden below the proof's historical size.
     inactive_peaks: usize,
+
+    /// Height of one complete bitmap chunk in the ops tree.
     grafting_height: u32,
+
+    /// Number of complete bitmap chunks committed by the grafted bitmap root.
     complete_chunks: u64,
 }
 

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -112,7 +112,7 @@ where
     }
 }
 
-// Lightweight view of the status bitmap as complete grafted chunks. Pruned chunks are represented
+// Lightweight view of the status bitmap as complete bitmap chunks. Pruned chunks are represented
 // by zero-filled chunks because their bits are folded into the inactive prefix.
 struct BitmapGrafting<'a, B, const N: usize> {
     status: &'a B,
@@ -192,7 +192,7 @@ fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     // The grafted list has three regions: already-grafted entries before the range-adjacent
     // chunks, ops-tree peak entries that may regroup with the proven range, and already-grafted
     // entries after that middle region. `middle_iter` covers exactly the chunk span from the first
-    // prefix peak through the last suffix peak that can share a grafted chunk with the proven
+    // prefix peak through the last suffix peak that can share a bitmap chunk with the proven
     // range.
     let middle_iter = geometry.prefix_peaks()[prefix_regroup_start..]
         .iter()
@@ -411,7 +411,7 @@ pub struct RangeProof<F: Family, D: Digest> {
     /// suffix accumulator that grafted reconstruction must inspect.
     ///
     /// This vector is intentionally split by convention. It starts with ops-tree peak digests
-    /// adjacent to the proven range, because those peaks may share grafted chunks with
+    /// adjacent to the proven range, because those peaks may share bitmap chunks with
     /// in-range peaks. It then contains already-grafted digests for the remaining
     /// suffix region. The verifier reconstructs the split point from the peak layout.
     pub unfolded_suffix_peaks: Vec<D>,
@@ -1623,8 +1623,8 @@ mod tests {
 
             // Grafted reconstruction needs the individual prefix/suffix peaks that generic
             // backward proofs may otherwise hide behind fold accumulators. These witnesses are
-            // already grouped by grafted chunk, so their counts can be smaller than the ops-tree
-            // peak counts.
+            // already grouped by bitmap chunk, so the witness vectors can have fewer entries
+            // than the ops-tree peak lists.
             let prefix_counts = geometry.witness_peak_counts(geometry.prefix_peaks(), 0);
             let suffix_start = geometry.after_start();
             let suffix_counts = geometry.witness_peak_counts(geometry.after_peaks(), suffix_start);
@@ -1717,7 +1717,7 @@ mod tests {
             let ops = build_test_mem(&hasher, mmb::mem::Mmb::new(), leaf_count);
 
             // The ops root is the inner QMDB log root and commits the ops-tree inactive peak count.
-            // The grafted bitmap root commits the chunk-aligned count, since grafted chunks are
+            // The grafted bitmap root commits the chunk-aligned count, since bitmap chunks are
             // the atomic inactive-prefix boundary for the current root.
             let ops_root = ops.root(&hasher, ops_inactive_peaks).unwrap();
 

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -5,6 +5,9 @@
 //! - [RangeProof]: Proves a range of operations exist in the database.
 //! - [OperationProof]: Proves a specific operation is active in the database.
 
+mod geometry;
+
+use self::geometry::{covered_leaves, RangeProofGeometry};
 use crate::{
     journal::contiguous::{Contiguous, Reader as _},
     merkle::{
@@ -109,41 +112,12 @@ where
     }
 }
 
-/// An inventory of all structural peaks for a Merkle-family tree, mapped linearly top-to-bottom
-/// relative to the bounds of a verified range proof.
-///
-/// Because the database operations log acts dynamically like an append-only structure (MMR or MMB),
-/// the elements verified in a range proof intersect with zero or more contiguous root peaks.
-/// This struct mechanically buckets every peak into exactly one of three sequential layout regions:
-/// those appearing structurally before the range, those structurally overlapping the range, and
-/// those physically placed after the range bounds.
-struct PeakLayout<F: Family> {
-    /// Peaks whose leaves are entirely preceding the operation range's starting location.
-    prefix: Vec<(Position<F>, u32)>,
-    /// Peaks that physically intersect with the operations proven within the range.
-    range: Vec<(Position<F>, u32)>,
-    /// Peaks whose leaves entirely succeed the operation range's ending location.
-    after: Vec<(Position<F>, u32)>,
-}
-
-#[derive(Clone, Copy)]
-struct GraftingInfo {
-    height: u32,
-    complete_chunks: u64,
-}
-
-impl GraftingInfo {
-    fn from_status<const N: usize>(status: &impl BitmapReadable<N>) -> Self {
-        Self {
-            height: grafting::height::<N>(),
-            complete_chunks: status.complete_chunks() as u64,
-        }
-    }
-}
-
+// Lightweight view of the status bitmap as complete grafted chunks. Pruned chunks are represented
+// by zero-filled chunks because their bits are folded into the inactive prefix.
 struct BitmapGrafting<'a, B, const N: usize> {
     status: &'a B,
-    info: GraftingInfo,
+    grafting_height: u32,
+    complete_chunks: u64,
     pruned_chunks: u64,
 }
 
@@ -151,13 +125,14 @@ impl<'a, B: BitmapReadable<N>, const N: usize> BitmapGrafting<'a, B, N> {
     fn new(status: &'a B) -> Self {
         Self {
             status,
-            info: GraftingInfo::from_status(status),
+            grafting_height: grafting::height::<N>(),
+            complete_chunks: status.complete_chunks() as u64,
             pruned_chunks: status.pruned_chunks() as u64,
         }
     }
 
     fn chunk(&self, idx: u64) -> Option<[u8; N]> {
-        if idx >= self.info.complete_chunks {
+        if idx >= self.complete_chunks {
             None
         } else if idx < self.pruned_chunks {
             Some([0u8; N])
@@ -167,358 +142,93 @@ impl<'a, B: BitmapReadable<N>, const N: usize> BitmapGrafting<'a, B, N> {
     }
 }
 
-struct ProofPlan<F: Family> {
-    leaves: Location<F>,
-    range: Range<Location<F>>,
-    layout: PeakLayout<F>,
-    inactive_peaks: usize,
-    start_chunk: u64,
-    end_chunk: u64,
-    grafting: GraftingInfo,
-}
-
-impl<F: Family> ProofPlan<F> {
-    fn new(
-        leaves: Location<F>,
-        range: Range<Location<F>>,
-        inactive_peaks: usize,
-        grafting: GraftingInfo,
-    ) -> Result<Self, merkle::Error<F>> {
-        let layout = peak_layout(leaves, range.clone())?;
-        let end_loc = range.end.checked_sub(1).expect("range is non-empty");
-        let start_chunk = *range.start >> grafting.height;
-        let end_chunk = *end_loc >> grafting.height;
-
-        Ok(Self {
-            leaves,
-            range,
-            layout,
-            inactive_peaks,
-            start_chunk,
-            end_chunk,
-            grafting,
-        })
-    }
-
-    fn range_start(&self) -> u64 {
-        peaks_leaf_len(&self.layout.prefix)
-    }
-
-    fn after_start(&self) -> u64 {
-        self.range_start() + peaks_leaf_len(&self.layout.range)
-    }
-
-    fn prefix_raw_start(&self) -> usize {
-        prefix_raw_start_idx(&self.layout.prefix, self.start_chunk, self.grafting.height)
-    }
-
-    fn after_raw_end(&self) -> usize {
-        after_raw_end_idx(
-            &self.layout.after,
-            self.after_start(),
-            self.end_chunk,
-            self.grafting.height,
-        )
-    }
-
-    const fn chunk_available(&self, idx: u64) -> bool {
-        idx < self.grafting.complete_chunks
-    }
-
-    const fn total_peaks(&self) -> usize {
-        self.layout.prefix.len() + self.layout.range.len() + self.layout.after.len()
-    }
-}
-
-impl<F: Graftable> ProofPlan<F> {
-    fn from_inactivity_floor(
-        leaves: Location<F>,
-        range: Range<Location<F>>,
-        inactivity_floor: Location<F>,
-        grafting: GraftingInfo,
-    ) -> Result<Self, merkle::Error<F>> {
-        let inactive_peaks =
-            grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting.height)?;
-        Self::new(leaves, range, inactive_peaks, grafting)
-    }
-
-    fn needs_grafted_peak_fold(&self) -> Result<bool, merkle::Error<F>> {
-        let size = Position::<F>::try_from(self.leaves)?;
-        Ok(proof_needs_grafted_peak_fold(
-            &self.layout,
-            size,
-            self.grafting.height,
-            self.grafting.complete_chunks,
-        ))
-    }
-}
-
-/// Helper to bucket a tree's current peaks into prefix, range, and after sub-vectors.
-///
-/// Traverses all structural peaks left-to-right (from largest/leftmost to smallest/rightmost)
-/// and divides them into the three regions described by [`PeakLayout`].
-fn peak_layout<F: Family>(
-    leaves: Location<F>,
-    range: Range<Location<F>>,
-) -> Result<PeakLayout<F>, merkle::Error<F>> {
-    if range.is_empty() {
-        return Err(merkle::Error::Empty);
-    }
-    let end_minus_one = range.end.checked_sub(1).expect("range is non-empty");
-    if end_minus_one >= leaves {
-        return Err(merkle::Error::RangeOutOfBounds(range.end));
-    }
-
-    let size = Position::<F>::try_from(leaves)?;
-    let mut prefix = Vec::new();
-    let mut range_peaks = Vec::new();
-    let mut after = Vec::new();
-    let mut leaf_cursor = 0u64;
-
-    for (peak_pos, height) in F::peaks(size) {
-        let leaf_end = leaf_cursor + (1u64 << height);
-        if leaf_end <= *range.start {
-            prefix.push((peak_pos, height));
-        } else if leaf_cursor >= *range.end {
-            after.push((peak_pos, height));
-        } else {
-            range_peaks.push((peak_pos, height));
-        }
-        leaf_cursor = leaf_end;
-    }
-
-    Ok(PeakLayout {
-        prefix,
-        range: range_peaks,
-        after,
-    })
-}
-
-/// Determines if a specific chunk index spans multiple peaks and has been fully sealed.
-///
-/// If `chunk_idx` is less than `complete_chunks` and structurally covers more than
-/// one peak, it implies those discrete ops peaks must be explicitly folded together (via the
-/// "grafted fold" interception mechanics) during proof verification.
-fn chunk_needs_grafted_fold<F: Graftable>(
-    size: Position<F>,
-    chunk_idx: u64,
-    grafting_height: u32,
-    complete_chunks: u64,
-) -> bool {
-    chunk_idx < complete_chunks
-        && F::chunk_peaks(size, chunk_idx, grafting_height)
-            .nth(1)
-            .is_some()
-}
-
-/// Checks if the provided proof interacts with ANY multi-peak complete chunks.
-///
-/// It scans all peaks dynamically bucketed by `layout` (prefix, active range, and suffix after).
-/// If any peak's height is sub-grafting-height and falls within a completely sealed chunk
-/// that spans multiple peaks, the standard contiguous root verification MUST be intercepted and
-/// rebuilt completely using the `reconstruct_grafted_root` algorithm.
-fn proof_needs_grafted_peak_fold<F: Graftable>(
-    layout: &PeakLayout<F>,
-    size: Position<F>,
-    grafting_height: u32,
-    complete_chunks: u64,
-) -> bool {
-    layout
-        .prefix
-        .iter()
-        .chain(layout.range.iter())
-        .chain(layout.after.iter())
-        .any(|(pos, height)| {
-            if *height < grafting_height {
-                let chunk_idx = *F::leftmost_leaf(*pos, *height) >> grafting_height;
-                chunk_needs_grafted_fold(size, chunk_idx, grafting_height, complete_chunks)
-            } else {
-                false
-            }
-        })
-}
-
-/// Return the number of leaves covered by `peaks`.
-fn peaks_leaf_len<F: Family>(peaks: &[(Position<F>, u32)]) -> u64 {
-    peaks
-        .iter()
-        .fold(0u64, |acc, (_pos, height)| acc + (1u64 << *height))
-}
-
-/// Return the prefix index where peaks may need to regroup with caller-provided chunks.
-fn prefix_raw_start_idx<F: Family>(
-    peaks: &[(Position<F>, u32)],
-    start_chunk: u64,
-    grafting_height: u32,
-) -> usize {
-    let chunk_start = start_chunk << grafting_height;
-    let mut leaf_cursor = 0u64;
-    for (idx, (_pos, height)) in peaks.iter().enumerate() {
-        leaf_cursor += 1u64 << *height;
-        if leaf_cursor > chunk_start {
-            return idx;
-        }
-    }
-    peaks.len()
-}
-
-/// Return the after-region index up to which peaks may need caller-provided chunks.
-fn after_raw_end_idx<F: Family>(
-    peaks: &[(Position<F>, u32)],
-    start_leaf: u64,
-    end_chunk: u64,
-    grafting_height: u32,
-) -> usize {
-    let chunk_end = (end_chunk + 1) << grafting_height;
-    let mut leaf_cursor = start_leaf;
-    for (idx, (_pos, height)) in peaks.iter().enumerate() {
-        if leaf_cursor >= chunk_end {
-            return idx;
-        }
-        leaf_cursor += 1u64 << *height;
-    }
-    peaks.len()
-}
-
-/// Return the transformed grafted witness shape for a peak slice.
-fn transformed_peak_counts<F: Graftable>(
-    peaks: &[(Position<F>, u32)],
-    start_leaf: u64,
-    grafting_height: u32,
-    has_chunk: impl Fn(u64) -> bool,
-) -> Vec<usize> {
-    let chunk_size = 1u64 << grafting_height;
-    let mut leaf_cursor = start_leaf;
-    let mut out = Vec::new();
-    let mut pending_chunk: Option<(u64, usize)> = None;
-
-    let flush = |out: &mut Vec<usize>, pending: &mut Option<(u64, usize)>| {
-        if let Some((_idx, count)) = pending.take() {
-            out.push(count);
-        }
-    };
-
-    for (_pos, height) in peaks {
-        let peak_start = leaf_cursor;
-        leaf_cursor += 1u64 << *height;
-
-        if *height >= grafting_height {
-            flush(&mut out, &mut pending_chunk);
-            out.push(1);
-            continue;
-        }
-
-        let chunk_idx = peak_start / chunk_size;
-        match pending_chunk.take() {
-            Some((idx, count)) if idx == chunk_idx => {
-                pending_chunk = Some((idx, count + 1));
-            }
-            old_chunk => {
-                pending_chunk = old_chunk;
-                flush(&mut out, &mut pending_chunk);
-                if has_chunk(chunk_idx) {
-                    pending_chunk = Some((chunk_idx, 1));
-                } else {
-                    out.push(1);
-                }
-            }
-        }
-    }
-    flush(&mut out, &mut pending_chunk);
-
-    out
-}
-
 // Reconstructs the canonical grafted root from the combination of generic proof boundaries,
 // operation elements, and grafted prefix/suffix witnesses provided by the prover.
 fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     verifier: &grafting::Verifier<'_, F, H>,
     proof: &RangeProof<F, H::Digest>,
-    plan: &ProofPlan<F>,
+    geometry: &RangeProofGeometry<F>,
     collected: &BTreeMap<Position<F>, H::Digest>,
     get_chunk: impl Fn(u64) -> Option<C>,
 ) -> Option<H::Digest> {
-    let prefix_start = 0;
-    let range_start = plan.range_start();
-    let after_start = plan.after_start();
-    let prefix_raw_start = plan.prefix_raw_start();
-    let after_raw_end = plan.after_raw_end();
+    let prefix_regroup_start = geometry.prefix_regroup_start();
+    let after_regroup_end = geometry.after_regroup_end();
+    let regroup_start_leaf = covered_leaves(&geometry.prefix_peaks()[..prefix_regroup_start]);
+    let suffix_grafted_start_leaf =
+        geometry.after_start() + covered_leaves(&geometry.after_peaks()[..after_regroup_end]);
 
-    let prefix_counts = transformed_peak_counts(
-        &plan.layout.prefix[..prefix_raw_start],
-        prefix_start,
-        plan.grafting.height,
-        |idx| plan.chunk_available(idx),
+    let prefix_counts =
+        geometry.witness_peak_counts(&geometry.prefix_peaks()[..prefix_regroup_start], 0);
+    let suffix_counts = geometry.witness_peak_counts(
+        &geometry.after_peaks()[after_regroup_end..],
+        suffix_grafted_start_leaf,
     );
-    let suffix_counts = transformed_peak_counts(
-        &plan.layout.after[after_raw_end..],
-        after_start + peaks_leaf_len(&plan.layout.after[..after_raw_end]),
-        plan.grafting.height,
-        |idx| plan.chunk_available(idx),
-    );
-    let prefix_witness_len = prefix_counts.len() + plan.layout.prefix[prefix_raw_start..].len();
-    let suffix_witness_len = plan.layout.after[..after_raw_end].len() + suffix_counts.len();
+    let prefix_witness_len =
+        prefix_counts.len() + geometry.prefix_peaks()[prefix_regroup_start..].len();
+    let suffix_witness_len =
+        geometry.after_peaks()[..after_regroup_end].len() + suffix_counts.len();
     if proof.unfolded_prefix_peaks.len() != prefix_witness_len
         || proof.unfolded_suffix_peaks.len() != suffix_witness_len
     {
         return None;
     }
 
-    let mut transformed = Vec::with_capacity(
+    let mut grafted_peaks = Vec::with_capacity(
         proof.unfolded_prefix_peaks.len()
-            + plan.layout.range.len()
+            + geometry.range_peaks().len()
             + proof.unfolded_suffix_peaks.len(),
     );
-    let (prefix_transformed, prefix_raw) =
+    let (prefix_grafted_peaks, prefix_ops_peaks) =
         proof.unfolded_prefix_peaks.split_at(prefix_counts.len());
-    transformed.extend(prefix_transformed.iter().copied().zip(prefix_counts));
-    let mut range_digests = Vec::with_capacity(plan.layout.range.len());
-    for (pos, _) in &plan.layout.range {
+    grafted_peaks.extend(prefix_grafted_peaks.iter().copied().zip(prefix_counts));
+    let mut range_digests = Vec::with_capacity(geometry.range_peaks().len());
+    for (pos, _) in geometry.range_peaks() {
         range_digests.push(*collected.get(pos)?);
     }
-    let (suffix_raw, suffix_transformed) = proof
+    let (suffix_ops_peaks, suffix_grafted_peaks) = proof
         .unfolded_suffix_peaks
-        .split_at(plan.layout.after[..after_raw_end].len());
+        .split_at(geometry.after_peaks()[..after_regroup_end].len());
 
-    // The transformed list has three regions: entries before the range-adjacent chunks, the
-    // middle chunks that may combine raw prefix/range/suffix peaks, and entries after that middle
-    // region. `middle_peaks` covers exactly the chunk span from the first raw prefix peak through
-    // the last raw suffix peak that can share a grafted chunk with the proven range.
-    let middle_iter = plan.layout.prefix[prefix_raw_start..]
+    // The grafted list has three regions: already-grafted entries before the range-adjacent
+    // chunks, ops-tree peak entries that may regroup with the proven range, and already-grafted
+    // entries after that middle region. `middle_iter` covers exactly the chunk span from the first
+    // prefix peak through the last suffix peak that can share a grafted chunk with the proven
+    // range.
+    let middle_iter = geometry.prefix_peaks()[prefix_regroup_start..]
         .iter()
         .map(|(_, h)| *h)
-        .zip(prefix_raw.iter().copied())
+        .zip(prefix_ops_peaks.iter().copied())
         .chain(
-            plan.layout
-                .range
+            geometry
+                .range_peaks()
                 .iter()
                 .map(|(_, h)| *h)
                 .zip(range_digests.iter().copied()),
         )
         .chain(
-            plan.layout.after[..after_raw_end]
+            geometry.after_peaks()[..after_regroup_end]
                 .iter()
                 .map(|(_, h)| *h)
-                .zip(suffix_raw.iter().copied()),
+                .zip(suffix_ops_peaks.iter().copied()),
         );
-    transformed.extend(grafting::transform_peak_digests::<F, _, _, _>(
+    grafted_peaks.extend(grafting::transform_peak_digests::<F, _, _, _>(
         verifier,
         middle_iter,
-        range_start - peaks_leaf_len(&plan.layout.prefix[prefix_raw_start..]),
-        plan.grafting.height,
+        regroup_start_leaf,
+        geometry.grafting_height(),
         get_chunk,
     ));
-    transformed.extend(suffix_transformed.iter().copied().zip(suffix_counts));
+    grafted_peaks.extend(suffix_grafted_peaks.iter().copied().zip(suffix_counts));
 
     let inactive_peaks = proof.proof.inactive_peaks;
     let inactive_to_fold = grafting::transformed_inactive_peaks::<F, _>(
-        &transformed,
+        &grafted_peaks,
         inactive_peaks,
-        plan.total_peaks(),
+        geometry.total_peaks(),
     )
     .ok()?;
-    let digests = transformed.iter().map(|(digest, _count)| digest);
-    verifier.root_with_folded_peaks(plan.leaves, inactive_to_fold, inactive_peaks, digests)
+    let digests = grafted_peaks.iter().map(|(digest, _count)| digest);
+    verifier.root_with_folded_peaks(geometry.leaves(), inactive_to_fold, inactive_peaks, digests)
 }
 
 struct GraftedProofParts<F: Family, D: Digest> {
@@ -552,23 +262,23 @@ fn prefix_witness<
     hasher: &StandardHasher<H>,
     bitmap: &BitmapGrafting<'_, B, N>,
     peaks: &[(Position<F>, u32)],
-    raw_digests: &[D],
-    raw_start: usize,
+    ops_peak_digests: &[D],
+    regroup_start: usize,
 ) -> Vec<D> {
     let mut witness = grafting::transform_peak_digests::<F, _, _, _>(
         hasher,
-        peaks[..raw_start]
+        peaks[..regroup_start]
             .iter()
             .map(|(_, h)| *h)
-            .zip(raw_digests[..raw_start].iter().copied()),
+            .zip(ops_peak_digests[..regroup_start].iter().copied()),
         0,
-        bitmap.info.height,
+        bitmap.grafting_height,
         |idx| bitmap.chunk(idx),
     )
     .into_iter()
     .map(|(digest, _count)| digest)
     .collect::<Vec<_>>();
-    witness.extend_from_slice(&raw_digests[raw_start..]);
+    witness.extend_from_slice(&ops_peak_digests[regroup_start..]);
     witness
 }
 
@@ -582,20 +292,20 @@ fn suffix_witness<
     hasher: &StandardHasher<H>,
     bitmap: &BitmapGrafting<'_, B, N>,
     peaks: &[(Position<F>, u32)],
-    raw_digests: &[D],
+    ops_peak_digests: &[D],
     suffix_start: u64,
-    raw_end: usize,
+    regroup_end: usize,
 ) -> Vec<D> {
-    let mut witness = raw_digests[..raw_end].to_vec();
+    let mut witness = ops_peak_digests[..regroup_end].to_vec();
     witness.extend(
         grafting::transform_peak_digests::<F, _, _, _>(
             hasher,
-            peaks[raw_end..]
+            peaks[regroup_end..]
                 .iter()
                 .map(|(_, h)| *h)
-                .zip(raw_digests[raw_end..].iter().copied()),
-            suffix_start + peaks_leaf_len(&peaks[..raw_end]),
-            bitmap.info.height,
+                .zip(ops_peak_digests[regroup_end..].iter().copied()),
+            suffix_start + covered_leaves(&peaks[..regroup_end]),
+            bitmap.grafting_height,
             |idx| bitmap.chunk(idx),
         )
         .into_iter()
@@ -615,13 +325,16 @@ async fn build_grafted_range_proof<
     hasher: &StandardHasher<H>,
     bitmap: &BitmapGrafting<'_, B, N>,
     storage: &S,
-    plan: &ProofPlan<F>,
+    geometry: &RangeProofGeometry<F>,
 ) -> Result<GraftedProofParts<F, D>, Error<F>> {
-    let proof_positions =
-        merkle::range_collection_nodes(plan.leaves, plan.inactive_peaks, plan.range.clone())?;
+    let proof_positions = merkle::range_collection_nodes(
+        geometry.leaves(),
+        geometry.inactive_peaks(),
+        geometry.range(),
+    )?;
     let mut fetch_positions = proof_positions.clone();
-    fetch_positions.extend(plan.layout.prefix.iter().map(|&(pos, _)| pos));
-    fetch_positions.extend(plan.layout.after.iter().map(|&(pos, _)| pos));
+    fetch_positions.extend(geometry.prefix_peaks().iter().map(|&(pos, _)| pos));
+    fetch_positions.extend(geometry.after_peaks().iter().map(|&(pos, _)| pos));
     fetch_positions.sort_unstable();
     debug_assert!(
         fetch_positions
@@ -645,31 +358,31 @@ async fn build_grafted_range_proof<
         .collect::<Result<_, Error<F>>>()?;
 
     let proof = merkle::build_range_collection_proof::<F, D, Error<F>>(
-        plan.leaves,
-        plan.inactive_peaks,
+        geometry.leaves(),
+        geometry.inactive_peaks(),
         &proof_positions,
         |pos| fetched.get(&pos).copied(),
         |pos| Error::from(merkle::Error::<F>::MissingNode(pos)),
     )?;
 
-    let prefix_raw = peak_digests(&plan.layout.prefix, &fetched)?;
+    let prefix_ops_peak_digests = peak_digests(geometry.prefix_peaks(), &fetched)?;
     let unfolded_prefix_peaks = prefix_witness::<F, D, H, B, N>(
         hasher,
         bitmap,
-        &plan.layout.prefix,
-        &prefix_raw,
-        plan.prefix_raw_start(),
+        geometry.prefix_peaks(),
+        &prefix_ops_peak_digests,
+        geometry.prefix_regroup_start(),
     );
 
-    let suffix_raw = peak_digests(&plan.layout.after, &fetched)?;
-    let suffix_start = plan.after_start();
+    let suffix_ops_peak_digests = peak_digests(geometry.after_peaks(), &fetched)?;
+    let suffix_start = geometry.after_start();
     let unfolded_suffix_peaks = suffix_witness::<F, D, H, B, N>(
         hasher,
         bitmap,
-        &plan.layout.after,
-        &suffix_raw,
+        geometry.after_peaks(),
+        &suffix_ops_peak_digests,
         suffix_start,
-        plan.after_raw_end(),
+        geometry.after_regroup_end(),
     );
 
     Ok(GraftedProofParts {
@@ -688,19 +401,19 @@ pub struct RangeProof<F: Family, D: Digest> {
     /// Extra prefix witnesses needed when generic proof collection would hide peaks behind a
     /// prefix accumulator that grafted reconstruction must inspect.
     ///
-    /// This vector is intentionally split by convention. It starts with already-transformed
-    /// grafted digests for the prefix region before the range-adjacent chunk span, then contains
-    /// raw peak digests that can regroup with the proven range. The verifier reconstructs the split
-    /// point from the peak layout.
+    /// This vector is intentionally split by convention. It starts with already-grafted
+    /// digests for the prefix region before the range-adjacent chunk span, then contains
+    /// ops-tree peak digests that can regroup with the proven range. The verifier
+    /// reconstructs the split point from the peak layout.
     pub unfolded_prefix_peaks: Vec<D>,
 
     /// Extra suffix witnesses needed when generic backward-bagged proofs hide peaks behind a
     /// suffix accumulator that grafted reconstruction must inspect.
     ///
-    /// This vector is intentionally split by convention. It starts with raw peak digests adjacent
-    /// to the proven range, because those peaks may share grafted chunks with in-range peaks. It
-    /// then contains already-transformed grafted digests for the remaining suffix region. The
-    /// verifier reconstructs the split point from the peak layout.
+    /// This vector is intentionally split by convention. It starts with ops-tree peak digests
+    /// adjacent to the proven range, because those peaks may share grafted chunks with
+    /// in-range peaks. It then contains already-grafted digests for the remaining
+    /// suffix region. The verifier reconstructs the split point from the peak layout.
     pub unfolded_suffix_peaks: Vec<D>,
 
     /// The partial chunk digest from the status bitmap at the time of proof generation, if any.
@@ -708,6 +421,22 @@ pub struct RangeProof<F: Family, D: Digest> {
 
     /// The ops-tree root at the time of proof generation.
     /// Needed by the verifier to reconstruct the canonical root.
+    pub ops_root: D,
+}
+
+/// Parameters that identify the operation span and snapshot used to build a range proof.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub struct RangeProofSpec<F: Family, D: Digest> {
+    /// First operation location to prove.
+    pub start_loc: Location<F>,
+
+    /// Maximum number of operations to include.
+    pub max_ops: NonZeroU64,
+
+    /// Inactivity floor used to fold old inactive peaks.
+    pub inactivity_floor: Location<F>,
+
+    /// The ops-tree root at the time of proof generation.
     pub ops_root: D,
 }
 
@@ -724,23 +453,34 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let std_hasher = qmdb::hasher::<H>();
         let bitmap = BitmapGrafting::new(status);
         let leaves = Location::try_from(storage.size().await)?;
-        let plan = ProofPlan::from_inactivity_floor(leaves, range, inactivity_floor, bitmap.info)?;
+        let inactive_peaks = grafting::chunk_aligned_inactive_peaks::<F>(
+            leaves,
+            inactivity_floor,
+            bitmap.grafting_height,
+        )?;
+        let geometry = RangeProofGeometry::new(
+            leaves,
+            range,
+            inactive_peaks,
+            bitmap.grafting_height,
+            bitmap.complete_chunks,
+        )?;
 
-        let needs_grafted_peak_fold = plan.needs_grafted_peak_fold()?;
+        let needs_unfolded_boundary_peaks = geometry.needs_unfolded_boundary_peaks()?;
         let GraftedProofParts {
             proof,
             unfolded_prefix_peaks,
             unfolded_suffix_peaks,
-        } = if needs_grafted_peak_fold {
-            build_grafted_range_proof(&std_hasher, &bitmap, storage, &plan).await?
+        } = if needs_unfolded_boundary_peaks {
+            build_grafted_range_proof(&std_hasher, &bitmap, storage, &geometry).await?
         } else {
             GraftedProofParts {
                 proof: merkle::verification::historical_range_proof(
                     &std_hasher,
                     storage,
-                    plan.leaves,
-                    plan.range.clone(),
-                    plan.inactive_peaks,
+                    geometry.leaves(),
+                    geometry.range(),
+                    geometry.inactive_peaks(),
                 )
                 .await?,
                 unfolded_prefix_peaks: Vec::new(),
@@ -776,7 +516,6 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
     /// Returns [Error::OperationPruned] if `start_loc` falls in a pruned bitmap chunk.
     /// Returns [`merkle::Error::LocationOverflow`] if `start_loc` > [merkle::Family::MAX_LEAVES].
     /// Returns [`merkle::Error::RangeOutOfBounds`] if `start_loc` >= number of leaves in the MMR.
-    #[allow(clippy::too_many_arguments)]
     pub async fn new_with_ops<
         H: CHasher<Digest = D>,
         C: Contiguous,
@@ -786,26 +525,23 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         hasher: &mut H,
         status: &impl BitmapReadable<N>,
         storage: &S,
-        inactivity_floor: Location<F>,
         log: &C,
-        start_loc: Location<F>,
-        max_ops: NonZeroU64,
-        ops_root: D,
+        request: RangeProofSpec<F, D>,
     ) -> Result<(Self, Vec<C::Item>, Vec<[u8; N]>), Error<F>> {
         // Compute the start and end locations & positions of the range.
         let leaves = Location::new(status.len());
-        if start_loc >= leaves {
-            return Err(merkle::Error::RangeOutOfBounds(start_loc).into());
+        if request.start_loc >= leaves {
+            return Err(merkle::Error::RangeOutOfBounds(request.start_loc).into());
         }
 
         // Reject ranges that start in pruned bitmap chunks.
         let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
-        let start = *start_loc / chunk_bits;
+        let start = *request.start_loc / chunk_bits;
         if (start as usize) < status.pruned_chunks() {
-            return Err(Error::OperationPruned(start_loc));
+            return Err(Error::OperationPruned(request.start_loc));
         }
 
-        let max_loc = start_loc.saturating_add(max_ops.get());
+        let max_loc = request.start_loc.saturating_add(request.max_ops.get());
         let end_loc = core::cmp::min(max_loc, leaves);
 
         // Generate the proof from the grafted storage.
@@ -813,15 +549,15 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             hasher,
             status,
             storage,
-            inactivity_floor,
-            start_loc..end_loc,
-            ops_root,
+            request.inactivity_floor,
+            request.start_loc..end_loc,
+            request.ops_root,
         )
         .await?;
 
         // Collect the operations necessary to verify the proof.
         let reader = log.reader().await;
-        let futures = (*start_loc..*end_loc)
+        let futures = (*request.start_loc..*end_loc)
             .map(|i| reader.read(i))
             .collect::<Vec<_>>();
         let ops = try_join_all(futures).await?;
@@ -834,9 +570,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
 
         Ok((proof, ops, chunks))
     }
-}
 
-impl<F: Graftable, D: Digest> RangeProof<F, D> {
     /// Return true if the given sequence of `ops` were applied starting at location `start_loc` in
     /// the db with the provided root, and having the activity status described by `chunks`.
     pub fn verify<H: CHasher<Digest = D>, O: Codec, const N: usize>(
@@ -883,10 +617,6 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let elements = ops.iter().map(|op| op.encode()).collect::<Vec<_>>();
         let chunk_vec = chunks.iter().map(|c| c.as_ref()).collect::<Vec<_>>();
         let grafting_height = grafting::height::<N>();
-        let grafting = GraftingInfo {
-            height: grafting_height,
-            complete_chunks,
-        };
         let verifier = grafting::Verifier::<F, H>::new(
             grafting_height,
             start_chunk,
@@ -915,26 +645,27 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             return false;
         }
 
-        let plan = match ProofPlan::new(
+        let geometry = match RangeProofGeometry::new(
             leaves,
             start_loc..end_loc,
             self.proof.inactive_peaks,
-            grafting,
+            grafting_height,
+            complete_chunks,
         ) {
-            Ok(plan) => plan,
+            Ok(geometry) => geometry,
             Err(error) => {
                 debug!(?error, "verification failed, invalid peak layout");
                 return false;
             }
         };
-        let needs_grafted_peak_fold = match plan.needs_grafted_peak_fold() {
-            Ok(needs_grafted_peak_fold) => needs_grafted_peak_fold,
+        let needs_unfolded_boundary_peaks = match geometry.needs_unfolded_boundary_peaks() {
+            Ok(needs_unfolded_boundary_peaks) => needs_unfolded_boundary_peaks,
             Err(error) => {
                 debug!(?error, "verification failed, invalid size");
                 return false;
             }
         };
-        let merkle_root = if !needs_grafted_peak_fold {
+        let merkle_root = if !needs_unfolded_boundary_peaks {
             if !self.unfolded_prefix_peaks.is_empty() || !self.unfolded_suffix_peaks.is_empty() {
                 debug!("verification failed, unexpected grafted metadata");
                 return false;
@@ -969,7 +700,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
                     .map(|idx| chunks[idx as usize].as_ref())
             };
             let Some(root) =
-                reconstruct_grafted_root(&verifier, self, &plan, &collected, get_chunk)
+                reconstruct_grafted_root(&verifier, self, &geometry, &collected, get_chunk)
             else {
                 debug!("verification failed, could not reconstruct grafted root");
                 return false;
@@ -1474,14 +1205,20 @@ mod tests {
                         if *loc >= leaves {
                             break;
                         }
-                        let after_peaks = peak_layout(mmb::Location::new(leaves), loc..loc + 1)
-                            .ok()?
-                            .after;
-                        let has_partial_suffix_peak = after_peaks.iter().any(|(pos, height)| {
-                            *height < grafting_height
-                                && (*F::leftmost_leaf(*pos, *height) >> grafting_height)
-                                    == complete_chunks
-                        });
+                        let geometry = RangeProofGeometry::<F>::new(
+                            mmb::Location::new(leaves),
+                            loc..loc + 1,
+                            0,
+                            grafting_height,
+                            complete_chunks,
+                        )
+                        .ok()?;
+                        let has_partial_suffix_peak =
+                            geometry.after_peaks().iter().any(|(pos, height)| {
+                                *height < grafting_height
+                                    && (*F::leftmost_leaf(*pos, *height) >> grafting_height)
+                                        == complete_chunks
+                            });
                         if has_partial_suffix_peak {
                             return Some((leaves, loc));
                         }
@@ -1598,14 +1335,19 @@ mod tests {
                         if *start_loc >= complete_chunks * chunk_bits {
                             return None;
                         }
-                        let layout = peak_layout(leaves_loc, start_loc..leaves_loc).ok()?;
-                        proof_needs_grafted_peak_fold(
-                            &layout,
-                            size,
+                        let geometry = RangeProofGeometry::<F>::new(
+                            leaves_loc,
+                            start_loc..leaves_loc,
+                            0,
                             grafting_height,
                             complete_chunks,
                         )
-                        .then_some((leaves, start_loc, complete_chunks))
+                        .ok()?;
+                        geometry.needs_unfolded_boundary_peaks().ok()?.then_some((
+                            leaves,
+                            start_loc,
+                            complete_chunks,
+                        ))
                     })
                 })
                 .expect("expected an MMB proof into the trailing partial chunk");
@@ -1794,25 +1536,28 @@ mod tests {
             let grafting_height = grafting::height::<N>();
             let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
 
-            let (leaf_count, loc, layout) = (chunk_bits * 3..=128u64)
+            let (leaf_count, loc, geometry) = (chunk_bits * 3..=128u64)
                 .filter(|leaves| leaves % chunk_bits == 0)
                 .find_map(|leaves| {
                     let leaves_loc = mmb::Location::new(leaves);
                     let complete_chunks = leaves / chunk_bits;
                     (0..leaves).find_map(|idx| {
                         let loc = mmb::Location::new(idx);
-                        let layout = peak_layout(leaves_loc, loc..loc + 1).ok()?;
-                        let size = F::location_to_position(leaves_loc);
-                        proof_needs_grafted_peak_fold(
-                            &layout,
-                            size,
+                        let geometry = RangeProofGeometry::<F>::new(
+                            leaves_loc,
+                            loc..loc + 1,
+                            0,
                             grafting_height,
                             complete_chunks,
                         )
-                        .then_some((leaves, loc, layout))
+                        .ok()?;
+                        geometry
+                            .needs_unfolded_boundary_peaks()
+                            .ok()?
+                            .then_some((leaves, loc, geometry))
                     })
                 })
-                .expect("expected an MMB proof requiring grafted peak folding");
+                .expect("expected an MMB proof requiring unfolded boundary peaks");
 
             let mut status = BitMap::<N>::new();
             for _ in 0..leaf_count {
@@ -1878,17 +1623,11 @@ mod tests {
 
             // Grafted reconstruction needs the individual prefix/suffix peaks that generic
             // backward proofs may otherwise hide behind fold accumulators. These witnesses are
-            // already grouped by grafted chunk, so their counts can be smaller than raw peak
-            // counts.
-            let prefix_counts =
-                transformed_peak_counts(&layout.prefix, 0, grafting_height, |idx| {
-                    idx < leaf_count / chunk_bits
-                });
-            let suffix_start = peaks_leaf_len(&layout.prefix) + peaks_leaf_len(&layout.range);
-            let suffix_counts =
-                transformed_peak_counts(&layout.after, suffix_start, grafting_height, |idx| {
-                    idx < leaf_count / chunk_bits
-                });
+            // already grouped by grafted chunk, so their counts can be smaller than the ops-tree
+            // peak counts.
+            let prefix_counts = geometry.witness_peak_counts(geometry.prefix_peaks(), 0);
+            let suffix_start = geometry.after_start();
+            let suffix_counts = geometry.witness_peak_counts(geometry.after_peaks(), suffix_start);
             assert_eq!(proof.unfolded_prefix_peaks.len(), prefix_counts.len());
             assert_eq!(proof.unfolded_suffix_peaks.len(), suffix_counts.len());
 
@@ -1961,14 +1700,15 @@ mod tests {
             let leaves = mmb::Location::new(leaf_count);
             let inactivity_floor = mmb::Location::new(chunk_bits - 2);
 
-            let raw_inactive = F::inactive_peaks(F::location_to_position(leaves), inactivity_floor);
+            let ops_inactive_peaks =
+                F::inactive_peaks(F::location_to_position(leaves), inactivity_floor);
             let aligned_inactive = grafting::chunk_aligned_inactive_peaks::<F>(
                 leaves,
                 inactivity_floor,
                 grafting_height,
             )
             .unwrap();
-            assert_ne!(raw_inactive, aligned_inactive);
+            assert_ne!(ops_inactive_peaks, aligned_inactive);
 
             let mut status = BitMap::<N>::new();
             for _ in 0..leaf_count {
@@ -1976,10 +1716,10 @@ mod tests {
             }
             let ops = build_test_mem(&hasher, mmb::mem::Mmb::new(), leaf_count);
 
-            // The ops root is the inner QMDB log root and commits the raw inactive peak count.
+            // The ops root is the inner QMDB log root and commits the ops-tree inactive peak count.
             // The grafted bitmap root commits the chunk-aligned count, since grafted chunks are
             // the atomic inactive-prefix boundary for the current root.
-            let ops_root = ops.root(&hasher, raw_inactive).unwrap();
+            let ops_root = ops.root(&hasher, ops_inactive_peaks).unwrap();
 
             let chunk_inputs: Vec<_> =
                 (0..<BitMap<N> as BitmapReadable<N>>::complete_chunks(&status))

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -7,7 +7,7 @@
 
 mod geometry;
 
-use self::geometry::{covered_leaves, RangeProofGeometry};
+use self::geometry::RangeProofGeometry;
 use crate::{
     journal::contiguous::{Contiguous, Reader as _},
     merkle::{
@@ -50,7 +50,7 @@ impl<D: Digest> OpsRootWitness<D> {
     /// Return true if this witness proves that `canonical_root` commits to `ops_root`.
     pub fn verify<H: CHasher<Digest = D>>(
         &self,
-        hasher: &mut StandardHasher<H>,
+        hasher: &StandardHasher<H>,
         ops_root: &D,
         canonical_root: &D,
     ) -> bool {
@@ -112,8 +112,8 @@ where
     }
 }
 
-// Lightweight view of the status bitmap as complete bitmap chunks. Pruned chunks are represented
-// by zero-filled chunks because their bits are folded into the inactive prefix.
+// Provides complete bitmap chunks by index for grafted reconstruction. Pruned chunks are returned
+// as zero chunks because their bits are already folded into the inactive prefix.
 struct BitmapGrafting<'a, B, const N: usize> {
     status: &'a B,
     grafting_height: u32,
@@ -142,8 +142,8 @@ impl<'a, B: BitmapReadable<N>, const N: usize> BitmapGrafting<'a, B, N> {
     }
 }
 
-// Reconstructs the canonical grafted root from the combination of generic proof boundaries,
-// operation elements, and grafted prefix/suffix witnesses provided by the prover.
+// Reconstructs the canonical grafted root from the ops-tree range proof, operation elements, and
+// the prefix/suffix witnesses described by the five-segment geometry.
 fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     verifier: &grafting::Verifier<'_, F, H>,
     proof: &RangeProof<F, H::Digest>,
@@ -151,99 +151,63 @@ fn reconstruct_grafted_root<F: Graftable, H: CHasher, C: AsRef<[u8]>>(
     collected: &BTreeMap<Position<F>, H::Digest>,
     get_chunk: impl Fn(u64) -> Option<C>,
 ) -> Option<H::Digest> {
-    let prefix_regroup_start = geometry.prefix_regroup_start();
-    let after_regroup_end = geometry.after_regroup_end();
-    let regroup_start_leaf = covered_leaves(&geometry.prefix_peaks()[..prefix_regroup_start]);
-    let suffix_grafted_start_leaf =
-        geometry.after_start() + covered_leaves(&geometry.after_peaks()[..after_regroup_end]);
+    let prefix_boundary = geometry.prefix_boundary();
+    let range_peaks = geometry.range_peaks();
+    let suffix_boundary = geometry.suffix_boundary();
+    let (prefix_counts, prefix_bitmap_witnesses, prefix_boundary_digests) =
+        geometry.split_prefix_witnesses(&proof.prefix_witnesses)?;
+    let (suffix_boundary_digests, suffix_bitmap_witnesses, suffix_counts) =
+        geometry.split_suffix_witnesses(&proof.suffix_witnesses)?;
 
-    let prefix_counts =
-        geometry.witness_peak_counts(&geometry.prefix_peaks()[..prefix_regroup_start], 0);
-    let suffix_counts = geometry.witness_peak_counts(
-        &geometry.after_peaks()[after_regroup_end..],
-        suffix_grafted_start_leaf,
+    let mut peak_entries = Vec::with_capacity(
+        proof.prefix_witnesses.len() + range_peaks.len() + proof.suffix_witnesses.len(),
     );
-    let prefix_witness_len =
-        prefix_counts.len() + geometry.prefix_peaks()[prefix_regroup_start..].len();
-    let suffix_witness_len =
-        geometry.after_peaks()[..after_regroup_end].len() + suffix_counts.len();
-    if proof.unfolded_prefix_peaks.len() != prefix_witness_len
-        || proof.unfolded_suffix_peaks.len() != suffix_witness_len
-    {
-        return None;
+    peak_entries.extend(prefix_bitmap_witnesses.iter().copied().zip(prefix_counts));
+    let mut range_digests = Vec::with_capacity(range_peaks.len());
+    for pos in range_peaks.positions() {
+        range_digests.push(*collected.get(&pos)?);
     }
 
-    let mut grafted_peaks = Vec::with_capacity(
-        proof.unfolded_prefix_peaks.len()
-            + geometry.range_peaks().len()
-            + proof.unfolded_suffix_peaks.len(),
-    );
-    let (prefix_grafted_peaks, prefix_ops_peaks) =
-        proof.unfolded_prefix_peaks.split_at(prefix_counts.len());
-    grafted_peaks.extend(prefix_grafted_peaks.iter().copied().zip(prefix_counts));
-    let mut range_digests = Vec::with_capacity(geometry.range_peaks().len());
-    for (pos, _) in geometry.range_peaks() {
-        range_digests.push(*collected.get(pos)?);
-    }
-    let (suffix_ops_peaks, suffix_grafted_peaks) = proof
-        .unfolded_suffix_peaks
-        .split_at(geometry.after_peaks()[..after_regroup_end].len());
-
-    // The grafted list has three regions: already-grafted entries before the range-adjacent
-    // chunks, ops-tree peak entries that may regroup with the proven range, and already-grafted
-    // entries after that middle region. `middle_iter` covers exactly the chunk span from the first
-    // prefix peak through the last suffix peak that can share a bitmap chunk with the proven
-    // range.
-    let middle_iter = geometry.prefix_peaks()[prefix_regroup_start..]
-        .iter()
-        .map(|(_, h)| *h)
-        .zip(prefix_ops_peaks.iter().copied())
-        .chain(
-            geometry
-                .range_peaks()
-                .iter()
-                .map(|(_, h)| *h)
-                .zip(range_digests.iter().copied()),
-        )
-        .chain(
-            geometry.after_peaks()[..after_regroup_end]
-                .iter()
-                .map(|(_, h)| *h)
-                .zip(suffix_ops_peaks.iter().copied()),
-        );
-    grafted_peaks.extend(grafting::transform_peak_digests::<F, _, _, _>(
+    // `root_with_folded_peaks` needs one ordered peak entry per reconstructed grafted peak. The
+    // pure prefix/suffix witnesses already contain grafted digests; the range-adjacent ops-tree
+    // digests must be transformed with their bitmap chunks first.
+    let middle_iter = prefix_boundary
+        .heights_with_digests(prefix_boundary_digests)
+        .chain(range_peaks.heights_with_digests(&range_digests))
+        .chain(suffix_boundary.heights_with_digests(suffix_boundary_digests));
+    peak_entries.extend(grafting::transform_peak_digests::<F, _, _, _>(
         verifier,
         middle_iter,
-        regroup_start_leaf,
+        prefix_boundary.start_leaf(),
         geometry.grafting_height(),
         get_chunk,
     ));
-    grafted_peaks.extend(suffix_grafted_peaks.iter().copied().zip(suffix_counts));
+    peak_entries.extend(suffix_bitmap_witnesses.iter().copied().zip(suffix_counts));
 
     let inactive_peaks = proof.proof.inactive_peaks;
     let inactive_to_fold = grafting::transformed_inactive_peaks::<F, _>(
-        &grafted_peaks,
+        &peak_entries,
         inactive_peaks,
         geometry.total_peaks(),
     )
     .ok()?;
-    let digests = grafted_peaks.iter().map(|(digest, _count)| digest);
+    let digests = peak_entries.iter().map(|(digest, _count)| digest);
     verifier.root_with_folded_peaks(geometry.leaves(), inactive_to_fold, inactive_peaks, digests)
 }
 
 struct GraftedProofParts<F: Family, D: Digest> {
     proof: Proof<F, D>,
-    unfolded_prefix_peaks: Vec<D>,
-    unfolded_suffix_peaks: Vec<D>,
+    prefix_witnesses: Vec<D>,
+    suffix_witnesses: Vec<D>,
 }
 
 fn peak_digests<F: Family, D: Digest>(
-    peaks: &[(Position<F>, u32)],
+    peaks: impl IntoIterator<Item = Position<F>>,
     fetched: &BTreeMap<Position<F>, D>,
 ) -> Result<Vec<D>, Error<F>> {
     peaks
-        .iter()
-        .map(|&(pos, _)| {
+        .into_iter()
+        .map(|pos| {
             fetched
                 .get(&pos)
                 .copied()
@@ -261,24 +225,24 @@ fn prefix_witness<
 >(
     hasher: &StandardHasher<H>,
     bitmap: &BitmapGrafting<'_, B, N>,
-    peaks: &[(Position<F>, u32)],
+    geometry: &RangeProofGeometry<F>,
     ops_peak_digests: &[D],
-    regroup_start: usize,
 ) -> Vec<D> {
+    let pure_prefix = geometry.pure_prefix();
+    let prefix_boundary = geometry.prefix_boundary();
+    let (pure_prefix_digests, boundary_digests) = ops_peak_digests.split_at(pure_prefix.len());
+    debug_assert_eq!(boundary_digests.len(), prefix_boundary.len());
     let mut witness = grafting::transform_peak_digests::<F, _, _, _>(
         hasher,
-        peaks[..regroup_start]
-            .iter()
-            .map(|(_, h)| *h)
-            .zip(ops_peak_digests[..regroup_start].iter().copied()),
-        0,
+        pure_prefix.heights_with_digests(pure_prefix_digests),
+        pure_prefix.start_leaf(),
         bitmap.grafting_height,
         |idx| bitmap.chunk(idx),
     )
     .into_iter()
     .map(|(digest, _count)| digest)
     .collect::<Vec<_>>();
-    witness.extend_from_slice(&ops_peak_digests[regroup_start..]);
+    witness.extend_from_slice(boundary_digests);
     witness
 }
 
@@ -291,20 +255,19 @@ fn suffix_witness<
 >(
     hasher: &StandardHasher<H>,
     bitmap: &BitmapGrafting<'_, B, N>,
-    peaks: &[(Position<F>, u32)],
+    geometry: &RangeProofGeometry<F>,
     ops_peak_digests: &[D],
-    suffix_start: u64,
-    regroup_end: usize,
 ) -> Vec<D> {
-    let mut witness = ops_peak_digests[..regroup_end].to_vec();
+    let suffix_boundary = geometry.suffix_boundary();
+    let pure_suffix = geometry.pure_suffix();
+    let (boundary_digests, pure_suffix_digests) = ops_peak_digests.split_at(suffix_boundary.len());
+    debug_assert_eq!(pure_suffix_digests.len(), pure_suffix.len());
+    let mut witness = boundary_digests.to_vec();
     witness.extend(
         grafting::transform_peak_digests::<F, _, _, _>(
             hasher,
-            peaks[regroup_end..]
-                .iter()
-                .map(|(_, h)| *h)
-                .zip(ops_peak_digests[regroup_end..].iter().copied()),
-            suffix_start + covered_leaves(&peaks[..regroup_end]),
+            pure_suffix.heights_with_digests(pure_suffix_digests),
+            pure_suffix.start_leaf(),
             bitmap.grafting_height,
             |idx| bitmap.chunk(idx),
         )
@@ -333,8 +296,8 @@ async fn build_grafted_range_proof<
         geometry.range(),
     )?;
     let mut fetch_positions = proof_positions.clone();
-    fetch_positions.extend(geometry.prefix_peaks().iter().map(|&(pos, _)| pos));
-    fetch_positions.extend(geometry.after_peaks().iter().map(|&(pos, _)| pos));
+    fetch_positions.extend(geometry.prefix_positions());
+    fetch_positions.extend(geometry.after_positions());
     fetch_positions.sort_unstable();
     debug_assert!(
         fetch_positions
@@ -365,30 +328,18 @@ async fn build_grafted_range_proof<
         |pos| Error::from(merkle::Error::<F>::MissingNode(pos)),
     )?;
 
-    let prefix_ops_peak_digests = peak_digests(geometry.prefix_peaks(), &fetched)?;
-    let unfolded_prefix_peaks = prefix_witness::<F, D, H, B, N>(
-        hasher,
-        bitmap,
-        geometry.prefix_peaks(),
-        &prefix_ops_peak_digests,
-        geometry.prefix_regroup_start(),
-    );
+    let prefix_ops_peak_digests = peak_digests(geometry.prefix_positions(), &fetched)?;
+    let prefix_witnesses =
+        prefix_witness::<F, D, H, B, N>(hasher, bitmap, geometry, &prefix_ops_peak_digests);
 
-    let suffix_ops_peak_digests = peak_digests(geometry.after_peaks(), &fetched)?;
-    let suffix_start = geometry.after_start();
-    let unfolded_suffix_peaks = suffix_witness::<F, D, H, B, N>(
-        hasher,
-        bitmap,
-        geometry.after_peaks(),
-        &suffix_ops_peak_digests,
-        suffix_start,
-        geometry.after_regroup_end(),
-    );
+    let suffix_ops_peak_digests = peak_digests(geometry.after_positions(), &fetched)?;
+    let suffix_witnesses =
+        suffix_witness::<F, D, H, B, N>(hasher, bitmap, geometry, &suffix_ops_peak_digests);
 
     Ok(GraftedProofParts {
         proof,
-        unfolded_prefix_peaks,
-        unfolded_suffix_peaks,
+        prefix_witnesses,
+        suffix_witnesses,
     })
 }
 
@@ -398,23 +349,19 @@ pub struct RangeProof<F: Family, D: Digest> {
     /// The Merkle digest material required to verify the proof.
     pub proof: Proof<F, D>,
 
-    /// Extra prefix witnesses needed when generic proof collection would hide peaks behind a
-    /// prefix accumulator that grafted reconstruction must inspect.
+    /// Extra prefix witnesses needed when grafted reconstruction must inspect peaks that ops-tree
+    /// proof collection could otherwise hide behind a prefix accumulator.
     ///
-    /// This vector is intentionally split by convention. It starts with already-grafted
-    /// digests for the prefix region before the range-adjacent chunk span, then contains
-    /// ops-tree peak digests that can regroup with the proven range. The verifier
-    /// reconstructs the split point from the peak layout.
-    pub unfolded_prefix_peaks: Vec<D>,
+    /// This vector follows the geometry's prefix segment order: bitmap witness digests for
+    /// `pure_prefix`, then ops-tree peak digests for `prefix_boundary`.
+    pub prefix_witnesses: Vec<D>,
 
-    /// Extra suffix witnesses needed when generic backward-bagged proofs hide peaks behind a
-    /// suffix accumulator that grafted reconstruction must inspect.
+    /// Extra suffix witnesses needed when grafted reconstruction must inspect peaks that ops-tree
+    /// proof collection could otherwise hide behind a suffix accumulator.
     ///
-    /// This vector is intentionally split by convention. It starts with ops-tree peak digests
-    /// adjacent to the proven range, because those peaks may share bitmap chunks with
-    /// in-range peaks. It then contains already-grafted digests for the remaining
-    /// suffix region. The verifier reconstructs the split point from the peak layout.
-    pub unfolded_suffix_peaks: Vec<D>,
+    /// This vector follows the geometry's suffix segment order: ops-tree peak digests for
+    /// `suffix_boundary`, then bitmap witness digests for `pure_suffix`.
+    pub suffix_witnesses: Vec<D>,
 
     /// The partial chunk digest from the status bitmap at the time of proof generation, if any.
     pub partial_chunk_digest: Option<D>,
@@ -443,14 +390,13 @@ pub struct RangeProofSpec<F: Family, D: Digest> {
 impl<F: Graftable, D: Digest> RangeProof<F, D> {
     /// Create a new range proof for the provided `range` of operations.
     pub async fn new<H: CHasher<Digest = D>, S: Storage<F, Digest = D>, const N: usize>(
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         status: &impl BitmapReadable<N>,
         storage: &S,
         inactivity_floor: Location<F>,
         range: Range<Location<F>>,
         ops_root: D,
     ) -> Result<Self, Error<F>> {
-        let std_hasher = qmdb::hasher::<H>();
         let bitmap = BitmapGrafting::new(status);
         let leaves = Location::try_from(storage.size().await)?;
         let inactive_peaks = grafting::chunk_aligned_inactive_peaks::<F>(
@@ -466,42 +412,41 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             bitmap.complete_chunks,
         )?;
 
-        let needs_unfolded_boundary_peaks = geometry.needs_unfolded_boundary_peaks()?;
+        let requires_grafted_reconstruction = geometry.requires_grafted_reconstruction()?;
         let GraftedProofParts {
             proof,
-            unfolded_prefix_peaks,
-            unfolded_suffix_peaks,
-        } = if needs_unfolded_boundary_peaks {
-            build_grafted_range_proof(&std_hasher, &bitmap, storage, &geometry).await?
+            prefix_witnesses,
+            suffix_witnesses,
+        } = if requires_grafted_reconstruction {
+            build_grafted_range_proof(hasher, &bitmap, storage, &geometry).await?
         } else {
             GraftedProofParts {
                 proof: merkle::verification::historical_range_proof(
-                    &std_hasher,
+                    hasher,
                     storage,
                     geometry.leaves(),
                     geometry.range(),
                     geometry.inactive_peaks(),
                 )
                 .await?,
-                unfolded_prefix_peaks: Vec::new(),
-                unfolded_suffix_peaks: Vec::new(),
+                prefix_witnesses: Vec::new(),
+                suffix_witnesses: Vec::new(),
             }
         };
 
         let (last_chunk, next_bit) = status.last_chunk();
         let partial_chunk_digest = if next_bit != BitMap::<N>::CHUNK_SIZE_BITS {
-            // Last chunk is incomplete, meaning it's not yet in the MMR and needs to be included
-            // in the proof.
-            hasher.update(&last_chunk);
-            Some(hasher.finalize())
+            // Last chunk is incomplete, meaning it is not yet committed by the grafted bitmap root
+            // and needs to be included in the proof.
+            Some(hasher.digest(&last_chunk))
         } else {
             None
         };
 
         Ok(Self {
             proof,
-            unfolded_prefix_peaks,
-            unfolded_suffix_peaks,
+            prefix_witnesses,
+            suffix_witnesses,
             partial_chunk_digest,
             ops_root,
         })
@@ -515,20 +460,20 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
     ///
     /// Returns [Error::OperationPruned] if `start_loc` falls in a pruned bitmap chunk.
     /// Returns [`merkle::Error::LocationOverflow`] if `start_loc` > [merkle::Family::MAX_LEAVES].
-    /// Returns [`merkle::Error::RangeOutOfBounds`] if `start_loc` >= number of leaves in the MMR.
+    /// Returns [`merkle::Error::RangeOutOfBounds`] if `start_loc` >= number of leaves in the tree.
     pub async fn new_with_ops<
         H: CHasher<Digest = D>,
         C: Contiguous,
         S: Storage<F, Digest = D>,
         const N: usize,
     >(
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         status: &impl BitmapReadable<N>,
         storage: &S,
         log: &C,
         request: RangeProofSpec<F, D>,
     ) -> Result<(Self, Vec<C::Item>, Vec<[u8; N]>), Error<F>> {
-        // Compute the start and end locations & positions of the range.
+        // Compute the end location of the range.
         let leaves = Location::new(status.len());
         if request.start_loc >= leaves {
             return Err(merkle::Error::RangeOutOfBounds(request.start_loc).into());
@@ -575,7 +520,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
     /// the db with the provided root, and having the activity status described by `chunks`.
     pub fn verify<H: CHasher<Digest = D>, O: Codec, const N: usize>(
         &self,
-        hasher: &mut H,
+        root_hasher: &StandardHasher<H>,
         start_loc: Location<F>,
         ops: &[O],
         chunks: &[[u8; N]],
@@ -617,7 +562,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let elements = ops.iter().map(|op| op.encode()).collect::<Vec<_>>();
         let chunk_vec = chunks.iter().map(|c| c.as_ref()).collect::<Vec<_>>();
         let grafting_height = grafting::height::<N>();
-        let verifier = grafting::Verifier::<F, H>::new(
+        let grafting_verifier = grafting::Verifier::<F, H>::new(
             grafting_height,
             start_chunk,
             chunk_vec,
@@ -635,7 +580,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             // chunk provided by the caller matches the digest embedded in the proof.
             if end_chunk == complete_chunks {
                 let last_chunk = chunks.last().expect("chunks non-empty");
-                if last_chunk_digest != verifier.digest(last_chunk) {
+                if last_chunk_digest != grafting_verifier.digest(last_chunk) {
                     debug!("last chunk digest does not match expected value");
                     return false;
                 }
@@ -654,23 +599,26 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         ) {
             Ok(geometry) => geometry,
             Err(error) => {
-                debug!(?error, "verification failed, invalid peak layout");
+                debug!(?error, "verification failed, invalid proof geometry");
                 return false;
             }
         };
-        let needs_unfolded_boundary_peaks = match geometry.needs_unfolded_boundary_peaks() {
-            Ok(needs_unfolded_boundary_peaks) => needs_unfolded_boundary_peaks,
+        let requires_grafted_reconstruction = match geometry.requires_grafted_reconstruction() {
+            Ok(requires_grafted_reconstruction) => requires_grafted_reconstruction,
             Err(error) => {
                 debug!(?error, "verification failed, invalid size");
                 return false;
             }
         };
-        let merkle_root = if !needs_unfolded_boundary_peaks {
-            if !self.unfolded_prefix_peaks.is_empty() || !self.unfolded_suffix_peaks.is_empty() {
-                debug!("verification failed, unexpected grafted metadata");
+        let merkle_root = if !requires_grafted_reconstruction {
+            if !self.prefix_witnesses.is_empty() || !self.suffix_witnesses.is_empty() {
+                debug!("verification failed, unexpected prefix/suffix witnesses");
                 return false;
             }
-            match self.proof.reconstruct_root(&verifier, &elements, start_loc) {
+            match self
+                .proof
+                .reconstruct_root(&grafting_verifier, &elements, start_loc)
+            {
                 Ok(root) => root,
                 Err(error) => {
                     debug!(?error, "invalid proof input");
@@ -680,7 +628,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         } else {
             let mut collected = Vec::new();
             if let Err(error) = self.proof.reconstruct_range_collecting(
-                &verifier,
+                &grafting_verifier,
                 &elements,
                 start_loc,
                 &mut collected,
@@ -699,33 +647,30 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
                     .filter(|&idx| idx < chunks.len() as u64)
                     .map(|idx| chunks[idx as usize].as_ref())
             };
-            let Some(root) =
-                reconstruct_grafted_root(&verifier, self, &geometry, &collected, get_chunk)
-            else {
+            let Some(root) = reconstruct_grafted_root(
+                &grafting_verifier,
+                self,
+                &geometry,
+                &collected,
+                get_chunk,
+            ) else {
                 debug!("verification failed, could not reconstruct grafted root");
                 return false;
             };
             root
         };
 
-        // Compute the canonical root and compare.
-        hasher.update(&self.ops_root);
-        hasher.update(&merkle_root);
-        if has_partial_chunk {
-            // partial_chunk_digest is guaranteed Some by the check above.
-            hasher.update(&next_bit.to_be_bytes());
-            hasher.update(self.partial_chunk_digest.as_ref().unwrap());
-        }
-        let reconstructed_root = hasher.finalize();
-        reconstructed_root == *root
+        let partial =
+            has_partial_chunk.then(|| (next_bit, self.partial_chunk_digest.as_ref().unwrap()));
+        combine_roots(root_hasher, &self.ops_root, &merkle_root, partial) == *root
     }
 }
 
 impl<F: Family, D: Digest> Write for RangeProof<F, D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.proof.write(buf);
-        self.unfolded_prefix_peaks.write(buf);
-        self.unfolded_suffix_peaks.write(buf);
+        self.prefix_witnesses.write(buf);
+        self.suffix_witnesses.write(buf);
         self.partial_chunk_digest.write(buf);
         self.ops_root.write(buf);
     }
@@ -734,8 +679,8 @@ impl<F: Family, D: Digest> Write for RangeProof<F, D> {
 impl<F: Family, D: Digest> EncodeSize for RangeProof<F, D> {
     fn encode_size(&self) -> usize {
         self.proof.encode_size()
-            + self.unfolded_prefix_peaks.encode_size()
-            + self.unfolded_suffix_peaks.encode_size()
+            + self.prefix_witnesses.encode_size()
+            + self.suffix_witnesses.encode_size()
             + self.partial_chunk_digest.encode_size()
             + self.ops_root.encode_size()
     }
@@ -751,15 +696,15 @@ impl<F: Family, D: Digest> Read for RangeProof<F, D> {
     ) -> Result<Self, commonware_codec::Error> {
         let proof = Proof::<F, D>::read_cfg(buf, max_digests)?;
         let remaining = max_digests - proof.digests.len();
-        let unfolded_prefix_peaks = Vec::<D>::read_range(buf, ..=remaining)?;
-        let remaining = remaining - unfolded_prefix_peaks.len();
-        let unfolded_suffix_peaks = Vec::<D>::read_range(buf, ..=remaining)?;
+        let prefix_witnesses = Vec::<D>::read_range(buf, ..=remaining)?;
+        let remaining = remaining - prefix_witnesses.len();
+        let suffix_witnesses = Vec::<D>::read_range(buf, ..=remaining)?;
         let partial_chunk_digest = Option::<D>::read(buf)?;
         let ops_root = D::read(buf)?;
         Ok(Self {
             proof,
-            unfolded_prefix_peaks,
-            unfolded_suffix_peaks,
+            prefix_witnesses,
+            suffix_witnesses,
             partial_chunk_digest,
             ops_root,
         })
@@ -774,8 +719,8 @@ where
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self {
             proof: u.arbitrary()?,
-            unfolded_prefix_peaks: u.arbitrary()?,
-            unfolded_suffix_peaks: u.arbitrary()?,
+            prefix_witnesses: u.arbitrary()?,
+            suffix_witnesses: u.arbitrary()?,
             partial_chunk_digest: u.arbitrary()?,
             ops_root: u.arbitrary()?,
         })
@@ -803,7 +748,7 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
     ///
     /// Returns [Error::OperationPruned] if `loc` falls in a pruned bitmap chunk.
     pub async fn new<H: CHasher<Digest = D>, S: Storage<F, Digest = D>>(
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         status: &impl BitmapReadable<N>,
         storage: &S,
         inactivity_floor: Location<F>,
@@ -837,7 +782,7 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
     /// `root`.
     pub fn verify<H: CHasher<Digest = D>, O: Codec>(
         &self,
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         operation: O,
         root: &D,
     ) -> bool {
@@ -937,9 +882,7 @@ mod tests {
     }
 
     fn range_proof_digest_count<F: Family, D: Digest>(proof: &RangeProof<F, D>) -> usize {
-        proof.proof.digests.len()
-            + proof.unfolded_prefix_peaks.len()
-            + proof.unfolded_suffix_peaks.len()
+        proof.proof.digests.len() + proof.prefix_witnesses.len() + proof.suffix_witnesses.len()
     }
 
     #[test]
@@ -959,27 +902,27 @@ mod tests {
         let ops_root = Sha256::hash(b"ops-root");
 
         let cases = [
-            // Minimal: no optional fields, no unfolded peaks.
+            // Minimal: no optional fields or prefix/suffix witnesses.
             RangeProof {
                 proof: proof.clone(),
-                unfolded_prefix_peaks: vec![],
-                unfolded_suffix_peaks: vec![],
+                prefix_witnesses: vec![],
+                suffix_witnesses: vec![],
                 partial_chunk_digest: None,
                 ops_root,
             },
-            // All optional fields populated, with unfolded peaks on both sides.
+            // All optional fields populated, with prefix/suffix witnesses on both sides.
             RangeProof {
                 proof,
-                unfolded_prefix_peaks: vec![Sha256::hash(b"u0"), Sha256::hash(b"u1")],
-                unfolded_suffix_peaks: vec![Sha256::hash(b"s0"), Sha256::hash(b"s1")],
+                prefix_witnesses: vec![Sha256::hash(b"u0"), Sha256::hash(b"u1")],
+                suffix_witnesses: vec![Sha256::hash(b"s0"), Sha256::hash(b"s1")],
                 partial_chunk_digest: Some(Sha256::hash(b"partial")),
                 ops_root,
             },
             // Default proof with only partial chunk digest.
             RangeProof {
                 proof: Proof::<F, sha256::Digest>::default(),
-                unfolded_prefix_peaks: vec![],
-                unfolded_suffix_peaks: vec![],
+                prefix_witnesses: vec![],
+                suffix_witnesses: vec![],
                 partial_chunk_digest: Some(Sha256::hash(b"only-partial")),
                 ops_root,
             },
@@ -1004,8 +947,8 @@ mod tests {
                 inactive_peaks: 0,
                 digests: vec![Sha256::hash(b"d0")],
             },
-            unfolded_prefix_peaks: vec![Sha256::hash(b"u0")],
-            unfolded_suffix_peaks: vec![Sha256::hash(b"s0")],
+            prefix_witnesses: vec![Sha256::hash(b"u0")],
+            suffix_witnesses: vec![Sha256::hash(b"s0")],
             partial_chunk_digest: None,
             ops_root: Sha256::hash(b"ops-root"),
         };
@@ -1033,8 +976,8 @@ mod tests {
                 inactive_peaks: 0,
                 digests: vec![Sha256::hash(b"sib")],
             },
-            unfolded_prefix_peaks: vec![Sha256::hash(b"peak")],
-            unfolded_suffix_peaks: vec![Sha256::hash(b"suf")],
+            prefix_witnesses: vec![Sha256::hash(b"peak")],
+            suffix_witnesses: vec![Sha256::hash(b"suf")],
             partial_chunk_digest: None,
             ops_root: Sha256::hash(b"ops"),
         };
@@ -1065,8 +1008,8 @@ mod tests {
                 inactive_peaks: 0,
                 digests: vec![Sha256::hash(b"sib")],
             },
-            unfolded_prefix_peaks: vec![Sha256::hash(b"peak")],
-            unfolded_suffix_peaks: vec![Sha256::hash(b"suf")],
+            prefix_witnesses: vec![Sha256::hash(b"peak")],
+            suffix_witnesses: vec![Sha256::hash(b"suf")],
             partial_chunk_digest: None,
             ops_root: Sha256::hash(b"ops"),
         };
@@ -1156,9 +1099,8 @@ mod tests {
             .unwrap();
 
             let loc = mmb::Location::new(BitMap::<N>::CHUNK_SIZE_BITS + 4);
-            let mut proof_hasher = Sha256::new();
             let proof = RangeProof::new(
-                &mut proof_hasher,
+                &hasher,
                 &status,
                 &storage,
                 Location::new(0),
@@ -1169,9 +1111,8 @@ mod tests {
             .unwrap();
 
             let element = hasher.digest(&(*loc).to_be_bytes());
-            let mut verify_hasher = Sha256::new();
             assert!(proof.verify(
-                &mut verify_hasher,
+                &hasher,
                 loc,
                 &[element],
                 &[<BitMap<N> as BitmapReadable<N>>::get_chunk(&status, 1)],
@@ -1189,41 +1130,18 @@ mod tests {
 
             let hasher = qmdb::hasher::<Sha256>();
             let grafting_height = grafting::height::<N>();
+            let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
 
-            let (leaf_count, loc) = (17..=64u64)
+            let (leaf_count, loc) = (chunk_bits * 2 + 1..=64u64)
                 .find_map(|leaves| {
-                    let complete_chunks = leaves / BitMap::<N>::CHUNK_SIZE_BITS;
-                    if complete_chunks < 2 || leaves % BitMap::<N>::CHUNK_SIZE_BITS == 0 {
+                    let complete_chunks = leaves / chunk_bits;
+                    if complete_chunks < 2 || leaves % chunk_bits == 0 {
                         return None;
                     }
 
                     let size = F::location_to_position(mmb::Location::new(leaves));
                     F::chunk_peaks(size, 1, grafting_height).nth(1)?;
-
-                    for offset in 0..BitMap::<N>::CHUNK_SIZE_BITS {
-                        let loc = mmb::Location::new(BitMap::<N>::CHUNK_SIZE_BITS + offset);
-                        if *loc >= leaves {
-                            break;
-                        }
-                        let geometry = RangeProofGeometry::<F>::new(
-                            mmb::Location::new(leaves),
-                            loc..loc + 1,
-                            0,
-                            grafting_height,
-                            complete_chunks,
-                        )
-                        .ok()?;
-                        let has_partial_suffix_peak =
-                            geometry.after_peaks().iter().any(|(pos, height)| {
-                                *height < grafting_height
-                                    && (*F::leftmost_leaf(*pos, *height) >> grafting_height)
-                                        == complete_chunks
-                            });
-                        if has_partial_suffix_peak {
-                            return Some((leaves, loc));
-                        }
-                    }
-                    None
+                    Some((leaves, mmb::Location::new(chunk_bits + 1)))
                 })
                 .expect("expected an MMB proof with a partial trailing suffix chunk");
 
@@ -1280,10 +1198,8 @@ mod tests {
             )
             .await
             .unwrap();
-
-            let mut proof_hasher = Sha256::new();
             let proof = RangeProof::new(
-                &mut proof_hasher,
+                &hasher,
                 &status,
                 &storage,
                 Location::new(0),
@@ -1295,9 +1211,8 @@ mod tests {
 
             let element = hasher.digest(&(*loc).to_be_bytes());
             let chunk_idx = (*loc / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
-            let mut verify_hasher = Sha256::new();
             assert!(proof.verify(
-                &mut verify_hasher,
+                &hasher,
                 loc,
                 &[element],
                 &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1343,7 +1258,7 @@ mod tests {
                             complete_chunks,
                         )
                         .ok()?;
-                        geometry.needs_unfolded_boundary_peaks().ok()?.then_some((
+                        geometry.requires_grafted_reconstruction().ok()?.then_some((
                             leaves,
                             start_loc,
                             complete_chunks,
@@ -1407,9 +1322,8 @@ mod tests {
             .unwrap();
 
             let leaves_loc = mmb::Location::new(leaf_count);
-            let mut proof_hasher = Sha256::new();
             let proof = RangeProof::new(
-                &mut proof_hasher,
+                &hasher,
                 &status,
                 &storage,
                 Location::new(0),
@@ -1427,9 +1341,7 @@ mod tests {
             let chunks = (start_chunk_idx..=end_chunk_idx)
                 .map(|chunk_idx| <BitMap<N> as BitmapReadable<N>>::get_chunk(&status, chunk_idx))
                 .collect::<Vec<_>>();
-
-            let mut verify_hasher = Sha256::new();
-            assert!(proof.verify(&mut verify_hasher, start_loc, &elements, &chunks, &root,));
+            assert!(proof.verify(&hasher, start_loc, &elements, &chunks, &root,));
         });
     }
     #[test_traced]
@@ -1495,9 +1407,8 @@ mod tests {
             .unwrap();
 
             let loc = mmb::Location::new(0);
-            let mut proof_hasher = Sha256::new();
             let mut proof = RangeProof::new(
-                &mut proof_hasher,
+                &hasher,
                 &status,
                 &storage,
                 Location::new(0),
@@ -1512,16 +1423,13 @@ mod tests {
 
             let mut tampered = proof.clone();
             tampered
-                .unfolded_prefix_peaks
-                .push(hasher.digest(b"fake unfolded prefix"));
-            let mut verify_hasher = Sha256::new();
-            assert!(!tampered.verify(&mut verify_hasher, loc, &[element], &[chunk], &root,));
+                .prefix_witnesses
+                .push(hasher.digest(b"fake prefix witness"));
+            assert!(!tampered.verify(&hasher, loc, &[element], &[chunk], &root,));
 
             // Tamper with the proof by injecting a fake partial chunk digest
             proof.partial_chunk_digest = Some(hasher.digest(b"fake partial chunk"));
-
-            let mut verify_hasher = Sha256::new();
-            assert!(!proof.verify(&mut verify_hasher, loc, &[element], &[chunk], &root,));
+            assert!(!proof.verify(&hasher, loc, &[element], &[chunk], &root,));
         });
     }
 
@@ -1552,12 +1460,12 @@ mod tests {
                         )
                         .ok()?;
                         geometry
-                            .needs_unfolded_boundary_peaks()
+                            .requires_grafted_reconstruction()
                             .ok()?
                             .then_some((leaves, loc, geometry))
                     })
                 })
-                .expect("expected an MMB proof requiring unfolded boundary peaks");
+                .expect("expected an MMB proof requiring grafted reconstruction");
 
             let mut status = BitMap::<N>::new();
             for _ in 0..leaf_count {
@@ -1608,10 +1516,8 @@ mod tests {
             )
             .await
             .unwrap();
-
-            let mut proof_hasher = Sha256::new();
             let proof = RangeProof::new(
-                &mut proof_hasher,
+                &hasher,
                 &status,
                 &storage,
                 Location::new(0),
@@ -1621,21 +1527,15 @@ mod tests {
             .await
             .unwrap();
 
-            // Grafted reconstruction needs the individual prefix/suffix peaks that generic
-            // backward proofs may otherwise hide behind fold accumulators. These witnesses are
-            // already grouped by bitmap chunk, so the witness vectors can have fewer entries
-            // than the ops-tree peak lists.
-            let prefix_counts = geometry.witness_peak_counts(geometry.prefix_peaks(), 0);
-            let suffix_start = geometry.after_start();
-            let suffix_counts = geometry.witness_peak_counts(geometry.after_peaks(), suffix_start);
-            assert_eq!(proof.unfolded_prefix_peaks.len(), prefix_counts.len());
-            assert_eq!(proof.unfolded_suffix_peaks.len(), suffix_counts.len());
+            // The prefix/suffix witnesses follow the five-segment geometry: bitmap witness
+            // digests for pure segments and individual ops-tree digests for boundary segments.
+            assert_eq!(proof.prefix_witnesses.len(), geometry.prefix_witness_len());
+            assert_eq!(proof.suffix_witnesses.len(), geometry.suffix_witness_len());
 
             let element = hasher.digest(&(*loc).to_be_bytes());
             let chunk_idx = (*loc / chunk_bits) as usize;
-            let mut verify_hasher = Sha256::new();
             assert!(proof.verify(
-                &mut verify_hasher,
+                &hasher,
                 loc,
                 &[element],
                 &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1646,9 +1546,8 @@ mod tests {
 
             let mut tampered = proof.clone();
             tampered.proof.inactive_peaks = 1;
-            let mut verify_hasher = Sha256::new();
             assert!(!tampered.verify(
-                &mut verify_hasher,
+                &hasher,
                 loc,
                 &[element],
                 &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1659,9 +1558,8 @@ mod tests {
 
             let mut tampered = proof.clone();
             tampered.proof.inactive_peaks = usize::MAX;
-            let mut verify_hasher = Sha256::new();
             assert!(!tampered.verify(
-                &mut verify_hasher,
+                &hasher,
                 loc,
                 &[element],
                 &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1673,9 +1571,8 @@ mod tests {
             let mut tampered = proof.clone();
             assert!(!tampered.proof.digests.is_empty());
             tampered.proof.digests[0] = hasher.digest(b"fake generic sibling");
-            let mut verify_hasher = Sha256::new();
             assert!(!tampered.verify(
-                &mut verify_hasher,
+                &hasher,
                 loc,
                 &[element],
                 &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1765,9 +1662,8 @@ mod tests {
             .unwrap();
 
             let loc = mmb::Location::new(chunk_bits - 1);
-            let mut proof_hasher = Sha256::new();
             let proof = RangeProof::new(
-                &mut proof_hasher,
+                &hasher,
                 &status,
                 &storage,
                 inactivity_floor,
@@ -1780,8 +1676,7 @@ mod tests {
 
             let element = hasher.digest(&(*loc).to_be_bytes());
             let chunk = <BitMap<N> as BitmapReadable<N>>::get_chunk(&status, 0);
-            let mut verify_hasher = Sha256::new();
-            assert!(proof.verify(&mut verify_hasher, loc, &[element], &[chunk], &root));
+            assert!(proof.verify(&hasher, loc, &[element], &[chunk], &root));
         });
     }
 

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -1568,7 +1568,7 @@ mod tests {
                 &root,
             ));
 
-            let mut tampered = proof.clone();
+            let mut tampered = proof;
             assert!(!tampered.proof.digests.is_empty());
             tampered.proof.digests[0] = hasher.digest(b"fake generic sibling");
             assert!(!tampered.verify(

--- a/storage/src/qmdb/current/unordered/db.rs
+++ b/storage/src/qmdb/current/unordered/db.rs
@@ -6,7 +6,7 @@
 use crate::{
     index::Unordered as UnorderedIndex,
     journal::contiguous::{Contiguous, Mutable},
-    merkle::{self, Location},
+    merkle::{self, hasher::Standard as StandardHasher, Location},
     qmdb::{
         any::{
             operation::update::Unordered as UnorderedUpdate,
@@ -56,7 +56,7 @@ where
     /// Return true if the proof authenticates that `key` currently has value `value` in the db with
     /// the provided `root`.
     pub fn verify_key_value_proof(
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         key: K,
         value: V::Value,
         proof: &KeyValueProof<F, H::Digest, N>,
@@ -91,7 +91,7 @@ where
     /// Returns [Error::KeyNotFound] if the key is not currently assigned any value.
     pub async fn key_value_proof(
         &self,
-        hasher: &mut H,
+        hasher: &StandardHasher<H>,
         key: K,
     ) -> Result<KeyValueProof<F, H::Digest, N>, Error<F>> {
         let op_loc = self.any.get_with_loc(&key).await?;

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -170,7 +170,7 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "build-small".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -186,26 +186,18 @@ pub mod tests {
             db.apply_batch(merkleized).await.unwrap();
 
             let (_, op_loc) = db.any.get_with_loc(&k).await.unwrap().unwrap();
-            let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+            let proof = db.key_value_proof(&hasher, k).await.unwrap();
 
             // Proof should be verifiable against current root.
             let root = db.root();
             assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v1,
-                &proof,
-                &root
+                &hasher, k, v1, &proof, &root
             ));
 
             let v2 = Sha256::fill(0xA2);
             // Proof should not verify against a different value.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v2,
-                &proof,
-                &root,
+                &hasher, k, v2, &proof, &root,
             ));
 
             // Update the key to a new value (v2), which inactivates the previous operation.
@@ -220,38 +212,24 @@ pub mod tests {
 
             // New value should not be verifiable against the old proof.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v2,
-                &proof,
-                &root,
+                &hasher, k, v2, &proof, &root,
             ));
 
             // But the new value should verify against a new proof.
-            let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+            let proof = db.key_value_proof(&hasher, k).await.unwrap();
             assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v2,
-                &proof,
-                &root,
+                &hasher, k, v2, &proof, &root,
             ));
 
             // Old value will not verify against new proof.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
-                k,
-                v1,
-                &proof,
-                &root,
+                &hasher, k, v1, &proof, &root,
             ));
 
             // Create a proof of the now-inactive update operation assigning v1 to k against the
             // current root.
-            let (range_proof, _, chunks) = db
-                .range_proof(&mut hasher, op_loc, NZU64!(1))
-                .await
-                .unwrap();
+            let (range_proof, _, chunks) =
+                db.range_proof(&hasher, op_loc, NZU64!(1)).await.unwrap();
             let proof_inactive = db::KeyValueProof {
                 loc: op_loc,
                 chunk: chunks[0],
@@ -261,7 +239,7 @@ pub mod tests {
             // status.
             let op = Operation::Update(UnorderedUpdate(k, v1));
             assert!(TestDb::<F, C, V>::verify_range_proof(
-                &mut hasher,
+                &hasher,
                 &proof_inactive.range_proof,
                 proof_inactive.loc,
                 &[op],
@@ -272,7 +250,7 @@ pub mod tests {
             // But this proof should *not* verify as a key value proof, since verification will see
             // that the operation is inactive.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
+                &hasher,
                 k,
                 v1,
                 &proof_inactive,
@@ -292,7 +270,7 @@ pub mod tests {
             let mut fake_proof = proof_inactive.clone();
             fake_proof.loc = active_loc;
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
+                &hasher,
                 k,
                 v1,
                 &fake_proof,
@@ -312,7 +290,7 @@ pub mod tests {
             let mut fake_proof = proof_inactive.clone();
             fake_proof.chunk = modified_chunk;
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &mut hasher,
+                &hasher,
                 k,
                 v1,
                 &fake_proof,
@@ -340,7 +318,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let db = open_db(context.child("db"), partition.clone()).await;
             let root = db.root();
 
@@ -348,13 +326,13 @@ pub mod tests {
             // commit op.
             let proof = RangeProof {
                 proof: Proof::default(),
-                unfolded_prefix_peaks: vec![],
-                unfolded_suffix_peaks: vec![],
+                prefix_witnesses: vec![],
+                suffix_witnesses: vec![],
                 partial_chunk_digest: None,
                 ops_root: Digest::EMPTY,
             };
             assert!(!TestDb::<F, C, V>::verify_range_proof(
-                &mut hasher,
+                &hasher,
                 &proof,
                 Location::<F>::new(0),
                 &[],
@@ -377,18 +355,11 @@ pub mod tests {
 
             for loc in *start_loc..*end_loc {
                 let loc = Location::<F>::new(loc);
-                let (proof, ops, chunks) = db
-                    .range_proof(&mut hasher, loc, NZU64!(max_ops))
-                    .await
-                    .unwrap();
+                let (proof, ops, chunks) =
+                    db.range_proof(&hasher, loc, NZU64!(max_ops)).await.unwrap();
                 assert!(
                     TestDb::<F, C, V>::verify_range_proof(
-                        &mut hasher,
-                        &proof,
-                        loc,
-                        &ops,
-                        &chunks,
-                        &root
+                        &hasher, &proof, loc, &ops, &chunks, &root
                     ),
                     "failed to verify range at start_loc {start_loc}",
                 );
@@ -396,7 +367,7 @@ pub mod tests {
                 let mut chunks_with_extra = chunks.clone();
                 chunks_with_extra.push(chunks[chunks.len() - 1]);
                 assert!(!TestDb::<F, C, V>::verify_range_proof(
-                    &mut hasher,
+                    &hasher,
                     &proof,
                     loc,
                     &ops,
@@ -426,7 +397,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let db = open_db(context.child("db"), partition.clone()).await;
             let mut db = apply_random_ops::<F, TestDb<F, C, V>>(500, true, context.next_u64(), db)
                 .await
@@ -437,7 +408,7 @@ pub mod tests {
 
             // Confirm bad keys produce the expected error.
             let bad_key = Sha256::fill(0xAA);
-            let res = db.key_value_proof(&mut hasher, bad_key).await;
+            let res = db.key_value_proof(&hasher, bad_key).await;
             assert!(matches!(res, Err(Error::KeyNotFound)));
 
             let start = *db.inactivity_floor_loc();
@@ -455,39 +426,27 @@ pub mod tests {
                     }
                 };
 
-                let proof = db.key_value_proof(&mut hasher, key).await.unwrap();
+                let proof = db.key_value_proof(&hasher, key).await.unwrap();
                 // Proof should validate against the current value and correct root.
                 assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                    &mut hasher,
-                    key,
-                    value,
-                    &proof,
-                    &root
+                    &hasher, key, value, &proof, &root
                 ));
                 // Proof should fail against the wrong value. Use hash instead of fill to ensure
                 // the value differs from any key/value created by TestKey::from_seed (which uses
                 // fill patterns).
                 let wrong_val = Sha256::hash(&[0xFF]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &mut hasher,
-                    key,
-                    wrong_val,
-                    &proof,
-                    &root
+                    &hasher, key, wrong_val, &proof, &root
                 ));
                 // Proof should fail against the wrong key.
                 let wrong_key = Sha256::hash(&[0xEE]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &mut hasher,
-                    wrong_key,
-                    value,
-                    &proof,
-                    &root
+                    &hasher, wrong_key, value, &proof, &root
                 ));
                 // Proof should fail against the wrong root.
                 let wrong_root = Sha256::hash(&[0xDD]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &mut hasher,
+                    &hasher,
                     key,
                     value,
                     &proof,
@@ -515,7 +474,7 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut hasher = Sha256::new();
+            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "build-small".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -535,20 +494,14 @@ pub mod tests {
                 let root = db.root();
 
                 // Create a proof for the current value of k.
-                let proof = db.key_value_proof(&mut hasher, k).await.unwrap();
+                let proof = db.key_value_proof(&hasher, k).await.unwrap();
                 assert!(
-                    TestDb::<F, C, V>::verify_key_value_proof(&mut hasher, k, v, &proof, &root),
+                    TestDb::<F, C, V>::verify_key_value_proof(&hasher, k, v, &proof, &root),
                     "proof of update {i} failed to verify"
                 );
                 // Ensure the proof does NOT verify if we use the previous value.
                 assert!(
-                    !TestDb::<F, C, V>::verify_key_value_proof(
-                        &mut hasher,
-                        k,
-                        old_val,
-                        &proof,
-                        &root,
-                    ),
+                    !TestDb::<F, C, V>::verify_key_value_proof(&hasher, k, old_val, &proof, &root,),
                     "proof of update {i} verified when it should not have"
                 );
                 old_val = v;


### PR DESCRIPTION
## Summary

Refactors current range proof construction and verification to make grafted proof geometry easier to follow.

## Changes

- Moves `current/proof.rs` into a `current/proof/` module with private geometry helpers.
- Introduces `RangeProofGeometry` to centralize grafting-aware range, ops-tree peak, and bitmap chunk boundary calculations.
- Models grafted reconstruction directly as five ordered peak segments:
  `pure prefix | prefix boundary | range | suffix boundary | pure suffix`.
- Consolidates `new_with_ops` arguments into `RangeProofSpec`.
- Updates proof construction and verification APIs to use the reusable QMDB `StandardHasher` instead of passing raw mutable hash state where it is not needed.
- Clarifies terminology around ops-tree peaks, bitmap chunks, unfolded witnesses, and bitmap-witness grouping.
