### PR TITLE
[cryptography] Parallel-capable `BatchVerifier`

### DIFF
--- a/cryptography/fuzz/fuzz_targets/bls12381_batch_operations.rs
+++ b/cryptography/fuzz/fuzz_targets/bls12381_batch_operations.rs
@@ -5,6 +5,7 @@ use commonware_cryptography::{
     bls12381::{self, Batch},
     BatchVerifier, Signer, Verifier,
 };
+use commonware_parallel::Sequential;
 use libfuzzer_sys::fuzz_target;
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -122,6 +123,6 @@ fuzz_target!(|data: &[u8]| {
         }
     }
 
-    let result = state.batch.verify(&mut rng);
+    let result = state.batch.verify(&mut rng, &Sequential);
     assert_eq!(result, state.expected_result, "Batch verification failed");
 });

--- a/cryptography/fuzz/fuzz_targets/ed25519_batch_verifier.rs
+++ b/cryptography/fuzz/fuzz_targets/ed25519_batch_verifier.rs
@@ -5,6 +5,7 @@ use commonware_cryptography::{
     ed25519::{self, Batch as Ed25519Batch},
     BatchVerifier, Signer, Verifier,
 };
+use commonware_parallel::Sequential;
 use libfuzzer_sys::fuzz_target;
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -101,7 +102,7 @@ fn fuzz(input: FuzzInput) {
             }
 
             BatchOperation::VerifyEd25519 => {
-                let result = ed25519_batch.verify(&mut rng);
+                let result = ed25519_batch.verify(&mut rng, &Sequential);
                 assert_eq!(
                     result, expected_ed25519_result,
                     "Ed25519 batch verification result mismatch: expected {expected_ed25519_result}, got {result}",
@@ -115,7 +116,7 @@ fn fuzz(input: FuzzInput) {
     }
 
     // Final verification of any remaining items
-    let ed25519_result = ed25519_batch.verify(&mut rng);
+    let ed25519_result = ed25519_batch.verify(&mut rng, &Sequential);
     assert_eq!(
         ed25519_result, expected_ed25519_result,
         "Final Ed25519 batch verification failed"

--- a/cryptography/src/bls12381/benches/aggregate_verify_same_signer.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_same_signer.rs
@@ -1,8 +1,8 @@
 use commonware_cryptography::bls12381::primitives::{ops, variant::MinSig};
 use commonware_parallel::{Rayon, Sequential};
+use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{thread_rng, Rng};
-use std::num::NonZeroUsize;
 
 fn bench_aggregate_verify_same_signer(c: &mut Criterion) {
     let namespace = b"namespace";
@@ -14,6 +14,7 @@ fn bench_aggregate_verify_same_signer(c: &mut Criterion) {
             msgs.push(msg);
         }
         for concurrency in [1, 8].into_iter() {
+            let rayon = (concurrency > 1).then(|| Rayon::new(NZUsize!(concurrency)).unwrap());
             c.bench_function(
                 &format!("{}/conc={} msgs={}", module_path!(), concurrency, n),
                 |b| {
@@ -32,10 +33,9 @@ fn bench_aggregate_verify_same_signer(c: &mut Criterion) {
                             (public, messages, agg_sig)
                         },
                         |(public, messages, agg_sig)| {
-                            let combined_msg = if concurrency > 1 {
-                                let strategy =
-                                    Rayon::new(NonZeroUsize::new(concurrency).unwrap()).unwrap();
-                                ops::aggregate::combine_messages::<MinSig, _>(&messages, &strategy)
+                            #[allow(clippy::option_if_let_else)]
+                            let combined_msg = if let Some(rayon) = rayon.as_ref() {
+                                ops::aggregate::combine_messages::<MinSig, _>(&messages, rayon)
                             } else {
                                 ops::aggregate::combine_messages::<MinSig, _>(
                                     &messages,

--- a/cryptography/src/bls12381/benches/scheme_batch_verify_same_message.rs
+++ b/cryptography/src/bls12381/benches/scheme_batch_verify_same_message.rs
@@ -12,6 +12,7 @@ fn bench_scheme_batch_verify_same_message(c: &mut Criterion) {
     thread_rng().fill(&mut msg);
     for n_signers in [1, 10, 100, 1000, 10000].into_iter() {
         for concurrency in [1, 8] {
+            let rayon = (concurrency > 1).then(|| Rayon::new(NZUsize!(concurrency)).unwrap());
             c.bench_function(
                 &format!("{}/pks={} conc={}", module_path!(), n_signers, concurrency),
                 |b| {
@@ -23,12 +24,12 @@ fn bench_scheme_batch_verify_same_message(c: &mut Criterion) {
                                 let sig = signer.sign(namespace, &msg);
                                 assert!(batch.add(namespace, &msg, &signer.public_key(), &sig));
                             }
-                            let strategy = Rayon::new(NZUsize!(concurrency)).unwrap();
-                            (batch, strategy)
+                            batch
                         },
-                        |(batch, strategy)| {
-                            if concurrency > 1 {
-                                black_box(batch.verify(&mut thread_rng(), &strategy))
+                        |batch| {
+                            #[allow(clippy::option_if_let_else)]
+                            if let Some(rayon) = rayon.as_ref() {
+                                black_box(batch.verify(&mut thread_rng(), rayon))
                             } else {
                                 black_box(batch.verify(&mut thread_rng(), &Sequential))
                             }

--- a/cryptography/src/bls12381/benches/scheme_batch_verify_same_message.rs
+++ b/cryptography/src/bls12381/benches/scheme_batch_verify_same_message.rs
@@ -1,5 +1,7 @@
 use commonware_cryptography::{bls12381, BatchVerifier, Signer as _};
 use commonware_math::algebra::Random;
+use commonware_parallel::{Rayon, Sequential};
+use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{thread_rng, Rng};
 use std::hint::black_box;
@@ -9,23 +11,33 @@ fn bench_scheme_batch_verify_same_message(c: &mut Criterion) {
     let mut msg = [0u8; 32];
     thread_rng().fill(&mut msg);
     for n_signers in [1, 10, 100, 1000, 10000].into_iter() {
-        c.bench_function(&format!("{}/pks={}", module_path!(), n_signers), |b| {
-            b.iter_batched(
-                || {
-                    let mut batch = bls12381::Batch::new();
-                    for _ in 0..n_signers {
-                        let signer = bls12381::PrivateKey::random(&mut thread_rng());
-                        let sig = signer.sign(namespace, &msg);
-                        assert!(batch.add(namespace, &msg, &signer.public_key(), &sig));
-                    }
-                    batch
+        for concurrency in [1, 8] {
+            c.bench_function(
+                &format!("{}/pks={} conc={}", module_path!(), n_signers, concurrency),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            let mut batch = bls12381::Batch::new();
+                            for _ in 0..n_signers {
+                                let signer = bls12381::PrivateKey::random(&mut thread_rng());
+                                let sig = signer.sign(namespace, &msg);
+                                assert!(batch.add(namespace, &msg, &signer.public_key(), &sig));
+                            }
+                            let strategy = Rayon::new(NZUsize!(concurrency)).unwrap();
+                            (batch, strategy)
+                        },
+                        |(batch, strategy)| {
+                            if concurrency > 1 {
+                                black_box(batch.verify(&mut thread_rng(), &strategy))
+                            } else {
+                                black_box(batch.verify(&mut thread_rng(), &Sequential))
+                            }
+                        },
+                        BatchSize::SmallInput,
+                    );
                 },
-                |batch| {
-                    black_box(batch.verify(&mut thread_rng()));
-                },
-                BatchSize::SmallInput,
             );
-        });
+        }
     }
 }
 

--- a/cryptography/src/bls12381/benches/scheme_batch_verify_same_signer.rs
+++ b/cryptography/src/bls12381/benches/scheme_batch_verify_same_signer.rs
@@ -10,6 +10,7 @@ fn bench_scheme_batch_verify_same_signer(c: &mut Criterion) {
     let namespace = b"namespace";
     for n_messages in [1, 10, 100, 1000, 10000].into_iter() {
         for concurrency in [1, 8] {
+            let rayon = (concurrency > 1).then(|| Rayon::new(NZUsize!(concurrency)).unwrap());
             let mut msgs = Vec::with_capacity(n_messages);
             for _ in 0..n_messages {
                 let mut msg = [0u8; 32];
@@ -32,12 +33,12 @@ fn bench_scheme_batch_verify_same_signer(c: &mut Criterion) {
                                 let sig = signer.sign(namespace, msg);
                                 assert!(batch.add(namespace, msg, &signer.public_key(), &sig));
                             }
-                            let strategy = Rayon::new(NZUsize!(concurrency)).unwrap();
-                            (batch, strategy)
+                            batch
                         },
-                        |(batch, strategy)| {
-                            if concurrency > 1 {
-                                black_box(batch.verify(&mut thread_rng(), &strategy))
+                        |batch| {
+                            #[allow(clippy::option_if_let_else)]
+                            if let Some(rayon) = rayon.as_ref() {
+                                black_box(batch.verify(&mut thread_rng(), rayon))
                             } else {
                                 black_box(batch.verify(&mut thread_rng(), &Sequential))
                             }

--- a/cryptography/src/bls12381/benches/scheme_batch_verify_same_signer.rs
+++ b/cryptography/src/bls12381/benches/scheme_batch_verify_same_signer.rs
@@ -1,5 +1,7 @@
 use commonware_cryptography::{bls12381, BatchVerifier as _, Signer as _};
 use commonware_math::algebra::Random;
+use commonware_parallel::{Rayon, Sequential};
+use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{thread_rng, Rng};
 use std::hint::black_box;
@@ -7,29 +9,44 @@ use std::hint::black_box;
 fn bench_scheme_batch_verify_same_signer(c: &mut Criterion) {
     let namespace = b"namespace";
     for n_messages in [1, 10, 100, 1000, 10000].into_iter() {
-        let mut msgs = Vec::with_capacity(n_messages);
-        for _ in 0..n_messages {
-            let mut msg = [0u8; 32];
-            thread_rng().fill(&mut msg);
-            msgs.push(msg);
-        }
-        c.bench_function(&format!("{}/msgs={}", module_path!(), n_messages), |b| {
-            b.iter_batched(
-                || {
-                    let mut batch = bls12381::Batch::new();
-                    let signer = bls12381::PrivateKey::random(&mut thread_rng());
-                    for msg in msgs.iter() {
-                        let sig = signer.sign(namespace, msg);
-                        assert!(batch.add(namespace, msg, &signer.public_key(), &sig));
-                    }
-                    batch
+        for concurrency in [1, 8] {
+            let mut msgs = Vec::with_capacity(n_messages);
+            for _ in 0..n_messages {
+                let mut msg = [0u8; 32];
+                thread_rng().fill(&mut msg);
+                msgs.push(msg);
+            }
+            c.bench_function(
+                &format!(
+                    "{}/msgs={} conc={}",
+                    module_path!(),
+                    n_messages,
+                    concurrency
+                ),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            let mut batch = bls12381::Batch::new();
+                            let signer = bls12381::PrivateKey::random(&mut thread_rng());
+                            for msg in msgs.iter() {
+                                let sig = signer.sign(namespace, msg);
+                                assert!(batch.add(namespace, msg, &signer.public_key(), &sig));
+                            }
+                            let strategy = Rayon::new(NZUsize!(concurrency)).unwrap();
+                            (batch, strategy)
+                        },
+                        |(batch, strategy)| {
+                            if concurrency > 1 {
+                                black_box(batch.verify(&mut thread_rng(), &strategy))
+                            } else {
+                                black_box(batch.verify(&mut thread_rng(), &Sequential))
+                            }
+                        },
+                        BatchSize::SmallInput,
+                    );
                 },
-                |batch| {
-                    black_box(batch.verify(&mut thread_rng()));
-                },
-                BatchSize::SmallInput,
             );
-        });
+        }
     }
 }
 

--- a/cryptography/src/bls12381/dkg.rs
+++ b/cryptography/src/bls12381/dkg.rs
@@ -660,7 +660,7 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
                 }
             }
         }
-        if !ack_batch.verify(&mut *rng) {
+        if !ack_batch.verify(&mut *rng, strategy) {
             return false;
         }
         let lhs = log.pub_msg.commitment.lin_comb_eval(

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -39,7 +39,7 @@ use commonware_codec::{
 };
 use commonware_formatting::Hex;
 use commonware_math::algebra::Random;
-use commonware_parallel::Sequential;
+use commonware_parallel::Strategy;
 use commonware_utils::{Array, Span};
 use core::{
     fmt::{Debug, Display, Formatter},
@@ -394,8 +394,8 @@ impl BatchVerifier for Batch {
         true
     }
 
-    fn verify<R: CryptoRngCore>(self, rng: &mut R) -> bool {
-        MinPk::batch_verify(rng, &self.publics, &self.hms, &self.signatures, &Sequential).is_ok()
+    fn verify<R: CryptoRngCore>(self, rng: &mut R, strategy: &impl Strategy) -> bool {
+        MinPk::batch_verify(rng, &self.publics, &self.hms, &self.signatures, strategy).is_ok()
     }
 }
 
@@ -405,6 +405,7 @@ mod tests {
     use crate::{bls12381, Verifier as _};
     use commonware_codec::{DecodeExt, Encode};
     use commonware_math::algebra::Random;
+    use commonware_parallel::Sequential;
     use commonware_utils::test_rng;
 
     #[test]
@@ -484,7 +485,7 @@ mod tests {
     #[test]
     fn batch_verify_empty() {
         let batch = Batch::new();
-        assert!(batch.verify(&mut test_rng()));
+        assert!(batch.verify(&mut test_rng(), &Sequential));
     }
 
     #[cfg(feature = "arbitrary")]

--- a/cryptography/src/ed25519/benches/batch_verify_same_message.rs
+++ b/cryptography/src/ed25519/benches/batch_verify_same_message.rs
@@ -1,5 +1,7 @@
 use commonware_cryptography::{ed25519, BatchVerifier, Signer as _};
 use commonware_math::algebra::Random;
+use commonware_parallel::{Rayon, Sequential};
+use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{thread_rng, Rng};
 use std::hint::black_box;
@@ -9,23 +11,33 @@ fn bench_batch_verify_same_message(c: &mut Criterion) {
     let mut msg = [0u8; 32];
     thread_rng().fill(&mut msg);
     for n_signers in [1, 10, 100, 1000, 10000].into_iter() {
-        c.bench_function(&format!("{}/pks={}", module_path!(), n_signers), |b| {
-            b.iter_batched(
-                || {
-                    let mut batch = ed25519::Batch::new();
-                    for _ in 0..n_signers {
-                        let signer = ed25519::PrivateKey::random(&mut thread_rng());
-                        let sig = signer.sign(namespace, &msg);
-                        assert!(batch.add(namespace, &msg, &signer.public_key(), &sig));
-                    }
-                    batch
+        for concurrency in [1, 8] {
+            c.bench_function(
+                &format!("{}/pks={} conc={}", module_path!(), n_signers, concurrency),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            let mut batch = ed25519::Batch::new();
+                            for _ in 0..n_signers {
+                                let signer = ed25519::PrivateKey::random(&mut thread_rng());
+                                let sig = signer.sign(namespace, &msg);
+                                assert!(batch.add(namespace, &msg, &signer.public_key(), &sig));
+                            }
+                            let strategy = Rayon::new(NZUsize!(concurrency)).unwrap();
+                            (batch, strategy)
+                        },
+                        |(batch, rayon)| {
+                            if concurrency > 1 {
+                                black_box(batch.verify(&mut thread_rng(), &rayon))
+                            } else {
+                                black_box(batch.verify(&mut thread_rng(), &Sequential))
+                            }
+                        },
+                        BatchSize::SmallInput,
+                    );
                 },
-                |batch| {
-                    black_box(batch.verify(&mut thread_rng()));
-                },
-                BatchSize::SmallInput,
             );
-        });
+        }
     }
 }
 

--- a/cryptography/src/ed25519/benches/batch_verify_same_message.rs
+++ b/cryptography/src/ed25519/benches/batch_verify_same_message.rs
@@ -12,6 +12,7 @@ fn bench_batch_verify_same_message(c: &mut Criterion) {
     thread_rng().fill(&mut msg);
     for n_signers in [1, 10, 100, 1000, 10000].into_iter() {
         for concurrency in [1, 8] {
+            let rayon = (concurrency > 1).then(|| Rayon::new(NZUsize!(concurrency)).unwrap());
             c.bench_function(
                 &format!("{}/pks={} conc={}", module_path!(), n_signers, concurrency),
                 |b| {
@@ -23,12 +24,12 @@ fn bench_batch_verify_same_message(c: &mut Criterion) {
                                 let sig = signer.sign(namespace, &msg);
                                 assert!(batch.add(namespace, &msg, &signer.public_key(), &sig));
                             }
-                            let strategy = Rayon::new(NZUsize!(concurrency)).unwrap();
-                            (batch, strategy)
+                            batch
                         },
-                        |(batch, rayon)| {
-                            if concurrency > 1 {
-                                black_box(batch.verify(&mut thread_rng(), &rayon))
+                        |batch| {
+                            #[allow(clippy::option_if_let_else)]
+                            if let Some(rayon) = rayon.as_ref() {
+                                black_box(batch.verify(&mut thread_rng(), rayon))
                             } else {
                                 black_box(batch.verify(&mut thread_rng(), &Sequential))
                             }

--- a/cryptography/src/ed25519/benches/batch_verify_same_signer.rs
+++ b/cryptography/src/ed25519/benches/batch_verify_same_signer.rs
@@ -1,5 +1,7 @@
 use commonware_cryptography::{ed25519, BatchVerifier, Signer as _};
 use commonware_math::algebra::Random;
+use commonware_parallel::{Rayon, Sequential};
+use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{thread_rng, Rng};
 use std::hint::black_box;
@@ -7,29 +9,44 @@ use std::hint::black_box;
 fn bench_batch_verify_same_signer(c: &mut Criterion) {
     let namespace = b"namespace";
     for n_messages in [1, 10, 100, 1000, 10000].into_iter() {
-        let mut msgs = Vec::with_capacity(n_messages);
-        for _ in 0..n_messages {
-            let mut msg = [0u8; 32];
-            thread_rng().fill(&mut msg);
-            msgs.push(msg);
-        }
-        c.bench_function(&format!("{}/msgs={}", module_path!(), n_messages), |b| {
-            b.iter_batched(
-                || {
-                    let mut batch = ed25519::Batch::new();
-                    let signer = ed25519::PrivateKey::random(&mut thread_rng());
-                    for msg in msgs.iter() {
-                        let sig = signer.sign(namespace, msg);
-                        assert!(batch.add(namespace, msg, &signer.public_key(), &sig));
-                    }
-                    batch
+        for concurrency in [1, 8] {
+            let mut msgs = Vec::with_capacity(n_messages);
+            for _ in 0..n_messages {
+                let mut msg = [0u8; 32];
+                thread_rng().fill(&mut msg);
+                msgs.push(msg);
+            }
+            c.bench_function(
+                &format!(
+                    "{}/msgs={} conc={}",
+                    module_path!(),
+                    n_messages,
+                    concurrency
+                ),
+                |b| {
+                    b.iter_batched(
+                        || {
+                            let mut batch = ed25519::Batch::new();
+                            let signer = ed25519::PrivateKey::random(&mut thread_rng());
+                            for msg in msgs.iter() {
+                                let sig = signer.sign(namespace, msg);
+                                assert!(batch.add(namespace, msg, &signer.public_key(), &sig));
+                            }
+                            let strategy = Rayon::new(NZUsize!(concurrency)).unwrap();
+                            (batch, strategy)
+                        },
+                        |(batch, strategy)| {
+                            if concurrency > 1 {
+                                black_box(batch.verify(&mut thread_rng(), &strategy))
+                            } else {
+                                black_box(batch.verify(&mut thread_rng(), &Sequential))
+                            }
+                        },
+                        BatchSize::SmallInput,
+                    );
                 },
-                |batch| {
-                    black_box(batch.verify(&mut thread_rng()));
-                },
-                BatchSize::SmallInput,
             );
-        });
+        }
     }
 }
 

--- a/cryptography/src/ed25519/benches/batch_verify_same_signer.rs
+++ b/cryptography/src/ed25519/benches/batch_verify_same_signer.rs
@@ -10,6 +10,7 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
     let namespace = b"namespace";
     for n_messages in [1, 10, 100, 1000, 10000].into_iter() {
         for concurrency in [1, 8] {
+            let rayon = (concurrency > 1).then(|| Rayon::new(NZUsize!(concurrency)).unwrap());
             let mut msgs = Vec::with_capacity(n_messages);
             for _ in 0..n_messages {
                 let mut msg = [0u8; 32];
@@ -32,12 +33,12 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
                                 let sig = signer.sign(namespace, msg);
                                 assert!(batch.add(namespace, msg, &signer.public_key(), &sig));
                             }
-                            let strategy = Rayon::new(NZUsize!(concurrency)).unwrap();
-                            (batch, strategy)
+                            batch
                         },
-                        |(batch, strategy)| {
-                            if concurrency > 1 {
-                                black_box(batch.verify(&mut thread_rng(), &strategy))
+                        |batch| {
+                            #[allow(clippy::option_if_let_else)]
+                            if let Some(rayon) = rayon.as_ref() {
+                                black_box(batch.verify(&mut thread_rng(), rayon))
                             } else {
                                 black_box(batch.verify(&mut thread_rng(), &Sequential))
                             }

--- a/cryptography/src/ed25519/certificate/mod.rs
+++ b/cryptography/src/ed25519/certificate/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 use alloc::{collections::BTreeSet, vec::Vec};
 use bytes::{Buf, BufMut};
 use commonware_codec::{types::lazy::Lazy, EncodeSize, Error, Read, ReadRangeExt, Write};
+use commonware_parallel::Strategy;
 use commonware_utils::{
     ordered::{Quorum, Set},
     Faults, Participant,
@@ -118,6 +119,7 @@ impl<N: Namespace> Generic<N> {
         rng: &mut R,
         subject: S::Subject<'a, D>,
         attestations: I,
+        strategy: &impl Strategy,
     ) -> Verification<S>
     where
         S: Scheme<Signature = Ed25519Signature>,
@@ -147,7 +149,7 @@ impl<N: Namespace> Generic<N> {
             candidates.push((attestation, public_key));
         }
 
-        if !candidates.is_empty() && !batch.verify(rng) {
+        if !candidates.is_empty() && !batch.verify(rng, strategy) {
             // Batch failed: fall back to per-signer verification to isolate faulty attestations.
             for (attestation, public_key) in &candidates {
                 let Some(signature) = attestation.signature.get() else {
@@ -259,6 +261,7 @@ impl<N: Namespace> Generic<N> {
         rng: &mut R,
         subject: S::Subject<'a, D>,
         certificate: &Certificate,
+        strategy: &impl Strategy,
     ) -> bool
     where
         S: Scheme,
@@ -272,11 +275,16 @@ impl<N: Namespace> Generic<N> {
             return false;
         }
 
-        batch.verify(rng)
+        batch.verify(rng, strategy)
     }
 
     /// Verifies multiple certificates in a batch.
-    pub fn verify_certificates<'a, S, R, D, I, M>(&self, rng: &mut R, certificates: I) -> bool
+    pub fn verify_certificates<'a, S, R, D, I, M>(
+        &self,
+        rng: &mut R,
+        certificates: I,
+        strategy: &impl Strategy,
+    ) -> bool
     where
         S: Scheme,
         S::Subject<'a, D>: Subject<Namespace = N>,
@@ -292,7 +300,7 @@ impl<N: Namespace> Generic<N> {
             }
         }
 
-        batch.verify(rng)
+        batch.verify(rng, strategy)
     }
 
     pub const fn is_attributable() -> bool {
@@ -513,7 +521,7 @@ macro_rules! impl_certificate_ed25519 {
                 rng: &mut R,
                 subject: Self::Subject<'_, D>,
                 attestations: I,
-                _strategy: &impl commonware_parallel::Strategy,
+                strategy: &impl commonware_parallel::Strategy,
             ) -> $crate::certificate::Verification<Self>
             where
                 R: rand_core::CryptoRngCore,
@@ -521,7 +529,7 @@ macro_rules! impl_certificate_ed25519 {
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
             {
                 self.generic
-                    .verify_attestations::<_, _, D, _>(rng, subject, attestations)
+                    .verify_attestations::<_, _, D, _>(rng, subject, attestations, strategy)
             }
 
             fn assemble<I, M>(
@@ -541,7 +549,7 @@ macro_rules! impl_certificate_ed25519 {
                 rng: &mut R,
                 subject: Self::Subject<'_, D>,
                 certificate: &Self::Certificate,
-                _strategy: &impl commonware_parallel::Strategy,
+                strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
                 R: rand_core::CryptoRngCore,
@@ -549,14 +557,14 @@ macro_rules! impl_certificate_ed25519 {
                 M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificate::<Self, _, D, M>(rng, subject, certificate)
+                    .verify_certificate::<Self, _, D, M>(rng, subject, certificate, strategy)
             }
 
             fn verify_certificates<'a, R, D, I, M>(
                 &self,
                 rng: &mut R,
                 certificates: I,
-                _strategy: &impl commonware_parallel::Strategy,
+                strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
                 R: rand::Rng + rand::CryptoRng,
@@ -565,7 +573,7 @@ macro_rules! impl_certificate_ed25519 {
                 M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificates::<Self, _, D, _, M>(rng, certificates)
+                    .verify_certificates::<Self, _, D, _, M>(rng, certificates, strategy)
             }
 
             fn is_attributable() -> bool {

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -132,6 +132,9 @@ impl Verifier {
             return Ok(());
         }
 
+        // Split all signatures into shards for parallel processing. Each shard is roughly
+        // `n_signatures / cores` in size. Random seeds are generated for each shard, derived
+        // from the provided RNG, to compute a random scalar for each signature in the shard.
         let groups: Vec<_> = self.signatures.into_iter().collect();
         let shard_count = strategy.parallelism_hint().max(1).min(groups.len());
         let shard_size = groups.len().div_ceil(shard_count);

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -35,22 +35,26 @@
 //! [ZIP215]: https://github.com/zcash/zips/blob/master/zip-0215.rst
 
 use super::{Error, Signature, VerificationKey};
+use crate::transcript::{Summary, Transcript};
 #[cfg(not(feature = "std"))]
 use alloc::{collections::BTreeMap as Map, vec::Vec};
+use commonware_math::algebra::Random;
 use commonware_parallel::Strategy;
+use core::iter::once;
 use curve25519_dalek::{
+    constants::ED25519_BASEPOINT_POINT as B,
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
     traits::{IsIdentity, VartimeMultiscalarMul},
 };
-use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
 use rand_core::{CryptoRng, RngCore};
 use sha2::{digest::Update, Sha512};
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 #[cfg(feature = "std")]
 type Map<K, V> = HashMap<K, V>;
+
+const NOISE_BATCH_VERIFY: &[u8] = b"batch_verify";
 
 // Shim to generate a u128 without importing `rand`.
 fn gen_u128<R: RngCore + CryptoRng>(mut rng: R) -> u128 {
@@ -128,20 +132,15 @@ impl Verifier {
         mut rng: R,
         strategy: &impl Strategy,
     ) -> Result<(), Error> {
-        if self.batch_size == 0 {
-            return Ok(());
-        }
-
         // Split all signatures into shards for parallel processing. Each shard is roughly
         // `n_signatures / cores` in size. Random seeds are generated for each shard, derived
         // from the provided RNG, to compute a random scalar for each signature in the shard.
         let groups: Vec<_> = self.signatures.into_iter().collect();
-        let shard_count = strategy.parallelism_hint().max(1).min(groups.len());
-        let shard_size = groups.len().div_ceil(shard_count);
+        let shard_count = strategy.parallelism_hint().max(1).min(groups.len().max(1));
+        let shard_size = groups.len().div_ceil(shard_count).max(1);
         let mut shards = Vec::with_capacity(shard_count);
         for shard in groups.chunks(shard_size) {
-            let mut seed = [0u8; 32];
-            rng.fill_bytes(&mut seed);
+            let seed = Summary::random(&mut rng);
             shards.push((shard, seed));
         }
 
@@ -150,7 +149,7 @@ impl Verifier {
             || Ok(()),
             |result, (shard, seed)| {
                 result?;
-                let mut rng = ChaCha20Rng::from_seed(seed);
+                let mut rng = Transcript::resume(seed).noise(NOISE_BATCH_VERIFY);
 
                 // The batch verification equation is
                 //
@@ -208,8 +207,6 @@ impl Verifier {
                     A_coeffs.push(A_coeff);
                 }
 
-                use core::iter::once;
-                use curve25519_dalek::constants::ED25519_BASEPOINT_POINT as B;
                 let check = EdwardsPoint::vartime_multiscalar_mul(
                     once(&B_coeff).chain(A_coeffs.iter()).chain(R_coeffs.iter()),
                     once(&B).chain(As.iter()).chain(Rs.iter()),
@@ -221,13 +218,7 @@ impl Verifier {
                     Err(Error::InvalidSignature)
                 }
             },
-            |left, right| {
-                if left.is_err() {
-                    left
-                } else {
-                    right
-                }
-            },
+            |left, right| left.and(right),
         )
     }
 }

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -37,11 +37,14 @@
 use super::{Error, Signature, VerificationKey};
 #[cfg(not(feature = "std"))]
 use alloc::{collections::BTreeMap as Map, vec::Vec};
+use commonware_parallel::Strategy;
 use curve25519_dalek::{
     edwards::{CompressedEdwardsY, EdwardsPoint},
     scalar::Scalar,
     traits::{IsIdentity, VartimeMultiscalarMul},
 };
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
 use rand_core::{CryptoRng, RngCore};
 use sha2::{digest::Update, Sha512};
 #[cfg(feature = "std")]
@@ -120,73 +123,108 @@ impl Verifier {
     /// as individual verification, which may reject some signatures this method
     /// accepts.
     #[allow(non_snake_case)]
-    pub fn verify<R: RngCore + CryptoRng>(self, mut rng: R) -> Result<(), Error> {
-        // The batch verification equation is
-        //
-        // [-sum(z_i * s_i)]B + sum([z_i]R_i) + sum([z_i * k_i]A_i) = 0.
-        //
-        // where for each signature i,
-        // - A_i is the verification key;
-        // - R_i is the signature's R value;
-        // - s_i is the signature's s value;
-        // - k_i is the hash of the message and other data;
-        // - z_i is a random 128-bit Scalar.
-        //
-        // Normally n signatures would require a multiscalar multiplication of
-        // size 2*n + 1, together with 2*n point decompressions (to obtain A_i
-        // and R_i). However, because we store batch entries in a map
-        // indexed by the verification key, we can "coalesce" all z_i * k_i
-        // terms for each distinct verification key into a single coefficient.
-        //
-        // For n signatures from m verification keys, this approach instead
-        // requires a multiscalar multiplication of size n + m + 1 together with
-        // only n point decompressions because verification keys are decompressed
-        // before they are queued. When m = n, so all signatures are from
-        // distinct verification keys, this saves n decompressions relative to
-        // the usual method. However, when m = 1 and all signatures are from a
-        // single verification key, this is nearly twice as fast.
-
-        let m = self.signatures.len();
-
-        let mut A_coeffs = Vec::with_capacity(m);
-        let mut As = Vec::with_capacity(m);
-        let mut R_coeffs = Vec::with_capacity(self.batch_size);
-        let mut Rs = Vec::with_capacity(self.batch_size);
-        let mut B_coeff = Scalar::ZERO;
-
-        for (vk, sigs) in self.signatures.iter() {
-            let A = -vk.minus_A;
-            let mut A_coeff = Scalar::ZERO;
-
-            for (k, sig) in sigs.iter() {
-                let R = CompressedEdwardsY(sig.R_bytes)
-                    .decompress()
-                    .ok_or(Error::InvalidSignature)?;
-                let s = Scalar::from_canonical_bytes(sig.s_bytes)
-                    .into_option()
-                    .ok_or(Error::InvalidSignature)?;
-                let z = Scalar::from(gen_u128(&mut rng));
-                B_coeff -= z * s;
-                Rs.push(R);
-                R_coeffs.push(z);
-                A_coeff += z * k;
-            }
-
-            As.push(A);
-            A_coeffs.push(A_coeff);
+    pub fn verify<R: RngCore + CryptoRng>(
+        self,
+        mut rng: R,
+        strategy: &impl Strategy,
+    ) -> Result<(), Error> {
+        if self.batch_size == 0 {
+            return Ok(());
         }
 
-        use core::iter::once;
-        use curve25519_dalek::constants::ED25519_BASEPOINT_POINT as B;
-        let check = EdwardsPoint::vartime_multiscalar_mul(
-            once(&B_coeff).chain(A_coeffs.iter()).chain(R_coeffs.iter()),
-            once(&B).chain(As.iter()).chain(Rs.iter()),
-        );
-
-        if check.mul_by_cofactor().is_identity() {
-            Ok(())
-        } else {
-            Err(Error::InvalidSignature)
+        let groups: Vec<_> = self.signatures.into_iter().collect();
+        let shard_count = strategy.parallelism_hint().max(1).min(groups.len());
+        let shard_size = groups.len().div_ceil(shard_count);
+        let mut shards = Vec::with_capacity(shard_count);
+        for shard in groups.chunks(shard_size) {
+            let mut seed = [0u8; 32];
+            rng.fill_bytes(&mut seed);
+            shards.push((shard, seed));
         }
+
+        strategy.fold(
+            shards,
+            || Ok(()),
+            |result, (shard, seed)| {
+                result?;
+                let mut rng = ChaCha20Rng::from_seed(seed);
+
+                // The batch verification equation is
+                //
+                // [-sum(z_i * s_i)]B + sum([z_i]R_i) + sum([z_i * k_i]A_i) = 0.
+                //
+                // where for each signature i,
+                // - A_i is the verification key;
+                // - R_i is the signature's R value;
+                // - s_i is the signature's s value;
+                // - k_i is the hash of the message and other data;
+                // - z_i is a random 128-bit Scalar.
+                //
+                // Normally n signatures would require a multiscalar multiplication of
+                // size 2*n + 1, together with 2*n point decompressions (to obtain A_i
+                // and R_i). However, because we store batch entries in a map
+                // indexed by the verification key, we can "coalesce" all z_i * k_i
+                // terms for each distinct verification key into a single coefficient.
+                //
+                // For n signatures from m verification keys, this approach instead
+                // requires a multiscalar multiplication of size n + m + 1 together with
+                // only n point decompressions because verification keys are decompressed
+                // before they are queued. When m = n, so all signatures are from
+                // distinct verification keys, this saves n decompressions relative to
+                // the usual method. However, when m = 1 and all signatures are from a
+                // single verification key, this is nearly twice as fast.
+
+                let m = shard.len();
+                let batch_size = shard.iter().map(|(_, sigs)| sigs.len()).sum();
+
+                let mut A_coeffs = Vec::with_capacity(m);
+                let mut As = Vec::with_capacity(m);
+                let mut R_coeffs = Vec::with_capacity(batch_size);
+                let mut Rs = Vec::with_capacity(batch_size);
+                let mut B_coeff = Scalar::ZERO;
+
+                for (vk, sigs) in shard {
+                    let A = -vk.minus_A;
+                    let mut A_coeff = Scalar::ZERO;
+
+                    for (k, sig) in sigs.iter() {
+                        let R = CompressedEdwardsY(sig.R_bytes)
+                            .decompress()
+                            .ok_or(Error::InvalidSignature)?;
+                        let s = Scalar::from_canonical_bytes(sig.s_bytes)
+                            .into_option()
+                            .ok_or(Error::InvalidSignature)?;
+                        let z = Scalar::from(gen_u128(&mut rng));
+                        B_coeff -= z * s;
+                        Rs.push(R);
+                        R_coeffs.push(z);
+                        A_coeff += z * k;
+                    }
+
+                    As.push(A);
+                    A_coeffs.push(A_coeff);
+                }
+
+                use core::iter::once;
+                use curve25519_dalek::constants::ED25519_BASEPOINT_POINT as B;
+                let check = EdwardsPoint::vartime_multiscalar_mul(
+                    once(&B_coeff).chain(A_coeffs.iter()).chain(R_coeffs.iter()),
+                    once(&B).chain(As.iter()).chain(Rs.iter()),
+                );
+
+                if check.mul_by_cofactor().is_identity() {
+                    Ok(())
+                } else {
+                    Err(Error::InvalidSignature)
+                }
+            },
+            |left, right| {
+                if left.is_err() {
+                    left
+                } else {
+                    right
+                }
+            },
+        )
     }
 }

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -365,8 +365,8 @@ impl BatchVerifier for Batch {
         self.add_inner(Some(namespace), message, public_key, signature)
     }
 
-    fn verify<R: CryptoRngCore>(self, rng: &mut R, _strategy: &impl Strategy) -> bool {
-        self.verifier.verify(rng).is_ok()
+    fn verify<R: CryptoRngCore>(self, rng: &mut R, strategy: &impl Strategy) -> bool {
+        self.verifier.verify(rng, strategy).is_ok()
     }
 }
 

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -8,6 +8,7 @@ use bytes::{Buf, BufMut};
 use commonware_codec::{Error as CodecError, FixedSize, Read, ReadExt, Write};
 use commonware_formatting::Hex;
 use commonware_math::algebra::Random;
+use commonware_parallel::Strategy;
 use commonware_utils::{union_unique, Array, Span};
 use core::{
     fmt::{Debug, Display},
@@ -364,7 +365,7 @@ impl BatchVerifier for Batch {
         self.add_inner(Some(namespace), message, public_key, signature)
     }
 
-    fn verify<R: CryptoRngCore>(self, rng: &mut R) -> bool {
+    fn verify<R: CryptoRngCore>(self, rng: &mut R, _strategy: &impl Strategy) -> bool {
         self.verifier.verify(rng).is_ok()
     }
 }
@@ -397,6 +398,7 @@ mod tests {
     use crate::{ed25519, Signer as _};
     use commonware_codec::{DecodeExt, Encode};
     use commonware_math::algebra::Random;
+    use commonware_parallel::Sequential;
     use commonware_utils::test_rng;
 
     fn test_sign_and_verify(
@@ -736,7 +738,7 @@ mod tests {
         let mut batch = ed25519::Batch::new();
         assert!(batch.add_inner(None, &v1.2, &v1.1, &v1.3));
         assert!(batch.add_inner(None, &v2.2, &v2.1, &v2.3));
-        assert!(batch.verify(&mut test_rng()));
+        assert!(batch.verify(&mut test_rng(), &Sequential));
     }
 
     #[test]
@@ -754,13 +756,13 @@ mod tests {
             &v2.1,
             &Signature::decode(bad_signature.as_ref()).unwrap()
         ));
-        assert!(!batch.verify(&mut test_rng()));
+        assert!(!batch.verify(&mut test_rng(), &Sequential));
     }
 
     #[test]
     fn batch_verify_empty() {
         let batch = Batch::new();
-        assert!(batch.verify(&mut test_rng()));
+        assert!(batch.verify(&mut test_rng(), &Sequential));
     }
 
     #[test]

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -10,8 +10,6 @@
 )]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
-use commonware_parallel::Strategy;
-
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
@@ -50,6 +48,7 @@ commonware_macros::stability_scope!(ALPHA {
 commonware_macros::stability_scope!(BETA {
     use commonware_codec::{Encode, ReadExt};
     use commonware_math::algebra::Random;
+    use commonware_parallel::Strategy;
     use commonware_utils::Array;
     use rand::SeedableRng as _;
     use rand_chacha::ChaCha20Rng;

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -10,6 +10,8 @@
 )]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
+use commonware_parallel::Strategy;
+
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
@@ -181,7 +183,7 @@ commonware_macros::stability_scope!(BETA {
         /// (`c_1 + d` and `c_2 - d`).
         ///
         /// You can read more about this [here](https://ethresear.ch/t/security-of-bls-batch-verification/10748#the-importance-of-randomness-4).
-        fn verify<R: CryptoRngCore>(self, rng: &mut R) -> bool;
+        fn verify<R: CryptoRngCore>(self, rng: &mut R, strategy: &impl Strategy) -> bool;
     }
 
     /// Specializes the [commonware_utils::Array] trait with the Copy trait for cryptographic digests

--- a/cryptography/src/transcript.rs
+++ b/cryptography/src/transcript.rs
@@ -416,6 +416,7 @@ mod test {
     use super::*;
     use crate::ed25519;
     use commonware_codec::{DecodeExt as _, Encode};
+    use commonware_parallel::Sequential;
     use commonware_utils::test_rng;
 
     #[test]
@@ -547,8 +548,8 @@ mod test {
         let mut transcript_batch = ed25519::Batch::new();
         assert!(transcript.add_to_batch(&mut transcript_batch, &pk, &sig));
 
-        assert!(summary_batch.verify(&mut test_rng()));
-        assert!(transcript_batch.verify(&mut test_rng()));
+        assert!(summary_batch.verify(&mut test_rng(), &Sequential));
+        assert!(transcript_batch.verify(&mut test_rng(), &Sequential));
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Modifies the `BatchVerifier` interface to accept a `commonware_parallel::Strategy` in the `verify` function, enabling verifiers to run in parallel when possible.

Uses this to parallelize both ed25519 and bls12381 batch verification. For ed25519, with `2^14` signatures:

```
ed25519::batch_verify_same_message/pks=16384 conc=1
                        time:   [111.16 ms 111.42 ms 111.73 ms]
ed25519::batch_verify_same_message/pks=16384 conc=8
                        time:   [17.746 ms 18.039 ms 18.312 ms]
```