### PR TITLE
improve testing

### DIFF
--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -52,6 +52,8 @@ enum CurrentOperation {
     ArbitraryProof {
         start_loc: u64,
         bad_digests: Vec<[u8; 32]>,
+        bad_pending_digest: Option<[u8; 32]>,
+        bad_partial_digest: Option<[u8; 32]>,
         max_ops: NonZeroU64,
         bad_chunks: Vec<[u8; 32]>,
     },
@@ -65,18 +67,27 @@ enum CurrentOperation {
 
 const MAX_OPERATIONS: usize = 100;
 
+// The number of key/values to write to the db at the start of each fuzz run. This value is
+// chosen to be large enough to ensure there is at least one pending chunk.
+const MAX_INITIAL_WRITES: u16 = 320;
+
 #[derive(Debug)]
 struct FuzzInput {
+    initial_writes: u16,
     operations: Vec<CurrentOperation>,
 }
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let initial_writes = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
         let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
         let operations = (0..num_ops)
             .map(|_| CurrentOperation::arbitrary(u))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(FuzzInput { operations })
+        Ok(FuzzInput {
+            initial_writes,
+            operations,
+        })
     }
 }
 
@@ -85,6 +96,15 @@ const PAGE_CACHE_SIZE: usize = 8;
 const MERKLE_ITEMS_PER_BLOB: u64 = 11;
 const LOG_ITEMS_PER_BLOB: u64 = 7;
 const WRITE_BUFFER_SIZE: usize = 1024;
