### PR TITLE
[ci] Bump build job timeout

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -353,7 +353,7 @@ jobs:
   build:
     name: "Build (toolchain: ${{ matrix.toolchain }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Overview

Bumps the timeout of the build job, as it is now failing on `main`: https://github.com/commonwarexyz/monorepo/actions/runs/25476390300/job/74750688181