### PR TITLE
[runtime/iobuf/pool] remove Arc from pooled hot path

### DIFF
--- a/runtime/src/iobuf/buffer.rs
+++ b/runtime/src/iobuf/buffer.rs
@@ -116,13 +116,13 @@ impl Drop for AlignedBuffer {
 /// moving pooled buffers through pooled backing values and thread-local caches
 /// does not need to move a per-buffer [`Layout`].
 ///
-/// `PooledBuffer` does not implement [`Drop`] and has no reference to its
-/// originating [`SizeClass`](super::pool::SizeClass). In normal pool use it is
-/// owned by [`PooledBacking`] while outside the global freelist and by the
-/// size-class [`super::freelist::Freelist`] while globally free. Only the
-/// freelist knows the layout needed to deallocate it.
+/// `PooledBuffer` does not implement [`Drop`] and does not retain its
+/// originating [`SizeClass`](super::pool::SizeClass). In normal pool use,
+/// [`PooledBacking`] owns it while it is outside the global freelist, and the
+/// size-class [`super::freelist::Freelist`] owns it while it is globally free.
+/// Only the freelist knows the layout needed to deallocate it.
 ///
-/// Code that takes a `PooledBuffer` out of pool state must either return it to
+/// Callers that take a `PooledBuffer` out of pool state must either return it to
 /// the same originating size class or explicitly deallocate it with the exact
 /// layout used to create it.
 pub struct PooledBuffer {

--- a/runtime/src/iobuf/buffer.rs
+++ b/runtime/src/iobuf/buffer.rs
@@ -6,14 +6,15 @@
 //!   deallocates directly on drop.
 //! - [`PooledBuffer`] is the raw pooled allocation handle: it carries only a
 //!   pointer and relies on pool-owned metadata to release it.
-//! - Pooled views pair that handle with its originating [`SizeClass`] so the
-//!   buffer is returned to the pool on drop.
+//! - Pooled views pair that handle with its originating
+//!   [`SizeClass`](super::pool::SizeClass) so the buffer is returned to the pool
+//!   on drop.
 //!
 //! The allocator-facing pool logic lives in `pool.rs`. This module only deals
 //! with backing ownership and view semantics.
 
 use super::IoBuf;
-use crate::iobuf::pool::{BufferPoolThreadCache, SizeClass};
+use crate::iobuf::pool::{BufferPoolThreadCache, SizeClassLease};
 use bytes::Bytes;
 use std::{
     alloc::{alloc, alloc_zeroed, dealloc, handle_alloc_error, Layout},
@@ -116,9 +117,9 @@ impl Drop for AlignedBuffer {
 /// does not need to move a per-buffer [`Layout`].
 ///
 /// `PooledBuffer` does not implement [`Drop`] and has no reference to its
-/// originating [`SizeClass`]. It must be paired with pool metadata that returns
-/// it to the size class, or explicitly deallocated with the exact layout used
-/// to create it.
+/// originating [`SizeClass`](super::pool::SizeClass). It must be paired with
+/// pool metadata that returns it to the size class, or explicitly deallocated
+/// with the exact layout used to create it.
 pub struct PooledBuffer {
     ptr: NonNull<u8>,
 }
@@ -194,8 +195,8 @@ impl PooledBuffer {
 /// [`Self::release`].
 ///
 /// [`AlignedBuffer`] is self-contained and releases directly. [`PooledBacking`]
-/// pairs a layoutless [`PooledBuffer`] with its [`SizeClass`] and slot id, so
-/// release returns the allocation to the pool.
+/// pairs a layoutless [`PooledBuffer`] with its [`SizeClassLease`] and slot id,
+/// so release returns the allocation to the pool.
 pub(crate) trait BufferBacking: Send + Sync + 'static {
     /// Returns the full allocation capacity, ignoring any view cursor/offset.
     fn capacity(&self) -> usize;
@@ -226,23 +227,20 @@ impl BufferBacking for AlignedBuffer {
 
 /// Pooled backing storage.
 ///
-/// This pairs a layoutless [`PooledBuffer`] with the metadata needed to return
-/// it to the pool. The [`Arc<SizeClass>`] keeps the originating size class, and
-/// therefore its freelist layout, alive while the buffer is checked out or
-/// shared through immutable views.
-///
-/// The `Arc<SizeClass>` is *moved* (not cloned) through the TLS cache on the
-/// steady-state alloc/free path, avoiding refcount traffic.
+/// This pairs a layoutless [`PooledBuffer`] with the lease needed to return it
+/// to the pool. The [`SizeClassLease`] points to the originating size class and
+/// owns that class reference while the buffer is checked out or shared through
+/// immutable views.
 pub(crate) struct PooledBacking {
     buffer: PooledBuffer,
-    class: Arc<SizeClass>,
+    lease: SizeClassLease,
     slot: u32,
 }
 
 impl BufferBacking for PooledBacking {
     #[inline(always)]
     fn capacity(&self) -> usize {
-        self.class.size()
+        self.lease.size()
     }
 
     #[inline(always)]
@@ -252,7 +250,7 @@ impl BufferBacking for PooledBacking {
 
     #[inline(always)]
     fn release(self) {
-        BufferPoolThreadCache::push(self.class, self.slot, self.buffer);
+        BufferPoolThreadCache::push(self.lease, self.slot, self.buffer);
     }
 }
 
@@ -713,8 +711,8 @@ pub(crate) type AlignedBuf = Buf<AlignedBuffer>;
 /// Immutable, reference-counted view over a pooled allocation.
 ///
 /// The final reference returns the underlying allocation to its originating
-/// [`SizeClass`]. See [`Buf`] for the shared immutable view layout and
-/// invariants.
+/// [`SizeClass`](super::pool::SizeClass). See [`Buf`] for the shared immutable
+/// view layout and invariants.
 pub(crate) type PooledBuf = Buf<PooledBacking>;
 
 /// Mutable view over an untracked aligned allocation.
@@ -726,7 +724,8 @@ pub(crate) type AlignedBufMut = BufMut<AlignedBuffer>;
 /// Mutable view over a pooled allocation.
 ///
 /// When dropped, the underlying allocation is returned to its originating
-/// [`SizeClass`]. See [`BufMut`] for the shared mutable layout and invariants.
+/// [`SizeClass`](super::pool::SizeClass). See [`BufMut`] for the shared mutable
+/// layout and invariants.
 pub(crate) type PooledBufMut = BufMut<PooledBacking>;
 
 impl std::fmt::Debug for Buf<AlignedBuffer> {
@@ -790,11 +789,11 @@ impl std::fmt::Debug for BufMut<PooledBacking> {
 
 impl BufMut<PooledBacking> {
     #[inline]
-    pub(crate) const fn new(buffer: PooledBuffer, class: Arc<SizeClass>, slot: u32) -> Self {
+    pub(crate) const fn new(buffer: PooledBuffer, lease: SizeClassLease, slot: u32) -> Self {
         Self {
             inner: ManuallyDrop::new(BufInner::new(PooledBacking {
                 buffer,
-                class,
+                lease,
                 slot,
             })),
             cursor: 0,

--- a/runtime/src/iobuf/buffer.rs
+++ b/runtime/src/iobuf/buffer.rs
@@ -5,10 +5,10 @@
 //! - [`AlignedBuffer`] is self-contained: it carries its own [`Layout`] and
 //!   deallocates directly on drop.
 //! - [`PooledBuffer`] is the raw pooled allocation handle: it carries only a
-//!   pointer and relies on pool-owned metadata to release it.
-//! - Pooled views pair that handle with its originating
-//!   [`SizeClass`](super::pool::SizeClass) so the buffer is returned to the pool
-//!   on drop.
+//!   pointer and does not know its allocation layout.
+//! - [`PooledBacking`] is the pooled ownership bundle outside the global
+//!   freelist: it pairs that handle with a [`SizeClassLease`] and slot id so the
+//!   buffer can return to its originating [`SizeClass`](super::pool::SizeClass).
 //!
 //! The allocator-facing pool logic lives in `pool.rs`. This module only deals
 //! with backing ownership and view semantics.
@@ -113,13 +113,18 @@ impl Drop for AlignedBuffer {
 ///
 /// Unlike [`AlignedBuffer`], this handle intentionally carries only the
 /// allocation pointer. The size-class freelist stores the allocation layout, so
-/// moving pooled buffers through checked-out values and thread-local caches
+/// moving pooled buffers through pooled backing values and thread-local caches
 /// does not need to move a per-buffer [`Layout`].
 ///
 /// `PooledBuffer` does not implement [`Drop`] and has no reference to its
-/// originating [`SizeClass`](super::pool::SizeClass). It must be paired with
-/// pool metadata that returns it to the size class, or explicitly deallocated
-/// with the exact layout used to create it.
+/// originating [`SizeClass`](super::pool::SizeClass). In normal pool use it is
+/// owned by [`PooledBacking`] while outside the global freelist and by the
+/// size-class [`super::freelist::Freelist`] while globally free. Only the
+/// freelist knows the layout needed to deallocate it.
+///
+/// Code that takes a `PooledBuffer` out of pool state must either return it to
+/// the same originating size class or explicitly deallocate it with the exact
+/// layout used to create it.
 pub struct PooledBuffer {
     ptr: NonNull<u8>,
 }
@@ -195,8 +200,8 @@ impl PooledBuffer {
 /// [`Self::release`].
 ///
 /// [`AlignedBuffer`] is self-contained and releases directly. [`PooledBacking`]
-/// pairs a layoutless [`PooledBuffer`] with its [`SizeClassLease`] and slot id,
-/// so release returns the allocation to the pool.
+/// owns the layoutless [`PooledBuffer`] together with the [`SizeClassLease`] and
+/// slot id needed to return that allocation to its size class.
 pub(crate) trait BufferBacking: Send + Sync + 'static {
     /// Returns the full allocation capacity, ignoring any view cursor/offset.
     fn capacity(&self) -> usize;
@@ -225,12 +230,17 @@ impl BufferBacking for AlignedBuffer {
     }
 }
 
-/// Pooled backing storage.
+/// Pooled backing storage outside the global freelist.
 ///
-/// This pairs a layoutless [`PooledBuffer`] with the lease needed to return it
-/// to the pool. The [`SizeClassLease`] points to the originating size class and
-/// owns that class reference while the buffer is checked out or shared through
-/// immutable views.
+/// This is the ownership bundle for a pooled allocation outside the global
+/// freelist. The [`PooledBuffer`] is the raw allocation pointer, `slot`
+/// identifies that allocation within the originating size class, and
+/// [`SizeClassLease`] owns the strong size-class reference needed to keep the
+/// freelist and allocation layout alive.
+///
+/// Releasing this backing transfers the whole bundle to
+/// [`BufferPoolThreadCache`]. The thread cache may keep the buffer locally, or
+/// return it to the class-global freelist and release the lease.
 pub(crate) struct PooledBacking {
     buffer: PooledBuffer,
     lease: SizeClassLease,
@@ -710,9 +720,9 @@ pub(crate) type AlignedBuf = Buf<AlignedBuffer>;
 
 /// Immutable, reference-counted view over a pooled allocation.
 ///
-/// The final reference returns the underlying allocation to its originating
-/// [`SizeClass`](super::pool::SizeClass). See [`Buf`] for the shared immutable
-/// view layout and invariants.
+/// The final reference releases its [`PooledBacking`], returning the allocation
+/// to its originating [`SizeClass`](super::pool::SizeClass). See [`Buf`] for
+/// the shared immutable view layout and invariants.
 pub(crate) type PooledBuf = Buf<PooledBacking>;
 
 /// Mutable view over an untracked aligned allocation.
@@ -723,9 +733,9 @@ pub(crate) type AlignedBufMut = BufMut<AlignedBuffer>;
 
 /// Mutable view over a pooled allocation.
 ///
-/// When dropped, the underlying allocation is returned to its originating
-/// [`SizeClass`](super::pool::SizeClass). See [`BufMut`] for the shared mutable
-/// layout and invariants.
+/// When dropped, this releases its [`PooledBacking`], returning the allocation
+/// to its originating [`SizeClass`](super::pool::SizeClass). See [`BufMut`] for
+/// the shared mutable layout and invariants.
 pub(crate) type PooledBufMut = BufMut<PooledBacking>;
 
 impl std::fmt::Debug for Buf<AlignedBuffer> {

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -319,7 +319,7 @@ impl Freelist {
     /// the matching `Acquire` operation before reading the buffer back out.
     ///
     /// The caller must own `slot`, and `slot` must not already be available in
-    /// this freelist. `buffer` must belong to this freelist, it must have been
+    /// this freelist. `buffer` must belong to this freelist and must have been
     /// allocated by this freelist.
     #[inline]
     pub fn put(&self, slot: u32, buffer: PooledBuffer) {

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -13,6 +13,11 @@
 //! [`Drop`] only release buffers currently parked here. **An outstanding buffer
 //! that is never returned will leak**.
 //!
+//! The buffer pool keeps this requirement by pairing every checked-out buffer
+//! with a size-class lease, and by banking one lease for every buffer held in a
+//! thread-local cache. Those leases keep the owning size class, and therefore
+//! this freelist, alive until the buffer returns here.
+//!
 //! This is intentionally narrower than a general multi-producer, multi-consumer
 //! queue:
 //!
@@ -144,8 +149,10 @@ const INLINE_PUT_BATCH_MASKS: usize = 128;
 /// The freelist owns the [`Layout`] shared by every tracked buffer in the size
 /// class. Checked-out buffers and thread-local caches may temporarily hold
 /// [`PooledBuffer`] handles, but those handles must eventually return here so
-/// they can be released with the correct layout. Draining or dropping the
-/// freelist only deallocates buffers currently parked in it.
+/// they can be released with the correct layout. The buffer pool keeps the
+/// freelist alive for those outstanding handles with checked-out or banked
+/// size-class leases. Draining or dropping the freelist only deallocates
+/// buffers currently parked in it.
 ///
 /// The bitmap is intentionally striped over a power-of-two number of words.
 /// That makes the slot-to-word mapping cheap and keeps small freelists from
@@ -263,7 +270,7 @@ impl Freelist {
     /// The returned buffer does not deallocate itself. The `(slot, buffer)`
     /// pair must be returned to this same freelist before the freelist is
     /// finally dropped, otherwise the buffer leaks.
-    #[inline]
+    #[inline(always)]
     pub(super) fn try_create(&self, zeroed: bool) -> Option<(u32, PooledBuffer)> {
         let slot = self
             .created

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -2,8 +2,8 @@
 //!
 //! A [`Freelist`] owns the allocation layout for one [`super::pool::BufferPool`]
 //! size class and is responsible for deallocating every tracked buffer created
-//! with that layout. Buffers that are not checked out and not held in a
-//! thread-local cache are parked in the freelist, making them available for
+//! with that layout. Buffers that are not owned by pooled views and not held in
+//! a thread-local cache are parked in the freelist, making them available for
 //! reuse by any thread in the pool. Each tracked buffer has a stable slot id
 //! within its size class.
 //!
@@ -13,10 +13,10 @@
 //! [`Drop`] only release buffers currently parked here. **An outstanding buffer
 //! that is never returned will leak**.
 //!
-//! The buffer pool keeps this requirement by pairing every checked-out buffer
-//! with a size-class lease, and by banking one lease for every buffer held in a
-//! thread-local cache. Those leases keep the owning size class, and therefore
-//! this freelist, alive until the buffer returns here.
+//! The buffer pool keeps this requirement by pairing every pooled backing
+//! outside the freelist with a size-class lease, and by banking one lease for
+//! every buffer held in a thread-local cache. Those leases keep the owning size
+//! class, and therefore this freelist, alive until the buffer returns here.
 //!
 //! This is intentionally narrower than a general multi-producer, multi-consumer
 //! queue:
@@ -110,9 +110,9 @@
 //!
 //! The shared bitmap operations are lock-free, but the structure is not a
 //! standalone general-purpose container. It relies on the buffer pool's
-//! ownership discipline: a slot is either checked out, parked in a thread-local
-//! cache, or available in this freelist. Only the thread that owns a slot
-//! outside the freelist may access that slot's parking cell.
+//! ownership discipline: a slot is either owned by a pooled backing, parked in a
+//! thread-local cache, or available in this freelist. Only the thread that owns
+//! a slot outside the freelist may access that slot's parking cell.
 use super::buffer::PooledBuffer;
 use crossbeam_utils::CachePadded;
 use std::{
@@ -147,12 +147,12 @@ const INLINE_PUT_BATCH_MASKS: usize = 128;
 /// Bounded lock-free freelist of tracked buffers for one size class.
 ///
 /// The freelist owns the [`Layout`] shared by every tracked buffer in the size
-/// class. Checked-out buffers and thread-local caches may temporarily hold
+/// class. Pooled backing values and thread-local caches may temporarily hold
 /// [`PooledBuffer`] handles, but those handles must eventually return here so
 /// they can be released with the correct layout. The buffer pool keeps the
-/// freelist alive for those outstanding handles with checked-out or banked
-/// size-class leases. Draining or dropping the freelist only deallocates
-/// buffers currently parked in it.
+/// freelist alive for those outstanding handles with pooled-backing or banked
+/// size-class leases. Draining or dropping the freelist only deallocates buffers
+/// currently parked in it.
 ///
 /// The bitmap is intentionally striped over a power-of-two number of words.
 /// That makes the slot-to-word mapping cheap and keeps small freelists from
@@ -164,7 +164,7 @@ pub struct Freelist {
     ///
     /// This is a monotonic high-water mark for slot assignment. Draining
     /// globally-free buffers does not decrement it because higher slot ids may
-    /// still be checked out or parked in thread-local caches.
+    /// still be owned by a pooled backing or parked in thread-local caches.
     created: AtomicUsize,
     /// Cache-line-padded striped bitmap of free slots.
     ///
@@ -581,9 +581,9 @@ impl Freelist {
     /// Drops every currently available buffer from the global freelist.
     ///
     /// This is a teardown operation. Drained slot ids are not made available for
-    /// new creations. Buffers currently checked out or parked in thread-local
-    /// caches are not visible to this method and remain the responsibility of
-    /// their current owner until they are returned.
+    /// new creations. Buffers currently owned by a pooled backing or parked in
+    /// thread-local caches are not visible to this method and remain the
+    /// responsibility of their current owner until they are returned.
     ///
     /// Returns the number of drained slots.
     #[inline]
@@ -905,7 +905,7 @@ pub(super) mod tests {
         assert!(seen.into_iter().all(|seen| seen));
         assert!(set.take().is_none());
 
-        // Return checked-out test buffers so the freelist owns deallocation.
+        // Return taken test buffers so the freelist owns deallocation.
         for (slot, buffer) in taken {
             set.put(slot, buffer);
         }
@@ -994,7 +994,7 @@ pub(super) mod tests {
         assert_eq!(slots, vec![1, 5, 7]);
         assert_eq!(len(&set), 0);
 
-        // Return checked-out test buffers so the freelist owns deallocation.
+        // Return taken test buffers so the freelist owns deallocation.
         set.put(single.0, single.1);
         for (slot, buffer) in taken {
             set.put(slot, buffer);
@@ -1040,7 +1040,7 @@ pub(super) mod tests {
         assert_eq!(slots, vec![0, 1, 64, 8192]);
         assert_eq!(len(&set), 0);
 
-        // Return checked-out test buffers so the freelist owns deallocation.
+        // Return taken test buffers so the freelist owns deallocation.
         for (slot, buffer) in taken {
             set.put(slot, buffer);
         }
@@ -1067,7 +1067,7 @@ pub(super) mod tests {
         assert_eq!(set.drain(), 3);
         assert_eq!(len(&set), 0);
 
-        // Return checked-out test buffer so the freelist owns deallocation.
+        // Return taken test buffer so the freelist owns deallocation.
         set.put(slot1, buffer1);
     }
 
@@ -1104,7 +1104,7 @@ pub(super) mod tests {
         slots.sort_unstable();
         assert_eq!(slots, vec![0, 1, 2]);
 
-        // Return checked-out test buffers so the freelist owns deallocation.
+        // Return taken test buffers so the freelist owns deallocation.
         for (slot, buffer) in taken {
             set.put(slot, buffer);
         }
@@ -1130,7 +1130,7 @@ pub(super) mod tests {
         assert_eq!(slots, vec![slot0, slot1]);
         assert_eq!(len(&set), 14);
 
-        // Return checked-out test buffers so the freelist owns deallocation.
+        // Return taken test buffers so the freelist owns deallocation.
         for (slot, buffer) in taken {
             set.put(slot, buffer);
         }
@@ -1162,7 +1162,7 @@ pub(super) mod tests {
         seen.sort_unstable();
         assert_eq!(seen, slots);
 
-        // Return checked-out test buffers so the freelist owns deallocation.
+        // Return taken test buffers so the freelist owns deallocation.
         for (slot, buffer) in taken {
             set.put(slot, buffer);
         }
@@ -1417,7 +1417,7 @@ mod loom_tests {
         }
     }
 
-    // Owns buffers that a loom model has checked out from the freelist. This
+    // Owns buffers that a loom model has taken from the freelist. This
     // keeps the test-side ownership rule in one place: every created buffer
     // must be returned to the same freelist before that freelist is dropped.
     struct Leases {

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -14,9 +14,10 @@
 //! that is never returned will leak**.
 //!
 //! The buffer pool keeps this requirement by pairing every pooled backing
-//! outside the freelist with a size-class lease, and by banking one lease for
-//! every buffer held in a thread-local cache. Those leases keep the owning size
-//! class, and therefore this freelist, alive until the buffer returns here.
+//! outside the freelist with a size-class lease, and by banking one strong
+//! size-class reference for every buffer held in a thread-local cache. Those
+//! leases and banked references keep the owning size class, and therefore this
+//! freelist, alive until the buffer returns here.
 //!
 //! This is intentionally narrower than a general multi-producer, multi-consumer
 //! queue:
@@ -150,9 +151,9 @@ const INLINE_PUT_BATCH_MASKS: usize = 128;
 /// class. Pooled backing values and thread-local caches may temporarily hold
 /// [`PooledBuffer`] handles, but those handles must eventually return here so
 /// they can be released with the correct layout. The buffer pool keeps the
-/// freelist alive for those outstanding handles with pooled-backing or banked
-/// size-class leases. Draining or dropping the freelist only deallocates buffers
-/// currently parked in it.
+/// freelist alive for those outstanding handles with pooled-backing leases
+/// or TLS-banked size-class references. Draining or dropping the freelist
+/// only deallocates buffers currently parked in it.
 ///
 /// The bitmap is intentionally striped over a power-of-two number of words.
 /// That makes the slot-to-word mapping cheap and keeps small freelists from

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -13,9 +13,9 @@
 //!
 //! # Pool Lifecycle
 //!
-//! Each tracked buffer keeps a strong reference to the originating size class.
-//! Buffers can outlive the public [`BufferPool`] handle and still return to
-//! their original size class.
+//! Checked-out tracked buffers and buffers cached in thread-local bins keep a
+//! strong reference to the originating size class. Buffers can outlive the
+//! public [`BufferPool`] handle and still return to their original size class.
 //! - Untracked fallback allocations store no class reference and deallocate
 //!   directly when dropped.
 //! - Requests smaller than [`BufferPoolConfig::pool_min_size`] bypass pooling
@@ -59,7 +59,7 @@ use crossbeam_utils::CachePadded;
 use std::{
     alloc::Layout,
     cell::{Cell, UnsafeCell},
-    mem::align_of,
+    mem::{align_of, MaybeUninit},
     num::{NonZeroU32, NonZeroUsize},
     ptr,
     sync::{
@@ -452,6 +452,140 @@ impl PoolMetrics {
     }
 }
 
+/// Owned size-class reference for a checked-out pooled buffer.
+///
+/// A checked-out pooled buffer must keep its originating [`SizeClass`] alive so
+/// it can be returned after the [`BufferPool`] handle is dropped. This is one
+/// strong `Arc<SizeClass>` reference represented as a raw pointer, with retain
+/// and release performed explicitly at the boundaries where a buffer enters or
+/// leaves global pool state.
+///
+/// The raw representation matters because the hot path mostly transfers
+/// ownership between a checked-out buffer and this thread's local cache. A real
+/// `Arc<SizeClass>` field is pointer-sized too, but it is a non-`Copy` value
+/// with drop glue. Even when the strong count would not change, moving it
+/// through pooled buffer and cache-entry structs makes the compiler preserve
+/// destructor paths for those structs. `SizeClassLease` has no automatic drop:
+/// moving between checked-out and local-cache state is a plain pointer
+/// transfer, and only explicit calls such as [`Self::return_global`] adjust the
+/// strong count.
+///
+/// Thread-local cache entries do not store a lease per entry. The cache stores
+/// the class identity once and owns one banked strong reference for each
+/// initialized entry. Popping from the local cache materializes a lease from one
+/// of those banked references without touching the strong count.
+///
+/// Globally parked buffers do not carry a class reference: taking from the
+/// global freelist retains the class, and returning to the global freelist
+/// releases it.
+pub(crate) struct SizeClassLease {
+    ptr: ptr::NonNull<SizeClass>,
+}
+
+// SAFETY: `SizeClassLease` points at a `SizeClass`, which is `Send`, and owns a
+// strong reference while it is live.
+unsafe impl Send for SizeClassLease {}
+// SAFETY: same argument as `Send`, shared access to `SizeClass` is synchronized.
+unsafe impl Sync for SizeClassLease {}
+
+impl SizeClassLease {
+    /// Builds a lease from a banked class reference.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have already retained one strong reference to `class`,
+    /// and that retained reference must be transferred to the returned lease.
+    #[inline(always)]
+    unsafe fn from_banked(class: &Arc<SizeClass>) -> Self {
+        // SAFETY: guaranteed by the caller.
+        unsafe { Self::from_banked_ptr(ptr::NonNull::from(class.as_ref())) }
+    }
+
+    /// Builds a lease from a banked class reference and raw class identity.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have already retained one strong reference to `ptr`, and
+    /// that retained reference must be transferred to the returned lease. `ptr`
+    /// must point to the matching live size class.
+    #[inline(always)]
+    const unsafe fn from_banked_ptr(ptr: ptr::NonNull<SizeClass>) -> Self {
+        Self { ptr }
+    }
+
+    /// Retains one banked class reference without materializing a lease.
+    #[inline(always)]
+    fn retain_banked(class: &Arc<SizeClass>) {
+        // SAFETY: the pointer comes from a live `Arc<SizeClass>` borrowed above.
+        unsafe { Arc::increment_strong_count(ptr::from_ref(class.as_ref())) };
+    }
+
+    /// Retains `class` for a buffer leaving the global freelist.
+    ///
+    /// Moving between checked-out state and TLS transfers the lease without
+    /// touching the strong count.
+    #[inline(always)]
+    fn retain(class: &Arc<SizeClass>) -> Self {
+        Self::retain_banked(class);
+        // SAFETY: `retain_banked` above retained the strong reference
+        // transferred to the returned lease.
+        unsafe { Self::from_banked(class) }
+    }
+
+    /// Transfers this checked-out lease into a TLS cache entry.
+    ///
+    /// The cache must later materialize or release exactly one lease for the
+    /// entry. This is a no-op at runtime; it exists to mark the ownership
+    /// transition.
+    #[inline(always)]
+    const fn into_banked(self) {}
+
+    /// Returns the referenced size class.
+    ///
+    /// The pointer is valid because `SizeClassLease` owns one strong reference.
+    #[inline(always)]
+    const fn class(&self) -> &SizeClass {
+        // SAFETY: guaranteed by the ownership invariant documented on
+        // `SizeClassLease`.
+        unsafe { self.ptr.as_ref() }
+    }
+
+    /// Returns the buffer size for this lease's size class.
+    #[inline(always)]
+    pub(crate) const fn size(&self) -> usize {
+        self.class().size()
+    }
+
+    /// Returns a buffer to this class's global freelist and releases the class
+    /// reference.
+    #[inline(always)]
+    fn return_global(self, slot: u32, buffer: PooledBuffer) {
+        self.class().global.put(slot, buffer);
+        // SAFETY: this pointer owns one strong reference.
+        unsafe { Arc::decrement_strong_count(self.ptr.as_ptr()) };
+    }
+
+    /// Returns several buffers to this class's global freelist and releases
+    /// their references.
+    ///
+    /// `count` must match the number of returned entries. All entries must
+    /// belong to the same size class as this pointer.
+    #[inline(always)]
+    fn return_global_batch(
+        self,
+        entries: impl IntoIterator<Item = (u32, PooledBuffer)>,
+        count: usize,
+    ) {
+        debug_assert!(count > 0);
+        self.class().global.put_batch(entries);
+        for _ in 0..count {
+            // SAFETY: each returned entry owned one strong reference to this
+            // same size class.
+            unsafe { Arc::decrement_strong_count(self.ptr.as_ptr()) };
+        }
+    }
+}
+
 /// Per-size-class state.
 ///
 /// Each class is a small two-level allocator:
@@ -459,8 +593,11 @@ impl PoolMetrics {
 /// - a per-thread local cache for same-thread reuse
 ///
 /// The global freelist owns the allocation layout and slot reservation counter
-/// for the class. Checked-out buffers and TLS entries carry an [`Arc`] back to
-/// this size class so the freelist remains alive until those buffers return.
+/// for the class. Checked-out buffers carry a [`SizeClassLease`] that owns one
+/// strong class reference. Thread-local caches store the class identity once and
+/// retain one extra strong reference per local entry instead of storing an `Arc`
+/// or pointer in each hot-path entry. Globally parked buffers do not carry a
+/// class reference.
 ///
 /// Allocation prefers the local cache, then refills from the global freelist,
 /// and only creates a new tracked buffer when no free buffer is available and
@@ -496,21 +633,29 @@ impl SizeClass {
         parallelism: NonZeroUsize,
         thread_cache_capacity: usize,
         prefill: bool,
-    ) -> Self {
+    ) -> Arc<Self> {
         let layout = Layout::from_size_align(size, alignment).expect("alignment is a power of two");
         let freelist = Freelist::new(max, parallelism, layout, prefill);
-        Self {
+        Arc::new(Self {
             class_id,
             size,
             global: freelist,
             thread_cache_capacity,
-        }
+        })
     }
 
     /// Returns the buffer size for this class.
     #[inline]
     pub(super) const fn size(&self) -> usize {
         self.size
+    }
+
+    /// Creates a new tracked buffer and retains this size class for its slot.
+    #[inline(always)]
+    fn try_create(self: &Arc<Self>, zeroed: bool) -> Option<(u32, PooledBuffer, SizeClassLease)> {
+        let (slot, buffer) = self.global.try_create(zeroed)?;
+        let class = SizeClassLease::retain(self);
+        Some((slot, buffer, class))
     }
 }
 
@@ -520,14 +665,10 @@ impl SizeClass {
 /// held here, the buffer is owned by the current thread and is not visible to
 /// the class-global freelist.
 ///
-/// The `slot` identifies the buffer within its [`SizeClass`]. The cached
-/// [`Arc<SizeClass>`] is moved back into a checked-out pooled buffer on a local
-/// hit, and is also what lets spill and thread-exit drop paths return the
-/// buffer to the correct class-global freelist even if the originating
-/// [`BufferPool`] handle has already been dropped.
+/// The `slot` identifies the buffer within its [`SizeClass`]. The enclosing
+/// cache owns one banked size-class reference for each initialized entry.
 struct TlsSizeClassCacheEntry {
     buffer: PooledBuffer,
-    class: Arc<SizeClass>,
     slot: u32,
 }
 
@@ -539,23 +680,38 @@ struct TlsSizeClassCacheEntry {
 /// returning them to the global freelist happens only on miss refill, overflow,
 /// explicit flush, or thread exit.
 ///
+/// `class` is a non-owning identity pointer. It can be stale while `len == 0`,
+/// because an empty cache does not keep its pool alive. When `len > 0`, each
+/// initialized entry in `entries[..len]` owns one banked size-class reference,
+/// which keeps the pointed-to class alive. The entry itself stays small
+/// (`buffer, slot`); popping it materializes the checked-out [`SizeClassLease`]
+/// from that banked reference.
+///
 /// The hot steady-state allocation path pops an entry from `entries`, and the
 /// hot return path pushes one back while there is room.
 struct TlsSizeClassCache {
-    entries: Vec<TlsSizeClassCacheEntry>,
+    class: ptr::NonNull<SizeClass>,
+    entries: Box<[MaybeUninit<TlsSizeClassCacheEntry>]>,
+    len: usize,
     capacity: usize,
 }
 
 impl TlsSizeClassCache {
     /// Creates a new empty cache with the given maximum thread-cache size.
-    fn new(capacity: usize) -> Self {
+    fn new(class: &Arc<SizeClass>, capacity: usize) -> Self {
+        let entries = (0..capacity)
+            .map(|_| MaybeUninit::uninit())
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
         Self {
-            entries: Vec::with_capacity(capacity),
+            class: ptr::NonNull::from(class.as_ref()),
+            entries,
+            len: 0,
             capacity,
         }
     }
 
-    /// Removes and returns one reusable buffer.
+    /// Removes and returns one reusable buffer entry.
     ///
     /// Local hits are served directly from the cache. On a local miss, small
     /// caches take only the buffer being returned to the caller. Larger caches
@@ -563,34 +719,46 @@ impl TlsSizeClassCache {
     /// and retain the rest locally for future allocations.
     #[inline(always)]
     fn pop(&mut self, class: &Arc<SizeClass>) -> Option<TlsSizeClassCacheEntry> {
-        // Serve local hits without touching shared state.
-        if let Some(entry) = self.entries.pop() {
+        if let Some(entry) = self.pop_local() {
             return Some(entry);
         }
 
-        // Refill from the global freelist on a local miss.
-        self.pop_miss(class)
+        // Take from the class-global freelist on a local miss.
+        self.pop_global(class)
     }
 
-    /// Handles a local-cache miss by taking from the class-global freelist.
+    /// Removes and returns one entry from this thread's local stack.
+    ///
+    /// This touches only thread-local cache state. A returned entry consumes one
+    /// banked size-class reference from this cache; the caller must materialize
+    /// or release that reference.
+    #[inline(always)]
+    fn pop_local(&mut self) -> Option<TlsSizeClassCacheEntry> {
+        if self.len == 0 {
+            return None;
+        }
+
+        self.len -= 1;
+        // SAFETY: entries in `0..self.len` are initialized. Decrementing
+        // `len` above makes this slot uninitialized again.
+        Some(unsafe { self.entries.get_unchecked(self.len).assume_init_read() })
+    }
+
+    /// Takes from the class-global freelist after the local stack misses.
     ///
     /// This is separate from [`Self::pop`] so the steady-state allocation hot path
     /// can inline only the local cache hit. We annotate with `inline(never)` to keep
     /// the refill and batching code out of `BufferPoolInner::try_alloc`, reducing
     /// hot-path code size and register pressure.
     #[inline(never)]
-    fn pop_miss(&mut self, class: &Arc<SizeClass>) -> Option<TlsSizeClassCacheEntry> {
+    fn pop_global(&mut self, class: &Arc<SizeClass>) -> Option<TlsSizeClassCacheEntry> {
         // Tiny caches do not batch enough to justify the wider global
         // claim. Keep their miss path equivalent to a single take.
         if self.capacity < MIN_TLS_BATCH_CAPACITY {
-            return class
-                .global
-                .take()
-                .map(|(slot, buffer)| TlsSizeClassCacheEntry {
-                    buffer,
-                    class: class.clone(),
-                    slot,
-                });
+            return class.global.take().map(|(slot, buffer)| {
+                SizeClassLease::retain_banked(class);
+                TlsSizeClassCacheEntry { buffer, slot }
+            });
         }
 
         // Refill larger caches to half capacity. That leaves room for future
@@ -599,12 +767,8 @@ impl TlsSizeClassCache {
         let mut entry = None;
         let take = self.capacity / 2;
         class.global.take_batch(take, |slot, buffer| {
-            let cache_entry = TlsSizeClassCacheEntry {
-                buffer,
-                class: class.clone(),
-                slot,
-            };
-
+            SizeClassLease::retain_banked(class);
+            let cache_entry = TlsSizeClassCacheEntry { buffer, slot };
             if entry.is_none() {
                 // Hand the first claimed buffer to the allocation that missed
                 // locally. Additional claimed buffers refill the local cache.
@@ -613,7 +777,7 @@ impl TlsSizeClassCache {
                 // The take count is derived from the target occupancy, so refill
                 // cannot overflow the local cache. Push directly to avoid the
                 // spill checks used by return-to-cache.
-                self.entries.push(cache_entry);
+                self.push_local(cache_entry);
             }
         });
 
@@ -627,56 +791,84 @@ impl TlsSizeClassCache {
     /// to batch effectively, half the entries are drained to amortize global
     /// queue traffic across future returns.
     #[inline(always)]
-    fn push(&mut self, entry: TlsSizeClassCacheEntry) {
-        // Preserve same-thread locality while the cache still has room.
-        if self.entries.len() < self.capacity {
-            self.entries.push(entry);
+    fn push(&mut self, class: SizeClassLease, slot: u32, buffer: PooledBuffer) {
+        let entry = TlsSizeClassCacheEntry { buffer, slot };
+
+        if self.len < self.capacity {
+            class.into_banked();
+            self.push_local(entry);
             return;
         }
 
-        // Spill to the global freelist when the local cache is full.
-        self.push_full(entry);
+        // Return to the class-global freelist when the local cache is full.
+        self.push_global(class, entry);
     }
 
-    /// Handles a full local cache by returning entries to the global freelist.
+    /// Pushes one entry onto this thread's local stack.
+    ///
+    /// The caller must ensure the stack has room and must transfer one
+    /// size-class reference into banked local-cache ownership.
+    #[inline(always)]
+    fn push_local(&mut self, entry: TlsSizeClassCacheEntry) {
+        debug_assert!(self.len < self.capacity);
+        // SAFETY: the caller ensured `self.len < self.capacity`, so this slot
+        // is in bounds and currently uninitialized.
+        unsafe {
+            self.entries.get_unchecked_mut(self.len).write(entry);
+        }
+        self.len += 1;
+    }
+
+    /// Returns entries to the class-global freelist after the local stack fills.
     ///
     /// This is separate from [`Self::push`] so the steady-state return hot path can
     /// inline only the local cache push. We annotate with `inline(never)` to keep the
     /// spill and batching code out of pooled buffer drop, which keeps that hot frame
     /// small when the local cache has room.
     #[inline(never)]
-    fn push_full(&mut self, entry: TlsSizeClassCacheEntry) {
+    fn push_global(&mut self, class: SizeClassLease, entry: TlsSizeClassCacheEntry) {
         // Very small caches cannot spill enough entries to amortize a batch
         // insert, so overflow goes straight to the global freelist.
         if self.capacity < MIN_TLS_BATCH_CAPACITY {
-            entry.class.global.put(entry.slot, entry.buffer);
+            class.return_global(entry.slot, entry.buffer);
             return;
         }
 
         // Spill half the cache to global to make room.
-        let spill = self.entries.len().min(self.capacity / 2).max(1);
-        let split = self.entries.len() - spill;
-        entry.class.global.put_batch(
-            self.entries
-                .drain(split..)
-                .map(|spilled| (spilled.slot, spilled.buffer)),
-        );
+        let spill = self.len.min(self.capacity / 2).max(1);
+        let mut spilled = Vec::with_capacity(spill);
+        for _ in 0..spill {
+            let spilled_entry = self
+                .pop_local()
+                .expect("spill count should not exceed local length");
+            spilled.push((spilled_entry.slot, spilled_entry.buffer));
+        }
+        // SAFETY: each spilled entry represents one banked class reference
+        // owned by this cache. `self.len` was non-zero, so those references keep
+        // `self.class` live.
+        unsafe { SizeClassLease::from_banked_ptr(self.class) }.return_global_batch(spilled, spill);
 
-        self.entries.push(entry);
+        debug_assert!(self.len < self.capacity);
+        class.into_banked();
+        self.push_local(entry);
     }
 }
 
 impl Drop for TlsSizeClassCache {
     fn drop(&mut self) {
-        let Some(entry) = self.entries.pop() else {
+        let count = self.len;
+        if count == 0 {
             return;
-        };
-        entry.class.global.put_batch(
-            self.entries
-                .drain(..)
-                .map(|entry| (entry.slot, entry.buffer))
-                .chain(std::iter::once((entry.slot, entry.buffer))),
-        );
+        }
+
+        let mut entries = Vec::with_capacity(count);
+        while let Some(entry) = self.pop_local() {
+            entries.push((entry.slot, entry.buffer));
+        }
+        // SAFETY: each initialized entry represented one banked class
+        // reference owned by this cache. Those references keep `self.class`
+        // live for the duration of this drop.
+        unsafe { SizeClassLease::from_banked_ptr(self.class) }.return_global_batch(entries, count);
     }
 }
 
@@ -692,6 +884,9 @@ impl Drop for TlsSizeClassCache {
 /// entry is a [`TlsSizeClassCache`] for that global size class. Missing entries
 /// mean this thread has not used that size class yet. Holes can remain for the
 /// lifetime of the thread because class ids are monotonic and never reused.
+/// Empty initialized caches can also remain after their pool has been dropped;
+/// their class identity is inert until another checked-out buffer or allocation
+/// for that same live class reaches the cache.
 ///
 /// We intentionally use `Vec<Option<...>>` because class ids are dense enough
 /// for direct indexing to be cheaper than hashing, but a thread may initialize
@@ -707,16 +902,23 @@ impl TlsSizeClassCaches {
         Self { bins: Vec::new() }
     }
 
-    /// Returns the cache for `class_id`, creating it lazily on first use.
+    /// Returns the cache for `class`, creating it lazily on first use.
     #[inline(always)]
-    fn get_or_init(&mut self, class_id: usize, capacity: usize) -> &mut TlsSizeClassCache {
+    fn get_or_init(&mut self, class: &Arc<SizeClass>) -> &mut TlsSizeClassCache {
+        let class_id = class.class_id;
         if class_id < self.bins.len() && self.bins[class_id].is_some() {
             return self.bins[class_id]
                 .as_mut()
                 .expect("class cache was checked as initialized");
         }
 
-        self.init(class_id, capacity)
+        self.init(class)
+    }
+
+    /// Returns an initialized cache without creating a missing one.
+    #[inline(always)]
+    fn get(&mut self, class_id: usize) -> Option<&mut TlsSizeClassCache> {
+        self.bins.get_mut(class_id).and_then(Option::as_mut)
     }
 
     /// Initializes and returns the cache for `class_id`.
@@ -726,11 +928,13 @@ impl TlsSizeClassCaches {
     /// `inline(never)` to keep the resize and allocation path out of pooled
     /// allocation and drop.
     #[inline(never)]
-    fn init(&mut self, class_id: usize, capacity: usize) -> &mut TlsSizeClassCache {
+    fn init(&mut self, class: &Arc<SizeClass>) -> &mut TlsSizeClassCache {
+        let class_id = class.class_id;
         if class_id >= self.bins.len() {
             self.bins.resize_with(class_id + 1, || None);
         }
-        self.bins[class_id].get_or_insert_with(|| TlsSizeClassCache::new(capacity))
+        self.bins[class_id]
+            .get_or_insert_with(|| TlsSizeClassCache::new(class, class.thread_cache_capacity))
     }
 }
 
@@ -791,29 +995,37 @@ impl BufferPoolThreadCache {
 
     /// Returns a buffer to the current thread's local cache for the given
     /// size class, spilling to the global freelist if the cache is full.
+    ///
+    /// This only uses an already-initialized local cache. If the current thread
+    /// has not initialized this size class, the buffer goes to the global
+    /// freelist rather than creating local state from a drop path.
     #[inline(always)]
-    pub(super) fn push(class: Arc<SizeClass>, slot: u32, buffer: PooledBuffer) {
-        if class.thread_cache_capacity == 0 {
-            class.global.put(slot, buffer);
+    pub(super) fn push(class: SizeClassLease, slot: u32, buffer: PooledBuffer) {
+        let (class_id, thread_cache_capacity) = {
+            let class_ref = class.class();
+            (class_ref.class_id, class_ref.thread_cache_capacity)
+        };
+
+        if thread_cache_capacity == 0 {
+            class.return_global(slot, buffer);
             return;
         }
 
         // Returning a pooled buffer can happen from arbitrary Drop code,
         // including during thread-local destruction. If the local cache is
         // unavailable, fall back to the global freelist instead of panicking.
-        match Self::cache(class.class_id, class.thread_cache_capacity) {
-            Some(mut cache) => {
-                // SAFETY: `cache` points to this thread's initialized TLS cache.
-                unsafe {
-                    cache.as_mut().push(TlsSizeClassCacheEntry {
-                        buffer,
-                        class,
-                        slot,
-                    });
-                }
+        let caches = Self::TLS_SIZE_CLASS_CACHES_FAST.with(|fast| fast.get());
+        if !caches.is_null() {
+            // SAFETY: the fast pointer is set only from this thread's
+            // `TLS_SIZE_CLASS_CACHES` value and cleared before that value
+            // drops.
+            if let Some(cache) = unsafe { (&mut *caches).get(class_id) } {
+                cache.push(class, slot, buffer);
+                return;
             }
-            None => class.global.put(slot, buffer),
         }
+
+        class.return_global(slot, buffer);
     }
 
     /// Takes a buffer from the current thread's local cache for the given
@@ -823,57 +1035,54 @@ impl BufferPoolThreadCache {
     /// is queried once. The first claimed buffer is returned to the caller, and
     /// any additional claimed buffers are appended directly to the local cache.
     #[inline(always)]
-    fn pop(class: &Arc<SizeClass>) -> Option<TlsSizeClassCacheEntry> {
+    fn pop(class: &Arc<SizeClass>) -> Option<(PooledBuffer, SizeClassLease, u32)> {
         if class.thread_cache_capacity == 0 {
             return class
                 .global
                 .take()
-                .map(|(slot, buffer)| TlsSizeClassCacheEntry {
-                    buffer,
-                    class: class.clone(),
-                    slot,
-                });
+                .map(|(slot, buffer)| (buffer, SizeClassLease::retain(class), slot));
         }
 
         // Allocation can happen from caller-owned TLS destructors during thread
         // teardown. If the local cache is unavailable, fall back to the global
         // freelist instead of panicking.
         #[allow(clippy::option_if_let_else)]
-        match Self::cache(class.class_id, class.thread_cache_capacity) {
+        match Self::cache(class) {
             Some(mut cache) => {
                 // SAFETY: `cache` points to this thread's initialized TLS cache.
-                unsafe { cache.as_mut().pop(class) }
+                unsafe { cache.as_mut().pop(class) }.map(|entry| {
+                    // SAFETY: `TlsSizeClassCache::pop` returns entries that own
+                    // one banked class reference for `class`.
+                    let lease = unsafe { SizeClassLease::from_banked(class) };
+                    (entry.buffer, lease, entry.slot)
+                })
             }
             None => class
                 .global
                 .take()
-                .map(|(slot, buffer)| TlsSizeClassCacheEntry {
-                    buffer,
-                    class: class.clone(),
-                    slot,
-                }),
+                .map(|(slot, buffer)| (buffer, SizeClassLease::retain(class), slot)),
         }
     }
 
-    /// Returns the current thread's local cache for `class_id`.
+    /// Returns the current thread's local cache for `class`.
     ///
     /// The raw fast path serves steady-state accesses and initializes missing
     /// size-class caches when the registry pointer is already available. The
     /// checked TLS path is only needed when this thread has not stored the raw
     /// registry pointer yet.
     #[inline(always)]
-    fn cache(class_id: usize, capacity: usize) -> Option<ptr::NonNull<TlsSizeClassCache>> {
+    fn cache(class: &Arc<SizeClass>) -> Option<ptr::NonNull<TlsSizeClassCache>> {
         let caches = Self::TLS_SIZE_CLASS_CACHES_FAST.with(|fast| fast.get());
         if !caches.is_null() {
             // SAFETY: the fast pointer is set only from this thread's
             // `TLS_SIZE_CLASS_CACHES` value and cleared before that value
             // drops.
             return Some(ptr::NonNull::from(unsafe {
-                (&mut *caches).get_or_init(class_id, capacity)
+                (&mut *caches).get_or_init(class)
             }));
         }
 
-        Self::cache_slow(class_id, capacity)
+        Self::cache_slow(class)
     }
 
     /// Initializes the TLS fast path, then returns the local cache.
@@ -884,7 +1093,7 @@ impl BufferPoolThreadCache {
     /// requested size-class cache if needed. We annotate with `inline(never)` to
     /// keep that one-time setup out of pooled allocation and drop.
     #[inline(never)]
-    fn cache_slow(class_id: usize, capacity: usize) -> Option<ptr::NonNull<TlsSizeClassCache>> {
+    fn cache_slow(class: &Arc<SizeClass>) -> Option<ptr::NonNull<TlsSizeClassCache>> {
         // The owning TLS key has a destructor, so it can be unavailable during
         // thread-local teardown.
         Self::TLS_SIZE_CLASS_CACHES
@@ -893,7 +1102,7 @@ impl BufferPoolThreadCache {
                 Self::TLS_SIZE_CLASS_CACHES_FAST.with(|fast| fast.set(caches));
 
                 // SAFETY: this TLS value is only ever accessed by the current thread.
-                ptr::NonNull::from(unsafe { (&mut *caches).get_or_init(class_id, capacity) })
+                ptr::NonNull::from(unsafe { (&mut *caches).get_or_init(class) })
             })
             .ok()
     }
@@ -903,7 +1112,7 @@ impl BufferPoolThreadCache {
 struct Allocation {
     buffer: PooledBuffer,
     is_new: bool,
-    class: Arc<SizeClass>,
+    lease: SizeClassLease,
     slot: u32,
 }
 
@@ -940,12 +1149,12 @@ impl BufferPoolInner {
 
         // Reuse path: try the thread-local cache first, then the global
         // freelist with batch refill when the local cache is large enough.
-        if let Some(entry) = BufferPoolThreadCache::pop(class) {
+        if let Some((buffer, lease, slot)) = BufferPoolThreadCache::pop(class) {
             return Some(Allocation {
-                buffer: entry.buffer,
+                buffer,
                 is_new: false,
-                class: entry.class,
-                slot: entry.slot,
+                lease,
+                slot,
             });
         }
 
@@ -963,7 +1172,7 @@ impl BufferPoolInner {
         let label = SizeClassLabel {
             size_class: class.size as u64,
         };
-        let Some((slot, buffer)) = class.global.try_create(zeroed) else {
+        let Some((slot, buffer, lease)) = class.try_create(zeroed) else {
             self.metrics.exhausted_total.get_or_create(&label).inc();
             return None;
         };
@@ -972,7 +1181,7 @@ impl BufferPoolInner {
         Some(Allocation {
             buffer,
             is_new: true,
-            class: class.clone(),
+            lease,
             slot,
         })
     }
@@ -1037,7 +1246,7 @@ impl BufferPool {
         for i in 0..num_classes {
             let size = BufferPoolConfig::class_size(config.min_size.get(), i);
             let class_id = NEXT_SIZE_CLASS_ID.fetch_add(1, Ordering::Relaxed);
-            let class = Arc::new(SizeClass::new(
+            let class = SizeClass::new(
                 class_id,
                 size,
                 config.alignment.get(),
@@ -1045,7 +1254,7 @@ impl BufferPool {
                 config.parallelism,
                 thread_cache_capacity,
                 config.prefill,
-            ));
+            );
             classes.push(class);
         }
 
@@ -1138,7 +1347,7 @@ impl BufferPool {
             .inner
             .try_alloc(class_index, false)
             .map(|allocation| {
-                PooledBufMut::new(allocation.buffer, allocation.class, allocation.slot)
+                PooledBufMut::new(allocation.buffer, allocation.lease, allocation.slot)
             })
             .ok_or(PoolError::Exhausted)?;
         Ok(IoBufMut::from_pooled(buffer))
@@ -1222,7 +1431,7 @@ impl BufferPool {
 
         let mut buf = IoBufMut::from_pooled(PooledBufMut::new(
             allocation.buffer,
-            allocation.class,
+            allocation.lease,
             allocation.slot,
         ));
         if allocation.is_new {
@@ -1290,7 +1499,7 @@ mod tests {
     };
 
     fn test_size_class(size: usize, alignment: usize) -> Arc<SizeClass> {
-        Arc::new(SizeClass::new(
+        SizeClass::new(
             NEXT_SIZE_CLASS_ID.fetch_add(1, Ordering::Relaxed),
             size,
             alignment,
@@ -1298,7 +1507,7 @@ mod tests {
             NZUsize!(4),
             4,
             false,
-        ))
+        )
     }
 
     fn test_pool(config: BufferPoolConfig) -> BufferPool {
@@ -1357,7 +1566,7 @@ mod tests {
                 .bins
                 .get(class.class_id)
                 .and_then(Option::as_ref)
-                .map_or(0, |cache| cache.entries.len())
+                .map_or(0, |cache| cache.len)
         })
     }
 
@@ -1978,29 +2187,29 @@ mod tests {
         // A short global freelist should return the allocation and stop
         // without filling the local cache to its batch target.
         class.global.put(slot, buffer);
-        let entry = BufferPoolThreadCache::pop(&class).expect("global allocation");
+        let (buffer, lease, slot) = BufferPoolThreadCache::pop(&class).expect("global allocation");
 
         assert_eq!(get_local_len(&class), 0);
         assert_eq!(get_global_len(&class), 0);
 
         // Return the manually popped entry so the freelist owns and deallocates
         // the buffer at test teardown.
-        class.global.put(entry.slot, entry.buffer);
+        lease.return_global(slot, buffer);
     }
 
     #[test]
     fn test_tls_size_class_cache_push_tolerates_empty_spill() {
         let class = test_size_class(64, 64);
         let (slot, buffer) = class.global.try_create(false).expect("slot reservation");
-        let mut cache = TlsSizeClassCache::new(0);
+        SizeClassLease::retain_banked(&class);
+        let mut cache = TlsSizeClassCache::new(&class, 0);
 
         // Small local capacities should bypass batching and push straight to global.
-        cache.push(TlsSizeClassCacheEntry {
-            buffer,
-            class,
-            slot,
-        });
-        assert_eq!(cache.entries.len(), 0);
+        // SAFETY: the retained reference above is represented by this lease and
+        // transferred into `cache.push`.
+        let class = unsafe { SizeClassLease::from_banked(&class) };
+        cache.push(class, slot, buffer);
+        assert_eq!(cache.len, 0);
         drop(cache);
     }
 
@@ -2009,7 +2218,7 @@ mod tests {
         // Use a two-slot class with TLS capacity one so this test can exercise
         // the class-global freelist directly without involving local-cache
         // refill or spill behavior.
-        let class = Arc::new(SizeClass::new(
+        let class = SizeClass::new(
             NEXT_SIZE_CLASS_ID.fetch_add(1, Ordering::Relaxed),
             64,
             64,
@@ -2017,7 +2226,7 @@ mod tests {
             NZUsize!(1),
             1,
             false,
-        ));
+        );
 
         // Create both slot ids and keep each allocation's pointer so we can
         // verify that the freelist returns the same buffer parked for that slot.
@@ -2059,28 +2268,30 @@ mod tests {
         // into_bytes should detach without retaining the pool allocation.
         let page = page_size();
         let class = test_size_class(page, page);
-        let (slot0, buffer0) = class.global.try_create(false).expect("first slot");
-        let (slot1, buffer1) = class.global.try_create(false).expect("second slot");
-        let (slot2, buffer2) = class.global.try_create(false).expect("third slot");
+        let (slot0, buffer0, class0) = class.try_create(false).expect("first slot");
+        let (slot1, buffer1, class1) = class.try_create(false).expect("second slot");
+        let (slot2, buffer2, class2) = class.try_create(false).expect("third slot");
 
         // Mutable pooled debug should include cursor position.
         let pooled_mut_debug = {
-            let pooled_mut = PooledBufMut::new(buffer0, class.clone(), slot0);
+            let pooled_mut = PooledBufMut::new(buffer0, class0, slot0);
             format!("{pooled_mut:?}")
         };
         assert!(pooled_mut_debug.contains("PooledBufMut"));
         assert!(pooled_mut_debug.contains("cursor"));
 
         // Empty mutable buffer converts to empty Bytes without retaining pool memory.
-        let empty_from_mut = PooledBufMut::new(buffer1, class.clone(), slot1);
+        let empty_from_mut = PooledBufMut::new(buffer1, class1, slot1);
         assert!(empty_from_mut.into_bytes().is_empty());
 
         // Immutable pooled debug should include capacity.
-        let pooled = PooledBufMut::new(buffer2, class, slot2).into_pooled();
+        let pooled = PooledBufMut::new(buffer2, class2, slot2).into_pooled();
         let pooled_debug = format!("{pooled:?}");
         assert!(pooled_debug.contains("PooledBuf"));
         assert!(pooled_debug.contains("capacity"));
         assert!(pooled.into_bytes().is_empty());
+
+        BufferPoolThreadCache::flush();
     }
 
     #[test]
@@ -2376,9 +2587,9 @@ mod tests {
         }
         drop(tx);
 
-        // Receive and drop on another thread. Those returns should populate the
-        // dropping thread's local cache, so allocations on that same thread
-        // should be able to reuse them immediately.
+        // Receive and drop on another thread. Since that thread has not
+        // initialized a local cache for this class, those returns should go to
+        // the global freelist instead of creating TLS state from a drop path.
         let handle = thread::spawn(move || {
             while let Ok(iobuf) = rx.recv() {
                 drop(iobuf);
@@ -2387,15 +2598,13 @@ mod tests {
             let class_index = pool
                 .class_index(page)
                 .expect("class exists for page-sized buffer");
-            assert!(
-                get_local_len(&pool.inner.classes[class_index]) >= 1,
-                "dropping thread should retain returned buffers in its local cache"
-            );
+            assert_eq!(get_local_len(&pool.inner.classes[class_index]), 0);
+            assert_eq!(get_global_len(&pool.inner.classes[class_index]), 50);
 
             for _ in 0..50 {
                 let _buf = pool
                     .try_alloc(page)
-                    .expect("dropping thread should be able to reuse returned buffers");
+                    .expect("dropping thread should be able to reuse globally returned buffers");
             }
         });
 

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -475,9 +475,9 @@ impl PoolMetrics {
 /// [`BufferPool`] handle and still return to the correct freelist.
 ///
 /// The freelist is the only place that deallocates tracked buffers. Returning a
-/// buffer to the freelist transfers buffer ownership back to `SizeClass` and
-/// releases the pooled-backing or banked strong reference that kept the class
-/// alive while the buffer was outside the global freelist.
+/// buffer to the freelist transfers buffer ownership back to that freelist and
+/// releases the pooled-backing lease or banked strong reference that kept the
+/// class alive while the buffer was outside the global freelist.
 ///
 /// Allocation prefers the local cache, then refills from the global freelist,
 /// and only creates a new tracked buffer when no free buffer is available and
@@ -687,7 +687,7 @@ impl SizeClassHandle {
         unsafe { self.token.retain() };
         // SAFETY: the increment above created the strong reference consumed by
         // this temporary Arc.
-        let arc = unsafe { Arc::from_raw(self.token.as_ptr()) };
+        let arc = unsafe { Arc::from_raw(self.token.ptr.as_ptr()) };
         Arc::strong_count(&arc) - 1
     }
 }

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -21,7 +21,7 @@
 //! - Requests smaller than [`BufferPoolConfig::pool_min_size`] bypass pooling
 //!   entirely and return untracked aligned allocations from both
 //!   [`BufferPool::try_alloc`] and [`BufferPool::alloc`].
-//! - Dropping [`BufferPool`] drains only the shared global freelists; pooled
+//! - Dropping [`BufferPool`] drains only the shared global freelists, pooled
 //!   views and buffers cached in a live thread's local cache can keep their
 //!   size class alive until they are dropped or the thread exits.
 //!
@@ -167,10 +167,6 @@ pub struct BufferPoolConfig {
     /// heap allocation.
     pub prefill: bool,
     /// Buffer alignment. Must be a power of two.
-    ///
-    /// Use page alignment for storage I/O that needs direct-I/O/DMA-compatible
-    /// buffers, and cache-line alignment for network I/O where smaller
-    /// alignment reduces internal fragmentation.
     pub alignment: NonZeroUsize,
     /// Expected number of threads concurrently accessing the pool.
     ///
@@ -389,9 +385,6 @@ impl BufferPoolConfig {
     }
 
     /// Returns the number of size classes between validated bounds.
-    ///
-    /// This assumes `min_size` and `max_size` came from a config that passed
-    /// [`Self::validate_size_class_bounds`]. No checking is repeated here.
     #[inline]
     const fn num_classes(min_size: usize, max_size: usize) -> usize {
         // Since sizes are powers of two, trailing zeros is the size-class
@@ -400,15 +393,6 @@ impl BufferPoolConfig {
     }
 
     /// Returns the buffer size for a validated size-class index.
-    ///
-    /// This assumes `min_size` is a validated power-of-two minimum and `index`
-    /// is less than [`Self::num_classes`] for the same validated bounds. No
-    /// range checking is done here.
-    ///
-    /// # Panics
-    ///
-    /// Panics on arithmetic overflow if `index` is outside the validated
-    /// size-class range.
     #[inline]
     const fn class_size(min_size: usize, index: usize) -> usize {
         min_size << index

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -500,14 +500,6 @@ unsafe impl Send for SizeClass {}
 // SAFETY: see above.
 unsafe impl Sync for SizeClass {}
 
-impl SizeClass {
-    /// Returns the buffer size for this class.
-    #[inline]
-    pub(super) const fn size(&self) -> usize {
-        self.size
-    }
-}
-
 /// Non-owning raw identity for a size class.
 ///
 /// # Size-class lifetime model
@@ -619,22 +611,18 @@ impl SizeClassToken {
 /// Owning pool reference to a size class.
 ///
 /// This is the pool's strong `Arc<SizeClass>` reference represented by a
-/// [`SizeClassToken`]. Keeping the pool's class vector in this form means the
-/// pointer used on hot allocation paths already satisfies the contract required
-/// by `Arc::{increment,decrement}_strong_count`.
-///
-/// `SizeClassHandle` is the long-lived owner for a class while the
-/// [`BufferPoolInner`] exists. Dropping the handle releases that pool-owned
-/// strong reference. A class may still outlive the handle if pooled backing
-/// values or thread-local cache entries own additional references through
-/// [`SizeClassLease`] or banked TLS refs.
+/// [`SizeClassToken`]. `SizeClassHandle` is the long-lived owner for a class
+/// while the [`BufferPoolInner`] exists. Dropping the handle releases that
+/// pool-owned strong reference. A class may still outlive the handle if pooled
+/// backing values or thread-local cache entries own additional references
+/// through [`SizeClassLease`] or banked TLS refs.
 ///
 /// Functionally this is an `Arc<SizeClass>` stored in raw-token form. It exists
 /// to keep the pool-owned reference alive and to provide a live token for
-/// allocation paths that need to retain pooled-backing or TLS-banked references.
-/// The raw form keeps the already-loaded class pointer usable for explicit
-/// refcount operations without calling [`Arc::as_ptr`] or storing a second token
-/// alongside an `Arc`.
+/// allocation paths that need to retain pooled-backing or TLS-banked
+/// references. The raw form keeps the already-loaded class pointer usable for
+/// explicit refcount operations without calling [`Arc::as_ptr`] or storing a
+/// second token alongside an `Arc`.
 struct SizeClassHandle {
     token: SizeClassToken,
 }
@@ -679,26 +667,6 @@ impl SizeClassHandle {
         let class = SizeClassLease::retain(self);
         Some((slot, buffer, class))
     }
-
-    #[cfg(test)]
-    fn strong_count(&self) -> usize {
-        // SAFETY: this handle owns one strong reference for `self.token` for
-        // the duration of this call.
-        unsafe { self.token.retain() };
-        // SAFETY: the increment above created the strong reference consumed by
-        // this temporary Arc.
-        let arc = unsafe { Arc::from_raw(self.token.ptr.as_ptr()) };
-        Arc::strong_count(&arc) - 1
-    }
-}
-
-#[cfg(test)]
-impl Clone for SizeClassHandle {
-    fn clone(&self) -> Self {
-        // SAFETY: this handle owns one strong reference for `self.token`.
-        unsafe { self.token.retain() };
-        Self { token: self.token }
-    }
 }
 
 impl Drop for SizeClassHandle {
@@ -726,12 +694,12 @@ impl std::ops::Deref for SizeClassHandle {
 /// [`SizeClassToken`], with retain and release performed explicitly at the
 /// boundaries where a buffer enters or leaves global pool state.
 ///
-/// Lifetime-wise this is the same kind of reference as [`SizeClassHandle`]: both
-/// own exactly one strong reference for a token. The types are separate because
-/// they live in different state machines. `SizeClassHandle` is ordinary RAII
-/// ownership for the pool's class vector. `SizeClassLease` is hot-path pooled
-/// view ownership that must be explicitly transferred into TLS cache state or
-/// returned to the global freelist.
+/// Lifetime-wise this is the same kind of reference as [`SizeClassHandle`]:
+/// both own exactly one strong reference for a token. The types are separate
+/// because they live in different state machines. `SizeClassHandle` is ordinary
+/// RAII ownership for the pool's class vector. `SizeClassLease` is hot-path
+/// pooled view ownership that must be explicitly transferred into TLS cache
+/// state or returned to the global freelist.
 ///
 /// The raw representation matters because the hot path mostly transfers
 /// ownership between pooled view state and this thread's local cache. A real
@@ -750,9 +718,9 @@ impl std::ops::Deref for SizeClassHandle {
 /// but means every owner must complete one of the explicit transitions.
 ///
 /// Thread-local cache entries do not store a lease per entry. The cache stores
-/// the class token once and owns one banked strong reference for each initialized
-/// entry. Popping from the local cache materializes a lease from one of those
-/// banked references without touching the strong count.
+/// the class token once and owns one banked strong reference for each
+/// initialized entry. Popping from the local cache materializes a lease from
+/// one of those banked references without touching the strong count.
 ///
 /// Globally parked buffers do not carry a class reference: taking from the
 /// global freelist retains the class, and returning to the global freelist
@@ -786,9 +754,6 @@ impl SizeClassLease {
     }
 
     /// Retains `class` for a buffer leaving the global freelist.
-    ///
-    /// Moving between pooled view state and TLS transfers the lease without
-    /// touching the strong count.
     #[inline(always)]
     fn retain(class: &SizeClassHandle) -> Self {
         let token = class.token;
@@ -804,7 +769,7 @@ impl SizeClassLease {
     /// normally by storing an entry and increasing the cache length. The cache
     /// must later materialize or release exactly one lease for that entry.
     ///
-    /// This is a no-op at runtime; it exists to mark the ownership transition.
+    /// This is a no-op at runtime, it exists to mark the ownership transition.
     #[inline(always)]
     const fn into_banked(self) {}
 
@@ -821,7 +786,7 @@ impl SizeClassLease {
     /// Returns the buffer size for this lease's size class.
     #[inline(always)]
     pub(crate) const fn size(&self) -> usize {
-        self.class().size()
+        self.class().size
     }
 
     /// Returns a buffer to this class's global freelist and releases the class
@@ -857,7 +822,7 @@ struct TlsSizeClassCacheEntry {
 ///
 /// Each instance is stored in [`TlsSizeClassCaches`] under one global
 /// [`SizeClass::class_id`], so all entries in the cache belong to the same size
-/// class. The cache owns full [`PooledBuffer`] values while they are local;
+/// class. The cache owns full [`PooledBuffer`] values while they are local,
 /// returning them to the global freelist happens only on miss refill, overflow,
 /// explicit flush, or thread exit.
 ///
@@ -865,17 +830,16 @@ struct TlsSizeClassCacheEntry {
 /// while `len == 0`, because an empty cache does not keep its pool alive. When
 /// `len > 0`, each initialized entry in `entries[..len]` owns one banked
 /// size-class reference, which keeps the pointed-to class alive. The entry
-/// itself stays small (`buffer, slot`); popping it materializes a
+/// itself stays small (`buffer, slot`), popping it materializes a
 /// [`SizeClassLease`] from one banked reference.
 ///
 /// As described in [`SizeClassToken`], a banked reference is represented by
-/// cache state rather than by a Rust value stored in the entry. Changing `len`
-/// is therefore an ownership transition as well as a stack operation.
+/// cache state rather than by a value stored in the entry. Changing `len` is
+/// therefore an ownership transition as well as a stack operation.
 ///
-/// The stale-token case is intentionally narrow: an empty cache may keep the
-/// token value for indexing/debug assertions, but it must not dereference that
-/// token or adjust its strong count unless a live [`SizeClassHandle`] or banked
-/// entry proves the class is still alive.
+/// An empty cache may keep a stale token only for identity checks. It must not
+/// dereference the token or adjust its strong count until a live
+/// [`SizeClassHandle`] or banked entry proves the class is still alive.
 ///
 /// The hot steady-state allocation path pops an entry from `entries`, and the
 /// hot return path pushes one back while there is room.
@@ -928,9 +892,9 @@ impl TlsSizeClassCache {
 
     /// Removes and returns one entry from this thread's local stack.
     ///
-    /// This touches only thread-local cache state. A returned entry consumes one
-    /// banked size-class reference from this cache; the caller must materialize
-    /// or release that reference.
+    /// This touches only thread-local cache state. A returned entry consumes
+    /// one banked size-class reference from this cache, the caller must
+    /// materialize or release that reference.
     #[inline(always)]
     fn pop_local(&mut self) -> Option<TlsSizeClassCacheEntry> {
         if self.len == 0 {
@@ -938,8 +902,8 @@ impl TlsSizeClassCache {
         }
 
         self.len -= 1;
-        // SAFETY: entries in `0..self.len` are initialized. Decrementing
-        // `len` above makes this slot uninitialized again.
+        // SAFETY: entries in `0..self.len` are initialized. Decrementing `len`
+        // above makes this slot uninitialized again.
         Some(unsafe { self.entries.get_unchecked(self.len).assume_init_read() })
     }
 
@@ -947,20 +911,20 @@ impl TlsSizeClassCache {
     ///
     /// Every claimed global entry gets one retained class reference. The first
     /// claimed entry is returned with that reference materialized as a
-    /// [`SizeClassLease`]; additional claimed entries are parked in this cache
+    /// [`SizeClassLease`], additional claimed entries are parked in this cache
     /// and counted by `len`.
     ///
-    /// This is separate from [`Self::pop`] so the steady-state allocation hot path
-    /// can inline only the local cache hit. We annotate with `inline(never)` to keep
-    /// the refill and batching code out of `BufferPoolInner::try_alloc`, reducing
-    /// hot-path code size and register pressure.
+    /// This is separate from [`Self::pop`] so the steady-state allocation hot
+    /// path can inline only the local cache hit. We annotate with `inline(never)`
+    /// to keep the refill and batching code out of `BufferPoolInner::try_alloc`,
+    /// reducing hot-path code size and register pressure.
     #[inline(never)]
     fn pop_global(
         &mut self,
         class: &SizeClassHandle,
     ) -> Option<(TlsSizeClassCacheEntry, SizeClassLease)> {
-        // Tiny caches do not batch enough to justify the wider global
-        // claim. Keep their miss path equivalent to a single take.
+        // Tiny caches do not batch enough to justify the wider global claim.
+        // Keep their miss path equivalent to a single take.
         if self.capacity < MIN_TLS_BATCH_CAPACITY {
             return class.global.take().map(|(slot, buffer)| {
                 let lease = SizeClassLease::retain(class);
@@ -975,8 +939,8 @@ impl TlsSizeClassCache {
         let take = self.capacity / 2;
         class.global.take_batch(take, |slot, buffer| {
             // Each claimed global entry becomes either the returned lease or a
-            // local cache entry, so each needs one retained class
-            // reference.
+            // local cache entry, so each needs one retained class reference.
+            //
             // SAFETY: the borrowed `class` owns one strong reference for its
             // token while the refill runs.
             unsafe { class.token.retain() };
@@ -984,14 +948,15 @@ impl TlsSizeClassCache {
             if entry.is_none() {
                 // Hand the first claimed buffer to the allocation that missed
                 // locally. Additional claimed buffers refill the local cache.
+                //
                 // SAFETY: `class.token.retain()` above retained the strong
                 // reference transferred to this returned lease.
                 let lease = unsafe { SizeClassLease::from_banked(class) };
                 entry = Some((cache_entry, lease));
             } else {
-                // The take count is derived from the target occupancy, so refill
-                // cannot overflow the local cache. Push directly to avoid the
-                // spill checks used by return-to-cache.
+                // The take count is derived from the target occupancy, so
+                // refill cannot overflow the local cache. Push directly to
+                // avoid the spill checks used by return-to-cache.
                 self.push_local(cache_entry);
             }
         });
@@ -1002,24 +967,23 @@ impl TlsSizeClassCache {
     /// Pushes an entry into the local cache, spilling to global if full.
     ///
     /// Small local caches prioritize same-thread locality and route overflow
-    /// directly to the global freelist. Once the local cache is large enough
-    /// to batch effectively, half the entries are drained to amortize global
-    /// queue traffic across future returns.
+    /// directly to the global freelist. Once the local cache is large enough to
+    /// batch effectively, half the entries are drained to amortize global queue
+    /// traffic across future returns.
     #[inline(always)]
     fn push(&mut self, class: SizeClassLease, slot: u32, buffer: PooledBuffer) {
         let entry = TlsSizeClassCacheEntry { buffer, slot };
 
         if self.len < self.capacity {
-            debug_assert_eq!(self.class, class.token);
-            // The returned lease becomes one banked reference represented
-            // by the new local stack entry.
+            // The returned lease becomes one banked reference represented by
+            // the new local stack entry.
             class.into_banked();
             self.push_local(entry);
             return;
         }
 
-        // Return to the class-global freelist when the local cache is full.
-        self.push_global(class, entry);
+        // Handle overflow when the local stack is full.
+        self.push_full(class, entry);
     }
 
     /// Pushes one entry onto this thread's local stack.
@@ -1028,7 +992,6 @@ impl TlsSizeClassCache {
     /// size-class reference into banked local-cache ownership.
     #[inline(always)]
     fn push_local(&mut self, entry: TlsSizeClassCacheEntry) {
-        debug_assert!(self.len < self.capacity);
         // SAFETY: the caller ensured `self.len < self.capacity`, so this slot
         // is in bounds and currently uninitialized.
         unsafe {
@@ -1037,14 +1000,19 @@ impl TlsSizeClassCache {
         self.len += 1;
     }
 
-    /// Returns entries to the class-global freelist after the local stack fills.
+    /// Handles a push after the local stack fills.
     ///
-    /// This is separate from [`Self::push`] so the steady-state return hot path can
-    /// inline only the local cache push. We annotate with `inline(never)` to keep the
-    /// spill and batching code out of pooled buffer drop, which keeps that hot frame
-    /// small when the local cache has room.
+    /// Very small caches return the incoming entry directly to the global
+    /// freelist. Larger caches spill older local entries in a batch, then keep
+    /// the incoming entry local so the dropping thread retains the freshest
+    /// buffer.
+    ///
+    /// This is separate from [`Self::push`] so the steady-state return hot path
+    /// can inline only the local cache push. We annotate with `inline(never)`
+    /// to keep the spill and batching code out of pooled buffer drop when the
+    /// local cache has room.
     #[inline(never)]
-    fn push_global(&mut self, class: SizeClassLease, entry: TlsSizeClassCacheEntry) {
+    fn push_full(&mut self, class: SizeClassLease, entry: TlsSizeClassCacheEntry) {
         // Very small caches cannot spill enough entries to amortize a batch
         // insert, so overflow goes straight to the global freelist.
         if self.capacity < MIN_TLS_BATCH_CAPACITY {
@@ -1054,51 +1022,30 @@ impl TlsSizeClassCache {
 
         // Spill half the cache to global to make room.
         let spill = self.len.min(self.capacity / 2).max(1);
-        let mut spilled = Vec::with_capacity(spill);
-        for _ in 0..spill {
-            let spilled_entry = self
-                .pop_local()
-                .expect("spill count should not exceed local length");
-            spilled.push((spilled_entry.slot, spilled_entry.buffer));
-        }
-        // SAFETY: each spilled entry represents one banked class reference
-        // owned by this cache. Because `spill > 0`, at least one of those
-        // references keeps `self.class` live for the batch release.
-        unsafe { Self::return_banked_global_batch(self.class, spilled, spill) };
+        let end = self.len;
+        let start = end - spill;
+        // Stop tracking slots before moving them out.
+        self.len = start;
 
-        debug_assert!(self.len < self.capacity);
-        debug_assert_eq!(self.class, class.token);
+        class
+            .class()
+            .global
+            .put_batch((start..end).rev().map(|index| {
+                // SAFETY: `start..end` was initialized before `len` was lowered
+                // to `start`. Reading each slot moves it out and leaves the
+                // slot uninitialized.
+                let entry = unsafe { self.entries.as_mut_ptr().add(index).read().assume_init() };
+                // SAFETY: this drained entry carried one banked reference. The
+                // incoming `class` lease keeps the size class live while
+                // `put_batch` parks the spilled entries.
+                unsafe { self.class.release() };
+                (entry.slot, entry.buffer)
+            }));
+
+        // The incoming lease becomes one banked reference represented by the
+        // new local stack entry.
         class.into_banked();
         self.push_local(entry);
-    }
-
-    /// Returns banked TLS entries to the class-global freelist.
-    ///
-    /// The caller passes the raw token instead of a [`SizeClassLease`] because
-    /// TLS cache entries do not store lease values. They store compact
-    /// `(buffer, slot)` entries, and the cache accounts for one banked strong
-    /// reference per initialized entry.
-    ///
-    /// # Safety
-    ///
-    /// `count` must match the number of returned entries. The caller must own
-    /// `count` banked strong references for `class`, and every entry must
-    /// belong to that size class. At least one of those references must keep
-    /// the class alive until after the entries are parked in the global
-    /// freelist.
-    #[inline(always)]
-    unsafe fn return_banked_global_batch(
-        class: SizeClassToken,
-        entries: impl IntoIterator<Item = (u32, PooledBuffer)>,
-        count: usize,
-    ) {
-        debug_assert!(count > 0);
-        // SAFETY: guaranteed by the caller.
-        unsafe { class.as_ref() }.global.put_batch(entries);
-        for _ in 0..count {
-            // SAFETY: guaranteed by the caller.
-            unsafe { class.release() };
-        }
     }
 }
 
@@ -1109,14 +1056,28 @@ impl Drop for TlsSizeClassCache {
             return;
         }
 
-        let mut entries = Vec::with_capacity(count);
-        while let Some(entry) = self.pop_local() {
-            entries.push((entry.slot, entry.buffer));
+        let class = self.class;
+        let end = self.len;
+        self.len = 0;
+        let entries = self.entries.as_mut_ptr();
+        {
+            let entries = (0..end).rev().map(move |index| {
+                // SAFETY: `0..end` was initialized before `len` was reset to 0.
+                // Reading each slot moves it out and leaves the slot
+                // uninitialized.
+                let entry = unsafe { entries.add(index).read().assume_init() };
+                (entry.slot, entry.buffer)
+            });
+            // SAFETY: each initialized entry carries one banked class reference
+            // out of this cache. Because `count > 0`, those references keep
+            // `class` live while the entries are parked.
+            unsafe { class.as_ref() }.global.put_batch(entries);
         }
-        // SAFETY: each initialized entry represented one banked class
-        // reference owned by this cache. Because `count > 0`, those references
-        // keep `self.class` live for this drop.
-        unsafe { Self::return_banked_global_batch(self.class, entries, count) };
+        for _ in 0..count {
+            // SAFETY: each drained entry was returned to the global freelist, so
+            // its banked reference can be released.
+            unsafe { class.release() };
+        }
     }
 }
 
@@ -1132,7 +1093,7 @@ impl Drop for TlsSizeClassCache {
 /// entry is a [`TlsSizeClassCache`] for that global size class. Missing entries
 /// mean this thread has not used that size class yet. Holes can remain for the
 /// lifetime of the thread because class ids are monotonic and never reused.
-/// Empty initialized caches can also remain after their pool has been dropped;
+/// Empty initialized caches can also remain after their pool has been dropped,
 /// their class token is inert while the cache is empty. If the class is still
 /// live because a pooled buffer is outstanding, a later return of that buffer
 /// to this same thread can bank a fresh reference and make the cache usable
@@ -1170,16 +1131,6 @@ impl TlsSizeClassCaches {
         self.init(class)
     }
 
-    /// Returns an initialized cache without creating a missing one.
-    ///
-    /// This is used on the drop path. If the dropping thread never allocated
-    /// from this size class, returning the buffer to the global freelist avoids
-    /// creating thread-local state from arbitrary destructor code.
-    #[inline(always)]
-    fn get(&mut self, class_id: usize) -> Option<&mut TlsSizeClassCache> {
-        self.bins.get_mut(class_id).and_then(Option::as_mut)
-    }
-
     /// Initializes and returns the cache for `class_id`.
     ///
     /// This is separate from [`Self::get_or_init`] so the steady-state TLS hit
@@ -1194,6 +1145,16 @@ impl TlsSizeClassCaches {
         }
         self.bins[class_id]
             .get_or_insert_with(|| TlsSizeClassCache::new(class, class.thread_cache_capacity))
+    }
+
+    /// Returns an initialized cache without creating a missing one.
+    ///
+    /// This is used on the drop path. If the dropping thread never allocated
+    /// from this size class, returning the buffer to the global freelist avoids
+    /// creating thread-local state from arbitrary destructor code.
+    #[inline(always)]
+    fn get(&mut self, class_id: usize) -> Option<&mut TlsSizeClassCache> {
+        self.bins.get_mut(class_id).and_then(Option::as_mut)
     }
 }
 
@@ -1796,6 +1757,18 @@ mod tests {
             prefill: false,
             alignment: NZUsize!(page_size()),
         }
+    }
+
+    /// Returns the current strong count without changing it after the helper
+    /// returns.
+    fn size_class_strong_count(class: &SizeClassHandle) -> usize {
+        // SAFETY: the borrowed handle owns one strong reference for `class.token`
+        // for the duration of this call.
+        unsafe { class.token.retain() };
+        // SAFETY: the increment above created the strong reference consumed by
+        // this temporary Arc.
+        let arc = unsafe { Arc::from_raw(class.token.ptr.as_ptr()) };
+        Arc::strong_count(&arc) - 1
     }
 
     /// Helper to get the number of caller-owned tracked buffers for a size class.
@@ -2470,21 +2443,21 @@ mod tests {
     fn test_size_class_leases_use_raw_arc_tokens_across_cache_paths() {
         let class = test_size_class(64, 64);
         let mut cache = TlsSizeClassCache::new(&class, MIN_TLS_BATCH_CAPACITY);
-        assert_eq!(class.strong_count(), 1);
+        assert_eq!(size_class_strong_count(&class), 1);
 
         let (slot, buffer) = class.global.try_create(false).expect("slot reservation");
         let lease = SizeClassLease::retain(&class);
-        assert_eq!(class.strong_count(), 2);
+        assert_eq!(size_class_strong_count(&class), 2);
 
         // Moving a pooled-buffer lease into the local cache banks the same strong
         // reference; it should not clone the class.
         cache.push(lease, slot, buffer);
-        assert_eq!(class.strong_count(), 2);
+        assert_eq!(size_class_strong_count(&class), 2);
 
         let (entry, lease) = cache.pop(&class).expect("local cache pop");
-        assert_eq!(class.strong_count(), 2);
+        assert_eq!(size_class_strong_count(&class), 2);
         lease.return_global(entry.slot, entry.buffer);
-        assert_eq!(class.strong_count(), 1);
+        assert_eq!(size_class_strong_count(&class), 1);
 
         for _ in 0..2 {
             let (slot, buffer) = class.global.try_create(false).expect("slot reservation");
@@ -2492,15 +2465,15 @@ mod tests {
         }
 
         let (entry, lease) = cache.pop(&class).expect("global refill");
-        assert_eq!(class.strong_count(), 3);
+        assert_eq!(size_class_strong_count(&class), 3);
 
         lease.return_global(entry.slot, entry.buffer);
-        assert_eq!(class.strong_count(), 2);
+        assert_eq!(size_class_strong_count(&class), 2);
 
         // Dropping the cache returns the banked refill entry and releases its
         // size-class reference.
         drop(cache);
-        assert_eq!(class.strong_count(), 1);
+        assert_eq!(size_class_strong_count(&class), 1);
     }
 
     #[test]
@@ -2957,7 +2930,12 @@ mod tests {
         let class_index = pool
             .class_index(page)
             .expect("class exists for page-sized buffer");
-        let class = pool.inner.classes[class_index].clone();
+        let class = &pool.inner.classes[class_index];
+        // Keep a test-owned handle so the class remains inspectable after
+        // dropping the public pool below.
+        // SAFETY: `class` owns one strong reference for `class.token`.
+        unsafe { class.token.retain() };
+        let class = SizeClassHandle { token: class.token };
 
         // Return one buffer to the current thread's local cache and overflow
         // the other into the shared global freelist.

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -13,7 +13,7 @@
 //!
 //! # Pool Lifecycle
 //!
-//! Checked-out tracked buffers and buffers cached in thread-local bins keep a
+//! Tracked buffers held by pooled views or cached in thread-local bins keep a
 //! strong reference to the originating size class. Buffers can outlive the
 //! public [`BufferPool`] handle and still return to their original size class.
 //! - Untracked fallback allocations store no class reference and deallocate
@@ -21,9 +21,9 @@
 //! - Requests smaller than [`BufferPoolConfig::pool_min_size`] bypass pooling
 //!   entirely and return untracked aligned allocations from both
 //!   [`BufferPool::try_alloc`] and [`BufferPool::alloc`].
-//! - Dropping [`BufferPool`] drains only the shared global freelists,
-//!   checked-out buffers and buffers cached in a live thread's local cache can
-//!   keep their size class alive until they are dropped or the thread exits.
+//! - Dropping [`BufferPool`] drains only the shared global freelists; pooled
+//!   views and buffers cached in a live thread's local cache can keep their
+//!   size class alive until they are dropped or the thread exits.
 //!
 //! # Size Classes
 //!
@@ -484,34 +484,41 @@ impl PoolMetrics {
 /// `SizeClass` alive until it returns.
 ///
 /// The pool has three buffer states, and those states determine where the
-/// strong size-class references live:
+/// strong size-class references live.
+///
+/// A "banked" strong reference is an owned `Arc<SizeClass>` reference counted by
+/// TLS cache state instead of represented by a [`SizeClassLease`] value in each
+/// [`TlsSizeClassCacheEntry`]. For a cache with `len` local entries, the cache
+/// owns exactly `len` banked references. Increasing `len` banks one reference;
+/// decreasing `len` transfers one reference back into a `SizeClassLease` or
+/// releases it to the global freelist.
 ///
 /// - Global freelist: the buffer is parked in [`SizeClass::global`] and carries
 ///   no per-buffer strong reference. While the public pool exists, the
 ///   [`SizeClassHandle`] in [`BufferPoolInner::classes`] keeps the class alive.
-/// - Checked out: the buffer is owned by a pooled I/O buffer and carries one
-///   [`SizeClassLease`], which is one strong reference to the class.
+/// - Pooled view: the buffer is owned by mutable or immutable I/O view state and
+///   carries one [`SizeClassLease`], which is one strong reference to the class.
 /// - Thread-local cache: the cache stores this token once and owns one banked
 ///   strong reference for each initialized [`TlsSizeClassCacheEntry`].
 ///
-/// Moving a buffer from the global freelist to checked-out or TLS state retains
+/// Moving a buffer from the global freelist to pooled view or TLS state retains
 /// one class reference. Moving it back to the global freelist releases that
-/// reference. Moving between checked-out and TLS state transfers the same
+/// reference. Moving between pooled view and TLS state transfers the same
 /// reference without touching the refcount.
 ///
 /// Dropping the public [`BufferPool`] drains globally parked buffers, then drops
-/// its `SizeClassHandle`s. Checked-out buffers and non-empty TLS caches may
+/// its `SizeClassHandle`s. Pooled views and non-empty TLS caches may
 /// keep the `SizeClass` alive after that point. Empty TLS caches may still
 /// remember a token value, but with no banked references that token is only an
 /// inert identity value and must not be dereferenced.
 ///
-/// This is the one raw pointer shape used by all pool-owned, checked-out, and
+/// This is the one raw pointer shape used by all pool-owned, pooled view, and
 /// thread-local references to a [`SizeClass`]. The pointer is always derived
 /// from [`Arc::into_raw`], so it satisfies the documented contract for
 /// [`Arc::increment_strong_count`] and [`Arc::decrement_strong_count`].
 ///
 /// `SizeClassToken` itself owns nothing. It is only an identity token and raw
-/// `Arc` handle:
+/// pointer accepted by the `Arc` refcount APIs:
 /// - [`SizeClassHandle`] pairs a token with ownership of one strong reference.
 /// - [`SizeClassLease`] pairs a token with ownership of one strong reference.
 /// - [`TlsSizeClassCache`] stores a token plus `len` banked strong references.
@@ -580,34 +587,35 @@ impl SizeClassToken {
     }
 }
 
-/// Owned size-class reference for a checked-out pooled buffer.
+/// Owned size-class reference for a pooled buffer outside the global freelist.
 ///
-/// A checked-out pooled buffer must keep its originating [`SizeClass`] alive so
-/// it can be returned after the [`BufferPool`] handle is dropped. This is one
-/// strong `Arc<SizeClass>` reference represented by a [`SizeClassToken`], with
-/// retain and release performed explicitly at the boundaries where a buffer
-/// enters or leaves global pool state.
+/// A pooled buffer outside the global freelist must keep its originating
+/// [`SizeClass`] alive so it can be returned after the [`BufferPool`] handle is
+/// dropped. This is one strong `Arc<SizeClass>` reference represented by a
+/// [`SizeClassToken`], with retain and release performed explicitly at the
+/// boundaries where a buffer enters or leaves global pool state.
 ///
 /// Lifetime-wise this is the same kind of reference as [`SizeClassHandle`]: both
 /// own exactly one strong reference for a token. The types are separate because
 /// they live in different state machines. `SizeClassHandle` is ordinary RAII
-/// ownership for the pool's class vector. `SizeClassLease` is hot-path
-/// checked-out ownership that must be explicitly transferred into TLS banking or
+/// ownership for the pool's class vector. `SizeClassLease` is hot-path pooled
+/// view ownership that must be explicitly transferred into TLS cache state or
 /// returned to the global freelist.
 ///
 /// The raw representation matters because the hot path mostly transfers
-/// ownership between a checked-out buffer and this thread's local cache. A real
+/// ownership between pooled view state and this thread's local cache. A real
 /// `Arc<SizeClass>` field is pointer-sized too, but it is a non-`Copy` value
 /// with drop glue. Even when the strong count would not change, moving it
 /// through pooled buffer and cache-entry structs makes the compiler preserve
 /// destructor paths for those structs. `SizeClassLease` has no automatic drop:
-/// moving between checked-out and local-cache state is a plain pointer
+/// moving between pooled view and local-cache state is a plain pointer
 /// transfer, and only explicit calls such as [`Self::return_global`] adjust the
 /// strong count.
 ///
-/// A lease must be consumed by one of those explicit transitions. Dropping the
-/// value without calling anything would leak the strong reference, which is why
-/// this type intentionally has no `Drop` implementation.
+/// A lease must be consumed by one of those explicit transitions, such as
+/// [`Self::into_banked`] or [`Self::return_global`]. Dropping the value without
+/// calling anything would leak the strong reference, which is why this type
+/// intentionally has no `Drop` implementation.
 ///
 /// Thread-local cache entries do not store a lease per entry. The cache stores
 /// the class token once and owns one banked strong reference for each initialized
@@ -628,7 +636,11 @@ unsafe impl Send for SizeClassLease {}
 unsafe impl Sync for SizeClassLease {}
 
 impl SizeClassLease {
-    /// Builds a lease from a banked class reference.
+    /// Converts one banked class reference into a lease.
+    ///
+    /// This does not retain the class. It only changes how an already-owned
+    /// strong reference is represented: from TLS cache state into a
+    /// `SizeClassLease` value.
     ///
     /// # Safety
     ///
@@ -640,7 +652,11 @@ impl SizeClassLease {
         Self { token: class.token }
     }
 
-    /// Builds a lease from a banked class reference and raw class token.
+    /// Converts one retained class reference into a lease using a raw token.
+    ///
+    /// This does not retain the class. It is used when the caller has a live
+    /// token plus ownership of a strong reference represented outside a
+    /// `SizeClassLease` value, usually in TLS cache state.
     ///
     /// # Safety
     ///
@@ -654,7 +670,7 @@ impl SizeClassLease {
 
     /// Retains `class` for a buffer leaving the global freelist.
     ///
-    /// Moving between checked-out state and TLS transfers the lease without
+    /// Moving between pooled view state and TLS transfers the lease without
     /// touching the strong count.
     #[inline(always)]
     fn retain(class: &SizeClassHandle) -> Self {
@@ -666,11 +682,14 @@ impl SizeClassLease {
         unsafe { Self::from_banked_token(token) }
     }
 
-    /// Transfers this checked-out lease into a TLS cache entry.
+    /// Transfers this lease into a TLS cache entry.
     ///
-    /// The cache must later materialize or release exactly one lease for the
-    /// entry. This is a no-op at runtime; it exists to mark the ownership
-    /// transition.
+    /// This does not release the class. It consumes the lease and relies on the
+    /// caller to record one additional banked reference in TLS cache state,
+    /// normally by storing an entry and increasing the cache length. The cache
+    /// must later materialize or release exactly one lease for that entry.
+    ///
+    /// This is a no-op at runtime; it exists to mark the ownership transition.
     #[inline(always)]
     const fn into_banked(self) {}
 
@@ -707,10 +726,11 @@ impl SizeClassLease {
     /// their references.
     ///
     /// `count` must match the number of returned entries. All entries must
-    /// belong to this lease's size class. This method consumes one logical
-    /// lease value but releases `count` strong references because it is used for
-    /// TLS cache state, where entries own banked references without storing one
-    /// [`SizeClassLease`] value per entry.
+    /// belong to this lease's size class. This method consumes one
+    /// `SizeClassLease` value as the live class handle for the batch, but it
+    /// releases `count` strong references because it is used for TLS cache
+    /// state, where entries own banked references without storing one lease
+    /// value per entry.
     ///
     /// As with [`Self::return_global`], buffers are inserted into the global
     /// freelist before any class references are released.
@@ -738,19 +758,19 @@ impl SizeClassLease {
 ///
 /// The global freelist owns the allocation layout, slot reservation counter,
 /// and parking cells for this class. A tracked buffer can be globally parked,
-/// checked out, or parked in one thread's local cache, but the slot always
-/// belongs to this `SizeClass`.
+/// owned by a pooled backing, or parked in one thread's local cache, but the
+/// slot always belongs to this `SizeClass`.
 ///
-/// Liveness is tied to where the buffer is parked. Global freelist entries rely
-/// on the pool's [`SizeClassHandle`] while the pool is alive and are drained
-/// when the pool is dropped. Checked-out buffers carry a [`SizeClassLease`].
+/// Liveness follows the buffer ownership state. Global freelist entries rely on
+/// the pool's [`SizeClassHandle`] while the pool is alive and are drained when
+/// the pool is dropped. Pooled backing values carry a [`SizeClassLease`].
 /// Thread-local cache entries use banked strong references owned by the cache.
 /// Those non-global states are what allow a buffer to outlive the public
 /// [`BufferPool`] handle and still return to the correct freelist.
 ///
 /// The freelist is the only place that deallocates tracked buffers. Returning a
 /// buffer to the freelist transfers buffer ownership back to `SizeClass` and
-/// releases the checked-out or banked strong reference that kept the class
+/// releases the pooled-backing or banked strong reference that kept the class
 /// alive while the buffer was outside the global freelist.
 ///
 /// Allocation prefers the local cache, then refills from the global freelist,
@@ -791,13 +811,13 @@ impl SizeClass {
 ///
 /// `SizeClassHandle` is the long-lived owner for a class while the
 /// [`BufferPoolInner`] exists. Dropping the handle releases that pool-owned
-/// strong reference. A class may still outlive the handle if checked-out buffers
-/// or thread-local cache entries own additional references through
+/// strong reference. A class may still outlive the handle if pooled backing
+/// values or thread-local cache entries own additional references through
 /// [`SizeClassLease`] or banked TLS refs.
 ///
 /// Functionally this is an `Arc<SizeClass>` stored in raw-token form. It exists
 /// to keep the pool-owned reference alive and to provide a live token for
-/// allocation paths that need to retain checked-out or TLS-banked references.
+/// allocation paths that need to retain pooled-backing or TLS-banked references.
 /// The raw form keeps the already-loaded class pointer usable for explicit
 /// refcount operations without calling [`Arc::as_ptr`] or storing a second token
 /// alongside an `Arc`.
@@ -885,9 +905,9 @@ impl std::ops::Deref for SizeClassHandle {
 
 /// Free tracked buffer owned by a thread-local size-class cache.
 ///
-/// This is allocator cache state, not a checked-out buffer. While an entry is
-/// held here, the buffer is owned by the current thread and is not visible to
-/// the class-global freelist.
+/// This is allocator cache state, not a caller-visible pooled view. While an
+/// entry is held here, the buffer is owned by the current thread and is not
+/// visible to the class-global freelist.
 ///
 /// The `slot` identifies the buffer within its [`SizeClass`]. The enclosing
 /// cache owns one banked size-class reference for this entry. The entry itself
@@ -910,13 +930,12 @@ struct TlsSizeClassCacheEntry {
 /// while `len == 0`, because an empty cache does not keep its pool alive. When
 /// `len > 0`, each initialized entry in `entries[..len]` owns one banked
 /// size-class reference, which keeps the pointed-to class alive. The entry
-/// itself stays small (`buffer, slot`); popping it materializes a checked-out
+/// itself stays small (`buffer, slot`); popping it materializes a
 /// [`SizeClassLease`] from one banked reference.
 ///
-/// "Banked" means the strong reference is represented by cache state rather
-/// than by a Rust value stored in the entry. The invariant is simply
-/// `len == number of banked class references`. Changing `len` is therefore an
-/// ownership transition as well as a stack operation.
+/// As described in [`SizeClassToken`], a banked reference is represented by
+/// cache state rather than by a Rust value stored in the entry. Changing `len`
+/// is therefore an ownership transition as well as a stack operation.
 ///
 /// The stale-token case is intentionally narrow: an empty cache may keep the
 /// token value for indexing/debug assertions, but it must not dereference that
@@ -1051,7 +1070,7 @@ impl TlsSizeClassCache {
 
         if self.len < self.capacity {
             debug_assert_eq!(self.class, class.token);
-            // The checked-out lease becomes one banked reference represented
+            // The returned lease becomes one banked reference represented
             // by the new local stack entry.
             class.into_banked();
             self.push_local(entry);
@@ -1147,7 +1166,7 @@ impl Drop for TlsSizeClassCache {
 /// lifetime of the thread because class ids are monotonic and never reused.
 /// Empty initialized caches can also remain after their pool has been dropped;
 /// their class token is inert while the cache is empty. It becomes usable again
-/// only if another checked-out buffer or allocation for that same live class
+/// only if another pooled buffer or allocation for that same live class
 /// reaches the cache and provides a live reference.
 ///
 /// We intentionally use `Vec<Option<...>>` because class ids are dense enough
@@ -1397,10 +1416,10 @@ pub(crate) struct BufferPoolInner {
 impl Drop for BufferPoolInner {
     fn drop(&mut self) {
         // The public pool is going away. Drain globally parked buffers while
-        // the pool-owned class handles are still live. Checked-out buffers and
-        // live TLS cache entries own their own size-class references; if they
-        // return later, they will park their buffer and release the reference
-        // that kept the class alive.
+        // the pool-owned class handles are still live. Pooled views and live
+        // TLS cache entries own their own size-class references; if they return
+        // later, they will park their buffer and release the reference that kept
+        // the class alive.
         for class in &self.classes {
             class.global.drain();
         }
@@ -1465,9 +1484,9 @@ impl BufferPoolInner {
 
 /// A pool of reusable, aligned buffers.
 ///
-/// Buffers are organized into power-of-two size classes. When a buffer is requested,
-/// the smallest size class that fits is used. Buffers are automatically returned to
-/// the pool when dropped.
+/// Buffers are organized into power-of-two size classes. When a buffer is
+/// requested, the smallest size class that fits is used. Pooled buffers are
+/// automatically returned when their final owning view is dropped.
 ///
 /// # Alignment
 ///
@@ -1814,7 +1833,7 @@ mod tests {
         }
     }
 
-    /// Helper to get the number of checked-out tracked buffers for a size class.
+    /// Helper to get the number of caller-owned tracked buffers for a size class.
     ///
     /// With TLS enabled, tracked buffers can be free in either the shared
     /// freelist or the current thread's local cache.
@@ -2436,7 +2455,7 @@ mod tests {
 
         assert!(class.thread_cache_capacity >= MIN_TLS_BATCH_CAPACITY);
 
-        // Drop enough distinct checked-out buffers to force an overflow from a
+        // Drop enough distinct pooled buffers to force an overflow from a
         // full local cache. Large bins should spill half the entries to global
         // and keep the remainder local for fast same-thread reuse.
         let mut bufs = Vec::new();
@@ -2492,14 +2511,14 @@ mod tests {
         let lease = SizeClassLease::retain(&class);
         assert_eq!(class.strong_count(), 2);
 
-        // Moving a checked-out lease into the local cache banks the same strong
+        // Moving a pooled-buffer lease into the local cache banks the same strong
         // reference; it should not clone the class.
         cache.push(lease, slot, buffer);
         assert_eq!(class.strong_count(), 2);
 
         let entry = cache.pop(&class).expect("local cache pop");
         // SAFETY: `cache.pop` transferred one banked size-class reference to
-        // this checked-out entry.
+        // this returned entry.
         let lease = unsafe { SizeClassLease::from_banked(&class) };
         assert_eq!(class.strong_count(), 2);
         lease.return_global(entry.slot, entry.buffer);
@@ -2512,7 +2531,7 @@ mod tests {
 
         let entry = cache.pop(&class).expect("global refill");
         // SAFETY: `cache.pop` transferred one banked size-class reference to
-        // this checked-out entry.
+        // this returned entry.
         let lease = unsafe { SizeClassLease::from_banked(&class) };
         assert_eq!(class.strong_count(), 3);
 

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -551,10 +551,10 @@ unsafe impl Sync for SizeClass {}
 ///
 /// Because the token is non-owning, it may be stale when held by an empty TLS
 /// cache. Code may dereference it or adjust the strong count only when another
-/// invariant proves the allocation is still live. For example, a
-/// [`SizeClassHandle`] proves liveness through its owned strong reference, and
-/// a non-empty [`TlsSizeClassCache`] proves liveness through its banked
-/// entries.
+/// invariant proves the allocation is still live. For example,
+/// [`SizeClassHandle`] and [`SizeClassLease`] prove liveness through owned
+/// strong references, and a non-empty [`TlsSizeClassCache`] proves liveness
+/// through its banked entries.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct SizeClassToken {
     ptr: ptr::NonNull<SizeClass>,
@@ -839,7 +839,8 @@ struct TlsSizeClassCacheEntry {
 ///
 /// An empty cache may keep a stale token only for identity checks. It must not
 /// dereference the token or adjust its strong count until a live
-/// [`SizeClassHandle`] or banked entry proves the class is still alive.
+/// [`SizeClassHandle`], [`SizeClassLease`], or banked entry proves the class is
+/// still alive.
 ///
 /// The hot steady-state allocation path pops an entry from `entries`, and the
 /// hot return path pushes one back while there is room.
@@ -853,15 +854,15 @@ struct TlsSizeClassCache {
 impl TlsSizeClassCache {
     /// Creates a new empty cache with the given maximum thread-cache size.
     ///
-    /// The cache stores `class.token` for identity, but starts with `len == 0`
-    /// and therefore owns no banked size-class references.
-    fn new(class: &SizeClassHandle, capacity: usize) -> Self {
+    /// The cache stores `class` for identity, but starts with `len == 0` and
+    /// therefore owns no banked size-class references.
+    fn new(class: SizeClassToken, capacity: usize) -> Self {
         let entries = (0..capacity)
             .map(|_| MaybeUninit::uninit())
             .collect::<Vec<_>>()
             .into_boxed_slice();
         Self {
-            class: class.token,
+            class,
             entries,
             len: 0,
             capacity,
@@ -1079,11 +1080,10 @@ impl Drop for TlsSizeClassCache {
 /// entry is a [`TlsSizeClassCache`] for that global size class. Missing entries
 /// mean this thread has not used that size class yet. Holes can remain for the
 /// lifetime of the thread because class ids are monotonic and never reused.
-/// Empty initialized caches can also remain after their pool has been dropped,
-/// their class token is inert while the cache is empty. If the class is still
-/// live because a pooled buffer is outstanding, a later return of that buffer
-/// to this same thread can bank a fresh reference and make the cache usable
-/// again.
+/// Empty initialized caches can also remain after their pool has been dropped.
+/// Their class token is inert while the cache is empty. If the class is still
+/// live because a pooled buffer is outstanding, a later return of that buffer to
+/// this same thread can bank a fresh reference and make the cache usable again.
 ///
 /// We intentionally use `Vec<Option<...>>` because class ids are dense enough
 /// for direct indexing to be cheaper than hashing, but a thread may initialize
@@ -1099,22 +1099,26 @@ impl TlsSizeClassCaches {
         Self { bins: Vec::new() }
     }
 
-    /// Returns the cache for `class`, creating it lazily on first use.
+    /// Returns the cache for the given class, creating it lazily on first use.
     ///
-    /// A missing cache is initialized from the live `class` handle. An existing
-    /// empty cache may contain a stale token from an older pool drop, but class
-    /// ids are never reused, so an existing entry for this `class_id` can only
-    /// refer to the same size class.
+    /// The caller must provide a live token from a [`SizeClassHandle`] or
+    /// [`SizeClassLease`]. A missing cache copies that token for identity only
+    /// and starts with no banked references. The first local push or global
+    /// refill is what banks references for entries in that cache.
     #[inline(always)]
-    fn get_or_init(&mut self, class: &SizeClassHandle) -> &mut TlsSizeClassCache {
-        let class_id = class.class_id;
+    fn get_or_init(
+        &mut self,
+        class: SizeClassToken,
+        class_id: usize,
+        capacity: usize,
+    ) -> &mut TlsSizeClassCache {
         if class_id < self.bins.len() && self.bins[class_id].is_some() {
             return self.bins[class_id]
                 .as_mut()
                 .expect("class cache was checked as initialized");
         }
 
-        self.init(class)
+        self.init(class, class_id, capacity)
     }
 
     /// Initializes and returns the cache for `class_id`.
@@ -1124,20 +1128,19 @@ impl TlsSizeClassCaches {
     /// `inline(never)` to keep the resize and allocation path out of pooled
     /// allocation and drop.
     #[inline(never)]
-    fn init(&mut self, class: &SizeClassHandle) -> &mut TlsSizeClassCache {
-        let class_id = class.class_id;
+    fn init(
+        &mut self,
+        class: SizeClassToken,
+        class_id: usize,
+        capacity: usize,
+    ) -> &mut TlsSizeClassCache {
         if class_id >= self.bins.len() {
             self.bins.resize_with(class_id + 1, || None);
         }
-        self.bins[class_id]
-            .get_or_insert_with(|| TlsSizeClassCache::new(class, class.thread_cache_capacity))
+        self.bins[class_id].get_or_insert_with(|| TlsSizeClassCache::new(class, capacity))
     }
 
     /// Returns an initialized cache without creating a missing one.
-    ///
-    /// This is used on the drop path. If the dropping thread never allocated
-    /// from this size class, returning the buffer to the global freelist avoids
-    /// creating thread-local state from arbitrary destructor code.
     #[inline(always)]
     fn get(&mut self, class_id: usize) -> Option<&mut TlsSizeClassCache> {
         self.bins.get_mut(class_id).and_then(Option::as_mut)
@@ -1161,6 +1164,12 @@ impl Drop for TlsSizeClassCaches {
 /// main TLS key owns the registry. It has a destructor, so thread exit drops
 /// the registry and each `TlsSizeClassCache` flushes its remaining entries to
 /// the class-global freelist.
+///
+/// Steady-state allocation and return first read `TLS_SIZE_CLASS_CACHES_FAST`.
+/// If it points at this thread's registry and the requested class cache is
+/// initialized, the caller touches only thread-local memory. Missing TLS state
+/// routes through `cache_slow` or `push_slow`, which access the owning TLS key,
+/// install the fast pointer, and lazily initialize the class cache.
 ///
 /// Rust's access path for TLS values with destructors includes checks for
 /// access during or after destruction. Those checks are correct, but they are
@@ -1202,9 +1211,13 @@ impl BufferPoolThreadCache {
     /// Returns a buffer to the current thread's local cache for the given
     /// size class, spilling to the global freelist if the cache is full.
     ///
-    /// This only uses an already-initialized local cache. If the current thread
-    /// has not initialized this size class, the buffer goes to the global
-    /// freelist rather than creating local state from a drop path.
+    /// The hot path uses only an already-initialized cache from the fast TLS
+    /// pointer. If the fast pointer is missing, or this thread has not
+    /// initialized the size class yet, [`Self::push_slow`] performs the checked
+    /// TLS access and creates the local cache. The returned lease is live proof
+    /// that initialization is safe. During thread-local teardown, checked TLS
+    /// access can fail, in that case the buffer falls back to the global
+    /// freelist.
     #[inline(always)]
     pub(super) fn push(lease: SizeClassLease, slot: u32, buffer: PooledBuffer) {
         let class = lease.class();
@@ -1213,9 +1226,6 @@ impl BufferPoolThreadCache {
             return;
         }
 
-        // Returning a pooled buffer can happen from arbitrary Drop code,
-        // including during thread-local destruction. If the local cache is
-        // unavailable, fall back to the global freelist instead of panicking.
         let caches = Self::TLS_SIZE_CLASS_CACHES_FAST.with(|fast| fast.get());
         if !caches.is_null() {
             // SAFETY: the fast pointer is set only from this thread's
@@ -1227,15 +1237,58 @@ impl BufferPoolThreadCache {
             }
         }
 
-        lease.return_global(slot, buffer);
+        Self::push_slow(lease, slot, buffer);
+    }
+
+    /// Returns a buffer to the current thread's local cache after the fast
+    /// lookup misses.
+    ///
+    /// This is called when the fast TLS pointer is not initialized, or when
+    /// that pointer exists but this size class has no local cache yet. It
+    /// installs the fast TLS pointer after successfully accessing the owning
+    /// TLS key, then initializes the size-class cache if needed.
+    ///
+    /// This is separate from [`Self::push`] so the steady-state return hot path
+    /// only contains the initialized-cache lookup and local push.
+    #[inline(never)]
+    fn push_slow(lease: SizeClassLease, slot: u32, buffer: PooledBuffer) {
+        // Returning a pooled buffer can happen from arbitrary Drop code,
+        // including during thread-local destruction. If the local cache is
+        // unavailable, fall back to the global freelist instead of panicking.
+        match Self::TLS_SIZE_CLASS_CACHES
+            .try_with(|caches| {
+                let class = lease.class();
+                let caches = caches.get();
+
+                // Publish the checked owner TLS address to the fast key.
+                Self::TLS_SIZE_CLASS_CACHES_FAST.with(|fast| fast.set(caches));
+
+                // SAFETY: this TLS value is only ever accessed by the current thread.
+                ptr::NonNull::from(unsafe {
+                    (&mut *caches).get_or_init(
+                        lease.token,
+                        class.class_id,
+                        class.thread_cache_capacity,
+                    )
+                })
+            })
+            .ok()
+        {
+            Some(mut cache) => {
+                // SAFETY: `cache` points to this thread's initialized TLS cache.
+                unsafe { cache.as_mut().push(lease, slot, buffer) };
+            }
+            None => lease.return_global(slot, buffer),
+        }
     }
 
     /// Takes a buffer from the current thread's local cache for the given
     /// size class, refilling from the global freelist if the cache is empty.
     ///
-    /// The local cache is checked first. On a local miss, the global freelist
-    /// is queried once. The first claimed buffer is returned to the caller, and
-    /// any additional claimed buffers are appended directly to the local cache.
+    /// The hot path uses only an already-initialized cache from the fast TLS
+    /// pointer. On a local miss, the global freelist is queried once. The first
+    /// claimed buffer is returned to the caller, and any additional claimed
+    /// buffers are appended directly to the local cache.
     #[inline(always)]
     fn pop(class: &SizeClassHandle) -> Option<(PooledBuffer, SizeClassLease, u32)> {
         if class.thread_cache_capacity == 0 {
@@ -1245,62 +1298,60 @@ impl BufferPoolThreadCache {
                 .map(|(slot, buffer)| (buffer, SizeClassLease::retain(class), slot));
         }
 
-        // Allocation can happen from caller-owned TLS destructors during thread
-        // teardown. If the local cache is unavailable, fall back to the global
-        // freelist instead of panicking.
-        #[allow(clippy::option_if_let_else)]
-        match Self::cache(class) {
-            Some(mut cache) => {
-                // SAFETY: `cache` points to this thread's initialized TLS cache.
-                unsafe { cache.as_mut().pop(class) }
-                    .map(|(entry, lease)| (entry.buffer, lease, entry.slot))
-            }
-            None => class
-                .global
-                .take()
-                .map(|(slot, buffer)| (buffer, SizeClassLease::retain(class), slot)),
-        }
-    }
-
-    /// Returns the current thread's local cache for `class`.
-    ///
-    /// The raw fast path serves steady-state accesses and initializes missing
-    /// size-class caches when the registry pointer is already available. The
-    /// checked TLS path is only needed when this thread has not stored the raw
-    /// registry pointer yet.
-    #[inline(always)]
-    fn cache(class: &SizeClassHandle) -> Option<ptr::NonNull<TlsSizeClassCache>> {
         let caches = Self::TLS_SIZE_CLASS_CACHES_FAST.with(|fast| fast.get());
         if !caches.is_null() {
             // SAFETY: the fast pointer is set only from this thread's
             // `TLS_SIZE_CLASS_CACHES` value and cleared before that value
             // drops.
-            return Some(ptr::NonNull::from(unsafe {
-                (&mut *caches).get_or_init(class)
-            }));
+            if let Some(cache) = unsafe { (&mut *caches).get(class.class_id) } {
+                return cache
+                    .pop(class)
+                    .map(|(entry, lease)| (entry.buffer, lease, entry.slot));
+            }
         }
 
-        Self::cache_slow(class)
+        // Resolve the cache and fall back to the global freelist if
+        // unavailable.
+        let Some(mut cache) = Self::cache_slow(class) else {
+            return class
+                .global
+                .take()
+                .map(|(slot, buffer)| (buffer, SizeClassLease::retain(class), slot));
+        };
+
+        // SAFETY: `cache` points to this thread's initialized TLS cache.
+        unsafe { cache.as_mut() }
+            .pop(class)
+            .map(|(entry, lease)| (entry.buffer, lease, entry.slot))
     }
 
-    /// Initializes the TLS fast path, then returns the local cache.
+    /// Resolves the local cache after the fast TLS or class-cache lookup
+    /// misses.
     ///
-    /// This runs once per thread, when [`Self::cache`] finds no cached registry
-    /// pointer. It goes through the checked owner TLS key, stores the registry
-    /// pointer in [`Self::TLS_SIZE_CLASS_CACHES_FAST`], and then initializes the
-    /// requested size-class cache if needed. We annotate with `inline(never)` to
-    /// keep that one-time setup out of pooled allocation and drop.
+    /// This is called when the fast TLS pointer is not initialized, or when
+    /// that pointer exists but this size class has no local cache yet. It
+    /// installs the fast TLS pointer after successfully accessing the owning
+    /// TLS key, then initializes the size-class cache if needed.
     #[inline(never)]
     fn cache_slow(class: &SizeClassHandle) -> Option<ptr::NonNull<TlsSizeClassCache>> {
-        // The owning TLS key has a destructor, so it can be unavailable during
-        // thread-local teardown.
+        // Allocation can happen from caller-owned TLS destructors during thread
+        // teardown. Return `None` instead of panicking if the owning TLS key is
+        // unavailable.
         Self::TLS_SIZE_CLASS_CACHES
             .try_with(|caches| {
                 let caches = caches.get();
+
+                // Publish the checked owner TLS address to the fast key.
                 Self::TLS_SIZE_CLASS_CACHES_FAST.with(|fast| fast.set(caches));
 
                 // SAFETY: this TLS value is only ever accessed by the current thread.
-                ptr::NonNull::from(unsafe { (&mut *caches).get_or_init(class) })
+                ptr::NonNull::from(unsafe {
+                    (&mut *caches).get_or_init(
+                        class.token,
+                        class.class_id,
+                        class.thread_cache_capacity,
+                    )
+                })
             })
             .ok()
     }
@@ -2418,7 +2469,7 @@ mod tests {
     #[test]
     fn test_size_class_leases_use_raw_arc_tokens_across_cache_paths() {
         let class = test_size_class(64, 64);
-        let mut cache = TlsSizeClassCache::new(&class, MIN_TLS_BATCH_CAPACITY);
+        let mut cache = TlsSizeClassCache::new(class.token, MIN_TLS_BATCH_CAPACITY);
         assert_eq!(size_class_strong_count(&class), 1);
 
         let (slot, buffer) = class.global.try_create(false).expect("slot reservation");
@@ -2457,7 +2508,7 @@ mod tests {
         let class = test_size_class(64, 64);
         let (slot, buffer) = class.global.try_create(false).expect("slot reservation");
         let lease = SizeClassLease::retain(&class);
-        let mut cache = TlsSizeClassCache::new(&class, 0);
+        let mut cache = TlsSizeClassCache::new(class.token, 0);
 
         // Small local capacities should bypass batching and push straight to
         // global. The retained reference above is represented by this lease and
@@ -2841,9 +2892,9 @@ mod tests {
         }
         drop(tx);
 
-        // Receive and drop on another thread. Since that thread has not
-        // initialized a local cache for this class, those returns should go to
-        // the global freelist instead of creating TLS state from a drop path.
+        // Receive and drop on another thread. Cross-thread returns initialize
+        // the dropping thread's local cache, so the buffers remain local to that
+        // thread instead of bouncing through the global freelist.
         let handle = thread::spawn(move || {
             while let Ok(iobuf) = rx.recv() {
                 drop(iobuf);
@@ -2852,13 +2903,13 @@ mod tests {
             let class_index = pool
                 .class_index(page)
                 .expect("class exists for page-sized buffer");
-            assert_eq!(get_local_len(&pool.inner.classes[class_index]), 0);
-            assert_eq!(get_global_len(&pool.inner.classes[class_index]), 50);
+            assert_eq!(get_local_len(&pool.inner.classes[class_index]), 50);
+            assert_eq!(get_global_len(&pool.inner.classes[class_index]), 0);
 
             for _ in 0..50 {
                 let _buf = pool
                     .try_alloc(page)
-                    .expect("dropping thread should be able to reuse globally returned buffers");
+                    .expect("dropping thread should be able to reuse locally returned buffers");
             }
         });
 

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -489,6 +489,18 @@ unsafe impl Send for SizeClassLease {}
 unsafe impl Sync for SizeClassLease {}
 
 impl SizeClassLease {
+    /// Returns the raw `Arc` pointer for `class`.
+    ///
+    /// `Arc::increment_strong_count` and `Arc::decrement_strong_count` require
+    /// pointers derived from `Arc::as_ptr`/`Arc::into_raw`. Building the pointer
+    /// through `&SizeClass` is equivalent for normal codegen, but loses the
+    /// provenance Miri expects for raw `Arc` refcount operations.
+    #[inline(always)]
+    fn class_ptr(class: &Arc<SizeClass>) -> ptr::NonNull<SizeClass> {
+        // SAFETY: `Arc::as_ptr` never returns null.
+        unsafe { ptr::NonNull::new_unchecked(Arc::as_ptr(class).cast_mut()) }
+    }
+
     /// Builds a lease from a banked class reference.
     ///
     /// # Safety
@@ -498,7 +510,7 @@ impl SizeClassLease {
     #[inline(always)]
     unsafe fn from_banked(class: &Arc<SizeClass>) -> Self {
         // SAFETY: guaranteed by the caller.
-        unsafe { Self::from_banked_ptr(ptr::NonNull::from(class.as_ref())) }
+        unsafe { Self::from_banked_ptr(Self::class_ptr(class)) }
     }
 
     /// Builds a lease from a banked class reference and raw class identity.
@@ -517,7 +529,7 @@ impl SizeClassLease {
     #[inline(always)]
     fn retain_banked(class: &Arc<SizeClass>) {
         // SAFETY: the pointer comes from a live `Arc<SizeClass>` borrowed above.
-        unsafe { Arc::increment_strong_count(ptr::from_ref(class.as_ref())) };
+        unsafe { Arc::increment_strong_count(Self::class_ptr(class).as_ptr()) };
     }
 
     /// Retains `class` for a buffer leaving the global freelist.
@@ -704,7 +716,7 @@ impl TlsSizeClassCache {
             .collect::<Vec<_>>()
             .into_boxed_slice();
         Self {
-            class: ptr::NonNull::from(class.as_ref()),
+            class: SizeClassLease::class_ptr(class),
             entries,
             len: 0,
             capacity,

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -159,10 +159,18 @@ pub struct BufferPoolConfig {
     /// Size-class slots are identified by `u32`, so the per-class capacity is
     /// capped by this type.
     pub max_per_class: NonZeroU32,
-    /// Whether to pre-allocate all buffers on pool creation.
+    /// Whether to create every tracked buffer during pool construction.
+    ///
+    /// When enabled, each size class creates `max_per_class` buffers and parks
+    /// them in the class-global freelist before the pool is returned. This
+    /// moves allocation cost to startup and makes the first reuse path avoid
+    /// heap allocation.
     pub prefill: bool,
     /// Buffer alignment. Must be a power of two.
-    /// Use `page_size()` for storage I/O and `cache_line_size()` for network I/O.
+    ///
+    /// Use page alignment for storage I/O that needs direct-I/O/DMA-compatible
+    /// buffers, and cache-line alignment for network I/O where smaller
+    /// alignment reduces internal fragmentation.
     pub alignment: NonZeroUsize,
     /// Expected number of threads concurrently accessing the pool.
     ///
@@ -381,6 +389,9 @@ impl BufferPoolConfig {
     }
 
     /// Returns the number of size classes between validated bounds.
+    ///
+    /// This assumes `min_size` and `max_size` came from a config that passed
+    /// [`Self::validate_size_class_bounds`]. No checking is repeated here.
     #[inline]
     const fn num_classes(min_size: usize, max_size: usize) -> usize {
         // Since sizes are powers of two, trailing zeros is the size-class
@@ -389,6 +400,15 @@ impl BufferPoolConfig {
     }
 
     /// Returns the buffer size for a validated size-class index.
+    ///
+    /// This assumes `min_size` is a validated power-of-two minimum and `index`
+    /// is less than [`Self::num_classes`] for the same validated bounds. No
+    /// range checking is done here.
+    ///
+    /// # Panics
+    ///
+    /// Panics on arithmetic overflow if `index` is outside the validated
+    /// size-class range.
     #[inline]
     const fn class_size(min_size: usize, index: usize) -> usize {
         min_size << index
@@ -452,13 +472,128 @@ impl PoolMetrics {
     }
 }
 
+/// Non-owning raw identity for a size class.
+///
+/// # Size-class lifetime model
+///
+/// A [`SizeClass`] owns the [`Freelist`] for one power-of-two buffer size. The
+/// freelist owns the allocation layout and deallocates every tracked
+/// [`PooledBuffer`] that is parked in it when the freelist is drained or
+/// dropped. A `PooledBuffer` does not carry enough information to deallocate
+/// itself, so any buffer outside the freelist must keep its originating
+/// `SizeClass` alive until it returns.
+///
+/// The pool has three buffer states, and those states determine where the
+/// strong size-class references live:
+///
+/// - Global freelist: the buffer is parked in [`SizeClass::global`] and carries
+///   no per-buffer strong reference. While the public pool exists, the
+///   [`SizeClassHandle`] in [`BufferPoolInner::classes`] keeps the class alive.
+/// - Checked out: the buffer is owned by a pooled I/O buffer and carries one
+///   [`SizeClassLease`], which is one strong reference to the class.
+/// - Thread-local cache: the cache stores this token once and owns one banked
+///   strong reference for each initialized [`TlsSizeClassCacheEntry`].
+///
+/// Moving a buffer from the global freelist to checked-out or TLS state retains
+/// one class reference. Moving it back to the global freelist releases that
+/// reference. Moving between checked-out and TLS state transfers the same
+/// reference without touching the refcount.
+///
+/// Dropping the public [`BufferPool`] drains globally parked buffers, then drops
+/// its `SizeClassHandle`s. Checked-out buffers and non-empty TLS caches may
+/// keep the `SizeClass` alive after that point. Empty TLS caches may still
+/// remember a token value, but with no banked references that token is only an
+/// inert identity value and must not be dereferenced.
+///
+/// This is the one raw pointer shape used by all pool-owned, checked-out, and
+/// thread-local references to a [`SizeClass`]. The pointer is always derived
+/// from [`Arc::into_raw`], so it satisfies the documented contract for
+/// [`Arc::increment_strong_count`] and [`Arc::decrement_strong_count`].
+///
+/// `SizeClassToken` itself owns nothing. It is only an identity token and raw
+/// `Arc` handle:
+/// - [`SizeClassHandle`] pairs a token with ownership of one strong reference.
+/// - [`SizeClassLease`] pairs a token with ownership of one strong reference.
+/// - [`TlsSizeClassCache`] stores a token plus `len` banked strong references.
+///
+/// Because the token is non-owning, it may be stale when held by an empty TLS
+/// cache. Code may dereference it or adjust the strong count only when another
+/// invariant proves the allocation is still live. For example, a
+/// [`SizeClassHandle`] proves liveness through its owned strong reference, and a
+/// non-empty [`TlsSizeClassCache`] proves liveness through its banked entries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SizeClassToken {
+    ptr: ptr::NonNull<SizeClass>,
+}
+
+impl SizeClassToken {
+    /// Creates a token from one owned `Arc` strong reference.
+    ///
+    /// The returned token is non-owning in the type system, but the raw pointer
+    /// still represents the strong reference consumed from `class`. The caller
+    /// must wrap it in an owning type, such as [`SizeClassHandle`], or otherwise
+    /// arrange for that strong reference to be released.
+    fn from_arc(class: Arc<SizeClass>) -> Self {
+        let ptr = Arc::into_raw(class).cast_mut();
+        // SAFETY: `Arc::into_raw` never returns null.
+        let ptr = unsafe { ptr::NonNull::new_unchecked(ptr) };
+        Self { ptr }
+    }
+
+    /// Returns the raw pointer accepted by `Arc` raw refcount APIs.
+    #[inline(always)]
+    const fn as_ptr(self) -> *const SizeClass {
+        self.ptr.as_ptr()
+    }
+
+    /// Returns the referenced size class.
+    ///
+    /// # Safety
+    ///
+    /// Some owner must currently hold a strong reference for this token.
+    #[inline(always)]
+    const unsafe fn as_ref(&self) -> &SizeClass {
+        // SAFETY: guaranteed by the caller.
+        unsafe { self.ptr.as_ref() }
+    }
+
+    /// Retains one strong reference for this token.
+    ///
+    /// # Safety
+    ///
+    /// Some owner must currently hold a strong reference for this token.
+    #[inline(always)]
+    unsafe fn retain(self) {
+        // SAFETY: guaranteed by the caller.
+        unsafe { Arc::increment_strong_count(self.as_ptr()) };
+    }
+
+    /// Releases one owned strong reference for this token.
+    ///
+    /// # Safety
+    ///
+    /// The caller must own one strong reference represented by this token.
+    #[inline(always)]
+    unsafe fn release(self) {
+        // SAFETY: guaranteed by the caller.
+        unsafe { Arc::decrement_strong_count(self.as_ptr()) };
+    }
+}
+
 /// Owned size-class reference for a checked-out pooled buffer.
 ///
 /// A checked-out pooled buffer must keep its originating [`SizeClass`] alive so
 /// it can be returned after the [`BufferPool`] handle is dropped. This is one
-/// strong `Arc<SizeClass>` reference represented as a raw pointer, with retain
-/// and release performed explicitly at the boundaries where a buffer enters or
-/// leaves global pool state.
+/// strong `Arc<SizeClass>` reference represented by a [`SizeClassToken`], with
+/// retain and release performed explicitly at the boundaries where a buffer
+/// enters or leaves global pool state.
+///
+/// Lifetime-wise this is the same kind of reference as [`SizeClassHandle`]: both
+/// own exactly one strong reference for a token. The types are separate because
+/// they live in different state machines. `SizeClassHandle` is ordinary RAII
+/// ownership for the pool's class vector. `SizeClassLease` is hot-path
+/// checked-out ownership that must be explicitly transferred into TLS banking or
+/// returned to the global freelist.
 ///
 /// The raw representation matters because the hot path mostly transfers
 /// ownership between a checked-out buffer and this thread's local cache. A real
@@ -470,66 +605,51 @@ impl PoolMetrics {
 /// transfer, and only explicit calls such as [`Self::return_global`] adjust the
 /// strong count.
 ///
+/// A lease must be consumed by one of those explicit transitions. Dropping the
+/// value without calling anything would leak the strong reference, which is why
+/// this type intentionally has no `Drop` implementation.
+///
 /// Thread-local cache entries do not store a lease per entry. The cache stores
-/// the class identity once and owns one banked strong reference for each
-/// initialized entry. Popping from the local cache materializes a lease from one
-/// of those banked references without touching the strong count.
+/// the class token once and owns one banked strong reference for each initialized
+/// entry. Popping from the local cache materializes a lease from one of those
+/// banked references without touching the strong count.
 ///
 /// Globally parked buffers do not carry a class reference: taking from the
 /// global freelist retains the class, and returning to the global freelist
 /// releases it.
 pub(crate) struct SizeClassLease {
-    ptr: ptr::NonNull<SizeClass>,
+    token: SizeClassToken,
 }
 
-// SAFETY: `SizeClassLease` points at a `SizeClass`, which is `Send`, and owns a
-// strong reference while it is live.
+// SAFETY: `SizeClassLease` owns one strong reference to a `SizeClass`, which is
+// `Send`.
 unsafe impl Send for SizeClassLease {}
 // SAFETY: same argument as `Send`, shared access to `SizeClass` is synchronized.
 unsafe impl Sync for SizeClassLease {}
 
 impl SizeClassLease {
-    /// Returns the raw `Arc` pointer for `class`.
-    ///
-    /// `Arc::increment_strong_count` and `Arc::decrement_strong_count` require
-    /// pointers derived from `Arc::as_ptr`/`Arc::into_raw`. Building the pointer
-    /// through `&SizeClass` is equivalent for normal codegen, but loses the
-    /// provenance Miri expects for raw `Arc` refcount operations.
-    #[inline(always)]
-    fn class_ptr(class: &Arc<SizeClass>) -> ptr::NonNull<SizeClass> {
-        // SAFETY: `Arc::as_ptr` never returns null.
-        unsafe { ptr::NonNull::new_unchecked(Arc::as_ptr(class).cast_mut()) }
-    }
-
     /// Builds a lease from a banked class reference.
     ///
     /// # Safety
     ///
-    /// The caller must have already retained one strong reference to `class`,
-    /// and that retained reference must be transferred to the returned lease.
+    /// The caller must own one banked strong reference for `class.token`, and
+    /// that retained reference must be transferred to the returned lease. This
+    /// must not consume the pool-owned reference held by `class` itself.
     #[inline(always)]
-    unsafe fn from_banked(class: &Arc<SizeClass>) -> Self {
-        // SAFETY: guaranteed by the caller.
-        unsafe { Self::from_banked_ptr(Self::class_ptr(class)) }
+    const unsafe fn from_banked(class: &SizeClassHandle) -> Self {
+        Self { token: class.token }
     }
 
-    /// Builds a lease from a banked class reference and raw class identity.
+    /// Builds a lease from a banked class reference and raw class token.
     ///
     /// # Safety
     ///
-    /// The caller must have already retained one strong reference to `ptr`, and
-    /// that retained reference must be transferred to the returned lease. `ptr`
-    /// must point to the matching live size class.
+    /// The caller must have already retained one strong reference for `token`,
+    /// and that retained reference must be transferred to the returned lease.
+    /// The token must identify the class that owns the returned buffer.
     #[inline(always)]
-    const unsafe fn from_banked_ptr(ptr: ptr::NonNull<SizeClass>) -> Self {
-        Self { ptr }
-    }
-
-    /// Retains one banked class reference without materializing a lease.
-    #[inline(always)]
-    fn retain_banked(class: &Arc<SizeClass>) {
-        // SAFETY: the pointer comes from a live `Arc<SizeClass>` borrowed above.
-        unsafe { Arc::increment_strong_count(Self::class_ptr(class).as_ptr()) };
+    const unsafe fn from_banked_token(token: SizeClassToken) -> Self {
+        Self { token }
     }
 
     /// Retains `class` for a buffer leaving the global freelist.
@@ -537,11 +657,13 @@ impl SizeClassLease {
     /// Moving between checked-out state and TLS transfers the lease without
     /// touching the strong count.
     #[inline(always)]
-    fn retain(class: &Arc<SizeClass>) -> Self {
-        Self::retain_banked(class);
-        // SAFETY: `retain_banked` above retained the strong reference
+    fn retain(class: &SizeClassHandle) -> Self {
+        let token = class.token;
+        // SAFETY: the borrowed `class` owns one strong reference for `token`.
+        unsafe { token.retain() };
+        // SAFETY: `retain` above retained the strong reference
         // transferred to the returned lease.
-        unsafe { Self::from_banked(class) }
+        unsafe { Self::from_banked_token(token) }
     }
 
     /// Transfers this checked-out lease into a TLS cache entry.
@@ -554,12 +676,12 @@ impl SizeClassLease {
 
     /// Returns the referenced size class.
     ///
-    /// The pointer is valid because `SizeClassLease` owns one strong reference.
+    /// The token is valid because `SizeClassLease` owns one strong reference.
     #[inline(always)]
     const fn class(&self) -> &SizeClass {
         // SAFETY: guaranteed by the ownership invariant documented on
         // `SizeClassLease`.
-        unsafe { self.ptr.as_ref() }
+        unsafe { self.token.as_ref() }
     }
 
     /// Returns the buffer size for this lease's size class.
@@ -570,18 +692,28 @@ impl SizeClassLease {
 
     /// Returns a buffer to this class's global freelist and releases the class
     /// reference.
+    ///
+    /// The buffer is parked before the strong reference is released. If this is
+    /// the last outstanding reference after the public pool has been dropped,
+    /// dropping the `SizeClass` will then drain the just-parked buffer.
     #[inline(always)]
     fn return_global(self, slot: u32, buffer: PooledBuffer) {
         self.class().global.put(slot, buffer);
-        // SAFETY: this pointer owns one strong reference.
-        unsafe { Arc::decrement_strong_count(self.ptr.as_ptr()) };
+        // SAFETY: this lease owns one strong reference.
+        unsafe { self.token.release() };
     }
 
     /// Returns several buffers to this class's global freelist and releases
     /// their references.
     ///
     /// `count` must match the number of returned entries. All entries must
-    /// belong to the same size class as this pointer.
+    /// belong to this lease's size class. This method consumes one logical
+    /// lease value but releases `count` strong references because it is used for
+    /// TLS cache state, where entries own banked references without storing one
+    /// [`SizeClassLease`] value per entry.
+    ///
+    /// As with [`Self::return_global`], buffers are inserted into the global
+    /// freelist before any class references are released.
     #[inline(always)]
     fn return_global_batch(
         self,
@@ -593,7 +725,7 @@ impl SizeClassLease {
         for _ in 0..count {
             // SAFETY: each returned entry owned one strong reference to this
             // same size class.
-            unsafe { Arc::decrement_strong_count(self.ptr.as_ptr()) };
+            unsafe { self.token.release() };
         }
     }
 }
@@ -604,12 +736,22 @@ impl SizeClassLease {
 /// - a shared global freelist for tracked buffers visible to all threads
 /// - a per-thread local cache for same-thread reuse
 ///
-/// The global freelist owns the allocation layout and slot reservation counter
-/// for the class. Checked-out buffers carry a [`SizeClassLease`] that owns one
-/// strong class reference. Thread-local caches store the class identity once and
-/// retain one extra strong reference per local entry instead of storing an `Arc`
-/// or pointer in each hot-path entry. Globally parked buffers do not carry a
-/// class reference.
+/// The global freelist owns the allocation layout, slot reservation counter,
+/// and parking cells for this class. A tracked buffer can be globally parked,
+/// checked out, or parked in one thread's local cache, but the slot always
+/// belongs to this `SizeClass`.
+///
+/// Liveness is tied to where the buffer is parked. Global freelist entries rely
+/// on the pool's [`SizeClassHandle`] while the pool is alive and are drained
+/// when the pool is dropped. Checked-out buffers carry a [`SizeClassLease`].
+/// Thread-local cache entries use banked strong references owned by the cache.
+/// Those non-global states are what allow a buffer to outlive the public
+/// [`BufferPool`] handle and still return to the correct freelist.
+///
+/// The freelist is the only place that deallocates tracked buffers. Returning a
+/// buffer to the freelist transfers buffer ownership back to `SizeClass` and
+/// releases the checked-out or banked strong reference that kept the class
+/// alive while the buffer was outside the global freelist.
 ///
 /// Allocation prefers the local cache, then refills from the global freelist,
 /// and only creates a new tracked buffer when no free buffer is available and
@@ -633,7 +775,44 @@ unsafe impl Send for SizeClass {}
 unsafe impl Sync for SizeClass {}
 
 impl SizeClass {
-    /// Creates a new size class with the given parameters.
+    /// Returns the buffer size for this class.
+    #[inline]
+    pub(super) const fn size(&self) -> usize {
+        self.size
+    }
+}
+
+/// Owning pool reference to a size class.
+///
+/// This is the pool's strong `Arc<SizeClass>` reference represented by a
+/// [`SizeClassToken`]. Keeping the pool's class vector in this form means the
+/// pointer used on hot allocation paths already satisfies the contract required
+/// by `Arc::{increment,decrement}_strong_count`.
+///
+/// `SizeClassHandle` is the long-lived owner for a class while the
+/// [`BufferPoolInner`] exists. Dropping the handle releases that pool-owned
+/// strong reference. A class may still outlive the handle if checked-out buffers
+/// or thread-local cache entries own additional references through
+/// [`SizeClassLease`] or banked TLS refs.
+///
+/// Functionally this is an `Arc<SizeClass>` stored in raw-token form. It exists
+/// to keep the pool-owned reference alive and to provide a live token for
+/// allocation paths that need to retain checked-out or TLS-banked references.
+/// The raw form keeps the already-loaded class pointer usable for explicit
+/// refcount operations without calling [`Arc::as_ptr`] or storing a second token
+/// alongside an `Arc`.
+struct SizeClassHandle {
+    token: SizeClassToken,
+}
+
+// SAFETY: `SizeClassHandle` owns a strong reference to a `SizeClass`, which is
+// `Send`.
+unsafe impl Send for SizeClassHandle {}
+// SAFETY: same argument as `Send`, shared access to `SizeClass` is synchronized.
+unsafe impl Sync for SizeClassHandle {}
+
+impl SizeClassHandle {
+    /// Creates a new size class and takes ownership of its initial strong ref.
     ///
     /// If `prefill` is true, the global freelist creates `max` buffers upfront
     /// and makes them immediately available for reuse.
@@ -645,29 +824,62 @@ impl SizeClass {
         parallelism: NonZeroUsize,
         thread_cache_capacity: usize,
         prefill: bool,
-    ) -> Arc<Self> {
+    ) -> Self {
         let layout = Layout::from_size_align(size, alignment).expect("alignment is a power of two");
         let freelist = Freelist::new(max, parallelism, layout, prefill);
-        Arc::new(Self {
+        let class = SizeClass {
             class_id,
             size,
             global: freelist,
             thread_cache_capacity,
-        })
-    }
-
-    /// Returns the buffer size for this class.
-    #[inline]
-    pub(super) const fn size(&self) -> usize {
-        self.size
+        };
+        Self {
+            token: SizeClassToken::from_arc(Arc::new(class)),
+        }
     }
 
     /// Creates a new tracked buffer and retains this size class for its slot.
     #[inline(always)]
-    fn try_create(self: &Arc<Self>, zeroed: bool) -> Option<(u32, PooledBuffer, SizeClassLease)> {
+    fn try_create(&self, zeroed: bool) -> Option<(u32, PooledBuffer, SizeClassLease)> {
         let (slot, buffer) = self.global.try_create(zeroed)?;
         let class = SizeClassLease::retain(self);
         Some((slot, buffer, class))
+    }
+
+    #[cfg(test)]
+    fn strong_count(&self) -> usize {
+        // SAFETY: this handle owns one strong reference for `self.token` for
+        // the duration of this call.
+        unsafe { self.token.retain() };
+        // SAFETY: the increment above created the strong reference consumed by
+        // this temporary Arc.
+        let arc = unsafe { Arc::from_raw(self.token.as_ptr()) };
+        Arc::strong_count(&arc) - 1
+    }
+}
+
+impl Clone for SizeClassHandle {
+    fn clone(&self) -> Self {
+        // SAFETY: this handle owns one strong reference for `self.token`.
+        unsafe { self.token.retain() };
+        Self { token: self.token }
+    }
+}
+
+impl Drop for SizeClassHandle {
+    fn drop(&mut self) {
+        // SAFETY: this handle owns one strong reference for `self.token`.
+        unsafe { self.token.release() };
+    }
+}
+
+impl std::ops::Deref for SizeClassHandle {
+    type Target = SizeClass;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: this handle owns one strong reference for `self.token`.
+        unsafe { self.token.as_ref() }
     }
 }
 
@@ -678,7 +890,9 @@ impl SizeClass {
 /// the class-global freelist.
 ///
 /// The `slot` identifies the buffer within its [`SizeClass`]. The enclosing
-/// cache owns one banked size-class reference for each initialized entry.
+/// cache owns one banked size-class reference for this entry. The entry itself
+/// intentionally stores only `(buffer, slot)` so local pop/push does not move a
+/// class pointer per buffer.
 struct TlsSizeClassCacheEntry {
     buffer: PooledBuffer,
     slot: u32,
@@ -688,21 +902,31 @@ struct TlsSizeClassCacheEntry {
 ///
 /// Each instance is stored in [`TlsSizeClassCaches`] under one global
 /// [`SizeClass::class_id`], so all entries in the cache belong to the same size
-/// class. The cache owns full [`PooledBuffer`] values while they are local,
+/// class. The cache owns full [`PooledBuffer`] values while they are local;
 /// returning them to the global freelist happens only on miss refill, overflow,
 /// explicit flush, or thread exit.
 ///
-/// `class` is a non-owning identity pointer. It can be stale while `len == 0`,
-/// because an empty cache does not keep its pool alive. When `len > 0`, each
-/// initialized entry in `entries[..len]` owns one banked size-class reference,
-/// which keeps the pointed-to class alive. The entry itself stays small
-/// (`buffer, slot`); popping it materializes the checked-out [`SizeClassLease`]
-/// from that banked reference.
+/// `class` is a non-owning token for this cache's size class. It can be stale
+/// while `len == 0`, because an empty cache does not keep its pool alive. When
+/// `len > 0`, each initialized entry in `entries[..len]` owns one banked
+/// size-class reference, which keeps the pointed-to class alive. The entry
+/// itself stays small (`buffer, slot`); popping it materializes a checked-out
+/// [`SizeClassLease`] from one banked reference.
+///
+/// "Banked" means the strong reference is represented by cache state rather
+/// than by a Rust value stored in the entry. The invariant is simply
+/// `len == number of banked class references`. Changing `len` is therefore an
+/// ownership transition as well as a stack operation.
+///
+/// The stale-token case is intentionally narrow: an empty cache may keep the
+/// token value for indexing/debug assertions, but it must not dereference that
+/// token or adjust its strong count unless a live [`SizeClassHandle`] or banked
+/// entry proves the class is still alive.
 ///
 /// The hot steady-state allocation path pops an entry from `entries`, and the
 /// hot return path pushes one back while there is room.
 struct TlsSizeClassCache {
-    class: ptr::NonNull<SizeClass>,
+    class: SizeClassToken,
     entries: Box<[MaybeUninit<TlsSizeClassCacheEntry>]>,
     len: usize,
     capacity: usize,
@@ -710,13 +934,16 @@ struct TlsSizeClassCache {
 
 impl TlsSizeClassCache {
     /// Creates a new empty cache with the given maximum thread-cache size.
-    fn new(class: &Arc<SizeClass>, capacity: usize) -> Self {
+    ///
+    /// The cache stores `class.token` for identity, but starts with `len == 0`
+    /// and therefore owns no banked size-class references.
+    fn new(class: &SizeClassHandle, capacity: usize) -> Self {
         let entries = (0..capacity)
             .map(|_| MaybeUninit::uninit())
             .collect::<Vec<_>>()
             .into_boxed_slice();
         Self {
-            class: SizeClassLease::class_ptr(class),
+            class: class.token,
             entries,
             len: 0,
             capacity,
@@ -729,8 +956,12 @@ impl TlsSizeClassCache {
     /// caches take only the buffer being returned to the caller. Larger caches
     /// batch-take from the global freelist, return the first claimed buffer,
     /// and retain the rest locally for future allocations.
+    ///
+    /// A returned entry always carries one banked size-class reference. The
+    /// caller must materialize that reference as a [`SizeClassLease`] or release
+    /// it.
     #[inline(always)]
-    fn pop(&mut self, class: &Arc<SizeClass>) -> Option<TlsSizeClassCacheEntry> {
+    fn pop(&mut self, class: &SizeClassHandle) -> Option<TlsSizeClassCacheEntry> {
         if let Some(entry) = self.pop_local() {
             return Some(entry);
         }
@@ -758,17 +989,24 @@ impl TlsSizeClassCache {
 
     /// Takes from the class-global freelist after the local stack misses.
     ///
+    /// Every claimed global entry gets one retained class reference. The first
+    /// claimed entry is returned to the caller as a banked entry; additional
+    /// claimed entries are parked in this cache and counted by `len`.
+    ///
     /// This is separate from [`Self::pop`] so the steady-state allocation hot path
     /// can inline only the local cache hit. We annotate with `inline(never)` to keep
     /// the refill and batching code out of `BufferPoolInner::try_alloc`, reducing
     /// hot-path code size and register pressure.
     #[inline(never)]
-    fn pop_global(&mut self, class: &Arc<SizeClass>) -> Option<TlsSizeClassCacheEntry> {
+    fn pop_global(&mut self, class: &SizeClassHandle) -> Option<TlsSizeClassCacheEntry> {
         // Tiny caches do not batch enough to justify the wider global
         // claim. Keep their miss path equivalent to a single take.
         if self.capacity < MIN_TLS_BATCH_CAPACITY {
             return class.global.take().map(|(slot, buffer)| {
-                SizeClassLease::retain_banked(class);
+                // Convert the globally parked buffer into a banked entry for
+                // the caller; `BufferPoolThreadCache::pop` materializes the
+                // lease immediately.
+                SizeClassLease::retain(class).into_banked();
                 TlsSizeClassCacheEntry { buffer, slot }
             });
         }
@@ -779,7 +1017,12 @@ impl TlsSizeClassCache {
         let mut entry = None;
         let take = self.capacity / 2;
         class.global.take_batch(take, |slot, buffer| {
-            SizeClassLease::retain_banked(class);
+            // Each claimed global entry becomes either the returned banked
+            // entry or a local cache entry, so each needs one retained class
+            // reference.
+            // SAFETY: the borrowed `class` owns one strong reference for its
+            // token while the refill runs.
+            unsafe { class.token.retain() };
             let cache_entry = TlsSizeClassCacheEntry { buffer, slot };
             if entry.is_none() {
                 // Hand the first claimed buffer to the allocation that missed
@@ -807,6 +1050,9 @@ impl TlsSizeClassCache {
         let entry = TlsSizeClassCacheEntry { buffer, slot };
 
         if self.len < self.capacity {
+            debug_assert_eq!(self.class, class.token);
+            // The checked-out lease becomes one banked reference represented
+            // by the new local stack entry.
             class.into_banked();
             self.push_local(entry);
             return;
@@ -856,11 +1102,13 @@ impl TlsSizeClassCache {
             spilled.push((spilled_entry.slot, spilled_entry.buffer));
         }
         // SAFETY: each spilled entry represents one banked class reference
-        // owned by this cache. `self.len` was non-zero, so those references keep
-        // `self.class` live.
-        unsafe { SizeClassLease::from_banked_ptr(self.class) }.return_global_batch(spilled, spill);
+        // owned by this cache. Because `spill > 0`, at least one of those
+        // references keeps `self.class` live for the batch release.
+        unsafe { SizeClassLease::from_banked_token(self.class) }
+            .return_global_batch(spilled, spill);
 
         debug_assert!(self.len < self.capacity);
+        debug_assert_eq!(self.class, class.token);
         class.into_banked();
         self.push_local(entry);
     }
@@ -878,9 +1126,10 @@ impl Drop for TlsSizeClassCache {
             entries.push((entry.slot, entry.buffer));
         }
         // SAFETY: each initialized entry represented one banked class
-        // reference owned by this cache. Those references keep `self.class`
-        // live for the duration of this drop.
-        unsafe { SizeClassLease::from_banked_ptr(self.class) }.return_global_batch(entries, count);
+        // reference owned by this cache. Because `count > 0`, those references
+        // keep `self.class` live for this drop.
+        unsafe { SizeClassLease::from_banked_token(self.class) }
+            .return_global_batch(entries, count);
     }
 }
 
@@ -897,8 +1146,9 @@ impl Drop for TlsSizeClassCache {
 /// mean this thread has not used that size class yet. Holes can remain for the
 /// lifetime of the thread because class ids are monotonic and never reused.
 /// Empty initialized caches can also remain after their pool has been dropped;
-/// their class identity is inert until another checked-out buffer or allocation
-/// for that same live class reaches the cache.
+/// their class token is inert while the cache is empty. It becomes usable again
+/// only if another checked-out buffer or allocation for that same live class
+/// reaches the cache and provides a live reference.
 ///
 /// We intentionally use `Vec<Option<...>>` because class ids are dense enough
 /// for direct indexing to be cheaper than hashing, but a thread may initialize
@@ -915,8 +1165,13 @@ impl TlsSizeClassCaches {
     }
 
     /// Returns the cache for `class`, creating it lazily on first use.
+    ///
+    /// A missing cache is initialized from the live `class` handle. An existing
+    /// empty cache may contain a stale token from an older pool drop, but class
+    /// ids are never reused, so an existing entry for this `class_id` can only
+    /// refer to the same size class.
     #[inline(always)]
-    fn get_or_init(&mut self, class: &Arc<SizeClass>) -> &mut TlsSizeClassCache {
+    fn get_or_init(&mut self, class: &SizeClassHandle) -> &mut TlsSizeClassCache {
         let class_id = class.class_id;
         if class_id < self.bins.len() && self.bins[class_id].is_some() {
             return self.bins[class_id]
@@ -928,6 +1183,10 @@ impl TlsSizeClassCaches {
     }
 
     /// Returns an initialized cache without creating a missing one.
+    ///
+    /// This is used on the drop path. If the dropping thread never allocated
+    /// from this size class, returning the buffer to the global freelist avoids
+    /// creating thread-local state from arbitrary destructor code.
     #[inline(always)]
     fn get(&mut self, class_id: usize) -> Option<&mut TlsSizeClassCache> {
         self.bins.get_mut(class_id).and_then(Option::as_mut)
@@ -940,7 +1199,7 @@ impl TlsSizeClassCaches {
     /// `inline(never)` to keep the resize and allocation path out of pooled
     /// allocation and drop.
     #[inline(never)]
-    fn init(&mut self, class: &Arc<SizeClass>) -> &mut TlsSizeClassCache {
+    fn init(&mut self, class: &SizeClassHandle) -> &mut TlsSizeClassCache {
         let class_id = class.class_id;
         if class_id >= self.bins.len() {
             self.bins.resize_with(class_id + 1, || None);
@@ -1047,7 +1306,7 @@ impl BufferPoolThreadCache {
     /// is queried once. The first claimed buffer is returned to the caller, and
     /// any additional claimed buffers are appended directly to the local cache.
     #[inline(always)]
-    fn pop(class: &Arc<SizeClass>) -> Option<(PooledBuffer, SizeClassLease, u32)> {
+    fn pop(class: &SizeClassHandle) -> Option<(PooledBuffer, SizeClassLease, u32)> {
         if class.thread_cache_capacity == 0 {
             return class
                 .global
@@ -1083,7 +1342,7 @@ impl BufferPoolThreadCache {
     /// checked TLS path is only needed when this thread has not stored the raw
     /// registry pointer yet.
     #[inline(always)]
-    fn cache(class: &Arc<SizeClass>) -> Option<ptr::NonNull<TlsSizeClassCache>> {
+    fn cache(class: &SizeClassHandle) -> Option<ptr::NonNull<TlsSizeClassCache>> {
         let caches = Self::TLS_SIZE_CLASS_CACHES_FAST.with(|fast| fast.get());
         if !caches.is_null() {
             // SAFETY: the fast pointer is set only from this thread's
@@ -1105,7 +1364,7 @@ impl BufferPoolThreadCache {
     /// requested size-class cache if needed. We annotate with `inline(never)` to
     /// keep that one-time setup out of pooled allocation and drop.
     #[inline(never)]
-    fn cache_slow(class: &Arc<SizeClass>) -> Option<ptr::NonNull<TlsSizeClassCache>> {
+    fn cache_slow(class: &SizeClassHandle) -> Option<ptr::NonNull<TlsSizeClassCache>> {
         // The owning TLS key has a destructor, so it can be unavailable during
         // thread-local teardown.
         Self::TLS_SIZE_CLASS_CACHES
@@ -1131,12 +1390,17 @@ struct Allocation {
 /// Internal state of the buffer pool.
 pub(crate) struct BufferPoolInner {
     config: BufferPoolConfig,
-    classes: Vec<Arc<SizeClass>>,
+    classes: Vec<SizeClassHandle>,
     metrics: PoolMetrics,
 }
 
 impl Drop for BufferPoolInner {
     fn drop(&mut self) {
+        // The public pool is going away. Drain globally parked buffers while
+        // the pool-owned class handles are still live. Checked-out buffers and
+        // live TLS cache entries own their own size-class references; if they
+        // return later, they will park their buffer and release the reference
+        // that kept the class alive.
         for class in &self.classes {
             class.global.drain();
         }
@@ -1180,7 +1444,7 @@ impl BufferPoolInner {
     /// path can inline the TLS hit without also carrying slot reservation,
     /// metrics, and heap-allocation code.
     #[inline(never)]
-    fn try_alloc_new(&self, class: &Arc<SizeClass>, zeroed: bool) -> Option<Allocation> {
+    fn try_alloc_new(&self, class: &SizeClassHandle, zeroed: bool) -> Option<Allocation> {
         let label = SizeClassLabel {
             size_class: class.size as u64,
         };
@@ -1258,7 +1522,7 @@ impl BufferPool {
         for i in 0..num_classes {
             let size = BufferPoolConfig::class_size(config.min_size.get(), i);
             let class_id = NEXT_SIZE_CLASS_ID.fetch_add(1, Ordering::Relaxed);
-            let class = SizeClass::new(
+            let class = SizeClassHandle::new(
                 class_id,
                 size,
                 config.alignment.get(),
@@ -1293,6 +1557,10 @@ impl BufferPool {
     }
 
     /// Returns the size class index for a given size, or `None` if `size > max_size`.
+    ///
+    /// Pool construction validates the size-class bounds. This helper is in the
+    /// allocation hot path, so it assumes those invariants and does not repeat
+    /// validation.
     #[inline(always)]
     fn class_index(&self, size: usize) -> Option<usize> {
         let min_size = self.inner.config.min_size.get();
@@ -1326,7 +1594,7 @@ impl BufferPool {
         class_index
     }
 
-    /// Attempts to allocate a pooled buffer.
+    /// Attempts to allocate a buffer without falling back on pool miss.
     ///
     /// Unlike [`Self::alloc`], this method does not fall back to untracked
     /// allocation on exhaustion or oversized requests. Requests smaller than
@@ -1343,7 +1611,7 @@ impl BufferPool {
     /// # Errors
     ///
     /// - [`PoolError::Oversized`]: `capacity` exceeds `max_size`
-    /// - [`PoolError::Exhausted`]: Pool exhausted for required size class
+    /// - [`PoolError::Exhausted`]: pool exhausted for the required size class
     #[inline(always)]
     pub fn try_alloc(&self, capacity: usize) -> Result<IoBufMut, PoolError> {
         if capacity < self.inner.config.pool_min_size {
@@ -1373,13 +1641,15 @@ impl BufferPool {
     /// other [`bytes::BufMut`] methods to write data to the buffer.
     ///
     /// If the pool can provide a buffer (capacity within limits and pool not
-    /// exhausted), returns a pooled buffer that will be returned to the pool
-    /// when dropped. Requests smaller than [`BufferPoolConfig::pool_min_size`]
-    /// bypass pooling and return an untracked aligned allocation. Otherwise, oversized or
-    /// exhausted requests fall back to an untracked aligned heap allocation
-    /// that is deallocated when dropped.
+    /// exhausted), this returns a pooled buffer that will be returned to the
+    /// pool when dropped. Requests smaller than
+    /// [`BufferPoolConfig::pool_min_size`] bypass pooling and return an
+    /// untracked aligned allocation. Oversized or exhausted requests also fall
+    /// back to an untracked aligned heap allocation that is deallocated when
+    /// dropped.
     ///
-    /// Use [`Self::try_alloc`] if you need pooled-only behavior.
+    /// Use [`Self::try_alloc`] if eligible requests must fail instead of
+    /// falling back to direct allocation.
     ///
     /// # Initialization
     ///
@@ -1407,7 +1677,8 @@ impl BufferPool {
         buf
     }
 
-    /// Attempts to allocate a zero-initialized pooled buffer.
+    /// Attempts to allocate a zero-initialized buffer without falling back on
+    /// pool miss.
     ///
     /// Unlike [`Self::alloc_zeroed`], this method does not fall back to
     /// untracked allocation on exhaustion or oversized requests. Requests
@@ -1424,7 +1695,7 @@ impl BufferPool {
     /// # Errors
     ///
     /// - [`PoolError::Oversized`]: `len` exceeds `max_size`
-    /// - [`PoolError::Exhausted`]: Pool exhausted for required size class
+    /// - [`PoolError::Exhausted`]: pool exhausted for the required size class
     pub fn try_alloc_zeroed(&self, len: usize) -> Result<IoBufMut, PoolError> {
         if len < self.inner.config.pool_min_size {
             let size = len.max(1);
@@ -1465,16 +1736,18 @@ impl BufferPool {
     /// The returned buffer has `len() == len` and `capacity() >= len`.
     ///
     /// If the pool can provide a buffer (len within limits and pool not
-    /// exhausted), returns a pooled buffer that will be returned to the pool
-    /// when dropped. Requests smaller than [`BufferPoolConfig::pool_min_size`]
-    /// bypass pooling and return an untracked aligned allocation. Otherwise, oversized or
-    /// exhausted requests fall back to an untracked aligned heap allocation
-    /// that is deallocated when dropped.
+    /// exhausted), this returns a pooled buffer that will be returned to the
+    /// pool when dropped. Requests smaller than
+    /// [`BufferPoolConfig::pool_min_size`] bypass pooling and return an
+    /// untracked aligned allocation. Oversized or exhausted requests also fall
+    /// back to an untracked aligned heap allocation that is deallocated when
+    /// dropped.
     ///
     /// Use this for read APIs that require an initialized `&mut [u8]`.
     /// This avoids `unsafe set_len` at callsites.
     ///
-    /// Use [`Self::try_alloc_zeroed`] if you need pooled-only behavior.
+    /// Use [`Self::try_alloc_zeroed`] if eligible requests must fail instead of
+    /// falling back to direct allocation.
     ///
     /// # Initialization
     ///
@@ -1510,8 +1783,8 @@ mod tests {
         thread,
     };
 
-    fn test_size_class(size: usize, alignment: usize) -> Arc<SizeClass> {
-        SizeClass::new(
+    fn test_size_class(size: usize, alignment: usize) -> SizeClassHandle {
+        SizeClassHandle::new(
             NEXT_SIZE_CLASS_ID.fetch_add(1, Ordering::Relaxed),
             size,
             alignment,
@@ -2210,17 +2483,59 @@ mod tests {
     }
 
     #[test]
+    fn test_size_class_leases_use_raw_arc_tokens_across_cache_paths() {
+        let class = test_size_class(64, 64);
+        let mut cache = TlsSizeClassCache::new(&class, MIN_TLS_BATCH_CAPACITY);
+        assert_eq!(class.strong_count(), 1);
+
+        let (slot, buffer) = class.global.try_create(false).expect("slot reservation");
+        let lease = SizeClassLease::retain(&class);
+        assert_eq!(class.strong_count(), 2);
+
+        // Moving a checked-out lease into the local cache banks the same strong
+        // reference; it should not clone the class.
+        cache.push(lease, slot, buffer);
+        assert_eq!(class.strong_count(), 2);
+
+        let entry = cache.pop(&class).expect("local cache pop");
+        // SAFETY: `cache.pop` transferred one banked size-class reference to
+        // this checked-out entry.
+        let lease = unsafe { SizeClassLease::from_banked(&class) };
+        assert_eq!(class.strong_count(), 2);
+        lease.return_global(entry.slot, entry.buffer);
+        assert_eq!(class.strong_count(), 1);
+
+        for _ in 0..2 {
+            let (slot, buffer) = class.global.try_create(false).expect("slot reservation");
+            class.global.put(slot, buffer);
+        }
+
+        let entry = cache.pop(&class).expect("global refill");
+        // SAFETY: `cache.pop` transferred one banked size-class reference to
+        // this checked-out entry.
+        let lease = unsafe { SizeClassLease::from_banked(&class) };
+        assert_eq!(class.strong_count(), 3);
+
+        lease.return_global(entry.slot, entry.buffer);
+        assert_eq!(class.strong_count(), 2);
+
+        // Dropping the cache returns the banked refill entry and releases its
+        // size-class reference.
+        drop(cache);
+        assert_eq!(class.strong_count(), 1);
+    }
+
+    #[test]
     fn test_tls_size_class_cache_push_tolerates_empty_spill() {
         let class = test_size_class(64, 64);
         let (slot, buffer) = class.global.try_create(false).expect("slot reservation");
-        SizeClassLease::retain_banked(&class);
+        let lease = SizeClassLease::retain(&class);
         let mut cache = TlsSizeClassCache::new(&class, 0);
 
-        // Small local capacities should bypass batching and push straight to global.
-        // SAFETY: the retained reference above is represented by this lease and
+        // Small local capacities should bypass batching and push straight to
+        // global. The retained reference above is represented by this lease and
         // transferred into `cache.push`.
-        let class = unsafe { SizeClassLease::from_banked(&class) };
-        cache.push(class, slot, buffer);
+        cache.push(lease, slot, buffer);
         assert_eq!(cache.len, 0);
         drop(cache);
     }
@@ -2230,7 +2545,7 @@ mod tests {
         // Use a two-slot class with TLS capacity one so this test can exercise
         // the class-global freelist directly without involving local-cache
         // refill or spill behavior.
-        let class = SizeClass::new(
+        let class = SizeClassHandle::new(
             NEXT_SIZE_CLASS_ID.fetch_add(1, Ordering::Relaxed),
             64,
             64,

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -940,24 +940,17 @@ impl TlsSizeClassCache {
         class.global.take_batch(take, |slot, buffer| {
             // Each claimed global entry becomes either the returned lease or a
             // local cache entry, so each needs one retained class reference.
-            //
-            // SAFETY: the borrowed `class` owns one strong reference for its
-            // token while the refill runs.
-            unsafe { class.token.retain() };
             let cache_entry = TlsSizeClassCacheEntry { buffer, slot };
+            let lease = SizeClassLease::retain(class);
             if entry.is_none() {
                 // Hand the first claimed buffer to the allocation that missed
                 // locally. Additional claimed buffers refill the local cache.
-                //
-                // SAFETY: `class.token.retain()` above retained the strong
-                // reference transferred to this returned lease.
-                let lease = unsafe { SizeClassLease::from_banked(class) };
                 entry = Some((cache_entry, lease));
             } else {
                 // The take count is derived from the target occupancy, so
                 // refill cannot overflow the local cache. Push directly to
                 // avoid the spill checks used by return-to-cache.
-                self.push_local(cache_entry);
+                self.push_local(cache_entry, lease);
             }
         });
 
@@ -975,10 +968,8 @@ impl TlsSizeClassCache {
         let entry = TlsSizeClassCacheEntry { buffer, slot };
 
         if self.len < self.capacity {
-            // The returned lease becomes one banked reference represented by
-            // the new local stack entry.
-            class.into_banked();
-            self.push_local(entry);
+            // Keep the returned entry local while there is room.
+            self.push_local(entry, class);
             return;
         }
 
@@ -988,10 +979,12 @@ impl TlsSizeClassCache {
 
     /// Pushes one entry onto this thread's local stack.
     ///
-    /// The caller must ensure the stack has room and must transfer one
-    /// size-class reference into banked local-cache ownership.
+    /// The caller must ensure the stack has room. `class` becomes the banked
+    /// size-class reference represented by `entry`.
     #[inline(always)]
-    fn push_local(&mut self, entry: TlsSizeClassCacheEntry) {
+    fn push_local(&mut self, entry: TlsSizeClassCacheEntry, class: SizeClassLease) {
+        class.into_banked();
+
         // SAFETY: the caller ensured `self.len < self.capacity`, so this slot
         // is in bounds and currently uninitialized.
         unsafe {
@@ -1042,10 +1035,8 @@ impl TlsSizeClassCache {
                 (entry.slot, entry.buffer)
             }));
 
-        // The incoming lease becomes one banked reference represented by the
-        // new local stack entry.
-        class.into_banked();
-        self.push_local(entry);
+        // Keep the incoming entry local after making room.
+        self.push_local(entry, class);
     }
 }
 
@@ -1338,7 +1329,7 @@ impl Drop for BufferPoolInner {
     fn drop(&mut self) {
         // The public pool is going away. Drain globally parked buffers while
         // the pool-owned class handles are still live. Pooled views and live
-        // TLS cache entries own their own size-class references; if they return
+        // TLS cache entries own their own size-class references, if they return
         // later, they will park their buffer and release the reference that kept
         // the class alive.
         for class in &self.classes {
@@ -1497,10 +1488,6 @@ impl BufferPool {
     }
 
     /// Returns the size class index for a given size, or `None` if `size > max_size`.
-    ///
-    /// Pool construction validates the size-class bounds. This helper is in the
-    /// allocation hot path, so it assumes those invariants and does not repeat
-    /// validation.
     #[inline(always)]
     fn class_index(&self, size: usize) -> Option<usize> {
         let min_size = self.inner.config.min_size.get();
@@ -1582,14 +1569,13 @@ impl BufferPool {
     ///
     /// If the pool can provide a buffer (capacity within limits and pool not
     /// exhausted), this returns a pooled buffer that will be returned to the
-    /// pool when dropped. Requests smaller than
-    /// [`BufferPoolConfig::pool_min_size`] bypass pooling and return an
-    /// untracked aligned allocation. Oversized or exhausted requests also fall
-    /// back to an untracked aligned heap allocation that is deallocated when
-    /// dropped.
+    /// pool when dropped. Requests smaller than [`BufferPoolConfig::pool_min_size`]
+    /// bypass pooling and return an untracked aligned allocation. Oversized or
+    /// exhausted requests also fall back to an untracked aligned heap allocation
+    /// that is deallocated when dropped.
     ///
-    /// Use [`Self::try_alloc`] if eligible requests must fail instead of
-    /// falling back to direct allocation.
+    /// Use [`Self::try_alloc`] if eligible requests must fail instead of falling
+    /// back to direct allocation.
     ///
     /// # Initialization
     ///
@@ -1677,14 +1663,13 @@ impl BufferPool {
     ///
     /// If the pool can provide a buffer (len within limits and pool not
     /// exhausted), this returns a pooled buffer that will be returned to the
-    /// pool when dropped. Requests smaller than
-    /// [`BufferPoolConfig::pool_min_size`] bypass pooling and return an
-    /// untracked aligned allocation. Oversized or exhausted requests also fall
-    /// back to an untracked aligned heap allocation that is deallocated when
-    /// dropped.
+    /// pool when dropped. Requests smaller than [`BufferPoolConfig::pool_min_size`]
+    /// bypass pooling and return an untracked aligned allocation. Oversized or
+    /// exhausted requests also fall back to an untracked aligned heap allocation
+    /// that is deallocated when dropped.
     ///
-    /// Use this for read APIs that require an initialized `&mut [u8]`.
-    /// This avoids `unsafe set_len` at callsites.
+    /// Use this for read APIs that require an initialized `&mut [u8]`. This
+    /// avoids `unsafe set_len` at callsites.
     ///
     /// Use [`Self::try_alloc_zeroed`] if eligible requests must fail instead of
     /// falling back to direct allocation.
@@ -2445,7 +2430,7 @@ mod tests {
         assert_eq!(size_class_strong_count(&class), 2);
 
         // Moving a pooled-buffer lease into the local cache banks the same strong
-        // reference; it should not clone the class.
+        // reference, it should not clone the class.
         cache.push(lease, slot, buffer);
         assert_eq!(size_class_strong_count(&class), 2);
 

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -456,50 +456,100 @@ impl PoolMetrics {
     }
 }
 
+/// Per-size-class state.
+///
+/// Each class is a small two-level allocator:
+/// - a shared global freelist for tracked buffers visible to all threads
+/// - a per-thread local cache for same-thread reuse
+///
+/// The global freelist owns the allocation layout, slot reservation counter,
+/// and parking cells for this class. A tracked buffer can be globally parked,
+/// owned by a pooled backing, or parked in one thread's local cache, but the
+/// slot always belongs to this `SizeClass`.
+///
+/// Liveness follows the buffer ownership state. Global freelist entries rely on
+/// the pool's [`SizeClassHandle`] while the pool is alive and are drained when
+/// the pool is dropped. Pooled backing values carry a [`SizeClassLease`].
+/// Thread-local cache entries use banked strong references owned by the cache.
+/// Those non-global states are what allow a buffer to outlive the public
+/// [`BufferPool`] handle and still return to the correct freelist.
+///
+/// The freelist is the only place that deallocates tracked buffers. Returning a
+/// buffer to the freelist transfers buffer ownership back to `SizeClass` and
+/// releases the pooled-backing or banked strong reference that kept the class
+/// alive while the buffer was outside the global freelist.
+///
+/// Allocation prefers the local cache, then refills from the global freelist,
+/// and only creates a new tracked buffer when no free buffer is available and
+/// the class still has remaining capacity.
+pub(super) struct SizeClass {
+    /// Dense global identifier for the TLS cache registry.
+    class_id: usize,
+    /// The buffer size for this class.
+    size: usize,
+    /// Global free list of tracked buffers available for reuse.
+    global: Freelist,
+    /// Maximum number of buffers retained in the current thread's local bin.
+    thread_cache_capacity: usize,
+}
+
+// SAFETY: shared state in `SizeClass` is synchronized through atomics and the
+// global free set. Per-thread bins are stored in thread-local registries and only
+// accessed by the current thread.
+unsafe impl Send for SizeClass {}
+// SAFETY: see above.
+unsafe impl Sync for SizeClass {}
+
+impl SizeClass {
+    /// Returns the buffer size for this class.
+    #[inline]
+    pub(super) const fn size(&self) -> usize {
+        self.size
+    }
+}
+
 /// Non-owning raw identity for a size class.
 ///
 /// # Size-class lifetime model
 ///
-/// A [`SizeClass`] owns the [`Freelist`] for one power-of-two buffer size. The
-/// freelist owns the allocation layout and deallocates every tracked
-/// [`PooledBuffer`] that is parked in it when the freelist is drained or
-/// dropped. A `PooledBuffer` does not carry enough information to deallocate
-/// itself, so any buffer outside the freelist must keep its originating
-/// `SizeClass` alive until it returns.
+/// A [`SizeClass`] owns the [`Freelist`] for one buffer size class. The
+/// freelist creates tracked [`PooledBuffer`]s, owns the allocation layout
+/// needed to deallocate them, and is the only place that releases their memory.
+/// A `PooledBuffer` outside the freelist does not carry enough information to
+/// deallocate itself, so it must keep its originating `SizeClass` alive until
+/// it can return to that freelist.
 ///
 /// The pool has three buffer states, and those states determine where the
 /// strong size-class references live.
 ///
-/// A "banked" strong reference is an owned `Arc<SizeClass>` reference counted by
-/// TLS cache state instead of represented by a [`SizeClassLease`] value in each
-/// [`TlsSizeClassCacheEntry`]. For a cache with `len` local entries, the cache
-/// owns exactly `len` banked references. Increasing `len` banks one reference;
-/// decreasing `len` transfers one reference back into a `SizeClassLease` or
-/// releases it to the global freelist.
-///
 /// - Global freelist: the buffer is parked in [`SizeClass::global`] and carries
 ///   no per-buffer strong reference. While the public pool exists, the
 ///   [`SizeClassHandle`] in [`BufferPoolInner::classes`] keeps the class alive.
-/// - Pooled view: the buffer is owned by mutable or immutable I/O view state and
-///   carries one [`SizeClassLease`], which is one strong reference to the class.
-/// - Thread-local cache: the cache stores this token once and owns one banked
-///   strong reference for each initialized [`TlsSizeClassCacheEntry`].
+/// - Pooled view: the buffer is owned by mutable or immutable I/O view state
+///   and carries one [`SizeClassLease`], which is one strong reference to the
+///   class.
+/// - Thread-local cache: the [`TlsSizeClassCache`] stores the
+///   [`SizeClassToken`] once, and owns one banked strong reference for each
+///   initialized [`TlsSizeClassCacheEntry`]. A banked reference is an owned
+///   `Arc<SizeClass>` reference counted by TLS cache state instead of
+///   represented by a `SizeClassLease` value in each entry. Increasing `len`
+///   banks one reference, decreasing `len` transfers one reference back into a
+///   `SizeClassLease` or releases it to the global freelist.
 ///
 /// Moving a buffer from the global freelist to pooled view or TLS state retains
 /// one class reference. Moving it back to the global freelist releases that
 /// reference. Moving between pooled view and TLS state transfers the same
 /// reference without touching the refcount.
 ///
-/// Dropping the public [`BufferPool`] drains globally parked buffers, then drops
-/// its `SizeClassHandle`s. Pooled views and non-empty TLS caches may
-/// keep the `SizeClass` alive after that point. Empty TLS caches may still
-/// remember a token value, but with no banked references that token is only an
-/// inert identity value and must not be dereferenced.
+/// Dropping the public [`BufferPool`] drains globally parked buffers, then
+/// drops its `SizeClassHandle`s. Pooled views and non-empty TLS caches may keep
+/// the `SizeClass` alive after that point. Empty TLS caches may still remember
+/// a token value, but with no banked references that token is only an inert
+/// identity value and must not be dereferenced.
 ///
 /// This is the one raw pointer shape used by all pool-owned, pooled view, and
 /// thread-local references to a [`SizeClass`]. The pointer is always derived
-/// from [`Arc::into_raw`], so it satisfies the documented contract for
-/// [`Arc::increment_strong_count`] and [`Arc::decrement_strong_count`].
+/// from [`Arc::into_raw`].
 ///
 /// `SizeClassToken` itself owns nothing. It is only an identity token and raw
 /// pointer accepted by the `Arc` refcount APIs:
@@ -510,31 +560,26 @@ impl PoolMetrics {
 /// Because the token is non-owning, it may be stale when held by an empty TLS
 /// cache. Code may dereference it or adjust the strong count only when another
 /// invariant proves the allocation is still live. For example, a
-/// [`SizeClassHandle`] proves liveness through its owned strong reference, and a
-/// non-empty [`TlsSizeClassCache`] proves liveness through its banked entries.
+/// [`SizeClassHandle`] proves liveness through its owned strong reference, and
+/// a non-empty [`TlsSizeClassCache`] proves liveness through its banked
+/// entries.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct SizeClassToken {
     ptr: ptr::NonNull<SizeClass>,
 }
 
 impl SizeClassToken {
-    /// Creates a token from one owned `Arc` strong reference.
+    /// Creates a token and owns the initial strong reference for `class`.
     ///
     /// The returned token is non-owning in the type system, but the raw pointer
-    /// still represents the strong reference consumed from `class`. The caller
-    /// must wrap it in an owning type, such as [`SizeClassHandle`], or otherwise
-    /// arrange for that strong reference to be released.
-    fn from_arc(class: Arc<SizeClass>) -> Self {
-        let ptr = Arc::into_raw(class).cast_mut();
+    /// still represents one strong reference. The caller must wrap it in an
+    /// owning type, such as [`SizeClassHandle`], or otherwise arrange for that
+    /// strong reference to be released.
+    fn new(class: SizeClass) -> Self {
+        let ptr = Arc::into_raw(Arc::new(class)).cast_mut();
         // SAFETY: `Arc::into_raw` never returns null.
         let ptr = unsafe { ptr::NonNull::new_unchecked(ptr) };
         Self { ptr }
-    }
-
-    /// Returns the raw pointer accepted by `Arc` raw refcount APIs.
-    #[inline(always)]
-    const fn as_ptr(self) -> *const SizeClass {
-        self.ptr.as_ptr()
     }
 
     /// Returns the referenced size class.
@@ -556,7 +601,7 @@ impl SizeClassToken {
     #[inline(always)]
     unsafe fn retain(self) {
         // SAFETY: guaranteed by the caller.
-        unsafe { Arc::increment_strong_count(self.as_ptr()) };
+        unsafe { Arc::increment_strong_count(self.ptr.as_ptr()) };
     }
 
     /// Releases one owned strong reference for this token.
@@ -567,7 +612,109 @@ impl SizeClassToken {
     #[inline(always)]
     unsafe fn release(self) {
         // SAFETY: guaranteed by the caller.
-        unsafe { Arc::decrement_strong_count(self.as_ptr()) };
+        unsafe { Arc::decrement_strong_count(self.ptr.as_ptr()) };
+    }
+}
+
+/// Owning pool reference to a size class.
+///
+/// This is the pool's strong `Arc<SizeClass>` reference represented by a
+/// [`SizeClassToken`]. Keeping the pool's class vector in this form means the
+/// pointer used on hot allocation paths already satisfies the contract required
+/// by `Arc::{increment,decrement}_strong_count`.
+///
+/// `SizeClassHandle` is the long-lived owner for a class while the
+/// [`BufferPoolInner`] exists. Dropping the handle releases that pool-owned
+/// strong reference. A class may still outlive the handle if pooled backing
+/// values or thread-local cache entries own additional references through
+/// [`SizeClassLease`] or banked TLS refs.
+///
+/// Functionally this is an `Arc<SizeClass>` stored in raw-token form. It exists
+/// to keep the pool-owned reference alive and to provide a live token for
+/// allocation paths that need to retain pooled-backing or TLS-banked references.
+/// The raw form keeps the already-loaded class pointer usable for explicit
+/// refcount operations without calling [`Arc::as_ptr`] or storing a second token
+/// alongside an `Arc`.
+struct SizeClassHandle {
+    token: SizeClassToken,
+}
+
+// SAFETY: `SizeClassHandle` owns a strong reference to a `SizeClass`, which is
+// `Send`.
+unsafe impl Send for SizeClassHandle {}
+// SAFETY: same argument as `Send`, shared access to `SizeClass` is synchronized.
+unsafe impl Sync for SizeClassHandle {}
+
+impl SizeClassHandle {
+    /// Creates a new size class and takes ownership of its initial strong ref.
+    ///
+    /// If `prefill` is true, the global freelist creates `max` buffers upfront
+    /// and makes them immediately available for reuse.
+    fn new(
+        class_id: usize,
+        size: usize,
+        alignment: usize,
+        max: NonZeroU32,
+        parallelism: NonZeroUsize,
+        thread_cache_capacity: usize,
+        prefill: bool,
+    ) -> Self {
+        let layout = Layout::from_size_align(size, alignment).expect("alignment is a power of two");
+        let freelist = Freelist::new(max, parallelism, layout, prefill);
+        let class = SizeClass {
+            class_id,
+            size,
+            global: freelist,
+            thread_cache_capacity,
+        };
+        Self {
+            token: SizeClassToken::new(class),
+        }
+    }
+
+    /// Creates a new tracked buffer and retains this size class for its slot.
+    #[inline(always)]
+    fn try_create(&self, zeroed: bool) -> Option<(u32, PooledBuffer, SizeClassLease)> {
+        let (slot, buffer) = self.global.try_create(zeroed)?;
+        let class = SizeClassLease::retain(self);
+        Some((slot, buffer, class))
+    }
+
+    #[cfg(test)]
+    fn strong_count(&self) -> usize {
+        // SAFETY: this handle owns one strong reference for `self.token` for
+        // the duration of this call.
+        unsafe { self.token.retain() };
+        // SAFETY: the increment above created the strong reference consumed by
+        // this temporary Arc.
+        let arc = unsafe { Arc::from_raw(self.token.as_ptr()) };
+        Arc::strong_count(&arc) - 1
+    }
+}
+
+#[cfg(test)]
+impl Clone for SizeClassHandle {
+    fn clone(&self) -> Self {
+        // SAFETY: this handle owns one strong reference for `self.token`.
+        unsafe { self.token.retain() };
+        Self { token: self.token }
+    }
+}
+
+impl Drop for SizeClassHandle {
+    fn drop(&mut self) {
+        // SAFETY: this handle owns one strong reference for `self.token`.
+        unsafe { self.token.release() };
+    }
+}
+
+impl std::ops::Deref for SizeClassHandle {
+    type Target = SizeClass;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: this handle owns one strong reference for `self.token`.
+        unsafe { self.token.as_ref() }
     }
 }
 
@@ -609,7 +756,7 @@ impl SizeClassToken {
 /// Globally parked buffers do not carry a class reference: taking from the
 /// global freelist retains the class, and returning to the global freelist
 /// releases it.
-#[must_use = "SizeClassLease owns one size-class reference and must be returned or banked"]
+#[must_use]
 pub(crate) struct SizeClassLease {
     token: SizeClassToken,
 }
@@ -687,160 +834,6 @@ impl SizeClassLease {
         self.class().global.put(slot, buffer);
         // SAFETY: this lease owns one strong reference.
         unsafe { self.token.release() };
-    }
-}
-
-/// Per-size-class state.
-///
-/// Each class is a small two-level allocator:
-/// - a shared global freelist for tracked buffers visible to all threads
-/// - a per-thread local cache for same-thread reuse
-///
-/// The global freelist owns the allocation layout, slot reservation counter,
-/// and parking cells for this class. A tracked buffer can be globally parked,
-/// owned by a pooled backing, or parked in one thread's local cache, but the
-/// slot always belongs to this `SizeClass`.
-///
-/// Liveness follows the buffer ownership state. Global freelist entries rely on
-/// the pool's [`SizeClassHandle`] while the pool is alive and are drained when
-/// the pool is dropped. Pooled backing values carry a [`SizeClassLease`].
-/// Thread-local cache entries use banked strong references owned by the cache.
-/// Those non-global states are what allow a buffer to outlive the public
-/// [`BufferPool`] handle and still return to the correct freelist.
-///
-/// The freelist is the only place that deallocates tracked buffers. Returning a
-/// buffer to the freelist transfers buffer ownership back to `SizeClass` and
-/// releases the pooled-backing or banked strong reference that kept the class
-/// alive while the buffer was outside the global freelist.
-///
-/// Allocation prefers the local cache, then refills from the global freelist,
-/// and only creates a new tracked buffer when no free buffer is available and
-/// the class still has remaining capacity.
-pub(super) struct SizeClass {
-    /// Dense global identifier for the TLS cache registry.
-    class_id: usize,
-    /// The buffer size for this class.
-    size: usize,
-    /// Global free list of tracked buffers available for reuse.
-    global: Freelist,
-    /// Maximum number of buffers retained in the current thread's local bin.
-    thread_cache_capacity: usize,
-}
-
-// SAFETY: shared state in `SizeClass` is synchronized through atomics and the
-// global free set. Per-thread bins are stored in thread-local registries and only
-// accessed by the current thread.
-unsafe impl Send for SizeClass {}
-// SAFETY: see above.
-unsafe impl Sync for SizeClass {}
-
-impl SizeClass {
-    /// Returns the buffer size for this class.
-    #[inline]
-    pub(super) const fn size(&self) -> usize {
-        self.size
-    }
-}
-
-/// Owning pool reference to a size class.
-///
-/// This is the pool's strong `Arc<SizeClass>` reference represented by a
-/// [`SizeClassToken`]. Keeping the pool's class vector in this form means the
-/// pointer used on hot allocation paths already satisfies the contract required
-/// by `Arc::{increment,decrement}_strong_count`.
-///
-/// `SizeClassHandle` is the long-lived owner for a class while the
-/// [`BufferPoolInner`] exists. Dropping the handle releases that pool-owned
-/// strong reference. A class may still outlive the handle if pooled backing
-/// values or thread-local cache entries own additional references through
-/// [`SizeClassLease`] or banked TLS refs.
-///
-/// Functionally this is an `Arc<SizeClass>` stored in raw-token form. It exists
-/// to keep the pool-owned reference alive and to provide a live token for
-/// allocation paths that need to retain pooled-backing or TLS-banked references.
-/// The raw form keeps the already-loaded class pointer usable for explicit
-/// refcount operations without calling [`Arc::as_ptr`] or storing a second token
-/// alongside an `Arc`.
-struct SizeClassHandle {
-    token: SizeClassToken,
-}
-
-// SAFETY: `SizeClassHandle` owns a strong reference to a `SizeClass`, which is
-// `Send`.
-unsafe impl Send for SizeClassHandle {}
-// SAFETY: same argument as `Send`, shared access to `SizeClass` is synchronized.
-unsafe impl Sync for SizeClassHandle {}
-
-impl SizeClassHandle {
-    /// Creates a new size class and takes ownership of its initial strong ref.
-    ///
-    /// If `prefill` is true, the global freelist creates `max` buffers upfront
-    /// and makes them immediately available for reuse.
-    fn new(
-        class_id: usize,
-        size: usize,
-        alignment: usize,
-        max: NonZeroU32,
-        parallelism: NonZeroUsize,
-        thread_cache_capacity: usize,
-        prefill: bool,
-    ) -> Self {
-        let layout = Layout::from_size_align(size, alignment).expect("alignment is a power of two");
-        let freelist = Freelist::new(max, parallelism, layout, prefill);
-        let class = SizeClass {
-            class_id,
-            size,
-            global: freelist,
-            thread_cache_capacity,
-        };
-        Self {
-            token: SizeClassToken::from_arc(Arc::new(class)),
-        }
-    }
-
-    /// Creates a new tracked buffer and retains this size class for its slot.
-    #[inline(always)]
-    fn try_create(&self, zeroed: bool) -> Option<(u32, PooledBuffer, SizeClassLease)> {
-        let (slot, buffer) = self.global.try_create(zeroed)?;
-        let class = SizeClassLease::retain(self);
-        Some((slot, buffer, class))
-    }
-
-    #[cfg(test)]
-    fn strong_count(&self) -> usize {
-        // SAFETY: this handle owns one strong reference for `self.token` for
-        // the duration of this call.
-        unsafe { self.token.retain() };
-        // SAFETY: the increment above created the strong reference consumed by
-        // this temporary Arc.
-        let arc = unsafe { Arc::from_raw(self.token.as_ptr()) };
-        Arc::strong_count(&arc) - 1
-    }
-}
-
-#[cfg(test)]
-impl Clone for SizeClassHandle {
-    fn clone(&self) -> Self {
-        // SAFETY: this handle owns one strong reference for `self.token`.
-        unsafe { self.token.retain() };
-        Self { token: self.token }
-    }
-}
-
-impl Drop for SizeClassHandle {
-    fn drop(&mut self) {
-        // SAFETY: this handle owns one strong reference for `self.token`.
-        unsafe { self.token.release() };
-    }
-}
-
-impl std::ops::Deref for SizeClassHandle {
-    type Target = SizeClass;
-
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        // SAFETY: this handle owns one strong reference for `self.token`.
-        unsafe { self.token.as_ref() }
     }
 }
 

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -625,6 +625,7 @@ impl SizeClassToken {
 /// Globally parked buffers do not carry a class reference: taking from the
 /// global freelist retains the class, and returning to the global freelist
 /// releases it.
+#[must_use = "SizeClassLease owns one size-class reference and must be returned or banked"]
 pub(crate) struct SizeClassLease {
     token: SizeClassToken,
 }
@@ -652,22 +653,6 @@ impl SizeClassLease {
         Self { token: class.token }
     }
 
-    /// Converts one retained class reference into a lease using a raw token.
-    ///
-    /// This does not retain the class. It is used when the caller has a live
-    /// token plus ownership of a strong reference represented outside a
-    /// `SizeClassLease` value, usually in TLS cache state.
-    ///
-    /// # Safety
-    ///
-    /// The caller must have already retained one strong reference for `token`,
-    /// and that retained reference must be transferred to the returned lease.
-    /// The token must identify the class that owns the returned buffer.
-    #[inline(always)]
-    const unsafe fn from_banked_token(token: SizeClassToken) -> Self {
-        Self { token }
-    }
-
     /// Retains `class` for a buffer leaving the global freelist.
     ///
     /// Moving between pooled view state and TLS transfers the lease without
@@ -677,9 +662,7 @@ impl SizeClassLease {
         let token = class.token;
         // SAFETY: the borrowed `class` owns one strong reference for `token`.
         unsafe { token.retain() };
-        // SAFETY: `retain` above retained the strong reference
-        // transferred to the returned lease.
-        unsafe { Self::from_banked_token(token) }
+        Self { token }
     }
 
     /// Transfers this lease into a TLS cache entry.
@@ -720,33 +703,6 @@ impl SizeClassLease {
         self.class().global.put(slot, buffer);
         // SAFETY: this lease owns one strong reference.
         unsafe { self.token.release() };
-    }
-
-    /// Returns several buffers to this class's global freelist and releases
-    /// their references.
-    ///
-    /// `count` must match the number of returned entries. All entries must
-    /// belong to this lease's size class. This method consumes one
-    /// `SizeClassLease` value as the live class handle for the batch, but it
-    /// releases `count` strong references because it is used for TLS cache
-    /// state, where entries own banked references without storing one lease
-    /// value per entry.
-    ///
-    /// As with [`Self::return_global`], buffers are inserted into the global
-    /// freelist before any class references are released.
-    #[inline(always)]
-    fn return_global_batch(
-        self,
-        entries: impl IntoIterator<Item = (u32, PooledBuffer)>,
-        count: usize,
-    ) {
-        debug_assert!(count > 0);
-        self.class().global.put_batch(entries);
-        for _ in 0..count {
-            // SAFETY: each returned entry owned one strong reference to this
-            // same size class.
-            unsafe { self.token.release() };
-        }
     }
 }
 
@@ -878,6 +834,7 @@ impl SizeClassHandle {
     }
 }
 
+#[cfg(test)]
 impl Clone for SizeClassHandle {
     fn clone(&self) -> Self {
         // SAFETY: this handle owns one strong reference for `self.token`.
@@ -976,13 +933,15 @@ impl TlsSizeClassCache {
     /// batch-take from the global freelist, return the first claimed buffer,
     /// and retain the rest locally for future allocations.
     ///
-    /// A returned entry always carries one banked size-class reference. The
-    /// caller must materialize that reference as a [`SizeClassLease`] or release
-    /// it.
+    /// The returned lease is materialized from the banked size-class reference
+    /// associated with the returned entry.
     #[inline(always)]
-    fn pop(&mut self, class: &SizeClassHandle) -> Option<TlsSizeClassCacheEntry> {
+    fn pop(&mut self, class: &SizeClassHandle) -> Option<(TlsSizeClassCacheEntry, SizeClassLease)> {
         if let Some(entry) = self.pop_local() {
-            return Some(entry);
+            // SAFETY: the popped entry consumed one banked reference owned by
+            // this cache. Transfer that reference to the returned lease.
+            let lease = unsafe { SizeClassLease::from_banked(class) };
+            return Some((entry, lease));
         }
 
         // Take from the class-global freelist on a local miss.
@@ -1017,16 +976,16 @@ impl TlsSizeClassCache {
     /// the refill and batching code out of `BufferPoolInner::try_alloc`, reducing
     /// hot-path code size and register pressure.
     #[inline(never)]
-    fn pop_global(&mut self, class: &SizeClassHandle) -> Option<TlsSizeClassCacheEntry> {
+    fn pop_global(
+        &mut self,
+        class: &SizeClassHandle,
+    ) -> Option<(TlsSizeClassCacheEntry, SizeClassLease)> {
         // Tiny caches do not batch enough to justify the wider global
         // claim. Keep their miss path equivalent to a single take.
         if self.capacity < MIN_TLS_BATCH_CAPACITY {
             return class.global.take().map(|(slot, buffer)| {
-                // Convert the globally parked buffer into a banked entry for
-                // the caller; `BufferPoolThreadCache::pop` materializes the
-                // lease immediately.
-                SizeClassLease::retain(class).into_banked();
-                TlsSizeClassCacheEntry { buffer, slot }
+                let lease = SizeClassLease::retain(class);
+                (TlsSizeClassCacheEntry { buffer, slot }, lease)
             });
         }
 
@@ -1046,7 +1005,10 @@ impl TlsSizeClassCache {
             if entry.is_none() {
                 // Hand the first claimed buffer to the allocation that missed
                 // locally. Additional claimed buffers refill the local cache.
-                entry = Some(cache_entry);
+                // SAFETY: `class.token.retain()` above retained the strong
+                // reference transferred to this returned lease.
+                let lease = unsafe { SizeClassLease::from_banked(class) };
+                entry = Some((cache_entry, lease));
             } else {
                 // The take count is derived from the target occupancy, so refill
                 // cannot overflow the local cache. Push directly to avoid the
@@ -1123,13 +1085,41 @@ impl TlsSizeClassCache {
         // SAFETY: each spilled entry represents one banked class reference
         // owned by this cache. Because `spill > 0`, at least one of those
         // references keeps `self.class` live for the batch release.
-        unsafe { SizeClassLease::from_banked_token(self.class) }
-            .return_global_batch(spilled, spill);
+        unsafe { Self::return_banked_global_batch(self.class, spilled, spill) };
 
         debug_assert!(self.len < self.capacity);
         debug_assert_eq!(self.class, class.token);
         class.into_banked();
         self.push_local(entry);
+    }
+
+    /// Returns banked TLS entries to the class-global freelist.
+    ///
+    /// The caller passes the raw token instead of a [`SizeClassLease`] because
+    /// TLS cache entries do not store lease values. They store compact
+    /// `(buffer, slot)` entries, and the cache accounts for one banked strong
+    /// reference per initialized entry.
+    ///
+    /// # Safety
+    ///
+    /// `count` must match the number of returned entries. The caller must own
+    /// `count` banked strong references for `class`, and every entry must
+    /// belong to that size class. At least one of those references must keep
+    /// the class alive until after the entries are parked in the global
+    /// freelist.
+    #[inline(always)]
+    unsafe fn return_banked_global_batch(
+        class: SizeClassToken,
+        entries: impl IntoIterator<Item = (u32, PooledBuffer)>,
+        count: usize,
+    ) {
+        debug_assert!(count > 0);
+        // SAFETY: guaranteed by the caller.
+        unsafe { class.as_ref() }.global.put_batch(entries);
+        for _ in 0..count {
+            // SAFETY: guaranteed by the caller.
+            unsafe { class.release() };
+        }
     }
 }
 
@@ -1147,8 +1137,7 @@ impl Drop for TlsSizeClassCache {
         // SAFETY: each initialized entry represented one banked class
         // reference owned by this cache. Because `count > 0`, those references
         // keep `self.class` live for this drop.
-        unsafe { SizeClassLease::from_banked_token(self.class) }
-            .return_global_batch(entries, count);
+        unsafe { Self::return_banked_global_batch(self.class, entries, count) };
     }
 }
 
@@ -1340,12 +1329,8 @@ impl BufferPoolThreadCache {
         match Self::cache(class) {
             Some(mut cache) => {
                 // SAFETY: `cache` points to this thread's initialized TLS cache.
-                unsafe { cache.as_mut().pop(class) }.map(|entry| {
-                    // SAFETY: `TlsSizeClassCache::pop` returns entries that own
-                    // one banked class reference for `class`.
-                    let lease = unsafe { SizeClassLease::from_banked(class) };
-                    (entry.buffer, lease, entry.slot)
-                })
+                unsafe { cache.as_mut().pop(class) }
+                    .map(|(entry, lease)| (entry.buffer, lease, entry.slot))
             }
             None => class
                 .global
@@ -2516,10 +2501,7 @@ mod tests {
         cache.push(lease, slot, buffer);
         assert_eq!(class.strong_count(), 2);
 
-        let entry = cache.pop(&class).expect("local cache pop");
-        // SAFETY: `cache.pop` transferred one banked size-class reference to
-        // this returned entry.
-        let lease = unsafe { SizeClassLease::from_banked(&class) };
+        let (entry, lease) = cache.pop(&class).expect("local cache pop");
         assert_eq!(class.strong_count(), 2);
         lease.return_global(entry.slot, entry.buffer);
         assert_eq!(class.strong_count(), 1);
@@ -2529,10 +2511,7 @@ mod tests {
             class.global.put(slot, buffer);
         }
 
-        let entry = cache.pop(&class).expect("global refill");
-        // SAFETY: `cache.pop` transferred one banked size-class reference to
-        // this returned entry.
-        let lease = unsafe { SizeClassLease::from_banked(&class) };
+        let (entry, lease) = cache.pop(&class).expect("global refill");
         assert_eq!(class.strong_count(), 3);
 
         lease.return_global(entry.slot, entry.buffer);

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -968,8 +968,9 @@ impl TlsSizeClassCache {
     /// Takes from the class-global freelist after the local stack misses.
     ///
     /// Every claimed global entry gets one retained class reference. The first
-    /// claimed entry is returned to the caller as a banked entry; additional
-    /// claimed entries are parked in this cache and counted by `len`.
+    /// claimed entry is returned with that reference materialized as a
+    /// [`SizeClassLease`]; additional claimed entries are parked in this cache
+    /// and counted by `len`.
     ///
     /// This is separate from [`Self::pop`] so the steady-state allocation hot path
     /// can inline only the local cache hit. We annotate with `inline(never)` to keep
@@ -995,8 +996,8 @@ impl TlsSizeClassCache {
         let mut entry = None;
         let take = self.capacity / 2;
         class.global.take_batch(take, |slot, buffer| {
-            // Each claimed global entry becomes either the returned banked
-            // entry or a local cache entry, so each needs one retained class
+            // Each claimed global entry becomes either the returned lease or a
+            // local cache entry, so each needs one retained class
             // reference.
             // SAFETY: the borrowed `class` owns one strong reference for its
             // token while the refill runs.
@@ -1154,9 +1155,10 @@ impl Drop for TlsSizeClassCache {
 /// mean this thread has not used that size class yet. Holes can remain for the
 /// lifetime of the thread because class ids are monotonic and never reused.
 /// Empty initialized caches can also remain after their pool has been dropped;
-/// their class token is inert while the cache is empty. It becomes usable again
-/// only if another pooled buffer or allocation for that same live class
-/// reaches the cache and provides a live reference.
+/// their class token is inert while the cache is empty. If the class is still
+/// live because a pooled buffer is outstanding, a later return of that buffer
+/// to this same thread can bank a fresh reference and make the cache usable
+/// again.
 ///
 /// We intentionally use `Vec<Option<...>>` because class ids are dense enough
 /// for direct indexing to be cheaper than hashing, but a thread may initialize

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -1051,32 +1051,27 @@ impl TlsSizeClassCache {
 
 impl Drop for TlsSizeClassCache {
     fn drop(&mut self) {
-        let count = self.len;
-        if count == 0 {
+        if self.len == 0 {
             return;
         }
 
-        let class = self.class;
-        let end = self.len;
-        self.len = 0;
         let entries = self.entries.as_mut_ptr();
-        {
-            let entries = (0..end).rev().map(move |index| {
-                // SAFETY: `0..end` was initialized before `len` was reset to 0.
-                // Reading each slot moves it out and leaves the slot
-                // uninitialized.
+        // SAFETY: each initialized entry carries one banked class reference out
+        // of this cache. Because `self.len > 0`, those references keep `class`
+        // live while the entries are parked.
+        unsafe { self.class.as_ref() }
+            .global
+            .put_batch((0..self.len).rev().map(move |index| {
+                // SAFETY: `0..self.len` is initialized. Reading each slot moves
+                // it out and leaves the slot uninitialized.
                 let entry = unsafe { entries.add(index).read().assume_init() };
                 (entry.slot, entry.buffer)
-            });
-            // SAFETY: each initialized entry carries one banked class reference
-            // out of this cache. Because `count > 0`, those references keep
-            // `class` live while the entries are parked.
-            unsafe { class.as_ref() }.global.put_batch(entries);
-        }
-        for _ in 0..count {
-            // SAFETY: each drained entry was returned to the global freelist, so
-            // its banked reference can be released.
-            unsafe { class.release() };
+            }));
+
+        for _ in 0..self.len {
+            // SAFETY: each drained entry was returned to the global freelist,
+            // so its banked reference can be released.
+            unsafe { self.class.release() };
         }
     }
 }

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -744,9 +744,10 @@ impl std::ops::Deref for SizeClassHandle {
 /// strong count.
 ///
 /// A lease must be consumed by one of those explicit transitions, such as
-/// [`Self::into_banked`] or [`Self::return_global`]. Dropping the value without
-/// calling anything would leak the strong reference, which is why this type
-/// intentionally has no `Drop` implementation.
+/// [`Self::into_banked`] or [`Self::return_global`]. Because this type
+/// intentionally has no `Drop` implementation, simply dropping a lease value
+/// would leak the strong reference. This keeps hot transfers free of drop glue,
+/// but means every owner must complete one of the explicit transitions.
 ///
 /// Thread-local cache entries do not store a lease per entry. The cache stores
 /// the class token once and owns one banked strong reference for each initialized

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -964,26 +964,26 @@ impl TlsSizeClassCache {
     /// batch effectively, half the entries are drained to amortize global queue
     /// traffic across future returns.
     #[inline(always)]
-    fn push(&mut self, class: SizeClassLease, slot: u32, buffer: PooledBuffer) {
+    fn push(&mut self, lease: SizeClassLease, slot: u32, buffer: PooledBuffer) {
         let entry = TlsSizeClassCacheEntry { buffer, slot };
 
         if self.len < self.capacity {
             // Keep the returned entry local while there is room.
-            self.push_local(entry, class);
+            self.push_local(entry, lease);
             return;
         }
 
         // Handle overflow when the local stack is full.
-        self.push_full(class, entry);
+        self.push_full(entry, lease);
     }
 
     /// Pushes one entry onto this thread's local stack.
     ///
-    /// The caller must ensure the stack has room. `class` becomes the banked
+    /// The caller must ensure the stack has room. `lease` becomes the banked
     /// size-class reference represented by `entry`.
     #[inline(always)]
-    fn push_local(&mut self, entry: TlsSizeClassCacheEntry, class: SizeClassLease) {
-        class.into_banked();
+    fn push_local(&mut self, entry: TlsSizeClassCacheEntry, lease: SizeClassLease) {
+        lease.into_banked();
 
         // SAFETY: the caller ensured `self.len < self.capacity`, so this slot
         // is in bounds and currently uninitialized.
@@ -1005,11 +1005,11 @@ impl TlsSizeClassCache {
     /// to keep the spill and batching code out of pooled buffer drop when the
     /// local cache has room.
     #[inline(never)]
-    fn push_full(&mut self, class: SizeClassLease, entry: TlsSizeClassCacheEntry) {
+    fn push_full(&mut self, entry: TlsSizeClassCacheEntry, lease: SizeClassLease) {
         // Very small caches cannot spill enough entries to amortize a batch
         // insert, so overflow goes straight to the global freelist.
         if self.capacity < MIN_TLS_BATCH_CAPACITY {
-            class.return_global(entry.slot, entry.buffer);
+            lease.return_global(entry.slot, entry.buffer);
             return;
         }
 
@@ -1020,7 +1020,7 @@ impl TlsSizeClassCache {
         // Stop tracking slots before moving them out.
         self.len = start;
 
-        class
+        lease
             .class()
             .global
             .put_batch((start..end).rev().map(|index| {
@@ -1029,14 +1029,14 @@ impl TlsSizeClassCache {
                 // slot uninitialized.
                 let entry = unsafe { self.entries.as_mut_ptr().add(index).read().assume_init() };
                 // SAFETY: this drained entry carried one banked reference. The
-                // incoming `class` lease keeps the size class live while
+                // incoming class lease keeps the size class live while
                 // `put_batch` parks the spilled entries.
                 unsafe { self.class.release() };
                 (entry.slot, entry.buffer)
             }));
 
         // Keep the incoming entry local after making room.
-        self.push_local(entry, class);
+        self.push_local(entry, lease);
     }
 }
 
@@ -1206,14 +1206,10 @@ impl BufferPoolThreadCache {
     /// has not initialized this size class, the buffer goes to the global
     /// freelist rather than creating local state from a drop path.
     #[inline(always)]
-    pub(super) fn push(class: SizeClassLease, slot: u32, buffer: PooledBuffer) {
-        let (class_id, thread_cache_capacity) = {
-            let class_ref = class.class();
-            (class_ref.class_id, class_ref.thread_cache_capacity)
-        };
-
-        if thread_cache_capacity == 0 {
-            class.return_global(slot, buffer);
+    pub(super) fn push(lease: SizeClassLease, slot: u32, buffer: PooledBuffer) {
+        let class = lease.class();
+        if class.thread_cache_capacity == 0 {
+            lease.return_global(slot, buffer);
             return;
         }
 
@@ -1225,13 +1221,13 @@ impl BufferPoolThreadCache {
             // SAFETY: the fast pointer is set only from this thread's
             // `TLS_SIZE_CLASS_CACHES` value and cleared before that value
             // drops.
-            if let Some(cache) = unsafe { (&mut *caches).get(class_id) } {
-                cache.push(class, slot, buffer);
+            if let Some(cache) = unsafe { (&mut *caches).get(class.class_id) } {
+                cache.push(lease, slot, buffer);
                 return;
             }
         }
 
-        class.return_global(slot, buffer);
+        lease.return_global(slot, buffer);
     }
 
     /// Takes a buffer from the current thread's local cache for the given


### PR DESCRIPTION
This PR removes `Arc<SizeClass>` from the pooled buffer hot path without changing the pool lifetime model. Before this PR, checked-out pooled buffers and TLS cache entries both carried an `Arc<SizeClass>`. The steady local reuse path did not increment or decrement the strong count, but `Arc` is still a non-`Copy` value with drop glue, so moving it through allocation, return, and cache-entry storage made the compiler preserve destructor-aware code around what should be a simple ownership transfer.

Checked-out pooled buffers now carry a `SizeClassLease`, which is one strong size-class reference represented as a raw pointer with explicit retain/release at the global freelist boundary. Moving between checked-out state and the thread-local cache is now a plain pointer transfer. The size class is still kept alive for every outstanding pooled buffer: the reference is banked in the TLS cache while the buffer is local, then materialized back into a lease when the buffer is checked out again.

The thread-local cache stores the size-class identity once and banks one strong reference for each initialized local entry. Individual cache entries shrink to just `(buffer, slot)`, and the cache storage is a fixed flat stack backed by `Box<[MaybeUninit<_>]>`. That keeps the steady local pop/push path to stack length updates plus one 16-byte entry load/store, while global refill, spill, flush, and drop continue to preserve the freelist ownership contract.

Representative local results for the 1KiB no-touch steady-state profile:

| Case | ns/op |
| --- | ---: |
| Direct (before) | 6.95 |
| Pooled (before) | 8.71 |
| | |
| Direct [glibc 2.42] (after) | 6.63 |
| Direct [mimalloc 3.3.0] (after) | 8.28 |
| Direct [jemalloc 5.3.0] (after) | 6.61 |
| Pooled (after) | **2.83** 🏆 |

Depends on #3752.
