### PR TITLE
[ci] Install Rust toolchain from `dtolnay/rust-toolchain`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,29 @@
 name: Setup
 inputs:
+  toolchain:
+    description: "The Rust toolchain to install."
+    required: false
+    default: "stable"
+  components:
+    description: "Rust components to install."
+    required: false
+    default: ""
+  targets:
+    description: "Rust targets to install."
+    required: false
+    default: ""
+  additional-toolchain:
+    description: "An additional Rust toolchain to install."
+    required: false
+    default: ""
+  additional-components:
+    description: "Rust components to install for the additional toolchain."
+    required: false
+    default: ""
+  additional-targets:
+    description: "Rust targets to install for the additional toolchain."
+    required: false
+    default: ""
   additional-cache-key:
     description: "An additional cache key that is added alongside the automatic `job`-based cache key."
     required: false
@@ -17,6 +41,19 @@ runs:
         echo "CARGO_TARGET_DIR=/mnt/target" >> "$GITHUB_ENV"
         echo "CARGO_HOME=/mnt/.cargo" >> "$GITHUB_ENV"
         echo "/mnt/.cargo/bin" >> "$GITHUB_PATH"
+    - name: Install additional Rust toolchain
+      if: inputs.additional-toolchain != ''
+      uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+      with:
+        toolchain: ${{ inputs.additional-toolchain }}
+        components: ${{ inputs.additional-components }}
+        targets: ${{ inputs.additional-targets }}
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}
     - name: Normalize cache key
       id: cache-key
       shell: bash

--- a/.github/dylints/borrowed_child_context/Cargo.lock
+++ b/.github/dylints/borrowed_child_context/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a937bab540c0c8cdcbd650a572e6899ef2b6ffbc277d61bd2ae8d17c0edce"
+checksum = "b795f98802f87352aab60584eea87f942c53ab30edcafab4b31a6cbdd9e8a3ac"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e11f358a59510be7fa5c4f412729fabbe31a3587a342e4241a6a72020a2a0c5"
+checksum = "a03ff51e671fceef87e50fef97ddc1569241af242d76e0b367dfcc812c860eb0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -228,10 +228,8 @@ dependencies = [
  "cargo_metadata",
  "git2",
  "home",
- "if_chain",
  "log",
  "regex",
- "rustversion",
  "serde",
  "tar",
  "thiserror 2.0.18",
@@ -240,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4588b33aafbd472a6468ad1521d74094faa2bbdb53d534c2d24320300ea94135"
+checksum = "c3efcb9b741bccdd6f1ce701c4b17b452112e8c0cd045c8b894a112584ff5d55"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -255,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc27f344ddb5488eb16b6e0f8aec889a30fb7e4d135060d336cfa60d1fd671c"
+checksum = "2eaa3ca6e1f740cd587630c321f61927b4cafdc2abf7c2fbacc3fca8635fcc48"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -552,12 +550,6 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
-
-[[package]]
-name = "if_chain"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "indexmap"
@@ -1136,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1146,14 +1138,14 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -1164,7 +1156,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -1416,12 +1408,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/.github/dylints/borrowed_child_context/Cargo.toml
+++ b/.github/dylints/borrowed_child_context/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "5.0.0"
+dylint_linting = "6.0.0"
 
 [dev-dependencies]
-dylint_testing = "5.0.0"
+dylint_testing = "6.0.0"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/.github/dylints/borrowed_child_context/rust-toolchain
+++ b/.github/dylints/borrowed_child_context/rust-toolchain
@@ -1,5 +1,5 @@
 # Dylint discovers library toolchains from this directory, so the just/CI
 # `cargo +nightly-... dylint` invocation does not pin the library build.
 [toolchain]
-channel = "nightly-2025-11-15"
+channel = "nightly"
 components = ["rustc-dev", "llvm-tools-preview"]

--- a/.github/dylints/borrowed_child_context/src/lib.rs
+++ b/.github/dylints/borrowed_child_context/src/lib.rs
@@ -1,9 +1,11 @@
 #![feature(rustc_private)]
 #![warn(unused_extern_crates)]
 
+extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_span;
 
+use rustc_errors::DiagDecorator;
 use rustc_hir::{BorrowKind, Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_span::{Span, Symbol};
@@ -47,13 +49,13 @@ impl<'tcx> LateLintPass<'tcx> for BorrowedChildContext {
         };
 
         if let Some(span) = first_child_call(borrowed) {
-            cx.span_lint(BORROWED_CHILD_CONTEXT, span, |diag| {
+            cx.emit_span_lint(BORROWED_CHILD_CONTEXT, span, DiagDecorator(|diag| {
                 diag.primary_message("borrowed temporary child context");
                 diag.span_help(
                     expr.span,
                     "pass a reference to an existing context, or bind the child context before borrowing it",
                 );
-            });
+            }));
         }
     }
 }

