### PR TITLE
[coding] Reject non-canonical RS encoding

### DIFF
--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -476,7 +476,7 @@ fn decode<'a, H: Hasher, S: Strategy>(
     let encoding = encoder.encode().map_err(Error::ReedSolomon)?;
     shards.extend(encoding.recovery_iter());
 
-    // Build Merkle tree from the canonical codeword.
+    // Build Merkle tree from the canonical codeword
     let mut builder = Builder::<H>::new(n);
     let shard_hashes = strategy.map_init_collect_vec(&shards, H::new, |hasher, shard| {
         hasher.update(shard);

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -210,7 +210,7 @@ const fn canonical_shard_len(data_len: usize, k: usize) -> usize {
 /// The first `k` shards, when concatenated, form `[length_prefix | data | padding]`.
 /// This function copies only the data bytes while validating trailing zero
 /// padding directly from the shard slices.
-fn extract_data(shards: &[&[u8]], k: usize, shard_len: usize) -> Result<Vec<u8>, Error> {
+fn extract_data(shards: &[&[u8]], k: usize, expected_shard_len: usize) -> Result<Vec<u8>, Error> {
     let shards = shards.get(..k).ok_or(Error::NotEnoughChunks)?;
     let data_len = read_data_len(shards)?;
     let mut data = Vec::with_capacity(data_len);
@@ -244,7 +244,7 @@ fn extract_data(shards: &[&[u8]], k: usize, shard_len: usize) -> Result<Vec<u8>,
     }
 
     // Validate that the original shards use the canonical shard width.
-    if canonical_shard_len(data.len(), k) != shard_len {
+    if canonical_shard_len(data.len(), k) != expected_shard_len {
         return Err(Error::Inconsistent);
     }
     Ok(data)

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -187,15 +187,8 @@ where
 /// The buffer layout is `[length_prefix | data | zero_padding]` split into
 /// `k` equal-sized shards of `shard_len` bytes each.
 fn prepare_data(mut data: impl Buf, k: usize) -> (Vec<u8>, usize) {
-    // Compute shard length
     let data_len = data.remaining();
-    let prefixed_len = u32::SIZE + data_len;
-    let mut shard_len = prefixed_len.div_ceil(k);
-
-    // Ensure shard length is even (required for optimizations in `reed-solomon-simd`)
-    if !shard_len.is_multiple_of(2) {
-        shard_len += 1;
-    }
+    let shard_len = canonical_shard_len(data_len, k);
 
     // Prepare data
     let length_bytes = (data_len as u32).to_be_bytes();
@@ -204,6 +197,24 @@ fn prepare_data(mut data: impl Buf, k: usize) -> (Vec<u8>, usize) {
     data.copy_to_slice(&mut padded[u32::SIZE..u32::SIZE + data_len]);
 
     (padded, shard_len)
+}
+
+/// Return the canonical shard width for a payload and shard count.
+///
+/// Encoding prefixes the payload with its length, splits the result across
+/// `k` original shards, and rounds up to an even width required by
+/// `reed-solomon-simd`. Decode uses the same calculation to reject commitments
+/// that decode to the same payload with a non-canonical shard width.
+fn canonical_shard_len(data_len: usize, k: usize) -> usize {
+    let prefixed_len = u32::SIZE + data_len;
+    let mut shard_len = prefixed_len.div_ceil(k);
+
+    // Ensure shard length is even (required for optimizations in `reed-solomon-simd`)
+    if !shard_len.is_multiple_of(2) {
+        shard_len += 1;
+    }
+
+    shard_len
 }
 
 /// Extract data from encoded shards.
@@ -244,6 +255,22 @@ fn extract_data(shards: &[&[u8]], k: usize) -> Result<Vec<u8>, Error> {
         return Err(Error::Inconsistent);
     }
 
+    Ok(data)
+}
+
+/// Extract data and verify that original shards use the canonical width.
+///
+/// `extract_data` validates the length prefix and zero padding, but zero
+/// padding alone does not make a commitment unique. A proposer can choose a
+/// larger even shard width, append zeroes, and produce a different valid root
+/// for the same payload. Checking the canonical shard width is sufficient
+/// because `extract_data` already validates the canonical byte layout within
+/// that width.
+fn extract_canonical_data(shards: &[&[u8]], k: usize, shard_len: usize) -> Result<Vec<u8>, Error> {
+    let data = extract_data(shards, k)?;
+    if canonical_shard_len(data.len(), k) != shard_len {
+        return Err(Error::Inconsistent);
+    }
     Ok(data)
 }
 
@@ -456,6 +483,7 @@ fn decode<'a, H: Hasher, S: Strategy>(
     {
         shards[idx] = shard;
     }
+    let data = extract_canonical_data(&shards, k, shard_len)?;
 
     // Re-encode recovered data to get recovery shards
     let mut encoder = Cached::take(
@@ -501,8 +529,7 @@ fn decode<'a, H: Hasher, S: Strategy>(
         return Err(Error::Inconsistent);
     }
 
-    // Extract original data
-    extract_data(&shards, k)
+    Ok(data)
 }
 
 /// A SIMD-optimized Reed-Solomon coder that emits chunks that can be proven against a [`bmt`].
@@ -1156,6 +1183,59 @@ mod tests {
                 fuzz_mixed_codeword(u)?;
                 Ok(())
             });
+    }
+
+    #[test]
+    fn test_oversized_zero_padded_shards_rejected() {
+        let data = b"X";
+        let total = 6u16;
+        let min = 3u16;
+        let k = min as usize;
+        let m = total as usize - k;
+
+        let oversized_shard_len = 4usize;
+        let mut padded = vec![0u8; k * oversized_shard_len];
+        padded[..u32::SIZE].copy_from_slice(&(data.len() as u32).to_be_bytes());
+        padded[u32::SIZE..u32::SIZE + data.len()].copy_from_slice(data);
+
+        let mut encoder = ReedSolomonEncoder::new(k, m, oversized_shard_len).unwrap();
+        for shard in padded.chunks(oversized_shard_len) {
+            encoder.add_original_shard(shard).unwrap();
+        }
+        let recovery = encoder.encode().unwrap();
+
+        let mut oversized_shards: Vec<Vec<u8>> = padded
+            .chunks(oversized_shard_len)
+            .map(|shard| shard.to_vec())
+            .collect();
+        oversized_shards.extend(recovery.recovery_iter().map(|shard| shard.to_vec()));
+
+        let mut builder = Builder::<Sha256>::new(total as usize);
+        for shard in &oversized_shards {
+            let mut hasher = Sha256::new();
+            hasher.update(shard);
+            builder.add(&hasher.finalize());
+        }
+        let oversized_tree = builder.build();
+        let oversized_root = oversized_tree.root();
+
+        let (canonical_root, _) =
+            encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        assert_ne!(oversized_root, canonical_root);
+
+        let pieces = [0u16, 1u16, 4u16]
+            .into_iter()
+            .map(|i| {
+                let proof = oversized_tree.proof(i as u32).unwrap();
+                checked(
+                    oversized_root,
+                    Chunk::new(oversized_shards[i as usize].clone().into(), i, proof),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let result = decode::<Sha256, _>(total, min, &oversized_root, pieces.iter(), &STRATEGY);
+        assert!(matches!(result, Err(Error::Inconsistent)));
     }
 
     #[test]

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -1213,7 +1213,6 @@ mod tests {
         let root = tree.root();
 
         let pieces = (0u16..=3u16)
-            .into_iter()
             .map(|i| {
                 let proof = tree.proof(i as u32).unwrap();
                 checked(

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -86,36 +86,24 @@ impl<D: Digest> Chunk<D> {
             .verify_element_inclusion(&mut hasher, &shard_digest, self.index as u32, root)
             .ok()?;
 
-        Some(CheckedChunk::new(
-            *root,
-            self.shard.clone(),
-            self.index,
-            shard_digest,
-        ))
+        Some(CheckedChunk::new(*root, self.shard.clone(), self.index))
     }
 }
 
 /// A shard that has been checked against a commitment.
 ///
-/// This stores the shard digest computed during [`Chunk::verify`] and the
-/// commitment root it was verified against. The root is checked at decode
-/// time to prevent cross-commitment shard mixing.
+/// This stores the commitment root that [`Chunk::verify`] checked against.
+/// The root is checked at decode time to prevent cross-commitment shard mixing.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CheckedChunk<D: Digest> {
     root: D,
     shard: Bytes,
     index: u16,
-    digest: D,
 }
 
 impl<D: Digest> CheckedChunk<D> {
-    const fn new(root: D, shard: Bytes, index: u16, digest: D) -> Self {
-        Self {
-            root,
-            shard,
-            index,
-            digest,
-        }
+    const fn new(root: D, shard: Bytes, index: u16) -> Self {
+        Self { root, shard, index }
     }
 }
 
@@ -205,7 +193,7 @@ fn prepare_data(mut data: impl Buf, k: usize) -> (Vec<u8>, usize) {
 /// `k` original shards, and rounds up to an even width required by
 /// `reed-solomon-simd`. Decode uses the same calculation to reject commitments
 /// that decode to the same payload with a non-canonical shard width.
-fn canonical_shard_len(data_len: usize, k: usize) -> usize {
+const fn canonical_shard_len(data_len: usize, k: usize) -> usize {
     let prefixed_len = u32::SIZE + data_len;
     let mut shard_len = prefixed_len.div_ceil(k);
 
@@ -425,7 +413,7 @@ fn decode<'a, H: Hasher, S: Strategy>(
 
     // Process checked chunks
     let shard_len = first.shard.len();
-    let mut shard_digests: Vec<Option<H::Digest>> = vec![None; n];
+    let mut seen_shards = vec![false; n];
     let mut provided_originals: Vec<(usize, &[u8])> = Vec::new();
     let mut provided_recoveries: Vec<(usize, &[u8])> = Vec::new();
     let mut provided = 0usize;
@@ -439,13 +427,13 @@ fn decode<'a, H: Hasher, S: Strategy>(
         if index >= total {
             return Err(Error::InvalidIndex(index));
         }
-        let digest_slot = &mut shard_digests[index as usize];
-        if digest_slot.is_some() {
+        let seen = &mut seen_shards[index as usize];
+        if *seen {
             return Err(Error::DuplicateIndex(index));
         }
 
-        // Add to provided shards and retain the checked digest for this index.
-        *digest_slot = Some(chunk.digest);
+        // Add to provided shards.
+        *seen = true;
         if index < min {
             provided_originals.push((index as usize, chunk.shard.as_ref()));
         } else {
@@ -500,28 +488,15 @@ fn decode<'a, H: Hasher, S: Strategy>(
     let encoding = encoder.encode().map_err(Error::ReedSolomon)?;
     shards.extend(encoding.recovery_iter());
 
-    // Build Merkle tree
-    for (i, digest) in strategy.map_init_collect_vec(
-        shard_digests
-            .iter()
-            .enumerate()
-            .filter_map(|(i, digest)| digest.is_none().then_some(i)),
-        H::new,
-        |hasher, i| {
-            hasher.update(shards[i]);
-            (i, hasher.finalize())
-        },
-    ) {
-        shard_digests[i] = Some(digest);
-    }
-
+    // Build Merkle tree from the canonical codeword.
     let mut builder = Builder::<H>::new(n);
-    shard_digests
-        .into_iter()
-        .map(|digest| digest.expect("digest must be present for every shard"))
-        .for_each(|digest| {
-            builder.add(&digest);
-        });
+    let shard_hashes = strategy.map_init_collect_vec(&shards, H::new, |hasher, shard| {
+        hasher.update(shard);
+        hasher.finalize()
+    });
+    for hash in &shard_hashes {
+        builder.add(hash);
+    }
     let tree = builder.build();
 
     // Confirm root is consistent
@@ -703,8 +678,7 @@ mod tests {
         chunk: Chunk<<Sha256 as Hasher>::Digest>,
     ) -> CheckedChunk<<Sha256 as Hasher>::Digest> {
         let Chunk { shard, index, .. } = chunk;
-        let digest = Sha256::hash(&shard);
-        CheckedChunk::new(root, shard, index, digest)
+        CheckedChunk::new(root, shard, index)
     }
 
     fn build_chunks(
@@ -1055,7 +1029,6 @@ mod tests {
             let mut shard = pieces[1].shard.to_vec();
             shard[0] ^= 0xFF; // Flip bits in first byte
             pieces[1].shard = shard.into();
-            pieces[1].digest = Sha256::hash(&pieces[1].shard);
         }
 
         // Try to decode with the tampered chunk
@@ -1235,6 +1208,43 @@ mod tests {
             .collect::<Vec<_>>();
 
         let result = decode::<Sha256, _>(total, min, &oversized_root, pieces.iter(), &STRATEGY);
+        assert!(matches!(result, Err(Error::Inconsistent)));
+    }
+
+    #[test]
+    fn test_extra_non_canonical_recovery_rejected() {
+        let data = b"canonical originals with bad recovery";
+        let total = 6u16;
+        let min = 3u16;
+
+        let (_root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let mut shards = chunks
+            .iter()
+            .map(|chunk| chunk.shard.to_vec())
+            .collect::<Vec<_>>();
+        shards[min as usize][0] ^= 0xFF;
+
+        let mut builder = Builder::<Sha256>::new(total as usize);
+        for shard in &shards {
+            let mut hasher = Sha256::new();
+            hasher.update(shard);
+            builder.add(&hasher.finalize());
+        }
+        let tree = builder.build();
+        let root = tree.root();
+
+        let pieces = [0u16, 1u16, 2u16, 3u16]
+            .into_iter()
+            .map(|i| {
+                let proof = tree.proof(i as u32).unwrap();
+                checked(
+                    root,
+                    Chunk::new(shards[i as usize].clone().into(), i, proof),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let result = decode::<Sha256, _>(total, min, &root, pieces.iter(), &STRATEGY);
         assert!(matches!(result, Err(Error::Inconsistent)));
     }
 

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -659,12 +659,17 @@ mod tests {
     use super::*;
     use commonware_codec::Encode;
     use commonware_cryptography::Sha256;
+    use commonware_invariants::minifuzz;
     use commonware_parallel::Sequential;
     use commonware_runtime::{deterministic, iobuf::EncodeExt, BufferPooler, Runner};
     use commonware_utils::NZU16;
 
     type RS = ReedSolomon<Sha256>;
     const STRATEGY: Sequential = Sequential;
+    const FUZZ_MAX_MIN_SHARDS: u16 = 8;
+    const FUZZ_MAX_EXTRA_SHARDS: u16 = 8;
+    const FUZZ_MAX_DATA_LEN: usize = 256;
+    const FUZZ_MAX_EXTRA_SHARD_WIDTH: usize = 16;
 
     fn checked(
         root: <Sha256 as Hasher>::Digest,
@@ -673,6 +678,148 @@ mod tests {
         let Chunk { shard, index, .. } = chunk;
         let digest = Sha256::hash(&shard);
         CheckedChunk::new(root, shard, index, digest)
+    }
+
+    fn build_chunks(
+        shards: &[Vec<u8>],
+    ) -> (
+        <Sha256 as Hasher>::Digest,
+        Vec<Chunk<<Sha256 as Hasher>::Digest>>,
+    ) {
+        let mut builder = Builder::<Sha256>::new(shards.len());
+        for shard in shards {
+            let mut hasher = Sha256::new();
+            hasher.update(shard);
+            builder.add(&hasher.finalize());
+        }
+        let tree = builder.build();
+        let root = tree.root();
+        let chunks = shards
+            .iter()
+            .enumerate()
+            .map(|(i, shard)| {
+                let proof = tree.proof(i as u32).unwrap();
+                Chunk::new(shard.clone().into(), i as u16, proof)
+            })
+            .collect();
+
+        (root, chunks)
+    }
+
+    fn selected_indices(
+        u: &mut arbitrary::Unstructured<'_>,
+        total: u16,
+        minimum: u16,
+    ) -> arbitrary::Result<Vec<u16>> {
+        let to_use = u.int_in_range(minimum..=total)?;
+        let mut selected = (0..total).collect::<Vec<_>>();
+        for i in 0..usize::from(to_use) {
+            let remaining = usize::from(total) - i;
+            let j = i + u.choose_index(remaining)?;
+            selected.swap(i, j);
+        }
+        selected.truncate(usize::from(to_use));
+        Ok(selected)
+    }
+
+    fn fuzz_canonical_shard_len(data_len: usize, k: usize) -> usize {
+        let prefixed_len = u32::SIZE + data_len;
+        let mut shard_len = prefixed_len.div_ceil(k);
+        if !shard_len.is_multiple_of(2) {
+            shard_len += 1;
+        }
+        shard_len
+    }
+
+    fn assert_decode_unique_commitment(
+        total: u16,
+        min: u16,
+        root: <Sha256 as Hasher>::Digest,
+        chunks: &[Chunk<<Sha256 as Hasher>::Digest>],
+        selected: &[u16],
+    ) {
+        let pieces = selected
+            .iter()
+            .map(|&i| chunks[usize::from(i)].verify::<Sha256>(i, &root).unwrap())
+            .collect::<Vec<_>>();
+
+        let Ok(decoded) = decode::<Sha256, _>(total, min, &root, pieces.iter(), &STRATEGY) else {
+            return;
+        };
+        let (canonical_root, _) =
+            encode::<Sha256, _>(total, min, decoded.as_slice(), &STRATEGY).unwrap();
+        assert_eq!(
+            root, canonical_root,
+            "decode accepted a root not produced by canonical encode"
+        );
+    }
+
+    fn fuzz_arbitrary_codeword(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<()> {
+        let min = u.int_in_range(1..=FUZZ_MAX_MIN_SHARDS)?;
+        let extra = u.int_in_range(1..=FUZZ_MAX_EXTRA_SHARDS)?;
+        let total = min + extra;
+        let k = usize::from(min);
+        let m = usize::from(extra);
+
+        let data_len = u.int_in_range(0..=FUZZ_MAX_DATA_LEN)?;
+        let data = u.bytes(data_len)?.to_vec();
+        let canonical = fuzz_canonical_shard_len(data.len(), k);
+        let extra_width = u.int_in_range(0..=FUZZ_MAX_EXTRA_SHARD_WIDTH / 2)? * 2;
+        let shard_len = canonical + extra_width;
+
+        let mut padded = vec![0u8; k * shard_len];
+        padded[..u32::SIZE].copy_from_slice(&(data.len() as u32).to_be_bytes());
+        padded[u32::SIZE..u32::SIZE + data.len()].copy_from_slice(&data);
+
+        let payload_end = u32::SIZE + data.len();
+        if payload_end < padded.len() && u.int_in_range(0..=3)? == 0 {
+            let offset = payload_end + u.choose_index(padded.len() - payload_end)?;
+            padded[offset] ^= u.arbitrary::<u8>()? | 1;
+        }
+
+        let mut encoder = ReedSolomonEncoder::new(k, m, shard_len).unwrap();
+        for shard in padded.chunks(shard_len) {
+            encoder.add_original_shard(shard).unwrap();
+        }
+        let recovery = encoder.encode().unwrap();
+
+        let mut shards = padded
+            .chunks(shard_len)
+            .map(|shard| shard.to_vec())
+            .collect::<Vec<_>>();
+        shards.extend(recovery.recovery_iter().map(|shard| shard.to_vec()));
+
+        let (root, chunks) = build_chunks(&shards);
+        let selected = selected_indices(u, total, min)?;
+        assert_decode_unique_commitment(total, min, root, &chunks, &selected);
+
+        Ok(())
+    }
+
+    fn fuzz_mixed_codeword(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<()> {
+        let min = u.int_in_range(1..=FUZZ_MAX_MIN_SHARDS)?;
+        let extra = u.int_in_range(1..=FUZZ_MAX_EXTRA_SHARDS)?;
+        let total = min + extra;
+
+        let data_len = u.int_in_range(0..=FUZZ_MAX_DATA_LEN)?;
+        let data = u.bytes(data_len)?.to_vec();
+        let (_canonical_root, chunks) =
+            encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let mut shards = chunks
+            .iter()
+            .map(|chunk| chunk.shard.to_vec())
+            .collect::<Vec<_>>();
+
+        let mutated = usize::from(min + u.int_in_range(0..=extra - 1)?);
+        let offset = u.choose_index(shards[mutated].len())?;
+        shards[mutated][offset] ^= u.arbitrary::<u8>()? | 1;
+
+        let (root, chunks) = build_chunks(&shards);
+        let mut selected = (0..min).collect::<Vec<_>>();
+        selected.push(mutated as u16);
+        assert_decode_unique_commitment(total, min, root, &chunks, &selected);
+
+        Ok(())
     }
 
     #[test]
@@ -998,6 +1145,17 @@ mod tests {
 
         let result = decode::<Sha256, _>(total, min, &non_canonical_root, pieces.iter(), &STRATEGY);
         assert!(matches!(result, Err(Error::Inconsistent)));
+    }
+
+    #[test]
+    fn minifuzz_decode_unique_commitment() {
+        minifuzz::Builder::default()
+            .with_search_limit(1024)
+            .test(|u| {
+                fuzz_arbitrary_codeword(u)?;
+                fuzz_mixed_codeword(u)?;
+                Ok(())
+            });
     }
 
     #[test]

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -4,7 +4,7 @@ use commonware_codec::{BufsMut, EncodeSize, FixedSize, RangeCfg, Read, ReadExt, 
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use commonware_storage::bmt::{self, Builder};
-use commonware_utils::{bitmap::BitMap, Cached};
+use commonware_utils::Cached;
 use reed_solomon_simd::{Error as RsError, ReedSolomonDecoder, ReedSolomonEncoder};
 use std::marker::PhantomData;
 use thiserror::Error;
@@ -86,24 +86,36 @@ impl<D: Digest> Chunk<D> {
             .verify_element_inclusion(&mut hasher, &shard_digest, self.index as u32, root)
             .ok()?;
 
-        Some(CheckedChunk::new(*root, self.shard.clone(), self.index))
+        Some(CheckedChunk::new(
+            *root,
+            self.shard.clone(),
+            self.index,
+            shard_digest,
+        ))
     }
 }
 
 /// A shard that has been checked against a commitment.
 ///
-/// This stores the commitment root that [`Chunk::verify`] checked against.
-/// The root is checked at decode time to prevent cross-commitment shard mixing.
+/// This stores the shard digest computed during [`Chunk::verify`] and the
+/// commitment root it was verified against. The root is checked at decode
+/// time to prevent cross-commitment shard mixing.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CheckedChunk<D: Digest> {
     root: D,
     shard: Bytes,
     index: u16,
+    digest: D,
 }
 
 impl<D: Digest> CheckedChunk<D> {
-    const fn new(root: D, shard: Bytes, index: u16) -> Self {
-        Self { root, shard, index }
+    const fn new(root: D, shard: Bytes, index: u16, digest: D) -> Self {
+        Self {
+            root,
+            shard,
+            index,
+            digest,
+        }
     }
 }
 
@@ -401,7 +413,8 @@ fn decode<'a, H: Hasher, S: Strategy>(
 
     // Process checked chunks
     let shard_len = first.shard.len();
-    let mut seen_shards: BitMap = BitMap::zeroes(n as u64);
+    let mut shard_digests: Vec<Option<H::Digest>> = vec![None; n];
+    let mut provided_shards: Vec<(usize, &[u8])> = Vec::new();
     let mut provided_originals: Vec<(usize, &[u8])> = Vec::new();
     let mut provided_recoveries: Vec<(usize, &[u8])> = Vec::new();
     let mut provided = 0usize;
@@ -415,12 +428,14 @@ fn decode<'a, H: Hasher, S: Strategy>(
         if index >= total {
             return Err(Error::InvalidIndex(index));
         }
-        if seen_shards.get(index as u64) {
+        let digest_slot = &mut shard_digests[index as usize];
+        if digest_slot.is_some() {
             return Err(Error::DuplicateIndex(index));
         }
 
-        // Add to provided shards.
-        seen_shards.set(index as u64, true);
+        // Add to provided shards and retain the checked digest for this index.
+        *digest_slot = Some(chunk.digest);
+        provided_shards.push((index as usize, chunk.shard.as_ref()));
         if index < min {
             provided_originals.push((index as usize, chunk.shard.as_ref()));
         } else {
@@ -475,15 +490,35 @@ fn decode<'a, H: Hasher, S: Strategy>(
     let encoding = encoder.encode().map_err(Error::ReedSolomon)?;
     shards.extend(encoding.recovery_iter());
 
-    // Build Merkle tree from the canonical codeword
-    let mut builder = Builder::<H>::new(n);
-    let shard_hashes = strategy.map_init_collect_vec(&shards, H::new, |hasher, shard| {
-        hasher.update(shard);
-        hasher.finalize()
-    });
-    for hash in &shard_hashes {
-        builder.add(hash);
+    // Confirm all checked shards match the canonical codeword before reusing their digests.
+    for (idx, shard) in provided_shards {
+        if shard != shards[idx] {
+            return Err(Error::Inconsistent);
+        }
     }
+
+    // Build Merkle tree from the canonical codeword.
+    for (i, digest) in strategy.map_init_collect_vec(
+        shard_digests
+            .iter()
+            .enumerate()
+            .filter_map(|(i, digest)| digest.is_none().then_some(i)),
+        H::new,
+        |hasher, i| {
+            hasher.update(shards[i]);
+            (i, hasher.finalize())
+        },
+    ) {
+        shard_digests[i] = Some(digest);
+    }
+
+    let mut builder = Builder::<H>::new(n);
+    shard_digests
+        .into_iter()
+        .map(|digest| digest.expect("digest must be present for every shard"))
+        .for_each(|digest| {
+            builder.add(&digest);
+        });
     let tree = builder.build();
 
     // Confirm root is consistent
@@ -665,7 +700,8 @@ mod tests {
         chunk: Chunk<<Sha256 as Hasher>::Digest>,
     ) -> CheckedChunk<<Sha256 as Hasher>::Digest> {
         let Chunk { shard, index, .. } = chunk;
-        CheckedChunk::new(root, shard, index)
+        let digest = Sha256::hash(&shard);
+        CheckedChunk::new(root, shard, index, digest)
     }
 
     fn build_chunks(

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -187,6 +187,7 @@ where
 /// The buffer layout is `[length_prefix | data | zero_padding]` split into
 /// `k` equal-sized shards of `shard_len` bytes each.
 fn prepare_data(mut data: impl Buf, k: usize) -> (Vec<u8>, usize) {
+    // Compute shard length
     let data_len = data.remaining();
     let shard_len = canonical_shard_len(data_len, k);
 
@@ -414,7 +415,7 @@ fn decode<'a, H: Hasher, S: Strategy>(
     // Process checked chunks
     let shard_len = first.shard.len();
     let mut shard_digests: Vec<Option<H::Digest>> = vec![None; n];
-    let mut provided_shards: Vec<(usize, &[u8])> = Vec::new();
+    let mut provided_shards: Vec<(usize, &[u8])> = Vec::with_capacity(n);
     let mut provided_originals: Vec<(usize, &[u8])> = Vec::new();
     let mut provided_recoveries: Vec<(usize, &[u8])> = Vec::new();
     let mut provided = 0usize;

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -1129,7 +1129,7 @@ mod tests {
     #[test]
     fn minifuzz_decode_unique_commitment() {
         minifuzz::Builder::default()
-            .with_search_limit(1024)
+            .with_search_limit(2048)
             .test(|u| {
                 fuzz_arbitrary_codeword(u)?;
                 fuzz_mixed_codeword(u)?;
@@ -1213,6 +1213,43 @@ mod tests {
         let root = tree.root();
 
         let pieces = (0u16..=3u16)
+            .into_iter()
+            .map(|i| {
+                let proof = tree.proof(i as u32).unwrap();
+                checked(
+                    root,
+                    Chunk::new(shards[i as usize].clone().into(), i, proof),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let result = decode::<Sha256, _>(total, min, &root, pieces.iter(), &STRATEGY);
+        assert!(matches!(result, Err(Error::Inconsistent)));
+    }
+
+    #[test]
+    fn test_reconstructed_original_with_extra_non_canonical_recovery_rejected() {
+        let data = b"canonical reconstructed originals with bad extra recovery";
+        let total = 6u16;
+        let min = 3u16;
+
+        let (_root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let mut shards = chunks
+            .iter()
+            .map(|chunk| chunk.shard.to_vec())
+            .collect::<Vec<_>>();
+        shards[4][0] ^= 0xFF;
+
+        let mut builder = Builder::<Sha256>::new(total as usize);
+        for shard in &shards {
+            let mut hasher = Sha256::new();
+            hasher.update(shard);
+            builder.add(&hasher.finalize());
+        }
+        let tree = builder.build();
+        let root = tree.root();
+
+        let pieces = [0u16, 1u16, 3u16, 4u16]
             .into_iter()
             .map(|i| {
                 let proof = tree.proof(i as u32).unwrap();

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -723,15 +723,6 @@ mod tests {
         Ok(selected)
     }
 
-    fn fuzz_canonical_shard_len(data_len: usize, k: usize) -> usize {
-        let prefixed_len = u32::SIZE + data_len;
-        let mut shard_len = prefixed_len.div_ceil(k);
-        if !shard_len.is_multiple_of(2) {
-            shard_len += 1;
-        }
-        shard_len
-    }
-
     fn assert_decode_unique_commitment(
         total: u16,
         min: u16,
@@ -764,7 +755,7 @@ mod tests {
 
         let data_len = u.int_in_range(0..=FUZZ_MAX_DATA_LEN)?;
         let data = u.bytes(data_len)?.to_vec();
-        let canonical = fuzz_canonical_shard_len(data.len(), k);
+        let canonical = canonical_shard_len(data.len(), k);
         let extra_width = u.int_in_range(0..=FUZZ_MAX_EXTRA_SHARD_WIDTH / 2)? * 2;
         let shard_len = canonical + extra_width;
 

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -4,7 +4,7 @@ use commonware_codec::{BufsMut, EncodeSize, FixedSize, RangeCfg, Read, ReadExt, 
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use commonware_storage::bmt::{self, Builder};
-use commonware_utils::Cached;
+use commonware_utils::{bitmap::BitMap, Cached};
 use reed_solomon_simd::{Error as RsError, ReedSolomonDecoder, ReedSolomonEncoder};
 use std::marker::PhantomData;
 use thiserror::Error;
@@ -401,7 +401,7 @@ fn decode<'a, H: Hasher, S: Strategy>(
 
     // Process checked chunks
     let shard_len = first.shard.len();
-    let mut seen_shards = vec![false; n];
+    let mut seen_shards: BitMap = BitMap::zeroes(n as u64);
     let mut provided_originals: Vec<(usize, &[u8])> = Vec::new();
     let mut provided_recoveries: Vec<(usize, &[u8])> = Vec::new();
     let mut provided = 0usize;
@@ -415,13 +415,12 @@ fn decode<'a, H: Hasher, S: Strategy>(
         if index >= total {
             return Err(Error::InvalidIndex(index));
         }
-        let seen = &mut seen_shards[index as usize];
-        if *seen {
+        if seen_shards.get(index as u64) {
             return Err(Error::DuplicateIndex(index));
         }
 
         // Add to provided shards.
-        *seen = true;
+        seen_shards.set(index as u64, true);
         if index < min {
             provided_originals.push((index as usize, chunk.shard.as_ref()));
         } else {

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -205,12 +205,12 @@ const fn canonical_shard_len(data_len: usize, k: usize) -> usize {
     shard_len
 }
 
-/// Extract data from encoded shards.
+/// Extract data from encoded shards and verify that original shards use the canonical width.
 ///
 /// The first `k` shards, when concatenated, form `[length_prefix | data | padding]`.
 /// This function copies only the data bytes while validating trailing zero
 /// padding directly from the shard slices.
-fn extract_data(shards: &[&[u8]], k: usize) -> Result<Vec<u8>, Error> {
+fn extract_data(shards: &[&[u8]], k: usize, shard_len: usize) -> Result<Vec<u8>, Error> {
     let shards = shards.get(..k).ok_or(Error::NotEnoughChunks)?;
     let data_len = read_data_len(shards)?;
     let mut data = Vec::with_capacity(data_len);
@@ -243,19 +243,7 @@ fn extract_data(shards: &[&[u8]], k: usize) -> Result<Vec<u8>, Error> {
         return Err(Error::Inconsistent);
     }
 
-    Ok(data)
-}
-
-/// Extract data and verify that original shards use the canonical width.
-///
-/// `extract_data` validates the length prefix and zero padding, but zero
-/// padding alone does not make a commitment unique. A proposer can choose a
-/// larger even shard width, append zeroes, and produce a different valid root
-/// for the same payload. Checking the canonical shard width is sufficient
-/// because `extract_data` already validates the canonical byte layout within
-/// that width.
-fn extract_canonical_data(shards: &[&[u8]], k: usize, shard_len: usize) -> Result<Vec<u8>, Error> {
-    let data = extract_data(shards, k)?;
+    // Validate that the original shards use the canonical shard width.
     if canonical_shard_len(data.len(), k) != shard_len {
         return Err(Error::Inconsistent);
     }
@@ -471,7 +459,7 @@ fn decode<'a, H: Hasher, S: Strategy>(
     {
         shards[idx] = shard;
     }
-    let data = extract_canonical_data(&shards, k, shard_len)?;
+    let data = extract_data(&shards, k, shard_len)?;
 
     // Re-encode recovered data to get recovery shards
     let mut encoder = Cached::take(
@@ -1224,7 +1212,7 @@ mod tests {
         let tree = builder.build();
         let root = tree.root();
 
-        let pieces = [0u16, 1u16, 2u16, 3u16]
+        let pieces = (0u16..=3u16)
             .into_iter()
             .map(|i| {
                 let proof = tree.proof(i as u32).unwrap();


### PR DESCRIPTION
## Overview

Fixes two issues in `ReedSolomon`:
- A byzantine proposer could construct a payload with non-canonical shard length that reconstructed to the same payload, but produced a different root when re-encoding.
- When rebuilding the BMT during `decode`, `check` would cache the digests of provided shards and only recompute the digests for missing shards. A root containing `k` canonical shards and one extra non-canonical checked shard could pass, even though `encode(data)` could produce a different root.