### PR TITLE
[storage] Expose QMDB batch bounds

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -14,7 +14,7 @@ use crate::{
             ordered::{find_next_key, find_prev_key},
             ValueEncoding,
         },
-        batch_chain,
+        batch_chain::{self, Bounds},
         bitmap::Shared,
         delete_known_loc,
         operation::{Key, Operation as OperationTrait},
@@ -1510,6 +1510,11 @@ where
     /// Return the speculative root.
     pub const fn root(&self) -> D {
         self.root
+    }
+
+    /// Return the [`Bounds`] of the batch.
+    pub const fn bounds(&self) -> &Bounds<F> {
+        &self.bounds
     }
 
     /// Iterate over ancestor batches (parent first, then grandparent, etc.). Stops when a

--- a/storage/src/qmdb/batch_chain.rs
+++ b/storage/src/qmdb/batch_chain.rs
@@ -5,8 +5,8 @@
 //! inactivity floor declared by its commit. Older batches in the chain are tracked as
 //! [`AncestorBounds`] in newest-first order; some may already be on disk and others may not.
 //!
-//! Before applying a batch to the DB, [`Bounds::validate_apply_to`] checks two things shared
-//! across QMDB variants (any, immutable, keyless):
+//! Before applying a batch to the DB, the internal validation checks two things shared across QMDB
+//! variants (any, immutable, keyless):
 //!
 //! - The batch is not stale: the current DB size must match either the batch's recorded
 //!   `db_size`, its `base_size`, or one of its ancestor boundaries.
@@ -14,9 +14,8 @@
 //!   its own commit location. Ancestors already on disk are skipped (their floors were
 //!   validated when they were first applied); the rest of the chain and the tip are checked.
 //!
-//! The helpers [`ancestors`] and [`parent_and_ancestors`] walk the chain via weak parent
-//! references; [`collect_ancestor_bounds`] snapshots them into a `Vec` for storage on a
-//! merkleized batch.
+//! Internal helpers walk the chain via weak parent references and snapshot ancestor bounds into a
+//! `Vec` for storage on a merkleized batch.
 
 use crate::{
     merkle::{Family, Location},
@@ -27,29 +26,29 @@ use std::sync::{Arc, Weak};
 
 /// Bounds declared by an ancestor batch's commit.
 #[derive(Clone)]
-pub(crate) struct AncestorBounds<F: Family> {
+pub struct AncestorBounds<F: Family> {
     /// Inactivity floor declared by the ancestor commit.
-    pub(crate) floor: Location<F>,
+    pub floor: Location<F>,
     /// Total operations after the ancestor batch.
-    pub(crate) end: u64,
+    pub end: u64,
 }
 
 /// Position and inactivity-floor state for a merkleized QMDB batch.
 #[derive(Clone)]
-pub(crate) struct Bounds<F: Family> {
+pub struct Bounds<F: Family> {
     /// Total operations before this batch's own operations.
-    pub(crate) base_size: u64,
+    pub base_size: u64,
     /// Boundary between committed DB operations and operations kept in this batch chain.
     ///
     /// Usually this is the DB size when the batch was created. If older ancestors were
     /// dropped, the boundary moves forward to the oldest ancestor still kept in memory.
-    pub(crate) db_size: u64,
+    pub db_size: u64,
     /// Total operations after this batch.
-    pub(crate) total_size: u64,
+    pub total_size: u64,
     /// Ancestor bounds in newest-first order.
-    pub(crate) ancestors: Vec<AncestorBounds<F>>,
+    pub ancestors: Vec<AncestorBounds<F>>,
     /// Inactivity floor declared by this batch's commit.
-    pub(crate) inactivity_floor: Location<F>,
+    pub inactivity_floor: Location<F>,
 }
 
 impl<F: Family> Bounds<F> {

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -17,6 +17,7 @@ use crate::{
             operation::{update, Operation},
             ValueEncoding,
         },
+        batch_chain::Bounds,
         bitmap::Shared,
         current::{
             db::{compute_db_root, compute_grafted_leaves},
@@ -807,6 +808,11 @@ where
     /// Return the QMDB ops-only root.
     pub fn ops_root(&self) -> D {
         self.inner.root()
+    }
+
+    /// Return the [`Bounds`] of the batch.
+    pub fn bounds(&self) -> &Bounds<F> {
+        self.inner.bounds()
     }
 }
 

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -6,7 +6,7 @@ use crate::{
     merkle::{Family, Location},
     qmdb::{
         any::{batch::lookup_sorted, ValueEncoding},
-        batch_chain,
+        batch_chain::{self, Bounds},
         immutable::operation::Operation,
         operation::Key,
         Error,
@@ -311,6 +311,11 @@ where
     /// Return the speculative root.
     pub const fn root(&self) -> D {
         self.root
+    }
+
+    /// Return the [`Bounds`] of the batch.
+    pub const fn bounds(&self) -> &Bounds<F> {
+        &self.bounds
     }
 
     /// Iterate over ancestor batches (parent first, then grandparent, etc.).

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -26,7 +26,7 @@ use crate::{
     qmdb::{
         self,
         any::value::ValueEncoding,
-        batch_chain,
+        batch_chain::{self, Bounds},
         compact::{
             batch as compact_batch,
             witness::{self, ServeState},
@@ -127,6 +127,11 @@ where
     /// Return the root digest after this batch is applied.
     pub const fn root(&self) -> D {
         self.root
+    }
+
+    /// Return the [`Bounds`] of the batch.
+    pub const fn bounds(&self) -> &Bounds<F> {
+        &self.bounds
     }
 
     /// Create a new speculative batch with this one as its parent.

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -4,7 +4,11 @@ use super::{operation::Operation, Keyless};
 use crate::{
     journal::{authenticated, contiguous::Mutable, Error as JournalError},
     merkle::{Family, Location},
-    qmdb::{any::value::ValueEncoding, batch_chain, Error},
+    qmdb::{
+        any::value::ValueEncoding,
+        batch_chain::{self, Bounds},
+        Error,
+    },
     Context, Persistable,
 };
 use commonware_codec::EncodeShared;
@@ -310,6 +314,11 @@ where
     /// Return the speculative root.
     pub const fn root(&self) -> D {
         self.root
+    }
+
+    /// Return the [`Bounds`] of the batch.
+    pub const fn bounds(&self) -> &Bounds<F> {
+        &self.bounds
     }
 
     /// Read a value at `loc`.

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -26,7 +26,7 @@ use crate::{
     qmdb::{
         self,
         any::value::ValueEncoding,
-        batch_chain,
+        batch_chain::{self, Bounds},
         compact::{
             batch as compact_batch,
             witness::{self, ServeState},
@@ -118,6 +118,11 @@ where
     /// Return the root digest after this batch is applied.
     pub const fn root(&self) -> D {
         self.root
+    }
+
+    /// Return the [`Bounds`] of the batch.
+    pub const fn bounds(&self) -> &Bounds<F> {
+        &self.bounds
     }
 
     /// Create a new speculative batch with this one as its parent.

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -58,7 +58,7 @@ use futures::{pin_mut, StreamExt as _};
 use thiserror::Error;
 
 pub mod any;
-pub(crate) mod batch_chain;
+pub mod batch_chain;
 pub(crate) mod bitmap;
 pub(crate) mod compact;
 #[cfg(test)]


### PR DESCRIPTION
## Overview

Exposes QMDB's `MerkleizedBatch::bounds` on each batch type. This allows block builders to easily include the `[inactivity_floor, total_size)` bounds in their blocks for state sync in #3381.