--- a/.github/dylints/child_attribute_name_conflict/Cargo.lock
+++ b/.github/dylints/child_attribute_name_conflict/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a937bab540c0c8cdcbd650a572e6899ef2b6ffbc277d61bd2ae8d17c0edce"
+checksum = "b795f98802f87352aab60584eea87f942c53ab30edcafab4b31a6cbdd9e8a3ac"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e11f358a59510be7fa5c4f412729fabbe31a3587a342e4241a6a72020a2a0c5"
+checksum = "a03ff51e671fceef87e50fef97ddc1569241af242d76e0b367dfcc812c860eb0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -228,10 +228,8 @@ dependencies = [
  "cargo_metadata",
  "git2",
  "home",
- "if_chain",
  "log",
  "regex",
- "rustversion",
  "serde",
  "tar",
  "thiserror 2.0.18",
@@ -240,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4588b33aafbd472a6468ad1521d74094faa2bbdb53d534c2d24320300ea94135"
+checksum = "c3efcb9b741bccdd6f1ce701c4b17b452112e8c0cd045c8b894a112584ff5d55"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -255,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc27f344ddb5488eb16b6e0f8aec889a30fb7e4d135060d336cfa60d1fd671c"
+checksum = "2eaa3ca6e1f740cd587630c321f61927b4cafdc2abf7c2fbacc3fca8635fcc48"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -552,12 +550,6 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
-
-[[package]]
-name = "if_chain"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "indexmap"
@@ -1136,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1146,14 +1138,14 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -1164,7 +1156,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -1416,12 +1408,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/.github/dylints/child_attribute_name_conflict/Cargo.toml
+++ b/.github/dylints/child_attribute_name_conflict/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "5.0.0"
+dylint_linting = "6.0.0"
 
 [dev-dependencies]
-dylint_testing = "5.0.0"
+dylint_testing = "6.0.0"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/.github/dylints/child_attribute_name_conflict/rust-toolchain
+++ b/.github/dylints/child_attribute_name_conflict/rust-toolchain
@@ -1,5 +1,5 @@
 # Dylint discovers library toolchains from this directory, so the just/CI
 # `cargo +nightly-... dylint` invocation does not pin the library build.
 [toolchain]
-channel = "nightly-2025-11-15"
+channel = "nightly"
 components = ["rustc-dev", "llvm-tools-preview"]

--- a/.github/dylints/child_attribute_name_conflict/src/lib.rs
+++ b/.github/dylints/child_attribute_name_conflict/src/lib.rs
@@ -2,10 +2,12 @@
 #![warn(unused_extern_crates)]
 
 extern crate rustc_ast;
+extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_span;
 
 use rustc_ast::ast::LitKind;
