### PR TITLE
[storage] Avoid blocking readers during metadata fsync and relax full Merkle apply_batch to &self

### DIFF
--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -270,7 +270,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
 
         let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-        let mut merkle = Merkle::<F>::init(
+        let merkle = Merkle::<F>::init(
             ctx.child("recovered"),
             &hasher,
             merkle_config(

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -774,8 +774,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             return Ok(());
         };
 
-        // Upgrade only for the metadata mutation/sync step; reads were allowed while syncing
-        // the tail section above.
+        // Upgrade only for the metadata mutation; reads were allowed while syncing
+        // the tail section above. Downgrade before the metadata fsync to unblock readers.
         let mut inner = inner.upgrade().await;
         if put {
             inner.metadata.put(
@@ -785,6 +785,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         } else {
             inner.metadata.remove(&PRUNING_BOUNDARY_KEY);
         }
+        let inner = inner.downgrade_to_upgradable();
         inner.metadata.sync().await?;
 
         Ok(())

--- a/storage/src/merkle/mmr/full.rs
+++ b/storage/src/merkle/mmr/full.rs
@@ -66,7 +66,7 @@ mod tests {
             let test_mmr = build_test_mmr(&hasher, test_mmr, NUM_ELEMENTS);
             let expected_root = test_mmr.root(&hasher, 0).unwrap();
 
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.child("storage"),
                 &Standard::<Sha256>::new(ForwardFold),
                 test_config(&context),
@@ -240,7 +240,7 @@ mod tests {
             let hasher: Standard<Sha256> = Standard::new(ForwardFold);
 
             // Build base full MMR with 10 elements.
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.child("storage"),
                 &Standard::<Sha256>::new(ForwardFold),
                 test_config(&context),
@@ -303,7 +303,7 @@ mod tests {
             let hasher = Standard::<Sha256>::new(ForwardFold);
 
             // Build an MMR with 5 leaves (size 8), sync, drop.
-            let mut mmr = Mmr::<_, Digest, Sequential>::init(
+            let mmr = Mmr::<_, Digest, Sequential>::init(
                 context.child("init"),
                 &hasher,
                 test_config(&context),
@@ -329,7 +329,7 @@ mod tests {
                 strategy: Sequential,
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
-            let mut ref_mmr =
+            let ref_mmr =
                 Mmr::<_, Digest, Sequential>::init(context.child("ref"), &hasher, ref_cfg)
                     .await
                     .unwrap();
@@ -354,7 +354,7 @@ mod tests {
                 range: non_empty_range!(Location::new(100), Location::new(200)),
                 pinned_nodes: Some(pinned),
             };
-            let mut sync_mmr = Mmr::init_sync(context.child("sync"), sync_cfg)
+            let sync_mmr = Mmr::init_sync(context.child("sync"), sync_cfg)
                 .await
                 .unwrap();
 

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -853,8 +853,8 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
     /// chain was created, or if only ancestors of this batch have been applied.
     /// Already-committed ancestors are skipped automatically.
     /// Applying a batch from a different fork returns [`Error::StaleBatch`].
-    pub fn apply_batch(&mut self, batch: &batch::MerkleizedBatch<F, D, S>) -> Result<(), Error<F>> {
-        self.inner.get_mut().mem.apply_batch(batch)?;
+    pub fn apply_batch(&self, batch: &batch::MerkleizedBatch<F, D, S>) -> Result<(), Error<F>> {
+        self.inner.write().mem.apply_batch(batch)?;
         Ok(())
     }
 
@@ -1185,7 +1185,7 @@ mod tests {
         assert_eq!(mmr.size(), 0);
         mmr.sync().await.unwrap();
 
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("second"),
             &hasher,
             test_config(&context),
@@ -1341,7 +1341,7 @@ mod tests {
     async fn full_basic_inner<F: Family>(context: deterministic::Context) {
         let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         let cfg = test_config(&context);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(context, &hasher, cfg)
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(context, &hasher, cfg)
             .await
             .unwrap();
         // Build a test structure with 255 leaves
@@ -1411,7 +1411,7 @@ mod tests {
         use crate::journal::contiguous::fixed::{Config as JConfig, Journal};
 
         let hasher: Standard<Sha256> = Standard::new(ForwardFold);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("first"),
             &hasher,
             test_config(&context),
@@ -1516,7 +1516,7 @@ mod tests {
             strategy: Sequential,
             page_cache: cfg_pruned.page_cache.clone(),
         };
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("unpruned"),
             &hasher,
             cfg_unpruned,
@@ -1670,7 +1670,7 @@ mod tests {
         let hasher: Standard<Sha256> = Standard::new(ForwardFold);
         const LEAF_COUNT: usize = 2000;
         let mut leaves = Vec::with_capacity(LEAF_COUNT);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("init"),
             &hasher,
             test_config(&context),
@@ -1762,7 +1762,7 @@ mod tests {
         // Create structure with 10 elements
         let hasher = Standard::<Sha256>::new(ForwardFold);
         let cfg = test_config(&context);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(context, &hasher, cfg)
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(context, &hasher, cfg)
             .await
             .unwrap();
         let mut elements = Vec::new();
@@ -1866,7 +1866,7 @@ mod tests {
         mmr.prune(prune_loc).await.unwrap();
 
         // Create reference structure for verification to get correct size
-        let mut ref_mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let ref_mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("ref"),
             &hasher,
             Config {
@@ -1930,7 +1930,7 @@ mod tests {
     async fn full_historical_proof_large_inner<F: Family>(context: deterministic::Context) {
         let hasher = Standard::<Sha256>::new(ForwardFold);
 
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("server"),
             &hasher,
             Config {
@@ -1959,7 +1959,7 @@ mod tests {
         let range = Location::<F>::new(30)..Location::<F>::new(61);
 
         // Only apply elements up to end_loc to the reference structure.
-        let mut ref_mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let ref_mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("client"),
             &hasher,
             Config {
@@ -2016,7 +2016,7 @@ mod tests {
     async fn full_historical_proof_singleton_inner<F: Family>(context: deterministic::Context) {
         let hasher = Standard::<Sha256>::new(ForwardFold);
         let cfg = test_config(&context);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(context, &hasher, cfg)
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(context, &hasher, cfg)
             .await
             .unwrap();
 
@@ -2070,7 +2070,7 @@ mod tests {
             pinned_nodes: None,
         };
 
-        let mut sync_mmr =
+        let sync_mmr =
             Merkle::<F, _, Digest, Sequential>::init_sync(context.child("storage"), sync_cfg)
                 .await
                 .unwrap();
@@ -2110,7 +2110,7 @@ mod tests {
         let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Create initial structure with elements.
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("init"),
             &hasher,
             test_config(&context),
@@ -2452,7 +2452,7 @@ mod tests {
         };
 
         // Create structure with enough elements to span multiple sections.
-        let mut mmr =
+        let mmr =
             Merkle::<F, _, Digest, Sequential>::init(context.child("init"), &hasher, cfg.clone())
                 .await
                 .unwrap();
@@ -2574,7 +2574,7 @@ mod tests {
         context: deterministic::Context,
     ) {
         let hasher = Standard::<Sha256>::new(ForwardFold);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("init"),
             &hasher,
             test_config(&context),
@@ -2630,7 +2630,7 @@ mod tests {
         context: deterministic::Context,
     ) {
         let hasher = Standard::<Sha256>::new(ForwardFold);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("init"),
             &hasher,
             test_config(&context),
@@ -2821,7 +2821,7 @@ mod tests {
 
     async fn full_historical_proof_out_of_bounds_inner<F: Family>(context: deterministic::Context) {
         let hasher = Standard::<Sha256>::new(ForwardFold);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("oob"),
             &hasher,
             test_config(&context),
@@ -2864,7 +2864,7 @@ mod tests {
         context: deterministic::Context,
     ) {
         let hasher = Standard::<Sha256>::new(ForwardFold);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("range_validation"),
             &hasher,
             test_config(&context),
@@ -3020,7 +3020,7 @@ mod tests {
         let hasher = Standard::<Sha256>::new(ForwardFold);
 
         // Build a structure with 3 leaves, sync, and drop.
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("init"),
             &hasher,
             test_config(&context),
@@ -3090,7 +3090,7 @@ mod tests {
 
     async fn full_stale_batch_inner<F: Family>(context: deterministic::Context) {
         let hasher: Standard<Sha256> = Standard::new(ForwardFold);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("storage"),
             &Standard::<Sha256>::new(ForwardFold),
             test_config(&context),
@@ -3167,7 +3167,7 @@ mod tests {
         context: deterministic::Context,
     ) {
         let hasher = Standard::<Sha256>::new(ForwardFold);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("storage"),
             &hasher,
             test_config(&context),


### PR DESCRIPTION
 ## Summary                                                                                                                                                                     
  - Downgrade write lock to upgradable read before metadata fsync in `contiguous::fixed::Journal::sync`, so readers aren't blocked during the (rare) metadata persistence step.
  - Change `merkle::persisted::full::Mmr::apply_batch` from `&mut self` to `&self` (uses `inner.write()` instead of `inner.get_mut()`). The `RwLock` already existed; no new locks are introduced.                                                                                                                                                          
                                                                                                                                                                                 
  ## Context                                                                                                                                                                     
  These are incremental steps toward reducing read blocking during write and sync operations. The full Merkle change is a prerequisite for eventually making the authenticated journal's `apply_batch` callable without exclusive ownership, which would in turn allow QMDB's `apply_batch` to avoid blocking concurrent readers during section-fill fsyncs.
