### PR TITLE
[storage] Parameterize resolver impls over Strategy

### DIFF
--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -376,8 +376,8 @@ impl_current_sync_database!(
 
 macro_rules! impl_current_resolver {
     ($db:ident, $op:ident, $val_bound:ident, $key_bound:path $(; $($where_extra:tt)+)?) => {
-        impl<F, E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
-            for std::sync::Arc<$db<F, E, K, V, H, T, N>>
+        impl<F, E, K, V, H, T, const N: usize, S> crate::qmdb::sync::Resolver
+            for std::sync::Arc<$db<F, E, K, V, H, T, N, S>>
         where
             F: Graftable,
             E: Context,
@@ -386,6 +386,7 @@ macro_rules! impl_current_resolver {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
             $($($where_extra)+)?
         {
             type Family = F;
@@ -418,10 +419,10 @@ macro_rules! impl_current_resolver {
             }
         }
 
-        impl<F, E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
+        impl<F, E, K, V, H, T, const N: usize, S> crate::qmdb::sync::Resolver
             for std::sync::Arc<
                 commonware_utils::sync::AsyncRwLock<
-                    $db<F, E, K, V, H, T, N>,
+                    $db<F, E, K, V, H, T, N, S>,
                 >,
             >
         where
@@ -432,6 +433,7 @@ macro_rules! impl_current_resolver {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
             $($($where_extra)+)?
         {
             type Family = F;
@@ -465,10 +467,10 @@ macro_rules! impl_current_resolver {
             }
         }
 
-        impl<F, E, K, V, H, T, const N: usize> crate::qmdb::sync::Resolver
+        impl<F, E, K, V, H, T, const N: usize, S> crate::qmdb::sync::Resolver
             for std::sync::Arc<
                 commonware_utils::sync::AsyncRwLock<
-                    Option<$db<F, E, K, V, H, T, N>>,
+                    Option<$db<F, E, K, V, H, T, N, S>>,
                 >,
             >
         where
@@ -479,6 +481,7 @@ macro_rules! impl_current_resolver {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
             $($($where_extra)+)?
         {
             type Family = F;

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -71,6 +71,7 @@ use commonware_codec::{
     Encode, EncodeSize, Error as CodecError, RangeCfg, Read, ReadExt as _, Write,
 };
 use commonware_cryptography::{Digest, Hasher};
+use commonware_parallel::Strategy;
 use commonware_runtime::{Buf, BufMut, Clock, Metrics, Storage};
 use commonware_utils::{sync::AsyncRwLock, Array};
 use std::{future::Future, num::NonZeroU64, sync::Arc};
@@ -401,12 +402,13 @@ where
 // historical tip proof and current frontier pins from the full source.
 macro_rules! impl_compact_resolver_keyless {
     ($db:ident, $op:ident, $val_bound:ident) => {
-        impl<F, E, V, H> Resolver for Arc<$db<F, E, V, H>>
+        impl<F, E, V, H, S> Resolver for Arc<$db<F, E, V, H, S>>
         where
             F: Family,
             E: crate::Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -438,12 +440,13 @@ macro_rules! impl_compact_resolver_keyless {
             }
         }
 
-        impl<F, E, V, H> Resolver for Arc<AsyncRwLock<$db<F, E, V, H>>>
+        impl<F, E, V, H, S> Resolver for Arc<AsyncRwLock<$db<F, E, V, H, S>>>
         where
             F: Family,
             E: crate::Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -476,12 +479,13 @@ macro_rules! impl_compact_resolver_keyless {
             }
         }
 
-        impl<F, E, V, H> Resolver for Arc<AsyncRwLock<Option<$db<F, E, V, H>>>>
+        impl<F, E, V, H, S> Resolver for Arc<AsyncRwLock<Option<$db<F, E, V, H, S>>>>
         where
             F: Family,
             E: crate::Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -521,7 +525,7 @@ macro_rules! impl_compact_resolver_keyless {
 // translator parameters carried by immutable variants.
 macro_rules! impl_compact_resolver_immutable {
     ($db:ident, $op:ident, $val_bound:ident, $key_bound:path) => {
-        impl<F, E, K, V, H, T> Resolver for Arc<$db<F, E, K, V, H, T>>
+        impl<F, E, K, V, H, T, S> Resolver for Arc<$db<F, E, K, V, H, T, S>>
         where
             F: Family,
             E: crate::Context,
@@ -530,6 +534,7 @@ macro_rules! impl_compact_resolver_immutable {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -561,7 +566,7 @@ macro_rules! impl_compact_resolver_immutable {
             }
         }
 
-        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T>>>
+        impl<F, E, K, V, H, T, S> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T, S>>>
         where
             F: Family,
             E: crate::Context,
@@ -570,6 +575,7 @@ macro_rules! impl_compact_resolver_immutable {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -602,7 +608,7 @@ macro_rules! impl_compact_resolver_immutable {
             }
         }
 
-        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T>>>>
+        impl<F, E, K, V, H, T, S> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T, S>>>>
         where
             F: Family,
             E: crate::Context,
@@ -611,6 +617,7 @@ macro_rules! impl_compact_resolver_immutable {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -650,7 +657,7 @@ macro_rules! impl_compact_resolver_immutable {
 // is just a validated `compact_state()` read rather than reconstructing anything from history.
 macro_rules! impl_compact_resolver_compact_keyless {
     ($db:ident, $op:ident) => {
-        impl<F, E, V, H, C> Resolver for Arc<$db<F, E, V, H, C>>
+        impl<F, E, V, H, C, S> Resolver for Arc<$db<F, E, V, H, C, S>>
         where
             F: Family,
             E: crate::Context,
@@ -658,6 +665,7 @@ macro_rules! impl_compact_resolver_compact_keyless {
             H: Hasher,
             $op<F, V>: Encode + Read<Cfg = C>,
             C: Clone + Send + Sync + 'static,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -672,7 +680,7 @@ macro_rules! impl_compact_resolver_compact_keyless {
             }
         }
 
-        impl<F, E, V, H, C> Resolver for Arc<AsyncRwLock<$db<F, E, V, H, C>>>
+        impl<F, E, V, H, C, S> Resolver for Arc<AsyncRwLock<$db<F, E, V, H, C, S>>>
         where
             F: Family,
             E: crate::Context,
@@ -680,6 +688,7 @@ macro_rules! impl_compact_resolver_compact_keyless {
             H: Hasher,
             $op<F, V>: Encode + Read<Cfg = C>,
             C: Clone + Send + Sync + 'static,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -694,7 +703,7 @@ macro_rules! impl_compact_resolver_compact_keyless {
             }
         }
 
-        impl<F, E, V, H, C> Resolver for Arc<AsyncRwLock<Option<$db<F, E, V, H, C>>>>
+        impl<F, E, V, H, C, S> Resolver for Arc<AsyncRwLock<Option<$db<F, E, V, H, C, S>>>>
         where
             F: Family,
             E: crate::Context,
@@ -702,6 +711,7 @@ macro_rules! impl_compact_resolver_compact_keyless {
             H: Hasher,
             $op<F, V>: Encode + Read<Cfg = C>,
             C: Clone + Send + Sync + 'static,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -724,7 +734,7 @@ macro_rules! impl_compact_resolver_compact_keyless {
 // persisted witness/cache directly instead of rebuilding it from a full operation log.
 macro_rules! impl_compact_resolver_compact_immutable {
     ($db:ident, $op:ident) => {
-        impl<F, E, K, V, H, C> Resolver for Arc<$db<F, E, K, V, H, C>>
+        impl<F, E, K, V, H, C, S> Resolver for Arc<$db<F, E, K, V, H, C, S>>
         where
             F: Family,
             E: crate::Context,
@@ -733,6 +743,7 @@ macro_rules! impl_compact_resolver_compact_immutable {
             H: Hasher,
             $op<F, K, V>: Encode + Read<Cfg = C>,
             C: Clone + Send + Sync + 'static,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -747,7 +758,7 @@ macro_rules! impl_compact_resolver_compact_immutable {
             }
         }
 
-        impl<F, E, K, V, H, C> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, C>>>
+        impl<F, E, K, V, H, C, S> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, C, S>>>
         where
             F: Family,
             E: crate::Context,
@@ -756,6 +767,7 @@ macro_rules! impl_compact_resolver_compact_immutable {
             H: Hasher,
             $op<F, K, V>: Encode + Read<Cfg = C>,
             C: Clone + Send + Sync + 'static,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -770,7 +782,7 @@ macro_rules! impl_compact_resolver_compact_immutable {
             }
         }
 
-        impl<F, E, K, V, H, C> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, C>>>>
+        impl<F, E, K, V, H, C, S> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, C, S>>>>
         where
             F: Family,
             E: crate::Context,
@@ -779,6 +791,7 @@ macro_rules! impl_compact_resolver_compact_immutable {
             H: Hasher,
             $op<F, K, V>: Encode + Read<Cfg = C>,
             C: Clone + Send + Sync + 'static,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -809,8 +822,63 @@ impl_compact_resolver_immutable!(ImmutableVariableDb, ImmutableVariableOp, Varia
 mod tests {
     use super::Target;
     use crate::merkle::mmr;
-    use commonware_codec::{DecodeExt as _, Encode as _};
+    use commonware_codec::{DecodeExt as _, Encode as _, RangeCfg};
     use commonware_cryptography::{sha256::Digest, Hasher as _};
+    use commonware_parallel::Rayon;
+    use commonware_runtime::deterministic;
+    use commonware_utils::sync::AsyncRwLock;
+    use std::sync::Arc;
+
+    macro_rules! assert_resolver_variants {
+        ($db:ty) => {
+            assert_resolver::<Arc<$db>>();
+            assert_resolver::<Arc<AsyncRwLock<$db>>>();
+            assert_resolver::<Arc<AsyncRwLock<Option<$db>>>>();
+        };
+    }
+
+    fn assert_resolver<R: super::Resolver>() {}
+
+    #[test]
+    fn test_all_compact_qmdb_variants_implement_strategy_resolvers() {
+        type KeylessFixedCompactDb = crate::qmdb::keyless::fixed::CompactDb<
+            mmr::Family,
+            deterministic::Context,
+            Digest,
+            commonware_cryptography::Sha256,
+            Rayon,
+        >;
+        type KeylessVariableCompactDb = crate::qmdb::keyless::variable::CompactDb<
+            mmr::Family,
+            deterministic::Context,
+            Vec<u8>,
+            commonware_cryptography::Sha256,
+            (RangeCfg<usize>, ()),
+            Rayon,
+        >;
+        type ImmutableFixedCompactDb = crate::qmdb::immutable::fixed::CompactDb<
+            mmr::Family,
+            deterministic::Context,
+            Digest,
+            Digest,
+            commonware_cryptography::Sha256,
+            Rayon,
+        >;
+        type ImmutableVariableCompactDb = crate::qmdb::immutable::variable::CompactDb<
+            mmr::Family,
+            deterministic::Context,
+            Digest,
+            Vec<u8>,
+            commonware_cryptography::Sha256,
+            ((), (RangeCfg<usize>, ())),
+            Rayon,
+        >;
+
+        assert_resolver_variants!(KeylessFixedCompactDb);
+        assert_resolver_variants!(KeylessVariableCompactDb);
+        assert_resolver_variants!(ImmutableFixedCompactDb);
+        assert_resolver_variants!(ImmutableVariableCompactDb);
+    }
 
     #[test]
     fn test_target_decode_rejects_zero_leaf_count() {

--- a/storage/src/qmdb/sync/resolver.rs
+++ b/storage/src/qmdb/sync/resolver.rs
@@ -27,6 +27,7 @@ use crate::{
     Context,
 };
 use commonware_cryptography::{Digest, Hasher};
+use commonware_parallel::Strategy;
 use commonware_utils::{channel::oneshot, sync::AsyncRwLock, Array};
 use std::{future::Future, num::NonZeroU64, sync::Arc};
 
@@ -90,7 +91,7 @@ pub trait Resolver: Send + Sync + Clone + 'static {
 
 macro_rules! impl_resolver {
     ($db:ident, $op:ident, $val_bound:ident) => {
-        impl<F, E, K, V, H, T> Resolver for Arc<$db<F, E, K, V, H, T>>
+        impl<F, E, K, V, H, T, S> Resolver for Arc<$db<F, E, K, V, H, T, S>>
         where
             F: Family,
             E: Context,
@@ -99,6 +100,7 @@ macro_rules! impl_resolver {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -129,7 +131,7 @@ macro_rules! impl_resolver {
             }
         }
 
-        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T>>>
+        impl<F, E, K, V, H, T, S> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T, S>>>
         where
             F: Family,
             E: Context,
@@ -138,6 +140,7 @@ macro_rules! impl_resolver {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -168,7 +171,7 @@ macro_rules! impl_resolver {
             }
         }
 
-        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T>>>>
+        impl<F, E, K, V, H, T, S> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T, S>>>>
         where
             F: Family,
             E: Context,
@@ -177,6 +180,7 @@ macro_rules! impl_resolver {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -227,7 +231,7 @@ impl_resolver!(OrderedVariableDb, OrderedVariableOperation, VariableValue);
 // always use Array.
 macro_rules! impl_resolver_immutable {
     ($db:ident, $op:ident, $val_bound:ident, $key_bound:path) => {
-        impl<F, E, K, V, H, T> Resolver for Arc<$db<F, E, K, V, H, T>>
+        impl<F, E, K, V, H, T, S> Resolver for Arc<$db<F, E, K, V, H, T, S>>
         where
             F: Family,
             E: Context,
@@ -236,6 +240,7 @@ macro_rules! impl_resolver_immutable {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -266,7 +271,7 @@ macro_rules! impl_resolver_immutable {
             }
         }
 
-        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T>>>
+        impl<F, E, K, V, H, T, S> Resolver for Arc<AsyncRwLock<$db<F, E, K, V, H, T, S>>>
         where
             F: Family,
             E: Context,
@@ -275,6 +280,7 @@ macro_rules! impl_resolver_immutable {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -305,7 +311,7 @@ macro_rules! impl_resolver_immutable {
             }
         }
 
-        impl<F, E, K, V, H, T> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T>>>>
+        impl<F, E, K, V, H, T, S> Resolver for Arc<AsyncRwLock<Option<$db<F, E, K, V, H, T, S>>>>
         where
             F: Family,
             E: Context,
@@ -314,6 +320,7 @@ macro_rules! impl_resolver_immutable {
             H: Hasher,
             T: Translator + Send + Sync + 'static,
             T::Key: Send + Sync,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -356,12 +363,13 @@ impl_resolver_immutable!(ImmutableVariableDb, ImmutableVariableOp, VariableValue
 // Keyless types have no key or translator, so they need their own macro.
 macro_rules! impl_resolver_keyless {
     ($db:ident, $op:ident, $val_bound:ident) => {
-        impl<F, E, V, H> Resolver for Arc<$db<F, E, V, H>>
+        impl<F, E, V, H, S> Resolver for Arc<$db<F, E, V, H, S>>
         where
             F: Family,
             E: Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -392,12 +400,13 @@ macro_rules! impl_resolver_keyless {
             }
         }
 
-        impl<F, E, V, H> Resolver for Arc<AsyncRwLock<$db<F, E, V, H>>>
+        impl<F, E, V, H, S> Resolver for Arc<AsyncRwLock<$db<F, E, V, H, S>>>
         where
             F: Family,
             E: Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -428,12 +437,13 @@ macro_rules! impl_resolver_keyless {
             }
         }
 
-        impl<F, E, V, H> Resolver for Arc<AsyncRwLock<Option<$db<F, E, V, H>>>>
+        impl<F, E, V, H, S> Resolver for Arc<AsyncRwLock<Option<$db<F, E, V, H, S>>>>
         where
             F: Family,
             E: Context,
             V: $val_bound + Send + Sync + 'static,
             H: Hasher,
+            S: Strategy,
         {
             type Family = F;
             type Digest = H::Digest;
@@ -476,7 +486,25 @@ impl_resolver_keyless!(KeylessVariableDb, KeylessVariableOp, VariableValue);
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use std::marker::PhantomData;
+    use crate::{
+        merkle::mmr,
+        translator::{OneCap, TwoCap},
+    };
+    use commonware_cryptography::{sha256::Digest as ShaDigest, Sha256};
+    use commonware_parallel::Rayon;
+    use commonware_runtime::deterministic;
+    use commonware_utils::sync::AsyncRwLock;
+    use std::{marker::PhantomData, sync::Arc};
+
+    macro_rules! assert_resolver_variants {
+        ($db:ty) => {
+            assert_resolver::<Arc<$db>>();
+            assert_resolver::<Arc<AsyncRwLock<$db>>>();
+            assert_resolver::<Arc<AsyncRwLock<Option<$db>>>>();
+        };
+    }
+
+    fn assert_resolver<R: Resolver>() {}
 
     /// A resolver that always fails.
     #[derive(Clone)]
@@ -513,5 +541,130 @@ pub(crate) mod tests {
                 _phantom: PhantomData,
             }
         }
+    }
+
+    #[test]
+    fn test_all_qmdb_variants_implement_strategy_resolvers() {
+        type AnyOrderedFixed = crate::qmdb::any::ordered::fixed::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            ShaDigest,
+            Sha256,
+            OneCap,
+            Rayon,
+        >;
+        type AnyOrderedVariable = crate::qmdb::any::ordered::variable::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            Vec<u8>,
+            Sha256,
+            OneCap,
+            Rayon,
+        >;
+        type AnyUnorderedFixed = crate::qmdb::any::unordered::fixed::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            ShaDigest,
+            Sha256,
+            TwoCap,
+            Rayon,
+        >;
+        type AnyUnorderedVariable = crate::qmdb::any::unordered::variable::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            Vec<u8>,
+            Sha256,
+            TwoCap,
+            Rayon,
+        >;
+        type CurrentOrderedFixed = crate::qmdb::current::ordered::fixed::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            ShaDigest,
+            Sha256,
+            OneCap,
+            32,
+            Rayon,
+        >;
+        type CurrentOrderedVariable = crate::qmdb::current::ordered::variable::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            Vec<u8>,
+            Sha256,
+            OneCap,
+            32,
+            Rayon,
+        >;
+        type CurrentUnorderedFixed = crate::qmdb::current::unordered::fixed::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            ShaDigest,
+            Sha256,
+            TwoCap,
+            32,
+            Rayon,
+        >;
+        type CurrentUnorderedVariable = crate::qmdb::current::unordered::variable::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            Vec<u8>,
+            Sha256,
+            TwoCap,
+            32,
+            Rayon,
+        >;
+        type ImmutableFixed = crate::qmdb::immutable::fixed::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            ShaDigest,
+            Sha256,
+            TwoCap,
+            Rayon,
+        >;
+        type ImmutableVariable = crate::qmdb::immutable::variable::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            Vec<u8>,
+            Sha256,
+            TwoCap,
+            Rayon,
+        >;
+        type KeylessFixed = crate::qmdb::keyless::fixed::Db<
+            mmr::Family,
+            deterministic::Context,
+            ShaDigest,
+            Sha256,
+            Rayon,
+        >;
+        type KeylessVariable = crate::qmdb::keyless::variable::Db<
+            mmr::Family,
+            deterministic::Context,
+            Vec<u8>,
+            Sha256,
+            Rayon,
+        >;
+
+        assert_resolver_variants!(AnyOrderedFixed);
+        assert_resolver_variants!(AnyOrderedVariable);
+        assert_resolver_variants!(AnyUnorderedFixed);
+        assert_resolver_variants!(AnyUnorderedVariable);
+        assert_resolver_variants!(CurrentOrderedFixed);
+        assert_resolver_variants!(CurrentOrderedVariable);
+        assert_resolver_variants!(CurrentUnorderedFixed);
+        assert_resolver_variants!(CurrentUnorderedVariable);
+        assert_resolver_variants!(ImmutableFixed);
+        assert_resolver_variants!(ImmutableVariable);
+        assert_resolver_variants!(KeylessFixed);
+        assert_resolver_variants!(KeylessVariable);
     }
 }


### PR DESCRIPTION
## Overview

Allows for QMDB state sync resolvers to be parameterized over the `commonware_parallel::Strategy` and adds test coverage to ensure that a resolver with a non-default `Strategy` can be constructed.