+use rustc_errors::DiagDecorator;
 use rustc_hir::{Expr, ExprKind, Node};
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_span::{Span, Symbol};
@@ -61,13 +63,13 @@ fn check_child_attribute_name_conflict(cx: &LateContext<'_>, expr: &Expr<'_>) {
     for attribute in attributes {
         for child in &children {
             if child.value == attribute.value {
-                cx.span_lint(CHILD_ATTRIBUTE_NAME_CONFLICT, attribute.span, |diag| {
+                cx.emit_span_lint(CHILD_ATTRIBUTE_NAME_CONFLICT, attribute.span, DiagDecorator(|diag| {
                     diag.primary_message("child name conflicts with context attribute name");
                     diag.span_help(
                         child.span,
                         "choose a child name for the component and an attribute name for the varying field",
                     );
-                });
+                }));
             }
         }
     }

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,8 +56,6 @@ jobs:
             benchmark_name: "commonware-utils"
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-      - name: Install nightly Rust toolchain
-        run: rustup toolchain install nightly
       - name: Run setup
         uses: ./.github/actions/setup
       - name: Compile benchmarks

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_VERSION: nightly-2025-11-15
+  NIGHTLY_VERSION: nightly
 
 jobs:
   Coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Install coverage tooling
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
-        tool: cargo-llvm-cov@0.8.4,cargo-nextest@0.9.129
+        tool: cargo-llvm-cov@0.8.4,cargo-nextest@0.9.133
     - name: Normalize flags for paths
       id: path-normalization
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Run setup
       uses: ./.github/actions/setup
       with:
+        additional-toolchain: ${{ env.NIGHTLY_VERSION }}
         additional-cache-key: ${{ matrix.flags || 'default' }}-part-${{ matrix.partition }}
     - name: Remove fuzz
       run: |
@@ -53,8 +54,6 @@ jobs:
     - name: Remove fuzz targets from Cargo.toml
       run: |
         sed -i.bak '/fuzz/d' Cargo.toml
-    - name: Install nightly Rust toolchain
-      run: rustup toolchain install ${{ env.NIGHTLY_VERSION }}
     - name: Install coverage tooling
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   UDEPS_VERSION: 0.1.57
-  NIGHTLY_VERSION: nightly-2025-11-15
+  NIGHTLY_VERSION: nightly
   PANDOC_VERSION: 3.8.2.1
 
 jobs:
@@ -109,7 +109,7 @@ jobs:
     - name: Install just & nextest
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
-        tool: just@1.43.0,cargo-nextest@0.9.129
+        tool: just@1.43.0,cargo-nextest@0.9.133
     - name: Run tests
       run: just test ${{ matrix.flags }} --partition hash:${{matrix.partition}}/2 --verbose
 
@@ -139,7 +139,7 @@ jobs:
     - name: Install just & nextest
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
-        tool: just@1.43.0,cargo-nextest@0.9.129
+        tool: just@1.43.0,cargo-nextest@0.9.133
     - name: Run subset tests
       run: just test ${{ matrix.flags }} -p ${{ matrix.package }} --verbose
     - name: Run subset doc tests

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -39,19 +39,16 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-    - name: Install nightly Rust toolchain
-      run: rustup toolchain install ${{ env.NIGHTLY_VERSION }} && rustup component add --toolchain ${{ env.NIGHTLY_VERSION }} rustfmt
     - name: Run setup
       uses: ./.github/actions/setup
       with:
+        additional-toolchain: ${{ env.NIGHTLY_VERSION }}
+        additional-components: ${{ matrix.os == 'ubuntu-latest' && matrix.flags == '' && 'rustfmt,rustc-dev,llvm-tools-preview' || 'rustfmt' }}
         additional-cache-key: ${{ matrix.flags || 'default' }}
     - name: Install just
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
         tool: just@1.43.0
-    - name: Install Dylint toolchain support
-      if: matrix.os == 'ubuntu-latest' && matrix.flags == ''
-      run: rustup component add --toolchain ${{ env.NIGHTLY_VERSION }} rustc-dev llvm-tools-preview
     - name: Install Dylint
       if: matrix.os == 'ubuntu-latest' && matrix.flags == ''
       run: |
@@ -180,13 +177,12 @@ jobs:
     - name: Run setup
       uses: ./.github/actions/setup
       with:
+        additional-toolchain: ${{ env.NIGHTLY_VERSION }}
         additional-cache-key: unstable-public
     - name: Install just
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
         tool: just@1.43.0
-    - name: Install nightly Rust toolchain
-      run: rustup toolchain install ${{ env.NIGHTLY_VERSION }}
     - name: Check for unmarked public items
       run: just unstable-public
 
@@ -222,13 +218,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-    - name: Install nightly Rust toolchain
-      run: rustup toolchain install ${{ env.NIGHTLY_VERSION }}
-    - name: Get Rust version
-      id: rust-version
-      run: echo "rust_version=$(rustc +${{ env.NIGHTLY_VERSION }} --version)" >> "$GITHUB_OUTPUT"
     - name: Run setup
       uses: ./.github/actions/setup
+      with:
+        additional-toolchain: ${{ env.NIGHTLY_VERSION }}
     - name: Install just & cargo-udeps
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
@@ -289,8 +282,8 @@ jobs:
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
     - name: Run setup
       uses: ./.github/actions/setup
-    - name: Add WASM target
-      run: rustup target add wasm32-unknown-unknown
+      with:
+        targets: wasm32-unknown-unknown
     - name: Build cryptography
       run: cargo rustc --target wasm32-unknown-unknown --release --manifest-path cryptography/Cargo.toml --crate-type cdylib && du -h "${CARGO_TARGET_DIR:-target}/wasm32-unknown-unknown/release/commonware_cryptography.wasm"
     - name: Build macros
@@ -388,11 +381,8 @@ jobs:
       - name: Run setup
         uses: ./.github/actions/setup
         with:
-          additional-cache-key: toolchain-${{ matrix.toolchain }}
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
-        with:
           toolchain: ${{ steps.toolchain.outputs.version }}
+          additional-cache-key: toolchain-${{ matrix.toolchain }}
       - name: Install just & cargo-hack
         uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
         with:

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -52,8 +52,8 @@ jobs:
     - name: Install Dylint
       if: matrix.os == 'ubuntu-latest' && matrix.flags == ''
       run: |
-        cargo install cargo-dylint --version 5.0.0 --locked
-        cargo install dylint-link --version 5.0.0 --locked
+        cargo install cargo-dylint --version 6.0.0 --locked
+        cargo install dylint-link --version 6.0.0 --locked
     - name: Fmt
       run: just check-fmt
     - name: Lint

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -38,6 +38,6 @@ jobs:
     - name: Install just & nextest
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
-        tool: just@1.43.0,cargo-nextest@0.9.129
+        tool: just@1.43.0,cargo-nextest@0.9.133
     - name: Run loom tests
       run: just test-loom ${{ matrix.flags }} --verbose

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -61,13 +61,10 @@ jobs:
           run-id: ${{ steps.baseline.outputs.run_id }}
           github-token: ${{ github.token }}
 
-      - name: Install nightly Rust toolchain
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
-        with:
-          toolchain: nightly
-
       - name: Run setup
         uses: ./.github/actions/setup
+        with:
+          toolchain: nightly
 
       - name: Run benchmark tracking
         id: run

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -56,10 +56,6 @@ jobs:
       uses: ./.github/actions/setup
       with:
         additional-cache-key: ${{ matrix.flags || 'default' }}-part-${{ matrix.partition }}
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
-      with:
-        toolchain: stable
     - name: Install just & nextest
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
@@ -107,8 +103,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-    - name: Install nightly Rust toolchain
-      run: rustup toolchain install ${{ env.NIGHTLY_VERSION }}
     - name: Run setup
       uses: ./.github/actions/setup
     - name: Install just
@@ -129,13 +123,13 @@ jobs:
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
     - name: Clear disk space
       uses: ./.github/actions/disk
-    - name: Install nightly Rust toolchain
-      run: rustup toolchain install ${{ env.NIGHTLY_VERSION }}
+    - name: Run setup
+      uses: ./.github/actions/setup
+      with:
+        additional-toolchain: ${{ env.NIGHTLY_VERSION }}
     - name: Get Rust version
       id: rust-version
       run: echo "rust_version=$(rustc +${{ env.NIGHTLY_VERSION }} --version)" >> "$GITHUB_OUTPUT"
-    - name: Run setup
-      uses: ./.github/actions/setup
     - name: Cache cargo-fuzz
       id: cargo-fuzz-cache
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -186,12 +180,11 @@ jobs:
     - name: Run setup
       uses: ./.github/actions/setup
       with:
+        toolchain: ${{ env.NIGHTLY_VERSION }}
+        components: miri
         additional-cache-key: part-${{ matrix.partition }}
     - name: Install miri
-      run: |
-        rustup toolchain install ${{ env.NIGHTLY_VERSION }} --component miri
-        rustup override set ${{ env.NIGHTLY_VERSION }}
-        cargo miri setup
+      run: cargo miri setup
     - name: Install just & nextest
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -16,7 +16,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   FUZZ_VERSION: 0.12.0
-  NIGHTLY_VERSION: nightly-2025-11-15
+  NIGHTLY_VERSION: nightly
 
 jobs:
   Tests:
@@ -59,7 +59,7 @@ jobs:
     - name: Install just & nextest
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
-        tool: just@1.43.0,cargo-nextest@0.9.129
+        tool: just@1.43.0,cargo-nextest@0.9.133
     - name: Run slow tests
       run: just test ${{ matrix.flags }} --partition hash:${{matrix.partition}}/8 --verbose --profile slow
 
@@ -191,7 +191,7 @@ jobs:
     - name: Install just & nextest
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
-        tool: just@1.43.0,cargo-nextest@0.9.129
+        tool: just@1.43.0,cargo-nextest@0.9.133
     - name: Run miri tests for storage::index
       run: |
         cd storage
@@ -244,7 +244,7 @@ jobs:
     - name: Install just
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
-        tool: just@1.43.0,cargo-nextest@0.9.129
+        tool: just@1.43.0,cargo-nextest@0.9.133
     - name: Run conformance tests
       run: just test-conformance --partition hash:${{ matrix.partition }}/8 && git diff --exit-code
 

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -56,6 +56,10 @@ jobs:
       uses: ./.github/actions/setup
       with:
         additional-cache-key: ${{ matrix.flags || 'default' }}-part-${{ matrix.partition }}
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
+      with:
+        toolchain: stable
     - name: Install just & nextest
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:


### PR DESCRIPTION
## Overview

Swaps the rust toolchain over to one downloaded from `rustup`, rather than the one that comes pre-loaded in the runner image. Also bumps the `cargo-nextest`, `nightly`, and `dylint` versions.