### PR TITLE
[consensus] Remove `VerifyingApplication`

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -270,18 +270,7 @@ stability_scope!(ALPHA, cfg(not(target_arch = "wasm32")) {
             context: (E, Self::Context),
             ancestry: AncestorStream<A, Self::Block>,
         ) -> impl Future<Output = Option<Self::Block>> + Send;
-    }
 
-    /// An extension of [Application] that provides the ability to implementations to verify blocks.
-    ///
-    /// Some [Application]s may not require this functionality. When employing
-    /// erasure coding, for example, verification only serves to verify the integrity of the
-    /// received shard relative to the consensus commitment, and can therefore be
-    /// hidden from the application.
-    pub trait VerifyingApplication<E>: Application<E>
-    where
-        E: Rng + Spawner + Metrics + Clock,
-    {
         /// Verify a block produced by the application's proposer, relative to its ancestry.
         ///
         /// This future should not resolve until the implementation can produce a stable verdict.

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -2,7 +2,7 @@
 //!
 //! # Overview
 //!
-//! [`Marshaled`] is an adapter that wraps any [`VerifyingApplication`] implementation to handle
+//! [`Marshaled`] is an adapter that wraps any [`Application`] implementation to handle
 //! epoch transitions and erasure coded broadcast automatically. It intercepts consensus
 //! operations (propose, verify, certify) and ensures blocks are only produced within valid epoch boundaries.
 //!
@@ -34,7 +34,7 @@
 //!
 //! # Usage
 //!
-//! Wrap your [`VerifyingApplication`] implementation with [`Marshaled::new`] and provide it to your
+//! Wrap your [`Application`] implementation with [`Marshaled::new`] and provide it to your
 //! consensus engine for the [`Automaton`] and [`Relay`]. The wrapper handles all epoch logic transparently.
 //!
 //! ```rust,ignore
@@ -96,7 +96,7 @@ use crate::{
     simplex::{scheme::Scheme, types::Context, Plan},
     types::{coding::Commitment, Epoch, Epocher, Round},
     Application, Automaton, Block, CertifiableAutomaton, CertifiableBlock, Epochable, Heightable,
-    Relay, Reporter, VerifyingApplication,
+    Relay, Reporter,
 };
 use commonware_coding::{Config as CodingConfig, Scheme as CodingScheme};
 use commonware_cryptography::{
@@ -225,7 +225,7 @@ where
 impl<E, A, B, C, H, Z, S, ES> Marshaled<E, A, B, C, H, Z, S, ES>
 where
     E: Rng + Storage + Spawner + Metrics + Clock,
-    A: VerifyingApplication<
+    A: Application<
         E,
         Block = B,
         SigningScheme = Z::Scheme,
@@ -464,7 +464,7 @@ where
 impl<E, A, B, C, H, Z, S, ES> Automaton for Marshaled<E, A, B, C, H, Z, S, ES>
 where
     E: Rng + Storage + Spawner + Metrics + Clock,
-    A: VerifyingApplication<
+    A: Application<
         E,
         Block = B,
         SigningScheme = Z::Scheme,
@@ -894,7 +894,7 @@ where
 impl<E, A, B, C, H, Z, S, ES> CertifiableAutomaton for Marshaled<E, A, B, C, H, Z, S, ES>
 where
     E: Rng + Storage + Spawner + Metrics + Clock,
-    A: VerifyingApplication<
+    A: Application<
         E,
         Block = B,
         SigningScheme = Z::Scheme,

--- a/consensus/src/marshal/mocks/verifying.rs
+++ b/consensus/src/marshal/mocks/verifying.rs
@@ -1,8 +1,8 @@
 //! Mock verifying application for Marshaled wrapper tests.
 //!
-//! This module provides a generic mock application that implements both
-//! `Application` and `VerifyingApplication` traits, suitable for testing
-//! the `Marshaled` wrapper in both standard and coding variants.
+//! This module provides a generic mock application that implements the
+//! `Application` trait, suitable for testing the `Marshaled` wrapper in
+//! both standard and coding variants.
 
 use crate::{
     marshal::ancestry::{AncestorStream, BlockProvider},
@@ -15,7 +15,7 @@ use commonware_utils::{
 };
 use std::{marker::PhantomData, sync::Arc};
 
-/// A mock application that implements `VerifyingApplication` for testing.
+/// A mock application that implements `Application` for testing.
 ///
 /// This mock:
 /// - Returns the provided genesis block from `genesis()`
@@ -81,14 +81,7 @@ where
     ) -> Option<Self::Block> {
         self.propose_result.clone()
     }
-}
 
-impl<B, S> crate::VerifyingApplication<deterministic::Context> for MockVerifyingApp<B, S>
-where
-    B: CertifiableBlock + Clone + Send + Sync + 'static,
-    B::Context: Epochable + Clone + Send + Sync + 'static,
-    S: commonware_cryptography::certificate::Scheme + Clone + Send + Sync + 'static,
-{
     async fn verify<A: BlockProvider<Block = Self::Block>>(
         &mut self,
         _context: (deterministic::Context, Self::Context),
@@ -149,14 +142,7 @@ where
     ) -> Option<Self::Block> {
         None
     }
-}
 
-impl<B, S> crate::VerifyingApplication<deterministic::Context> for GatedVerifyingApp<B, S>
-where
-    B: CertifiableBlock + Clone + Send + Sync + 'static,
-    B::Context: Epochable + Clone + Send + Sync + 'static,
-    S: commonware_cryptography::certificate::Scheme + Clone + Send + Sync + 'static,
-{
     async fn verify<A: BlockProvider<Block = Self::Block>>(
         &mut self,
         _context: (deterministic::Context, Self::Context),

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -2,7 +2,7 @@
 //!
 //! # Overview
 //!
-//! [`Deferred`] is an adapter that wraps any [`VerifyingApplication`] implementation to handle
+//! [`Deferred`] is an adapter that wraps any [`Application`] implementation to handle
 //! epoch transitions automatically. It intercepts consensus operations (propose, verify) and
 //! ensures blocks are only produced within valid epoch boundaries.
 //!
@@ -89,7 +89,6 @@ use crate::{
     simplex::{types::Context, Plan},
     types::{Epoch, Epocher, Round},
     Application, Automaton, CertifiableAutomaton, CertifiableBlock, Epochable, Relay, Reporter,
-    VerifyingApplication,
 };
 use commonware_cryptography::{certificate::Scheme, Digestible};
 use commonware_macros::select;
@@ -178,12 +177,7 @@ impl<E, S, A, B, ES> Deferred<E, S, A, B, ES>
 where
     E: Rng + Spawner + Metrics + Clock,
     S: Scheme,
-    A: VerifyingApplication<
-        E,
-        Block = B,
-        SigningScheme = S,
-        Context = Context<B::Digest, S::PublicKey>,
-    >,
+    A: Application<E, Block = B, SigningScheme = S, Context = Context<B::Digest, S::PublicKey>>,
     B: CertifiableBlock<Context = <A as Application<E>>::Context>,
     ES: Epocher,
 {
@@ -266,12 +260,7 @@ impl<E, S, A, B, ES> Automaton for Deferred<E, S, A, B, ES>
 where
     E: Rng + Spawner + Metrics + Clock,
     S: Scheme,
-    A: VerifyingApplication<
-        E,
-        Block = B,
-        SigningScheme = S,
-        Context = Context<B::Digest, S::PublicKey>,
-    >,
+    A: Application<E, Block = B, SigningScheme = S, Context = Context<B::Digest, S::PublicKey>>,
     B: CertifiableBlock<Context = <A as Application<E>>::Context>,
     ES: Epocher,
 {
@@ -585,12 +574,7 @@ impl<E, S, A, B, ES> CertifiableAutomaton for Deferred<E, S, A, B, ES>
 where
     E: Rng + Spawner + Metrics + Clock,
     S: Scheme,
-    A: VerifyingApplication<
-        E,
-        Block = B,
-        SigningScheme = S,
-        Context = Context<B::Digest, S::PublicKey>,
-    >,
+    A: Application<E, Block = B, SigningScheme = S, Context = Context<B::Digest, S::PublicKey>>,
     B: CertifiableBlock<Context = <A as Application<E>>::Context>,
     ES: Epocher,
 {

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -2,7 +2,7 @@
 //!
 //! # Overview
 //!
-//! [`Inline`] adapts any [`VerifyingApplication`] to the marshal/consensus interfaces
+//! [`Inline`] adapts any [`Application`] to the marshal/consensus interfaces
 //! while keeping block validation in the [`Automaton::verify`] path. Unlike
 //! [`super::Deferred`], it does not defer application verification to certification.
 //! Instead, it only reports `true` from `verify` after parent/height checks and
@@ -58,7 +58,6 @@ use crate::{
     simplex::{types::Context, Plan},
     types::{Epoch, Epocher, Round},
     Application, Automaton, Block, CertifiableAutomaton, Epochable, Relay, Reporter,
-    VerifyingApplication,
 };
 use commonware_cryptography::certificate::Scheme;
 use commonware_macros::select;
@@ -172,12 +171,7 @@ impl<E, S, A, B, ES> Inline<E, S, A, B, ES>
 where
     E: Rng + Spawner + Metrics + Clock,
     S: Scheme,
-    A: VerifyingApplication<
-        E,
-        Block = B,
-        SigningScheme = S,
-        Context = Context<B::Digest, S::PublicKey>,
-    >,
+    A: Application<E, Block = B, SigningScheme = S, Context = Context<B::Digest, S::PublicKey>>,
     B: Block + Clone,
     ES: Epocher,
 {
@@ -207,12 +201,7 @@ impl<E, S, A, B, ES> Automaton for Inline<E, S, A, B, ES>
 where
     E: Rng + Spawner + Metrics + Clock,
     S: Scheme,
-    A: VerifyingApplication<
-        E,
-        Block = B,
-        SigningScheme = S,
-        Context = Context<B::Digest, S::PublicKey>,
-    >,
+    A: Application<E, Block = B, SigningScheme = S, Context = Context<B::Digest, S::PublicKey>>,
     B: Block + Clone,
     ES: Epocher,
 {
@@ -482,12 +471,7 @@ impl<E, S, A, B, ES> CertifiableAutomaton for Inline<E, S, A, B, ES>
 where
     E: Rng + Spawner + Metrics + Clock,
     S: Scheme,
-    A: VerifyingApplication<
-        E,
-        Block = B,
-        SigningScheme = S,
-        Context = Context<B::Digest, S::PublicKey>,
-    >,
+    A: Application<E, Block = B, SigningScheme = S, Context = Context<B::Digest, S::PublicKey>>,
     B: Block + Clone,
     ES: Epocher,
 {
@@ -599,7 +583,7 @@ mod tests {
         },
         simplex::{scheme::bls12381_threshold::vrf as bls12381_threshold_vrf, types::Context},
         types::{Epoch, FixedEpocher, Height, Round, View},
-        Automaton, Block, CertifiableAutomaton, Relay, VerifyingApplication,
+        Application, Automaton, Block, CertifiableAutomaton, Relay,
     };
     use commonware_broadcast::Broadcaster;
     use commonware_cryptography::{
@@ -619,12 +603,7 @@ mod tests {
     where
         E: Rng + Spawner + Metrics + Clock,
         S: Scheme,
-        A: VerifyingApplication<
-            E,
-            Block = B,
-            SigningScheme = S,
-            Context = Context<B::Digest, S::PublicKey>,
-        >,
+        A: Application<E, Block = B, SigningScheme = S, Context = Context<B::Digest, S::PublicKey>>,
         B: Block + Clone,
         ES: crate::types::Epocher,
     {

--- a/consensus/src/marshal/standard/validation.rs
+++ b/consensus/src/marshal/standard/validation.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     simplex::types::Context,
     types::{Epocher, Round},
-    Application, Block, Epochable, VerifyingApplication,
+    Application, Block, Epochable,
 };
 use commonware_cryptography::certificate::Scheme;
 use commonware_macros::select;
@@ -130,12 +130,7 @@ pub(super) async fn verify_with_parent<E, S, A, B>(
 where
     E: Rng + Spawner + Metrics + Clock,
     S: Scheme,
-    A: VerifyingApplication<
-        E,
-        Block = B,
-        SigningScheme = S,
-        Context = Context<B::Digest, S::PublicKey>,
-    >,
+    A: Application<E, Block = B, SigningScheme = S, Context = Context<B::Digest, S::PublicKey>>,
     B: Block + Clone,
 {
     let (parent_view, parent_digest) = context.parent;

--- a/docs/blogs/coding.html
+++ b/docs/blogs/coding.html
@@ -132,7 +132,7 @@
 
         <h2>Out-of-the-Box Performance (If You Want It)</h2>
 
-        <p>Applications do not need to be rewritten to use this feature. If you already implement the <code>Application</code>/<code>VerifyingApplication</code> interfaces, wrap the same application with <code>marshal::coding</code> and get erasure-coded dissemination automatically.</p>
+        <p>Applications do not need to be rewritten to use this feature. If you already implement the <code>Application</code> interface, wrap the same application with <code>marshal::coding</code> and get erasure-coded dissemination automatically.</p>
 
         <p>Interested in upgrading to <code>marshal::coding</code> at some point but not quite ready yet? We continue to support <code>marshal::standard::Inline</code> (all you need is a height and a parent digest) and <code>marshal::standard::Deferred</code> (if your block stores the consensus context, we can defer the verification check until <code>certify</code>).</p>
 

--- a/examples/reshare/src/application/core.rs
+++ b/examples/reshare/src/application/core.rs
@@ -8,7 +8,7 @@ use commonware_consensus::{
     marshal::ancestry::{AncestorStream, BlockProvider},
     simplex::types::Context,
     types::{Epoch, Round, View},
-    Heightable, VerifyingApplication,
+    Heightable,
 };
 use commonware_cryptography::{
     bls12381::primitives::variant::Variant, certificate::Scheme, Committable, Digest, Hasher,
@@ -110,16 +110,7 @@ where
             reshare,
         ))
     }
-}
 
-impl<E, S, H, C, V> VerifyingApplication<E> for Application<E, S, H, C, V>
-where
-    E: Rng + Spawner + Metrics + Clock,
-    S: Scheme,
-    H: Hasher,
-    C: Signer,
-    V: Variant,
-{
     async fn verify<A: BlockProvider<Block = Self::Block>>(
         &mut self,
         _: (E, Self::Context),


### PR DESCRIPTION
## Overview

Removes the `VerifyingApplication` trait, which was a legacy indirection that is no longer relevant. With the marshaled application wrappers, `Application::verify` is used in different places, though the requirement for a `verify` implementation is consistent.