+
+// Generates a deterministic key/value pair for seeding the db.
+fn generate_seed_kv(index: u64) -> (RawKey, RawValue) {
+    let mut key = [0u8; 32];
+    key[..8].copy_from_slice(&index.to_be_bytes());
+    let mut value = [0u8; 32];
+    value[24..].copy_from_slice(&index.to_be_bytes());
+    (key, value)
+}
 
 async fn commit_pending<F: Graftable>(
     db: &mut Db<F>,
@@ -112,6 +132,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     let suffix = suffix.to_string();
+    let initial_writes = data.initial_writes;
     let operations = data.operations.clone();
     runner.start(|context| async move {
         let hasher = qmdb::hasher::<Sha256>();
@@ -151,6 +172,24 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
         let mut all_keys = HashSet::new();
         let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
         let mut committed_op_count = Location::<F>::new(1);
+
+        for i in 0..u64::from(initial_writes) {
+            let (key, value) = generate_seed_kv(i);
+            pending_writes.push((Key::new(key), Some(Value::new(value))));
+            pending_inserts.insert(key, value);
+            all_keys.insert(key);
+        }
+        if !pending_writes.is_empty() {
+            commit_pending(
+                &mut db,
+                &mut pending_writes,
+                &mut committed_state,
+                &mut pending_inserts,
+                &mut pending_deletes,
+            )
+            .await;
+            committed_op_count = db.bounds().await.end;
+        }
 
         for op in &operations {
             match op {
@@ -273,6 +312,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 CurrentOperation::ArbitraryProof {
                     start_loc,
                     bad_digests,
+                    bad_pending_digest,
+                    bad_partial_digest,
                     max_ops,
                     bad_chunks,
                 } => {
@@ -296,16 +337,44 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         // Try to verify the proof when providing bad proof digests.
                         let bad_digests = bad_digests.iter().map(|d| Digest::from(*d)).collect();
                         if range_proof.proof.digests != bad_digests {
-                            let mut bad_proof = range_proof.clone();
-                            bad_proof.proof.digests = bad_digests;
+                            let mut bad_digest_proof = range_proof.clone();
+                            bad_digest_proof.proof.digests = bad_digests;
                             assert!(!Db::<F>::verify_range_proof(
                                 &hasher,
-                                &bad_proof,
+                                &bad_digest_proof,
                                 start_loc,
                                 &ops,
                                 &chunks,
                                 &root
                             ), "proof with bad digests should not verify");
+                        }
+
+                        let bad_pending_digest = (*bad_pending_digest).map(Digest::from);
+                        if range_proof.pending_chunk_digest != bad_pending_digest {
+                            let mut bad_pending_proof = range_proof.clone();
+                            bad_pending_proof.pending_chunk_digest = bad_pending_digest;
+                            assert!(!Db::<F>::verify_range_proof(
+                                &hasher,
+                                &bad_pending_proof,
+                                start_loc,
+                                &ops,
+                                &chunks,
+                                &root
+                            ), "proof with bad pending chunk digest should not verify");
+                        }
+
+                        let bad_partial_digest = (*bad_partial_digest).map(Digest::from);
+                        if range_proof.partial_chunk_digest != bad_partial_digest {
+                            let mut bad_partial_proof = range_proof.clone();
+                            bad_partial_proof.partial_chunk_digest = bad_partial_digest;
+                            assert!(!Db::<F>::verify_range_proof(
+                                &hasher,
+                                &bad_partial_proof,
+                                start_loc,
+                                &ops,
+                                &chunks,
+                                &root
+                            ), "proof with bad partial chunk digest should not verify");
                         }
 
                         // Try to verify the proof when providing bad input chunks.

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -52,6 +52,8 @@ enum CurrentOperation {
     ArbitraryProof {
         start_loc: u64,
         bad_digests: Vec<[u8; 32]>,
+        bad_pending_digest: Option<[u8; 32]>,
+        bad_partial_digest: Option<[u8; 32]>,
         max_ops: NonZeroU64,
         bad_chunks: Vec<[u8; 32]>,
     },
@@ -59,18 +61,27 @@ enum CurrentOperation {
 
 const MAX_OPERATIONS: usize = 100;
 
+// The number of key/values to write to the db at the start of each fuzz run. This value is
+// chosen to be large enough to ensure there is at least one pending chunk.
+const MAX_INITIAL_WRITES: u16 = 320;
+
 #[derive(Debug)]
 struct FuzzInput {
+    initial_writes: u16,
     operations: Vec<CurrentOperation>,
 }
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let initial_writes = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
         let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
         let operations = (0..num_ops)
             .map(|_| CurrentOperation::arbitrary(u))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(FuzzInput { operations })
+        Ok(FuzzInput {
+            initial_writes,
+            operations,
+        })
     }
 }
 
@@ -79,6 +90,15 @@ const PAGE_CACHE_SIZE: usize = 8;
 const MERKLE_ITEMS_PER_BLOB: u64 = 11;
 const LOG_ITEMS_PER_BLOB: u64 = 7;
 const WRITE_BUFFER_SIZE: usize = 1024;
+
+// Generates a deterministic key/value pair for seeding the db.
+fn generate_seed_kv(index: u64) -> (RawKey, RawValue) {
+    let mut key = [0u8; 32];
+    key[..8].copy_from_slice(&index.to_be_bytes());
+    let mut value = [0u8; 32];
+    value[24..].copy_from_slice(&index.to_be_bytes());
+    (key, value)
+}
 
 async fn commit_pending<F: Graftable>(
     db: &mut Db<F>,
@@ -102,6 +122,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
     let suffix = suffix.to_string();
+    let initial_writes = data.initial_writes;
     let operations = data.operations.clone();
     runner.start(|context| async move {
         let hasher = qmdb::hasher::<Sha256>();
@@ -140,6 +161,23 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
         let mut all_keys = std::collections::HashSet::new();
         let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
         let mut committed_op_count = Location::<F>::new(1);
+
+        for i in 0..u64::from(initial_writes) {
+            let (key, value) = generate_seed_kv(i);
+            pending_writes.push((Key::new(key), Some(Value::new(value))));
+            pending_expected.insert(key, Some(value));
+            all_keys.insert(key);
+        }
+        if !pending_writes.is_empty() {
+            commit_pending(
+                &mut db,
+                &mut pending_writes,
+                &mut committed_state,
+                &mut pending_expected,
+            )
+            .await;
+            committed_op_count = db.bounds().await.end;
+        }
 
         for op in &operations {
             match op {
@@ -248,6 +286,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 CurrentOperation::ArbitraryProof {
                     start_loc,
                     bad_digests,
+                    bad_pending_digest,
+                    bad_partial_digest,
                     max_ops,
                     bad_chunks,
                 } => {
@@ -268,16 +308,44 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         // Try to verify the proof when providing bad proof digests.
                         let bad_digests = bad_digests.iter().map(|d| Digest::from(*d)).collect();
                         if range_proof.proof.digests != bad_digests {
-                            let mut bad_proof = range_proof.clone();
-                            bad_proof.proof.digests = bad_digests;
+                            let mut bad_digest_proof = range_proof.clone();
+                            bad_digest_proof.proof.digests = bad_digests;
                             assert!(!Db::<F>::verify_range_proof(
                                 &hasher,
-                                &bad_proof,
+                                &bad_digest_proof,
                                 start_loc,
                                 &ops,
                                 &chunks,
                                 &root
                             ), "proof with bad digests should not verify");
+                        }
+
+                        let bad_pending_digest = (*bad_pending_digest).map(Digest::from);
+                        if range_proof.pending_chunk_digest != bad_pending_digest {
+                            let mut bad_pending_proof = range_proof.clone();
+                            bad_pending_proof.pending_chunk_digest = bad_pending_digest;
+                            assert!(!Db::<F>::verify_range_proof(
+                                &hasher,
+                                &bad_pending_proof,
+                                start_loc,
+                                &ops,
+                                &chunks,
+                                &root
+                            ), "proof with bad pending chunk digest should not verify");
+                        }
+
+                        let bad_partial_digest = (*bad_partial_digest).map(Digest::from);
+                        if range_proof.partial_chunk_digest != bad_partial_digest {
+                            let mut bad_partial_proof = range_proof.clone();
+                            bad_partial_proof.partial_chunk_digest = bad_partial_digest;
+                            assert!(!Db::<F>::verify_range_proof(
+                                &hasher,
+                                &bad_partial_proof,
+                                start_loc,
+                                &ops,
+                                &chunks,
+                                &root
+                            ), "proof with bad partial chunk digest should not verify");
                         }
 
                         // Try to verify the proof when providing bad input chunks.

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -292,7 +292,7 @@ where
             self.any.bitmap.as_ref(),
             ops_leaves,
             grafting::height::<N>(),
-        )
+        )?
         .map(|chunk| hasher.digest(&chunk));
         Ok(OpsRootWitness {
             grafted_root,
@@ -851,6 +851,30 @@ pub(super) fn partial_chunk<B: bitmap::Readable<N>, const N: usize>(
     }
 }
 
+/// Return complete and active chunk counts, enforcing the pending and pruning invariants.
+///
+/// Returns [`Error::DataCorrupted`] if `bitmap` and `ops_leaves` imply more than one
+/// pending chunk, or if pruning has advanced past the active chunk boundary.
+fn active_chunk_window<F: merkle::Graftable, B: bitmap::Readable<N>, const N: usize>(
+    bitmap: &B,
+    ops_leaves: u64,
+    grafting_height: u32,
+) -> Result<(u64, u64), Error<F>> {
+    let complete = bitmap.complete_chunks() as u64;
+    let active = grafting::ops_active_chunks::<F>(ops_leaves, grafting_height).min(complete);
+    let pending = complete - active;
+    if pending > 1 {
+        return Err(Error::DataCorrupted("multiple pending bitmap chunks"));
+    }
+
+    let pruned = bitmap.pruned_chunks() as u64;
+    if pruned > active {
+        return Err(Error::DataCorrupted("pruned chunks exceed active chunks"));
+    }
+
+    Ok((complete, active))
+}
+
 /// Returns the bytes of the "pending" chunk if the bitmap currently has one, else `None`.
 ///
 /// A chunk is pending when its bits are fully written to the bitmap but its h=G ancestor
@@ -860,28 +884,19 @@ pub(super) fn partial_chunk<B: bitmap::Readable<N>, const N: usize>(
 ///
 /// The caller must pass a consistent snapshot of `ops_leaves` (the ops tree's leaf count)
 /// and the bitmap state. Both inputs are used to derive `active_chunks`; deriving them from
-/// independent snapshots can result in `active_chunks > complete_chunks`, which would
-/// violate the pending-window invariant.
+/// independent snapshots can violate the pending-window or pruning invariants.
+///
+/// Returns [`Error::DataCorrupted`] when those invariants are violated.
 pub(super) fn pending_chunk<F: merkle::Graftable, B: bitmap::Readable<N>, const N: usize>(
     bitmap: &B,
     ops_leaves: u64,
     grafting_height: u32,
-) -> Option<[u8; N]> {
-    let complete = bitmap.complete_chunks() as u64;
-    let active = grafting::ops_active_chunks::<F>(ops_leaves, grafting_height).min(complete);
-    let pruned = bitmap.pruned_chunks() as u64;
-    // The pending chunk is the most recently completed one (right edge of the bitmap),
-    // while pruning advances from the left edge. Since pruning only retires chunks that
-    // are already inactive (covered by the inactivity floor), the pending chunk's index
-    // is strictly greater than `pruned`.
-    debug_assert!(
-        pruned <= active,
-        "pruned_chunks {pruned} > active_chunks {active}"
-    );
-    if complete.saturating_sub(active) != 1 {
-        return None;
+) -> Result<Option<[u8; N]>, Error<F>> {
+    let (complete, active) = active_chunk_window::<F, B, N>(bitmap, ops_leaves, grafting_height)?;
+    if complete - active != 1 {
+        return Ok(None);
     }
-    Some(bitmap.get_chunk(active as usize))
+    Ok(Some(bitmap.get_chunk(active as usize)))
 }
 
 /// Compute the canonical root from the ops root, grafted tree root, and optional pending /
@@ -949,7 +964,7 @@ pub(super) async fn compute_db_root<
 ) -> Result<H::Digest, Error<F>> {
     let grafted_root =
         compute_grafted_root(hasher, status, storage, ops_leaves, inactivity_floor).await?;
-    let pending = pending_chunk::<F, B, N>(status, ops_leaves, grafting::height::<N>())
+    let pending = pending_chunk::<F, B, N>(status, ops_leaves, grafting::height::<N>())?
         .map(|chunk| hasher.digest(&chunk));
     let partial = partial_chunk.map(|(chunk, next_bit)| {
         let digest = hasher.digest(&chunk);
@@ -1000,14 +1015,8 @@ pub(super) async fn compute_grafted_root<
     }
 
     let grafting_height = grafting::height::<N>();
-    let complete_chunks = status.complete_chunks() as u64;
-    let active_chunks =
-        grafting::ops_active_chunks::<F>(ops_leaves, grafting_height).min(complete_chunks);
-    let pruned_chunks = status.pruned_chunks() as u64;
-    debug_assert!(
-        pruned_chunks <= active_chunks && active_chunks <= complete_chunks,
-        "invariant violated: pruned={pruned_chunks} active={active_chunks} complete={complete_chunks}"
-    );
+    let (_complete_chunks, _active_chunks) =
+        active_chunk_window::<F, B, N>(status, ops_leaves, grafting_height)?;
 
     let inactive_peaks =
         grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting_height)?;

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -37,7 +37,10 @@ use crate::{
     },
     qmdb::{
         self,
-        current::{db::combine_roots, grafting},
+        current::{
+            db::{combine_roots, pending_chunk},
+            grafting,
+        },
         Error,
     },
 };
@@ -228,9 +231,8 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             None
         };
 
-        let pending_chunk_digest =
-            crate::qmdb::current::db::pending_chunk::<F, _, N>(status, ops_leaves, grafting_height)
-                .map(|chunk| hasher.digest(&chunk));
+        let pending_chunk_digest = pending_chunk::<F, _, N>(status, ops_leaves, grafting_height)?
+            .map(|chunk| hasher.digest(&chunk));
 
         Ok(Self {
             proof,
@@ -356,8 +358,16 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         // (i.e., `complete - active == 1`); a presence/absence mismatch is a verification failure.
         let active_chunks =
             grafting::ops_active_chunks::<F>(*leaves, grafting_height).min(complete_chunks);
-        let has_pending_chunk = complete_chunks > active_chunks;
-        debug_assert!(complete_chunks - active_chunks <= 1);
+        let pending_chunks = complete_chunks - active_chunks;
+        if pending_chunks > 1 {
+            debug!(
+                ?complete_chunks,
+                ?active_chunks,
+                "verification failed, multiple pending chunks"
+            );
+            return false;
+        }
+        let has_pending_chunk = pending_chunks == 1;
 
         let grafting_verifier = grafting::Verifier::<F, H>::new(
             grafting_height,
@@ -1483,6 +1493,7 @@ mod tests {
                 // OpsRootWitness round-trip
                 let pending_chunk_digest =
                     db::pending_chunk::<F, _, N>(&status, ops_leaves_for_root, grafting_height)
+                        .unwrap()
                         .map(|c| hasher.digest(&c));
                 let partial_digest =
                     db::partial_chunk::<_, N>(&status).map(|(c, nb)| (nb, hasher.digest(&c)));
@@ -1547,12 +1558,53 @@ mod tests {
                     "RangeProof verify failed at k={k}"
                 );
 
-                // Tamper with the pending chunk digest; verification must fail.
+                let pending_loc = mmb::Location::new(3);
+                let pending_proof = RangeProof::new(
+                    &hasher,
+                    &status,
+                    &storage,
+                    Location::new(0),
+                    pending_loc..pending_loc + 1,
+                    ops_root,
+                )
+                .await
+                .unwrap();
+                assert!(
+                    pending_proof.pending_chunk_digest.is_some(),
+                    "expected single-element proof to carry pending chunk digest at k={k}"
+                );
+                let pending_element = hasher.digest(&(*pending_loc).to_be_bytes());
+                assert!(
+                    pending_proof.verify(
+                        &hasher,
+                        pending_loc,
+                        &[pending_element],
+                        &[chunks[0]],
+                        &canonical_root,
+                    ),
+                    "single-element proof inside pending chunk failed at k={k}"
+                );
+
+                // Tamper with the pending chunk digest or its supplied bytes.
                 let mut tampered = proof.clone();
                 tampered.pending_chunk_digest = Some(hasher.digest(b"fake pending"));
                 assert!(
                     !tampered.verify(&hasher, start, &elements, &chunks, &canonical_root),
                     "tampered pending digest accepted at k={k}"
+                );
+
+                let mut tampered = proof.clone();
+                tampered.pending_chunk_digest = None;
+                assert!(
+                    !tampered.verify(&hasher, start, &elements, &chunks, &canonical_root),
+                    "missing pending digest accepted at k={k}"
+                );
+
+                let mut bad_chunks = chunks.clone();
+                bad_chunks[0][0] ^= 1;
+                assert!(
+                    !proof.verify(&hasher, start, &elements, &bad_chunks, &canonical_root),
+                    "tampered pending chunk bytes accepted at k={k}"
                 );
             }
         });

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -218,7 +218,7 @@ where
         (next_bit, digest)
     });
     let pending_digest =
-        db::pending_chunk::<F, _, N>(any.bitmap.as_ref(), ops_leaves, grafting::height::<N>())
+        db::pending_chunk::<F, _, N>(any.bitmap.as_ref(), ops_leaves, grafting::height::<N>())?
             .map(|chunk| hasher.digest(&chunk));
     let root = db::combine_roots(
         &hasher,


### PR DESCRIPTION
## Summary

Improves coverage and hardening for current QMDB pending chunk proofs.

## Changes

- Replace debug-only pending/pruned chunk invariant checks with real errors during root/proof construction.
- Reject range proofs whose bitmap state would require multiple pending chunks.
- Add unit coverage for:
  - proving an element inside a pending chunk
  - missing pending chunk digest
  - tampered pending chunk digest
  - tampered pending chunk bytes
- Update current ordered/unordered fuzz targets so pending and partial chunks are reachable in short fuzz plans.
- Extend fuzz proof mutation coverage to tamper with pending and partial chunk digest fields.