### PR TITLE
[Storage] Add `qmdb::any` tracing

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -985,6 +985,16 @@ where
     Operation<F, update::Unordered<K, V>>: Codec,
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
+    #[allow(clippy::type_complexity)]
+    #[tracing::instrument(
+        name = "qmdb::any::batch::merkleize",
+        level = "info",
+        skip_all,
+        fields(
+            variant = "unordered",
+            mutations = self.mutations.len() as u64,
+        ),
+    )]
     pub async fn merkleize<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
@@ -1147,6 +1157,16 @@ where
     Operation<F, update::Ordered<K, V>>: Codec,
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
+    #[allow(clippy::type_complexity)]
+    #[tracing::instrument(
+        name = "qmdb::any::batch::merkleize",
+        level = "info",
+        skip_all,
+        fields(
+            variant = "ordered",
+            mutations = self.mutations.len() as u64,
+        ),
+    )]
     pub async fn merkleize<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Ordered<K, V>, N, S>,
@@ -1512,6 +1532,17 @@ where
     /// All uncommitted ancestors in the chain must be kept alive until the child (or any
     /// descendant) is merkleized. Dropping an uncommitted ancestor causes data
     /// loss detected at `apply_batch` time.
+    #[tracing::instrument(
+        name = "qmdb::any::batch::new",
+        level = "info",
+        skip_all,
+        fields(
+            source = "batch",
+            base_size = self.base_size,
+            total_size = self.total_size,
+            ancestor_batches = self.ancestor_diff_ends.len() as u64,
+        ),
+    )]
     pub fn new_batch<H>(self: &Arc<Self>) -> UnmerkleizedBatch<F, H, U, S>
     where
         H: Hasher<Digest = D>,
@@ -1620,6 +1651,17 @@ where
     Operation<F, U>: Codec,
 {
     /// Create a new speculative batch of operations with this database as its parent.
+    #[tracing::instrument(
+        name = "qmdb::any::batch::new",
+        level = "info",
+        skip_all,
+        fields(
+            source = "db",
+            base_size = *self.last_commit_loc + 1,
+            inactivity_floor = *self.inactivity_floor_loc,
+            active_keys = self.active_keys as u64,
+        ),
+    )]
     pub fn new_batch(&self) -> UnmerkleizedBatch<F, H, U, S> {
         // The DB is always committed, so journal size = last_commit_loc + 1.
         let journal_size = *self.last_commit_loc + 1;
@@ -1655,6 +1697,17 @@ where
     /// This publishes the batch to the in-memory database state and appends it to the
     /// journal, but does not durably persist it. Call [`Db::commit`] or [`Db::sync`] to
     /// guarantee durability.
+    #[tracing::instrument(
+        name = "qmdb::any::Db::apply_batch",
+        level = "info",
+        skip_all,
+        fields(
+            batch_total_size = batch.total_size,
+            batch_base_size = batch.base_size,
+            db_size = *self.last_commit_loc + 1,
+            ancestor_batches = batch.ancestor_diff_ends.len() as u64,
+        ),
+    )]
     pub async fn apply_batch(
         &mut self,
         batch: Arc<MerkleizedBatch<F, H::Digest, U, S>>,
@@ -1746,6 +1799,16 @@ where
     /// Create an initial [`MerkleizedBatch`] from the committed DB state.
     ///
     /// This is the starting point for building owned batch chains.
+    #[tracing::instrument(
+        name = "qmdb::any::Db::to_batch",
+        level = "info",
+        skip_all,
+        fields(
+            db_size = *self.last_commit_loc + 1,
+            inactivity_floor = *self.inactivity_floor_loc,
+            active_keys = self.active_keys as u64,
+        ),
+    )]
     pub fn to_batch(&self) -> Arc<MerkleizedBatch<F, H::Digest, U, S>> {
         // The DB is always committed, so journal size = last_commit_loc + 1.
         let journal_size = *self.last_commit_loc + 1;

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1534,13 +1534,13 @@ where
     /// loss detected at `apply_batch` time.
     #[tracing::instrument(
         name = "qmdb::any::batch::new",
-        level = "info",
+        level = "debug",
         skip_all,
         fields(
             source = "batch",
-            base_size = self.base_size,
-            total_size = self.total_size,
-            ancestor_batches = self.ancestor_diff_ends.len() as u64,
+            base_size = self.bounds.base_size,
+            total_size = self.bounds.total_size,
+            ancestor_batches = self.ancestor_diffs.len() as u64,
         ),
     )]
     pub fn new_batch<H>(self: &Arc<Self>) -> UnmerkleizedBatch<F, H, U, S>
@@ -1653,7 +1653,7 @@ where
     /// Create a new speculative batch of operations with this database as its parent.
     #[tracing::instrument(
         name = "qmdb::any::batch::new",
-        level = "info",
+        level = "debug",
         skip_all,
         fields(
             source = "db",
@@ -1702,10 +1702,10 @@ where
         level = "info",
         skip_all,
         fields(
-            batch_total_size = batch.total_size,
-            batch_base_size = batch.base_size,
+            batch_total_size = batch.bounds.total_size,
+            batch_base_size = batch.bounds.base_size,
             db_size = *self.last_commit_loc + 1,
-            ancestor_batches = batch.ancestor_diff_ends.len() as u64,
+            ancestor_batches = batch.ancestor_diffs.len() as u64,
         ),
     )]
     pub async fn apply_batch(

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -360,6 +360,15 @@ where
 
     /// Prune historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
+    #[tracing::instrument(
+        name = "qmdb::any::Db::prune",
+        level = "info",
+        skip_all,
+        fields(
+            requested_loc = *prune_loc,
+            inactivity_floor = *self.inactivity_floor_loc,
+        ),
+    )]
     pub async fn prune(&mut self, prune_loc: Location<F>) -> Result<(), crate::qmdb::Error<F>> {
         let _timer = self.metrics.operations.prune_timer();
         self.metrics.operations.prune_calls.inc();
@@ -382,6 +391,17 @@ where
     /// Returns [`crate::qmdb::Error::HistoricalFloorPruned`] if `historical_size - 1` is retained
     /// but is not a commit op, either because the caller passed a non-commit-boundary size or
     /// because pruning removed the commit that would have governed it.
+    #[allow(clippy::type_complexity)]
+    #[tracing::instrument(
+        name = "qmdb::any::Db::historical_proof",
+        level = "info",
+        skip_all,
+        fields(
+            historical_size = *historical_size,
+            start_loc = *start_loc,
+            max_ops = max_ops.get(),
+        ),
+    )]
     pub async fn historical_proof(
         &self,
         historical_size: Location<F>,
@@ -436,6 +456,15 @@ where
     ///
     /// A successful rewind is not restart-stable until a subsequent [`Db::commit`] or
     /// [`Db::sync`].
+    #[tracing::instrument(
+        name = "qmdb::any::Db::rewind",
+        level = "info",
+        skip_all,
+        fields(
+            target_size = *size,
+            prev_size = *self.last_commit_loc + 1,
+        ),
+    )]
     pub async fn rewind(&mut self, size: Location<F>) -> Result<(), Error<F>> {
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
@@ -711,6 +740,16 @@ where
     }
 
     /// Sync all database state to disk.
+    #[tracing::instrument(
+        name = "qmdb::any::Db::sync",
+        level = "info",
+        skip_all,
+        fields(
+            db_size = *self.last_commit_loc + 1,
+            inactivity_floor = *self.inactivity_floor_loc,
+            active_keys = self.active_keys as u64,
+        ),
+    )]
     pub async fn sync(&self) -> Result<(), crate::qmdb::Error<F>> {
         let _timer = self.metrics.operations.sync_timer();
         self.metrics.operations.sync_calls.inc();
@@ -720,6 +759,16 @@ where
 
     /// Durably commit the journal state published by prior [`Db::apply_batch`]
     /// calls.
+    #[tracing::instrument(
+        name = "qmdb::any::Db::commit",
+        level = "info",
+        skip_all,
+        fields(
+            db_size = *self.last_commit_loc + 1,
+            inactivity_floor = *self.inactivity_floor_loc,
+            active_keys = self.active_keys as u64,
+        ),
+    )]
     pub async fn commit(&self) -> Result<(), crate::qmdb::Error<F>> {
         let _timer = self.metrics.operations.commit_timer();
         self.metrics.operations.commit_calls.inc();


### PR DESCRIPTION
## Summary

Adds `tracing` spans around the main `qmdb::any` database and batch operations so deployments can collect timing and high-level operation metadata through normal tracing infrastructure.

The spans are emitted at `INFO` level because they are intended for routine performance monitoring, not only ad hoc debugging.

## What Changed

- Added `#[tracing::instrument(...)]` spans to `qmdb::any` batch operations:
  - `qmdb::any::batch::new`
  - `qmdb::any::batch::merkleize`
  - `qmdb::any::Db::apply_batch`
  - `qmdb::any::Db::to_batch`

- Added `#[tracing::instrument(...)]` spans to `qmdb::any::Db` operations:
  - `qmdb::any::Db::commit`
  - `qmdb::any::Db::sync`
  - `qmdb::any::Db::historical_proof`
  - `qmdb::any::Db::rewind`
  - `qmdb::any::Db::prune`

- Recorded static, already-available fields such as operation sizes, floors, active-key counts, mutation counts, and batch ancestry counts.

- `proof` now reuses the instrumented `historical_proof` path, so current and explicit historical proof requests are reported through the same span.