### PR TITLE
[storage/qmdb/sync] Avoid requiring a trusted ops root in current qmdb sync

### DIFF
--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -217,15 +217,14 @@ where
 
 /// Repeatedly sync a Current database to the server's state.
 ///
-/// Uses the canonical-root-aware [current::sync::sync] wrapper. The initial target includes
-/// a canonical root and [OpsRootWitness]; the wrapper verifies the witness before starting
-/// the engine and checks the canonical root after completion. Target updates during sync
-/// use verified ops-root targets.
+/// Uses the `current::sync::sync` wrapper. The wrapper verifies each target's `OpsRootWitness`
+/// before forwarding its ops root to the shared sync engine, then checks the canonical root for the
+/// target the engine finishes on.
 async fn run_current<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
     E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
 {
-    use commonware_storage::qmdb::{self, current as current_qmdb};
+    use commonware_storage::qmdb::current as current_qmdb;
 
     info!("starting Current database sync process");
     let mut iteration = 0u32;
@@ -242,68 +241,58 @@ where
             "received current sync target"
         );
 
-        let hasher = qmdb::hasher::<commonware_sync::Hasher>();
-        let initial_ops_target = initial_target
-            .to_engine_target(&hasher)
-            .ok_or("initial ops root witness verification failed")?;
-
         let (update_sender, update_receiver) = mpsc::channel(UPDATE_CHANNEL_SIZE);
 
         let target_update_handle = {
             let resolver = resolver.clone();
-            let initial_ops_target = initial_ops_target.clone();
+            let mut current_target_root = initial_target.canonical_root;
             let target_update_interval = config.target_update_interval;
-            context.child("target_update").spawn(move |context| async move {
-                let hasher = qmdb::hasher::<commonware_sync::Hasher>();
-                let mut current_ops_target = initial_ops_target;
-                loop {
-                    context.sleep(target_update_interval).await;
-                    match resolver.get_current_sync_target().await {
-                        Ok(new_target) => {
-                            let Some(new_ops_target) = new_target.to_engine_target(&hasher) else {
-                                warn!("target update witness verification failed, skipping");
-                                continue;
-                            };
-                            if current_ops_target != new_ops_target {
-                                match update_sender.clone().try_send(new_ops_target.clone()) {
-                                    Ok(()) => {
-                                        info!("target updated");
-                                        current_ops_target = new_ops_target;
-                                    }
-                                    Err(mpsc::error::TrySendError::Closed(_)) => return Ok(()),
-                                    Err(err) => {
-                                        warn!(?err, "failed to send target update");
-                                        return Err(Error::TargetUpdateChannel {
-                                            reason: err.to_string(),
-                                        });
+            context
+                .child("target_update")
+                .spawn(move |context| async move {
+                    loop {
+                        context.sleep(target_update_interval).await;
+                        match resolver.get_current_sync_target().await {
+                            Ok(new_target) => {
+                                if current_target_root != new_target.canonical_root {
+                                    let new_root = new_target.canonical_root;
+                                    match update_sender.clone().try_send(new_target) {
+                                        Ok(()) => {
+                                            info!("target updated");
+                                            current_target_root = new_root;
+                                        }
+                                        Err(mpsc::error::TrySendError::Closed(_)) => return Ok(()),
+                                        Err(err) => {
+                                            warn!(?err, "failed to send target update");
+                                            return Err(Error::TargetUpdateChannel {
+                                                reason: err.to_string(),
+                                            });
+                                        }
                                     }
                                 }
                             }
-                        }
-                        Err(err) => {
-                            warn!(?err, "failed to get sync target from server");
+                            Err(err) => {
+                                warn!(?err, "failed to get sync target from server");
+                            }
                         }
                     }
-                }
-            })
+                })
         };
 
         let db_config = current::create_config(&context);
-        let database: current::Database<_> = current_qmdb::sync::sync(
-            current_qmdb::sync::Config {
-                context: context.child("sync"),
-                resolver,
-                target: initial_target,
-                max_outstanding_requests: config.max_outstanding_requests,
-                fetch_batch_size: config.batch_size,
-                apply_batch_size: 1024,
-                db_config,
-                update_rx: Some(update_receiver),
-                finish_rx: None,
-                reached_target_tx: None,
-                max_retained_roots: 8,
-            },
-        )
+        let database: current::Database<_> = current_qmdb::sync::sync(current_qmdb::sync::Config {
+            context: context.child("sync"),
+            resolver,
+            target: initial_target,
+            max_outstanding_requests: config.max_outstanding_requests,
+            fetch_batch_size: config.batch_size,
+            apply_batch_size: 1024,
+            db_config,
+            update_rx: Some(update_receiver),
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        })
         .await?;
 
         target_update_handle.abort();

--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -217,44 +217,107 @@ where
 
 /// Repeatedly sync a Current database to the server's state.
 ///
-/// The sync engine targets the ops root (not the canonical root). After sync completes,
-/// the bitmap and grafted MMR are reconstructed from the synced operations.
+/// Uses the canonical-root-aware [current::sync::sync] wrapper. The initial target includes
+/// a canonical root and [OpsRootWitness]; the wrapper verifies the witness before starting
+/// the engine and checks the canonical root after completion. Target updates during sync
+/// use verified ops-root targets.
 async fn run_current<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
     E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
 {
-    run_full_sync::<current::Database<_>, current::Operation, _, _, _>(
-        context,
-        config,
-        |context, config, resolver, initial_target, update_receiver, iteration| async move {
-            let db_config = current::create_config(&context);
-            let sync_config =
-                sync::engine::Config::<current::Database<_>, Resolver<current::Operation, Key>> {
-                    context,
-                    db_config,
-                    fetch_batch_size: config.batch_size,
-                    target: initial_target,
-                    resolver,
-                    apply_batch_size: 1024,
-                    max_outstanding_requests: config.max_outstanding_requests,
-                    update_rx: Some(update_receiver),
-                    finish_rx: None,
-                    reached_target_tx: None,
-                    max_retained_roots: 8,
-                };
-            let database: current::Database<_> = sync::sync(sync_config).await?;
-            info!(
-                sync_iteration = iteration,
-                canonical_root = %database.root(),
-                ops_root = %database.ops_root(),
-                sync_interval = ?config.sync_interval,
-                "Current sync completed successfully"
-            );
-            Ok(database)
-        },
-        "Current database",
-    )
-    .await
+    use commonware_storage::qmdb::{self, current as current_qmdb};
+
+    info!("starting Current database sync process");
+    let mut iteration = 0u32;
+    loop {
+        let resolver =
+            Resolver::<current::Operation, Key>::connect(context.child("resolver"), config.server)
+                .await?;
+
+        let initial_target = resolver.get_current_sync_target().await?;
+        info!(
+            canonical_root = %initial_target.canonical_root,
+            ops_root = %initial_target.ops_root,
+            range = ?initial_target.range,
+            "received current sync target"
+        );
+
+        let hasher = qmdb::hasher::<commonware_sync::Hasher>();
+        let initial_ops_target = initial_target
+            .to_engine_target(&hasher)
+            .ok_or("initial ops root witness verification failed")?;
+
+        let (update_sender, update_receiver) = mpsc::channel(UPDATE_CHANNEL_SIZE);
+
+        let target_update_handle = {
+            let resolver = resolver.clone();
+            let initial_ops_target = initial_ops_target.clone();
+            let target_update_interval = config.target_update_interval;
+            context.child("target_update").spawn(move |context| async move {
+                let hasher = qmdb::hasher::<commonware_sync::Hasher>();
+                let mut current_ops_target = initial_ops_target;
+                loop {
+                    context.sleep(target_update_interval).await;
+                    match resolver.get_current_sync_target().await {
+                        Ok(new_target) => {
+                            let Some(new_ops_target) = new_target.to_engine_target(&hasher) else {
+                                warn!("target update witness verification failed, skipping");
+                                continue;
+                            };
+                            if current_ops_target != new_ops_target {
+                                match update_sender.clone().try_send(new_ops_target.clone()) {
+                                    Ok(()) => {
+                                        info!("target updated");
+                                        current_ops_target = new_ops_target;
+                                    }
+                                    Err(mpsc::error::TrySendError::Closed(_)) => return Ok(()),
+                                    Err(err) => {
+                                        warn!(?err, "failed to send target update");
+                                        return Err(Error::TargetUpdateChannel {
+                                            reason: err.to_string(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            warn!(?err, "failed to get sync target from server");
+                        }
+                    }
+                }
+            })
+        };
+
+        let db_config = current::create_config(&context);
+        let database: current::Database<_> = current_qmdb::sync::sync(
+            current_qmdb::sync::Config {
+                context: context.child("sync"),
+                resolver,
+                target: initial_target,
+                max_outstanding_requests: config.max_outstanding_requests,
+                fetch_batch_size: config.batch_size,
+                apply_batch_size: 1024,
+                db_config,
+                update_rx: Some(update_receiver),
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            },
+        )
+        .await?;
+
+        target_update_handle.abort();
+        info!(
+            sync_iteration = iteration,
+            canonical_root = %database.root(),
+            ops_root = %database.ops_root(),
+            sync_interval = ?config.sync_interval,
+            "Current sync completed successfully"
+        );
+        database.destroy().await?;
+        context.sleep(config.sync_interval).await;
+        iteration += 1;
+    }
 }
 
 /// Repeatedly sync an Immutable database to the server's state.

--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -11,7 +11,10 @@ use commonware_runtime::{
 };
 use commonware_storage::{
     mmr,
-    qmdb::sync::{self, compact},
+    qmdb::{
+        current as current_qmdb,
+        sync::{self, compact},
+    },
 };
 use commonware_sync::{
     any, crate_version, current,
@@ -218,14 +221,12 @@ where
 /// Repeatedly sync a Current database to the server's state.
 ///
 /// Uses the `current::sync::sync` wrapper. The wrapper verifies each target's `OpsRootWitness`
-/// before forwarding its ops root to the shared sync engine, then checks the canonical root for the
+/// before forwarding its ops root to the shared sync engine, then checks the database root for the
 /// target the engine finishes on.
 async fn run_current<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
     E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
 {
-    use commonware_storage::qmdb::current as current_qmdb;
-
     info!("starting Current database sync process");
     let mut iteration = 0u32;
     loop {
@@ -235,7 +236,7 @@ where
 
         let initial_target = resolver.get_current_sync_target().await?;
         info!(
-            canonical_root = %initial_target.canonical_root,
+            root = %initial_target.root,
             ops_root = %initial_target.ops_root,
             range = ?initial_target.range,
             "received current sync target"
@@ -245,7 +246,7 @@ where
 
         let target_update_handle = {
             let resolver = resolver.clone();
-            let mut current_target_root = initial_target.canonical_root;
+            let mut current_target_root = initial_target.root;
             let target_update_interval = config.target_update_interval;
             context
                 .child("target_update")
@@ -254,8 +255,8 @@ where
                         context.sleep(target_update_interval).await;
                         match resolver.get_current_sync_target().await {
                             Ok(new_target) => {
-                                if current_target_root != new_target.canonical_root {
-                                    let new_root = new_target.canonical_root;
+                                if current_target_root != new_target.root {
+                                    let new_root = new_target.root;
                                     match update_sender.clone().try_send(new_target) {
                                         Ok(()) => {
                                             info!("target updated");
@@ -298,7 +299,7 @@ where
         target_update_handle.abort();
         info!(
             sync_iteration = iteration,
-            canonical_root = %database.root(),
+            root = %database.root(),
             ops_root = %database.ops_root(),
             sync_interval = ?config.sync_interval,
             "Current sync completed successfully"

--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -12,6 +12,7 @@ use commonware_runtime::{
 use commonware_storage::{
     mmr,
     qmdb::{
+        any::sync::Target,
         current as current_qmdb,
         sync::{self, compact},
     },
@@ -73,9 +74,9 @@ struct Config {
 async fn target_update_task<E, Op, D>(
     context: E,
     resolver: Resolver<Op, D>,
-    update_tx: mpsc::Sender<sync::Target<mmr::Family, D>>,
+    update_tx: mpsc::Sender<Target<mmr::Family, D>>,
     interval_duration: Duration,
-    initial_target: sync::Target<mmr::Family, D>,
+    initial_target: Target<mmr::Family, D>,
 ) -> Result<(), Error>
 where
     E: Clock,
@@ -135,8 +136,8 @@ where
         E,
         Config,
         Resolver<Op, Key>,
-        sync::Target<mmr::Family, Key>,
-        mpsc::Receiver<sync::Target<mmr::Family, Key>>,
+        Target<mmr::Family, Key>,
+        mpsc::Receiver<Target<mmr::Family, Key>>,
         u32,
     ) -> SyncFut,
     SyncFut: Future<Output = Result<DB, Box<dyn std::error::Error>>>,
@@ -191,7 +192,7 @@ where
         |context, config, resolver, initial_target, update_receiver, iteration| async move {
             let db_config = any::create_config(&context);
             let sync_config =
-                sync::engine::Config::<any::Database<_>, Resolver<any::Operation, Key>> {
+                sync::engine::Config::<any::Database<_>, Resolver<any::Operation, Key>, _> {
                     context,
                     db_config,
                     fetch_batch_size: config.batch_size,
@@ -323,6 +324,7 @@ where
             let sync_config = sync::engine::Config::<
                 immutable::Database<_>,
                 Resolver<immutable::Operation, Key>,
+                _,
             > {
                 context,
                 db_config,
@@ -360,20 +362,23 @@ where
         config,
         |context, config, resolver, initial_target, update_receiver, iteration| async move {
             let db_config = keyless::create_config(&context);
-            let sync_config =
-                sync::engine::Config::<keyless::Database<_>, Resolver<keyless::Operation, Key>> {
-                    context,
-                    db_config,
-                    fetch_batch_size: config.batch_size,
-                    target: initial_target,
-                    resolver,
-                    apply_batch_size: 1024,
-                    max_outstanding_requests: config.max_outstanding_requests,
-                    update_rx: Some(update_receiver),
-                    finish_rx: None,
-                    reached_target_tx: None,
-                    max_retained_roots: 8,
-                };
+            let sync_config = sync::engine::Config::<
+                keyless::Database<_>,
+                Resolver<keyless::Operation, Key>,
+                _,
+            > {
+                context,
+                db_config,
+                fetch_batch_size: config.batch_size,
+                target: initial_target,
+                resolver,
+                apply_batch_size: 1024,
+                max_outstanding_requests: config.max_outstanding_requests,
+                update_rx: Some(update_receiver),
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            };
             let database: keyless::Database<_> = sync::sync(sync_config).await?;
             info!(
                 sync_iteration = iteration,

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -232,7 +232,6 @@ where
         request_id: request.request_id,
         target: Target {
             root,
-            canonical_root: None,
             range: non_empty_range!(sync_boundary, size),
         },
     };

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -232,6 +232,7 @@ where
         request_id: request.request_id,
         target: Target {
             root,
+            canonical_root: None,
             range: non_empty_range!(sync_boundary, size),
         },
     };
@@ -402,6 +403,49 @@ where
                 wire::Message::GetSyncTargetResponse,
                 handle_get_sync_target::<DB>(state, request)
             ),
+            _ => unexpected_message(state, request_id),
+        }
+    }
+}
+
+struct CurrentFullMode;
+
+impl<E> ServeMode<current::Database<E>> for CurrentFullMode
+where
+    E: Storage + Clock + Metrics + Send + Sync + 'static,
+{
+    const LISTENING_MESSAGE: &'static str =
+        "current server listening and continuously adding operations";
+    const SHUTDOWN_MESSAGE: &'static str = "context shutdown, stopping current server";
+
+    async fn handle_message(
+        state: &State<current::Database<E>>,
+        message: wire::Message<current::Operation, Key>,
+    ) -> wire::Message<current::Operation, Key> {
+        let request_id = message.request_id();
+        match message {
+            wire::Message::GetOperationsRequest(request) => dispatch_message!(
+                state,
+                request_id,
+                wire::Message::GetOperationsResponse,
+                handle_get_operations::<current::Database<E>>(state, request)
+            ),
+            wire::Message::GetSyncTargetRequest(request) => {
+                state.request_counter.inc();
+                let database = state.database.read().await;
+                match current::current_sync_target(&*database).await {
+                    Ok(target) => {
+                        debug!(?target, "serving current sync target");
+                        wire::Message::GetCurrentSyncTargetResponse(
+                            wire::GetCurrentSyncTargetResponse {
+                                request_id: request.request_id,
+                                target,
+                            },
+                        )
+                    }
+                    Err(err) => error_message(state, request_id, err.into()),
+                }
+            }
             _ => unexpected_message(state, request_id),
         }
     }
@@ -710,14 +754,18 @@ where
 }
 
 /// Run the Current database server.
-async fn run_current<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
+///
+/// Uses `CurrentFullMode` to serve canonical-root-aware sync targets with an
+/// [OpsRootWitness](commonware_storage::qmdb::current::proof::OpsRootWitness).
+async fn run_current<E>(mut context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
     E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
 {
     let db_config = current::create_config(&context);
     let database = current::Database::init(context.child("database"), db_config).await?;
+    let database = initialize_database(database, &config, &mut context).await?;
 
-    run_helper(context, config, database).await
+    run_server::<current::Database<_>, E, CurrentFullMode>(context, config, database).await
 }
 
 /// Run the Immutable database server.

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -220,7 +220,7 @@ where
     state.request_counter.inc();
 
     // Get the current database state
-    let (root, sync_boundary, size) = {
+    let (ops_root, sync_boundary, size) = {
         let database = state.database.read().await;
         (
             database.root(),
@@ -231,7 +231,8 @@ where
     let response = wire::GetSyncTargetResponse::<Key> {
         request_id: request.request_id,
         target: Target {
-            root,
+            root: ops_root,
+            ops_root,
             range: non_empty_range!(sync_boundary, size),
         },
     };
@@ -754,7 +755,7 @@ where
 
 /// Run the Current database server.
 ///
-/// Uses `CurrentFullMode` to serve canonical-root-aware sync targets with an
+/// Uses `CurrentFullMode` to serve database-root-aware sync targets with an
 /// [OpsRootWitness](commonware_storage::qmdb::current::proof::OpsRootWitness).
 async fn run_current<E>(mut context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -14,7 +14,7 @@ use commonware_runtime::{
 };
 use commonware_storage::{
     mmr,
-    qmdb::sync::{compact, Target},
+    qmdb::{any::sync::Target, sync::compact},
 };
 use commonware_stream::utils::codec::{recv_frame, send_frame};
 use commonware_sync::{
@@ -230,11 +230,7 @@ where
     };
     let response = wire::GetSyncTargetResponse::<Key> {
         request_id: request.request_id,
-        target: Target {
-            root: ops_root,
-            ops_root,
-            range: non_empty_range!(sync_boundary, size),
-        },
+        target: Target::new(ops_root, non_empty_range!(sync_boundary, size)),
     };
 
     debug!(?response, "serving target update");

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -6,10 +6,11 @@
 //! with ops subtree roots), and an optional partial-chunk digest. See [current] module
 //! documentation for more details.
 //!
-//! For sync, the engine targets the **ops root** (not the canonical root). The operations and proof
-//! format are identical to `any`; direct proof verifiers should use `qmdb::hasher`. The bitmap is
-//! reconstructed deterministically from the operations after sync completes. See the
-//! [Root structure](commonware_storage::qmdb::current) module documentation for details.
+//! For sync, the engine internally targets the **ops root** (not the canonical root). The
+//! operations and proof format are identical to `any`; direct proof verifiers should use
+//! `qmdb::hasher`. The bitmap is reconstructed deterministically from the operations after sync
+//! completes. The [current::sync](commonware_storage::qmdb::current::sync) wrapper verifies an
+//! [OpsRootWitness] against a trusted canonical root before and after syncing.
 //!
 //! This module re-uses the same [`Operation`] type as [`super::any`] since the underlying
 //! operations log is the same.
@@ -25,11 +26,11 @@ use commonware_storage::{
     qmdb::{
         self,
         any::unordered::{fixed::Operation as FixedOperation, Update},
-        current::{self, FixedConfig as Config},
+        current::{self, sync::Target as CurrentTarget, FixedConfig as Config},
         operation::Committable,
     },
 };
-use commonware_utils::{NZUsize, NZU16, NZU64};
+use commonware_utils::{non_empty_range, NZUsize, NZU16, NZU64};
 use std::{future::Future, num::NonZeroU64};
 use tracing::error;
 
@@ -145,9 +146,7 @@ where
     }
 
     fn root(&self) -> Key {
-        // Return the ops root (not the canonical root) because this is what the
-        // sync engine verifies against.
-        self.ops_root()
+        self.root()
     }
 
     fn name() -> &'static str {
@@ -184,6 +183,21 @@ where
     ) -> impl Future<Output = Result<Vec<Key>, qmdb::Error<mmr::Family>>> + Send {
         self.pinned_nodes_at(loc)
     }
+}
+
+pub async fn current_sync_target<E: Storage + Clock + Metrics>(
+    db: &Database<E>,
+) -> Result<CurrentTarget<mmr::Family, Key>, qmdb::Error<mmr::Family>> {
+    let hasher = qmdb::hasher::<Hasher>();
+    let witness = db.ops_root_witness(&hasher).await?;
+    let sync_boundary = db.sync_boundary();
+    let size = db.bounds().await.end;
+    Ok(CurrentTarget {
+        canonical_root: db.root(),
+        ops_root: db.ops_root(),
+        witness,
+        range: non_empty_range!(sync_boundary, size),
+    })
 }
 
 #[cfg(test)]

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -9,8 +9,9 @@
 //! For sync, the engine internally targets the **ops root** (not the canonical root). The
 //! operations and proof format are identical to `any`; direct proof verifiers should use
 //! `qmdb::hasher`. The bitmap is reconstructed deterministically from the operations after sync
-//! completes. The [current::sync](commonware_storage::qmdb::current::sync) wrapper verifies an
-//! [OpsRootWitness] against a trusted canonical root before and after syncing.
+//! completes. The `current::sync` wrapper verifies each target's `OpsRootWitness` against its
+//! trusted canonical root, then checks the reconstructed canonical root for the target the
+//! engine finishes on.
 //!
 //! This module re-uses the same [`Operation`] type as [`super::any`] since the underlying
 //! operations log is the same.

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -2,15 +2,15 @@
 //!
 //! A `current` database extends an `any` database with an activity bitmap that tracks which
 //! operations are active (i.e. represent the current state of their key) vs inactive (superseded or
-//! deleted). Its canonical root folds the ops root, a grafted merkle root (combining bitmap chunks
+//! deleted). Its database root folds the ops root, a grafted merkle root (combining bitmap chunks
 //! with ops subtree roots), and an optional partial-chunk digest. See [current] module
 //! documentation for more details.
 //!
-//! For sync, the engine internally targets the **ops root** (not the canonical root). The
+//! For sync, the engine internally targets the **ops root** (not the database root). The
 //! operations and proof format are identical to `any`; direct proof verifiers should use
 //! `qmdb::hasher`. The bitmap is reconstructed deterministically from the operations after sync
 //! completes. The `current::sync` wrapper verifies each target's `OpsRootWitness` against its
-//! trusted canonical root, then checks the reconstructed canonical root for the target the
+//! trusted database root, then checks the reconstructed database root for the target the
 //! engine finishes on.
 //!
 //! This module re-uses the same [`Operation`] type as [`super::any`] since the underlying
@@ -194,7 +194,7 @@ pub async fn current_sync_target<E: Storage + Clock + Metrics>(
     let sync_boundary = db.sync_boundary();
     let size = db.bounds().await.end;
     Ok(CurrentTarget {
-        canonical_root: db.root(),
+        root: db.root(),
         ops_root: db.ops_root(),
         witness,
         range: non_empty_range!(sync_boundary, size),

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -193,12 +193,12 @@ pub async fn current_sync_target<E: Storage + Clock + Metrics>(
     let witness = db.ops_root_witness(&hasher).await?;
     let sync_boundary = db.sync_boundary();
     let size = db.bounds().await.end;
-    Ok(CurrentTarget {
-        root: db.root(),
-        ops_root: db.ops_root(),
+    Ok(CurrentTarget::new(
+        db.root(),
+        db.ops_root(),
         witness,
-        range: non_empty_range!(sync_boundary, size),
-    })
+        non_empty_range!(sync_boundary, size),
+    ))
 }
 
 #[cfg(test)]

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -173,9 +173,6 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn current_target(&self) -> compact::Target<Self::Family, Key> {
-        compact::Target {
-            root: self.root(),
-            leaf_count: self.bounds().await.end,
-        }
+        compact::Target::new(self.root(), self.bounds().await.end)
     }
 }

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -164,10 +164,7 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn current_target(&self) -> compact::Target<Self::Family, Key> {
-        compact::Target {
-            root: self.root(),
-            leaf_count: self.bounds().await.end,
-        }
+        compact::Target::new(self.root(), self.bounds().await.end)
     }
 }
 

--- a/examples/sync/src/net/resolver.rs
+++ b/examples/sync/src/net/resolver.rs
@@ -5,7 +5,10 @@ use commonware_cryptography::Digest;
 use commonware_runtime::{Network, Spawner};
 use commonware_storage::{
     mmr::{self, Location},
-    qmdb::sync::{self, compact},
+    qmdb::{
+        current::sync::Target as CurrentTarget,
+        sync::{self, compact},
+    },
 };
 use commonware_utils::channel::{mpsc, oneshot};
 use std::num::NonZeroU64;
@@ -63,6 +66,35 @@ where
             .map_err(|_| crate::Error::ResponseChannelClosed { request_id })??;
         match response {
             wire::Message::GetSyncTargetResponse(r) => Ok(r.target),
+            wire::Message::Error(err) => Err(crate::Error::Server {
+                code: err.error_code,
+                message: err.message,
+            }),
+            _ => Err(crate::Error::UnexpectedResponse { request_id }),
+        }
+    }
+
+    /// Returns the current-database sync target (canonical root + witness).
+    pub async fn get_current_sync_target(
+        &self,
+    ) -> Result<CurrentTarget<mmr::Family, D>, crate::Error> {
+        let request_id = self.request_id_generator.next();
+        let request =
+            wire::Message::GetSyncTargetRequest(wire::GetSyncTargetRequest { request_id });
+        let (tx, rx) = oneshot::channel();
+        self.request_tx
+            .clone()
+            .send(io::Request {
+                request,
+                response_tx: tx,
+            })
+            .await
+            .map_err(|_| crate::Error::RequestChannelClosed)?;
+        let response = rx
+            .await
+            .map_err(|_| crate::Error::ResponseChannelClosed { request_id })??;
+        match response {
+            wire::Message::GetCurrentSyncTargetResponse(r) => Ok(r.target),
             wire::Message::Error(err) => Err(crate::Error::Server {
                 code: err.error_code,
                 message: err.message,

--- a/examples/sync/src/net/resolver.rs
+++ b/examples/sync/src/net/resolver.rs
@@ -74,7 +74,7 @@ where
         }
     }
 
-    /// Returns the current-database sync target (canonical root + witness).
+    /// Returns the current-database sync target (database root + witness).
     pub async fn get_current_sync_target(
         &self,
     ) -> Result<CurrentTarget<mmr::Family, D>, crate::Error> {

--- a/examples/sync/src/net/resolver.rs
+++ b/examples/sync/src/net/resolver.rs
@@ -6,6 +6,7 @@ use commonware_runtime::{Network, Spawner};
 use commonware_storage::{
     mmr::{self, Location},
     qmdb::{
+        any::sync::Target,
         current::sync::Target as CurrentTarget,
         sync::{self, compact},
     },
@@ -48,7 +49,7 @@ where
     }
 
     /// Returns the current sync target from the server.
-    pub async fn get_sync_target(&self) -> Result<sync::Target<mmr::Family, D>, crate::Error> {
+    pub async fn get_sync_target(&self) -> Result<Target<mmr::Family, D>, crate::Error> {
         let request_id = self.request_id_generator.next();
         let request =
             wire::Message::GetSyncTargetRequest(wire::GetSyncTargetRequest { request_id });

--- a/examples/sync/src/net/wire.rs
+++ b/examples/sync/src/net/wire.rs
@@ -57,7 +57,7 @@ where
     pub target: Target<mmr::Family, D>,
 }
 
-/// Response with current-database sync target (canonical root + witness).
+/// Response with current-database sync target (database root + witness).
 #[derive(Debug)]
 pub struct GetCurrentSyncTargetResponse<D>
 where

--- a/examples/sync/src/net/wire.rs
+++ b/examples/sync/src/net/wire.rs
@@ -6,7 +6,10 @@ use commonware_cryptography::Digest;
 use commonware_runtime::{Buf, BufMut};
 use commonware_storage::{
     mmr::{self, Location, Proof},
-    qmdb::sync::{compact, compact::State, Target},
+    qmdb::{
+        current::sync::Target as CurrentTarget,
+        sync::{compact, compact::State, Target},
+    },
 };
 use std::num::NonZeroU64;
 
@@ -52,6 +55,16 @@ where
 {
     pub request_id: RequestId,
     pub target: Target<mmr::Family, D>,
+}
+
+/// Response with current-database sync target (canonical root + witness).
+#[derive(Debug)]
+pub struct GetCurrentSyncTargetResponse<D>
+where
+    D: Digest,
+{
+    pub request_id: RequestId,
+    pub target: CurrentTarget<mmr::Family, D>,
 }
 
 /// Request for compact authenticated state.
@@ -104,6 +117,7 @@ where
     GetCompactTargetResponse(GetCompactTargetResponse<D>),
     GetCompactStateRequest(GetCompactStateRequest<D>),
     GetCompactStateResponse(GetCompactStateResponse<Op, D>),
+    GetCurrentSyncTargetResponse(GetCurrentSyncTargetResponse<D>),
     Error(ErrorResponse),
 }
 
@@ -121,6 +135,7 @@ where
             Self::GetCompactTargetResponse(r) => r.request_id,
             Self::GetCompactStateRequest(r) => r.request_id,
             Self::GetCompactStateResponse(r) => r.request_id,
+            Self::GetCurrentSyncTargetResponse(r) => r.request_id,
             Self::Error(e) => e.request_id,
         }
     }
@@ -176,6 +191,10 @@ where
                 7u8.write(buf);
                 resp.write(buf);
             }
+            Self::GetCurrentSyncTargetResponse(resp) => {
+                9u8.write(buf);
+                resp.write(buf);
+            }
             Self::Error(err) => {
                 8u8.write(buf);
                 err.write(buf);
@@ -199,6 +218,7 @@ where
             Self::GetCompactTargetResponse(resp) => resp.encode_size(),
             Self::GetCompactStateRequest(req) => req.encode_size(),
             Self::GetCompactStateResponse(resp) => resp.encode_size(),
+            Self::GetCurrentSyncTargetResponse(resp) => resp.encode_size(),
             Self::Error(err) => err.encode_size(),
         }
     }
@@ -235,6 +255,9 @@ where
                 GetCompactStateResponse::read(buf)?,
             )),
             8 => Ok(Self::Error(ErrorResponse::read(buf)?)),
+            9 => Ok(Self::GetCurrentSyncTargetResponse(
+                GetCurrentSyncTargetResponse::read(buf)?,
+            )),
             d => Err(CodecError::InvalidEnum(d)),
         }
     }
@@ -411,6 +434,28 @@ where
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let request_id = RequestId::read_cfg(buf, &())?;
         let target = Target::<mmr::Family, D>::read_cfg(buf, &())?;
+        Ok(Self { request_id, target })
+    }
+}
+
+impl<D: Digest> Write for GetCurrentSyncTargetResponse<D> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.request_id.write(buf);
+        self.target.write(buf);
+    }
+}
+
+impl<D: Digest> EncodeSize for GetCurrentSyncTargetResponse<D> {
+    fn encode_size(&self) -> usize {
+        self.request_id.encode_size() + self.target.encode_size()
+    }
+}
+
+impl<D: Digest> Read for GetCurrentSyncTargetResponse<D> {
+    type Cfg = ();
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+        let request_id = RequestId::read_cfg(buf, &())?;
+        let target = CurrentTarget::<mmr::Family, D>::read_cfg(buf, &())?;
         Ok(Self { request_id, target })
     }
 }

--- a/examples/sync/src/net/wire.rs
+++ b/examples/sync/src/net/wire.rs
@@ -7,8 +7,9 @@ use commonware_runtime::{Buf, BufMut};
 use commonware_storage::{
     mmr::{self, Location, Proof},
     qmdb::{
+        any::sync::Target,
         current::sync::Target as CurrentTarget,
-        sync::{compact, compact::State, Target},
+        sync::{compact, compact::State},
     },
 };
 use std::num::NonZeroU64;

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -332,7 +332,7 @@ hash = "c6702e8b8d2e96438df00786289df9ee4ec92a767974fa1484766a246ebc71b7"
 
 ["commonware_storage::qmdb::sync::target::tests::conformance::CodecConformance<Target<MmrFamily,sha256::Digest>>"]
 n_cases = 65536
-hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
+hash = "db1c6cc1cd9c4dedb2a4a04c38f25c2e309f6162df163bb16ce83549e3b403c5"
 
 ["commonware_storage::queue::conformance::QueueConformance"]
 n_cases = 512

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -332,7 +332,7 @@ hash = "c6702e8b8d2e96438df00786289df9ee4ec92a767974fa1484766a246ebc71b7"
 
 ["commonware_storage::qmdb::sync::target::tests::conformance::CodecConformance<Target<MmrFamily,sha256::Digest>>"]
 n_cases = 65536
-hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
+hash = "0cab3319c9a7849035524b432c8a17dcc7c44d15412760ec2b2e3ce8139dfb2e"
 
 ["commonware_storage::queue::conformance::QueueConformance"]
 n_cases = 512

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -332,7 +332,7 @@ hash = "c6702e8b8d2e96438df00786289df9ee4ec92a767974fa1484766a246ebc71b7"
 
 ["commonware_storage::qmdb::sync::target::tests::conformance::CodecConformance<Target<MmrFamily,sha256::Digest>>"]
 n_cases = 65536
-hash = "db1c6cc1cd9c4dedb2a4a04c38f25c2e309f6162df163bb16ce83549e3b403c5"
+hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
 
 ["commonware_storage::queue::conformance::QueueConformance"]
 n_cases = 512

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -134,6 +134,14 @@ hash = "f5456580eb69727a23bfb0281e33f467acc0c91273efebd334d3e82c9770ae76"
 n_cases = 65536
 hash = "a3fbb5f749fa5b73a684e9f0bebd8973c456e5ee43a0a3db75a99aa550dee302"
 
+["commonware_storage::qmdb::any::sync::conformance::CodecConformance<Target<mmb::Family,sha256::Digest>>"]
+n_cases = 65536
+hash = "fae4fc2ff4f22c0614eea3f0928dec8940398014bb4d696b2bb89d880ad02bac"
+
+["commonware_storage::qmdb::any::sync::conformance::CodecConformance<Target<mmr::Family,sha256::Digest>>"]
+n_cases = 65536
+hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
+
 ["commonware_storage::qmdb::conformance::AnyMmbOrderedFixedConf"]
 n_cases = 200
 hash = "b3c1e2f17435b89294b6fc2f9b779574dc3fe9cc1d9e86a0ba76f3bd3f9361a0"
@@ -310,6 +318,14 @@ hash = "21375f68b817719323839af311b70dcd01925b413d3e2557fd4bbe75fd47008b"
 n_cases = 65536
 hash = "39ea177ae9f1c765339b4bfb88f0adb97812ab421daad405c041241324796f11"
 
+["commonware_storage::qmdb::current::sync::conformance::CodecConformance<Target<mmb::Family,Sha256Digest>>"]
+n_cases = 65536
+hash = "627d183063857a61fdb2e6cfc3599efc73111275bc197b7b92b7d2f5b81807ba"
+
+["commonware_storage::qmdb::current::sync::conformance::CodecConformance<Target<mmr::Family,Sha256Digest>>"]
+n_cases = 65536
+hash = "ea64a65b50482b6f7f5146e3623efd2100920c66c5397675268a350d8b9734a9"
+
 ["commonware_storage::qmdb::immutable::operation::fixed::tests::conformance::CodecConformance<FixedOp>"]
 n_cases = 65536
 hash = "1737c49c112fc9dfdc4dde3626d8ab08a9df8353b9a702e488d3a1fd8e9428dc"
@@ -330,9 +346,13 @@ hash = "1ad07a5388e328474b353c153617b6a8a3a4713a9895f3f505148f919c49b86d"
 n_cases = 65536
 hash = "c6702e8b8d2e96438df00786289df9ee4ec92a767974fa1484766a246ebc71b7"
 
-["commonware_storage::qmdb::sync::target::tests::conformance::CodecConformance<Target<MmrFamily,sha256::Digest>>"]
+["commonware_storage::qmdb::sync::compact::conformance::CodecConformance<Target<mmb::Family,Sha256Digest>>"]
 n_cases = 65536
-hash = "0cab3319c9a7849035524b432c8a17dcc7c44d15412760ec2b2e3ce8139dfb2e"
+hash = "c59085de482697991f0202388605c751020e257b858d4af35386495d4db7c14c"
+
+["commonware_storage::qmdb::sync::compact::conformance::CodecConformance<Target<mmr::Family,Sha256Digest>>"]
+n_cases = 65536
+hash = "290187801284530d0d7e82c33bb6ce975a5f4daa4b104230291cea9cffcd7686"
 
 ["commonware_storage::queue::conformance::QueueConformance"]
 n_cases = 512

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -131,7 +131,7 @@ where
     >,
 {
     let db_config = test_config(test_name, &context);
-    let expected_root = target.root;
+    let expected_root = target.ops_root;
 
     let sync_config: sync::engine::Config<FixedDb<F>, R> = sync::engine::Config {
         context: context.child("sync").with_attribute("id", sync_id),
@@ -240,6 +240,7 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
                     db.commit().await.expect("Commit should not fail");
                     let target = sync::Target {
                         root: db.root(),
+                        ops_root: db.root(),
                         range: non_empty_range!(db.sync_boundary(), db.bounds().await.end),
                     };
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -131,7 +131,7 @@ where
     >,
 {
     let db_config = test_config(test_name, &context);
-    let expected_root = target.ops_root;
+    let expected_root = target.root;
 
     let sync_config: sync::engine::Config<FixedDb<F>, R> = sync::engine::Config {
         context: context.child("sync").with_attribute("id", sync_id),

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -11,6 +11,7 @@ use commonware_storage::{
     merkle::{full::Config as MerkleConfig, mmb, mmr, Family as MerkleFamily},
     qmdb::{
         any::{
+            sync::Target,
             unordered::fixed::{Db, Operation as FixedOperation},
             FixedConfig as Config,
         },
@@ -117,7 +118,7 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
 async fn test_sync<F, R>(
     context: deterministic::Context,
     resolver: R,
-    target: sync::Target<F, commonware_cryptography::sha256::Digest>,
+    target: Target<F, commonware_cryptography::sha256::Digest>,
     fetch_batch_size: u64,
     test_name: &str,
     sync_id: usize,
@@ -133,7 +134,11 @@ where
     let db_config = test_config(test_name, &context);
     let expected_root = target.root;
 
-    let sync_config: sync::engine::Config<FixedDb<F>, R> = sync::engine::Config {
+    let sync_config: sync::engine::Config<
+        FixedDb<F>,
+        R,
+        Target<F, commonware_cryptography::sha256::Digest>,
+    > = sync::engine::Config {
         context: context.child("sync").with_attribute("id", sync_id),
         update_rx: None,
         finish_rx: None,
@@ -238,11 +243,10 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
                         .await
                         .expect("commit should not fail");
                     db.commit().await.expect("Commit should not fail");
-                    let target = sync::Target {
-                        root: db.root(),
-                        ops_root: db.root(),
-                        range: non_empty_range!(db.sync_boundary(), db.bounds().await.end),
-                    };
+                    let target = Target::new(
+                        db.root(),
+                        non_empty_range!(db.sync_boundary(), db.bounds().await.end),
+                    );
 
                     let wrapped_src = Arc::new(db);
                     let _result = test_sync(

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -93,7 +93,7 @@ pub mod traits;
 pub mod value;
 pub use value::{FixedValue, ValueEncoding, VariableValue};
 pub mod ordered;
-pub(crate) mod sync;
+pub mod sync;
 pub mod unordered;
 
 pub(crate) const BITMAP_CHUNK_BYTES: usize = 64;

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -1646,7 +1646,7 @@ pub(crate) mod test {
         use super::*;
         use crate::{
             merkle::mmr::{self, full::Mmr},
-            qmdb::any::sync::tests::FromSyncTestable,
+            qmdb::sync::tests::FromSyncTestable,
         };
         use futures::future::join_all;
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -579,7 +579,7 @@ pub(crate) mod test {
         use super::*;
         use crate::{
             merkle::mmr::{self, full::Mmr},
-            qmdb::any::sync::tests::FromSyncTestable,
+            qmdb::sync::tests::FromSyncTestable,
         };
         use futures::future::join_all;
 

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -83,7 +83,7 @@ where
     matches!(
         peek,
         Ok(Some((_, journal_leaves, root)))
-            if journal_leaves == target.range.end() && root == target.root
+            if journal_leaves == target.range.end() && root == target.ops_root
     )
 }
 
@@ -210,6 +210,10 @@ macro_rules! impl_sync_database {
                     inactive_peaks,
                 )
                 .await
+            }
+
+            fn ops_root(&self) -> Self::Digest {
+                crate::qmdb::any::db::Db::root(self)
             }
 
             fn root(&self) -> Self::Digest {

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -50,14 +50,8 @@ use commonware_utils::{range::NonEmptyRange, Array};
 #[cfg(test)]
 pub(crate) mod tests;
 
-/// Returns whether persisted local state already matches the requested sync target.
-///
-/// Shared helper for [crate::qmdb::any] sync implementations, which can reuse persisted
-/// state by checking only the operations-tree size and root.
-///
-/// [crate::qmdb::current] performs an additional lower-bound check because its grafted-state
-/// reconstruction depends on the persisted pruning point remaining at or below
-/// `target.range.start()`.
+/// Returns whether persisted local state already matches the requested sync target by confirming
+/// that the derived `ops_root` matches the one from the target.
 pub async fn has_local_target_state<F, E, H, S>(
     context: E,
     merkle_config: full::Config<S>,
@@ -82,8 +76,8 @@ where
     // the persisted DB without fetching boundary pins.
     matches!(
         peek,
-        Ok(Some((_, journal_leaves, root)))
-            if journal_leaves == target.range.end() && root == target.ops_root
+        Ok(Some((_, journal_leaves, ops_root)))
+            if journal_leaves == target.range.end() && ops_root == target.ops_root
     )
 }
 

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -1,5 +1,5 @@
 //! Shared synchronization logic for [crate::qmdb::any] databases.
-//! Contains implementation of [crate::qmdb::sync::Database] for all [Db] variants
+//! Contains implementation of `qmdb::sync::Database` for all [Db] variants
 //! (ordered/unordered, fixed/variable).
 //!
 //! Callers verifying `any` sync proofs directly should use `qmdb::hasher`.
@@ -42,20 +42,103 @@ use crate::{
     translator::Translator,
     Context, Persistable,
 };
-use commonware_codec::{Codec, CodecShared, Read as CodecRead};
-use commonware_cryptography::Hasher;
+use commonware_codec::{
+    Codec, CodecShared, EncodeSize, Error as CodecError, Read, Read as CodecRead, ReadExt as _,
+    Write,
+};
+use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
+use commonware_runtime::{Buf, BufMut};
 use commonware_utils::{range::NonEmptyRange, Array};
 
 #[cfg(test)]
-pub(crate) mod tests;
+mod tests;
+
+/// Sync target for `any` databases.
+#[derive(Debug)]
+pub struct Target<F: merkle::Family, D: Digest> {
+    /// The database root expected after sync completes.
+    pub root: D,
+    /// Range of operations to sync.
+    pub range: NonEmptyRange<Location<F>>,
+}
+
+impl<F: merkle::Family, D: Digest> Target<F, D> {
+    /// Create a target from a root and operation range.
+    pub const fn new(root: D, range: NonEmptyRange<Location<F>>) -> Self {
+        Self { root, range }
+    }
+}
+
+impl<F: merkle::Family, D: Digest> Clone for Target<F, D> {
+    fn clone(&self) -> Self {
+        Self {
+            root: self.root,
+            range: self.range.clone(),
+        }
+    }
+}
+
+impl<F: merkle::Family, D: Digest> PartialEq for Target<F, D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root && self.range == other.range
+    }
+}
+
+impl<F: merkle::Family, D: Digest> Eq for Target<F, D> {}
+
+impl<F: merkle::Family, D: Digest> qmdb::sync::Target for Target<F, D> {
+    type Family = F;
+    type Digest = D;
+
+    fn root(&self) -> Self::Digest {
+        self.root
+    }
+
+    fn ops_root(&self) -> Self::Digest {
+        self.root
+    }
+
+    fn range(&self) -> &NonEmptyRange<Location<Self::Family>> {
+        &self.range
+    }
+}
+
+impl<F: merkle::Family, D: Digest> Write for Target<F, D> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.root.write(buf);
+        self.range.write(buf);
+    }
+}
+
+impl<F: merkle::Family, D: Digest> EncodeSize for Target<F, D> {
+    fn encode_size(&self) -> usize {
+        self.root.encode_size() + self.range.encode_size()
+    }
+}
+
+impl<F: merkle::Family, D: Digest> Read for Target<F, D> {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+        let root = D::read(buf)?;
+        let range = NonEmptyRange::<Location<F>>::read(buf)?;
+        if !range.start().is_valid() || !range.end().is_valid() {
+            return Err(CodecError::Invalid(
+                "storage::qmdb::any::sync::Target",
+                "range bounds out of valid range",
+            ));
+        }
+        Ok(Self { root, range })
+    }
+}
 
 /// Returns whether persisted local state already matches the requested sync target by confirming
 /// that the derived `ops_root` matches the one from the target.
-pub async fn has_local_target_state<F, E, H, S>(
+pub(crate) async fn has_local_target_state<F, E, H, S, T>(
     context: E,
     merkle_config: full::Config<S>,
-    target: &qmdb::sync::Target<F, H::Digest>,
+    target: &T,
     inactive_peaks: usize,
 ) -> bool
 where
@@ -63,6 +146,7 @@ where
     E: Context,
     H: Hasher,
     S: Strategy,
+    T: qmdb::sync::Target<Family = F, Digest = H::Digest>,
 {
     let hasher = qmdb::hasher::<H>();
     let peek = full::Merkle::<F, _, _, S>::peek_root(
@@ -77,7 +161,7 @@ where
     matches!(
         peek,
         Ok(Some((_, journal_leaves, ops_root)))
-            if journal_leaves == target.range.end() && ops_root == target.ops_root
+            if journal_leaves == target.range().end() && ops_root == target.ops_root()
     )
 }
 
@@ -176,11 +260,14 @@ macro_rules! impl_sync_database {
                 .await
             }
 
-            async fn has_local_target_state(
+            async fn has_local_target_state<Target>(
                 context: Self::Context,
                 config: &Self::Config,
-                target: &qmdb::sync::Target<Self::Family, Self::Digest>,
-            ) -> bool {
+                target: &Target,
+            ) -> bool
+            where
+                Target: qmdb::sync::Target<Family = Self::Family, Digest = Self::Digest>,
+            {
                 let Ok(journal) = <$journal>::init(
                     context.child("local_target_journal_probe"),
                     config.journal_config.clone(),
@@ -189,15 +276,15 @@ macro_rules! impl_sync_database {
                 else {
                     return false;
                 };
-                if Location::new(journal.reader().await.bounds().start) > target.range.start() {
+                if Location::new(journal.reader().await.bounds().start) > target.range().start() {
                     return false;
                 }
 
                 let inactive_peaks = F::inactive_peaks(
-                    F::location_to_position(target.range.end()),
-                    target.range.start(),
+                    F::location_to_position(target.range().end()),
+                    target.range().start(),
                 );
-                qmdb::any::sync::has_local_target_state::<F, _, H, S>(
+                qmdb::any::sync::has_local_target_state::<F, _, H, S, _>(
                     context.child("local_target_merkle_probe"),
                     config.merkle_config.clone(),
                     target,
@@ -244,3 +331,33 @@ impl_sync_database!(
     Key, VariableValue;
     OrderedVariableOp<F, K, V>: CodecShared
 );
+
+#[cfg(feature = "arbitrary")]
+impl<F: merkle::Family, D: Digest> arbitrary::Arbitrary<'_> for Target<F, D>
+where
+    D: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let root = u.arbitrary()?;
+        let max_loc = F::MAX_LEAVES;
+        let lower = u.int_in_range(0..=*max_loc - 1)?;
+        let upper = u.int_in_range(lower + 1..=*max_loc)?;
+        Ok(Self {
+            root,
+            range: commonware_utils::non_empty_range!(Location::new(lower), Location::new(upper)),
+        })
+    }
+}
+
+#[cfg(all(test, feature = "arbitrary"))]
+mod conformance {
+    use super::*;
+    use crate::merkle::{mmb, mmr};
+    use commonware_codec::conformance::CodecConformance;
+    use commonware_cryptography::sha256;
+
+    commonware_conformance::conformance_tests! {
+        CodecConformance<Target<mmr::Family, sha256::Digest>>,
+        CodecConformance<Target<mmb::Family, sha256::Digest>>,
+    }
+}

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -156,7 +156,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: Digest::from([1u8; 32]),
-                canonical_root: None,
                 range: non_empty_range!(Location::new(0), Location::new(10)),
             },
             context: context.child("client"),
@@ -201,7 +200,6 @@ where
             context: context.child("client"),
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(Location::new(0), Location::new(5)),
             },
             resolver,
@@ -254,7 +252,6 @@ where
             fetch_batch_size,
             target: Target {
                 root: sync_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, target_op_count),
             },
             context: client_context.child("client"),
@@ -337,7 +334,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: sync_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("client"),
@@ -418,7 +414,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: sync_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: client_context.child("sync"),
@@ -522,7 +517,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: sync_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: client_context.child("sync"),
@@ -594,7 +588,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -611,7 +604,6 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound.checked_add(1).unwrap()
@@ -665,7 +657,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -682,7 +673,6 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(
                     initial_lower_bound,
                     initial_upper_bound.checked_sub(1).unwrap()
@@ -750,7 +740,6 @@ where
                 fetch_batch_size: NZU64!(1),
                 target: Target {
                     root: initial_root,
-                    canonical_root: None,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -766,7 +755,6 @@ where
             update_sender
                 .send(Target {
                     root: new_sync_root,
-                    canonical_root: None,
                     range: non_empty_range!(new_lower_bound, new_upper_bound),
                 })
                 .await
@@ -824,7 +812,6 @@ where
             fetch_batch_size: NZU64!(20),
             target: Target {
                 root: sync_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -845,7 +832,6 @@ where
             .send(Target {
                 // Dummy target update
                 root: Digest::from([2u8; 32]),
-                canonical_root: None,
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
             })
             .await;
@@ -893,7 +879,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -908,12 +893,10 @@ where
 
         let first_target = Target {
             root,
-            canonical_root: None,
             range: non_empty_range!(initial_lower_bound.checked_add(1).unwrap(), upper_bound),
         };
         let second_target = Target {
             root,
-            canonical_root: None,
             range: non_empty_range!(initial_lower_bound.checked_add(2).unwrap(), upper_bound),
         };
         update_sender.send(first_target).await.unwrap();
@@ -948,7 +931,6 @@ where
         target_db = H::apply_ops(target_db, H::create_ops(10)).await;
         let initial_target = Target {
             root: H::sync_target_root(&target_db),
-            canonical_root: None,
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -960,7 +942,6 @@ where
         let updated_upper_bound = target_db.bounds().await.end;
         let updated_target = Target {
             root: H::sync_target_root(&target_db),
-            canonical_root: None,
             range: non_empty_range!(updated_lower_bound, updated_upper_bound),
         };
         let updated_verification_root = target_db.root();
@@ -1074,7 +1055,6 @@ where
         target_db = H::apply_ops(target_db, H::create_ops(8)).await;
         let initial_target = Target {
             root: H::sync_target_root(&target_db),
-            canonical_root: None,
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -1084,7 +1064,6 @@ where
         target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
         let first_update = Target {
             root: H::sync_target_root(&target_db),
-            canonical_root: None,
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -1094,7 +1073,6 @@ where
         target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 2)).await;
         let second_update = Target {
             root: H::sync_target_root(&target_db),
-            canonical_root: None,
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -1199,7 +1177,6 @@ where
         let upper_bound = target_db.bounds().await.end;
         let target = Target {
             root: H::sync_target_root(&target_db),
-            canonical_root: None,
             range: non_empty_range!(lower_bound, upper_bound),
         };
         let verification_root = target_db.root();
@@ -1272,7 +1249,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: H::sync_target_root(&target_db),
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -1323,7 +1299,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: H::sync_target_root(&target_db),
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -1385,7 +1360,6 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
                 db_config: H::config(&context.next_u64().to_string(), &context),
                 target: Target {
                     root: initial_sync_root,
-                    canonical_root: None,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -1402,7 +1376,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
                 // Step the client until we have processed a batch of operations
                 client = match client.step().await.unwrap() {
                     NextStep::Continue(new_client) => new_client,
-                    NextStep::Complete(_) => panic!("client should not be complete"),
+                    NextStep::Complete(..) => panic!("client should not be complete"),
                 };
                 let log_size = client.journal().size().await;
                 if log_size > initial_lower_bound {
@@ -1430,7 +1404,6 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
             update_sender
                 .send(Target {
                     root: new_sync_root,
-                    canonical_root: None,
                     range: non_empty_range!(new_lower_bound, new_upper_bound),
                 })
                 .await
@@ -1496,7 +1469,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: sync_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: client_context.child("client"),
@@ -1564,7 +1536,6 @@ where
             fetch_batch_size: NZU64!(100),
             target: Target {
                 root: sync_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("client"),
@@ -1915,7 +1886,6 @@ where
             fetch_batch_size: NZU64!(100),
             target: Target {
                 root: sync_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("client"),
@@ -2048,7 +2018,6 @@ where
 
         let old_target = Target {
             root: H::sync_target_root(&target_db),
-            canonical_root: None,
             range: non_empty_range!(
                 target_db.inactivity_floor_loc().await,
                 target_db.bounds().await.end
@@ -2058,7 +2027,6 @@ where
         target_db = H::apply_ops(target_db, H::create_ops_seeded(3, seed + 1)).await;
         let new_target = Target {
             root: H::sync_target_root(&target_db),
-            canonical_root: None,
             range: non_empty_range!(
                 target_db.inactivity_floor_loc().await,
                 target_db.bounds().await.end
@@ -2106,7 +2074,7 @@ where
 
         engine = match engine.step().await.unwrap() {
             NextStep::Continue(engine) => engine,
-            NextStep::Complete(_) => panic!("target update should not complete sync"),
+            NextStep::Complete(..) => panic!("target update should not complete sync"),
         };
 
         let _ = release_historical_gap_tx.send(());
@@ -2120,7 +2088,7 @@ where
                 result = next_step.as_mut() => {
                     engine = match result.unwrap() {
                         NextStep::Continue(engine) => engine,
-                        NextStep::Complete(_) => panic!("boundary retry should still be required"),
+                        NextStep::Complete(..) => panic!("boundary retry should still be required"),
                     };
                     assert_eq!(
                         engine.journal().size().await,

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -265,7 +265,7 @@ where
         };
 
         // Perform sync
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
+        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
 
         // Verify database state (root hash is the key verification)
         assert_eq!(synced_db.bounds().await.end, target_op_count);
@@ -346,7 +346,7 @@ where
             max_retained_roots: 8,
         };
 
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
+        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
 
         // Verify the synced database has the correct range of operations
         assert_eq!(synced_db.sync_boundary().await, lower_bound);
@@ -528,7 +528,7 @@ where
             reached_target_tx: None,
             max_retained_roots: 8,
         };
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
+        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
 
         // Verify database state
         let bounds = synced_db.bounds().await;
@@ -761,7 +761,7 @@ where
                 .unwrap();
 
             // Complete the sync
-            let synced_db: H::Db = sync::sync(config).await.unwrap();
+            let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
 
             // Verify the synced database has the expected final state
             assert_eq!(synced_db.root(), new_verification_root);
@@ -824,7 +824,7 @@ where
         };
 
         // Complete the sync
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
+        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
 
         // Attempt to apply a target update after sync is complete to verify
         // we don't panic
@@ -1097,8 +1097,7 @@ where
             max_retained_roots: 1,
         };
 
-        let sync_handle = sync::sync(config);
-        pin_mut!(sync_handle);
+        let mut sync_handle = Box::pin(sync::sync(config));
 
         select! {
             _ = sync_handle.as_mut() => {
@@ -1260,7 +1259,7 @@ where
             max_retained_roots: 1,
         };
 
-        let result: Result<H::Db, _> = sync::sync(config).await;
+        let result: Result<H::Db, _> = Box::pin(sync::sync(config)).await;
         assert!(matches!(
             result,
             Err(sync::Error::Engine(sync::EngineError::FinishChannelClosed))
@@ -1480,7 +1479,7 @@ where
             reached_target_tx: None,
             max_retained_roots: 8,
         };
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
+        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
 
         // Verify initial sync worked
         assert_eq!(synced_db.root(), verification_root);
@@ -1547,7 +1546,7 @@ where
             reached_target_tx: None,
             max_retained_roots: 8,
         };
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
+        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
 
         let root_after_sync = synced_db.root();
 
@@ -1900,7 +1899,7 @@ where
 
         // Sync should succeed on the second attempt after the first corrupted pinned nodes
         // are rejected.
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
+        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
         assert_eq!(synced_db.root(), sync_root);
         synced_db.destroy().await.unwrap();
     });

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -108,7 +108,12 @@ pub(crate) trait SyncTestHarness: Sized + 'static {
             Config: Clone,
         > + DbAny<Self::Family, Key = Digest, Digest = Digest>;
 
-    /// Return the root the sync engine targets.
+    /// Return the database root expected after sync completes.
+    fn target_root(db: &Self::Db) -> Digest {
+        qmdb::sync::Database::root(db)
+    }
+
+    /// Return the ops root the sync engine targets for range proof verification.
     fn sync_target_root(db: &Self::Db) -> Digest;
 
     /// Create a config with unique partition names
@@ -156,6 +161,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: Digest::from([1u8; 32]),
+                ops_root: Digest::from([1u8; 32]),
                 range: non_empty_range!(Location::new(0), Location::new(10)),
             },
             context: context.child("client"),
@@ -200,6 +206,7 @@ where
             context: context.child("client"),
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(Location::new(0), Location::new(5)),
             },
             resolver,
@@ -251,7 +258,8 @@ where
             db_config: db_config.clone(),
             fetch_batch_size,
             target: Target {
-                root: sync_root,
+                root: verification_root,
+                ops_root: sync_root,
                 range: non_empty_range!(lower_bound, target_op_count),
             },
             context: client_context.child("client"),
@@ -333,7 +341,8 @@ where
             db_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root: sync_root,
+                root: verification_root,
+                ops_root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("client"),
@@ -413,7 +422,8 @@ where
             db_config: sync_db_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root: sync_root,
+                root: verification_root,
+                ops_root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: client_context.child("sync"),
@@ -516,7 +526,8 @@ where
             db_config: sync_config, // Use same config to access same partitions
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root: sync_root,
+                root: verification_root,
+                ops_root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: client_context.child("sync"),
@@ -578,6 +589,7 @@ where
         );
         let initial_upper_bound = target_db.bounds().await.end;
         let initial_root = H::sync_target_root(&target_db);
+        let initial_verification_root = H::target_root(&target_db);
 
         // Create client with initial target
         let (update_sender, update_receiver) = mpsc::channel(1);
@@ -587,7 +599,8 @@ where
             db_config: H::config(&context.next_u64().to_string(), &context),
             fetch_batch_size: NZU64!(5),
             target: Target {
-                root: initial_root,
+                root: initial_verification_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -603,7 +616,8 @@ where
         // Send target update with decreased lower bound
         update_sender
             .send(Target {
-                root: initial_root,
+                root: initial_verification_root,
+                ops_root: initial_root,
                 range: non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound.checked_add(1).unwrap()
@@ -647,6 +661,7 @@ where
         let initial_lower_bound = target_db.sync_boundary().await;
         let initial_upper_bound = target_db.bounds().await.end;
         let initial_root = H::sync_target_root(&target_db);
+        let initial_verification_root = H::target_root(&target_db);
 
         // Create client with initial target
         let (update_sender, update_receiver) = mpsc::channel(1);
@@ -656,7 +671,8 @@ where
             db_config: H::config(&context.next_u64().to_string(), &context),
             fetch_batch_size: NZU64!(5),
             target: Target {
-                root: initial_root,
+                root: initial_verification_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -672,7 +688,8 @@ where
         // Send target update with decreased upper bound
         update_sender
             .send(Target {
-                root: initial_root,
+                root: initial_verification_root,
+                ops_root: initial_root,
                 range: non_empty_range!(
                     initial_lower_bound,
                     initial_upper_bound.checked_sub(1).unwrap()
@@ -716,6 +733,7 @@ where
         let initial_lower_bound = target_db.sync_boundary().await;
         let initial_upper_bound = target_db.bounds().await.end;
         let initial_root = H::sync_target_root(&target_db);
+        let initial_verification_root = H::target_root(&target_db);
 
         // Apply more operations to the target database
         // (use different seed to avoid key collisions)
@@ -739,7 +757,8 @@ where
                 db_config: H::config(&context.next_u64().to_string(), &context),
                 fetch_batch_size: NZU64!(1),
                 target: Target {
-                    root: initial_root,
+                    root: initial_verification_root,
+                    ops_root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -754,7 +773,8 @@ where
             // Send target update with increased bounds
             update_sender
                 .send(Target {
-                    root: new_sync_root,
+                    root: new_verification_root,
+                    ops_root: new_sync_root,
                     range: non_empty_range!(new_lower_bound, new_upper_bound),
                 })
                 .await
@@ -811,7 +831,8 @@ where
             db_config: H::config(&context.next_u64().to_string(), &context),
             fetch_batch_size: NZU64!(20),
             target: Target {
-                root: sync_root,
+                root: verification_root,
+                ops_root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -832,6 +853,7 @@ where
             .send(Target {
                 // Dummy target update
                 root: Digest::from([2u8; 32]),
+                ops_root: Digest::from([2u8; 32]),
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
             })
             .await;
@@ -869,7 +891,8 @@ where
             "test setup requires lower bound that can advance twice"
         );
         let upper_bound = target_db.bounds().await.end;
-        let root = H::sync_target_root(&target_db);
+        let root = H::target_root(&target_db);
+        let ops_root = H::sync_target_root(&target_db);
 
         let (update_sender, update_receiver) = mpsc::channel(2);
         let target_db = Arc::new(target_db);
@@ -879,6 +902,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root,
+                ops_root,
                 range: non_empty_range!(initial_lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -893,10 +917,12 @@ where
 
         let first_target = Target {
             root,
+            ops_root,
             range: non_empty_range!(initial_lower_bound.checked_add(1).unwrap(), upper_bound),
         };
         let second_target = Target {
             root,
+            ops_root,
             range: non_empty_range!(initial_lower_bound.checked_add(2).unwrap(), upper_bound),
         };
         update_sender.send(first_target).await.unwrap();
@@ -930,7 +956,8 @@ where
         let mut target_db = H::init_db(context.child("target")).await;
         target_db = H::apply_ops(target_db, H::create_ops(10)).await;
         let initial_target = Target {
-            root: H::sync_target_root(&target_db),
+            root: H::target_root(&target_db),
+            ops_root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -941,7 +968,8 @@ where
         let updated_lower_bound = target_db.sync_boundary().await;
         let updated_upper_bound = target_db.bounds().await.end;
         let updated_target = Target {
-            root: H::sync_target_root(&target_db),
+            root: H::target_root(&target_db),
+            ops_root: H::sync_target_root(&target_db),
             range: non_empty_range!(updated_lower_bound, updated_upper_bound),
         };
         let updated_verification_root = target_db.root();
@@ -1054,7 +1082,8 @@ where
 
         target_db = H::apply_ops(target_db, H::create_ops(8)).await;
         let initial_target = Target {
-            root: H::sync_target_root(&target_db),
+            root: H::target_root(&target_db),
+            ops_root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -1063,7 +1092,8 @@ where
 
         target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
         let first_update = Target {
-            root: H::sync_target_root(&target_db),
+            root: H::target_root(&target_db),
+            ops_root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -1072,7 +1102,8 @@ where
 
         target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 2)).await;
         let second_update = Target {
-            root: H::sync_target_root(&target_db),
+            root: H::target_root(&target_db),
+            ops_root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -1175,7 +1206,8 @@ where
         let lower_bound = target_db.sync_boundary().await;
         let upper_bound = target_db.bounds().await.end;
         let target = Target {
-            root: H::sync_target_root(&target_db),
+            root: H::target_root(&target_db),
+            ops_root: H::sync_target_root(&target_db),
             range: non_empty_range!(lower_bound, upper_bound),
         };
         let verification_root = target_db.root();
@@ -1247,7 +1279,8 @@ where
             db_config: H::config(&context.next_u64().to_string(), &context),
             fetch_batch_size: NZU64!(5),
             target: Target {
-                root: H::sync_target_root(&target_db),
+                root: H::target_root(&target_db),
+                ops_root: H::sync_target_root(&target_db),
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -1297,7 +1330,8 @@ where
             db_config: H::config(&context.next_u64().to_string(), &context),
             fetch_batch_size: NZU64!(5),
             target: Target {
-                root: H::sync_target_root(&target_db),
+                root: H::target_root(&target_db),
+                ops_root: H::sync_target_root(&target_db),
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -1346,6 +1380,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
         let initial_lower_bound = target_db.sync_boundary().await;
         let initial_upper_bound = target_db.bounds().await.end;
         let initial_sync_root = H::sync_target_root(&target_db);
+        let initial_verification_root = H::target_root(&target_db);
 
         // Wrap target database for shared mutable access (using Option so we can take ownership)
         let target_db = Arc::new(AsyncRwLock::new(Some(target_db)));
@@ -1358,7 +1393,8 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
                 context: context.child("client"),
                 db_config: H::config(&context.next_u64().to_string(), &context),
                 target: Target {
-                    root: initial_sync_root,
+                    root: initial_verification_root,
+                    ops_root: initial_sync_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -1402,7 +1438,8 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
             // Send target update with new target
             update_sender
                 .send(Target {
-                    root: new_sync_root,
+                    root: new_verification_root,
+                    ops_root: new_sync_root,
                     range: non_empty_range!(new_lower_bound, new_upper_bound),
                 })
                 .await
@@ -1467,7 +1504,8 @@ where
             db_config: db_config.clone(),
             fetch_batch_size: NZU64!(5),
             target: Target {
-                root: sync_root,
+                root: verification_root,
+                ops_root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: client_context.child("client"),
@@ -1525,6 +1563,7 @@ where
         target_db = H::apply_ops(target_db, target_ops).await;
 
         let sync_root = H::sync_target_root(&target_db);
+        let verification_root = H::target_root(&target_db);
         let lower_bound = target_db.sync_boundary().await;
         let upper_bound = target_db.bounds().await.end;
         let target_db = Arc::new(target_db);
@@ -1534,7 +1573,8 @@ where
             db_config: config,
             fetch_batch_size: NZU64!(100),
             target: Target {
-                root: sync_root,
+                root: verification_root,
+                ops_root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("client"),
@@ -1870,6 +1910,7 @@ where
             .unwrap();
 
         let sync_root = H::sync_target_root(&target_db);
+        let verification_root = H::target_root(&target_db);
         let lower_bound = target_db.sync_boundary().await;
         let upper_bound = target_db.bounds().await.end;
 
@@ -1884,7 +1925,8 @@ where
             db_config,
             fetch_batch_size: NZU64!(100),
             target: Target {
-                root: sync_root,
+                root: verification_root,
+                ops_root: sync_root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("client"),
@@ -2016,7 +2058,8 @@ where
         }
 
         let old_target = Target {
-            root: H::sync_target_root(&target_db),
+            root: H::target_root(&target_db),
+            ops_root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.inactivity_floor_loc().await,
                 target_db.bounds().await.end
@@ -2025,7 +2068,8 @@ where
 
         target_db = H::apply_ops(target_db, H::create_ops_seeded(3, seed + 1)).await;
         let new_target = Target {
-            root: H::sync_target_root(&target_db),
+            root: H::target_root(&target_db),
+            ops_root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.inactivity_floor_loc().await,
                 target_db.bounds().await.end

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -156,6 +156,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: Digest::from([1u8; 32]),
+                canonical_root: None,
                 range: non_empty_range!(Location::new(0), Location::new(10)),
             },
             context: context.child("client"),
@@ -200,6 +201,7 @@ where
             context: context.child("client"),
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(Location::new(0), Location::new(5)),
             },
             resolver,
@@ -252,6 +254,7 @@ where
             fetch_batch_size,
             target: Target {
                 root: sync_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, target_op_count),
             },
             context: client_context.child("client"),
@@ -334,6 +337,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: sync_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("client"),
@@ -414,6 +418,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: sync_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: client_context.child("sync"),
@@ -517,6 +522,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: sync_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: client_context.child("sync"),
@@ -588,6 +594,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -604,6 +611,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound.checked_add(1).unwrap()
@@ -657,6 +665,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -673,6 +682,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(
                     initial_lower_bound,
                     initial_upper_bound.checked_sub(1).unwrap()
@@ -740,6 +750,7 @@ where
                 fetch_batch_size: NZU64!(1),
                 target: Target {
                     root: initial_root,
+                    canonical_root: None,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -755,6 +766,7 @@ where
             update_sender
                 .send(Target {
                     root: new_sync_root,
+                    canonical_root: None,
                     range: non_empty_range!(new_lower_bound, new_upper_bound),
                 })
                 .await
@@ -812,6 +824,7 @@ where
             fetch_batch_size: NZU64!(20),
             target: Target {
                 root: sync_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -832,6 +845,7 @@ where
             .send(Target {
                 // Dummy target update
                 root: Digest::from([2u8; 32]),
+                canonical_root: None,
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
             })
             .await;
@@ -879,6 +893,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -893,10 +908,12 @@ where
 
         let first_target = Target {
             root,
+            canonical_root: None,
             range: non_empty_range!(initial_lower_bound.checked_add(1).unwrap(), upper_bound),
         };
         let second_target = Target {
             root,
+            canonical_root: None,
             range: non_empty_range!(initial_lower_bound.checked_add(2).unwrap(), upper_bound),
         };
         update_sender.send(first_target).await.unwrap();
@@ -931,6 +948,7 @@ where
         target_db = H::apply_ops(target_db, H::create_ops(10)).await;
         let initial_target = Target {
             root: H::sync_target_root(&target_db),
+            canonical_root: None,
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -942,6 +960,7 @@ where
         let updated_upper_bound = target_db.bounds().await.end;
         let updated_target = Target {
             root: H::sync_target_root(&target_db),
+            canonical_root: None,
             range: non_empty_range!(updated_lower_bound, updated_upper_bound),
         };
         let updated_verification_root = target_db.root();
@@ -1055,6 +1074,7 @@ where
         target_db = H::apply_ops(target_db, H::create_ops(8)).await;
         let initial_target = Target {
             root: H::sync_target_root(&target_db),
+            canonical_root: None,
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -1064,6 +1084,7 @@ where
         target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
         let first_update = Target {
             root: H::sync_target_root(&target_db),
+            canonical_root: None,
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -1073,6 +1094,7 @@ where
         target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 2)).await;
         let second_update = Target {
             root: H::sync_target_root(&target_db),
+            canonical_root: None,
             range: non_empty_range!(
                 target_db.sync_boundary().await,
                 target_db.bounds().await.end
@@ -1177,6 +1199,7 @@ where
         let upper_bound = target_db.bounds().await.end;
         let target = Target {
             root: H::sync_target_root(&target_db),
+            canonical_root: None,
             range: non_empty_range!(lower_bound, upper_bound),
         };
         let verification_root = target_db.root();
@@ -1249,6 +1272,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: H::sync_target_root(&target_db),
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -1299,6 +1323,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: H::sync_target_root(&target_db),
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -1360,6 +1385,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
                 db_config: H::config(&context.next_u64().to_string(), &context),
                 target: Target {
                     root: initial_sync_root,
+                    canonical_root: None,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -1404,6 +1430,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
             update_sender
                 .send(Target {
                     root: new_sync_root,
+                    canonical_root: None,
                     range: non_empty_range!(new_lower_bound, new_upper_bound),
                 })
                 .await
@@ -1469,6 +1496,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: sync_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: client_context.child("client"),
@@ -1536,6 +1564,7 @@ where
             fetch_batch_size: NZU64!(100),
             target: Target {
                 root: sync_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("client"),
@@ -1886,6 +1915,7 @@ where
             fetch_batch_size: NZU64!(100),
             target: Target {
                 root: sync_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("client"),
@@ -2018,6 +2048,7 @@ where
 
         let old_target = Target {
             root: H::sync_target_root(&target_db),
+            canonical_root: None,
             range: non_empty_range!(
                 target_db.inactivity_floor_loc().await,
                 target_db.bounds().await.end
@@ -2027,6 +2058,7 @@ where
         target_db = H::apply_ops(target_db, H::create_ops_seeded(3, seed + 1)).await;
         let new_target = Target {
             root: H::sync_target_root(&target_db),
+            canonical_root: None,
             range: non_empty_range!(
                 target_db.inactivity_floor_loc().await,
                 target_db.bounds().await.end

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -265,7 +265,7 @@ where
         };
 
         // Perform sync
-        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         // Verify database state (root hash is the key verification)
         assert_eq!(synced_db.bounds().await.end, target_op_count);
@@ -346,7 +346,7 @@ where
             max_retained_roots: 8,
         };
 
-        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         // Verify the synced database has the correct range of operations
         assert_eq!(synced_db.sync_boundary().await, lower_bound);
@@ -428,7 +428,7 @@ where
         // Heap-pin the sync future so its (large, monomorphized-per-variant) state
         // machine doesn't inflate this test's outer state machine and overflow the
         // test thread stack.
-        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         // Verify database state
         let bounds = synced_db.bounds().await;
@@ -528,7 +528,7 @@ where
             reached_target_tx: None,
             max_retained_roots: 8,
         };
-        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         // Verify database state
         let bounds = synced_db.bounds().await;
@@ -761,7 +761,7 @@ where
                 .unwrap();
 
             // Complete the sync
-            let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
+            let synced_db: H::Db = sync::sync(config).await.unwrap();
 
             // Verify the synced database has the expected final state
             assert_eq!(synced_db.root(), new_verification_root);
@@ -824,7 +824,7 @@ where
         };
 
         // Complete the sync
-        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         // Attempt to apply a target update after sync is complete to verify
         // we don't panic
@@ -1259,7 +1259,7 @@ where
             max_retained_roots: 1,
         };
 
-        let result: Result<H::Db, _> = Box::pin(sync::sync(config)).await;
+        let result: Result<H::Db, _> = sync::sync(config).await;
         assert!(matches!(
             result,
             Err(sync::Error::Engine(sync::EngineError::FinishChannelClosed))
@@ -1479,7 +1479,7 @@ where
             reached_target_tx: None,
             max_retained_roots: 8,
         };
-        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         // Verify initial sync worked
         assert_eq!(synced_db.root(), verification_root);
@@ -1546,7 +1546,7 @@ where
             reached_target_tx: None,
             max_retained_roots: 8,
         };
-        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         let root_after_sync = synced_db.root();
 
@@ -1899,7 +1899,7 @@ where
 
         // Sync should succeed on the second attempt after the first corrupted pinned nodes
         // are rejected.
-        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
         assert_eq!(synced_db.root(), sync_root);
         synced_db.destroy().await.unwrap();
     });

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -1,2185 +1,83 @@
-//! Generic sync tests that work for both fixed and variable databases.
+//! `any` database tests for the shared sync test suite.
 //!
-//! This module provides a test harness trait and generic test functions that can be
-//! parameterized to run against either fixed-size or variable-size value databases.
-//! The shared functions are `pub(crate)` so that `current::sync::tests` can reuse them.
+//! Shared sync test helpers live in [crate::qmdb::sync::tests]. This module keeps only
+//! the `any`-specific target tests, harness implementations, and test instantiations.
 
 use crate::{
-    journal::contiguous::Contiguous,
-    merkle::{self, Location},
-    qmdb::{
-        self,
-        any::traits::DbAny,
-        operation::Operation as OperationTrait,
-        sync::{
-            self,
-            engine::{Config, NextStep},
-            resolver::{self, FetchResult, Resolver},
-            Engine, Target,
-        },
-    },
-    Persistable,
+    merkle::{mmr, Location},
+    qmdb::any::sync::Target,
 };
-use commonware_codec::Encode;
-use commonware_cryptography::sha256::Digest;
-use commonware_macros::select;
-use commonware_runtime::{
-    deterministic, BufferPooler, Clock, Metrics as _, Runner as _, Supervisor as _,
-};
-use commonware_utils::{
-    channel::{mpsc, oneshot},
-    non_empty_range,
-    sync::{AsyncRwLock, Mutex},
-    NZU64,
-};
-use futures::{pin_mut, FutureExt};
-use rand::RngCore as _;
-use std::{
-    num::NonZeroU64,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+use commonware_codec::{EncodeSize, Error as CodecError, ReadExt as _, Write};
+use commonware_cryptography::sha256;
+use commonware_utils::non_empty_range;
+use std::io::Cursor;
 
-/// Type alias for the database type of a harness.
-pub(crate) type DbOf<H> = <H as SyncTestHarness>::Db;
+#[test]
+fn test_sync_target_serialization() {
+    let target = Target::<mmr::Family, sha256::Digest>::new(
+        sha256::Digest::from([42; 32]),
+        non_empty_range!(Location::new(100), Location::new(500)),
+    );
 
-/// Type alias for the operation type of a harness.
-pub(crate) type OpOf<H> = <DbOf<H> as qmdb::sync::Database>::Op;
+    let mut buffer = Vec::new();
+    target.write(&mut buffer);
 
-/// Type alias for the config type of a harness.
-pub(crate) type ConfigOf<H> = <DbOf<H> as qmdb::sync::Database>::Config;
+    assert_eq!(buffer.len(), target.encode_size());
 
-/// Type alias for the journal type of a harness.
-pub(crate) type JournalOf<H> = <DbOf<H> as qmdb::sync::Database>::Journal;
+    let mut cursor = Cursor::new(buffer);
+    let deserialized = Target::read(&mut cursor).unwrap();
 
-/// Trait for cleanup operations in tests.
-pub(crate) trait Destructible {
-    type Family: merkle::Family;
-
-    fn destroy(
-        self,
-    ) -> impl std::future::Future<Output = Result<(), qmdb::Error<Self::Family>>> + Send;
+    assert_eq!(target, deserialized);
+    assert_eq!(target.root, deserialized.root);
+    assert_eq!(target.range, deserialized.range);
 }
 
-// Implement Destructible once for the generic full Merkle type used in tests.
-// This is here (rather than in fixed/variable modules) to avoid duplicate implementations.
-impl<F: merkle::Family> Destructible
-    for crate::merkle::full::Merkle<
-        F,
-        deterministic::Context,
-        Digest,
-        commonware_parallel::Sequential,
-    >
-{
-    type Family = F;
-
-    async fn destroy(self) -> Result<(), qmdb::Error<F>> {
-        self.destroy().await.map_err(qmdb::Error::Merkle)
-    }
-}
-
-/// Trait providing internal access for from_sync_result tests.
-pub(crate) trait FromSyncTestable: qmdb::sync::Database {
-    type Merkle: Destructible<Family = Self::Family> + Send;
-
-    /// Get the Merkle structure and journal from the database.
-    fn into_log_components(self) -> (Self::Merkle, Self::Journal);
-
-    /// Get the pinned nodes at a given location
-    fn pinned_nodes_at(
-        &self,
-        loc: Location<Self::Family>,
-    ) -> impl std::future::Future<Output = Vec<Self::Digest>> + Send;
-}
-
-/// Harness for sync tests.
-pub(crate) trait SyncTestHarness: Sized + 'static {
-    /// The merkle family the database under test uses.
-    type Family: merkle::Family;
-
-    /// The database type being tested.
-    type Db: qmdb::sync::Database<
-            Family = Self::Family,
-            Context = deterministic::Context,
-            Digest = Digest,
-            Config: Clone,
-        > + DbAny<Self::Family, Key = Digest, Digest = Digest>;
-
-    /// Return the database root expected after sync completes.
-    fn target_root(db: &Self::Db) -> Digest {
-        qmdb::sync::Database::root(db)
-    }
-
-    /// Return the ops root the sync engine targets for range proof verification.
-    fn sync_target_root(db: &Self::Db) -> Digest;
-
-    /// Create a config with unique partition names
-    fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self>;
-
-    /// Generate n test operations using the default seed (0)
-    fn create_ops(n: usize) -> Vec<OpOf<Self>>;
-
-    /// Generate n test operations using a specific seed.
-    /// Use different seeds when you need non-overlapping keys in the same test.
-    fn create_ops_seeded(n: usize, seed: u64) -> Vec<OpOf<Self>>;
-
-    /// Initialize a database
-    fn init_db(ctx: deterministic::Context) -> impl std::future::Future<Output = Self::Db> + Send;
-
-    /// Initialize a database with a config
-    fn init_db_with_config(
-        ctx: deterministic::Context,
-        config: ConfigOf<Self>,
-    ) -> impl std::future::Future<Output = Self::Db> + Send;
-
-    /// Apply operations to a database and commit.
-    fn apply_ops(
-        db: Self::Db,
-        ops: Vec<OpOf<Self>>,
-    ) -> impl std::future::Future<Output = Self::Db> + Send;
-}
-
-/// Test that empty operations arrays fetched do not cause panics when stored and applied
-pub(crate) fn test_sync_empty_operations_no_panic<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Init target_db to satisfy engine configuration bounds
-        let target_db = H::init_db(context.child("target")).await;
-
-        // Use an arbitrary target
-        let db_config = H::config(&context.next_u64().to_string(), &context);
-        let config = Config {
-            db_config,
-            fetch_batch_size: NZU64!(10),
-            target: Target {
-                root: Digest::from([1u8; 32]),
-                ops_root: Digest::from([1u8; 32]),
-                range: non_empty_range!(Location::new(0), Location::new(10)),
-            },
-            context: context.child("client"),
-            resolver: Arc::new(target_db),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-
-        // Create the engine
-        let mut client: Engine<H::Db, _> = Engine::new(config).await.unwrap();
-
-        // Pass empty operations vectors which should not cause panics
-        client.store_operations(Location::new(0), vec![]);
-        client.store_operations(Location::new(5), vec![]);
-
-        // Apply operations which also shouldn't panic
-        client.apply_operations().await.unwrap();
-
-        // It is considered a success simply if it didn't panic.
-    });
-}
-
-/// Test that resolver failure is handled correctly
-pub(crate) fn test_sync_resolver_fails<H: SyncTestHarness>()
-where
-    resolver::tests::FailResolver<H::Family, OpOf<H>, Digest>:
-        Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let resolver = resolver::tests::FailResolver::<H::Family, OpOf<H>, Digest>::new();
-        let target_root = Digest::from([0; 32]);
-
-        let db_config = H::config(&context.next_u64().to_string(), &context);
-        let engine_config = Config {
-            context: context.child("client"),
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(Location::new(0), Location::new(5)),
-            },
-            resolver,
-            apply_batch_size: 2,
-            max_outstanding_requests: 2,
-            fetch_batch_size: NZU64!(2),
-            db_config,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-
-        let result: Result<H::Db, _> = sync::sync(engine_config).await;
-        assert!(result.is_err());
-    });
-}
-
-/// Test basic sync functionality with various batch sizes
-pub(crate) fn test_sync<H: SyncTestHarness>(target_db_ops: usize, fetch_batch_size: NonZeroU64)
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create and populate target database
-        let mut target_db = H::init_db(context.child("target")).await;
-        let target_ops = H::create_ops(target_db_ops);
-        target_db = H::apply_ops(target_db, target_ops).await;
-        // commit already done in apply_ops
-        target_db
-            .prune(target_db.sync_boundary().await)
-            .await
-            .unwrap();
-
-        let target_op_count = target_db.bounds().await.end;
-        let target_inactivity_floor = target_db.inactivity_floor_loc().await;
-        let sync_root = H::sync_target_root(&target_db);
-        let verification_root = target_db.root();
-        let lower_bound = target_db.sync_boundary().await;
-
-        // Configure sync
-        let db_config = H::config(&context.next_u64().to_string(), &context);
-        let target_db = Arc::new(target_db);
-        let client_context = context.child("client");
-        let config = Config {
-            db_config: db_config.clone(),
-            fetch_batch_size,
-            target: Target {
-                root: verification_root,
-                ops_root: sync_root,
-                range: non_empty_range!(lower_bound, target_op_count),
-            },
-            context: client_context.child("client"),
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-
-        // Perform sync
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
-
-        // Verify database state (root hash is the key verification)
-        assert_eq!(synced_db.bounds().await.end, target_op_count);
-        assert_eq!(
-            synced_db.inactivity_floor_loc().await,
-            target_inactivity_floor
-        );
-        assert_eq!(synced_db.root(), verification_root);
-
-        // Verify persistence
-        let final_root = synced_db.root();
-        let final_op_count = synced_db.bounds().await.end;
-        let final_inactivity_floor = synced_db.inactivity_floor_loc().await;
-
-        // Reopen and verify state persisted
-        drop(synced_db);
-        let reopened_db = H::init_db_with_config(client_context.child("reopened"), db_config).await;
-        assert_eq!(reopened_db.bounds().await.end, final_op_count);
-        assert_eq!(
-            reopened_db.inactivity_floor_loc().await,
-            final_inactivity_floor
-        );
-        assert_eq!(reopened_db.root(), final_root);
-
-        // Cleanup
-        reopened_db.destroy().await.unwrap();
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test syncing to a subset of the target database (target has additional ops beyond sync range)
-pub(crate) fn test_sync_subset_of_target_database<H: SyncTestHarness>(target_db_ops: usize)
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone + OperationTrait<H::Family, Key = Digest>,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let mut target_db = H::init_db(context.child("target")).await;
-        let target_ops = H::create_ops(target_db_ops);
-
-        // Apply all but the last operation
-        target_db = H::apply_ops(target_db, target_ops[0..target_db_ops - 1].to_vec()).await;
-        // commit already done in apply_ops
-
-        let upper_bound = target_db.bounds().await.end;
-        let sync_root = H::sync_target_root(&target_db);
-        let verification_root = target_db.root();
-        let lower_bound = target_db.sync_boundary().await;
-
-        // Add another operation after the sync range
-        let final_op = target_ops[target_db_ops - 1].clone();
-        let final_key = final_op.key().cloned(); // Store the key before applying
-        target_db = H::apply_ops(target_db, vec![final_op]).await;
-        // commit already done in apply_ops
-
-        // Sync to the original root (before final_op was added)
-        let db_config = H::config(&context.next_u64().to_string(), &context);
-        let config = Config {
-            db_config,
-            fetch_batch_size: NZU64!(10),
-            target: Target {
-                root: verification_root,
-                ops_root: sync_root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
-            context: context.child("client"),
-            resolver: Arc::new(target_db),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
-
-        // Verify the synced database has the correct range of operations
-        assert_eq!(synced_db.sync_boundary().await, lower_bound);
-        assert_eq!(synced_db.bounds().await.end, upper_bound);
-
-        // Verify the final root digest matches our target
-        assert_eq!(synced_db.root(), verification_root);
-
-        // Verify the synced database doesn't have any operations beyond the sync range.
-        // (the final_op should not be present)
-        if let Some(key) = final_key {
-            assert!(synced_db.get(&key).await.unwrap().is_none());
-        }
-
-        synced_db.destroy().await.unwrap();
-    });
-}
-
-/// Test syncing where the sync client has some but not all of the operations in the target DB.
-/// Tests the scenario where sync_db already has partial data and needs to sync additional ops.
-pub(crate) fn test_sync_use_existing_db_partial_match<H: SyncTestHarness>(original_ops: usize)
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone + OperationTrait<H::Family, Key = Digest>,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let original_ops_data = H::create_ops(original_ops);
-
-        // Heap-pin large sub-futures so their state machines don't inflate this test's outer
-        // state machine and overflow the test thread stack.
-        let mut target_db = Box::pin(H::init_db(context.child("target"))).await;
-        let sync_db_config = H::config(&context.next_u64().to_string(), &context);
-        let client_context = context.child("client");
-        let mut sync_db: H::Db = Box::pin(H::init_db_with_config(
-            client_context.child("client"),
-            sync_db_config.clone(),
-        ))
-        .await;
-
-        // Apply the same operations to both databases
-        target_db = Box::pin(H::apply_ops(target_db, original_ops_data.clone())).await;
-        sync_db = Box::pin(H::apply_ops(sync_db, original_ops_data.clone())).await;
-        // commit already done in apply_ops
-        // commit already done in apply_ops
-
-        drop(sync_db);
-
-        // Add more operations and commit the target database
-        // (use different seed to avoid key collisions)
-        let more_ops = H::create_ops_seeded(1, 1);
-        target_db = Box::pin(H::apply_ops(target_db, more_ops.clone())).await;
-        // commit already done in apply_ops
-
-        let sync_root = H::sync_target_root(&target_db);
-        let verification_root = target_db.root();
-        let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
-
-        // Reopen the sync database and sync it to the target database
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            db_config: sync_db_config,
-            fetch_batch_size: NZU64!(10),
-            target: Target {
-                root: verification_root,
-                ops_root: sync_root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
-            context: client_context.child("sync"),
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-        // Heap-pin the sync future so its (large, monomorphized-per-variant) state
-        // machine doesn't inflate this test's outer state machine and overflow the
-        // test thread stack.
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
-
-        // Verify database state
-        let bounds = synced_db.bounds().await;
-        assert_eq!(bounds.end, upper_bound);
-        assert_eq!(
-            synced_db.inactivity_floor_loc().await,
-            target_db.inactivity_floor_loc().await
-        );
-        assert_eq!(bounds.end, target_db.bounds().await.end);
-        // Verify the root digest matches the target
-        assert_eq!(synced_db.root(), verification_root);
-
-        // Verify that original operations are present and correct (by key lookup)
-        for target_op in &original_ops_data {
-            if let Some(key) = target_op.key() {
-                let target_value = target_db.get(key).await.unwrap();
-                let synced_value = synced_db.get(key).await.unwrap();
-                assert_eq!(target_value.is_some(), synced_value.is_some());
-            }
-        }
-
-        // Verify the last operation is present (if it's an update)
-        if let Some(key) = more_ops[0].key() {
-            let synced_value = synced_db.get(key).await.unwrap();
-            let target_value = target_db.get(key).await.unwrap();
-            assert_eq!(synced_value.is_some(), target_value.is_some());
-        }
-
-        synced_db.destroy().await.unwrap();
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test case where existing database on disk exactly matches the sync target.
-/// Uses FailResolver to verify that no network requests are made since data already exists.
-pub(crate) fn test_sync_use_existing_db_exact_match<H: SyncTestHarness>(num_ops: usize)
-where
-    resolver::tests::FailResolver<H::Family, OpOf<H>, Digest>:
-        Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone + OperationTrait<H::Family, Key = Digest>,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let target_ops = H::create_ops(num_ops);
-
-        // Create two databases with their own configs
-        let target_config = H::config(&context.next_u64().to_string(), &context);
-        let mut target_db = H::init_db_with_config(context.child("target"), target_config).await;
-        let sync_config = H::config(&context.next_u64().to_string(), &context);
-        let client_context = context.child("client");
-        let mut sync_db =
-            H::init_db_with_config(client_context.child("client"), sync_config.clone()).await;
-
-        // Apply the same operations to both databases
-        target_db = H::apply_ops(target_db, target_ops.clone()).await;
-        sync_db = H::apply_ops(sync_db, target_ops.clone()).await;
-        // commit already done in apply_ops
-        // commit already done in apply_ops
-
-        target_db
-            .prune(target_db.sync_boundary().await)
-            .await
-            .unwrap();
-        sync_db.prune(sync_db.sync_boundary().await).await.unwrap();
-
-        sync_db.sync().await.unwrap();
-        drop(sync_db);
-
-        // Capture target state
-        let sync_root = H::sync_target_root(&target_db);
-        let verification_root = target_db.root();
-        let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
-
-        // sync_db should never ask the resolver for operations
-        // because it is already complete. Use a resolver that always fails
-        // to ensure that it's not being used.
-        let resolver = resolver::tests::FailResolver::<H::Family, OpOf<H>, Digest>::new();
-        let config = Config {
-            db_config: sync_config, // Use same config to access same partitions
-            fetch_batch_size: NZU64!(10),
-            target: Target {
-                root: verification_root,
-                ops_root: sync_root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
-            context: client_context.child("sync"),
-            resolver,
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
-
-        // Verify database state
-        let bounds = synced_db.bounds().await;
-        assert_eq!(bounds.end, upper_bound);
-        assert_eq!(bounds.end, target_db.bounds().await.end);
-        assert_eq!(synced_db.sync_boundary().await, lower_bound);
-
-        // Verify the root digest matches the target
-        assert_eq!(synced_db.root(), verification_root);
-
-        // Verify state matches for sample operations (via key lookup)
-        for target_op in &target_ops {
-            if let Some(key) = target_op.key() {
-                let target_value = target_db.get(key).await.unwrap();
-                let synced_value = synced_db.get(key).await.unwrap();
-                assert_eq!(target_value.is_some(), synced_value.is_some());
-            }
-        }
-
-        synced_db.destroy().await.unwrap();
-        target_db.destroy().await.unwrap();
-    });
-}
-
-/// Test that the client fails to sync if the lower bound is decreased via target update.
-pub(crate) fn test_target_update_lower_bound_decrease<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create and populate target database
-        let mut target_db = H::init_db(context.child("target")).await;
-        let target_ops = H::create_ops(50);
-        target_db = H::apply_ops(target_db, target_ops).await;
-        // commit already done in apply_ops
-
-        // Use inactivity_floor as range.start so we have a non-zero bound to decrement.
-        // The engine only checks that range.start does not decrease on updates; it doesn't
-        // require range.start to equal sync_boundary here.
-        let initial_lower_bound = target_db.inactivity_floor_loc().await;
-        assert!(
-            *initial_lower_bound > 0,
-            "test setup requires non-zero inactivity floor"
-        );
-        let initial_upper_bound = target_db.bounds().await.end;
-        let initial_root = H::sync_target_root(&target_db);
-        let initial_verification_root = H::target_root(&target_db);
-
-        // Create client with initial target
-        let (update_sender, update_receiver) = mpsc::channel(1);
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: initial_verification_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-            },
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 10,
-            update_rx: Some(update_receiver),
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 1,
-        };
-        let client: Engine<H::Db, _> = Engine::new(config).await.unwrap();
-
-        // Send target update with decreased lower bound
-        update_sender
-            .send(Target {
-                root: initial_verification_root,
-                ops_root: initial_root,
-                range: non_empty_range!(
-                    initial_lower_bound.checked_sub(1).unwrap(),
-                    initial_upper_bound.checked_add(1).unwrap()
-                ),
-            })
-            .await
-            .unwrap();
-
-        let result = client.step().await;
-        assert!(matches!(
-            result,
-            Err(sync::Error::Engine(
-                sync::EngineError::SyncTargetMovedBackward { .. }
-            ))
-        ));
-
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test that the client fails to sync if the upper bound is decreased via target update.
-pub(crate) fn test_target_update_upper_bound_decrease<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create and populate target database
-        let mut target_db = H::init_db(context.child("target")).await;
-        let target_ops = H::create_ops(50);
-        target_db = H::apply_ops(target_db, target_ops).await;
-        // commit already done in apply_ops
-
-        // Capture initial target state
-        let initial_lower_bound = target_db.sync_boundary().await;
-        let initial_upper_bound = target_db.bounds().await.end;
-        let initial_root = H::sync_target_root(&target_db);
-        let initial_verification_root = H::target_root(&target_db);
-
-        // Create client with initial target
-        let (update_sender, update_receiver) = mpsc::channel(1);
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: initial_verification_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-            },
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 10,
-            update_rx: Some(update_receiver),
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 1,
-        };
-        let client: Engine<H::Db, _> = Engine::new(config).await.unwrap();
-
-        // Send target update with decreased upper bound
-        update_sender
-            .send(Target {
-                root: initial_verification_root,
-                ops_root: initial_root,
-                range: non_empty_range!(
-                    initial_lower_bound,
-                    initial_upper_bound.checked_sub(1).unwrap()
-                ),
-            })
-            .await
-            .unwrap();
-
-        let result = client.step().await;
-        assert!(matches!(
-            result,
-            Err(sync::Error::Engine(
-                sync::EngineError::SyncTargetMovedBackward { .. }
-            ))
-        ));
-
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test that the client succeeds when bounds are updated (increased).
-pub(crate) fn test_target_update_bounds_increase<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create and populate target database
-        let mut target_db = H::init_db(context.child("target")).await;
-        let target_ops = H::create_ops(100);
-        target_db = H::apply_ops(target_db, target_ops).await;
-        // commit already done in apply_ops
-
-        // Capture initial target state
-        let initial_lower_bound = target_db.sync_boundary().await;
-        let initial_upper_bound = target_db.bounds().await.end;
-        let initial_root = H::sync_target_root(&target_db);
-        let initial_verification_root = H::target_root(&target_db);
-
-        // Apply more operations to the target database
-        // (use different seed to avoid key collisions)
-        let additional_ops = H::create_ops_seeded(1, 1);
-        let new_verification_root = {
-            target_db = H::apply_ops(target_db, additional_ops).await;
-            // commit already done in apply_ops
-
-            // Capture new target state
-            let new_lower_bound = target_db.sync_boundary().await;
-            let new_upper_bound = target_db.bounds().await.end;
-            let new_sync_root = H::sync_target_root(&target_db);
-            let new_verification_root = target_db.root();
-
-            // Create client with placeholder initial target (stale compared to final target)
-            let (update_sender, update_receiver) = mpsc::channel(1);
-
-            let target_db = Arc::new(target_db);
-            let config = Config {
-                context: context.child("client"),
-                db_config: H::config(&context.next_u64().to_string(), &context),
-                fetch_batch_size: NZU64!(1),
-                target: Target {
-                    root: initial_verification_root,
-                    ops_root: initial_root,
-                    range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-                },
-                resolver: target_db.clone(),
-                apply_batch_size: 1024,
-                max_outstanding_requests: 1,
-                update_rx: Some(update_receiver),
-                finish_rx: None,
-                reached_target_tx: None,
-                max_retained_roots: 1,
-            };
-
-            // Send target update with increased bounds
-            update_sender
-                .send(Target {
-                    root: new_verification_root,
-                    ops_root: new_sync_root,
-                    range: non_empty_range!(new_lower_bound, new_upper_bound),
-                })
-                .await
-                .unwrap();
-
-            // Complete the sync
-            let synced_db: H::Db = sync::sync(config).await.unwrap();
-
-            // Verify the synced database has the expected final state
-            assert_eq!(synced_db.root(), new_verification_root);
-            assert_eq!(synced_db.bounds().await.end, new_upper_bound);
-            assert_eq!(synced_db.sync_boundary().await, new_lower_bound);
-
-            synced_db.destroy().await.unwrap();
-
-            Arc::try_unwrap(target_db)
-                .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-                .destroy()
-                .await
-                .unwrap();
-
-            new_verification_root
-        };
-        let _ = new_verification_root; // Silence unused variable warning
-    });
-}
-
-/// Test that target updates can be sent even after the client is done (no panic).
-pub(crate) fn test_target_update_on_done_client<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create and populate target database
-        let mut target_db = H::init_db(context.child("target")).await;
-        let target_ops = H::create_ops(10);
-        target_db = H::apply_ops(target_db, target_ops).await;
-        // commit already done in apply_ops
-
-        // Capture target state
-        let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
-        let sync_root = H::sync_target_root(&target_db);
-        let verification_root = target_db.root();
-
-        // Create client with target that will complete immediately
-        let (update_sender, update_receiver) = mpsc::channel(1);
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(20),
-            target: Target {
-                root: verification_root,
-                ops_root: sync_root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 10,
-            update_rx: Some(update_receiver),
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 1,
-        };
-
-        // Complete the sync
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
-
-        // Attempt to apply a target update after sync is complete to verify
-        // we don't panic
-        let _ = update_sender
-            .send(Target {
-                // Dummy target update
-                root: Digest::from([2u8; 32]),
-                ops_root: Digest::from([2u8; 32]),
-                range: non_empty_range!(lower_bound + 1, upper_bound + 1),
-            })
-            .await;
-
-        // Verify the synced database has the expected state
-        assert_eq!(synced_db.root(), verification_root);
-        assert_eq!(synced_db.bounds().await.end, upper_bound);
-        assert_eq!(synced_db.sync_boundary().await, lower_bound);
-
-        synced_db.destroy().await.unwrap();
-
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test that prune-only target updates are rejected as backward target movement.
-pub(crate) fn test_target_update_prune_only_rejected<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let mut target_db = H::init_db(context.child("target")).await;
-        target_db = H::apply_ops(target_db, H::create_ops(50)).await;
-
-        let initial_lower_bound = target_db.inactivity_floor_loc().await;
-        assert!(
-            *initial_lower_bound > 1,
-            "test setup requires lower bound that can advance twice"
-        );
-        let upper_bound = target_db.bounds().await.end;
-        let root = H::target_root(&target_db);
-        let ops_root = H::sync_target_root(&target_db);
-
-        let (update_sender, update_receiver) = mpsc::channel(2);
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(5),
-            target: Target {
-                root,
-                ops_root,
-                range: non_empty_range!(initial_lower_bound, upper_bound),
-            },
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 10,
-            update_rx: Some(update_receiver),
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 1,
-        };
-        let client: Engine<H::Db, _> = Engine::new(config).await.unwrap();
-
-        let first_target = Target {
-            root,
-            ops_root,
-            range: non_empty_range!(initial_lower_bound.checked_add(1).unwrap(), upper_bound),
-        };
-        let second_target = Target {
-            root,
-            ops_root,
-            range: non_empty_range!(initial_lower_bound.checked_add(2).unwrap(), upper_bound),
-        };
-        update_sender.send(first_target).await.unwrap();
-        update_sender.send(second_target).await.unwrap();
-
-        let result = client.step().await;
-        assert!(matches!(
-            result,
-            Err(sync::Error::Engine(
-                sync::EngineError::SyncTargetMovedBackward { .. }
-            ))
-        ));
-
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test that explicit finish control waits for a finish signal even after reaching target.
-pub(crate) fn test_sync_waits_for_explicit_finish<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let mut target_db = H::init_db(context.child("target")).await;
-        target_db = H::apply_ops(target_db, H::create_ops(10)).await;
-        let initial_target = Target {
-            root: H::target_root(&target_db),
-            ops_root: H::sync_target_root(&target_db),
-            range: non_empty_range!(
-                target_db.sync_boundary().await,
-                target_db.bounds().await.end
-            ),
-        };
-
-        target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
-        let updated_lower_bound = target_db.sync_boundary().await;
-        let updated_upper_bound = target_db.bounds().await.end;
-        let updated_target = Target {
-            root: H::target_root(&target_db),
-            ops_root: H::sync_target_root(&target_db),
-            range: non_empty_range!(updated_lower_bound, updated_upper_bound),
-        };
-        let updated_verification_root = target_db.root();
-
-        let (update_sender, update_receiver) = mpsc::channel(1);
-        let (finish_sender, finish_receiver) = mpsc::channel(1);
-        let (reached_sender, mut reached_receiver) = mpsc::channel(1);
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(10),
-            target: initial_target.clone(),
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: Some(update_receiver),
-            finish_rx: Some(finish_receiver),
-            reached_target_tx: Some(reached_sender),
-            max_retained_roots: 0,
-        };
-
-        // Heap-pin the sync future so its (large, monomorphized-per-variant) state
-        // machine doesn't inflate this test's outer state machine and overflow the
-        // test thread stack.
-        let mut sync_handle = Box::pin(sync::sync(config));
-
-        select! {
-            _ = sync_handle.as_mut() => {
-                panic!("sync completed before explicit finish signal");
-            },
-            reached = reached_receiver.recv() => {
-                let reached = reached.expect("engine should report reached-target before finish");
-                assert_eq!(reached, initial_target);
-            },
-        }
-        assert!(
-            sync_handle.as_mut().now_or_never().is_none(),
-            "sync must wait for explicit finish signal after reaching target"
-        );
-
-        update_sender
-            .send(updated_target.clone())
-            .await
-            .expect("target update channel should be open");
-
-        select! {
-            _ = sync_handle.as_mut() => {
-                panic!("sync completed before explicit finish signal for updated target");
-            },
-            reached = reached_receiver.recv() => {
-                let reached = reached.expect("engine should report updated target before finish");
-                assert_eq!(reached, updated_target);
-            },
-        }
-        assert!(
-            sync_handle.as_mut().now_or_never().is_none(),
-            "sync must still wait for explicit finish signal after updated target is reached"
-        );
-
-        finish_sender
-            .send(())
-            .await
-            .expect("finish signal channel should be open");
-
-        let synced_db: H::Db = sync_handle
-            .await
-            .expect("sync should succeed after finish signal");
-        assert_eq!(synced_db.root(), updated_verification_root);
-        assert_eq!(synced_db.bounds().await.end, updated_upper_bound);
-        assert_eq!(synced_db.sync_boundary().await, updated_lower_bound);
-
-        synced_db.destroy().await.unwrap();
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-async fn wait_for_reached_progress<F: merkle::Family>(
-    context: deterministic::Context,
-    target: &Target<F, Digest>,
-) {
-    let target_end = *target.range.end();
-    let journal_size = format!("client_sync_journal_size {target_end}");
-    let target_end = format!("client_sync_target_end {target_end}");
-    loop {
-        let metrics = context.encode();
-        if metrics.contains(&journal_size) && metrics.contains(&target_end) {
-            return;
-        }
-        context.sleep(Duration::from_millis(1)).await;
-    }
-}
-
-/// Test progress metrics for reached targets across target updates and explicit finish.
-pub(crate) fn test_sync_reports_progress_for_reached_targets_before_explicit_finish<
-    H: SyncTestHarness,
->()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let mut target_db = H::init_db(context.child("target")).await;
-
-        target_db = H::apply_ops(target_db, H::create_ops(8)).await;
-        let initial_target = Target {
-            root: H::target_root(&target_db),
-            ops_root: H::sync_target_root(&target_db),
-            range: non_empty_range!(
-                target_db.sync_boundary().await,
-                target_db.bounds().await.end
-            ),
-        };
-
-        target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
-        let first_update = Target {
-            root: H::target_root(&target_db),
-            ops_root: H::sync_target_root(&target_db),
-            range: non_empty_range!(
-                target_db.sync_boundary().await,
-                target_db.bounds().await.end
-            ),
-        };
-
-        target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 2)).await;
-        let second_update = Target {
-            root: H::target_root(&target_db),
-            ops_root: H::sync_target_root(&target_db),
-            range: non_empty_range!(
-                target_db.sync_boundary().await,
-                target_db.bounds().await.end
-            ),
-        };
-        let final_root = target_db.root();
-
-        let (update_sender, update_receiver) = mpsc::channel(1);
-        let (finish_sender, finish_receiver) = mpsc::channel(1);
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(2),
-            target: initial_target.clone(),
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: Some(update_receiver),
-            finish_rx: Some(finish_receiver),
-            reached_target_tx: None,
-            max_retained_roots: 1,
-        };
-
-        let mut sync_handle = Box::pin(sync::sync(config));
-
-        select! {
-            _ = sync_handle.as_mut() => {
-                panic!("sync completed before explicit finish signal");
-            },
-            _ = wait_for_reached_progress(context.child("storage"), &initial_target) => {},
-        }
-        assert!(
-            sync_handle.as_mut().now_or_never().is_none(),
-            "sync must wait for a target update or explicit finish after reaching the initial target"
-        );
-
-        update_sender
-            .send(first_update.clone())
-            .await
-            .expect("target update channel should be open");
-        select! {
-            _ = sync_handle.as_mut() => {
-                panic!("sync completed before explicit finish signal after first update");
-            },
-            _ = wait_for_reached_progress(context.child("storage"), &first_update) => {},
-        }
-        assert!(
-            sync_handle.as_mut().now_or_never().is_none(),
-            "sync must wait for another update or explicit finish after reaching the first update"
-        );
-
-        update_sender
-            .send(second_update.clone())
-            .await
-            .expect("target update channel should be open");
-        select! {
-            _ = sync_handle.as_mut() => {
-                panic!("sync completed before explicit finish signal after second update");
-            },
-            _ = wait_for_reached_progress(context.child("storage"), &second_update) => {},
-        }
-        assert!(
-            sync_handle.as_mut().now_or_never().is_none(),
-            "sync must wait for explicit finish after reporting final progress"
-        );
-
-        finish_sender
-            .send(())
-            .await
-            .expect("finish signal channel should be open");
-
-        let synced_db: H::Db = sync_handle
-            .await
-            .expect("sync should succeed after finish signal");
-        assert_eq!(synced_db.root(), final_root);
-        assert_eq!(synced_db.bounds().await.end, *second_update.range.end());
-        assert_eq!(synced_db.sync_boundary().await, *second_update.range.start());
-
-        synced_db.destroy().await.unwrap();
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test that a finish signal received before target completion still allows full sync.
-pub(crate) fn test_sync_handles_early_finish_signal<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let mut target_db = H::init_db(context.child("target")).await;
-        target_db = H::apply_ops(target_db, H::create_ops(30)).await;
-        let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
-        let target = Target {
-            root: H::target_root(&target_db),
-            ops_root: H::sync_target_root(&target_db),
-            range: non_empty_range!(lower_bound, upper_bound),
-        };
-        let verification_root = target_db.root();
-
-        let (finish_sender, finish_receiver) = mpsc::channel(1);
-        let (reached_sender, mut reached_receiver) = mpsc::channel(1);
-        finish_sender
-            .send(())
-            .await
-            .expect("finish signal channel should be open");
-
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(3),
-            target: target.clone(),
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: Some(finish_receiver),
-            reached_target_tx: Some(reached_sender),
-            max_retained_roots: 1,
-        };
-
-        let synced_db: H::Db = sync::sync(config)
-            .await
-            .expect("sync should complete after early finish signal");
-        let reached = reached_receiver
-            .recv()
-            .await
-            .expect("engine should report reached-target");
-
-        assert_eq!(reached, target);
-        assert_eq!(synced_db.root(), verification_root);
-        assert_eq!(synced_db.bounds().await.end, upper_bound);
-        assert_eq!(synced_db.sync_boundary().await, lower_bound);
-
-        synced_db.destroy().await.unwrap();
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test that dropping finish sender without sending is treated as an error.
-pub(crate) fn test_sync_fails_when_finish_sender_dropped<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let mut target_db = H::init_db(context.child("target")).await;
-        target_db = H::apply_ops(target_db, H::create_ops(10)).await;
-        let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
-
-        let (finish_sender, finish_receiver) = mpsc::channel(1);
-        drop(finish_sender);
-
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: H::target_root(&target_db),
-                ops_root: H::sync_target_root(&target_db),
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: Some(finish_receiver),
-            reached_target_tx: None,
-            max_retained_roots: 1,
-        };
-
-        let result: Result<H::Db, _> = sync::sync(config).await;
-        assert!(matches!(
-            result,
-            Err(sync::Error::Engine(sync::EngineError::FinishChannelClosed))
-        ));
-
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test that dropping reached-target receiver does not fail sync.
-pub(crate) fn test_sync_allows_dropped_reached_target_receiver<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let mut target_db = H::init_db(context.child("target")).await;
-        target_db = H::apply_ops(target_db, H::create_ops(10)).await;
-        let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
-        let verification_root = target_db.root();
-
-        let (reached_sender, reached_receiver) = mpsc::channel(1);
-        drop(reached_receiver);
-
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: H::target_root(&target_db),
-                ops_root: H::sync_target_root(&target_db),
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: Some(reached_sender),
-            max_retained_roots: 1,
-        };
-
-        let synced_db: H::Db = sync::sync(config)
-            .await
-            .expect("sync should succeed when reached-target receiver is dropped");
-        assert_eq!(synced_db.root(), verification_root);
-        assert_eq!(synced_db.bounds().await.end, upper_bound);
-        assert_eq!(synced_db.sync_boundary().await, lower_bound);
-
-        synced_db.destroy().await.unwrap();
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test that the client can handle target updates during sync execution.
-pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
-    initial_ops: usize,
-    additional_ops: usize,
-) where
-    Arc<AsyncRwLock<Option<DbOf<H>>>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create and populate target database with initial operations
-        let mut target_db = H::init_db(context.child("target")).await;
-        let target_ops = H::create_ops(initial_ops);
-        target_db = H::apply_ops(target_db, target_ops).await;
-        // commit already done in apply_ops
-
-        // Capture initial target state
-        let initial_lower_bound = target_db.sync_boundary().await;
-        let initial_upper_bound = target_db.bounds().await.end;
-        let initial_sync_root = H::sync_target_root(&target_db);
-        let initial_verification_root = H::target_root(&target_db);
-
-        // Wrap target database for shared mutable access (using Option so we can take ownership)
-        let target_db = Arc::new(AsyncRwLock::new(Some(target_db)));
-
-        // Create client with initial target and small batch size
-        let (update_sender, update_receiver) = mpsc::channel(1);
-        // Step the client to process a batch
-        let client = {
-            let config = Config {
-                context: context.child("client"),
-                db_config: H::config(&context.next_u64().to_string(), &context),
-                target: Target {
-                    root: initial_verification_root,
-                    ops_root: initial_sync_root,
-                    range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-                },
-                resolver: target_db.clone(),
-                fetch_batch_size: NZU64!(1), // Small batch size so we don't finish after one batch
-                max_outstanding_requests: 10,
-                apply_batch_size: 1024,
-                update_rx: Some(update_receiver),
-                finish_rx: None,
-                reached_target_tx: None,
-                max_retained_roots: 1,
-            };
-            let mut client: Engine<H::Db, _> = Engine::new(config).await.unwrap();
-            loop {
-                // Step the client until we have processed a batch of operations
-                client = match client.step().await.unwrap() {
-                    NextStep::Continue(new_client) => new_client,
-                    NextStep::Complete(..) => panic!("client should not be complete"),
-                };
-                let log_size = client.journal().size().await;
-                if log_size > initial_lower_bound {
-                    break client;
-                }
-            }
-        };
-
-        // Modify the target database by adding more operations
-        // (use different seed to avoid key collisions)
-        let additional_ops_data = H::create_ops_seeded(additional_ops, 1);
-        let new_verification_root = {
-            let mut db_guard = target_db.write().await;
-            let db = db_guard.take().unwrap();
-            let db = H::apply_ops(db, additional_ops_data).await;
-
-            // Capture new target state
-            let new_lower_bound = db.sync_boundary().await;
-            let new_upper_bound = db.bounds().await.end;
-            let new_sync_root = H::sync_target_root(&db);
-            let new_verification_root = db.root();
-            *db_guard = Some(db);
-
-            // Send target update with new target
-            update_sender
-                .send(Target {
-                    root: new_verification_root,
-                    ops_root: new_sync_root,
-                    range: non_empty_range!(new_lower_bound, new_upper_bound),
-                })
-                .await
-                .unwrap();
-
-            new_verification_root
-        };
-
-        // Complete the sync
-        let synced_db = client.sync().await.unwrap();
-
-        // Verify the synced database has the expected final state
-        assert_eq!(synced_db.root(), new_verification_root);
-
-        // Verify the target database matches the synced database
-        let target_db = Arc::try_unwrap(target_db).map_or_else(
-            |_| panic!("Failed to unwrap Arc - still has references"),
-            |rw_lock| rw_lock.into_inner().expect("db should be present"),
-        );
-        {
-            let synced_bounds = synced_db.bounds().await;
-            let target_bounds = target_db.bounds().await;
-            assert_eq!(synced_bounds.end, target_bounds.end);
-            assert_eq!(
-                synced_db.inactivity_floor_loc().await,
-                target_db.inactivity_floor_loc().await
-            );
-            assert_eq!(synced_db.root(), target_db.root());
-        }
-
-        synced_db.destroy().await.unwrap();
-        target_db.destroy().await.unwrap();
-    });
-}
-
-/// Test demonstrating that a synced database can be reopened and retain its state.
-pub(crate) fn test_sync_database_persistence<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode + Clone,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create and populate a simple target database
-        let mut target_db = H::init_db(context.child("target")).await;
-        let target_ops = H::create_ops(10);
-        target_db = H::apply_ops(target_db, target_ops).await;
-        // commit already done in apply_ops
-
-        // Capture target state
-        let sync_root = H::sync_target_root(&target_db);
-        let verification_root = target_db.root();
-        let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
-
-        // Perform sync
-        let db_config = H::config(&context.next_u64().to_string(), &context);
-        let client_context = context.child("client");
-        let target_db = Arc::new(target_db);
-        let config = Config {
-            db_config: db_config.clone(),
-            fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: verification_root,
-                ops_root: sync_root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
-            context: client_context.child("client"),
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
-
-        // Verify initial sync worked
-        assert_eq!(synced_db.root(), verification_root);
-
-        // Save state before dropping
-        let expected_root = synced_db.root();
-        let expected_op_count = synced_db.bounds().await.end;
-        let expected_inactivity_floor_loc = synced_db.inactivity_floor_loc().await;
-
-        // Re-open the database
-        drop(synced_db);
-        let reopened_db = H::init_db_with_config(client_context.child("reopened"), db_config).await;
-
-        // Verify the state is unchanged
-        assert_eq!(reopened_db.root(), expected_root);
-        assert_eq!(reopened_db.bounds().await.end, expected_op_count);
-        assert_eq!(
-            reopened_db.inactivity_floor_loc().await,
-            expected_inactivity_floor_loc
-        );
-
-        // Cleanup
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-        reopened_db.destroy().await.unwrap();
-    });
-}
-
-/// Test post-sync usability: after syncing, the database supports normal operations.
-pub(crate) fn test_sync_post_sync_usability<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let mut target_db = H::init_db(context.child("target")).await;
-        let target_ops = H::create_ops(50);
-        target_db = H::apply_ops(target_db, target_ops).await;
-
-        let sync_root = H::sync_target_root(&target_db);
-        let verification_root = H::target_root(&target_db);
-        let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
-        let target_db = Arc::new(target_db);
-
-        let config = H::config(&context.next_u64().to_string(), &context);
-        let config = Config {
-            db_config: config,
-            fetch_batch_size: NZU64!(100),
-            target: Target {
-                root: verification_root,
-                ops_root: sync_root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
-            context: context.child("client"),
-            resolver: target_db.clone(),
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
-
-        let root_after_sync = synced_db.root();
-
-        // Apply additional operations after sync.
-        let more_ops = H::create_ops_seeded(10, 1);
-        let synced_db = H::apply_ops(synced_db, more_ops).await;
-
-        // Root should change after applying more ops.
-        assert_ne!(synced_db.root(), root_after_sync);
-        assert!(synced_db.bounds().await.end > upper_bound);
-
-        synced_db.destroy().await.unwrap();
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
-}
-
-/// Test `from_sync_result` where the database has all operations in the target range.
-pub(crate) fn test_from_sync_result_nonempty_to_nonempty_exact_match<H: SyncTestHarness>()
-where
-    DbOf<H>: FromSyncTestable,
-    OpOf<H>: Encode + Clone,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let db_config = H::config(&context.next_u64().to_string(), &context);
-        let mut db = H::init_db_with_config(context.child("source"), db_config.clone()).await;
-        let ops = H::create_ops(100);
-        db = H::apply_ops(db, ops).await;
-        // commit already done in apply_ops
-
-        let sync_lower_bound = db.sync_boundary().await;
-        let bounds = db.bounds().await;
-        let sync_upper_bound = bounds.end;
-        let target_db_op_count = bounds.end;
-        let target_db_inactivity_floor_loc = db.inactivity_floor_loc().await;
-
-        let pinned_nodes = db.pinned_nodes_at(sync_lower_bound).await;
-        let (_, journal) = db.into_log_components();
-
-        let sync_db: DbOf<H> = <DbOf<H> as qmdb::sync::Database>::from_sync_result(
-            context.child("synced"),
-            db_config,
-            journal,
-            Some(pinned_nodes),
-            non_empty_range!(sync_lower_bound, sync_upper_bound),
-            1024,
-        )
-        .await
-        .unwrap();
-
-        // Verify database state
-        assert_eq!(sync_db.bounds().await.end, target_db_op_count);
-        assert_eq!(
-            sync_db.inactivity_floor_loc().await,
-            target_db_inactivity_floor_loc
-        );
-        assert_eq!(sync_db.sync_boundary().await, sync_lower_bound);
-
-        sync_db.destroy().await.unwrap();
-    });
-}
-
-/// Test `from_sync_result` where the database has some but not all operations in the target range.
-pub(crate) fn test_from_sync_result_nonempty_to_nonempty_partial_match<H: SyncTestHarness>()
-where
-    DbOf<H>: FromSyncTestable,
-    OpOf<H>: Encode + Clone,
-    JournalOf<H>: Contiguous,
-{
-    const NUM_OPS: usize = 100;
-    const NUM_ADDITIONAL_OPS: usize = 5;
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create and populate two databases.
-        let mut target_db = H::init_db(context.child("target")).await;
-        let sync_db_config = H::config(&context.next_u64().to_string(), &context);
-        let client_context = context.child("client");
-        let mut sync_db =
-            H::init_db_with_config(client_context.child("client"), sync_db_config.clone()).await;
-        let original_ops = H::create_ops(NUM_OPS);
-        target_db = H::apply_ops(target_db, original_ops.clone()).await;
-        // commit already done in apply_ops
-        target_db
-            .prune(target_db.sync_boundary().await)
-            .await
-            .unwrap();
-        sync_db = H::apply_ops(sync_db, original_ops.clone()).await;
-        // commit already done in apply_ops
-        sync_db.prune(sync_db.sync_boundary().await).await.unwrap();
-        sync_db.sync().await.unwrap();
-        drop(sync_db);
-
-        // Add more operations to the target db
-        // (use different seed to avoid key collisions)
-        let more_ops = H::create_ops_seeded(NUM_ADDITIONAL_OPS, 1);
-        target_db = H::apply_ops(target_db, more_ops).await;
-        // commit already done in apply_ops
-
-        // Capture target db state for comparison
-        let bounds = target_db.bounds().await;
-        let target_db_op_count = bounds.end;
-        let target_db_inactivity_floor_loc = target_db.inactivity_floor_loc().await;
-        let sync_lower_bound = target_db.sync_boundary().await;
-        let sync_upper_bound = bounds.end;
-        let target_hash = target_db.root();
-
-        // Get pinned nodes at the sync lower bound from the target db (which has all the data).
-        let pinned_nodes = target_db.pinned_nodes_at(sync_lower_bound).await;
-
-        let (mmr, journal) = target_db.into_log_components();
-
-        // Re-open `sync_db` using from_sync_result
-        let sync_db: DbOf<H> = <DbOf<H> as qmdb::sync::Database>::from_sync_result(
-            client_context.child("synced"),
-            sync_db_config,
-            journal,
-            Some(pinned_nodes),
-            non_empty_range!(sync_lower_bound, sync_upper_bound),
-            1024,
-        )
-        .await
-        .unwrap();
-
-        // Verify database state
-        assert_eq!(sync_db.bounds().await.end, target_db_op_count);
-        assert_eq!(
-            sync_db.inactivity_floor_loc().await,
-            target_db_inactivity_floor_loc
-        );
-        assert_eq!(sync_db.sync_boundary().await, sync_lower_bound);
-
-        // Verify the root digest matches the target (verifies content integrity)
-        assert_eq!(sync_db.root(), target_hash);
-
-        sync_db.destroy().await.unwrap();
-        mmr.destroy().await.unwrap();
-    });
-}
-
-/// Test `from_sync_result` with an empty destination database syncing to a non-empty source.
-/// This tests the scenario where a sync client starts fresh with no existing data.
-pub(crate) fn test_from_sync_result_empty_to_nonempty<H: SyncTestHarness>()
-where
-    DbOf<H>: FromSyncTestable,
-    OpOf<H>: Encode + Clone,
-    JournalOf<H>: Contiguous,
-{
-    const NUM_OPS: usize = 100;
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create and populate a source database
-        let mut source_db = H::init_db(context.child("source")).await;
-        let ops = H::create_ops(NUM_OPS);
-        source_db = H::apply_ops(source_db, ops).await;
-        // commit already done in apply_ops
-        source_db
-            .prune(source_db.sync_boundary().await)
-            .await
-            .unwrap();
-
-        let lower_bound = source_db.sync_boundary().await;
-        let upper_bound = source_db.bounds().await.end;
-
-        // Get pinned nodes and target hash before deconstructing source_db
-        let pinned_nodes = source_db.pinned_nodes_at(lower_bound).await;
-        let target_hash = source_db.root();
-        let target_op_count = source_db.bounds().await.end;
-        let target_inactivity_floor = source_db.inactivity_floor_loc().await;
-
-        let (mmr, journal) = source_db.into_log_components();
-
-        // Use a different config (simulating a new empty database)
-        let new_db_config = H::config(&context.next_u64().to_string(), &context);
-
-        let db: DbOf<H> = <DbOf<H> as qmdb::sync::Database>::from_sync_result(
-            context.child("synced"),
-            new_db_config,
-            journal,
-            Some(pinned_nodes),
-            non_empty_range!(lower_bound, upper_bound),
-            1024,
-        )
-        .await
-        .unwrap();
-
-        // Verify database state
-        assert_eq!(db.bounds().await.end, target_op_count);
-        assert_eq!(db.inactivity_floor_loc().await, target_inactivity_floor);
-        assert_eq!(db.sync_boundary().await, lower_bound);
-
-        // Verify the root digest matches the target
-        assert_eq!(db.root(), target_hash);
-
-        db.destroy().await.unwrap();
-        mmr.destroy().await.unwrap();
-    });
-}
-
-/// Test `from_sync_result` with an empty source database syncing to an empty target database.
-pub(crate) fn test_from_sync_result_empty_to_empty<H: SyncTestHarness>()
-where
-    DbOf<H>: FromSyncTestable,
-    OpOf<H>: Encode + Clone,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Create an empty database (initialized with a single CommitFloor operation)
-        let source_db = H::init_db(context.child("source")).await;
-
-        // An empty database has exactly 1 operation (the initial CommitFloor)
-        assert_eq!(source_db.bounds().await.end, Location::new(1));
-
-        let target_hash = source_db.root();
-        let (mmr, journal) = source_db.into_log_components();
-
-        // Use a different config (simulating a new empty database)
-        let new_db_config = H::config(&context.next_u64().to_string(), &context);
-
-        let mut synced_db: DbOf<H> = <DbOf<H> as qmdb::sync::Database>::from_sync_result(
-            context.child("synced"),
-            new_db_config,
-            journal,
-            None,
-            non_empty_range!(Location::new(0), Location::new(1)),
-            1024,
-        )
-        .await
-        .unwrap();
-
-        // Verify database state
-        assert_eq!(synced_db.bounds().await.end, Location::new(1));
-        assert_eq!(synced_db.inactivity_floor_loc().await, Location::new(0));
-        assert_eq!(synced_db.root(), target_hash);
-
-        // Test that we can perform operations on the synced database
-        let ops = H::create_ops(10);
-        synced_db = H::apply_ops(synced_db, ops).await;
-
-        // Verify the operations worked
-        assert!(synced_db.bounds().await.end > Location::new(1));
-
-        synced_db.destroy().await.unwrap();
-        mmr.destroy().await.unwrap();
-    });
-}
-
-/// A resolver wrapper that corrupts pinned nodes on the first request, then returns correct
-/// data on subsequent requests.
-#[derive(Clone)]
-struct CorruptFirstPinnedNodesResolver<R> {
-    inner: R,
-    corrupted: Arc<std::sync::atomic::AtomicBool>,
-}
-
-impl<R> Resolver for CorruptFirstPinnedNodesResolver<R>
-where
-    R: Resolver<Digest = Digest>,
-{
-    type Family = R::Family;
-    type Digest = Digest;
-    type Op = R::Op;
-    type Error = R::Error;
-
-    async fn get_operations(
-        &self,
-        op_count: Location<Self::Family>,
-        start_loc: Location<Self::Family>,
-        max_ops: NonZeroU64,
-        include_pinned_nodes: bool,
-        cancel_rx: oneshot::Receiver<()>,
-    ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
-        let mut result = self
-            .inner
-            .get_operations(
-                op_count,
-                start_loc,
-                max_ops,
-                include_pinned_nodes,
-                cancel_rx,
-            )
-            .await?;
-        // Corrupt pinned nodes only on the first request that includes them.
-        if result.pinned_nodes.is_some()
-            && !self
-                .corrupted
-                .swap(true, std::sync::atomic::Ordering::Relaxed)
-        {
-            if let Some(ref mut nodes) = result.pinned_nodes {
-                if !nodes.is_empty() {
-                    nodes[0] = Digest::from([0xFFu8; 32]);
-                }
-            }
-        }
-        Ok(result)
-    }
-}
-
-/// Test that corrupted pinned nodes on the first attempt are rejected and the sync
-/// succeeds on retry when the resolver returns correct data.
-pub(crate) fn test_sync_retries_bad_pinned_nodes<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        // Build a target database with some operations and prune so that pinned nodes are needed.
-        let mut target_db = H::init_db(context.child("target")).await;
-        let ops = H::create_ops(20);
-        target_db = H::apply_ops(target_db, ops).await;
-        target_db
-            .prune(target_db.sync_boundary().await)
-            .await
-            .unwrap();
-
-        let sync_root = H::sync_target_root(&target_db);
-        let verification_root = H::target_root(&target_db);
-        let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
-
-        let db_config = H::config(&context.next_u64().to_string(), &context);
-
-        let resolver = CorruptFirstPinnedNodesResolver {
-            inner: Arc::new(target_db),
-            corrupted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        };
-
-        let config = sync::engine::Config {
-            db_config,
-            fetch_batch_size: NZU64!(100),
-            target: Target {
-                root: verification_root,
-                ops_root: sync_root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
-            context: context.child("client"),
-            resolver,
-            apply_batch_size: 1024,
-            max_outstanding_requests: 1,
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-            max_retained_roots: 8,
-        };
-
-        // Sync should succeed on the second attempt after the first corrupted pinned nodes
-        // are rejected.
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
-        assert_eq!(synced_db.root(), sync_root);
-        synced_db.destroy().await.unwrap();
-    });
-}
-
-/// A resolver wrapper that replays the first fresh boundary request against the retained
-/// historical root, then blocks the retry until the test releases it.
-#[derive(Clone)]
-struct ReplayFreshBoundaryResolver<R: Resolver<Digest = Digest>> {
-    inner: R,
-    historical_target_size: Location<R::Family>,
-    boundary_start: Location<R::Family>,
-    release_historical_gap: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
-    release_boundary_retry: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
-    boundary_attempts: Arc<AtomicUsize>,
-}
-
-impl<R: Resolver<Digest = Digest>> Resolver for ReplayFreshBoundaryResolver<R> {
-    type Family = R::Family;
-    type Digest = Digest;
-    type Op = R::Op;
-    type Error = R::Error;
-
-    async fn get_operations(
-        &self,
-        op_count: Location<Self::Family>,
-        start_loc: Location<Self::Family>,
-        max_ops: NonZeroU64,
-        include_pinned_nodes: bool,
-        cancel_rx: oneshot::Receiver<()>,
-    ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
-        if op_count == self.historical_target_size {
-            if include_pinned_nodes {
-                let _ = cancel_rx.await;
-                return self
-                    .inner
-                    .get_operations(
-                        op_count,
-                        start_loc,
-                        max_ops,
-                        include_pinned_nodes,
-                        oneshot::channel().1,
-                    )
-                    .await;
-            }
-
-            let release = self.release_historical_gap.lock().take();
-            if let Some(release) = release {
-                let _ = release.await;
-            }
-        }
-
-        if include_pinned_nodes && start_loc == self.boundary_start {
-            let attempt = self.boundary_attempts.fetch_add(1, Ordering::Relaxed);
-            if attempt == 0 {
-                let mut result = self
-                    .inner
-                    .get_operations(
-                        self.historical_target_size,
-                        start_loc,
-                        max_ops,
-                        false,
-                        oneshot::channel().1,
-                    )
-                    .await?;
-                result.pinned_nodes = None;
-                return Ok(result);
-            }
-
-            let release = self.release_boundary_retry.lock().take();
-            if let Some(release) = release {
-                let _ = release.await;
-            }
-        }
-
-        self.inner
-            .get_operations(
-                op_count,
-                start_loc,
-                max_ops,
-                include_pinned_nodes,
-                cancel_rx,
-            )
-            .await
-    }
-}
-
-/// Test that reaching the journal target does not report completion while the pruned
-/// boundary retry is still outstanding.
-pub(crate) fn test_sync_waits_for_boundary_retry_after_target_update<H: SyncTestHarness>()
-where
-    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
-    OpOf<H>: Encode,
-    JournalOf<H>: Contiguous,
-{
-    let executor = deterministic::Runner::default();
-    executor.start(|mut context| async move {
-        let mut target_db = H::init_db(context.child("target")).await;
-
-        let mut seed = 0;
-        loop {
-            target_db = H::apply_ops(target_db, H::create_ops_seeded(32, seed)).await;
-            target_db
-                .prune(target_db.sync_boundary().await)
-                .await
-                .unwrap();
-
-            if target_db.inactivity_floor_loc().await > Location::new(0) {
-                break;
-            }
-
-            seed += 1;
-            assert!(seed < 8, "expected prune floor to advance");
-        }
-
-        let old_target = Target {
-            root: H::target_root(&target_db),
-            ops_root: H::sync_target_root(&target_db),
-            range: non_empty_range!(
-                target_db.inactivity_floor_loc().await,
-                target_db.bounds().await.end
-            ),
-        };
-
-        target_db = H::apply_ops(target_db, H::create_ops_seeded(3, seed + 1)).await;
-        let new_target = Target {
-            root: H::target_root(&target_db),
-            ops_root: H::sync_target_root(&target_db),
-            range: non_empty_range!(
-                target_db.inactivity_floor_loc().await,
-                target_db.bounds().await.end
-            ),
-        };
-        let verification_root = target_db.root();
-
-        assert!(old_target.range.start() > Location::new(0));
-        assert!(new_target.range.end() > old_target.range.end());
-
-        let (release_historical_gap_tx, release_historical_gap_rx) = oneshot::channel();
-        let (release_boundary_retry_tx, release_boundary_retry_rx) = oneshot::channel();
-        let target_db = Arc::new(target_db);
-        let resolver = ReplayFreshBoundaryResolver {
-            inner: target_db.clone(),
-            historical_target_size: old_target.range.end(),
-            boundary_start: new_target.range.start(),
-            release_historical_gap: Arc::new(Mutex::new(Some(release_historical_gap_rx))),
-            release_boundary_retry: Arc::new(Mutex::new(Some(release_boundary_retry_rx))),
-            boundary_attempts: Arc::new(AtomicUsize::new(0)),
-        };
-
-        let (update_sender, update_receiver) = mpsc::channel(1);
-        let (finish_sender, finish_receiver) = mpsc::channel(1);
-        let (reached_sender, mut reached_receiver) = mpsc::channel(1);
-
-        let config = Config {
-            context: context.child("client"),
-            db_config: H::config(&context.next_u64().to_string(), &context),
-            fetch_batch_size: NZU64!(1),
-            target: old_target.clone(),
-            resolver,
-            apply_batch_size: 1024,
-            max_outstanding_requests: 2,
-            update_rx: Some(update_receiver),
-            finish_rx: Some(finish_receiver),
-            reached_target_tx: Some(reached_sender),
-            max_retained_roots: 1,
-        };
-
-        let mut engine: Engine<H::Db, _> = Engine::new(config).await.unwrap();
-
-        update_sender.send(new_target.clone()).await.unwrap();
-        finish_sender.send(()).await.unwrap();
-
-        engine = match engine.step().await.unwrap() {
-            NextStep::Continue(engine) => engine,
-            NextStep::Complete(..) => panic!("target update should not complete sync"),
-        };
-
-        let _ = release_historical_gap_tx.send(());
-
-        let journal_start = engine.journal().size().await;
-        for step_idx in 0..4 {
-            let next_step = engine.step();
-            pin_mut!(next_step);
-
-            select! {
-                result = next_step.as_mut() => {
-                    engine = match result.unwrap() {
-                        NextStep::Continue(engine) => engine,
-                        NextStep::Complete(..) => panic!("boundary retry should still be required"),
-                    };
-                    assert_eq!(
-                        engine.journal().size().await,
-                        journal_start,
-                        "replayed fresh boundary responses must not advance the journal"
-                    );
-                },
-                _ = context.sleep(Duration::from_millis(100)) => {
-                    panic!(
-                        "engine should keep processing fetch results while the boundary retry is blocked: step={step_idx}"
-                    );
-                },
-            }
-        }
-        assert!(
-            reached_receiver.recv().now_or_never().is_none(),
-            "engine should not report reached-target while boundary state is missing"
-        );
-
-        let _ = release_boundary_retry_tx.send(());
-
-        let synced_db = engine.sync().await.unwrap();
-
-        let reached = reached_receiver.recv().await.unwrap();
-        assert_eq!(reached, new_target);
-        assert_eq!(synced_db.root(), verification_root);
-
-        synced_db.destroy().await.unwrap();
-        Arc::try_unwrap(target_db)
-            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
-            .destroy()
-            .await
-            .unwrap();
-    });
+#[test]
+fn test_sync_target_read_invalid_bounds() {
+    let mut buffer = Vec::new();
+    sha256::Digest::from([42; 32]).write(&mut buffer);
+    Location::<mmr::Family>::new(100).write(&mut buffer);
+    Location::<mmr::Family>::new(50).write(&mut buffer);
+
+    let mut cursor = Cursor::new(buffer);
+    assert!(matches!(
+        Target::<mmr::Family, sha256::Digest>::read(&mut cursor),
+        Err(CodecError::Invalid("Range", "start must be <= end"))
+    ));
+
+    let mut buffer = Vec::new();
+    sha256::Digest::from([42; 32]).write(&mut buffer);
+    (Location::<mmr::Family>::new(100)..Location::<mmr::Family>::new(100)).write(&mut buffer);
+
+    let mut cursor = Cursor::new(buffer);
+    assert!(matches!(
+        Target::<mmr::Family, sha256::Digest>::read(&mut cursor),
+        Err(CodecError::Invalid("NonEmptyRange", "start must be < end"))
+    ));
 }
 
 mod harnesses {
-    use super::SyncTestHarness;
     use crate::{
         merkle::{self, mmb},
-        qmdb::any::value::VariableEncoding,
+        qmdb::{
+            any::value::VariableEncoding,
+            sync::tests::{OpOf, SyncTestHarness},
+        },
         translator::TwoCap,
     };
     use commonware_cryptography::sha256::Digest;
     use commonware_math::algebra::Random;
     use commonware_runtime::{deterministic::Context, BufferPooler};
-    use commonware_utils::test_rng_seeded;
+    use commonware_utils::{range::NonEmptyRange, test_rng_seeded};
     use rand::RngCore;
+
+    fn target<F: merkle::Family>(
+        root: Digest,
+        _ops_root: Digest,
+        range: NonEmptyRange<crate::merkle::Location<F>>,
+    ) -> crate::qmdb::any::sync::Target<F, Digest> {
+        crate::qmdb::any::sync::Target::new(root, range)
+    }
 
     // ===== Family-generic op creation helpers =====
     //
@@ -2291,9 +189,14 @@ mod harnesses {
     impl SyncTestHarness for OrderedFixedHarness {
         type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::ordered::fixed::test::AnyTest;
+        type Target = crate::qmdb::any::sync::Target<crate::mmr::Family, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            db.root()
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(
@@ -2349,9 +252,14 @@ mod harnesses {
     impl SyncTestHarness for OrderedVariableHarness {
         type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::ordered::variable::test::AnyTest;
+        type Target = crate::qmdb::any::sync::Target<crate::mmr::Family, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            db.root()
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(
@@ -2414,9 +322,14 @@ mod harnesses {
     impl SyncTestHarness for UnorderedFixedHarness {
         type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::unordered::fixed::test::AnyTest;
+        type Target = crate::qmdb::any::sync::Target<crate::mmr::Family, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            db.root()
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(
@@ -2472,9 +385,14 @@ mod harnesses {
     impl SyncTestHarness for UnorderedVariableHarness {
         type Family = crate::mmr::Family;
         type Db = crate::qmdb::any::unordered::variable::test::AnyTest;
+        type Target = crate::qmdb::any::sync::Target<crate::mmr::Family, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            db.root()
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(
@@ -2499,7 +417,7 @@ mod harnesses {
             crate::qmdb::any::unordered::variable::test::create_test_ops(n)
         }
 
-        fn create_ops_seeded(n: usize, seed: u64) -> Vec<super::OpOf<Self>> {
+        fn create_ops_seeded(n: usize, seed: u64) -> Vec<OpOf<Self>> {
             crate::qmdb::any::unordered::variable::test::create_test_ops_seeded(n, seed)
         }
 
@@ -2552,9 +470,14 @@ mod harnesses {
             TwoCap,
             commonware_parallel::Sequential,
         >;
+        type Target = crate::qmdb::any::sync::Target<mmb::Family, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            db.root()
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(
@@ -2630,9 +553,14 @@ mod harnesses {
             TwoCap,
             commonware_parallel::Sequential,
         >;
+        type Target = crate::qmdb::any::sync::Target<mmb::Family, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            db.root()
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(
@@ -2717,9 +645,14 @@ mod harnesses {
             TwoCap,
             commonware_parallel::Sequential,
         >;
+        type Target = crate::qmdb::any::sync::Target<mmb::Family, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            db.root()
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(
@@ -2797,9 +730,14 @@ mod harnesses {
             TwoCap,
             commonware_parallel::Sequential,
         >;
+        type Target = crate::qmdb::any::sync::Target<mmb::Family, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            db.root()
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(
@@ -2886,12 +824,12 @@ macro_rules! sync_tests_for_harness {
 
             #[test_traced]
             fn test_sync_empty_operations_no_panic() {
-                super::test_sync_empty_operations_no_panic::<$harness>();
+                crate::qmdb::sync::tests::test_sync_empty_operations_no_panic::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_subset_of_target_database() {
-                super::test_sync_subset_of_target_database::<$harness>(1000);
+                crate::qmdb::sync::tests::test_sync_subset_of_target_database::<$harness>(1000);
             }
 
             #[rstest]
@@ -2904,7 +842,7 @@ macro_rules! sync_tests_for_harness {
             #[case::db_size_eq_batch_size(1000, 1000)]
             #[case::batch_size_gt_db_size(1000, 1001)]
             fn test_sync(#[case] target_db_ops: usize, #[case] fetch_batch_size: u64) {
-                super::test_sync::<$harness>(
+                crate::qmdb::sync::tests::test_sync::<$harness>(
                     target_db_ops,
                     NonZeroU64::new(fetch_batch_size).unwrap(),
                 );
@@ -2912,64 +850,64 @@ macro_rules! sync_tests_for_harness {
 
             #[test_traced]
             fn test_sync_use_existing_db_partial_match() {
-                super::test_sync_use_existing_db_partial_match::<$harness>(1000);
+                crate::qmdb::sync::tests::test_sync_use_existing_db_partial_match::<$harness>(1000);
             }
 
             #[test_traced]
             fn test_sync_use_existing_db_exact_match() {
-                super::test_sync_use_existing_db_exact_match::<$harness>(1000);
+                crate::qmdb::sync::tests::test_sync_use_existing_db_exact_match::<$harness>(1000);
             }
 
             #[test_traced("WARN")]
             fn test_target_update_lower_bound_decrease() {
-                super::test_target_update_lower_bound_decrease::<$harness>();
+                crate::qmdb::sync::tests::test_target_update_lower_bound_decrease::<$harness>();
             }
 
             #[test_traced("WARN")]
             fn test_target_update_upper_bound_decrease() {
-                super::test_target_update_upper_bound_decrease::<$harness>();
+                crate::qmdb::sync::tests::test_target_update_upper_bound_decrease::<$harness>();
             }
 
             #[test_traced("WARN")]
             fn test_target_update_bounds_increase() {
-                super::test_target_update_bounds_increase::<$harness>();
+                crate::qmdb::sync::tests::test_target_update_bounds_increase::<$harness>();
             }
 
             #[test]
             fn test_target_update_prune_only_rejected() {
-                super::test_target_update_prune_only_rejected::<$harness>();
+                crate::qmdb::sync::tests::test_target_update_prune_only_rejected::<$harness>();
             }
 
             #[test_traced("WARN")]
             fn test_target_update_on_done_client() {
-                super::test_target_update_on_done_client::<$harness>();
+                crate::qmdb::sync::tests::test_target_update_on_done_client::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_waits_for_explicit_finish() {
-                super::test_sync_waits_for_explicit_finish::<$harness>();
+                crate::qmdb::sync::tests::test_sync_waits_for_explicit_finish::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_reports_progress_for_reached_targets_before_explicit_finish() {
-                super::test_sync_reports_progress_for_reached_targets_before_explicit_finish::<
+                crate::qmdb::sync::tests::test_sync_reports_progress_for_reached_targets_before_explicit_finish::<
                     $harness,
                 >();
             }
 
             #[test_traced]
             fn test_sync_handles_early_finish_signal() {
-                super::test_sync_handles_early_finish_signal::<$harness>();
+                crate::qmdb::sync::tests::test_sync_handles_early_finish_signal::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_fails_when_finish_sender_dropped() {
-                super::test_sync_fails_when_finish_sender_dropped::<$harness>();
+                crate::qmdb::sync::tests::test_sync_fails_when_finish_sender_dropped::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_allows_dropped_reached_target_receiver() {
-                super::test_sync_allows_dropped_reached_target_receiver::<$harness>();
+                crate::qmdb::sync::tests::test_sync_allows_dropped_reached_target_receiver::<$harness>();
             }
 
             #[rstest]
@@ -2989,32 +927,32 @@ macro_rules! sync_tests_for_harness {
                 #[case] initial_ops: usize,
                 #[case] additional_ops: usize,
             ) {
-                super::test_target_update_during_sync::<$harness>(initial_ops, additional_ops);
+                crate::qmdb::sync::tests::test_target_update_during_sync::<$harness>(initial_ops, additional_ops);
             }
 
             #[test_traced]
             fn test_sync_database_persistence() {
-                super::test_sync_database_persistence::<$harness>();
+                crate::qmdb::sync::tests::test_sync_database_persistence::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_post_sync_usability() {
-                super::test_sync_post_sync_usability::<$harness>();
+                crate::qmdb::sync::tests::test_sync_post_sync_usability::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_resolver_fails() {
-                super::test_sync_resolver_fails::<$harness>();
+                crate::qmdb::sync::tests::test_sync_resolver_fails::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_retries_bad_pinned_nodes() {
-                super::test_sync_retries_bad_pinned_nodes::<$harness>();
+                crate::qmdb::sync::tests::test_sync_retries_bad_pinned_nodes::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_waits_for_boundary_retry_after_target_update() {
-                super::test_sync_waits_for_boundary_retry_after_target_update::<$harness>();
+                crate::qmdb::sync::tests::test_sync_waits_for_boundary_retry_after_target_update::<$harness>();
             }
         }
     };
@@ -3030,22 +968,22 @@ macro_rules! from_sync_result_tests_for_harness {
 
             #[test_traced("WARN")]
             fn test_from_sync_result_empty_to_empty() {
-                super::test_from_sync_result_empty_to_empty::<$harness>();
+                crate::qmdb::sync::tests::test_from_sync_result_empty_to_empty::<$harness>();
             }
 
             #[test_traced]
             fn test_from_sync_result_empty_to_nonempty() {
-                super::test_from_sync_result_empty_to_nonempty::<$harness>();
+                crate::qmdb::sync::tests::test_from_sync_result_empty_to_nonempty::<$harness>();
             }
 
             #[test_traced]
             fn test_from_sync_result_nonempty_to_nonempty_partial_match() {
-                super::test_from_sync_result_nonempty_to_nonempty_partial_match::<$harness>();
+                crate::qmdb::sync::tests::test_from_sync_result_nonempty_to_nonempty_partial_match::<$harness>();
             }
 
             #[test_traced]
             fn test_from_sync_result_nonempty_to_nonempty_exact_match() {
-                super::test_from_sync_result_nonempty_to_nonempty_exact_match::<$harness>();
+                crate::qmdb::sync::tests::test_from_sync_result_nonempty_to_nonempty_exact_match::<$harness>();
             }
         }
     };

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -73,9 +73,10 @@ mod harnesses {
 
     fn target<F: merkle::Family>(
         root: Digest,
-        _ops_root: Digest,
+        ops_root: Digest,
         range: NonEmptyRange<crate::merkle::Location<F>>,
     ) -> crate::qmdb::any::sync::Target<F, Digest> {
+        assert_eq!(root, ops_root);
         crate::qmdb::any::sync::Target::new(root, range)
     }
 

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -823,7 +823,7 @@ pub(crate) mod test {
         use super::*;
         use crate::{
             merkle::mmr::{self, full::Mmr},
-            qmdb::any::sync::tests::FromSyncTestable,
+            qmdb::sync::tests::FromSyncTestable,
         };
         use futures::future::join_all;
 

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -694,7 +694,7 @@ pub(crate) mod test {
         use super::*;
         use crate::{
             merkle::mmr::{self, full::Mmr},
-            qmdb::any::sync::tests::FromSyncTestable,
+            qmdb::sync::tests::FromSyncTestable,
         };
         use futures::future::join_all;
 

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -408,8 +408,8 @@ where
     /// Returns the most recent location from which this database can safely be synced, and the
     /// upper bound on [`Self::prune`]'s `prune_loc`.
     ///
-    /// Callers constructing a sync [`Target`](crate::qmdb::sync::Target) may use this value, or
-    /// any earlier retained location, as `range.start`. Values *above* this boundary are unsafe:
+    /// Callers constructing a sync [`Target`](crate::qmdb::current::sync::Target) may use this
+    /// value, or any earlier retained location, as `range.start`. Values *above* this boundary are unsafe:
     /// the receiver's grafted-pin derivation requires absorption-settled state for every fully
     /// pruned chunk, which this value guarantees.
     ///

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -315,7 +315,7 @@
 //! partial.
 //!
 //! The canonical root is returned by [Db](db::Db)`::`[root()](db::Db::root). The ops root is
-//! returned by the `sync::Database` trait's `root()` method, since the sync engine verifies batches
+//! returned by the `sync::Database` trait's `ops_root()` method, since the sync engine verifies batches
 //! against the ops root, not the canonical root.
 //!
 //! For state sync, the sync engine targets the ops root and verifies each batch against it. Callers

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -356,7 +356,7 @@ pub mod grafting;
 
 pub mod ordered;
 pub mod proof;
-pub(crate) mod sync;
+pub mod sync;
 pub mod unordered;
 
 use self::db::Metrics;

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -2,26 +2,25 @@
 //!
 //! Contains implementation of the sync `Database` trait for all
 //! [Db](crate::qmdb::current::db::Db) variants (ordered/unordered, fixed/variable), plus a
-//! [sync()] wrapper for targets anchored by canonical roots.
+//! [sync()] wrapper for targets anchored by trusted database roots.
 //!
-//! The canonical root of a `current` database combines the ops root, grafted root, and optional
+//! The database root of a `current` database combines the ops root, grafted root, and optional
 //! pending and partial chunk digests into a single hash (see the [Root structure](super) section in
 //! the module documentation). The shared sync engine operates on the **ops root** internally,
 //! downloading operations and verifying each batch against the ops root using ops-tree range proofs
 //! (identical to `any` sync).
 //!
-//! Callers that only trust a canonical root (e.g., from consensus) should use [sync()] with a
+//! Callers that only trust a database root (e.g., from consensus) should use [sync()] with a
 //! [Target] that includes an [OpsRootWitness]. The wrapper verifies each target's witness before
-//! forwarding its ops root to the shared sync engine, then checks the reconstructed canonical root
+//! forwarding its ops root to the shared sync engine, then checks the reconstructed database root
 //! for the target the engine finishes on.
 //!
 //! After all operations are synced, the bitmap and grafted tree are reconstructed deterministically
-//! from the operations. The canonical root is then computed from the ops root, the reconstructed
+//! from the operations. The database root is then computed from the ops root, the reconstructed
 //! grafted root, and any pending or partial chunk digests.
 //!
-//! The `Database::root()` implementation returns the **ops root** (not the canonical root)
-//! because that is what the sync engine verifies against. `Database::canonical_root()` returns
-//! the full canonical root.
+//! `Database::ops_root()` returns the ops root because that is what the sync engine verifies
+//! against. `Database::root()` returns the full database root.
 //!
 //! For pruned databases (`range.start > 0`), grafted pinned nodes for the pruned region are read
 //! directly from the ops tree after it is built. This works because of the zero-chunk identity: for
@@ -92,17 +91,17 @@ use std::{num::NonZeroU64, sync::Arc};
 #[cfg(test)]
 pub(crate) mod tests;
 
-/// Sync target for `current` databases, anchored by a trusted canonical root.
+/// Sync target for `current` databases, anchored by a trusted database root.
 ///
-/// The witness authenticates `ops_root` against `canonical_root`; the shared sync engine
+/// The witness authenticates `ops_root` against `root`; the shared sync engine
 /// uses the authenticated ops root as its target.
 #[derive(Clone, Debug)]
 pub struct Target<F: Graftable, D: Digest> {
-    /// The trusted canonical root.
-    pub canonical_root: D,
+    /// The trusted database root.
+    pub root: D,
     /// The ops root provided by the sync source.
     pub ops_root: D,
-    /// Witness proving that `canonical_root` commits to `ops_root`.
+    /// Witness proving the `root` commits to `ops_root`.
     pub witness: OpsRootWitness<F, D>,
     /// Range of operations to sync.
     pub range: NonEmptyRange<Location<F>>,
@@ -114,12 +113,10 @@ impl<F: Graftable, D: Digest> Target<F, D> {
         &self,
         hasher: &StandardHasher<H>,
     ) -> Option<qmdb_sync::Target<F, D>> {
-        if self
-            .witness
-            .verify(hasher, &self.ops_root, &self.canonical_root)
-        {
+        if self.witness.verify(hasher, &self.ops_root, &self.root) {
             Some(qmdb_sync::Target {
-                root: self.ops_root,
+                root: self.root,
+                ops_root: self.ops_root,
                 range: self.range.clone(),
             })
         } else {
@@ -130,7 +127,7 @@ impl<F: Graftable, D: Digest> Target<F, D> {
 
 impl<F: Graftable, D: Digest> commonware_codec::Write for Target<F, D> {
     fn write(&self, buf: &mut impl bytes::BufMut) {
-        self.canonical_root.write(buf);
+        self.root.write(buf);
         self.ops_root.write(buf);
         self.witness.write(buf);
         self.range.write(buf);
@@ -139,7 +136,7 @@ impl<F: Graftable, D: Digest> commonware_codec::Write for Target<F, D> {
 
 impl<F: Graftable, D: Digest> commonware_codec::EncodeSize for Target<F, D> {
     fn encode_size(&self) -> usize {
-        self.canonical_root.encode_size()
+        self.root.encode_size()
             + self.ops_root.encode_size()
             + self.witness.encode_size()
             + self.range.encode_size()
@@ -150,7 +147,7 @@ impl<F: Graftable, D: Digest> commonware_codec::Read for Target<F, D> {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl bytes::Buf, _: &()) -> Result<Self, commonware_codec::Error> {
-        let canonical_root = D::read(buf)?;
+        let root = D::read(buf)?;
         let ops_root = D::read(buf)?;
         let witness = OpsRootWitness::<F, D>::read(buf)?;
         let range = NonEmptyRange::<Location<F>>::read(buf)?;
@@ -161,7 +158,7 @@ impl<F: Graftable, D: Digest> commonware_codec::Read for Target<F, D> {
             ));
         }
         Ok(Self {
-            canonical_root,
+            root,
             ops_root,
             witness,
             range,
@@ -169,7 +166,7 @@ impl<F: Graftable, D: Digest> commonware_codec::Read for Target<F, D> {
     }
 }
 
-/// Configuration for syncing a `current` database from canonical-root targets.
+/// Configuration for syncing a `current` database from trusted database-root targets.
 pub struct Config<DB: Database, R: DbResolver<DB>>
 where
     DB::Family: Graftable,
@@ -179,7 +176,7 @@ where
     pub context: DB::Context,
     /// Resolver for fetching operations and proofs.
     pub resolver: R,
-    /// Sync target with canonical root and witness.
+    /// Sync target with trusted database root and witness.
     pub target: Target<DB::Family, DB::Digest>,
     /// Maximum parallel outstanding requests.
     pub max_outstanding_requests: usize,
@@ -191,7 +188,7 @@ where
     pub db_config: DB::Config,
     /// Channel for receiving target updates during sync.
     ///
-    /// Each update must include a witness authenticating its ops root against its canonical root.
+    /// Each update must include a witness authenticating its ops root against its trusted root.
     pub update_rx: Option<mpsc::Receiver<Target<DB::Family, DB::Digest>>>,
     /// Channel that requests sync completion once the current target is reached.
     pub finish_rx: Option<mpsc::Receiver<()>>,
@@ -201,10 +198,10 @@ where
     pub max_retained_roots: usize,
 }
 
-/// Sync a `current` database from a trusted canonical root.
+/// Sync a `current` database from a trusted database root.
 ///
 /// Verifies the initial target and any target update witnesses before forwarding ops-root targets
-/// to the shared sync engine, then checks the reconstructed canonical root for the target the
+/// to the shared sync engine, then checks the reconstructed database root for the target the
 /// engine finishes on.
 pub async fn sync<DB, R>(
     config: Config<DB, R>,
@@ -221,7 +218,7 @@ where
         .target
         .to_engine_target(&hasher)
         .ok_or(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid))?;
-    let mut canonical_roots = vec![(engine_target.clone(), config.target.canonical_root)];
+    let mut roots = vec![(engine_target.clone(), config.target.root)];
 
     // The caller controls the public update channel capacity. Once updates reach this wrapper,
     // keep the internal queue shallow so verified current targets cannot get far ahead of the
@@ -262,7 +259,7 @@ where
                 if update_tx.send(engine_target.clone()).await.is_err() {
                     break;
                 }
-                canonical_roots.push((engine_target, current_target.canonical_root));
+                roots.push((engine_target, current_target.root));
             }
             Ok(())
         });
@@ -278,17 +275,18 @@ where
         engine_fut.await?
     };
 
-    let expected = canonical_roots
+    let expected = roots
         .iter()
         .rev()
         .find(|(target, _)| target == &final_target)
         .expect("final current sync target was verified")
         .1;
-    let actual = database.canonical_root();
+    let actual = database.root();
     if actual != expected {
-        return Err(qmdb_sync::Error::Engine(
-            EngineError::CanonicalRootMismatch { expected, actual },
-        ));
+        return Err(qmdb_sync::Error::Engine(EngineError::RootMismatch {
+            expected,
+            actual,
+        }));
     }
 
     Ok(database)
@@ -308,7 +306,7 @@ impl<T: Translator, J: Clone, S: Strategy> DatabaseConfig for super::Config<T, J
 /// * Builds the activity bitmap by replaying the operations log.
 /// * Extracts grafted pinned nodes from the ops tree (zero-chunk identity).
 /// * Builds the grafted tree from the bitmap and ops tree.
-/// * Computes and caches the canonical root.
+/// * Computes and caches the database root.
 #[allow(clippy::too_many_arguments)]
 async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
     context: E,
@@ -407,7 +405,7 @@ where
     )
     .await?;
 
-    // Compute the canonical root. The grafted root is deterministic from the ops
+    // Compute the database root. The grafted root is deterministic from the ops
     // (which are authenticated by the engine) and the bitmap (which is deterministic
     // from the ops).
     let storage = grafting::Storage::new(
@@ -560,13 +558,11 @@ macro_rules! impl_current_sync_database {
                 true
             }
 
-            /// Returns the ops root (not the canonical root), since the sync engine verifies
-            /// batches against the ops tree.
-            fn root(&self) -> Self::Digest {
+            fn ops_root(&self) -> Self::Digest {
                 self.any.root()
             }
 
-            fn canonical_root(&self) -> Self::Digest {
+            fn root(&self) -> Self::Digest {
                 self.root
             }
         }

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -1,16 +1,18 @@
-//! Shared synchronization logic for [crate::qmdb::current] databases.
+//! Synchronization logic for [crate::qmdb::current] databases.
 //!
 //! Contains implementation of [crate::qmdb::sync::Database] for all
-//! [Db](crate::qmdb::current::db::Db) variants (ordered/unordered, fixed/variable).
+//! [Db](crate::qmdb::current::db::Db) variants (ordered/unordered, fixed/variable), plus a
+//! canonical-root-aware [sync()] wrapper.
 //!
 //! The canonical root of a `current` database combines the ops root, grafted root, and optional
 //! pending and partial chunk digests into a single hash (see the [Root structure](super) section in
-//! the module documentation). The sync engine operates on the **ops root**, not the canonical root:
-//! it downloads operations and verifies each batch against the ops root using ops-tree range proofs
-//! (identical to `any` sync). Callers that verify current ops proofs directly should use
-//! `qmdb::hasher`. [crate::qmdb::current::proof::OpsRootWitness] can be used by callers that need
-//! to authenticate the synced ops root against a trusted canonical root; the sync engine does not
-//! perform this check itself.
+//! the module documentation). The generic sync engine operates on the **ops root** internally,
+//! downloading operations and verifying each batch against the ops root using ops-tree range proofs
+//! (identical to `any` sync).
+//!
+//! Callers that only trust a canonical root (e.g., from consensus) should use [sync()] with a
+//! [Target] that includes an [OpsRootWitness]. The wrapper verifies the witness before starting
+//! the engine and checks the reconstructed canonical root after sync completes.
 //!
 //! After all operations are synced, the bitmap and grafted tree are reconstructed deterministically
 //! from the operations. The canonical root is then computed from the ops root, the reconstructed
@@ -18,6 +20,8 @@
 //!
 //! The [Database]`::`[root()](crate::qmdb::sync::Database::root) implementation returns the **ops
 //! root** (not the canonical root) because that is what the sync engine verifies against.
+//! [Database::canonical_root()](crate::qmdb::sync::Database::canonical_root) returns the full
+//! canonical root.
 //!
 //! For pruned databases (`range.start > 0`), grafted pinned nodes for the pruned region are read
 //! directly from the ops tree after it is built. This works because of the zero-chunk identity: for
@@ -33,6 +37,7 @@ use crate::{
     },
     merkle::{
         full::{self, Merkle},
+        hasher::Standard as StandardHasher,
         Graftable, Location,
     },
     qmdb::{
@@ -56,29 +61,181 @@ use crate::{
             ordered::{
                 fixed::Db as CurrentOrderedFixedDb, variable::Db as CurrentOrderedVariableDb,
             },
+            proof::OpsRootWitness,
             unordered::{
                 fixed::Db as CurrentUnorderedFixedDb, variable::Db as CurrentUnorderedVariableDb,
             },
             FixedConfig, VariableConfig,
         },
         operation::{Committable, Key, Operation as _},
-        sync::{Database, DatabaseConfig as Config},
+        sync::{
+            self as qmdb_sync, engine::Config as EngineConfig, Database,
+            DatabaseConfig, DbResolver, EngineError,
+        },
     },
     translator::Translator,
     Context, Persistable,
 };
-use commonware_codec::{Codec, CodecShared, Read as CodecRead};
-use commonware_cryptography::{DigestOf, Hasher};
+use commonware_codec::{Codec, CodecShared, Encode, Read as CodecRead, ReadExt as _};
+use commonware_cryptography::{Digest, DigestOf, Hasher};
 use commonware_parallel::Strategy;
 use commonware_utils::{
-    bitmap::Prunable as BitMap, channel::oneshot, range::NonEmptyRange, sync::AsyncMutex, Array,
+    bitmap::Prunable as BitMap,
+    channel::{mpsc, oneshot},
+    range::NonEmptyRange,
+    sync::AsyncMutex,
+    Array,
 };
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 #[cfg(test)]
 pub(crate) mod tests;
 
-impl<T: Translator, J: Clone, S: Strategy> Config for super::Config<T, J, S> {
+/// Sync target for `current` databases that trusts a canonical root.
+///
+/// The caller trusts `canonical_root` (e.g., from consensus). The server provides
+/// `ops_root` and `witness`; the sync wrapper verifies
+/// `witness.verify(hasher, &ops_root, &canonical_root)` before starting the engine.
+#[derive(Clone, Debug)]
+pub struct Target<F: Graftable, D: Digest> {
+    /// The trusted canonical root.
+    pub canonical_root: D,
+    /// The ops root provided by the sync source.
+    pub ops_root: D,
+    /// Witness proving that `canonical_root` commits to `ops_root`.
+    pub witness: OpsRootWitness<F, D>,
+    /// Range of operations to sync.
+    pub range: NonEmptyRange<Location<F>>,
+}
+
+impl<F: Graftable, D: Digest> Target<F, D> {
+    /// Verify the witness and return the corresponding engine-level target.
+    pub fn to_engine_target<H: commonware_cryptography::Hasher<Digest = D>>(
+        &self,
+        hasher: &StandardHasher<H>,
+    ) -> Option<qmdb_sync::Target<F, D>> {
+        if self.witness.verify(hasher, &self.ops_root, &self.canonical_root) {
+            Some(qmdb_sync::Target {
+                root: self.ops_root,
+                canonical_root: Some(self.canonical_root),
+                range: self.range.clone(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<F: Graftable, D: Digest> commonware_codec::Write for Target<F, D> {
+    fn write(&self, buf: &mut impl bytes::BufMut) {
+        self.canonical_root.write(buf);
+        self.ops_root.write(buf);
+        self.witness.write(buf);
+        self.range.write(buf);
+    }
+}
+
+impl<F: Graftable, D: Digest> commonware_codec::EncodeSize for Target<F, D> {
+    fn encode_size(&self) -> usize {
+        self.canonical_root.encode_size()
+            + self.ops_root.encode_size()
+            + self.witness.encode_size()
+            + self.range.encode_size()
+    }
+}
+
+impl<F: Graftable, D: Digest> commonware_codec::Read for Target<F, D> {
+    type Cfg = ();
+
+    fn read_cfg(
+        buf: &mut impl bytes::Buf,
+        _: &(),
+    ) -> Result<Self, commonware_codec::Error> {
+        let canonical_root = D::read(buf)?;
+        let ops_root = D::read(buf)?;
+        let witness = OpsRootWitness::<F, D>::read(buf)?;
+        let range = NonEmptyRange::<Location<F>>::read(buf)?;
+        Ok(Self {
+            canonical_root,
+            ops_root,
+            witness,
+            range,
+        })
+    }
+}
+
+/// Configuration for canonical-root-aware sync of a `current` database.
+pub struct Config<DB: Database, R: DbResolver<DB>>
+where
+    DB::Family: Graftable,
+    DB::Op: Encode,
+{
+    /// Runtime context.
+    pub context: DB::Context,
+    /// Resolver for fetching operations and proofs.
+    pub resolver: R,
+    /// Sync target with canonical root and witness.
+    pub target: Target<DB::Family, DB::Digest>,
+    /// Maximum parallel outstanding requests.
+    pub max_outstanding_requests: usize,
+    /// Maximum operations per fetch batch.
+    pub fetch_batch_size: NonZeroU64,
+    /// Operations to apply per internal batch.
+    pub apply_batch_size: usize,
+    /// Database-specific configuration.
+    pub db_config: DB::Config,
+    /// Channel for receiving target updates during sync.
+    ///
+    /// Each update's `canonical_root` must match the updated database state. Callers are
+    /// responsible for verifying any witness before sending.
+    pub update_rx: Option<mpsc::Receiver<qmdb_sync::Target<DB::Family, DB::Digest>>>,
+    /// Channel that requests sync completion once the current target is reached.
+    pub finish_rx: Option<mpsc::Receiver<()>>,
+    /// Channel to notify an observer when the current target is reached.
+    pub reached_target_tx: Option<mpsc::Sender<qmdb_sync::Target<DB::Family, DB::Digest>>>,
+    /// Historical roots to retain for in-flight request verification.
+    pub max_retained_roots: usize,
+}
+
+/// Sync a `current` database from a trusted canonical root.
+///
+/// Verifies the [OpsRootWitness] against the trusted canonical root before starting the
+/// engine, and checks the reconstructed canonical root after sync completes.
+pub async fn sync<DB, R>(
+    config: Config<DB, R>,
+) -> Result<DB, qmdb_sync::Error<DB::Family, R::Error, DB::Digest>>
+where
+    DB: Database,
+    DB::Family: Graftable,
+    DB::Op: Encode,
+    R: DbResolver<DB>,
+{
+    let hasher = qmdb::hasher::<DB::Hasher>();
+
+    let engine_target = config
+        .target
+        .to_engine_target(&hasher)
+        .ok_or(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid))?;
+
+    let engine_config = EngineConfig::<DB, R> {
+        context: config.context,
+        resolver: config.resolver,
+        target: engine_target,
+        max_outstanding_requests: config.max_outstanding_requests,
+        fetch_batch_size: config.fetch_batch_size,
+        apply_batch_size: config.apply_batch_size,
+        db_config: config.db_config,
+        update_rx: config.update_rx,
+        finish_rx: config.finish_rx,
+        reached_target_tx: config.reached_target_tx,
+        max_retained_roots: config.max_retained_roots,
+    };
+
+    qmdb_sync::sync(engine_config).await
+}
+
+impl<T: Translator, J: Clone, S: Strategy> DatabaseConfig for super::Config<T, J, S> {
     type JournalConfig = J;
 
     fn journal_config(&self) -> Self::JournalConfig {
@@ -348,6 +505,10 @@ macro_rules! impl_current_sync_database {
             /// batches against the ops tree.
             fn root(&self) -> Self::Digest {
                 self.any.root()
+            }
+
+            fn canonical_root(&self) -> Self::Digest {
+                self.root
             }
         }
     };

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -247,6 +247,7 @@ where
     let (database, final_target) = if let Some(mut update_rx) = config.update_rx {
         let update_tx = engine_update_tx.expect("engine update sender must exist");
         let forward_fut = Box::pin(async {
+            let update_tx = update_tx;
             while let Some(current_target) = update_rx.recv().await {
                 let Some(engine_target) = current_target.to_engine_target(&hasher) else {
                     tracing::warn!("target update witness verification failed");

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -1,27 +1,27 @@
 //! Synchronization logic for [crate::qmdb::current] databases.
 //!
-//! Contains implementation of [crate::qmdb::sync::Database] for all
+//! Contains implementation of the sync `Database` trait for all
 //! [Db](crate::qmdb::current::db::Db) variants (ordered/unordered, fixed/variable), plus a
-//! canonical-root-aware [sync()] wrapper.
+//! [sync()] wrapper for targets anchored by canonical roots.
 //!
 //! The canonical root of a `current` database combines the ops root, grafted root, and optional
 //! pending and partial chunk digests into a single hash (see the [Root structure](super) section in
-//! the module documentation). The generic sync engine operates on the **ops root** internally,
+//! the module documentation). The shared sync engine operates on the **ops root** internally,
 //! downloading operations and verifying each batch against the ops root using ops-tree range proofs
 //! (identical to `any` sync).
 //!
 //! Callers that only trust a canonical root (e.g., from consensus) should use [sync()] with a
-//! [Target] that includes an [OpsRootWitness]. The wrapper verifies the witness before starting
-//! the engine and checks the reconstructed canonical root after sync completes.
+//! [Target] that includes an [OpsRootWitness]. The wrapper verifies each target's witness before
+//! forwarding its ops root to the shared sync engine, then checks the reconstructed canonical root
+//! for the target the engine finishes on.
 //!
 //! After all operations are synced, the bitmap and grafted tree are reconstructed deterministically
 //! from the operations. The canonical root is then computed from the ops root, the reconstructed
 //! grafted root, and any pending or partial chunk digests.
 //!
-//! The [Database]`::`[root()](crate::qmdb::sync::Database::root) implementation returns the **ops
-//! root** (not the canonical root) because that is what the sync engine verifies against.
-//! [Database::canonical_root()](crate::qmdb::sync::Database::canonical_root) returns the full
-//! canonical root.
+//! The `Database::root()` implementation returns the **ops root** (not the canonical root)
+//! because that is what the sync engine verifies against. `Database::canonical_root()` returns
+//! the full canonical root.
 //!
 //! For pruned databases (`range.start > 0`), grafted pinned nodes for the pruned region are read
 //! directly from the ops tree after it is built. This works because of the zero-chunk identity: for
@@ -69,8 +69,8 @@ use crate::{
         },
         operation::{Committable, Key, Operation as _},
         sync::{
-            self as qmdb_sync, engine::Config as EngineConfig, Database,
-            DatabaseConfig, DbResolver, EngineError,
+            self as qmdb_sync, engine::Config as EngineConfig, Database, DatabaseConfig,
+            DbResolver, EngineError,
         },
     },
     translator::Translator,
@@ -86,17 +86,16 @@ use commonware_utils::{
     sync::AsyncMutex,
     Array,
 };
-use std::num::NonZeroU64;
-use std::sync::Arc;
+use futures::future::{select, Either};
+use std::{num::NonZeroU64, sync::Arc};
 
 #[cfg(test)]
 pub(crate) mod tests;
 
-/// Sync target for `current` databases that trusts a canonical root.
+/// Sync target for `current` databases, anchored by a trusted canonical root.
 ///
-/// The caller trusts `canonical_root` (e.g., from consensus). The server provides
-/// `ops_root` and `witness`; the sync wrapper verifies
-/// `witness.verify(hasher, &ops_root, &canonical_root)` before starting the engine.
+/// The witness authenticates `ops_root` against `canonical_root`; the shared sync engine
+/// uses the authenticated ops root as its target.
 #[derive(Clone, Debug)]
 pub struct Target<F: Graftable, D: Digest> {
     /// The trusted canonical root.
@@ -110,15 +109,17 @@ pub struct Target<F: Graftable, D: Digest> {
 }
 
 impl<F: Graftable, D: Digest> Target<F, D> {
-    /// Verify the witness and return the corresponding engine-level target.
+    /// Verify the witness and return the ops-root target consumed by the shared sync engine.
     pub fn to_engine_target<H: commonware_cryptography::Hasher<Digest = D>>(
         &self,
         hasher: &StandardHasher<H>,
     ) -> Option<qmdb_sync::Target<F, D>> {
-        if self.witness.verify(hasher, &self.ops_root, &self.canonical_root) {
+        if self
+            .witness
+            .verify(hasher, &self.ops_root, &self.canonical_root)
+        {
             Some(qmdb_sync::Target {
                 root: self.ops_root,
-                canonical_root: Some(self.canonical_root),
                 range: self.range.clone(),
             })
         } else {
@@ -148,10 +149,7 @@ impl<F: Graftable, D: Digest> commonware_codec::EncodeSize for Target<F, D> {
 impl<F: Graftable, D: Digest> commonware_codec::Read for Target<F, D> {
     type Cfg = ();
 
-    fn read_cfg(
-        buf: &mut impl bytes::Buf,
-        _: &(),
-    ) -> Result<Self, commonware_codec::Error> {
+    fn read_cfg(buf: &mut impl bytes::Buf, _: &()) -> Result<Self, commonware_codec::Error> {
         let canonical_root = D::read(buf)?;
         let ops_root = D::read(buf)?;
         let witness = OpsRootWitness::<F, D>::read(buf)?;
@@ -165,7 +163,7 @@ impl<F: Graftable, D: Digest> commonware_codec::Read for Target<F, D> {
     }
 }
 
-/// Configuration for canonical-root-aware sync of a `current` database.
+/// Configuration for syncing a `current` database from canonical-root targets.
 pub struct Config<DB: Database, R: DbResolver<DB>>
 where
     DB::Family: Graftable,
@@ -187,9 +185,8 @@ where
     pub db_config: DB::Config,
     /// Channel for receiving target updates during sync.
     ///
-    /// Each update's `canonical_root` must match the updated database state. Callers are
-    /// responsible for verifying any witness before sending.
-    pub update_rx: Option<mpsc::Receiver<qmdb_sync::Target<DB::Family, DB::Digest>>>,
+    /// Each update must include a witness authenticating its ops root against its canonical root.
+    pub update_rx: Option<mpsc::Receiver<Target<DB::Family, DB::Digest>>>,
     /// Channel that requests sync completion once the current target is reached.
     pub finish_rx: Option<mpsc::Receiver<()>>,
     /// Channel to notify an observer when the current target is reached.
@@ -200,8 +197,9 @@ where
 
 /// Sync a `current` database from a trusted canonical root.
 ///
-/// Verifies the [OpsRootWitness] against the trusted canonical root before starting the
-/// engine, and checks the reconstructed canonical root after sync completes.
+/// Verifies the initial target and any target update witnesses before forwarding ops-root targets
+/// to the shared sync engine, then checks the reconstructed canonical root for the target the
+/// engine finishes on.
 pub async fn sync<DB, R>(
     config: Config<DB, R>,
 ) -> Result<DB, qmdb_sync::Error<DB::Family, R::Error, DB::Digest>>
@@ -217,6 +215,17 @@ where
         .target
         .to_engine_target(&hasher)
         .ok_or(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid))?;
+    let mut canonical_roots = vec![(engine_target.clone(), config.target.canonical_root)];
+
+    // The caller controls the public update channel capacity. Once updates reach this wrapper,
+    // keep the internal queue shallow so verified current targets cannot get far ahead of the
+    // target the shared sync engine has consumed.
+    let (engine_update_tx, engine_update_rx) = if config.update_rx.is_some() {
+        let (tx, rx) = mpsc::channel(1);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
 
     let engine_config = EngineConfig::<DB, R> {
         context: config.context,
@@ -226,13 +235,56 @@ where
         fetch_batch_size: config.fetch_batch_size,
         apply_batch_size: config.apply_batch_size,
         db_config: config.db_config,
-        update_rx: config.update_rx,
+        update_rx: engine_update_rx,
         finish_rx: config.finish_rx,
         reached_target_tx: config.reached_target_tx,
         max_retained_roots: config.max_retained_roots,
     };
 
-    qmdb_sync::sync(engine_config).await
+    let engine = qmdb_sync::Engine::new(engine_config).await?;
+    let engine_fut = Box::pin(engine.sync_with_target());
+
+    let (database, final_target) = if let Some(mut update_rx) = config.update_rx {
+        let update_tx = engine_update_tx.expect("engine update sender must exist");
+        let forward_fut = Box::pin(async {
+            while let Some(current_target) = update_rx.recv().await {
+                let Some(engine_target) = current_target.to_engine_target(&hasher) else {
+                    tracing::warn!("target update witness verification failed");
+                    return Err(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid));
+                };
+                if update_tx.send(engine_target.clone()).await.is_err() {
+                    break;
+                }
+                canonical_roots.push((engine_target, current_target.canonical_root));
+            }
+            Ok(())
+        });
+        let result = match select(engine_fut, forward_fut).await {
+            Either::Left((result, _)) => result?,
+            Either::Right((forward_result, engine_fut)) => {
+                forward_result?;
+                engine_fut.await?
+            }
+        };
+        result
+    } else {
+        engine_fut.await?
+    };
+
+    let expected = canonical_roots
+        .iter()
+        .rev()
+        .find(|(target, _)| target == &final_target)
+        .expect("final current sync target was verified")
+        .1;
+    let actual = database.canonical_root();
+    if actual != expected {
+        return Err(qmdb_sync::Error::Engine(
+            EngineError::CanonicalRootMismatch { expected, actual },
+        ));
+    }
+
+    Ok(database)
 }
 
 impl<T: Translator, J: Clone, S: Strategy> DatabaseConfig for super::Config<T, J, S> {

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -154,6 +154,12 @@ impl<F: Graftable, D: Digest> commonware_codec::Read for Target<F, D> {
         let ops_root = D::read(buf)?;
         let witness = OpsRootWitness::<F, D>::read(buf)?;
         let range = NonEmptyRange::<Location<F>>::read(buf)?;
+        if !range.start().is_valid() || !range.end().is_valid() {
+            return Err(commonware_codec::Error::Invalid(
+                "storage::qmdb::current::sync::Target",
+                "range bounds out of valid range",
+            ));
+        }
         Ok(Self {
             canonical_root,
             ops_root,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -107,21 +107,58 @@ pub struct Target<F: Graftable, D: Digest> {
     pub range: NonEmptyRange<Location<F>>,
 }
 
+impl<F: Graftable, D: Digest> PartialEq for Target<F, D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.root == other.root
+            && self.ops_root == other.ops_root
+            && self.witness.grafted_root == other.witness.grafted_root
+            && self.witness.pending_chunk_digest == other.witness.pending_chunk_digest
+            && self.witness.partial_chunk == other.witness.partial_chunk
+            && self.range == other.range
+    }
+}
+
+impl<F: Graftable, D: Digest> Eq for Target<F, D> {}
+
 impl<F: Graftable, D: Digest> Target<F, D> {
-    /// Verify the witness and return the ops-root target consumed by the shared sync engine.
-    pub fn to_engine_target<H: commonware_cryptography::Hasher<Digest = D>>(
+    /// Create a target anchored by a trusted database root and an authenticated ops root.
+    pub const fn new(
+        root: D,
+        ops_root: D,
+        witness: OpsRootWitness<F, D>,
+        range: NonEmptyRange<Location<F>>,
+    ) -> Self {
+        Self {
+            root,
+            ops_root,
+            witness,
+            range,
+        }
+    }
+
+    /// Return true if the witness authenticates the ops root against the trusted root.
+    pub fn verify<H: commonware_cryptography::Hasher<Digest = D>>(
         &self,
         hasher: &StandardHasher<H>,
-    ) -> Option<qmdb_sync::Target<F, D>> {
-        if self.witness.verify(hasher, &self.ops_root, &self.root) {
-            Some(qmdb_sync::Target {
-                root: self.root,
-                ops_root: self.ops_root,
-                range: self.range.clone(),
-            })
-        } else {
-            None
-        }
+    ) -> bool {
+        self.witness.verify(hasher, &self.ops_root, &self.root)
+    }
+}
+
+impl<F: Graftable, D: Digest> qmdb_sync::Target for Target<F, D> {
+    type Family = F;
+    type Digest = D;
+
+    fn root(&self) -> Self::Digest {
+        self.root
+    }
+
+    fn ops_root(&self) -> Self::Digest {
+        self.ops_root
+    }
+
+    fn range(&self) -> &NonEmptyRange<Location<Self::Family>> {
+        &self.range
     }
 }
 
@@ -193,16 +230,15 @@ where
     /// Channel that requests sync completion once the current target is reached.
     pub finish_rx: Option<mpsc::Receiver<()>>,
     /// Channel to notify an observer when the current target is reached.
-    pub reached_target_tx: Option<mpsc::Sender<qmdb_sync::Target<DB::Family, DB::Digest>>>,
+    pub reached_target_tx: Option<mpsc::Sender<Target<DB::Family, DB::Digest>>>,
     /// Historical roots to retain for in-flight request verification.
     pub max_retained_roots: usize,
 }
 
 /// Sync a `current` database from a trusted database root.
 ///
-/// Verifies the initial target and any target update witnesses before forwarding ops-root targets
-/// to the shared sync engine, then checks the reconstructed database root for the target the
-/// engine finishes on.
+/// Verifies the initial target and any target update witnesses before giving them to the shared
+/// sync engine, then checks the reconstructed database root for the target the engine finishes on.
 pub async fn sync<DB, R>(
     config: Config<DB, R>,
 ) -> Result<DB, qmdb_sync::Error<DB::Family, R::Error, DB::Digest>>
@@ -214,26 +250,25 @@ where
 {
     let hasher = qmdb::hasher::<DB::Hasher>();
 
-    let engine_target = config
-        .target
-        .to_engine_target(&hasher)
-        .ok_or(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid))?;
-    let mut roots = vec![(engine_target.clone(), config.target.root)];
+    if !config.target.verify(&hasher) {
+        return Err(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid));
+    }
+    let update_rx = config.update_rx;
 
     // The caller controls the public update channel capacity. Once updates reach this wrapper,
     // keep the internal queue shallow so verified current targets cannot get far ahead of the
     // target the shared sync engine has consumed.
-    let (engine_update_tx, engine_update_rx) = if config.update_rx.is_some() {
+    let (engine_update_tx, engine_update_rx) = if update_rx.is_some() {
         let (tx, rx) = mpsc::channel(1);
         (Some(tx), Some(rx))
     } else {
         (None, None)
     };
 
-    let engine_config = EngineConfig::<DB, R> {
+    let engine_config = EngineConfig {
         context: config.context,
         resolver: config.resolver,
-        target: engine_target,
+        target: config.target,
         max_outstanding_requests: config.max_outstanding_requests,
         fetch_batch_size: config.fetch_batch_size,
         apply_batch_size: config.apply_batch_size,
@@ -247,19 +282,18 @@ where
     let engine = qmdb_sync::Engine::new(engine_config).await?;
     let engine_fut = Box::pin(engine.sync_with_target());
 
-    let (database, final_target) = if let Some(mut update_rx) = config.update_rx {
+    let (database, final_target) = if let Some(mut update_rx) = update_rx {
         let update_tx = engine_update_tx.expect("engine update sender must exist");
         let forward_fut = Box::pin(async {
             let update_tx = update_tx;
             while let Some(current_target) = update_rx.recv().await {
-                let Some(engine_target) = current_target.to_engine_target(&hasher) else {
+                if !current_target.verify(&hasher) {
                     tracing::warn!("target update witness verification failed");
                     return Err(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid));
-                };
-                if update_tx.send(engine_target.clone()).await.is_err() {
+                }
+                if update_tx.send(current_target).await.is_err() {
                     break;
                 }
-                roots.push((engine_target, current_target.root));
             }
             Ok(())
         });
@@ -275,12 +309,7 @@ where
         engine_fut.await?
     };
 
-    let expected = roots
-        .iter()
-        .rev()
-        .find(|(target, _)| target == &final_target)
-        .expect("final current sync target was verified")
-        .1;
+    let expected = final_target.root;
     let actual = database.root();
     if actual != expected {
         return Err(qmdb_sync::Error::Engine(EngineError::RootMismatch {
@@ -513,11 +542,14 @@ macro_rules! impl_current_sync_database {
                 .await
             }
 
-            async fn has_local_target_state(
+            async fn has_local_target_state<Target>(
                 context: Self::Context,
                 config: &Self::Config,
-                target: &qmdb::sync::Target<Self::Family, Self::Digest>,
-            ) -> bool {
+                target: &Target,
+            ) -> bool
+            where
+                Target: qmdb_sync::Target<Family = Self::Family, Digest = Self::Digest>,
+            {
                 let Ok(journal) = <$journal>::init(
                     context.child("local_target_journal_probe"),
                     config.journal_config(),
@@ -528,11 +560,11 @@ macro_rules! impl_current_sync_database {
                 };
                 let reader = journal.reader().await;
                 let bounds = reader.bounds();
-                if Location::new(bounds.start) > target.range.start() {
+                if Location::new(bounds.start) > target.range().start() {
                     return false;
                 }
                 let Ok(inactivity_floor) =
-                    qmdb::find_inactivity_floor_at::<F, _>(&reader, target.range.end(), |op| {
+                    qmdb::find_inactivity_floor_at::<F, _>(&reader, target.range().end(), |op| {
                         op.has_floor()
                     })
                     .await
@@ -541,10 +573,10 @@ macro_rules! impl_current_sync_database {
                 };
 
                 let inactive_peaks = F::inactive_peaks(
-                    F::location_to_position(target.range.end()),
+                    F::location_to_position(target.range().end()),
                     inactivity_floor,
                 );
-                if !qmdb::any::sync::has_local_target_state::<F, _, H, S>(
+                if !qmdb::any::sync::has_local_target_state::<F, _, H, S, _>(
                     context.child("local_target_merkle_probe"),
                     config.merkle_config.clone(),
                     target,
@@ -763,3 +795,38 @@ impl_current_resolver!(
     CurrentOrderedVariableDb, OrderedVariableOp, VariableValue, Key;
     OrderedVariableOp<F, K, V>: CodecShared,
 );
+
+#[cfg(feature = "arbitrary")]
+impl<F: Graftable, D: Digest> arbitrary::Arbitrary<'_> for Target<F, D>
+where
+    D: for<'a> arbitrary::Arbitrary<'a>,
+    F::PendingChunk<D>: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let root = u.arbitrary()?;
+        let ops_root = u.arbitrary()?;
+        let witness = u.arbitrary()?;
+        let max_loc = F::MAX_LEAVES;
+        let lower = u.int_in_range(0..=*max_loc - 1)?;
+        let upper = u.int_in_range(lower + 1..=*max_loc)?;
+        Ok(Self {
+            root,
+            ops_root,
+            witness,
+            range: commonware_utils::non_empty_range!(Location::new(lower), Location::new(upper)),
+        })
+    }
+}
+
+#[cfg(all(test, feature = "arbitrary"))]
+mod conformance {
+    use super::*;
+    use crate::merkle::{mmb, mmr};
+    use commonware_codec::conformance::CodecConformance;
+    use commonware_cryptography::sha256::Digest as Sha256Digest;
+
+    commonware_conformance::conformance_tests! {
+        CodecConformance<Target<mmr::Family, Sha256Digest>>,
+        CodecConformance<Target<mmb::Family, Sha256Digest>>,
+    }
+}

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -531,6 +531,7 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
             fetch_batch_size: commonware_utils::NZU64!(64),
             target: crate::qmdb::sync::Target {
                 root: sync_root,
+                canonical_root: None,
                 range: commonware_utils::non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -611,6 +612,7 @@ fn test_current_has_local_target_state_rejects_target_before_local_lower_bound()
 
         let stale_target = crate::qmdb::sync::Target {
             root: sync_root,
+            canonical_root: None,
             range: non_empty_range!(local_start.checked_sub(1).unwrap(), local_end),
         };
         assert!(
@@ -624,6 +626,7 @@ fn test_current_has_local_target_state_rejects_target_before_local_lower_bound()
 
         let matching_target = crate::qmdb::sync::Target {
             root: sync_root,
+            canonical_root: None,
             range: non_empty_range!(local_start, local_end),
         };
         assert!(
@@ -788,3 +791,144 @@ current_sync_tests_for_harness!(harnesses::OrderedFixedMmrHarness, ordered_fixed
 current_sync_tests_for_harness!(harnesses::OrderedFixedMmbHarness, ordered_fixed_mmb);
 current_sync_tests_for_harness!(harnesses::OrderedVariableMmrHarness, ordered_variable_mmr);
 current_sync_tests_for_harness!(harnesses::OrderedVariableMmbHarness, ordered_variable_mmb);
+
+mod canonical_root_sync {
+    use super::*;
+    use crate::{
+        merkle::mmr,
+        qmdb::{
+            self,
+            current::{
+                proof::OpsRootWitness,
+                sync::{self as current_sync, Target as CurrentTarget},
+                tests::variable_config,
+            },
+        },
+    };
+    use commonware_utils::NZU64;
+
+    type Db = crate::qmdb::current::unordered::variable::Db<
+        mmr::Family,
+        Context,
+        Digest,
+        Digest,
+        Sha256,
+        crate::translator::TwoCap,
+        32,
+        Sequential,
+    >;
+
+    async fn build_target_db(context: &mut Context) -> Db {
+        let suffix = context.next_u64().to_string();
+        let cfg = variable_config::<crate::translator::TwoCap>(&suffix, context);
+        let mut db: Db = Db::init(context.child("target"), cfg).await.unwrap();
+
+        let key = Digest::from([7u8; 32]);
+        for round in 0..10u64 {
+            let merkleized = db
+                .new_batch()
+                .write(key, Some(Digest::from([round as u8; 32])))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap();
+        }
+        db.sync().await.unwrap();
+        db
+    }
+
+    async fn make_current_target(db: &Db) -> CurrentTarget<mmr::Family, Digest> {
+        let hasher = qmdb::hasher::<Sha256>();
+        let witness = db.ops_root_witness(&hasher).await.unwrap();
+        let lower = db.sync_boundary();
+        let upper = db.bounds().await.end;
+        CurrentTarget {
+            canonical_root: db.root(),
+            ops_root: db.ops_root(),
+            witness,
+            range: non_empty_range!(lower, upper),
+        }
+    }
+
+    #[test_traced("INFO")]
+    fn test_canonical_root_sync_succeeds() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let target_db = build_target_db(&mut context).await;
+            let target = make_current_target(&target_db).await;
+            let canonical_root = target.canonical_root;
+
+            let client_suffix = context.next_u64().to_string();
+            let client_config =
+                variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+
+            let target_db = std::sync::Arc::new(target_db);
+            let synced_db: Db = current_sync::sync(current_sync::Config {
+                context: context.child("client"),
+                resolver: target_db.clone(),
+                target,
+                max_outstanding_requests: 4,
+                fetch_batch_size: NZU64!(64),
+                apply_batch_size: 1024,
+                db_config: client_config,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(synced_db.root(), canonical_root);
+
+            synced_db.destroy().await.unwrap();
+            let target_db = std::sync::Arc::into_inner(target_db).unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_canonical_root_sync_rejects_invalid_witness() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let target_db = build_target_db(&mut context).await;
+            let mut target = make_current_target(&target_db).await;
+
+            target.witness = OpsRootWitness {
+                grafted_root: Digest::from([0xFFu8; 32]),
+                ..target.witness
+            };
+
+            let client_suffix = context.next_u64().to_string();
+            let client_config =
+                variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+
+            let target_db = std::sync::Arc::new(target_db);
+            let result: Result<Db, _> = current_sync::sync(current_sync::Config {
+                context: context.child("client"),
+                resolver: target_db.clone(),
+                target,
+                max_outstanding_requests: 4,
+                fetch_batch_size: NZU64!(64),
+                apply_batch_size: 1024,
+                db_config: client_config,
+                update_rx: None,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            })
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(crate::qmdb::sync::Error::Engine(
+                    crate::qmdb::sync::EngineError::OpsRootWitnessInvalid
+                ))
+            ));
+
+            let target_db = std::sync::Arc::into_inner(target_db).unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+}

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -3,14 +3,14 @@
 //! This module reuses the shared sync test functions from [crate::qmdb::any::sync::tests] by
 //! implementing [SyncTestHarness] for current database types. The key difference from `any`
 //! harnesses is that `sync_target_root` returns the **QMDB ops root** (via
-//! [qmdb::sync::Database::root](crate::qmdb::sync::Database::root)), not the canonical root
+//! [qmdb::sync::Database::ops_root](crate::qmdb::sync::Database::ops_root)), not the database root
 //! returned by `Db::root()`.
 //!
 //! Harnesses are instantiated for **both** MMR and MMB merkle families across each (ordered,
 //! unordered) x (fixed, variable) database variant, so the shared suite runs twice per variant.
 //!
 //! In addition to the shared harness-based suite, this module contains focused tests for
-//! `current`-specific sync behavior: overlay-state authentication (canonical-root check), pruned
+//! `current`-specific sync behavior: overlay-state authentication (database-root check), pruned
 //! MMB round-trip, and target-update regression coverage.
 
 use crate::qmdb::{
@@ -278,7 +278,7 @@ mod harnesses {
         type Db = UnorderedFixedDb<F>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
-            SyncDatabase::root(db)
+            SyncDatabase::ops_root(db)
         }
 
         fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
@@ -325,7 +325,7 @@ mod harnesses {
         type Db = UnorderedVariableDb<F>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
-            SyncDatabase::root(db)
+            SyncDatabase::ops_root(db)
         }
 
         fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
@@ -372,7 +372,7 @@ mod harnesses {
         type Db = OrderedFixedDb<F>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
-            SyncDatabase::root(db)
+            SyncDatabase::ops_root(db)
         }
 
         fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
@@ -419,7 +419,7 @@ mod harnesses {
         type Db = OrderedVariableDb<F>;
 
         fn sync_target_root(db: &Self::Db) -> Digest {
-            SyncDatabase::root(db)
+            SyncDatabase::ops_root(db)
         }
 
         fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
@@ -461,12 +461,12 @@ mod harnesses {
 }
 
 /// Regression test: sync a pruned MMB-backed current DB and verify the synced DB has the
-/// same canonical root, reopens cleanly, and returns the expected value.
+/// same database root, reopens cleanly, and returns the expected value.
 ///
 /// The target DB commits the same key 100 times, forcing the inactivity floor past a full
 /// 256-bit chunk boundary. Without overlay-state in the sync protocol, the receiver
 /// re-derives `pruned_chunks` from `range.start / chunk_bits` and builds a grafted tree
-/// whose pinned nodes don't match the sender's. The canonical roots diverge.
+/// whose pinned nodes don't match the sender's. The database roots diverge.
 #[test_traced("INFO")]
 fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
     let executor = deterministic::Runner::default();
@@ -514,7 +514,7 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
 
         target_db.prune(target_db.sync_boundary()).await.unwrap();
 
-        let sync_root = SyncDatabase::root(&target_db);
+        let sync_root = SyncDatabase::ops_root(&target_db);
         let verification_root = target_db.root();
         let lower_bound = target_db.sync_boundary();
         let upper_bound = target_db.bounds().await.end;
@@ -523,14 +523,15 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
         let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
         let target_db = std::sync::Arc::new(target_db);
         // This uses the shared sync engine's ops-root target directly. The focused
-        // `canonical_root_sync` tests below cover the current sync wrapper that authenticates ops
-        // roots against trusted canonical roots.
+        // `root_sync` tests below cover the current sync wrapper that authenticates ops
+        // roots against trusted database roots.
         let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
             context: context.child("client"),
             db_config: client_config.clone(),
             fetch_batch_size: commonware_utils::NZU64!(64),
             target: crate::qmdb::sync::Target {
-                root: sync_root,
+                root: verification_root,
+                ops_root: sync_root,
                 range: commonware_utils::non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -544,7 +545,7 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
         .await
         .unwrap();
 
-        assert_eq!(SyncDatabase::root(&synced_db), sync_root);
+        assert_eq!(SyncDatabase::ops_root(&synced_db), sync_root);
         assert_eq!(synced_db.root(), verification_root);
         assert_eq!(synced_db.sync_boundary(), lower_bound);
         assert_eq!(synced_db.get(&key).await.unwrap(), expected);
@@ -554,7 +555,7 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
         let reopened: Db = Db::init(context.child("reopened"), client_config)
             .await
             .unwrap();
-        assert_eq!(SyncDatabase::root(&reopened), sync_root);
+        assert_eq!(SyncDatabase::ops_root(&reopened), sync_root);
         assert_eq!(reopened.root(), verification_root);
         assert_eq!(reopened.sync_boundary(), lower_bound);
         assert_eq!(reopened.get(&key).await.unwrap(), expected);
@@ -605,12 +606,14 @@ fn test_current_has_local_target_state_rejects_target_before_local_lower_bound()
         let bounds = db.bounds().await;
         let local_start = bounds.start;
         let local_end = bounds.end;
-        let sync_root = SyncDatabase::root(&db);
+        let sync_root = SyncDatabase::ops_root(&db);
 
         assert!(local_start > crate::merkle::Location::new(0));
 
+        let root = db.root();
         let stale_target = crate::qmdb::sync::Target {
-            root: sync_root,
+            root,
+            ops_root: sync_root,
             range: non_empty_range!(local_start.checked_sub(1).unwrap(), local_end),
         };
         assert!(
@@ -623,7 +626,8 @@ fn test_current_has_local_target_state_rejects_target_before_local_lower_bound()
         );
 
         let matching_target = crate::qmdb::sync::Target {
-            root: sync_root,
+            root,
+            ops_root: sync_root,
             range: non_empty_range!(local_start, local_end),
         };
         assert!(
@@ -789,7 +793,7 @@ current_sync_tests_for_harness!(harnesses::OrderedFixedMmbHarness, ordered_fixed
 current_sync_tests_for_harness!(harnesses::OrderedVariableMmrHarness, ordered_variable_mmr);
 current_sync_tests_for_harness!(harnesses::OrderedVariableMmbHarness, ordered_variable_mmb);
 
-mod canonical_root_sync {
+mod root_sync {
     use super::*;
     use crate::{
         merkle::mmr,
@@ -846,7 +850,7 @@ mod canonical_root_sync {
         let lower = db.sync_boundary();
         let upper = db.bounds().await.end;
         CurrentTarget {
-            canonical_root: db.root(),
+            root: db.root(),
             ops_root: db.ops_root(),
             witness,
             range: non_empty_range!(lower, upper),
@@ -854,12 +858,12 @@ mod canonical_root_sync {
     }
 
     #[test_traced("INFO")]
-    fn test_canonical_root_sync_succeeds() {
+    fn test_root_sync_succeeds() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
             let target_db = build_target_db(&mut context).await;
             let target = make_current_target(&target_db).await;
-            let canonical_root = target.canonical_root;
+            let root = target.root;
 
             let client_suffix = context.next_u64().to_string();
             let client_config =
@@ -882,7 +886,7 @@ mod canonical_root_sync {
             .await
             .unwrap();
 
-            assert_eq!(synced_db.root(), canonical_root);
+            assert_eq!(synced_db.root(), root);
 
             synced_db.destroy().await.unwrap();
             let target_db = std::sync::Arc::into_inner(target_db).unwrap();
@@ -891,7 +895,7 @@ mod canonical_root_sync {
     }
 
     #[test_traced("INFO")]
-    fn test_canonical_root_sync_tracks_target_update() {
+    fn test_root_sync_tracks_target_update() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
             let mut target_db = build_target_db(&mut context).await;
@@ -903,7 +907,7 @@ mod canonical_root_sync {
             }
             target_db.sync().await.unwrap();
             let updated_target = make_current_target(&target_db).await;
-            let expected_root = updated_target.canonical_root;
+            let expected_root = updated_target.root;
 
             let (update_sender, update_receiver) = commonware_utils::channel::mpsc::channel(1);
             let (finish_sender, finish_receiver) = commonware_utils::channel::mpsc::channel(1);
@@ -944,7 +948,7 @@ mod canonical_root_sync {
     }
 
     #[test_traced("INFO")]
-    fn test_canonical_root_sync_rejects_invalid_witness() {
+    fn test_root_sync_rejects_invalid_witness() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
             let target_db = build_target_db(&mut context).await;
@@ -988,7 +992,7 @@ mod canonical_root_sync {
     }
 
     #[test_traced("INFO")]
-    fn test_canonical_root_sync_rejects_invalid_update_witness() {
+    fn test_root_sync_rejects_invalid_update_witness() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
             let mut target_db = build_target_db(&mut context).await;
@@ -1048,12 +1052,12 @@ mod canonical_root_sync {
     /// future exits, update_tx must be dropped so the engine sees
     /// UpdateChannelClosed, and then finish completes sync.
     #[test_traced("INFO")]
-    fn test_canonical_root_sync_update_channel_close_unblocks_engine() {
+    fn test_root_sync_update_channel_close_unblocks_engine() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
             let target_db = build_target_db(&mut context).await;
             let target = make_current_target(&target_db).await;
-            let canonical_root = target.canonical_root;
+            let root = target.root;
 
             let client_suffix = context.next_u64().to_string();
             let client_config =
@@ -1086,7 +1090,7 @@ mod canonical_root_sync {
             finish_tx.send(()).await.unwrap();
 
             let synced_db: Db = sync_fut.await.unwrap();
-            assert_eq!(synced_db.root(), canonical_root);
+            assert_eq!(synced_db.root(), root);
 
             synced_db.destroy().await.unwrap();
             let target_db = std::sync::Arc::into_inner(target_db).unwrap();

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -525,7 +525,7 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
         // This uses the shared sync engine's ops-root target directly. The focused
         // `canonical_root_sync` tests below cover the current sync wrapper that authenticates ops
         // roots against trusted canonical roots.
-        let synced_db: Db = Box::pin(crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
+        let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
             context: context.child("client"),
             db_config: client_config.clone(),
             fetch_batch_size: commonware_utils::NZU64!(64),
@@ -540,7 +540,7 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
             finish_rx: None,
             reached_target_tx: None,
             max_retained_roots: 8,
-        }))
+        })
         .await
         .unwrap();
 
@@ -866,7 +866,7 @@ mod canonical_root_sync {
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
 
             let target_db = std::sync::Arc::new(target_db);
-            let synced_db: Db = Box::pin(current_sync::sync(current_sync::Config {
+            let synced_db: Db = current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
                 target,
@@ -878,7 +878,7 @@ mod canonical_root_sync {
                 finish_rx: None,
                 reached_target_tx: None,
                 max_retained_roots: 8,
-            }))
+            })
             .await
             .unwrap();
 
@@ -919,7 +919,7 @@ mod canonical_root_sync {
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
             let target_db = std::sync::Arc::new(target_db);
 
-            let synced_db: Db = Box::pin(current_sync::sync(current_sync::Config {
+            let synced_db: Db = current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
                 target: initial_target,
@@ -931,7 +931,7 @@ mod canonical_root_sync {
                 finish_rx: Some(finish_receiver),
                 reached_target_tx: None,
                 max_retained_roots: 8,
-            }))
+            })
             .await
             .unwrap();
 
@@ -960,7 +960,7 @@ mod canonical_root_sync {
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
 
             let target_db = std::sync::Arc::new(target_db);
-            let result: Result<Db, _> = Box::pin(current_sync::sync(current_sync::Config {
+            let result: Result<Db, _> = current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
                 target,
@@ -972,7 +972,7 @@ mod canonical_root_sync {
                 finish_rx: None,
                 reached_target_tx: None,
                 max_retained_roots: 8,
-            }))
+            })
             .await;
 
             assert!(matches!(
@@ -1015,7 +1015,7 @@ mod canonical_root_sync {
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
             let target_db = std::sync::Arc::new(target_db);
 
-            let result: Result<Db, _> = Box::pin(current_sync::sync(current_sync::Config {
+            let result: Result<Db, _> = current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
                 target: initial_target,
@@ -1027,7 +1027,7 @@ mod canonical_root_sync {
                 finish_rx: Some(finish_receiver),
                 reached_target_tx: None,
                 max_retained_roots: 8,
-            }))
+            })
             .await;
 
             assert!(matches!(
@@ -1037,6 +1037,58 @@ mod canonical_root_sync {
                 ))
             ));
 
+            let target_db = std::sync::Arc::into_inner(target_db).unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    /// Verify that closing the caller's update channel while the engine is waiting
+    /// for updates (with finish_rx) allows the engine to eventually complete.
+    /// This exercises the Either::Right path in the forwarding select: the forward
+    /// future exits, update_tx must be dropped so the engine sees
+    /// UpdateChannelClosed, and then finish completes sync.
+    #[test_traced("INFO")]
+    fn test_canonical_root_sync_update_channel_close_unblocks_engine() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let target_db = build_target_db(&mut context).await;
+            let target = make_current_target(&target_db).await;
+            let canonical_root = target.canonical_root;
+
+            let client_suffix = context.next_u64().to_string();
+            let client_config =
+                variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+
+            let target_db = std::sync::Arc::new(target_db);
+
+            let (update_tx, update_rx) = commonware_utils::channel::mpsc::channel(1);
+            let (finish_tx, finish_rx) = commonware_utils::channel::mpsc::channel(1);
+
+            let sync_fut = current_sync::sync(current_sync::Config {
+                context: context.child("client"),
+                resolver: target_db.clone(),
+                target,
+                max_outstanding_requests: 4,
+                fetch_batch_size: NZU64!(64),
+                apply_batch_size: 1024,
+                db_config: client_config,
+                update_rx: Some(update_rx),
+                finish_rx: Some(finish_rx),
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            });
+
+            // Drop the update sender to close the channel while the engine is
+            // waiting for updates or a finish signal.
+            drop(update_tx);
+
+            // Send the finish signal so the engine can complete.
+            finish_tx.send(()).await.unwrap();
+
+            let synced_db: Db = sync_fut.await.unwrap();
+            assert_eq!(synced_db.root(), canonical_root);
+
+            synced_db.destroy().await.unwrap();
             let target_db = std::sync::Arc::into_inner(target_db).unwrap();
             target_db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -525,7 +525,7 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
         // This uses the shared sync engine's ops-root target directly. The focused
         // `canonical_root_sync` tests below cover the current sync wrapper that authenticates ops
         // roots against trusted canonical roots.
-        let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
+        let synced_db: Db = Box::pin(crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
             context: context.child("client"),
             db_config: client_config.clone(),
             fetch_batch_size: commonware_utils::NZU64!(64),
@@ -540,7 +540,7 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
             finish_rx: None,
             reached_target_tx: None,
             max_retained_roots: 8,
-        })
+        }))
         .await
         .unwrap();
 
@@ -866,7 +866,7 @@ mod canonical_root_sync {
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
 
             let target_db = std::sync::Arc::new(target_db);
-            let synced_db: Db = current_sync::sync(current_sync::Config {
+            let synced_db: Db = Box::pin(current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
                 target,
@@ -878,7 +878,7 @@ mod canonical_root_sync {
                 finish_rx: None,
                 reached_target_tx: None,
                 max_retained_roots: 8,
-            })
+            }))
             .await
             .unwrap();
 
@@ -919,7 +919,7 @@ mod canonical_root_sync {
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
             let target_db = std::sync::Arc::new(target_db);
 
-            let synced_db: Db = current_sync::sync(current_sync::Config {
+            let synced_db: Db = Box::pin(current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
                 target: initial_target,
@@ -931,7 +931,7 @@ mod canonical_root_sync {
                 finish_rx: Some(finish_receiver),
                 reached_target_tx: None,
                 max_retained_roots: 8,
-            })
+            }))
             .await
             .unwrap();
 
@@ -960,7 +960,7 @@ mod canonical_root_sync {
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
 
             let target_db = std::sync::Arc::new(target_db);
-            let result: Result<Db, _> = current_sync::sync(current_sync::Config {
+            let result: Result<Db, _> = Box::pin(current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
                 target,
@@ -972,7 +972,7 @@ mod canonical_root_sync {
                 finish_rx: None,
                 reached_target_tx: None,
                 max_retained_roots: 8,
-            })
+            }))
             .await;
 
             assert!(matches!(
@@ -1015,7 +1015,7 @@ mod canonical_root_sync {
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
             let target_db = std::sync::Arc::new(target_db);
 
-            let result: Result<Db, _> = current_sync::sync(current_sync::Config {
+            let result: Result<Db, _> = Box::pin(current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
                 target: initial_target,
@@ -1027,7 +1027,7 @@ mod canonical_root_sync {
                 finish_rx: Some(finish_receiver),
                 reached_target_tx: None,
                 max_retained_roots: 8,
-            })
+            }))
             .await;
 
             assert!(matches!(

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -522,16 +522,15 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
         let client_suffix = context.next_u64().to_string();
         let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
         let target_db = std::sync::Arc::new(target_db);
-        // Supply the trusted canonical root so `build_db`'s authentication check actually
-        // runs: this is the success-path coverage for the overlay-state authentication
-        // anchor. A bad-root rejection path test belongs with the focused sync tests.
+        // This uses the shared sync engine's ops-root target directly. The focused
+        // `canonical_root_sync` tests below cover the current sync wrapper that authenticates ops
+        // roots against trusted canonical roots.
         let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
             context: context.child("client"),
             db_config: client_config.clone(),
             fetch_batch_size: commonware_utils::NZU64!(64),
             target: crate::qmdb::sync::Target {
                 root: sync_root,
-                canonical_root: None,
                 range: commonware_utils::non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -612,7 +611,6 @@ fn test_current_has_local_target_state_rejects_target_before_local_lower_bound()
 
         let stale_target = crate::qmdb::sync::Target {
             root: sync_root,
-            canonical_root: None,
             range: non_empty_range!(local_start.checked_sub(1).unwrap(), local_end),
         };
         assert!(
@@ -626,7 +624,6 @@ fn test_current_has_local_target_state_rejects_target_before_local_lower_bound()
 
         let matching_target = crate::qmdb::sync::Target {
             root: sync_root,
-            canonical_root: None,
             range: non_empty_range!(local_start, local_end),
         };
         assert!(
@@ -805,6 +802,7 @@ mod canonical_root_sync {
             },
         },
     };
+    use commonware_runtime::{Clock, Spawner};
     use commonware_utils::NZU64;
 
     type Db = crate::qmdb::current::unordered::variable::Db<
@@ -818,6 +816,17 @@ mod canonical_root_sync {
         Sequential,
     >;
 
+    async fn apply_round(db: &mut Db, key: Digest, round: u64) {
+        let merkleized = db
+            .new_batch()
+            .write(key, Some(Digest::from([round as u8; 32])))
+            .merkleize(db, None)
+            .await
+            .unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+    }
+
     async fn build_target_db(context: &mut Context) -> Db {
         let suffix = context.next_u64().to_string();
         let cfg = variable_config::<crate::translator::TwoCap>(&suffix, context);
@@ -825,14 +834,7 @@ mod canonical_root_sync {
 
         let key = Digest::from([7u8; 32]);
         for round in 0..10u64 {
-            let merkleized = db
-                .new_batch()
-                .write(key, Some(Digest::from([round as u8; 32])))
-                .merkleize(&db, None)
-                .await
-                .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            apply_round(&mut db, key, round).await;
         }
         db.sync().await.unwrap();
         db
@@ -889,6 +891,59 @@ mod canonical_root_sync {
     }
 
     #[test_traced("INFO")]
+    fn test_canonical_root_sync_tracks_target_update() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let mut target_db = build_target_db(&mut context).await;
+            let initial_target = make_current_target(&target_db).await;
+
+            let key = Digest::from([7u8; 32]);
+            for round in 10..20u64 {
+                apply_round(&mut target_db, key, round).await;
+            }
+            target_db.sync().await.unwrap();
+            let updated_target = make_current_target(&target_db).await;
+            let expected_root = updated_target.canonical_root;
+
+            let (update_sender, update_receiver) = commonware_utils::channel::mpsc::channel(1);
+            let (finish_sender, finish_receiver) = commonware_utils::channel::mpsc::channel(1);
+            update_sender.send(updated_target).await.unwrap();
+            drop(update_sender);
+            context.child("finish").spawn(move |context| async move {
+                context.sleep(std::time::Duration::from_millis(1)).await;
+                finish_sender.send(()).await.unwrap();
+            });
+
+            let client_suffix = context.next_u64().to_string();
+            let client_config =
+                variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+            let target_db = std::sync::Arc::new(target_db);
+
+            let synced_db: Db = current_sync::sync(current_sync::Config {
+                context: context.child("client"),
+                resolver: target_db.clone(),
+                target: initial_target,
+                max_outstanding_requests: 1,
+                fetch_batch_size: NZU64!(1),
+                apply_batch_size: 1024,
+                db_config: client_config,
+                update_rx: Some(update_receiver),
+                finish_rx: Some(finish_receiver),
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(synced_db.root(), expected_root);
+
+            synced_db.destroy().await.unwrap();
+            let target_db = std::sync::Arc::into_inner(target_db).unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
     fn test_canonical_root_sync_rejects_invalid_witness() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
@@ -915,6 +970,61 @@ mod canonical_root_sync {
                 db_config: client_config,
                 update_rx: None,
                 finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            })
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(crate::qmdb::sync::Error::Engine(
+                    crate::qmdb::sync::EngineError::OpsRootWitnessInvalid
+                ))
+            ));
+
+            let target_db = std::sync::Arc::into_inner(target_db).unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_canonical_root_sync_rejects_invalid_update_witness() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let mut target_db = build_target_db(&mut context).await;
+            let initial_target = make_current_target(&target_db).await;
+
+            let key = Digest::from([7u8; 32]);
+            for round in 10..20u64 {
+                apply_round(&mut target_db, key, round).await;
+            }
+            target_db.sync().await.unwrap();
+            let mut updated_target = make_current_target(&target_db).await;
+            updated_target.witness = OpsRootWitness {
+                grafted_root: Digest::from([0xFFu8; 32]),
+                ..updated_target.witness
+            };
+
+            let (update_sender, update_receiver) = commonware_utils::channel::mpsc::channel(1);
+            let (_finish_sender, finish_receiver) = commonware_utils::channel::mpsc::channel(1);
+            update_sender.send(updated_target).await.unwrap();
+            drop(update_sender);
+
+            let client_suffix = context.next_u64().to_string();
+            let client_config =
+                variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+            let target_db = std::sync::Arc::new(target_db);
+
+            let result: Result<Db, _> = current_sync::sync(current_sync::Config {
+                context: context.child("client"),
+                resolver: target_db.clone(),
+                target: initial_target,
+                max_outstanding_requests: 1,
+                fetch_batch_size: NZU64!(1),
+                apply_batch_size: 1024,
+                db_config: client_config,
+                update_rx: Some(update_receiver),
+                finish_rx: Some(finish_receiver),
                 reached_target_tx: None,
                 max_retained_roots: 8,
             })

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -1,10 +1,7 @@
 //! Tests for [crate::qmdb::current] state sync.
 //!
-//! This module reuses the shared sync test functions from [crate::qmdb::any::sync::tests] by
-//! implementing [SyncTestHarness] for current database types. The key difference from `any`
-//! harnesses is that `sync_target_root` returns the **QMDB ops root** (via
-//! [qmdb::sync::Database::ops_root](crate::qmdb::sync::Database::ops_root)), not the database root
-//! returned by `Db::root()`.
+//! This module reuses the shared sync test functions from [crate::qmdb::sync::tests] by
+//! implementing [SyncTestHarness] for current database types.
 //!
 //! Harnesses are instantiated for **both** MMR and MMB merkle families across each (ordered,
 //! unordered) x (fixed, variable) database variant, so the shared suite runs twice per variant.
@@ -14,9 +11,11 @@
 //! MMB round-trip, and target-update regression coverage.
 
 use crate::qmdb::{
-    any::sync::tests::{ConfigOf, SyncTestHarness},
     current::tests::{fixed_config, variable_config},
-    sync::Database as SyncDatabase,
+    sync::{
+        tests::{ConfigOf, SyncTestHarness},
+        Database as SyncDatabase,
+    },
 };
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_macros::test_traced;
@@ -24,14 +23,34 @@ use commonware_parallel::Sequential;
 use commonware_runtime::{
     deterministic, deterministic::Context, BufferPooler, Runner as _, Supervisor as _,
 };
-use commonware_utils::non_empty_range;
+use commonware_utils::{non_empty_range, range::NonEmptyRange};
 use rand::RngCore as _;
+
+fn dummy_current_target<F: crate::merkle::Graftable>(
+    root: Digest,
+    ops_root: Digest,
+    range: NonEmptyRange<crate::merkle::Location<F>>,
+) -> crate::qmdb::current::sync::Target<F, Digest> {
+    crate::qmdb::current::sync::Target::new(
+        root,
+        ops_root,
+        crate::qmdb::current::proof::OpsRootWitness {
+            grafted_root: Digest::from([0; 32]),
+            pending_chunk_digest: None.try_into().unwrap(),
+            partial_chunk: None,
+        },
+        range,
+    )
+}
 
 // ===== Harness Implementations =====
 
 mod harnesses {
     use super::*;
-    use crate::merkle::{self, mmb, mmr};
+    use crate::{
+        merkle::{self, mmb, mmr},
+        qmdb::current::{proof::OpsRootWitness, sync::Target as CurrentTarget},
+    };
     use commonware_math::algebra::Random;
     use commonware_utils::test_rng_seeded;
 
@@ -75,6 +94,23 @@ mod harnesses {
         32,
         Sequential,
     >;
+
+    fn target<F: merkle::Graftable>(
+        root: Digest,
+        ops_root: Digest,
+        range: NonEmptyRange<crate::merkle::Location<F>>,
+    ) -> CurrentTarget<F, Digest> {
+        CurrentTarget::new(
+            root,
+            ops_root,
+            OpsRootWitness {
+                grafted_root: Digest::from([0; 32]),
+                pending_chunk_digest: None.try_into().unwrap(),
+                partial_chunk: None,
+            },
+            range,
+        )
+    }
 
     fn create_unordered_fixed_ops<F: merkle::Family>(
         n: usize,
@@ -276,9 +312,14 @@ mod harnesses {
     impl<F: merkle::Graftable> SyncTestHarness for UnorderedFixedHarness<F> {
         type Family = F;
         type Db = UnorderedFixedDb<F>;
+        type Target = CurrentTarget<F, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            SyncDatabase::ops_root(db)
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
@@ -323,9 +364,14 @@ mod harnesses {
     impl<F: merkle::Graftable> SyncTestHarness for UnorderedVariableHarness<F> {
         type Family = F;
         type Db = UnorderedVariableDb<F>;
+        type Target = CurrentTarget<F, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            SyncDatabase::ops_root(db)
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
@@ -370,9 +416,14 @@ mod harnesses {
     impl<F: merkle::Graftable> SyncTestHarness for OrderedFixedHarness<F> {
         type Family = F;
         type Db = OrderedFixedDb<F>;
+        type Target = CurrentTarget<F, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            SyncDatabase::ops_root(db)
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
@@ -417,9 +468,14 @@ mod harnesses {
     impl<F: merkle::Graftable> SyncTestHarness for OrderedVariableHarness<F> {
         type Family = F;
         type Db = OrderedVariableDb<F>;
+        type Target = CurrentTarget<F, Digest>;
 
-        fn sync_target_root(db: &Self::Db) -> Digest {
-            SyncDatabase::ops_root(db)
+        fn target(
+            root: Digest,
+            ops_root: Digest,
+            range: NonEmptyRange<crate::merkle::Location<Self::Family>>,
+        ) -> Self::Target {
+            target(root, ops_root, range)
         }
 
         fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self> {
@@ -522,18 +578,17 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
         let client_suffix = context.next_u64().to_string();
         let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
         let target_db = std::sync::Arc::new(target_db);
-        // This uses the shared sync engine's ops-root target directly. The focused
-        // `root_sync` tests below cover the current sync wrapper that authenticates ops
-        // roots against trusted database roots.
+        // This uses the shared sync engine directly. The focused `root_sync` tests below cover the
+        // current sync wrapper that authenticates target witnesses before starting the engine.
         let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
             context: context.child("client"),
             db_config: client_config.clone(),
             fetch_batch_size: commonware_utils::NZU64!(64),
-            target: crate::qmdb::sync::Target {
-                root: verification_root,
-                ops_root: sync_root,
-                range: commonware_utils::non_empty_range!(lower_bound, upper_bound),
-            },
+            target: dummy_current_target(
+                verification_root,
+                sync_root,
+                commonware_utils::non_empty_range!(lower_bound, upper_bound),
+            ),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
             max_outstanding_requests: 4,
@@ -611,11 +666,11 @@ fn test_current_has_local_target_state_rejects_target_before_local_lower_bound()
         assert!(local_start > crate::merkle::Location::new(0));
 
         let root = db.root();
-        let stale_target = crate::qmdb::sync::Target {
+        let stale_target = dummy_current_target(
             root,
-            ops_root: sync_root,
-            range: non_empty_range!(local_start.checked_sub(1).unwrap(), local_end),
-        };
+            sync_root,
+            non_empty_range!(local_start.checked_sub(1).unwrap(), local_end),
+        );
         assert!(
             !<Db as SyncDatabase>::has_local_target_state(
                 context.child("probe_stale"),
@@ -625,11 +680,8 @@ fn test_current_has_local_target_state_rejects_target_before_local_lower_bound()
             .await
         );
 
-        let matching_target = crate::qmdb::sync::Target {
-            root,
-            ops_root: sync_root,
-            range: non_empty_range!(local_start, local_end),
-        };
+        let matching_target =
+            dummy_current_target(root, sync_root, non_empty_range!(local_start, local_end));
         assert!(
             <Db as SyncDatabase>::has_local_target_state(
                 context.child("probe_matching"),
@@ -645,7 +697,7 @@ fn test_current_has_local_target_state_rejects_target_before_local_lower_bound()
 
 // ===== Test Generation Macro =====
 
-/// Dispatches to the shared test functions in [crate::qmdb::any::sync::tests].
+/// Dispatches to the shared test functions in [crate::qmdb::sync::tests].
 macro_rules! current_sync_tests_for_harness {
     ($harness:ty, $mod_name:ident) => {
         mod $mod_name {
@@ -656,7 +708,7 @@ macro_rules! current_sync_tests_for_harness {
 
             #[test_traced]
             fn test_sync_resolver_fails() {
-                crate::qmdb::any::sync::tests::test_sync_resolver_fails::<$harness>();
+                crate::qmdb::sync::tests::test_sync_resolver_fails::<$harness>();
             }
 
             #[rstest]
@@ -669,7 +721,7 @@ macro_rules! current_sync_tests_for_harness {
             #[case::db_size_eq_batch_size(1000, 1000)]
             #[case::batch_size_gt_db_size(1000, 1001)]
             fn test_sync(#[case] target_db_ops: usize, #[case] fetch_batch_size: u64) {
-                crate::qmdb::any::sync::tests::test_sync::<$harness>(
+                crate::qmdb::sync::tests::test_sync::<$harness>(
                     target_db_ops,
                     NonZeroU64::new(fetch_batch_size).unwrap(),
                 );
@@ -677,67 +729,57 @@ macro_rules! current_sync_tests_for_harness {
 
             #[test_traced]
             fn test_sync_subset_of_target_database() {
-                crate::qmdb::any::sync::tests::test_sync_subset_of_target_database::<$harness>(
-                    1000,
-                );
+                crate::qmdb::sync::tests::test_sync_subset_of_target_database::<$harness>(1000);
             }
 
             #[test_traced]
             fn test_sync_use_existing_db_partial_match() {
-                crate::qmdb::any::sync::tests::test_sync_use_existing_db_partial_match::<$harness>(
-                    1000,
-                );
+                crate::qmdb::sync::tests::test_sync_use_existing_db_partial_match::<$harness>(1000);
             }
 
             #[test_traced]
             fn test_sync_use_existing_db_exact_match() {
-                crate::qmdb::any::sync::tests::test_sync_use_existing_db_exact_match::<$harness>(
-                    1000,
-                );
+                crate::qmdb::sync::tests::test_sync_use_existing_db_exact_match::<$harness>(1000);
             }
 
             #[test_traced("WARN")]
             fn test_target_update_lower_bound_decrease() {
-                crate::qmdb::any::sync::tests::test_target_update_lower_bound_decrease::<$harness>(
-                );
+                crate::qmdb::sync::tests::test_target_update_lower_bound_decrease::<$harness>();
             }
 
             #[test_traced("WARN")]
             fn test_target_update_upper_bound_decrease() {
-                crate::qmdb::any::sync::tests::test_target_update_upper_bound_decrease::<$harness>(
-                );
+                crate::qmdb::sync::tests::test_target_update_upper_bound_decrease::<$harness>();
             }
 
             #[test_traced("WARN")]
             fn test_target_update_bounds_increase() {
-                crate::qmdb::any::sync::tests::test_target_update_bounds_increase::<$harness>();
+                crate::qmdb::sync::tests::test_target_update_bounds_increase::<$harness>();
             }
 
             #[test_traced("WARN")]
             fn test_target_update_on_done_client() {
-                crate::qmdb::any::sync::tests::test_target_update_on_done_client::<$harness>();
+                crate::qmdb::sync::tests::test_target_update_on_done_client::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_waits_for_explicit_finish() {
-                crate::qmdb::any::sync::tests::test_sync_waits_for_explicit_finish::<$harness>();
+                crate::qmdb::sync::tests::test_sync_waits_for_explicit_finish::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_handles_early_finish_signal() {
-                crate::qmdb::any::sync::tests::test_sync_handles_early_finish_signal::<$harness>();
+                crate::qmdb::sync::tests::test_sync_handles_early_finish_signal::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_fails_when_finish_sender_dropped() {
-                crate::qmdb::any::sync::tests::test_sync_fails_when_finish_sender_dropped::<
-                    $harness,
-                >();
+                crate::qmdb::sync::tests::test_sync_fails_when_finish_sender_dropped::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_allows_dropped_reached_target_receiver() {
-                crate::qmdb::any::sync::tests::test_sync_allows_dropped_reached_target_receiver::<
+                crate::qmdb::sync::tests::test_sync_allows_dropped_reached_target_receiver::<
                     $harness,
                 >();
             }
@@ -759,7 +801,7 @@ macro_rules! current_sync_tests_for_harness {
                 #[case] initial_ops: usize,
                 #[case] additional_ops: usize,
             ) {
-                crate::qmdb::any::sync::tests::test_target_update_during_sync::<$harness>(
+                crate::qmdb::sync::tests::test_target_update_during_sync::<$harness>(
                     initial_ops,
                     additional_ops,
                 );
@@ -767,12 +809,12 @@ macro_rules! current_sync_tests_for_harness {
 
             #[test_traced]
             fn test_sync_database_persistence() {
-                crate::qmdb::any::sync::tests::test_sync_database_persistence::<$harness>();
+                crate::qmdb::sync::tests::test_sync_database_persistence::<$harness>();
             }
 
             #[test_traced]
             fn test_sync_post_sync_usability() {
-                crate::qmdb::any::sync::tests::test_sync_post_sync_usability::<$harness>();
+                crate::qmdb::sync::tests::test_sync_post_sync_usability::<$harness>();
             }
         }
     };
@@ -849,12 +891,12 @@ mod root_sync {
         let witness = db.ops_root_witness(&hasher).await.unwrap();
         let lower = db.sync_boundary();
         let upper = db.bounds().await.end;
-        CurrentTarget {
-            root: db.root(),
-            ops_root: db.ops_root(),
+        CurrentTarget::new(
+            db.root(),
+            db.ops_root(),
             witness,
-            range: non_empty_range!(lower, upper),
-        }
+            non_empty_range!(lower, upper),
+        )
     }
 
     #[test_traced("INFO")]

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -145,6 +145,10 @@ where
         Ok(db)
     }
 
+    fn ops_root(&self) -> Self::Digest {
+        self.root()
+    }
+
     fn root(&self) -> Self::Digest {
         self.root()
     }

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -128,7 +128,6 @@ where
             fetch_batch_size,
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -191,7 +190,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -243,7 +241,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: client_context.child("client"),
@@ -317,7 +314,6 @@ where
                 db_config: H::config(&format!("update_test_{}", context.next_u64()), &context),
                 target: Target {
                     root: initial_root,
-                    canonical_root: None,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -333,7 +329,7 @@ where
             loop {
                 client = match client.step().await.unwrap() {
                     NextStep::Continue(new_client) => new_client,
-                    NextStep::Complete(_) => panic!("client should not be complete"),
+                    NextStep::Complete(..) => panic!("client should not be complete"),
                 };
                 let log_size = Contiguous::size(client.journal()).await;
                 if log_size > *initial_lower_bound {
@@ -345,7 +341,6 @@ where
         update_sender
             .send(Target {
                 root: final_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, final_upper_bound),
             })
             .await
@@ -401,7 +396,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: context.child("client"),
@@ -457,7 +451,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -511,7 +504,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -561,7 +553,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -577,7 +568,6 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound
@@ -624,7 +614,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -640,7 +629,6 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
             })
             .await
@@ -698,7 +686,6 @@ where
             fetch_batch_size: NZU64!(1),
             target: Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -713,7 +700,6 @@ where
         update_sender
             .send(Target {
                 root: final_root,
-                canonical_root: None,
                 range: non_empty_range!(final_lower_bound, final_upper_bound),
             })
             .await
@@ -771,7 +757,6 @@ where
             fetch_batch_size: NZU64!(100),
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(bounds.start, bounds.end),
             },
             context: context.child("client"),
@@ -836,7 +821,6 @@ where
             fetch_batch_size: NZU64!(20),
             target: Target {
                 root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -853,7 +837,6 @@ where
         let _ = update_sender
             .send(Target {
                 root: sha256::Digest::from([2u8; 32]),
-                canonical_root: None,
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
             })
             .await;

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -128,6 +128,7 @@ where
             fetch_batch_size,
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -190,6 +191,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -241,6 +243,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: client_context.child("client"),
@@ -314,6 +317,7 @@ where
                 db_config: H::config(&format!("update_test_{}", context.next_u64()), &context),
                 target: Target {
                     root: initial_root,
+                    canonical_root: None,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -341,6 +345,7 @@ where
         update_sender
             .send(Target {
                 root: final_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, final_upper_bound),
             })
             .await
@@ -396,6 +401,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: context.child("client"),
@@ -451,6 +457,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -504,6 +511,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -553,6 +561,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -568,6 +577,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound
@@ -614,6 +624,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -629,6 +640,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
             })
             .await
@@ -686,6 +698,7 @@ where
             fetch_batch_size: NZU64!(1),
             target: Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -700,6 +713,7 @@ where
         update_sender
             .send(Target {
                 root: final_root,
+                canonical_root: None,
                 range: non_empty_range!(final_lower_bound, final_upper_bound),
             })
             .await
@@ -757,6 +771,7 @@ where
             fetch_batch_size: NZU64!(100),
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(bounds.start, bounds.end),
             },
             context: context.child("client"),
@@ -821,6 +836,7 @@ where
             fetch_batch_size: NZU64!(20),
             target: Target {
                 root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -837,6 +853,7 @@ where
         let _ = update_sender
             .send(Target {
                 root: sha256::Digest::from([2u8; 32]),
+                canonical_root: None,
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
             })
             .await;

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -128,6 +128,7 @@ where
             fetch_batch_size,
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -190,6 +191,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -241,6 +243,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: client_context.child("client"),
@@ -314,6 +317,7 @@ where
                 db_config: H::config(&format!("update_test_{}", context.next_u64()), &context),
                 target: Target {
                     root: initial_root,
+                    ops_root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -341,6 +345,7 @@ where
         update_sender
             .send(Target {
                 root: final_root,
+                ops_root: final_root,
                 range: non_empty_range!(initial_lower_bound, final_upper_bound),
             })
             .await
@@ -396,6 +401,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: context.child("client"),
@@ -450,7 +456,8 @@ where
             db_config: sync_db_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root,
+                root: root,
+                ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -503,7 +510,8 @@ where
             db_config: sync_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root,
+                root: root,
+                ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -553,6 +561,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -568,6 +577,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound
@@ -614,6 +624,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -629,6 +640,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
             })
             .await
@@ -686,6 +698,7 @@ where
             fetch_batch_size: NZU64!(1),
             target: Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -700,6 +713,7 @@ where
         update_sender
             .send(Target {
                 root: final_root,
+                ops_root: final_root,
                 range: non_empty_range!(final_lower_bound, final_upper_bound),
             })
             .await
@@ -757,6 +771,7 @@ where
             fetch_batch_size: NZU64!(100),
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(bounds.start, bounds.end),
             },
             context: context.child("client"),
@@ -820,7 +835,8 @@ where
             db_config: H::config(&format!("done_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(20),
             target: Target {
-                root,
+                root: root,
+                ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -837,6 +853,7 @@ where
         let _ = update_sender
             .send(Target {
                 root: sha256::Digest::from([2u8; 32]),
+                ops_root: sha256::Digest::from([2u8; 32]),
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
             })
             .await;

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -456,7 +456,7 @@ where
             db_config: sync_db_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root: root,
+                root,
                 ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
@@ -510,7 +510,7 @@ where
             db_config: sync_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root: root,
+                root,
                 ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
@@ -835,7 +835,7 @@ where
             db_config: H::config(&format!("done_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(20),
             target: Target {
-                root: root,
+                root,
                 ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -10,12 +10,13 @@ use crate::{
     merkle::{self, full::Config as MerkleConfig, Location},
     qmdb::{
         self,
+        any::sync::Target,
         immutable::{self, variable::Operation},
         sync::{
             self,
             engine::{Config, NextStep},
             resolver::Resolver,
-            Engine, Target,
+            Engine,
         },
     },
     translator::TwoCap,
@@ -126,11 +127,10 @@ where
         let config = Config {
             db_config: db_config.clone(),
             fetch_batch_size,
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(target_oldest_retained_loc, target_op_count),
-            },
+            target: Target::new(
+                target_root,
+                non_empty_range!(target_oldest_retained_loc, target_op_count),
+            ),
             context: context.child("client"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -189,11 +189,10 @@ where
         let config = Config {
             db_config,
             fetch_batch_size: NZU64!(10),
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(target_oldest_retained_loc, target_op_count),
-            },
+            target: Target::new(
+                target_root,
+                non_empty_range!(target_oldest_retained_loc, target_op_count),
+            ),
             context: context.child("client"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -241,11 +240,7 @@ where
         let config = Config {
             db_config: db_config.clone(),
             fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(lower_bound, op_count),
-            },
+            target: Target::new(target_root, non_empty_range!(lower_bound, op_count)),
             context: client_context.child("client"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -315,11 +310,10 @@ where
             let config = Config {
                 context: context.child("client"),
                 db_config: H::config(&format!("update_test_{}", context.next_u64()), &context),
-                target: Target {
-                    root: initial_root,
-                    ops_root: initial_root,
-                    range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-                },
+                target: Target::new(
+                    initial_root,
+                    non_empty_range!(initial_lower_bound, initial_upper_bound),
+                ),
                 resolver: target_db.clone(),
                 fetch_batch_size: NZU64!(2),
                 max_outstanding_requests: 10,
@@ -329,7 +323,8 @@ where
                 reached_target_tx: None,
                 max_retained_roots: 1,
             };
-            let mut client: Engine<DbOf<H>, _> = Engine::new(config).await.unwrap();
+            let mut client: Engine<DbOf<H>, _, Target<H::Family, sha256::Digest>> =
+                Engine::new(config).await.unwrap();
             loop {
                 client = match client.step().await.unwrap() {
                     NextStep::Continue(new_client) => new_client,
@@ -343,11 +338,10 @@ where
         };
 
         update_sender
-            .send(Target {
-                root: final_root,
-                ops_root: final_root,
-                range: non_empty_range!(initial_lower_bound, final_upper_bound),
-            })
+            .send(Target::new(
+                final_root,
+                non_empty_range!(initial_lower_bound, final_upper_bound),
+            ))
             .await
             .unwrap();
 
@@ -399,11 +393,7 @@ where
         let config = Config {
             db_config: H::config(&format!("subset_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(10),
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(lower_bound, op_count),
-            },
+            target: Target::new(target_root, non_empty_range!(lower_bound, op_count)),
             context: context.child("client"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -455,11 +445,7 @@ where
         let config = Config {
             db_config: sync_db_config,
             fetch_batch_size: NZU64!(10),
-            target: Target {
-                root,
-                ops_root: root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
+            target: Target::new(root, non_empty_range!(lower_bound, upper_bound)),
             context: context.child("sync"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -509,11 +495,7 @@ where
         let config = Config {
             db_config: sync_config,
             fetch_batch_size: NZU64!(10),
-            target: Target {
-                root,
-                ops_root: root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
+            target: Target::new(root, non_empty_range!(lower_bound, upper_bound)),
             context: context.child("sync"),
             resolver: resolver.clone(),
             apply_batch_size: 1024,
@@ -559,11 +541,10 @@ where
             context: context.child("client"),
             db_config: H::config(&format!("lb-dec-{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-            },
+            target: Target::new(
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound),
+            ),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
             max_outstanding_requests: 10,
@@ -572,17 +553,17 @@ where
             reached_target_tx: None,
             max_retained_roots: 1,
         };
-        let client: Engine<DbOf<H>, _> = Engine::new(config).await.unwrap();
+        let client: Engine<DbOf<H>, _, Target<H::Family, sha256::Digest>> =
+            Engine::new(config).await.unwrap();
 
         update_sender
-            .send(Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(
+            .send(Target::new(
+                initial_root,
+                non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound
                 ),
-            })
+            ))
             .await
             .unwrap();
 
@@ -622,11 +603,10 @@ where
             context: context.child("client"),
             db_config: H::config(&format!("ub-dec-{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-            },
+            target: Target::new(
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound),
+            ),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
             max_outstanding_requests: 10,
@@ -635,14 +615,14 @@ where
             reached_target_tx: None,
             max_retained_roots: 1,
         };
-        let client: Engine<DbOf<H>, _> = Engine::new(config).await.unwrap();
+        let client: Engine<DbOf<H>, _, Target<H::Family, sha256::Digest>> =
+            Engine::new(config).await.unwrap();
 
         update_sender
-            .send(Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
-            })
+            .send(Target::new(
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
+            ))
             .await
             .unwrap();
 
@@ -696,11 +676,10 @@ where
             context: context.child("client"),
             db_config: H::config(&format!("bounds_inc_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(1),
-            target: Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-            },
+            target: Target::new(
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound),
+            ),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
             max_outstanding_requests: 1,
@@ -711,11 +690,10 @@ where
         };
 
         update_sender
-            .send(Target {
-                root: final_root,
-                ops_root: final_root,
-                range: non_empty_range!(final_lower_bound, final_upper_bound),
-            })
+            .send(Target::new(
+                final_root,
+                non_empty_range!(final_lower_bound, final_upper_bound),
+            ))
             .await
             .unwrap();
 
@@ -769,11 +747,7 @@ where
         let config = Config {
             db_config,
             fetch_batch_size: NZU64!(100),
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(bounds.start, bounds.end),
-            },
+            target: Target::new(target_root, non_empty_range!(bounds.start, bounds.end)),
             context: context.child("client"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -834,11 +808,7 @@ where
             context: context.child("client"),
             db_config: H::config(&format!("done_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(20),
-            target: Target {
-                root,
-                ops_root: root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
+            target: Target::new(root, non_empty_range!(lower_bound, upper_bound)),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
             max_outstanding_requests: 10,
@@ -851,11 +821,10 @@ where
         let synced_db: DbOf<H> = sync::sync(config).await.unwrap();
 
         let _ = update_sender
-            .send(Target {
-                root: sha256::Digest::from([2u8; 32]),
-                ops_root: sha256::Digest::from([2u8; 32]),
-                range: non_empty_range!(lower_bound + 1, upper_bound + 1),
-            })
+            .send(Target::new(
+                sha256::Digest::from([2u8; 32]),
+                non_empty_range!(lower_bound + 1, upper_bound + 1),
+            ))
             .await;
 
         assert_eq!(H::db_root(&synced_db), root);
@@ -1253,10 +1222,8 @@ mod compact_variable_mmr {
         deterministic::Runner::default().start(|_context| async move {
             let resolver: Arc<commonware_utils::sync::AsyncRwLock<Option<SourceDb>>> =
                 Arc::new(commonware_utils::sync::AsyncRwLock::new(None));
-            let target = sync::compact::Target {
-                root: sha256::Digest::from([0; 32]),
-                leaf_count: Location::new(1),
-            };
+            let target =
+                sync::compact::Target::new(sha256::Digest::from([0; 32]), Location::new(1));
 
             assert!(matches!(
                 sync::compact::Resolver::get_compact_state(&resolver, target).await,
@@ -1286,10 +1253,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let client_cfg = client_config(&suffix);
             let client: ClientDb = sync::compact::sync(sync::compact::Config {
@@ -1335,10 +1299,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1381,10 +1342,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1438,10 +1396,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1482,10 +1437,7 @@ mod compact_variable_mmr {
                 .merkleize(&source, Some(vec![1]), Location::new(1));
             source.apply_batch(batch1).await.unwrap();
             source.commit().await.unwrap();
-            let stale_target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: source.bounds().await.end,
-            };
+            let stale_target = sync::compact::Target::new(source.root(), source.bounds().await.end);
 
             let batch2 = source
                 .new_batch()
@@ -1493,10 +1445,8 @@ mod compact_variable_mmr {
                 .merkleize(&source, Some(vec![2]), Location::new(2));
             source.apply_batch(batch2).await.unwrap();
             source.commit().await.unwrap();
-            let current_target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: source.bounds().await.end,
-            };
+            let current_target =
+                sync::compact::Target::new(source.root(), source.bounds().await.end);
             assert_ne!(stale_target, current_target);
 
             let source = Arc::new(source);
@@ -1729,10 +1679,8 @@ mod compact_variable_mmb {
         deterministic::Runner::default().start(|_context| async move {
             let resolver: Arc<commonware_utils::sync::AsyncRwLock<Option<SourceDb>>> =
                 Arc::new(commonware_utils::sync::AsyncRwLock::new(None));
-            let target = sync::compact::Target {
-                root: sha256::Digest::from([0; 32]),
-                leaf_count: Location::new(1),
-            };
+            let target =
+                sync::compact::Target::new(sha256::Digest::from([0; 32]), Location::new(1));
 
             assert!(matches!(
                 sync::compact::Resolver::get_compact_state(&resolver, target).await,
@@ -1762,10 +1710,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let client_cfg = client_config(&suffix);
             let client: ClientDb = sync::compact::sync(sync::compact::Config {
@@ -1811,10 +1756,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1857,10 +1799,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1914,10 +1853,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1958,10 +1894,7 @@ mod compact_variable_mmb {
                 .merkleize(&source, Some(vec![1]), Location::new(1));
             source.apply_batch(batch1).await.unwrap();
             source.commit().await.unwrap();
-            let stale_target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: source.bounds().await.end,
-            };
+            let stale_target = sync::compact::Target::new(source.root(), source.bounds().await.end);
 
             let batch2 = source
                 .new_batch()
@@ -1969,10 +1902,8 @@ mod compact_variable_mmb {
                 .merkleize(&source, Some(vec![2]), Location::new(2));
             source.apply_batch(batch2).await.unwrap();
             source.commit().await.unwrap();
-            let current_target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: source.bounds().await.end,
-            };
+            let current_target =
+                sync::compact::Target::new(source.root(), source.bounds().await.end);
             assert_ne!(stale_target, current_target);
 
             let source = Arc::new(source);

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -968,7 +968,6 @@ mod test {
                 fetch_batch_size: NZU64!(5),
                 target: Target {
                     root: target_root,
-                    canonical_root: None,
                     range: non_empty_range!(lower_bound, upper_bound),
                 },
                 context: ctx.child("client"),

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -968,6 +968,7 @@ mod test {
                 fetch_batch_size: NZU64!(5),
                 target: Target {
                     root: target_root,
+                    ops_root: target_root,
                     range: non_empty_range!(lower_bound, upper_bound),
                 },
                 context: ctx.child("client"),

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -968,6 +968,7 @@ mod test {
                 fetch_batch_size: NZU64!(5),
                 target: Target {
                     root: target_root,
+                    canonical_root: None,
                     range: non_empty_range!(lower_bound, upper_bound),
                 },
                 context: ctx.child("client"),

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -936,7 +936,10 @@ mod test {
     fn test_keyless_fixed_sync() {
         use crate::{
             merkle::Location,
-            qmdb::sync::{self, engine::Config, Target},
+            qmdb::{
+                any::sync::Target,
+                sync::{self, engine::Config},
+            },
         };
         use commonware_utils::{non_empty_range, sequence::U64};
         use std::sync::Arc;
@@ -966,11 +969,7 @@ mod test {
             let config = Config {
                 db_config: client_config,
                 fetch_batch_size: NZU64!(5),
-                target: Target {
-                    root: target_root,
-                    ops_root: target_root,
-                    range: non_empty_range!(lower_bound, upper_bound),
-                },
+                target: Target::new(target_root, non_empty_range!(lower_bound, upper_bound)),
                 context: ctx.child("client"),
                 resolver: target_db.clone(),
                 apply_batch_size: 1024,

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -121,6 +121,10 @@ where
         Ok(db)
     }
 
+    fn ops_root(&self) -> Self::Digest {
+        self.root()
+    }
+
     fn root(&self) -> Self::Digest {
         self.root()
     }

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -461,7 +461,7 @@ where
             db_config: sync_db_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root: root,
+                root,
                 ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
@@ -515,7 +515,7 @@ where
             db_config: sync_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root: root,
+                root,
                 ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
@@ -761,7 +761,7 @@ where
             db_config: H::config(&format!("done_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(20),
             target: Target {
-                root: root,
+                root,
                 ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -99,6 +99,7 @@ where
             context: context.child("client"),
             target: Target {
                 root: sha256::Digest::from([0; 32]),
+                ops_root: sha256::Digest::from([0; 32]),
                 range: non_empty_range!(Location::new(0), Location::new(5)),
             },
             resolver,
@@ -141,6 +142,7 @@ where
             fetch_batch_size,
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -202,6 +204,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -253,6 +256,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: client_context.child("client"),
@@ -326,6 +330,7 @@ where
                 db_config: H::config(&format!("update_test_{}", context.next_u64()), &context),
                 target: Target {
                     root: initial_root,
+                    ops_root: initial_root,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -353,6 +358,7 @@ where
         update_sender
             .send(Target {
                 root: final_root,
+                ops_root: final_root,
                 range: non_empty_range!(initial_lower_bound, final_upper_bound),
             })
             .await
@@ -400,6 +406,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
+                ops_root: target_root,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: context.child("client"),
@@ -454,7 +461,8 @@ where
             db_config: sync_db_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root,
+                root: root,
+                ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -507,7 +515,8 @@ where
             db_config: sync_config,
             fetch_batch_size: NZU64!(10),
             target: Target {
-                root,
+                root: root,
+                ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -557,6 +566,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -572,6 +582,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound
@@ -618,6 +629,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -633,6 +645,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
             })
             .await
@@ -690,6 +703,7 @@ where
             fetch_batch_size: NZU64!(1),
             target: Target {
                 root: initial_root,
+                ops_root: initial_root,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -704,6 +718,7 @@ where
         update_sender
             .send(Target {
                 root: final_root,
+                ops_root: final_root,
                 range: non_empty_range!(final_lower_bound, final_upper_bound),
             })
             .await
@@ -746,7 +761,8 @@ where
             db_config: H::config(&format!("done_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(20),
             target: Target {
-                root,
+                root: root,
+                ops_root: root,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -763,6 +779,7 @@ where
         let _ = update_sender
             .send(Target {
                 root: sha256::Digest::from([2u8; 32]),
+                ops_root: sha256::Digest::from([2u8; 32]),
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
             })
             .await;

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -99,6 +99,7 @@ where
             context: context.child("client"),
             target: Target {
                 root: sha256::Digest::from([0; 32]),
+                canonical_root: None,
                 range: non_empty_range!(Location::new(0), Location::new(5)),
             },
             resolver,
@@ -141,6 +142,7 @@ where
             fetch_batch_size,
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -202,6 +204,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -253,6 +256,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: client_context.child("client"),
@@ -326,6 +330,7 @@ where
                 db_config: H::config(&format!("update_test_{}", context.next_u64()), &context),
                 target: Target {
                     root: initial_root,
+                    canonical_root: None,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -353,6 +358,7 @@ where
         update_sender
             .send(Target {
                 root: final_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, final_upper_bound),
             })
             .await
@@ -400,6 +406,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: context.child("client"),
@@ -455,6 +462,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -508,6 +516,7 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -557,6 +566,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -572,6 +582,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound
@@ -618,6 +629,7 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -633,6 +645,7 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
             })
             .await
@@ -690,6 +703,7 @@ where
             fetch_batch_size: NZU64!(1),
             target: Target {
                 root: initial_root,
+                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -704,6 +718,7 @@ where
         update_sender
             .send(Target {
                 root: final_root,
+                canonical_root: None,
                 range: non_empty_range!(final_lower_bound, final_upper_bound),
             })
             .await
@@ -747,6 +762,7 @@ where
             fetch_batch_size: NZU64!(20),
             target: Target {
                 root,
+                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -763,6 +779,7 @@ where
         let _ = update_sender
             .send(Target {
                 root: sha256::Digest::from([2u8; 32]),
+                canonical_root: None,
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
             })
             .await;

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -99,7 +99,6 @@ where
             context: context.child("client"),
             target: Target {
                 root: sha256::Digest::from([0; 32]),
-                canonical_root: None,
                 range: non_empty_range!(Location::new(0), Location::new(5)),
             },
             resolver,
@@ -142,7 +141,6 @@ where
             fetch_batch_size,
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -204,7 +202,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(target_oldest_retained_loc, target_op_count),
             },
             context: context.child("client"),
@@ -256,7 +253,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: client_context.child("client"),
@@ -330,7 +326,6 @@ where
                 db_config: H::config(&format!("update_test_{}", context.next_u64()), &context),
                 target: Target {
                     root: initial_root,
-                    canonical_root: None,
                     range: non_empty_range!(initial_lower_bound, initial_upper_bound),
                 },
                 resolver: target_db.clone(),
@@ -346,7 +341,7 @@ where
             loop {
                 client = match client.step().await.unwrap() {
                     NextStep::Continue(new_client) => new_client,
-                    NextStep::Complete(_) => panic!("client should not be complete"),
+                    NextStep::Complete(..) => panic!("client should not be complete"),
                 };
                 let log_size = Contiguous::size(client.journal()).await;
                 if log_size > *initial_lower_bound {
@@ -358,7 +353,6 @@ where
         update_sender
             .send(Target {
                 root: final_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, final_upper_bound),
             })
             .await
@@ -406,7 +400,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root: target_root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, op_count),
             },
             context: context.child("client"),
@@ -462,7 +455,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -516,7 +508,6 @@ where
             fetch_batch_size: NZU64!(10),
             target: Target {
                 root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             context: context.child("sync"),
@@ -566,7 +557,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -582,7 +572,6 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound
@@ -629,7 +618,6 @@ where
             fetch_batch_size: NZU64!(5),
             target: Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -645,7 +633,6 @@ where
         update_sender
             .send(Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
             })
             .await
@@ -703,7 +690,6 @@ where
             fetch_batch_size: NZU64!(1),
             target: Target {
                 root: initial_root,
-                canonical_root: None,
                 range: non_empty_range!(initial_lower_bound, initial_upper_bound),
             },
             resolver: target_db.clone(),
@@ -718,7 +704,6 @@ where
         update_sender
             .send(Target {
                 root: final_root,
-                canonical_root: None,
                 range: non_empty_range!(final_lower_bound, final_upper_bound),
             })
             .await
@@ -762,7 +747,6 @@ where
             fetch_batch_size: NZU64!(20),
             target: Target {
                 root,
-                canonical_root: None,
                 range: non_empty_range!(lower_bound, upper_bound),
             },
             resolver: target_db.clone(),
@@ -779,7 +763,6 @@ where
         let _ = update_sender
             .send(Target {
                 root: sha256::Digest::from([2u8; 32]),
-                canonical_root: None,
                 range: non_empty_range!(lower_bound + 1, upper_bound + 1),
             })
             .await;

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -10,12 +10,13 @@ use crate::{
     merkle::{self, full::Config as MerkleConfig, mmb, mmr, Family, Location},
     qmdb::{
         self,
+        any::sync::Target,
         keyless::{self, variable, Operation},
         sync::{
             self,
             engine::{Config, NextStep},
             resolver::{tests::FailResolver, Resolver},
-            Engine, Target,
+            Engine,
         },
     },
 };
@@ -97,11 +98,10 @@ where
         let db_config = H::config(&context.next_u64().to_string(), &context);
         let config = Config {
             context: context.child("client"),
-            target: Target {
-                root: sha256::Digest::from([0; 32]),
-                ops_root: sha256::Digest::from([0; 32]),
-                range: non_empty_range!(Location::new(0), Location::new(5)),
-            },
+            target: Target::new(
+                sha256::Digest::from([0; 32]),
+                non_empty_range!(Location::new(0), Location::new(5)),
+            ),
             resolver,
             apply_batch_size: 2,
             max_outstanding_requests: 2,
@@ -140,11 +140,10 @@ where
         let config = Config {
             db_config: db_config.clone(),
             fetch_batch_size,
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(target_oldest_retained_loc, target_op_count),
-            },
+            target: Target::new(
+                target_root,
+                non_empty_range!(target_oldest_retained_loc, target_op_count),
+            ),
             context: context.child("client"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -202,11 +201,10 @@ where
         let config = Config {
             db_config,
             fetch_batch_size: NZU64!(10),
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(target_oldest_retained_loc, target_op_count),
-            },
+            target: Target::new(
+                target_root,
+                non_empty_range!(target_oldest_retained_loc, target_op_count),
+            ),
             context: context.child("client"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -254,11 +252,7 @@ where
         let config = Config {
             db_config: db_config.clone(),
             fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(lower_bound, op_count),
-            },
+            target: Target::new(target_root, non_empty_range!(lower_bound, op_count)),
             context: client_context.child("client"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -328,11 +322,10 @@ where
             let config = Config {
                 context: context.child("client"),
                 db_config: H::config(&format!("update_test_{}", context.next_u64()), &context),
-                target: Target {
-                    root: initial_root,
-                    ops_root: initial_root,
-                    range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-                },
+                target: Target::new(
+                    initial_root,
+                    non_empty_range!(initial_lower_bound, initial_upper_bound),
+                ),
                 resolver: target_db.clone(),
                 fetch_batch_size: NZU64!(2),
                 max_outstanding_requests: 10,
@@ -342,7 +335,8 @@ where
                 reached_target_tx: None,
                 max_retained_roots: 1,
             };
-            let mut client: Engine<DbOf<H>, _> = Engine::new(config).await.unwrap();
+            let mut client: Engine<DbOf<H>, _, Target<H::Family, sha256::Digest>> =
+                Engine::new(config).await.unwrap();
             loop {
                 client = match client.step().await.unwrap() {
                     NextStep::Continue(new_client) => new_client,
@@ -356,11 +350,10 @@ where
         };
 
         update_sender
-            .send(Target {
-                root: final_root,
-                ops_root: final_root,
-                range: non_empty_range!(initial_lower_bound, final_upper_bound),
-            })
+            .send(Target::new(
+                final_root,
+                non_empty_range!(initial_lower_bound, final_upper_bound),
+            ))
             .await
             .unwrap();
 
@@ -404,11 +397,7 @@ where
         let config = Config {
             db_config: H::config(&format!("subset_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(10),
-            target: Target {
-                root: target_root,
-                ops_root: target_root,
-                range: non_empty_range!(lower_bound, op_count),
-            },
+            target: Target::new(target_root, non_empty_range!(lower_bound, op_count)),
             context: context.child("client"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -460,11 +449,7 @@ where
         let config = Config {
             db_config: sync_db_config,
             fetch_batch_size: NZU64!(10),
-            target: Target {
-                root,
-                ops_root: root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
+            target: Target::new(root, non_empty_range!(lower_bound, upper_bound)),
             context: context.child("sync"),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
@@ -514,11 +499,7 @@ where
         let config = Config {
             db_config: sync_config,
             fetch_batch_size: NZU64!(10),
-            target: Target {
-                root,
-                ops_root: root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
+            target: Target::new(root, non_empty_range!(lower_bound, upper_bound)),
             context: context.child("sync"),
             resolver: resolver.clone(),
             apply_batch_size: 1024,
@@ -564,11 +545,10 @@ where
             context: context.child("client"),
             db_config: H::config(&format!("lb-dec-{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-            },
+            target: Target::new(
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound),
+            ),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
             max_outstanding_requests: 10,
@@ -577,17 +557,17 @@ where
             reached_target_tx: None,
             max_retained_roots: 1,
         };
-        let client: Engine<DbOf<H>, _> = Engine::new(config).await.unwrap();
+        let client: Engine<DbOf<H>, _, Target<H::Family, sha256::Digest>> =
+            Engine::new(config).await.unwrap();
 
         update_sender
-            .send(Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(
+            .send(Target::new(
+                initial_root,
+                non_empty_range!(
                     initial_lower_bound.checked_sub(1).unwrap(),
                     initial_upper_bound
                 ),
-            })
+            ))
             .await
             .unwrap();
 
@@ -627,11 +607,10 @@ where
             context: context.child("client"),
             db_config: H::config(&format!("ub-dec-{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(5),
-            target: Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-            },
+            target: Target::new(
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound),
+            ),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
             max_outstanding_requests: 10,
@@ -640,14 +619,14 @@ where
             reached_target_tx: None,
             max_retained_roots: 1,
         };
-        let client: Engine<DbOf<H>, _> = Engine::new(config).await.unwrap();
+        let client: Engine<DbOf<H>, _, Target<H::Family, sha256::Digest>> =
+            Engine::new(config).await.unwrap();
 
         update_sender
-            .send(Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
-            })
+            .send(Target::new(
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound - 1),
+            ))
             .await
             .unwrap();
 
@@ -701,11 +680,10 @@ where
             context: context.child("client"),
             db_config: H::config(&format!("bounds_inc_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(1),
-            target: Target {
-                root: initial_root,
-                ops_root: initial_root,
-                range: non_empty_range!(initial_lower_bound, initial_upper_bound),
-            },
+            target: Target::new(
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound),
+            ),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
             max_outstanding_requests: 1,
@@ -716,11 +694,10 @@ where
         };
 
         update_sender
-            .send(Target {
-                root: final_root,
-                ops_root: final_root,
-                range: non_empty_range!(final_lower_bound, final_upper_bound),
-            })
+            .send(Target::new(
+                final_root,
+                non_empty_range!(final_lower_bound, final_upper_bound),
+            ))
             .await
             .unwrap();
 
@@ -760,11 +737,7 @@ where
             context: context.child("client"),
             db_config: H::config(&format!("done_{}", context.next_u64()), &context),
             fetch_batch_size: NZU64!(20),
-            target: Target {
-                root,
-                ops_root: root,
-                range: non_empty_range!(lower_bound, upper_bound),
-            },
+            target: Target::new(root, non_empty_range!(lower_bound, upper_bound)),
             resolver: target_db.clone(),
             apply_batch_size: 1024,
             max_outstanding_requests: 10,
@@ -777,11 +750,10 @@ where
         let synced_db: DbOf<H> = sync::sync(config).await.unwrap();
 
         let _ = update_sender
-            .send(Target {
-                root: sha256::Digest::from([2u8; 32]),
-                ops_root: sha256::Digest::from([2u8; 32]),
-                range: non_empty_range!(lower_bound + 1, upper_bound + 1),
-            })
+            .send(Target::new(
+                sha256::Digest::from([2u8; 32]),
+                non_empty_range!(lower_bound + 1, upper_bound + 1),
+            ))
             .await;
 
         assert_eq!(H::db_root(&synced_db), root);
@@ -1123,10 +1095,8 @@ mod compact_variable_mmr {
         deterministic::Runner::default().start(|_context| async move {
             let resolver: Arc<commonware_utils::sync::AsyncRwLock<Option<SourceDb>>> =
                 Arc::new(commonware_utils::sync::AsyncRwLock::new(None));
-            let target = sync::compact::Target {
-                root: sha256::Digest::from([0; 32]),
-                leaf_count: Location::new(1),
-            };
+            let target =
+                sync::compact::Target::new(sha256::Digest::from([0; 32]), Location::new(1));
 
             assert!(matches!(
                 sync::compact::Resolver::get_compact_state(&resolver, target).await,
@@ -1154,10 +1124,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let client_cfg = client_config(&suffix);
             let client: ClientDb = sync::compact::sync(sync::compact::Config {
@@ -1204,10 +1171,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1248,10 +1212,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1303,10 +1264,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1348,10 +1306,7 @@ mod compact_variable_mmr {
             );
             source.apply_batch(batch1).await.unwrap();
             source.commit().await.unwrap();
-            let stale_target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: source.bounds().await.end,
-            };
+            let stale_target = sync::compact::Target::new(source.root(), source.bounds().await.end);
 
             let batch2 = source.new_batch().append(vec![4, 5, 6]).merkleize(
                 &source,
@@ -1360,10 +1315,8 @@ mod compact_variable_mmr {
             );
             source.apply_batch(batch2).await.unwrap();
             source.commit().await.unwrap();
-            let current_target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: source.bounds().await.end,
-            };
+            let current_target =
+                sync::compact::Target::new(source.root(), source.bounds().await.end);
             assert_ne!(stale_target, current_target);
 
             let source = Arc::new(source);
@@ -1591,10 +1544,8 @@ mod compact_variable_mmb {
         deterministic::Runner::default().start(|_context| async move {
             let resolver: Arc<commonware_utils::sync::AsyncRwLock<Option<SourceDb>>> =
                 Arc::new(commonware_utils::sync::AsyncRwLock::new(None));
-            let target = sync::compact::Target {
-                root: sha256::Digest::from([0; 32]),
-                leaf_count: Location::new(1),
-            };
+            let target =
+                sync::compact::Target::new(sha256::Digest::from([0; 32]), Location::new(1));
 
             assert!(matches!(
                 sync::compact::Resolver::get_compact_state(&resolver, target).await,
@@ -1622,10 +1573,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let client_cfg = client_config(&suffix);
             let client: ClientDb = sync::compact::sync(sync::compact::Config {
@@ -1672,10 +1620,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1716,10 +1661,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1771,10 +1713,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
 
             let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
+            let target = sync::compact::Target::new(source.root(), bounds.end);
             let source = Arc::new(source);
             let mut state = sync::compact::Resolver::get_compact_state(&source, target.clone())
                 .await
@@ -1816,10 +1755,7 @@ mod compact_variable_mmb {
             );
             source.apply_batch(batch1).await.unwrap();
             source.commit().await.unwrap();
-            let stale_target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: source.bounds().await.end,
-            };
+            let stale_target = sync::compact::Target::new(source.root(), source.bounds().await.end);
 
             let batch2 = source.new_batch().append(vec![4, 5, 6]).merkleize(
                 &source,
@@ -1828,10 +1764,8 @@ mod compact_variable_mmb {
             );
             source.apply_batch(batch2).await.unwrap();
             source.commit().await.unwrap();
-            let current_target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: source.bounds().await.end,
-            };
+            let current_target =
+                sync::compact::Target::new(source.root(), source.bounds().await.end);
             assert_ne!(stale_target, current_target);
 
             let source = Arc::new(source);

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -92,6 +92,11 @@ pub struct Target<F: Family, D: Digest> {
 impl<F: Family, D: Digest> Target<F, D> {
     const INVALID_LEAF_COUNT: &'static str = "leaf_count must be in 1..=MAX_LEAVES";
 
+    /// Create a compact-sync target.
+    pub const fn new(root: D, leaf_count: Location<F>) -> Self {
+        Self { root, leaf_count }
+    }
+
     /// Validate a compact target that may have been constructed programmatically.
     pub fn validate(&self) -> Result<(), &'static str> {
         if !self.leaf_count.is_valid() || self.leaf_count == 0 {
@@ -421,12 +426,7 @@ macro_rules! impl_compact_resolver_keyless {
             ) -> Result<State<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 fetch_state_from_full_source(
                     target,
-                    || async {
-                        Target {
-                            root: self.root(),
-                            leaf_count: self.bounds().await.end,
-                        }
-                    },
+                    || async { Target::new(self.root(), self.bounds().await.end) },
                     |leaf_count, last_commit_loc| {
                         self.historical_proof(
                             leaf_count,
@@ -460,12 +460,7 @@ macro_rules! impl_compact_resolver_keyless {
                 let db = self.read().await;
                 fetch_state_from_full_source(
                     target,
-                    || async {
-                        Target {
-                            root: db.root(),
-                            leaf_count: db.bounds().await.end,
-                        }
-                    },
+                    || async { Target::new(db.root(), db.bounds().await.end) },
                     |leaf_count, last_commit_loc| {
                         db.historical_proof(
                             leaf_count,
@@ -500,12 +495,7 @@ macro_rules! impl_compact_resolver_keyless {
                 let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
                 fetch_state_from_full_source(
                     target,
-                    || async {
-                        Target {
-                            root: db.root(),
-                            leaf_count: db.bounds().await.end,
-                        }
-                    },
+                    || async { Target::new(db.root(), db.bounds().await.end) },
                     |leaf_count, last_commit_loc| {
                         db.historical_proof(
                             leaf_count,
@@ -547,12 +537,7 @@ macro_rules! impl_compact_resolver_immutable {
             ) -> Result<State<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 fetch_state_from_full_source(
                     target,
-                    || async {
-                        Target {
-                            root: self.root(),
-                            leaf_count: self.bounds().await.end,
-                        }
-                    },
+                    || async { Target::new(self.root(), self.bounds().await.end) },
                     |leaf_count, last_commit_loc| {
                         self.historical_proof(
                             leaf_count,
@@ -589,12 +574,7 @@ macro_rules! impl_compact_resolver_immutable {
                 let db = self.read().await;
                 fetch_state_from_full_source(
                     target,
-                    || async {
-                        Target {
-                            root: db.root(),
-                            leaf_count: db.bounds().await.end,
-                        }
-                    },
+                    || async { Target::new(db.root(), db.bounds().await.end) },
                     |leaf_count, last_commit_loc| {
                         db.historical_proof(
                             leaf_count,
@@ -632,12 +612,7 @@ macro_rules! impl_compact_resolver_immutable {
                 let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
                 fetch_state_from_full_source(
                     target,
-                    || async {
-                        Target {
-                            root: db.root(),
-                            leaf_count: db.bounds().await.end,
-                        }
-                    },
+                    || async { Target::new(db.root(), db.bounds().await.end) },
                     |leaf_count, last_commit_loc| {
                         db.historical_proof(
                             leaf_count,
@@ -892,5 +867,33 @@ mod tests {
         .encode();
 
         assert!(Target::<mmr::Family, Digest>::decode(encoded).is_err());
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<F: Family, D: Digest> arbitrary::Arbitrary<'_> for Target<F, D>
+where
+    D: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let root = u.arbitrary()?;
+        let leaf_count = u.int_in_range(1..=*F::MAX_LEAVES)?;
+        Ok(Self {
+            root,
+            leaf_count: Location::new(leaf_count),
+        })
+    }
+}
+
+#[cfg(all(test, feature = "arbitrary"))]
+mod conformance {
+    use super::*;
+    use crate::merkle::{mmb, mmr};
+    use commonware_codec::conformance::CodecConformance;
+    use commonware_cryptography::sha256::Digest as Sha256Digest;
+
+    commonware_conformance::conformance_tests! {
+        CodecConformance<Target<mmr::Family, Sha256Digest>>,
+        CodecConformance<Target<mmb::Family, Sha256Digest>>,
     }
 }

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -73,7 +73,7 @@ pub trait Database: Sized + Send {
         async { false }
     }
 
-    /// Get the ops root digest used for streaming verification.
+    /// Get the root of the operation log for range verification.
     fn ops_root(&self) -> Self::Digest;
 
     /// Get the database root digest.

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -73,6 +73,17 @@ pub trait Database: Sized + Send {
         async { false }
     }
 
-    /// Get the root digest of the database for verification
+    /// Get the root digest of the database for verification.
+    ///
+    /// For databases where the public root differs from the ops root used for streaming
+    /// verification (e.g., `current`), this returns the **ops root**.
     fn root(&self) -> Self::Digest;
+
+    /// Returns the database's canonical (public) root digest.
+    ///
+    /// For most databases, the canonical root equals the ops root. For `current` databases,
+    /// the canonical root additionally commits to the activity bitmap and grafted tree state.
+    fn canonical_root(&self) -> Self::Digest {
+        self.root()
+    }
 }

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -73,17 +73,9 @@ pub trait Database: Sized + Send {
         async { false }
     }
 
-    /// Get the root digest of the database for verification.
-    ///
-    /// For databases where the public root differs from the ops root used for streaming
-    /// verification (e.g., `current`), this returns the **ops root**.
-    fn root(&self) -> Self::Digest;
+    /// Get the ops root digest used for streaming verification.
+    fn ops_root(&self) -> Self::Digest;
 
-    /// Returns the database's canonical (public) root digest.
-    ///
-    /// For most databases, the canonical root equals the ops root. For `current` databases,
-    /// the canonical root additionally commits to the activity bitmap and grafted tree state.
-    fn canonical_root(&self) -> Self::Digest {
-        self.root()
-    }
+    /// Get the database root digest.
+    fn root(&self) -> Self::Digest;
 }

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -1,6 +1,6 @@
 use crate::{
     merkle::{Family, Location},
-    qmdb::sync::Journal,
+    qmdb::sync::{Journal, Target},
     translator::Translator,
 };
 use commonware_cryptography::Digest;
@@ -64,12 +64,15 @@ pub trait Database: Sized + Send {
     /// on-disk database already reflects the target. Simple append-only variants may
     /// verify only the persisted tree size and root. Variants with additional
     /// pruning-dependent state should also ensure their persisted lower bound still
-    /// covers `target.range.start()`.
-    fn has_local_target_state(
+    /// covers `target.range().start()`.
+    fn has_local_target_state<T>(
         _context: Self::Context,
         _config: &Self::Config,
-        _target: &crate::qmdb::sync::Target<Self::Family, Self::Digest>,
-    ) -> impl Future<Output = bool> + Send {
+        _target: &T,
+    ) -> impl Future<Output = bool> + Send
+    where
+        T: Target<Family = Self::Family, Digest = Self::Digest>,
+    {
         async { false }
     }
 

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -820,6 +820,7 @@ where
             )
             .await?;
 
+            // Verify the final root digest matches the final target.
             let got_root = database.root();
             let expected_root = self.target.root;
             if got_root != expected_root {

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -44,11 +44,11 @@ type Error<DB, R> =
 
 /// Whether sync should continue or complete
 #[derive(Debug)]
-pub(crate) enum NextStep<C, D> {
+pub(crate) enum NextStep<C, D: Database> {
     /// Sync should continue with the updated client
     Continue(C),
-    /// Sync is complete with the final database
-    Complete(D),
+    /// Sync is complete with the final database and target
+    Complete(D, Target<D::Family, D::Digest>),
 }
 
 /// Events that can occur during synchronization
@@ -783,8 +783,8 @@ where
     /// 3. Handles different event types (target updates, fetch results)
     /// 4. Coordinates request scheduling and operation application
     ///
-    /// Returns `StepResult::Complete(database)` when sync is finished, or
-    /// `StepResult::Continue(self)` when more work remains.
+    /// Returns `NextStep::Complete(database, target)` when sync is finished, or
+    /// `NextStep::Continue(self)` when more work remains.
     pub(crate) async fn step(mut self) -> Result<NextStep<Self, DB>, Error<DB, R>> {
         self.drain_finish_requests()?;
 
@@ -826,17 +826,7 @@ where
                 }));
             }
 
-            if let Some(expected_canonical) = self.target.canonical_root {
-                let got_canonical = database.canonical_root();
-                if got_canonical != expected_canonical {
-                    return Err(SyncError::Engine(EngineError::CanonicalRootMismatch {
-                        expected: expected_canonical,
-                        actual: got_canonical,
-                    }));
-                }
-            }
-
-            return Ok(NextStep::Complete(database));
+            return Ok(NextStep::Complete(database, self.target));
         }
 
         // Wait for the next synchronization event
@@ -850,18 +840,26 @@ where
         self.handle_event(event).await
     }
 
-    /// Run sync to completion, returning the final database when done.
+    /// Run sync to completion, returning the final database and accepted target.
     ///
     /// This method repeatedly calls `step()` until sync is complete. The `step()` method
-    /// handles building the final database and verifying the root digest.
-    pub async fn sync(mut self) -> Result<DB, Error<DB, R>> {
+    /// handles building the final database and verifying the root digest. Returning the target lets
+    /// wrappers check any metadata they attach to target updates.
+    pub(crate) async fn sync_with_target(
+        mut self,
+    ) -> Result<(DB, Target<DB::Family, DB::Digest>), Error<DB, R>> {
         // Run sync loop until completion
         loop {
             match self.step().await? {
                 NextStep::Continue(new_engine) => self = new_engine,
-                NextStep::Complete(database) => return Ok(database),
+                NextStep::Complete(database, target) => return Ok((database, target)),
             }
         }
+    }
+
+    /// Run sync to completion, returning the final database.
+    pub async fn sync(self) -> Result<DB, Error<DB, R>> {
+        self.sync_with_target().await.map(|(database, _)| database)
     }
 }
 

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -455,7 +455,7 @@ where
             let old_target_size = self.target.range.end();
             assert!(
                 self.retained_roots
-                    .insert(old_target_size, self.target.root)
+                    .insert(old_target_size, self.target.ops_root)
                     .is_none(),
                 "duplicate retained root for tree size {old_target_size:?}"
             );
@@ -682,7 +682,7 @@ where
         // requests match a historical root that was explicitly retained.
         let is_current_target = request.target_size == self.target.range.end();
         let target_root = if is_current_target {
-            &self.target.root
+            &self.target.ops_root
         } else {
             let Some(root) = self.retained_roots.get(&request.target_size) else {
                 // No historical root to verify against (evicted or
@@ -820,7 +820,6 @@ where
             )
             .await?;
 
-            // Verify the final root digest matches the final target
             let got_root = database.root();
             let expected_root = self.target.root;
             if got_root != expected_root {

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -785,7 +785,11 @@ where
     ///
     /// Returns `NextStep::Complete(database, target)` when sync is finished, or
     /// `NextStep::Continue(self)` when more work remains.
-    pub(crate) async fn step(mut self) -> Result<NextStep<Self, DB>, Error<DB, R>> {
+    pub(crate) async fn step(self) -> Result<NextStep<Self, DB>, Error<DB, R>> {
+        Box::pin(Self::step_inner(self)).await
+    }
+
+    async fn step_inner(mut self) -> Result<NextStep<Self, DB>, Error<DB, R>> {
         self.drain_finish_requests()?;
 
         // Check if sync is complete
@@ -848,7 +852,6 @@ where
     pub(crate) async fn sync_with_target(
         mut self,
     ) -> Result<(DB, Target<DB::Family, DB::Digest>), Error<DB, R>> {
-        // Run sync loop until completion
         loop {
             match self.step().await? {
                 NextStep::Continue(new_engine) => self = new_engine,

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -826,6 +826,16 @@ where
                 }));
             }
 
+            if let Some(expected_canonical) = self.target.canonical_root {
+                let got_canonical = database.canonical_root();
+                if got_canonical != expected_canonical {
+                    return Err(SyncError::Engine(EngineError::CanonicalRootMismatch {
+                        expected: expected_canonical,
+                        actual: got_canonical,
+                    }));
+                }
+            }
+
             return Ok(NextStep::Complete(database));
         }
 

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -44,20 +44,20 @@ type Error<DB, R> =
 
 /// Whether sync should continue or complete
 #[derive(Debug)]
-pub(crate) enum NextStep<C, D: Database> {
+pub(crate) enum NextStep<C, D: Database, T: Target> {
     /// Sync should continue with the updated client
     Continue(C),
     /// Sync is complete with the final database and target
-    Complete(D, Target<D::Family, D::Digest>),
+    Complete(D, T),
 }
 
 /// Events that can occur during synchronization
 #[derive(Debug)]
-enum Event<F: Family, Op, D: Digest, E> {
+enum Event<T: Target, Op, E> {
     /// A target update was received
-    TargetUpdate(Target<F, D>),
+    TargetUpdate(T),
     /// A batch of operations was received
-    BatchReceived(IndexedFetchResult<F, Op, D, E>),
+    BatchReceived(IndexedFetchResult<T::Family, Op, T::Digest, E>),
     /// The target update channel was closed
     UpdateChannelClosed,
     /// A finish signal was received
@@ -105,11 +105,11 @@ pub(super) struct IndexedFetchResult<F: Family, Op, D: Digest, E> {
 
 /// Wait for the next synchronization event.
 /// Returns `None` when there are no outstanding requests and no channels to wait on.
-async fn wait_for_event<F: Family, Op, D: Digest, E>(
-    update_rx: &mut Option<mpsc::Receiver<Target<F, D>>>,
+async fn wait_for_event<T: Target, Op, E>(
+    update_rx: &mut Option<mpsc::Receiver<T>>,
     finish_rx: &mut Option<mpsc::Receiver<()>>,
-    outstanding_requests: &mut Requests<F, Op, D, E>,
-) -> Option<Event<F, Op, D, E>> {
+    outstanding_requests: &mut Requests<T::Family, Op, T::Digest, E>,
+) -> Option<Event<T, Op, E>> {
     if outstanding_requests.len() == 0 && update_rx.is_none() && finish_rx.is_none() {
         return None;
     }
@@ -142,10 +142,11 @@ async fn wait_for_event<F: Family, Op, D: Digest, E>(
 }
 
 /// Configuration for creating a new Engine
-pub struct Config<DB, R>
+pub struct Config<DB, R, T>
 where
     DB: Database,
     R: DbResolver<DB>,
+    T: Target<Family = DB::Family, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     /// Runtime context for creating database components
@@ -153,7 +154,7 @@ where
     /// Network resolver for fetching operations and proofs
     pub resolver: R,
     /// Sync target (root digest and operation bounds)
-    pub target: Target<DB::Family, DB::Digest>,
+    pub target: T,
     /// Maximum number of outstanding requests for operation batches
     pub max_outstanding_requests: usize,
     /// Maximum operations to fetch per batch
@@ -163,7 +164,7 @@ where
     /// Database-specific configuration
     pub db_config: DB::Config,
     /// Channel for receiving sync target updates
-    pub update_rx: Option<mpsc::Receiver<Target<DB::Family, DB::Digest>>>,
+    pub update_rx: Option<mpsc::Receiver<T>>,
     /// Channel that requests sync completion once the current target is reached.
     ///
     /// When `None`, sync completes as soon as the target is reached.
@@ -174,17 +175,18 @@ where
     /// When `reached_target_tx` is `Some(...)`, this receiver must be actively
     /// drained by the observer. The engine awaits send capacity on this channel before
     /// proceeding, so backpressure can pause progress at target.
-    pub reached_target_tx: Option<mpsc::Sender<Target<DB::Family, DB::Digest>>>,
+    pub reached_target_tx: Option<mpsc::Sender<T>>,
     /// Maximum number of previous roots to retain for verifying in-flight
     /// requests after target updates. Set to 0 to disable (all retained
     /// requests will be re-fetched).
     pub max_retained_roots: usize,
 }
 /// A shared sync engine that manages the core synchronization state and operations.
-pub(crate) struct Engine<DB, R>
+pub(crate) struct Engine<DB, R, T>
 where
     DB: Database,
     R: DbResolver<DB>,
+    T: Target<Family = DB::Family, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     /// Tracks outstanding fetch requests and their futures
@@ -219,7 +221,7 @@ where
     max_retained_roots: usize,
 
     /// The current sync target (root digest and operation bounds)
-    target: Target<DB::Family, DB::Digest>,
+    target: T,
 
     /// Maximum number of parallel outstanding requests
     max_outstanding_requests: usize,
@@ -246,7 +248,7 @@ where
     config: DB::Config,
 
     /// Optional receiver for target updates during sync
-    update_rx: Option<mpsc::Receiver<Target<DB::Family, DB::Digest>>>,
+    update_rx: Option<mpsc::Receiver<T>>,
 
     /// Channel that requests sync completion once the current target is reached.
     ///
@@ -259,7 +261,7 @@ where
     /// When `reached_target_tx` is `Some(...)`, this receiver must be actively
     /// drained by the observer. The engine awaits send capacity on this channel before
     /// proceeding, so backpressure can pause progress at target.
-    reached_target_tx: Option<mpsc::Sender<Target<DB::Family, DB::Digest>>>,
+    reached_target_tx: Option<mpsc::Sender<T>>,
 
     /// Progress gauges updated after target updates and batch application.
     progress_metrics: ProgressMetrics,
@@ -272,10 +274,11 @@ where
 }
 
 #[cfg(test)]
-impl<DB, R> Engine<DB, R>
+impl<DB, R, T> Engine<DB, R, T>
 where
     DB: Database,
     R: DbResolver<DB>,
+    T: Target<Family = DB::Family, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     pub(crate) fn journal(&self) -> &DB::Journal {
@@ -283,24 +286,25 @@ where
     }
 }
 
-impl<DB, R> Engine<DB, R>
+impl<DB, R, T> Engine<DB, R, T>
 where
     DB: Database,
     R: DbResolver<DB>,
+    T: Target<Family = DB::Family, Digest = DB::Digest>,
     DB::Op: Encode,
 {
     /// Create a new sync engine with the given configuration
-    pub async fn new(config: Config<DB, R>) -> Result<Self, Error<DB, R>> {
-        if !config.target.range.end().is_valid() {
+    pub async fn new(config: Config<DB, R, T>) -> Result<Self, Error<DB, R>> {
+        if !config.target.range().end().is_valid() {
             return Err(SyncError::Engine(EngineError::InvalidTarget {
-                lower_bound_pos: config.target.range.start(),
-                upper_bound_pos: config.target.range.end(),
+                lower_bound_pos: config.target.range().start(),
+                upper_bound_pos: config.target.range().end(),
             }));
         }
 
         // Probe for persisted local state matching the target before opening
         // any engine-owned handles.
-        let local_target_state_available = if config.target.range.start() > Location::new(0) {
+        let local_target_state_available = if config.target.range().start() > Location::new(0) {
             DB::has_local_target_state(
                 config.context.child("local_target_probe"),
                 &config.db_config,
@@ -315,7 +319,7 @@ where
         let journal = <DB::Journal as Journal<DB::Family>>::new(
             config.context.child("journal"),
             config.db_config.journal_config(),
-            config.target.range.clone(),
+            config.target.range().clone(),
         )
         .await?;
 
@@ -352,16 +356,16 @@ where
 
     /// Schedule new fetch requests for operations in the sync range that we haven't yet fetched.
     async fn schedule_requests(&mut self) -> Result<(), Error<DB, R>> {
-        let target_size = self.target.range.end();
+        let target_size = self.target.range().end();
 
         // Schedule a pinned-nodes request at the lower sync bound if we don't
         // have boundary state yet and one isn't already in flight.
         if !self.has_boundary_state()
             && !self
                 .outstanding_requests
-                .contains(&self.target.range.start())
+                .contains(&self.target.range().start())
         {
-            let start_loc = self.target.range.start();
+            let start_loc = self.target.range().start();
             let resolver = self.resolver.clone();
             let (cancel_tx, cancel_rx) = oneshot::channel();
             let id = self.outstanding_requests.next_id();
@@ -396,7 +400,7 @@ where
 
             // Find the next gap in the sync range that needs to be fetched.
             let Some(gap_range) = crate::qmdb::sync::gaps::find_next(
-                Location::new(log_size)..self.target.range.end(),
+                Location::new(log_size)..self.target.range().end(),
                 &operation_counts,
                 self.outstanding_requests.locations(),
                 self.fetch_batch_size,
@@ -436,15 +440,12 @@ where
     /// start. Requests at or after the new start are retained; their proofs
     /// will be verified against the saved historical root (see
     /// `retained_roots`) so the fetched operations can still be used.
-    pub async fn reset_for_target_update(
-        mut self,
-        new_target: Target<DB::Family, DB::Digest>,
-    ) -> Result<Self, Error<DB, R>> {
-        self.journal.resize(new_target.range.start()).await?;
+    pub async fn reset_for_target_update(mut self, new_target: T) -> Result<Self, Error<DB, R>> {
+        self.journal.resize(new_target.range().start()).await?;
         // Remove requests at or before the new start. The request at start
         // must be re-issued as a pinned-nodes request with the new target size.
         self.outstanding_requests
-            .remove_before(new_target.range.start().checked_add(1).unwrap());
+            .remove_before(new_target.range().start().checked_add(1).unwrap());
         self.fetched_operations.clear();
         self.pinned_nodes = None;
         self.local_target_state_available = false;
@@ -452,10 +453,10 @@ where
         // Save the current root keyed by its tree size for verifying
         // retained requests that were issued against this target.
         if self.max_retained_roots > 0 {
-            let old_target_size = self.target.range.end();
+            let old_target_size = self.target.range().end();
             assert!(
                 self.retained_roots
-                    .insert(old_target_size, self.target.ops_root)
+                    .insert(old_target_size, self.target.ops_root())
                     .is_none(),
                 "duplicate retained root for tree size {old_target_size:?}"
             );
@@ -524,7 +525,7 @@ where
     /// Record a progress snapshot in metrics.
     async fn record_progress(&self) {
         self.progress_metrics
-            .record(self.journal.size().await, *self.target.range.end());
+            .record(self.journal.size().await, *self.target.range().end());
     }
 
     /// Store a batch of fetched operations. If the input list is empty, this is a no-op.
@@ -607,7 +608,7 @@ where
     /// Check if sync is complete based on the current journal size and target
     pub async fn is_at_target(&self) -> Result<bool, Error<DB, R>> {
         let journal_size = self.journal.size().await;
-        let target_journal_size = self.target.range.end();
+        let target_journal_size = self.target.range().end();
 
         // Check if we've completed sync
         if journal_size >= target_journal_size {
@@ -623,7 +624,7 @@ where
 
     /// Returns whether this target needs pinned boundary nodes to reconstruct pruned state.
     fn needs_pinned_boundary(&self) -> bool {
-        self.target.range.start() > Location::new(0)
+        self.target.range().start() > Location::new(0)
     }
 
     /// Returns whether the current target has the boundary state needed for completion.
@@ -677,12 +678,14 @@ where
             return Ok(());
         }
 
-        // Look up the root to verify against using the tree size the request
+        // Look up the ops-tree proof root using the tree size the request
         // asked for. Fresh requests match the current target; retained
         // requests match a historical root that was explicitly retained.
-        let is_current_target = request.target_size == self.target.range.end();
-        let target_root = if is_current_target {
-            &self.target.ops_root
+        let is_current_target = request.target_size == self.target.range().end();
+        let current_ops_root;
+        let proof_root = if is_current_target {
+            current_ops_root = self.target.ops_root();
+            &current_ops_root
         } else {
             let Some(root) = self.retained_roots.get(&request.target_size) else {
                 // No historical root to verify against (evicted or
@@ -704,7 +707,7 @@ where
         let need_pinned = is_current_target
             && self.pinned_nodes.is_none()
             && !self.local_target_state_available
-            && start_loc == self.target.range.start();
+            && start_loc == self.target.range().start();
         let elements = operations.iter().map(|op| op.encode()).collect::<Vec<_>>();
         let valid = if need_pinned {
             let nodes = pinned_nodes.as_deref().unwrap_or(&[]);
@@ -713,10 +716,10 @@ where
                 &elements,
                 start_loc,
                 nodes,
-                target_root,
+                proof_root,
             )
         } else {
-            proof.verify_range_inclusion(&self.hasher, &elements, start_loc, target_root)
+            proof.verify_range_inclusion(&self.hasher, &elements, start_loc, proof_root)
         };
 
         // Report success or failure to the resolver.
@@ -745,8 +748,8 @@ where
     /// Handle a sync event and return the next engine state.
     async fn handle_event(
         mut self,
-        event: Event<DB::Family, DB::Op, DB::Digest, R::Error>,
-    ) -> Result<NextStep<Self, DB>, Error<DB, R>> {
+        event: Event<T, DB::Op, R::Error>,
+    ) -> Result<NextStep<Self, DB, T>, Error<DB, R>> {
         match event {
             Event::TargetUpdate(new_target) => {
                 validate_update(&self.target, &new_target)?;
@@ -785,11 +788,11 @@ where
     ///
     /// Returns `NextStep::Complete(database, target)` when sync is finished, or
     /// `NextStep::Continue(self)` when more work remains.
-    pub(crate) async fn step(self) -> Result<NextStep<Self, DB>, Error<DB, R>> {
+    pub(crate) async fn step(self) -> Result<NextStep<Self, DB, T>, Error<DB, R>> {
         Box::pin(Self::step_inner(self)).await
     }
 
-    async fn step_inner(mut self) -> Result<NextStep<Self, DB>, Error<DB, R>> {
+    async fn step_inner(mut self) -> Result<NextStep<Self, DB, T>, Error<DB, R>> {
         self.drain_finish_requests()?;
 
         // Check if sync is complete
@@ -815,14 +818,14 @@ where
                 self.config,
                 self.journal,
                 self.pinned_nodes,
-                self.target.range.clone(),
+                self.target.range().clone(),
                 self.apply_batch_size,
             )
             .await?;
 
             // Verify the final root digest matches the final target.
             let got_root = database.root();
-            let expected_root = self.target.root;
+            let expected_root = self.target.root();
             if got_root != expected_root {
                 return Err(SyncError::Engine(EngineError::RootMismatch {
                     expected: expected_root,
@@ -849,9 +852,7 @@ where
     /// This method repeatedly calls `step()` until sync is complete. The `step()` method
     /// handles building the final database and verifying the root digest. Returning the target lets
     /// wrappers check any metadata they attach to target updates.
-    pub(crate) async fn sync_with_target(
-        mut self,
-    ) -> Result<(DB, Target<DB::Family, DB::Digest>), Error<DB, R>> {
+    pub(crate) async fn sync_with_target(mut self) -> Result<(DB, T), Error<DB, R>> {
         loop {
             match self.step().await? {
                 NextStep::Continue(new_engine) => self = new_engine,

--- a/storage/src/qmdb/sync/error.rs
+++ b/storage/src/qmdb/sync/error.rs
@@ -53,6 +53,12 @@ pub enum EngineError<F: Family, D: Digest> {
     /// Error extracting pinned nodes
     #[error("error extracting pinned nodes: {0}")]
     PinnedNodes(String),
+    /// Ops root witness failed verification against the trusted canonical root
+    #[error("ops root witness failed verification")]
+    OpsRootWitnessInvalid,
+    /// Canonical root mismatch after sync
+    #[error("canonical root mismatch - expected {expected:?}, got {actual:?}")]
+    CanonicalRootMismatch { expected: D, actual: D },
 }
 
 /// Errors that can occur during database synchronization.

--- a/storage/src/qmdb/sync/error.rs
+++ b/storage/src/qmdb/sync/error.rs
@@ -8,7 +8,7 @@ use commonware_cryptography::Digest;
 
 #[derive(Debug, thiserror::Error)]
 pub enum EngineError<F: Family, D: Digest> {
-    /// Hash mismatch after sync
+    /// Database root mismatch after sync.
     #[error("root digest mismatch - expected {expected:?}, got {actual:?}")]
     RootMismatch { expected: D, actual: D },
     /// Compact proof did not verify against the requested root.
@@ -53,12 +53,9 @@ pub enum EngineError<F: Family, D: Digest> {
     /// Error extracting pinned nodes
     #[error("error extracting pinned nodes: {0}")]
     PinnedNodes(String),
-    /// Ops root witness failed verification against the trusted canonical root
+    /// Witness for the `ops_root` failed verification against the root commitment.
     #[error("ops root witness failed verification")]
     OpsRootWitnessInvalid,
-    /// Canonical root mismatch after sync
-    #[error("canonical root mismatch - expected {expected:?}, got {actual:?}")]
-    CanonicalRootMismatch { expected: D, actual: D },
 }
 
 /// Errors that can occur during database synchronization.

--- a/storage/src/qmdb/sync/error.rs
+++ b/storage/src/qmdb/sync/error.rs
@@ -1,10 +1,8 @@
 //! Shared sync error types that can be used across different database implementations.
 
-use crate::{
-    merkle::{Family, Location},
-    qmdb::sync::Target,
-};
+use crate::merkle::{Family, Location};
 use commonware_cryptography::Digest;
+use commonware_utils::range::NonEmptyRange;
 
 #[derive(Debug, thiserror::Error)]
 pub enum EngineError<F: Family, D: Digest> {
@@ -38,8 +36,8 @@ pub enum EngineError<F: Family, D: Digest> {
     /// Sync target moved backward
     #[error("sync target moved backward: {old:?} -> {new:?}")]
     SyncTargetMovedBackward {
-        old: Target<F, D>,
-        new: Target<F, D>,
+        old: NonEmptyRange<Location<F>>,
+        new: NonEmptyRange<Location<F>>,
     },
     /// Sync already completed
     #[error("sync already completed")]

--- a/storage/src/qmdb/sync/mod.rs
+++ b/storage/src/qmdb/sync/mod.rs
@@ -50,5 +50,5 @@ where
     DB::Op: Encode,
     R: DbResolver<DB>,
 {
-    Engine::new(config).await?.sync().await
+    Box::pin(Engine::new(config).await?.sync()).await
 }

--- a/storage/src/qmdb/sync/mod.rs
+++ b/storage/src/qmdb/sync/mod.rs
@@ -50,5 +50,5 @@ where
     DB::Op: Encode,
     R: DbResolver<DB>,
 {
-    Box::pin(Engine::new(config).await?.sync()).await
+    Engine::new(config).await?.sync().await
 }

--- a/storage/src/qmdb/sync/mod.rs
+++ b/storage/src/qmdb/sync/mod.rs
@@ -20,6 +20,9 @@ pub(crate) use database::{Config as DatabaseConfig, Database};
 pub mod resolver;
 pub(crate) use resolver::{FetchResult, Resolver};
 
+#[cfg(test)]
+pub(crate) mod tests;
+
 mod target;
 pub use target::Target;
 
@@ -42,13 +45,14 @@ where
 }
 
 /// Create/open a database and sync it to a target state
-pub async fn sync<DB, R>(
-    config: Config<DB, R>,
+pub async fn sync<DB, R, T>(
+    config: Config<DB, R, T>,
 ) -> Result<DB, Error<DB::Family, R::Error, DB::Digest>>
 where
     DB: Database,
     DB::Op: Encode,
     R: DbResolver<DB>,
+    T: Target<Family = DB::Family, Digest = DB::Digest>,
 {
     Engine::new(config).await?.sync().await
 }

--- a/storage/src/qmdb/sync/target.rs
+++ b/storage/src/qmdb/sync/target.rs
@@ -15,12 +15,7 @@ use commonware_utils::range::NonEmptyRange;
 pub struct Target<F: Family, D: Digest> {
     /// The ops root the sync engine verifies streaming batches against.
     pub root: D,
-    /// The canonical (public) root, if it differs from the ops root.
-    ///
-    /// For `current` databases, this is the full canonical root that additionally commits
-    /// to the activity bitmap. For other database types, leave this as `None`.
-    pub canonical_root: Option<D>,
-    /// Range of operations to sync.
+    /// Range of operations to sync
     pub range: NonEmptyRange<Location<F>>,
 }
 
@@ -28,7 +23,6 @@ impl<F: Family, D: Digest> Clone for Target<F, D> {
     fn clone(&self) -> Self {
         Self {
             root: self.root,
-            canonical_root: self.canonical_root,
             range: self.range.clone(),
         }
     }
@@ -36,9 +30,7 @@ impl<F: Family, D: Digest> Clone for Target<F, D> {
 
 impl<F: Family, D: Digest> PartialEq for Target<F, D> {
     fn eq(&self, other: &Self) -> bool {
-        self.root == other.root
-            && self.canonical_root == other.canonical_root
-            && self.range == other.range
+        self.root == other.root && self.range == other.range
     }
 }
 
@@ -47,14 +39,13 @@ impl<F: Family, D: Digest> Eq for Target<F, D> {}
 impl<F: Family, D: Digest> Write for Target<F, D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.root.write(buf);
-        self.canonical_root.write(buf);
         self.range.write(buf);
     }
 }
 
 impl<F: Family, D: Digest> EncodeSize for Target<F, D> {
     fn encode_size(&self) -> usize {
-        self.root.encode_size() + self.canonical_root.encode_size() + self.range.encode_size()
+        self.root.encode_size() + self.range.encode_size()
     }
 }
 
@@ -63,7 +54,6 @@ impl<F: Family, D: Digest> Read for Target<F, D> {
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let root = D::read(buf)?;
-        let canonical_root = Option::<D>::read(buf)?;
         let range = NonEmptyRange::<Location<F>>::read(buf)?;
         if !range.start().is_valid() || !range.end().is_valid() {
             return Err(CodecError::Invalid(
@@ -71,11 +61,7 @@ impl<F: Family, D: Digest> Read for Target<F, D> {
                 "range bounds out of valid range",
             ));
         }
-        Ok(Self {
-            root,
-            canonical_root,
-            range,
-        })
+        Ok(Self { root, range })
     }
 }
 
@@ -91,7 +77,6 @@ where
         let upper = u.int_in_range(lower + 1..=*max_loc)?;
         Ok(Self {
             root,
-            canonical_root: None,
             range: commonware_utils::non_empty_range!(Location::new(lower), Location::new(upper)),
         })
     }
@@ -149,7 +134,6 @@ mod tests {
     fn target(root: sha256::Digest, start: u64, end: u64) -> Target<MmrFamily, sha256::Digest> {
         Target {
             root,
-            canonical_root: None,
             range: non_empty_range!(Location::new(start), Location::new(end)),
         }
     }
@@ -177,10 +161,9 @@ mod tests {
 
     #[test]
     fn test_sync_target_read_invalid_bounds() {
-        // Manually encode root + canonical_root + two Locations to bypass the Range write panic
+        // Manually encode root + two Locations to bypass the Range write panic
         let mut buffer = Vec::new();
         sha256::Digest::from([42; 32]).write(&mut buffer);
-        Option::<sha256::Digest>::None.write(&mut buffer);
         Location::<MmrFamily>::new(100).write(&mut buffer); // start
         Location::<MmrFamily>::new(50).write(&mut buffer); // end (< start = invalid)
 
@@ -194,7 +177,6 @@ mod tests {
         let root = sha256::Digest::from([42; 32]);
         let mut buffer = Vec::new();
         root.write(&mut buffer);
-        Option::<sha256::Digest>::None.write(&mut buffer);
         (Location::<MmrFamily>::new(100)..Location::<MmrFamily>::new(100)).write(&mut buffer);
 
         let mut cursor = Cursor::new(buffer);

--- a/storage/src/qmdb/sync/target.rs
+++ b/storage/src/qmdb/sync/target.rs
@@ -15,9 +15,9 @@ use commonware_utils::range::NonEmptyRange;
 pub struct Target<F: Family, D: Digest> {
     /// The database root expected after sync completes.
     pub root: D,
-    /// The ops root the sync engine verifies streaming batches against.
+    /// The ops root used to verify range proofs.
     pub ops_root: D,
-    /// Range of operations to sync
+    /// Range of operations to sync.
     pub range: NonEmptyRange<Location<F>>,
 }
 

--- a/storage/src/qmdb/sync/target.rs
+++ b/storage/src/qmdb/sync/target.rs
@@ -13,8 +13,10 @@ use commonware_utils::range::NonEmptyRange;
 /// them.
 #[derive(Debug)]
 pub struct Target<F: Family, D: Digest> {
-    /// The ops root the sync engine verifies streaming batches against.
+    /// The database root expected after sync completes.
     pub root: D,
+    /// The ops root the sync engine verifies streaming batches against.
+    pub ops_root: D,
     /// Range of operations to sync
     pub range: NonEmptyRange<Location<F>>,
 }
@@ -23,6 +25,7 @@ impl<F: Family, D: Digest> Clone for Target<F, D> {
     fn clone(&self) -> Self {
         Self {
             root: self.root,
+            ops_root: self.ops_root,
             range: self.range.clone(),
         }
     }
@@ -30,7 +33,7 @@ impl<F: Family, D: Digest> Clone for Target<F, D> {
 
 impl<F: Family, D: Digest> PartialEq for Target<F, D> {
     fn eq(&self, other: &Self) -> bool {
-        self.root == other.root && self.range == other.range
+        self.root == other.root && self.ops_root == other.ops_root && self.range == other.range
     }
 }
 
@@ -39,13 +42,14 @@ impl<F: Family, D: Digest> Eq for Target<F, D> {}
 impl<F: Family, D: Digest> Write for Target<F, D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.root.write(buf);
+        self.ops_root.write(buf);
         self.range.write(buf);
     }
 }
 
 impl<F: Family, D: Digest> EncodeSize for Target<F, D> {
     fn encode_size(&self) -> usize {
-        self.root.encode_size() + self.range.encode_size()
+        self.root.encode_size() + self.ops_root.encode_size() + self.range.encode_size()
     }
 }
 
@@ -54,6 +58,7 @@ impl<F: Family, D: Digest> Read for Target<F, D> {
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let root = D::read(buf)?;
+        let ops_root = D::read(buf)?;
         let range = NonEmptyRange::<Location<F>>::read(buf)?;
         if !range.start().is_valid() || !range.end().is_valid() {
             return Err(CodecError::Invalid(
@@ -61,7 +66,11 @@ impl<F: Family, D: Digest> Read for Target<F, D> {
                 "range bounds out of valid range",
             ));
         }
-        Ok(Self { root, range })
+        Ok(Self {
+            root,
+            ops_root,
+            range,
+        })
     }
 }
 
@@ -72,11 +81,13 @@ where
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         let root = u.arbitrary()?;
+        let ops_root = u.arbitrary()?;
         let max_loc = F::MAX_LEAVES;
         let lower = u.int_in_range(0..=*max_loc - 1)?;
         let upper = u.int_in_range(lower + 1..=*max_loc)?;
         Ok(Self {
             root,
+            ops_root,
             range: commonware_utils::non_empty_range!(Location::new(lower), Location::new(upper)),
         })
     }
@@ -111,7 +122,7 @@ where
         }));
     }
 
-    if new_target.root == old_target.root {
+    if new_target.ops_root == old_target.ops_root {
         return Err(sync::Error::Engine(EngineError::SyncTargetRootUnchanged));
     }
 
@@ -131,9 +142,10 @@ mod tests {
     use rstest::rstest;
     use std::io::Cursor;
 
-    fn target(root: sha256::Digest, start: u64, end: u64) -> Target<MmrFamily, sha256::Digest> {
+    fn target(ops_root: sha256::Digest, start: u64, end: u64) -> Target<MmrFamily, sha256::Digest> {
         Target {
-            root,
+            root: ops_root,
+            ops_root,
             range: non_empty_range!(Location::new(start), Location::new(end)),
         }
     }
@@ -156,13 +168,15 @@ mod tests {
         // Verify
         assert_eq!(target, deserialized);
         assert_eq!(target.root, deserialized.root);
+        assert_eq!(target.ops_root, deserialized.ops_root);
         assert_eq!(target.range, deserialized.range);
     }
 
     #[test]
     fn test_sync_target_read_invalid_bounds() {
-        // Manually encode root + two Locations to bypass the Range write panic
+        // Manually encode root + ops root + two Locations to bypass the Range write panic
         let mut buffer = Vec::new();
+        sha256::Digest::from([42; 32]).write(&mut buffer);
         sha256::Digest::from([42; 32]).write(&mut buffer);
         Location::<MmrFamily>::new(100).write(&mut buffer); // start
         Location::<MmrFamily>::new(50).write(&mut buffer); // end (< start = invalid)
@@ -176,6 +190,7 @@ mod tests {
         // Manually encode a target with an empty range (start == end)
         let root = sha256::Digest::from([42; 32]);
         let mut buffer = Vec::new();
+        root.write(&mut buffer);
         root.write(&mut buffer);
         (Location::<MmrFamily>::new(100)..Location::<MmrFamily>::new(100)).write(&mut buffer);
 

--- a/storage/src/qmdb/sync/target.rs
+++ b/storage/src/qmdb/sync/target.rs
@@ -15,7 +15,12 @@ use commonware_utils::range::NonEmptyRange;
 pub struct Target<F: Family, D: Digest> {
     /// The ops root the sync engine verifies streaming batches against.
     pub root: D,
-    /// Range of operations to sync
+    /// The canonical (public) root, if it differs from the ops root.
+    ///
+    /// For `current` databases, this is the full canonical root that additionally commits
+    /// to the activity bitmap. For other database types, leave this as `None`.
+    pub canonical_root: Option<D>,
+    /// Range of operations to sync.
     pub range: NonEmptyRange<Location<F>>,
 }
 
@@ -23,6 +28,7 @@ impl<F: Family, D: Digest> Clone for Target<F, D> {
     fn clone(&self) -> Self {
         Self {
             root: self.root,
+            canonical_root: self.canonical_root,
             range: self.range.clone(),
         }
     }
@@ -30,7 +36,9 @@ impl<F: Family, D: Digest> Clone for Target<F, D> {
 
 impl<F: Family, D: Digest> PartialEq for Target<F, D> {
     fn eq(&self, other: &Self) -> bool {
-        self.root == other.root && self.range == other.range
+        self.root == other.root
+            && self.canonical_root == other.canonical_root
+            && self.range == other.range
     }
 }
 
@@ -39,13 +47,14 @@ impl<F: Family, D: Digest> Eq for Target<F, D> {}
 impl<F: Family, D: Digest> Write for Target<F, D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.root.write(buf);
+        self.canonical_root.write(buf);
         self.range.write(buf);
     }
 }
 
 impl<F: Family, D: Digest> EncodeSize for Target<F, D> {
     fn encode_size(&self) -> usize {
-        self.root.encode_size() + self.range.encode_size()
+        self.root.encode_size() + self.canonical_root.encode_size() + self.range.encode_size()
     }
 }
 
@@ -54,6 +63,7 @@ impl<F: Family, D: Digest> Read for Target<F, D> {
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let root = D::read(buf)?;
+        let canonical_root = Option::<D>::read(buf)?;
         let range = NonEmptyRange::<Location<F>>::read(buf)?;
         if !range.start().is_valid() || !range.end().is_valid() {
             return Err(CodecError::Invalid(
@@ -61,7 +71,11 @@ impl<F: Family, D: Digest> Read for Target<F, D> {
                 "range bounds out of valid range",
             ));
         }
-        Ok(Self { root, range })
+        Ok(Self {
+            root,
+            canonical_root,
+            range,
+        })
     }
 }
 
@@ -77,6 +91,7 @@ where
         let upper = u.int_in_range(lower + 1..=*max_loc)?;
         Ok(Self {
             root,
+            canonical_root: None,
             range: commonware_utils::non_empty_range!(Location::new(lower), Location::new(upper)),
         })
     }
@@ -134,6 +149,7 @@ mod tests {
     fn target(root: sha256::Digest, start: u64, end: u64) -> Target<MmrFamily, sha256::Digest> {
         Target {
             root,
+            canonical_root: None,
             range: non_empty_range!(Location::new(start), Location::new(end)),
         }
     }
@@ -161,9 +177,10 @@ mod tests {
 
     #[test]
     fn test_sync_target_read_invalid_bounds() {
-        // Manually encode root + two Locations to bypass the Range write panic
+        // Manually encode root + canonical_root + two Locations to bypass the Range write panic
         let mut buffer = Vec::new();
         sha256::Digest::from([42; 32]).write(&mut buffer);
+        Option::<sha256::Digest>::None.write(&mut buffer);
         Location::<MmrFamily>::new(100).write(&mut buffer); // start
         Location::<MmrFamily>::new(50).write(&mut buffer); // end (< start = invalid)
 
@@ -177,6 +194,7 @@ mod tests {
         let root = sha256::Digest::from([42; 32]);
         let mut buffer = Vec::new();
         root.write(&mut buffer);
+        Option::<sha256::Digest>::None.write(&mut buffer);
         (Location::<MmrFamily>::new(100)..Location::<MmrFamily>::new(100)).write(&mut buffer);
 
         let mut cursor = Cursor::new(buffer);

--- a/storage/src/qmdb/sync/target.rs
+++ b/storage/src/qmdb/sync/target.rs
@@ -2,127 +2,56 @@ use crate::{
     merkle::{Family, Location},
     qmdb::sync::{self, error::EngineError},
 };
-use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
 use commonware_cryptography::Digest;
-use commonware_runtime::{Buf, BufMut};
 use commonware_utils::range::NonEmptyRange;
+use std::fmt::Debug;
 
 /// Target state to sync to.
-///
-/// `PartialEq`, `Eq`, and `Clone` are implemented manually to avoid requiring `F` to implement
-/// them.
-#[derive(Debug)]
-pub struct Target<F: Family, D: Digest> {
-    /// The database root expected after sync completes.
-    pub root: D,
-    /// The ops root used to verify range proofs.
-    pub ops_root: D,
+pub trait Target: Clone + Debug + Send + Sync + 'static {
+    /// Merkle family used by the target range.
+    type Family: Family;
+    /// Root digest type.
+    type Digest: Digest;
+
+    /// Database root expected after sync completes.
+    fn root(&self) -> Self::Digest;
+
+    /// Operation root used to verify range proofs.
+    fn ops_root(&self) -> Self::Digest;
+
     /// Range of operations to sync.
-    pub range: NonEmptyRange<Location<F>>,
+    fn range(&self) -> &NonEmptyRange<Location<Self::Family>>;
 }
 
-impl<F: Family, D: Digest> Clone for Target<F, D> {
-    fn clone(&self) -> Self {
-        Self {
-            root: self.root,
-            ops_root: self.ops_root,
-            range: self.range.clone(),
-        }
-    }
-}
-
-impl<F: Family, D: Digest> PartialEq for Target<F, D> {
-    fn eq(&self, other: &Self) -> bool {
-        self.root == other.root && self.ops_root == other.ops_root && self.range == other.range
-    }
-}
-
-impl<F: Family, D: Digest> Eq for Target<F, D> {}
-
-impl<F: Family, D: Digest> Write for Target<F, D> {
-    fn write(&self, buf: &mut impl BufMut) {
-        self.root.write(buf);
-        self.ops_root.write(buf);
-        self.range.write(buf);
-    }
-}
-
-impl<F: Family, D: Digest> EncodeSize for Target<F, D> {
-    fn encode_size(&self) -> usize {
-        self.root.encode_size() + self.ops_root.encode_size() + self.range.encode_size()
-    }
-}
-
-impl<F: Family, D: Digest> Read for Target<F, D> {
-    type Cfg = ();
-
-    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
-        let root = D::read(buf)?;
-        let ops_root = D::read(buf)?;
-        let range = NonEmptyRange::<Location<F>>::read(buf)?;
-        if !range.start().is_valid() || !range.end().is_valid() {
-            return Err(CodecError::Invalid(
-                "storage::qmdb::sync::Target",
-                "range bounds out of valid range",
-            ));
-        }
-        Ok(Self {
-            root,
-            ops_root,
-            range,
-        })
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<F: Family, D: Digest> arbitrary::Arbitrary<'_> for Target<F, D>
+/// Validate a target update against the current target.
+pub fn validate_update<T, U>(
+    old_target: &T,
+    new_target: &T,
+) -> Result<(), sync::Error<T::Family, U, T::Digest>>
 where
-    D: for<'a> arbitrary::Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        let root = u.arbitrary()?;
-        let ops_root = u.arbitrary()?;
-        let max_loc = F::MAX_LEAVES;
-        let lower = u.int_in_range(0..=*max_loc - 1)?;
-        let upper = u.int_in_range(lower + 1..=*max_loc)?;
-        Ok(Self {
-            root,
-            ops_root,
-            range: commonware_utils::non_empty_range!(Location::new(lower), Location::new(upper)),
-        })
-    }
-}
-
-/// Validate a target update against the current target
-pub fn validate_update<F, U, D>(
-    old_target: &Target<F, D>,
-    new_target: &Target<F, D>,
-) -> Result<(), sync::Error<F, U, D>>
-where
-    F: Family,
+    T: Target,
     U: std::error::Error + Send + 'static,
-    D: Digest,
 {
-    if !new_target.range.end().is_valid() {
+    if !new_target.range().end().is_valid() {
         return Err(sync::Error::Engine(EngineError::InvalidTarget {
-            lower_bound_pos: new_target.range.start(),
-            upper_bound_pos: new_target.range.end(),
+            lower_bound_pos: new_target.range().start(),
+            upper_bound_pos: new_target.range().end(),
         }));
     }
 
     // Start must not decrease; end must strictly increase. Same end implies same tree size implies
     // same root (the Merkle structure is append-only), so retaining the old root under the old tree
     // size in `retained_roots` requires a distinct end.
-    if new_target.range.start() < old_target.range.start()
-        || new_target.range.end() <= old_target.range.end()
+    if new_target.range().start() < old_target.range().start()
+        || new_target.range().end() <= old_target.range().end()
     {
         return Err(sync::Error::Engine(EngineError::SyncTargetMovedBackward {
-            old: old_target.clone(),
-            new: new_target.clone(),
+            old: old_target.range().clone(),
+            new: new_target.range().clone(),
         }));
     }
 
-    if new_target.ops_root == old_target.ops_root {
+    if new_target.ops_root() == old_target.ops_root() {
         return Err(sync::Error::Engine(EngineError::SyncTargetRootUnchanged));
     }
 
@@ -130,75 +59,46 @@ where
 }
 
 #[cfg(test)]
-// Only `MmrFamily` is exercised here: `Target`'s codec and `validate_update` logic are
-// family-agnostic (the family only influences `Location::is_valid` via `F::MAX_LEAVES` and
-// the `arbitrary` range picker), so an MMB variant would duplicate coverage without catching
-// anything new.
+// Only `MmrFamily` is exercised here: `validate_update` logic is family-agnostic (the family
+// only influences `Location::is_valid` via `F::MAX_LEAVES`), so an MMB variant would duplicate
+// coverage without catching anything new.
 mod tests {
     use super::*;
     use crate::merkle::mmr::Family as MmrFamily;
     use commonware_cryptography::sha256;
     use commonware_utils::non_empty_range;
     use rstest::rstest;
-    use std::io::Cursor;
 
-    fn target(ops_root: sha256::Digest, start: u64, end: u64) -> Target<MmrFamily, sha256::Digest> {
-        Target {
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct TestTarget {
+        root: sha256::Digest,
+        ops_root: sha256::Digest,
+        range: NonEmptyRange<Location<MmrFamily>>,
+    }
+
+    impl Target for TestTarget {
+        type Family = MmrFamily;
+        type Digest = sha256::Digest;
+
+        fn root(&self) -> Self::Digest {
+            self.root
+        }
+
+        fn ops_root(&self) -> Self::Digest {
+            self.ops_root
+        }
+
+        fn range(&self) -> &NonEmptyRange<Location<Self::Family>> {
+            &self.range
+        }
+    }
+
+    fn target(ops_root: sha256::Digest, start: u64, end: u64) -> TestTarget {
+        TestTarget {
             root: ops_root,
             ops_root,
             range: non_empty_range!(Location::new(start), Location::new(end)),
         }
-    }
-
-    #[test]
-    fn test_sync_target_serialization() {
-        let target = target(sha256::Digest::from([42; 32]), 100, 500);
-
-        // Serialize
-        let mut buffer = Vec::new();
-        target.write(&mut buffer);
-
-        // Verify encoded size matches actual size
-        assert_eq!(buffer.len(), target.encode_size());
-
-        // Deserialize
-        let mut cursor = Cursor::new(buffer);
-        let deserialized = Target::read(&mut cursor).unwrap();
-
-        // Verify
-        assert_eq!(target, deserialized);
-        assert_eq!(target.root, deserialized.root);
-        assert_eq!(target.ops_root, deserialized.ops_root);
-        assert_eq!(target.range, deserialized.range);
-    }
-
-    #[test]
-    fn test_sync_target_read_invalid_bounds() {
-        // Manually encode root + ops root + two Locations to bypass the Range write panic
-        let mut buffer = Vec::new();
-        sha256::Digest::from([42; 32]).write(&mut buffer);
-        sha256::Digest::from([42; 32]).write(&mut buffer);
-        Location::<MmrFamily>::new(100).write(&mut buffer); // start
-        Location::<MmrFamily>::new(50).write(&mut buffer); // end (< start = invalid)
-
-        let mut cursor = Cursor::new(buffer);
-        assert!(matches!(
-            Target::<MmrFamily, sha256::Digest>::read(&mut cursor),
-            Err(CodecError::Invalid("Range", "start must be <= end"))
-        ));
-
-        // Manually encode a target with an empty range (start == end)
-        let root = sha256::Digest::from([42; 32]);
-        let mut buffer = Vec::new();
-        root.write(&mut buffer);
-        root.write(&mut buffer);
-        (Location::<MmrFamily>::new(100)..Location::<MmrFamily>::new(100)).write(&mut buffer);
-
-        let mut cursor = Cursor::new(buffer);
-        assert!(matches!(
-            Target::<MmrFamily, sha256::Digest>::read(&mut cursor),
-            Err(CodecError::Invalid("NonEmptyRange", "start must be < end"))
-        ));
     }
 
     type TestError = sync::Error<MmrFamily, std::io::Error, sha256::Digest>;
@@ -218,16 +118,16 @@ mod tests {
         target(sha256::Digest::from([0; 32]), 0, 100),
         target(sha256::Digest::from([1; 32]), 50, 100),
         Err(TestError::Engine(EngineError::SyncTargetMovedBackward {
-            old: target(sha256::Digest::from([0; 32]), 0, 100),
-            new: target(sha256::Digest::from([1; 32]), 50, 100),
+            old: non_empty_range!(Location::new(0), Location::new(100)),
+            new: non_empty_range!(Location::new(50), Location::new(100)),
         }))
     )]
     #[case::moves_backward(
         target(sha256::Digest::from([0; 32]), 0, 100),
         target(sha256::Digest::from([1; 32]), 0, 50),
         Err(TestError::Engine(EngineError::SyncTargetMovedBackward {
-            old: target(sha256::Digest::from([0; 32]), 0, 100),
-            new: target(sha256::Digest::from([1; 32]), 0, 50),
+            old: non_empty_range!(Location::new(0), Location::new(100)),
+            new: non_empty_range!(Location::new(0), Location::new(50)),
         }))
     )]
     #[case::same_root(
@@ -236,8 +136,8 @@ mod tests {
         Err(TestError::Engine(EngineError::SyncTargetRootUnchanged))
     )]
     fn test_validate_update(
-        #[case] old_target: Target<MmrFamily, sha256::Digest>,
-        #[case] new_target: Target<MmrFamily, sha256::Digest>,
+        #[case] old_target: TestTarget,
+        #[case] new_target: TestTarget,
         #[case] expected: Result<(), TestError>,
     ) {
         let result = validate_update(&old_target, &new_target);
@@ -264,25 +164,24 @@ mod tests {
                     assert_eq!(a_upper, e_upper);
                 }
                 (
-                    TestError::Engine(EngineError::SyncTargetMovedBackward { .. }),
-                    TestError::Engine(EngineError::SyncTargetMovedBackward { .. }),
-                ) => {}
+                    TestError::Engine(EngineError::SyncTargetMovedBackward {
+                        old: a_old,
+                        new: a_new,
+                    }),
+                    TestError::Engine(EngineError::SyncTargetMovedBackward {
+                        old: e_old,
+                        new: e_new,
+                    }),
+                ) => {
+                    assert_eq!(a_old, e_old);
+                    assert_eq!(a_new, e_new);
+                }
                 (
                     TestError::Engine(EngineError::SyncTargetRootUnchanged),
                     TestError::Engine(EngineError::SyncTargetRootUnchanged),
                 ) => {}
                 _ => panic!("Error type mismatch: got {actual_err:?}, expected {expected_err:?}"),
             },
-        }
-    }
-
-    #[cfg(feature = "arbitrary")]
-    mod conformance {
-        use super::*;
-        use commonware_codec::conformance::CodecConformance;
-
-        commonware_conformance::conformance_tests! {
-            CodecConformance<Target<MmrFamily, sha256::Digest>>,
         }
     }
 }

--- a/storage/src/qmdb/sync/tests.rs
+++ b/storage/src/qmdb/sync/tests.rs
@@ -1,0 +1,2183 @@
+//! Generic sync tests for database implementations of [super::Database].
+//!
+//! This module provides a test harness trait and generic test functions that can be
+//! parameterized to run against either fixed-size or variable-size value databases.
+//! The shared functions are reused by `any` and `current` sync tests.
+
+use crate::{
+    journal::contiguous::Contiguous,
+    merkle::{self, Location},
+    qmdb::{
+        self,
+        any::traits::DbAny,
+        operation::Operation as OperationTrait,
+        sync::{
+            self,
+            engine::{Config, NextStep},
+            resolver::{self, FetchResult, Resolver},
+            Engine, Target as SyncTarget,
+        },
+    },
+    Persistable,
+};
+use commonware_codec::Encode;
+use commonware_cryptography::sha256::Digest;
+use commonware_macros::select;
+use commonware_runtime::{
+    deterministic, BufferPooler, Clock, Metrics as _, Runner as _, Supervisor as _,
+};
+use commonware_utils::{
+    channel::{mpsc, oneshot},
+    non_empty_range,
+    range::NonEmptyRange,
+    sync::{AsyncRwLock, Mutex},
+    NZU64,
+};
+use futures::{pin_mut, FutureExt};
+use rand::RngCore as _;
+use std::{
+    num::NonZeroU64,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+/// Type alias for the database type of a harness.
+pub(crate) type DbOf<H> = <H as SyncTestHarness>::Db;
+
+/// Type alias for the operation type of a harness.
+pub(crate) type OpOf<H> = <DbOf<H> as qmdb::sync::Database>::Op;
+
+/// Type alias for the config type of a harness.
+pub(crate) type ConfigOf<H> = <DbOf<H> as qmdb::sync::Database>::Config;
+
+/// Type alias for the journal type of a harness.
+pub(crate) type JournalOf<H> = <DbOf<H> as qmdb::sync::Database>::Journal;
+
+/// Type alias for the sync target type of a harness.
+pub(crate) type TargetOf<H> = <H as SyncTestHarness>::Target;
+
+/// Trait for cleanup operations in tests.
+pub(crate) trait Destructible {
+    type Family: merkle::Family;
+
+    fn destroy(
+        self,
+    ) -> impl std::future::Future<Output = Result<(), qmdb::Error<Self::Family>>> + Send;
+}
+
+// Implement Destructible once for the generic full Merkle type used in tests.
+// This is here (rather than in fixed/variable modules) to avoid duplicate implementations.
+impl<F: merkle::Family> Destructible
+    for crate::merkle::full::Merkle<
+        F,
+        deterministic::Context,
+        Digest,
+        commonware_parallel::Sequential,
+    >
+{
+    type Family = F;
+
+    async fn destroy(self) -> Result<(), qmdb::Error<F>> {
+        self.destroy().await.map_err(qmdb::Error::Merkle)
+    }
+}
+
+/// Trait providing internal access for from_sync_result tests.
+pub(crate) trait FromSyncTestable: qmdb::sync::Database {
+    type Merkle: Destructible<Family = Self::Family> + Send;
+
+    /// Get the Merkle structure and journal from the database.
+    fn into_log_components(self) -> (Self::Merkle, Self::Journal);
+
+    /// Get the pinned nodes at a given location
+    fn pinned_nodes_at(
+        &self,
+        loc: Location<Self::Family>,
+    ) -> impl std::future::Future<Output = Vec<Self::Digest>> + Send;
+}
+
+/// Harness for sync tests.
+pub(crate) trait SyncTestHarness: Sized + 'static {
+    /// The merkle family the database under test uses.
+    type Family: merkle::Family;
+
+    /// The database type being tested.
+    type Db: qmdb::sync::Database<
+            Family = Self::Family,
+            Context = deterministic::Context,
+            Digest = Digest,
+            Config: Clone,
+        > + DbAny<Self::Family, Key = Digest, Digest = Digest>;
+
+    /// Target type used by the shared sync engine for this harness.
+    type Target: SyncTarget<Family = Self::Family, Digest = Digest> + Eq;
+
+    /// Create a sync target from database and operation roots.
+    fn target(
+        root: Digest,
+        ops_root: Digest,
+        range: NonEmptyRange<Location<Self::Family>>,
+    ) -> Self::Target;
+
+    /// Create a sync target whose database root and operation root are identical.
+    fn target_from_root(
+        root: Digest,
+        range: NonEmptyRange<Location<Self::Family>>,
+    ) -> Self::Target {
+        Self::target(root, root, range)
+    }
+
+    /// Create a config with unique partition names
+    fn config(suffix: &str, pooler: &impl BufferPooler) -> ConfigOf<Self>;
+
+    /// Generate n test operations using the default seed (0)
+    fn create_ops(n: usize) -> Vec<OpOf<Self>>;
+
+    /// Generate n test operations using a specific seed.
+    /// Use different seeds when you need non-overlapping keys in the same test.
+    fn create_ops_seeded(n: usize, seed: u64) -> Vec<OpOf<Self>>;
+
+    /// Initialize a database
+    fn init_db(ctx: deterministic::Context) -> impl std::future::Future<Output = Self::Db> + Send;
+
+    /// Initialize a database with a config
+    fn init_db_with_config(
+        ctx: deterministic::Context,
+        config: ConfigOf<Self>,
+    ) -> impl std::future::Future<Output = Self::Db> + Send;
+
+    /// Apply operations to a database and commit.
+    fn apply_ops(
+        db: Self::Db,
+        ops: Vec<OpOf<Self>>,
+    ) -> impl std::future::Future<Output = Self::Db> + Send;
+}
+
+/// Test that empty operations arrays fetched do not cause panics when stored and applied
+pub(crate) fn test_sync_empty_operations_no_panic<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Init target_db to satisfy engine configuration bounds
+        let target_db = H::init_db(context.child("target")).await;
+
+        // Use an arbitrary target
+        let db_config = H::config(&context.next_u64().to_string(), &context);
+        let config = Config {
+            db_config,
+            fetch_batch_size: NZU64!(10),
+            target: H::target_from_root(
+                Digest::from([1u8; 32]),
+                non_empty_range!(Location::new(0), Location::new(10)),
+            ),
+            context: context.child("client"),
+            resolver: Arc::new(target_db),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        };
+
+        // Create the engine
+        let mut client: Engine<H::Db, _, TargetOf<H>> = Engine::new(config).await.unwrap();
+
+        // Pass empty operations vectors which should not cause panics
+        client.store_operations(Location::new(0), vec![]);
+        client.store_operations(Location::new(5), vec![]);
+
+        // Apply operations which also shouldn't panic
+        client.apply_operations().await.unwrap();
+
+        // It is considered a success simply if it didn't panic.
+    });
+}
+
+/// Test that resolver failure is handled correctly
+pub(crate) fn test_sync_resolver_fails<H: SyncTestHarness>()
+where
+    resolver::tests::FailResolver<H::Family, OpOf<H>, Digest>:
+        Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let resolver = resolver::tests::FailResolver::<H::Family, OpOf<H>, Digest>::new();
+        let target_root = Digest::from([0; 32]);
+
+        let db_config = H::config(&context.next_u64().to_string(), &context);
+        let engine_config = Config {
+            context: context.child("client"),
+            target: H::target_from_root(
+                target_root,
+                non_empty_range!(Location::new(0), Location::new(5)),
+            ),
+            resolver,
+            apply_batch_size: 2,
+            max_outstanding_requests: 2,
+            fetch_batch_size: NZU64!(2),
+            db_config,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        };
+
+        let result: Result<H::Db, _> = sync::sync(engine_config).await;
+        assert!(result.is_err());
+    });
+}
+
+/// Test basic sync functionality with various batch sizes
+pub(crate) fn test_sync<H: SyncTestHarness>(target_db_ops: usize, fetch_batch_size: NonZeroU64)
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create and populate target database
+        let mut target_db = H::init_db(context.child("target")).await;
+        let target_ops = H::create_ops(target_db_ops);
+        target_db = H::apply_ops(target_db, target_ops).await;
+        // commit already done in apply_ops
+        target_db
+            .prune(target_db.sync_boundary().await)
+            .await
+            .unwrap();
+
+        let target_op_count = target_db.bounds().await.end;
+        let target_inactivity_floor = target_db.inactivity_floor_loc().await;
+        let sync_root = qmdb::sync::Database::ops_root(&target_db);
+        let verification_root = target_db.root();
+        let lower_bound = target_db.sync_boundary().await;
+
+        // Configure sync
+        let db_config = H::config(&context.next_u64().to_string(), &context);
+        let target_db = Arc::new(target_db);
+        let client_context = context.child("client");
+        let config = Config {
+            db_config: db_config.clone(),
+            fetch_batch_size,
+            target: H::target(
+                verification_root,
+                sync_root,
+                non_empty_range!(lower_bound, target_op_count),
+            ),
+            context: client_context.child("client"),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        };
+
+        // Perform sync
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
+
+        // Verify database state (root hash is the key verification)
+        assert_eq!(synced_db.bounds().await.end, target_op_count);
+        assert_eq!(
+            synced_db.inactivity_floor_loc().await,
+            target_inactivity_floor
+        );
+        assert_eq!(synced_db.root(), verification_root);
+
+        // Verify persistence
+        let final_root = synced_db.root();
+        let final_op_count = synced_db.bounds().await.end;
+        let final_inactivity_floor = synced_db.inactivity_floor_loc().await;
+
+        // Reopen and verify state persisted
+        drop(synced_db);
+        let reopened_db = H::init_db_with_config(client_context.child("reopened"), db_config).await;
+        assert_eq!(reopened_db.bounds().await.end, final_op_count);
+        assert_eq!(
+            reopened_db.inactivity_floor_loc().await,
+            final_inactivity_floor
+        );
+        assert_eq!(reopened_db.root(), final_root);
+
+        // Cleanup
+        reopened_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test syncing to a subset of the target database (target has additional ops beyond sync range)
+pub(crate) fn test_sync_subset_of_target_database<H: SyncTestHarness>(target_db_ops: usize)
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone + OperationTrait<H::Family, Key = Digest>,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.child("target")).await;
+        let target_ops = H::create_ops(target_db_ops);
+
+        // Apply all but the last operation
+        target_db = H::apply_ops(target_db, target_ops[0..target_db_ops - 1].to_vec()).await;
+        // commit already done in apply_ops
+
+        let upper_bound = target_db.bounds().await.end;
+        let sync_root = qmdb::sync::Database::ops_root(&target_db);
+        let verification_root = target_db.root();
+        let lower_bound = target_db.sync_boundary().await;
+
+        // Add another operation after the sync range
+        let final_op = target_ops[target_db_ops - 1].clone();
+        let final_key = final_op.key().cloned(); // Store the key before applying
+        target_db = H::apply_ops(target_db, vec![final_op]).await;
+        // commit already done in apply_ops
+
+        // Sync to the original root (before final_op was added)
+        let db_config = H::config(&context.next_u64().to_string(), &context);
+        let config = Config {
+            db_config,
+            fetch_batch_size: NZU64!(10),
+            target: H::target(
+                verification_root,
+                sync_root,
+                non_empty_range!(lower_bound, upper_bound),
+            ),
+            context: context.child("client"),
+            resolver: Arc::new(target_db),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        };
+
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
+
+        // Verify the synced database has the correct range of operations
+        assert_eq!(synced_db.sync_boundary().await, lower_bound);
+        assert_eq!(synced_db.bounds().await.end, upper_bound);
+
+        // Verify the final root digest matches our target
+        assert_eq!(synced_db.root(), verification_root);
+
+        // Verify the synced database doesn't have any operations beyond the sync range.
+        // (the final_op should not be present)
+        if let Some(key) = final_key {
+            assert!(synced_db.get(&key).await.unwrap().is_none());
+        }
+
+        synced_db.destroy().await.unwrap();
+    });
+}
+
+/// Test syncing where the sync client has some but not all of the operations in the target DB.
+/// Tests the scenario where sync_db already has partial data and needs to sync additional ops.
+pub(crate) fn test_sync_use_existing_db_partial_match<H: SyncTestHarness>(original_ops: usize)
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone + OperationTrait<H::Family, Key = Digest>,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let original_ops_data = H::create_ops(original_ops);
+
+        // Heap-pin large sub-futures so their state machines don't inflate this test's outer
+        // state machine and overflow the test thread stack.
+        let mut target_db = Box::pin(H::init_db(context.child("target"))).await;
+        let sync_db_config = H::config(&context.next_u64().to_string(), &context);
+        let client_context = context.child("client");
+        let mut sync_db: H::Db = Box::pin(H::init_db_with_config(
+            client_context.child("client"),
+            sync_db_config.clone(),
+        ))
+        .await;
+
+        // Apply the same operations to both databases
+        target_db = Box::pin(H::apply_ops(target_db, original_ops_data.clone())).await;
+        sync_db = Box::pin(H::apply_ops(sync_db, original_ops_data.clone())).await;
+        // commit already done in apply_ops
+        // commit already done in apply_ops
+
+        drop(sync_db);
+
+        // Add more operations and commit the target database
+        // (use different seed to avoid key collisions)
+        let more_ops = H::create_ops_seeded(1, 1);
+        target_db = Box::pin(H::apply_ops(target_db, more_ops.clone())).await;
+        // commit already done in apply_ops
+
+        let sync_root = qmdb::sync::Database::ops_root(&target_db);
+        let verification_root = target_db.root();
+        let lower_bound = target_db.sync_boundary().await;
+        let upper_bound = target_db.bounds().await.end;
+
+        // Reopen the sync database and sync it to the target database
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            db_config: sync_db_config,
+            fetch_batch_size: NZU64!(10),
+            target: H::target(
+                verification_root,
+                sync_root,
+                non_empty_range!(lower_bound, upper_bound),
+            ),
+            context: client_context.child("sync"),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        };
+        // Heap-pin the sync future so its (large, monomorphized-per-variant) state
+        // machine doesn't inflate this test's outer state machine and overflow the
+        // test thread stack.
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
+
+        // Verify database state
+        let bounds = synced_db.bounds().await;
+        assert_eq!(bounds.end, upper_bound);
+        assert_eq!(
+            synced_db.inactivity_floor_loc().await,
+            target_db.inactivity_floor_loc().await
+        );
+        assert_eq!(bounds.end, target_db.bounds().await.end);
+        // Verify the root digest matches the target
+        assert_eq!(synced_db.root(), verification_root);
+
+        // Verify that original operations are present and correct (by key lookup)
+        for target_op in &original_ops_data {
+            if let Some(key) = target_op.key() {
+                let target_value = target_db.get(key).await.unwrap();
+                let synced_value = synced_db.get(key).await.unwrap();
+                assert_eq!(target_value.is_some(), synced_value.is_some());
+            }
+        }
+
+        // Verify the last operation is present (if it's an update)
+        if let Some(key) = more_ops[0].key() {
+            let synced_value = synced_db.get(key).await.unwrap();
+            let target_value = target_db.get(key).await.unwrap();
+            assert_eq!(synced_value.is_some(), target_value.is_some());
+        }
+
+        synced_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test case where existing database on disk exactly matches the sync target.
+/// Uses FailResolver to verify that no network requests are made since data already exists.
+pub(crate) fn test_sync_use_existing_db_exact_match<H: SyncTestHarness>(num_ops: usize)
+where
+    resolver::tests::FailResolver<H::Family, OpOf<H>, Digest>:
+        Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone + OperationTrait<H::Family, Key = Digest>,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let target_ops = H::create_ops(num_ops);
+
+        // Create two databases with their own configs
+        let target_config = H::config(&context.next_u64().to_string(), &context);
+        let mut target_db = H::init_db_with_config(context.child("target"), target_config).await;
+        let sync_config = H::config(&context.next_u64().to_string(), &context);
+        let client_context = context.child("client");
+        let mut sync_db =
+            H::init_db_with_config(client_context.child("client"), sync_config.clone()).await;
+
+        // Apply the same operations to both databases
+        target_db = H::apply_ops(target_db, target_ops.clone()).await;
+        sync_db = H::apply_ops(sync_db, target_ops.clone()).await;
+        // commit already done in apply_ops
+        // commit already done in apply_ops
+
+        target_db
+            .prune(target_db.sync_boundary().await)
+            .await
+            .unwrap();
+        sync_db.prune(sync_db.sync_boundary().await).await.unwrap();
+
+        sync_db.sync().await.unwrap();
+        drop(sync_db);
+
+        // Capture target state
+        let sync_root = qmdb::sync::Database::ops_root(&target_db);
+        let verification_root = target_db.root();
+        let lower_bound = target_db.sync_boundary().await;
+        let upper_bound = target_db.bounds().await.end;
+
+        // sync_db should never ask the resolver for operations
+        // because it is already complete. Use a resolver that always fails
+        // to ensure that it's not being used.
+        let resolver = resolver::tests::FailResolver::<H::Family, OpOf<H>, Digest>::new();
+        let config = Config {
+            db_config: sync_config, // Use same config to access same partitions
+            fetch_batch_size: NZU64!(10),
+            target: H::target(
+                verification_root,
+                sync_root,
+                non_empty_range!(lower_bound, upper_bound),
+            ),
+            context: client_context.child("sync"),
+            resolver,
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        };
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
+
+        // Verify database state
+        let bounds = synced_db.bounds().await;
+        assert_eq!(bounds.end, upper_bound);
+        assert_eq!(bounds.end, target_db.bounds().await.end);
+        assert_eq!(synced_db.sync_boundary().await, lower_bound);
+
+        // Verify the root digest matches the target
+        assert_eq!(synced_db.root(), verification_root);
+
+        // Verify state matches for sample operations (via key lookup)
+        for target_op in &target_ops {
+            if let Some(key) = target_op.key() {
+                let target_value = target_db.get(key).await.unwrap();
+                let synced_value = synced_db.get(key).await.unwrap();
+                assert_eq!(target_value.is_some(), synced_value.is_some());
+            }
+        }
+
+        synced_db.destroy().await.unwrap();
+        target_db.destroy().await.unwrap();
+    });
+}
+
+/// Test that the client fails to sync if the lower bound is decreased via target update.
+pub(crate) fn test_target_update_lower_bound_decrease<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create and populate target database
+        let mut target_db = H::init_db(context.child("target")).await;
+        let target_ops = H::create_ops(50);
+        target_db = H::apply_ops(target_db, target_ops).await;
+        // commit already done in apply_ops
+
+        // Use inactivity_floor as range.start so we have a non-zero bound to decrement.
+        // The engine only checks that range.start does not decrease on updates; it doesn't
+        // require range.start to equal sync_boundary here.
+        let initial_lower_bound = target_db.inactivity_floor_loc().await;
+        assert!(
+            *initial_lower_bound > 0,
+            "test setup requires non-zero inactivity floor"
+        );
+        let initial_upper_bound = target_db.bounds().await.end;
+        let initial_root = qmdb::sync::Database::ops_root(&target_db);
+        let initial_verification_root = qmdb::sync::Database::root(&target_db);
+
+        // Create client with initial target
+        let (update_sender, update_receiver) = mpsc::channel(1);
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(5),
+            target: H::target(
+                initial_verification_root,
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound),
+            ),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 10,
+            update_rx: Some(update_receiver),
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 1,
+        };
+        let client: Engine<H::Db, _, TargetOf<H>> = Engine::new(config).await.unwrap();
+
+        // Send target update with decreased lower bound
+        update_sender
+            .send(H::target(
+                initial_verification_root,
+                initial_root,
+                non_empty_range!(
+                    initial_lower_bound.checked_sub(1).unwrap(),
+                    initial_upper_bound.checked_add(1).unwrap()
+                ),
+            ))
+            .await
+            .unwrap();
+
+        let result = client.step().await;
+        assert!(matches!(
+            result,
+            Err(sync::Error::Engine(
+                sync::EngineError::SyncTargetMovedBackward { .. }
+            ))
+        ));
+
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test that the client fails to sync if the upper bound is decreased via target update.
+pub(crate) fn test_target_update_upper_bound_decrease<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create and populate target database
+        let mut target_db = H::init_db(context.child("target")).await;
+        let target_ops = H::create_ops(50);
+        target_db = H::apply_ops(target_db, target_ops).await;
+        // commit already done in apply_ops
+
+        // Capture initial target state
+        let initial_lower_bound = target_db.sync_boundary().await;
+        let initial_upper_bound = target_db.bounds().await.end;
+        let initial_root = qmdb::sync::Database::ops_root(&target_db);
+        let initial_verification_root = qmdb::sync::Database::root(&target_db);
+
+        // Create client with initial target
+        let (update_sender, update_receiver) = mpsc::channel(1);
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(5),
+            target: H::target(
+                initial_verification_root,
+                initial_root,
+                non_empty_range!(initial_lower_bound, initial_upper_bound),
+            ),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 10,
+            update_rx: Some(update_receiver),
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 1,
+        };
+        let client: Engine<H::Db, _, TargetOf<H>> = Engine::new(config).await.unwrap();
+
+        // Send target update with decreased upper bound
+        update_sender
+            .send(H::target(
+                initial_verification_root,
+                initial_root,
+                non_empty_range!(
+                    initial_lower_bound,
+                    initial_upper_bound.checked_sub(1).unwrap()
+                ),
+            ))
+            .await
+            .unwrap();
+
+        let result = client.step().await;
+        assert!(matches!(
+            result,
+            Err(sync::Error::Engine(
+                sync::EngineError::SyncTargetMovedBackward { .. }
+            ))
+        ));
+
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test that the client succeeds when bounds are updated (increased).
+pub(crate) fn test_target_update_bounds_increase<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create and populate target database
+        let mut target_db = H::init_db(context.child("target")).await;
+        let target_ops = H::create_ops(100);
+        target_db = H::apply_ops(target_db, target_ops).await;
+        // commit already done in apply_ops
+
+        // Capture initial target state
+        let initial_lower_bound = target_db.sync_boundary().await;
+        let initial_upper_bound = target_db.bounds().await.end;
+        let initial_root = qmdb::sync::Database::ops_root(&target_db);
+        let initial_verification_root = qmdb::sync::Database::root(&target_db);
+
+        // Apply more operations to the target database
+        // (use different seed to avoid key collisions)
+        let additional_ops = H::create_ops_seeded(1, 1);
+        let new_verification_root = {
+            target_db = H::apply_ops(target_db, additional_ops).await;
+            // commit already done in apply_ops
+
+            // Capture new target state
+            let new_lower_bound = target_db.sync_boundary().await;
+            let new_upper_bound = target_db.bounds().await.end;
+            let new_sync_root = qmdb::sync::Database::ops_root(&target_db);
+            let new_verification_root = target_db.root();
+
+            // Create client with placeholder initial target (stale compared to final target)
+            let (update_sender, update_receiver) = mpsc::channel(1);
+
+            let target_db = Arc::new(target_db);
+            let config = Config {
+                context: context.child("client"),
+                db_config: H::config(&context.next_u64().to_string(), &context),
+                fetch_batch_size: NZU64!(1),
+                target: H::target(
+                    initial_verification_root,
+                    initial_root,
+                    non_empty_range!(initial_lower_bound, initial_upper_bound),
+                ),
+                resolver: target_db.clone(),
+                apply_batch_size: 1024,
+                max_outstanding_requests: 1,
+                update_rx: Some(update_receiver),
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 1,
+            };
+
+            // Send target update with increased bounds
+            update_sender
+                .send(H::target(
+                    new_verification_root,
+                    new_sync_root,
+                    non_empty_range!(new_lower_bound, new_upper_bound),
+                ))
+                .await
+                .unwrap();
+
+            // Complete the sync
+            let synced_db: H::Db = sync::sync(config).await.unwrap();
+
+            // Verify the synced database has the expected final state
+            assert_eq!(synced_db.root(), new_verification_root);
+            assert_eq!(synced_db.bounds().await.end, new_upper_bound);
+            assert_eq!(synced_db.sync_boundary().await, new_lower_bound);
+
+            synced_db.destroy().await.unwrap();
+
+            Arc::try_unwrap(target_db)
+                .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+                .destroy()
+                .await
+                .unwrap();
+
+            new_verification_root
+        };
+        let _ = new_verification_root; // Silence unused variable warning
+    });
+}
+
+/// Test that target updates can be sent even after the client is done (no panic).
+pub(crate) fn test_target_update_on_done_client<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create and populate target database
+        let mut target_db = H::init_db(context.child("target")).await;
+        let target_ops = H::create_ops(10);
+        target_db = H::apply_ops(target_db, target_ops).await;
+        // commit already done in apply_ops
+
+        // Capture target state
+        let lower_bound = target_db.sync_boundary().await;
+        let upper_bound = target_db.bounds().await.end;
+        let sync_root = qmdb::sync::Database::ops_root(&target_db);
+        let verification_root = target_db.root();
+
+        // Create client with target that will complete immediately
+        let (update_sender, update_receiver) = mpsc::channel(1);
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(20),
+            target: H::target(
+                verification_root,
+                sync_root,
+                non_empty_range!(lower_bound, upper_bound),
+            ),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 10,
+            update_rx: Some(update_receiver),
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 1,
+        };
+
+        // Complete the sync
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
+
+        // Attempt to apply a target update after sync is complete to verify
+        // we don't panic
+        let _ = update_sender
+            .send(H::target_from_root(
+                Digest::from([2u8; 32]),
+                non_empty_range!(lower_bound + 1, upper_bound + 1),
+            ))
+            .await;
+
+        // Verify the synced database has the expected state
+        assert_eq!(synced_db.root(), verification_root);
+        assert_eq!(synced_db.bounds().await.end, upper_bound);
+        assert_eq!(synced_db.sync_boundary().await, lower_bound);
+
+        synced_db.destroy().await.unwrap();
+
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test that prune-only target updates are rejected as backward target movement.
+pub(crate) fn test_target_update_prune_only_rejected<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.child("target")).await;
+        target_db = H::apply_ops(target_db, H::create_ops(50)).await;
+
+        let initial_lower_bound = target_db.inactivity_floor_loc().await;
+        assert!(
+            *initial_lower_bound > 1,
+            "test setup requires lower bound that can advance twice"
+        );
+        let upper_bound = target_db.bounds().await.end;
+        let root = qmdb::sync::Database::root(&target_db);
+        let ops_root = qmdb::sync::Database::ops_root(&target_db);
+
+        let (update_sender, update_receiver) = mpsc::channel(2);
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(5),
+            target: H::target(
+                root,
+                ops_root,
+                non_empty_range!(initial_lower_bound, upper_bound),
+            ),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 10,
+            update_rx: Some(update_receiver),
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 1,
+        };
+        let client: Engine<H::Db, _, TargetOf<H>> = Engine::new(config).await.unwrap();
+
+        let first_target = H::target(
+            root,
+            ops_root,
+            non_empty_range!(initial_lower_bound.checked_add(1).unwrap(), upper_bound),
+        );
+        let second_target = H::target(
+            root,
+            ops_root,
+            non_empty_range!(initial_lower_bound.checked_add(2).unwrap(), upper_bound),
+        );
+        update_sender.send(first_target).await.unwrap();
+        update_sender.send(second_target).await.unwrap();
+
+        let result = client.step().await;
+        assert!(matches!(
+            result,
+            Err(sync::Error::Engine(
+                sync::EngineError::SyncTargetMovedBackward { .. }
+            ))
+        ));
+
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test that explicit finish control waits for a finish signal even after reaching target.
+pub(crate) fn test_sync_waits_for_explicit_finish<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.child("target")).await;
+        target_db = H::apply_ops(target_db, H::create_ops(10)).await;
+        let initial_target = H::target(
+            qmdb::sync::Database::root(&target_db),
+            qmdb::sync::Database::ops_root(&target_db),
+            non_empty_range!(
+                target_db.sync_boundary().await,
+                target_db.bounds().await.end
+            ),
+        );
+
+        target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
+        let updated_lower_bound = target_db.sync_boundary().await;
+        let updated_upper_bound = target_db.bounds().await.end;
+        let updated_target = H::target(
+            qmdb::sync::Database::root(&target_db),
+            qmdb::sync::Database::ops_root(&target_db),
+            non_empty_range!(updated_lower_bound, updated_upper_bound),
+        );
+        let updated_verification_root = target_db.root();
+
+        let (update_sender, update_receiver) = mpsc::channel(1);
+        let (finish_sender, finish_receiver) = mpsc::channel(1);
+        let (reached_sender, mut reached_receiver) = mpsc::channel(1);
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(10),
+            target: initial_target.clone(),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: Some(update_receiver),
+            finish_rx: Some(finish_receiver),
+            reached_target_tx: Some(reached_sender),
+            max_retained_roots: 0,
+        };
+
+        // Heap-pin the sync future so its (large, monomorphized-per-variant) state
+        // machine doesn't inflate this test's outer state machine and overflow the
+        // test thread stack.
+        let mut sync_handle = Box::pin(sync::sync(config));
+
+        select! {
+            _ = sync_handle.as_mut() => {
+                panic!("sync completed before explicit finish signal");
+            },
+            reached = reached_receiver.recv() => {
+                let reached = reached.expect("engine should report reached-target before finish");
+                assert_eq!(reached, initial_target);
+            },
+        }
+        assert!(
+            sync_handle.as_mut().now_or_never().is_none(),
+            "sync must wait for explicit finish signal after reaching target"
+        );
+
+        update_sender
+            .send(updated_target.clone())
+            .await
+            .expect("target update channel should be open");
+
+        select! {
+            _ = sync_handle.as_mut() => {
+                panic!("sync completed before explicit finish signal for updated target");
+            },
+            reached = reached_receiver.recv() => {
+                let reached = reached.expect("engine should report updated target before finish");
+                assert_eq!(reached, updated_target);
+            },
+        }
+        assert!(
+            sync_handle.as_mut().now_or_never().is_none(),
+            "sync must still wait for explicit finish signal after updated target is reached"
+        );
+
+        finish_sender
+            .send(())
+            .await
+            .expect("finish signal channel should be open");
+
+        let synced_db: H::Db = sync_handle
+            .await
+            .expect("sync should succeed after finish signal");
+        assert_eq!(synced_db.root(), updated_verification_root);
+        assert_eq!(synced_db.bounds().await.end, updated_upper_bound);
+        assert_eq!(synced_db.sync_boundary().await, updated_lower_bound);
+
+        synced_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+async fn wait_for_reached_progress<F, T>(context: deterministic::Context, target: &T)
+where
+    F: merkle::Family,
+    T: SyncTarget<Family = F, Digest = Digest>,
+{
+    let target_end = *target.range().end();
+    let journal_size = format!("client_sync_journal_size {target_end}");
+    let target_end = format!("client_sync_target_end {target_end}");
+    loop {
+        let metrics = context.encode();
+        if metrics.contains(&journal_size) && metrics.contains(&target_end) {
+            return;
+        }
+        context.sleep(Duration::from_millis(1)).await;
+    }
+}
+
+/// Test progress metrics for reached targets across target updates and explicit finish.
+pub(crate) fn test_sync_reports_progress_for_reached_targets_before_explicit_finish<
+    H: SyncTestHarness,
+>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.child("target")).await;
+
+        target_db = H::apply_ops(target_db, H::create_ops(8)).await;
+        let initial_target = H::target(
+            qmdb::sync::Database::root(&target_db),
+            qmdb::sync::Database::ops_root(&target_db),
+            non_empty_range!(
+                target_db.sync_boundary().await,
+                target_db.bounds().await.end
+            ),
+        );
+
+        target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
+        let first_update = H::target(
+            qmdb::sync::Database::root(&target_db),
+            qmdb::sync::Database::ops_root(&target_db),
+            non_empty_range!(
+                target_db.sync_boundary().await,
+                target_db.bounds().await.end
+            ),
+        );
+
+        target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 2)).await;
+        let second_update = H::target(
+            qmdb::sync::Database::root(&target_db),
+            qmdb::sync::Database::ops_root(&target_db),
+            non_empty_range!(
+                target_db.sync_boundary().await,
+                target_db.bounds().await.end
+            ),
+        );
+        let final_root = target_db.root();
+
+        let (update_sender, update_receiver) = mpsc::channel(1);
+        let (finish_sender, finish_receiver) = mpsc::channel(1);
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(2),
+            target: initial_target.clone(),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: Some(update_receiver),
+            finish_rx: Some(finish_receiver),
+            reached_target_tx: None,
+            max_retained_roots: 1,
+        };
+
+        let mut sync_handle = Box::pin(sync::sync(config));
+
+        select! {
+            _ = sync_handle.as_mut() => {
+                panic!("sync completed before explicit finish signal");
+            },
+            _ = wait_for_reached_progress(context.child("storage"), &initial_target) => {},
+        }
+        assert!(
+            sync_handle.as_mut().now_or_never().is_none(),
+            "sync must wait for a target update or explicit finish after reaching the initial target"
+        );
+
+        update_sender
+            .send(first_update.clone())
+            .await
+            .expect("target update channel should be open");
+        select! {
+            _ = sync_handle.as_mut() => {
+                panic!("sync completed before explicit finish signal after first update");
+            },
+            _ = wait_for_reached_progress(context.child("storage"), &first_update) => {},
+        }
+        assert!(
+            sync_handle.as_mut().now_or_never().is_none(),
+            "sync must wait for another update or explicit finish after reaching the first update"
+        );
+
+        update_sender
+            .send(second_update.clone())
+            .await
+            .expect("target update channel should be open");
+        select! {
+            _ = sync_handle.as_mut() => {
+                panic!("sync completed before explicit finish signal after second update");
+            },
+            _ = wait_for_reached_progress(context.child("storage"), &second_update) => {},
+        }
+        assert!(
+            sync_handle.as_mut().now_or_never().is_none(),
+            "sync must wait for explicit finish after reporting final progress"
+        );
+
+        finish_sender
+            .send(())
+            .await
+            .expect("finish signal channel should be open");
+
+        let synced_db: H::Db = sync_handle
+            .await
+            .expect("sync should succeed after finish signal");
+        assert_eq!(synced_db.root(), final_root);
+        assert_eq!(synced_db.bounds().await.end, *second_update.range().end());
+        assert_eq!(
+            synced_db.sync_boundary().await,
+            *second_update.range().start()
+        );
+
+        synced_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test that a finish signal received before target completion still allows full sync.
+pub(crate) fn test_sync_handles_early_finish_signal<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.child("target")).await;
+        target_db = H::apply_ops(target_db, H::create_ops(30)).await;
+        let lower_bound = target_db.sync_boundary().await;
+        let upper_bound = target_db.bounds().await.end;
+        let target = H::target(
+            qmdb::sync::Database::root(&target_db),
+            qmdb::sync::Database::ops_root(&target_db),
+            non_empty_range!(lower_bound, upper_bound),
+        );
+        let verification_root = target_db.root();
+
+        let (finish_sender, finish_receiver) = mpsc::channel(1);
+        let (reached_sender, mut reached_receiver) = mpsc::channel(1);
+        finish_sender
+            .send(())
+            .await
+            .expect("finish signal channel should be open");
+
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(3),
+            target: target.clone(),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: Some(finish_receiver),
+            reached_target_tx: Some(reached_sender),
+            max_retained_roots: 1,
+        };
+
+        let synced_db: H::Db = sync::sync(config)
+            .await
+            .expect("sync should complete after early finish signal");
+        let reached = reached_receiver
+            .recv()
+            .await
+            .expect("engine should report reached-target");
+
+        assert_eq!(reached, target);
+        assert_eq!(synced_db.root(), verification_root);
+        assert_eq!(synced_db.bounds().await.end, upper_bound);
+        assert_eq!(synced_db.sync_boundary().await, lower_bound);
+
+        synced_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test that dropping finish sender without sending is treated as an error.
+pub(crate) fn test_sync_fails_when_finish_sender_dropped<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.child("target")).await;
+        target_db = H::apply_ops(target_db, H::create_ops(10)).await;
+        let lower_bound = target_db.sync_boundary().await;
+        let upper_bound = target_db.bounds().await.end;
+
+        let (finish_sender, finish_receiver) = mpsc::channel(1);
+        drop(finish_sender);
+
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(5),
+            target: H::target(
+                qmdb::sync::Database::root(target_db.as_ref()),
+                qmdb::sync::Database::ops_root(target_db.as_ref()),
+                non_empty_range!(lower_bound, upper_bound),
+            ),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: Some(finish_receiver),
+            reached_target_tx: None,
+            max_retained_roots: 1,
+        };
+
+        let result: Result<H::Db, _> = sync::sync(config).await;
+        assert!(matches!(
+            result,
+            Err(sync::Error::Engine(sync::EngineError::FinishChannelClosed))
+        ));
+
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test that dropping reached-target receiver does not fail sync.
+pub(crate) fn test_sync_allows_dropped_reached_target_receiver<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.child("target")).await;
+        target_db = H::apply_ops(target_db, H::create_ops(10)).await;
+        let lower_bound = target_db.sync_boundary().await;
+        let upper_bound = target_db.bounds().await.end;
+        let verification_root = target_db.root();
+
+        let (reached_sender, reached_receiver) = mpsc::channel(1);
+        drop(reached_receiver);
+
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(5),
+            target: H::target(
+                qmdb::sync::Database::root(target_db.as_ref()),
+                qmdb::sync::Database::ops_root(target_db.as_ref()),
+                non_empty_range!(lower_bound, upper_bound),
+            ),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: Some(reached_sender),
+            max_retained_roots: 1,
+        };
+
+        let synced_db: H::Db = sync::sync(config)
+            .await
+            .expect("sync should succeed when reached-target receiver is dropped");
+        assert_eq!(synced_db.root(), verification_root);
+        assert_eq!(synced_db.bounds().await.end, upper_bound);
+        assert_eq!(synced_db.sync_boundary().await, lower_bound);
+
+        synced_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test that the client can handle target updates during sync execution.
+pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
+    initial_ops: usize,
+    additional_ops: usize,
+) where
+    Arc<AsyncRwLock<Option<DbOf<H>>>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create and populate target database with initial operations
+        let mut target_db = H::init_db(context.child("target")).await;
+        let target_ops = H::create_ops(initial_ops);
+        target_db = H::apply_ops(target_db, target_ops).await;
+        // commit already done in apply_ops
+
+        // Capture initial target state
+        let initial_lower_bound = target_db.sync_boundary().await;
+        let initial_upper_bound = target_db.bounds().await.end;
+        let initial_sync_root = qmdb::sync::Database::ops_root(&target_db);
+        let initial_verification_root = qmdb::sync::Database::root(&target_db);
+
+        // Wrap target database for shared mutable access (using Option so we can take ownership)
+        let target_db = Arc::new(AsyncRwLock::new(Some(target_db)));
+
+        // Create client with initial target and small batch size
+        let (update_sender, update_receiver) = mpsc::channel(1);
+        // Step the client to process a batch
+        let client = {
+            let config = Config {
+                context: context.child("client"),
+                db_config: H::config(&context.next_u64().to_string(), &context),
+                target: H::target(
+                    initial_verification_root,
+                    initial_sync_root,
+                    non_empty_range!(initial_lower_bound, initial_upper_bound),
+                ),
+                resolver: target_db.clone(),
+                fetch_batch_size: NZU64!(1), // Small batch size so we don't finish after one batch
+                max_outstanding_requests: 10,
+                apply_batch_size: 1024,
+                update_rx: Some(update_receiver),
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 1,
+            };
+            let mut client: Engine<H::Db, _, TargetOf<H>> = Engine::new(config).await.unwrap();
+            loop {
+                // Step the client until we have processed a batch of operations
+                client = match client.step().await.unwrap() {
+                    NextStep::Continue(new_client) => new_client,
+                    NextStep::Complete(..) => panic!("client should not be complete"),
+                };
+                let log_size = client.journal().size().await;
+                if log_size > initial_lower_bound {
+                    break client;
+                }
+            }
+        };
+
+        // Modify the target database by adding more operations
+        // (use different seed to avoid key collisions)
+        let additional_ops_data = H::create_ops_seeded(additional_ops, 1);
+        let new_verification_root = {
+            let mut db_guard = target_db.write().await;
+            let db = db_guard.take().unwrap();
+            let db = H::apply_ops(db, additional_ops_data).await;
+
+            // Capture new target state
+            let new_lower_bound = db.sync_boundary().await;
+            let new_upper_bound = db.bounds().await.end;
+            let new_sync_root = qmdb::sync::Database::ops_root(&db);
+            let new_verification_root = db.root();
+            *db_guard = Some(db);
+
+            // Send target update with new target
+            update_sender
+                .send(H::target(
+                    new_verification_root,
+                    new_sync_root,
+                    non_empty_range!(new_lower_bound, new_upper_bound),
+                ))
+                .await
+                .unwrap();
+
+            new_verification_root
+        };
+
+        // Complete the sync
+        let synced_db = client.sync().await.unwrap();
+
+        // Verify the synced database has the expected final state
+        assert_eq!(synced_db.root(), new_verification_root);
+
+        // Verify the target database matches the synced database
+        let target_db = Arc::try_unwrap(target_db).map_or_else(
+            |_| panic!("Failed to unwrap Arc - still has references"),
+            |rw_lock| rw_lock.into_inner().expect("db should be present"),
+        );
+        {
+            let synced_bounds = synced_db.bounds().await;
+            let target_bounds = target_db.bounds().await;
+            assert_eq!(synced_bounds.end, target_bounds.end);
+            assert_eq!(
+                synced_db.inactivity_floor_loc().await,
+                target_db.inactivity_floor_loc().await
+            );
+            assert_eq!(synced_db.root(), target_db.root());
+        }
+
+        synced_db.destroy().await.unwrap();
+        target_db.destroy().await.unwrap();
+    });
+}
+
+/// Test demonstrating that a synced database can be reopened and retain its state.
+pub(crate) fn test_sync_database_persistence<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode + Clone,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create and populate a simple target database
+        let mut target_db = H::init_db(context.child("target")).await;
+        let target_ops = H::create_ops(10);
+        target_db = H::apply_ops(target_db, target_ops).await;
+        // commit already done in apply_ops
+
+        // Capture target state
+        let sync_root = qmdb::sync::Database::ops_root(&target_db);
+        let verification_root = target_db.root();
+        let lower_bound = target_db.sync_boundary().await;
+        let upper_bound = target_db.bounds().await.end;
+
+        // Perform sync
+        let db_config = H::config(&context.next_u64().to_string(), &context);
+        let client_context = context.child("client");
+        let target_db = Arc::new(target_db);
+        let config = Config {
+            db_config: db_config.clone(),
+            fetch_batch_size: NZU64!(5),
+            target: H::target(
+                verification_root,
+                sync_root,
+                non_empty_range!(lower_bound, upper_bound),
+            ),
+            context: client_context.child("client"),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        };
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
+
+        // Verify initial sync worked
+        assert_eq!(synced_db.root(), verification_root);
+
+        // Save state before dropping
+        let expected_root = synced_db.root();
+        let expected_op_count = synced_db.bounds().await.end;
+        let expected_inactivity_floor_loc = synced_db.inactivity_floor_loc().await;
+
+        // Re-open the database
+        drop(synced_db);
+        let reopened_db = H::init_db_with_config(client_context.child("reopened"), db_config).await;
+
+        // Verify the state is unchanged
+        assert_eq!(reopened_db.root(), expected_root);
+        assert_eq!(reopened_db.bounds().await.end, expected_op_count);
+        assert_eq!(
+            reopened_db.inactivity_floor_loc().await,
+            expected_inactivity_floor_loc
+        );
+
+        // Cleanup
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+        reopened_db.destroy().await.unwrap();
+    });
+}
+
+/// Test post-sync usability: after syncing, the database supports normal operations.
+pub(crate) fn test_sync_post_sync_usability<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.child("target")).await;
+        let target_ops = H::create_ops(50);
+        target_db = H::apply_ops(target_db, target_ops).await;
+
+        let sync_root = qmdb::sync::Database::ops_root(&target_db);
+        let verification_root = qmdb::sync::Database::root(&target_db);
+        let lower_bound = target_db.sync_boundary().await;
+        let upper_bound = target_db.bounds().await.end;
+        let target_db = Arc::new(target_db);
+
+        let config = H::config(&context.next_u64().to_string(), &context);
+        let config = Config {
+            db_config: config,
+            fetch_batch_size: NZU64!(100),
+            target: H::target(
+                verification_root,
+                sync_root,
+                non_empty_range!(lower_bound, upper_bound),
+            ),
+            context: context.child("client"),
+            resolver: target_db.clone(),
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        };
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
+
+        let root_after_sync = synced_db.root();
+
+        // Apply additional operations after sync.
+        let more_ops = H::create_ops_seeded(10, 1);
+        let synced_db = H::apply_ops(synced_db, more_ops).await;
+
+        // Root should change after applying more ops.
+        assert_ne!(synced_db.root(), root_after_sync);
+        assert!(synced_db.bounds().await.end > upper_bound);
+
+        synced_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}
+
+/// Test `from_sync_result` where the database has all operations in the target range.
+pub(crate) fn test_from_sync_result_nonempty_to_nonempty_exact_match<H: SyncTestHarness>()
+where
+    DbOf<H>: FromSyncTestable,
+    OpOf<H>: Encode + Clone,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let db_config = H::config(&context.next_u64().to_string(), &context);
+        let mut db = H::init_db_with_config(context.child("source"), db_config.clone()).await;
+        let ops = H::create_ops(100);
+        db = H::apply_ops(db, ops).await;
+        // commit already done in apply_ops
+
+        let sync_lower_bound = db.sync_boundary().await;
+        let bounds = db.bounds().await;
+        let sync_upper_bound = bounds.end;
+        let target_db_op_count = bounds.end;
+        let target_db_inactivity_floor_loc = db.inactivity_floor_loc().await;
+
+        let pinned_nodes = db.pinned_nodes_at(sync_lower_bound).await;
+        let (_, journal) = db.into_log_components();
+
+        let sync_db: DbOf<H> = <DbOf<H> as qmdb::sync::Database>::from_sync_result(
+            context.child("synced"),
+            db_config,
+            journal,
+            Some(pinned_nodes),
+            non_empty_range!(sync_lower_bound, sync_upper_bound),
+            1024,
+        )
+        .await
+        .unwrap();
+
+        // Verify database state
+        assert_eq!(sync_db.bounds().await.end, target_db_op_count);
+        assert_eq!(
+            sync_db.inactivity_floor_loc().await,
+            target_db_inactivity_floor_loc
+        );
+        assert_eq!(sync_db.sync_boundary().await, sync_lower_bound);
+
+        sync_db.destroy().await.unwrap();
+    });
+}
+
+/// Test `from_sync_result` where the database has some but not all operations in the target range.
+pub(crate) fn test_from_sync_result_nonempty_to_nonempty_partial_match<H: SyncTestHarness>()
+where
+    DbOf<H>: FromSyncTestable,
+    OpOf<H>: Encode + Clone,
+    JournalOf<H>: Contiguous,
+{
+    const NUM_OPS: usize = 100;
+    const NUM_ADDITIONAL_OPS: usize = 5;
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create and populate two databases.
+        let mut target_db = H::init_db(context.child("target")).await;
+        let sync_db_config = H::config(&context.next_u64().to_string(), &context);
+        let client_context = context.child("client");
+        let mut sync_db =
+            H::init_db_with_config(client_context.child("client"), sync_db_config.clone()).await;
+        let original_ops = H::create_ops(NUM_OPS);
+        target_db = H::apply_ops(target_db, original_ops.clone()).await;
+        // commit already done in apply_ops
+        target_db
+            .prune(target_db.sync_boundary().await)
+            .await
+            .unwrap();
+        sync_db = H::apply_ops(sync_db, original_ops.clone()).await;
+        // commit already done in apply_ops
+        sync_db.prune(sync_db.sync_boundary().await).await.unwrap();
+        sync_db.sync().await.unwrap();
+        drop(sync_db);
+
+        // Add more operations to the target db
+        // (use different seed to avoid key collisions)
+        let more_ops = H::create_ops_seeded(NUM_ADDITIONAL_OPS, 1);
+        target_db = H::apply_ops(target_db, more_ops).await;
+        // commit already done in apply_ops
+
+        // Capture target db state for comparison
+        let bounds = target_db.bounds().await;
+        let target_db_op_count = bounds.end;
+        let target_db_inactivity_floor_loc = target_db.inactivity_floor_loc().await;
+        let sync_lower_bound = target_db.sync_boundary().await;
+        let sync_upper_bound = bounds.end;
+        let target_hash = target_db.root();
+
+        // Get pinned nodes at the sync lower bound from the target db (which has all the data).
+        let pinned_nodes = target_db.pinned_nodes_at(sync_lower_bound).await;
+
+        let (mmr, journal) = target_db.into_log_components();
+
+        // Re-open `sync_db` using from_sync_result
+        let sync_db: DbOf<H> = <DbOf<H> as qmdb::sync::Database>::from_sync_result(
+            client_context.child("synced"),
+            sync_db_config,
+            journal,
+            Some(pinned_nodes),
+            non_empty_range!(sync_lower_bound, sync_upper_bound),
+            1024,
+        )
+        .await
+        .unwrap();
+
+        // Verify database state
+        assert_eq!(sync_db.bounds().await.end, target_db_op_count);
+        assert_eq!(
+            sync_db.inactivity_floor_loc().await,
+            target_db_inactivity_floor_loc
+        );
+        assert_eq!(sync_db.sync_boundary().await, sync_lower_bound);
+
+        // Verify the root digest matches the target (verifies content integrity)
+        assert_eq!(sync_db.root(), target_hash);
+
+        sync_db.destroy().await.unwrap();
+        mmr.destroy().await.unwrap();
+    });
+}
+
+/// Test `from_sync_result` with an empty destination database syncing to a non-empty source.
+/// This tests the scenario where a sync client starts fresh with no existing data.
+pub(crate) fn test_from_sync_result_empty_to_nonempty<H: SyncTestHarness>()
+where
+    DbOf<H>: FromSyncTestable,
+    OpOf<H>: Encode + Clone,
+    JournalOf<H>: Contiguous,
+{
+    const NUM_OPS: usize = 100;
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create and populate a source database
+        let mut source_db = H::init_db(context.child("source")).await;
+        let ops = H::create_ops(NUM_OPS);
+        source_db = H::apply_ops(source_db, ops).await;
+        // commit already done in apply_ops
+        source_db
+            .prune(source_db.sync_boundary().await)
+            .await
+            .unwrap();
+
+        let lower_bound = source_db.sync_boundary().await;
+        let upper_bound = source_db.bounds().await.end;
+
+        // Get pinned nodes and target hash before deconstructing source_db
+        let pinned_nodes = source_db.pinned_nodes_at(lower_bound).await;
+        let target_hash = source_db.root();
+        let target_op_count = source_db.bounds().await.end;
+        let target_inactivity_floor = source_db.inactivity_floor_loc().await;
+
+        let (mmr, journal) = source_db.into_log_components();
+
+        // Use a different config (simulating a new empty database)
+        let new_db_config = H::config(&context.next_u64().to_string(), &context);
+
+        let db: DbOf<H> = <DbOf<H> as qmdb::sync::Database>::from_sync_result(
+            context.child("synced"),
+            new_db_config,
+            journal,
+            Some(pinned_nodes),
+            non_empty_range!(lower_bound, upper_bound),
+            1024,
+        )
+        .await
+        .unwrap();
+
+        // Verify database state
+        assert_eq!(db.bounds().await.end, target_op_count);
+        assert_eq!(db.inactivity_floor_loc().await, target_inactivity_floor);
+        assert_eq!(db.sync_boundary().await, lower_bound);
+
+        // Verify the root digest matches the target
+        assert_eq!(db.root(), target_hash);
+
+        db.destroy().await.unwrap();
+        mmr.destroy().await.unwrap();
+    });
+}
+
+/// Test `from_sync_result` with an empty source database syncing to an empty target database.
+pub(crate) fn test_from_sync_result_empty_to_empty<H: SyncTestHarness>()
+where
+    DbOf<H>: FromSyncTestable,
+    OpOf<H>: Encode + Clone,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Create an empty database (initialized with a single CommitFloor operation)
+        let source_db = H::init_db(context.child("source")).await;
+
+        // An empty database has exactly 1 operation (the initial CommitFloor)
+        assert_eq!(source_db.bounds().await.end, Location::new(1));
+
+        let target_hash = source_db.root();
+        let (mmr, journal) = source_db.into_log_components();
+
+        // Use a different config (simulating a new empty database)
+        let new_db_config = H::config(&context.next_u64().to_string(), &context);
+
+        let mut synced_db: DbOf<H> = <DbOf<H> as qmdb::sync::Database>::from_sync_result(
+            context.child("synced"),
+            new_db_config,
+            journal,
+            None,
+            non_empty_range!(Location::new(0), Location::new(1)),
+            1024,
+        )
+        .await
+        .unwrap();
+
+        // Verify database state
+        assert_eq!(synced_db.bounds().await.end, Location::new(1));
+        assert_eq!(synced_db.inactivity_floor_loc().await, Location::new(0));
+        assert_eq!(synced_db.root(), target_hash);
+
+        // Test that we can perform operations on the synced database
+        let ops = H::create_ops(10);
+        synced_db = H::apply_ops(synced_db, ops).await;
+
+        // Verify the operations worked
+        assert!(synced_db.bounds().await.end > Location::new(1));
+
+        synced_db.destroy().await.unwrap();
+        mmr.destroy().await.unwrap();
+    });
+}
+
+/// A resolver wrapper that corrupts pinned nodes on the first request, then returns correct
+/// data on subsequent requests.
+#[derive(Clone)]
+struct CorruptFirstPinnedNodesResolver<R> {
+    inner: R,
+    corrupted: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl<R> Resolver for CorruptFirstPinnedNodesResolver<R>
+where
+    R: Resolver<Digest = Digest>,
+{
+    type Family = R::Family;
+    type Digest = Digest;
+    type Op = R::Op;
+    type Error = R::Error;
+
+    async fn get_operations(
+        &self,
+        op_count: Location<Self::Family>,
+        start_loc: Location<Self::Family>,
+        max_ops: NonZeroU64,
+        include_pinned_nodes: bool,
+        cancel_rx: oneshot::Receiver<()>,
+    ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
+        let mut result = self
+            .inner
+            .get_operations(
+                op_count,
+                start_loc,
+                max_ops,
+                include_pinned_nodes,
+                cancel_rx,
+            )
+            .await?;
+        // Corrupt pinned nodes only on the first request that includes them.
+        if result.pinned_nodes.is_some()
+            && !self
+                .corrupted
+                .swap(true, std::sync::atomic::Ordering::Relaxed)
+        {
+            if let Some(ref mut nodes) = result.pinned_nodes {
+                if !nodes.is_empty() {
+                    nodes[0] = Digest::from([0xFFu8; 32]);
+                }
+            }
+        }
+        Ok(result)
+    }
+}
+
+/// Test that corrupted pinned nodes on the first attempt are rejected and the sync
+/// succeeds on retry when the resolver returns correct data.
+pub(crate) fn test_sync_retries_bad_pinned_nodes<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        // Build a target database with some operations and prune so that pinned nodes are needed.
+        let mut target_db = H::init_db(context.child("target")).await;
+        let ops = H::create_ops(20);
+        target_db = H::apply_ops(target_db, ops).await;
+        target_db
+            .prune(target_db.sync_boundary().await)
+            .await
+            .unwrap();
+
+        let sync_root = qmdb::sync::Database::ops_root(&target_db);
+        let verification_root = qmdb::sync::Database::root(&target_db);
+        let lower_bound = target_db.sync_boundary().await;
+        let upper_bound = target_db.bounds().await.end;
+
+        let db_config = H::config(&context.next_u64().to_string(), &context);
+
+        let resolver = CorruptFirstPinnedNodesResolver {
+            inner: Arc::new(target_db),
+            corrupted: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        };
+
+        let config = sync::engine::Config {
+            db_config,
+            fetch_batch_size: NZU64!(100),
+            target: H::target(
+                verification_root,
+                sync_root,
+                non_empty_range!(lower_bound, upper_bound),
+            ),
+            context: context.child("client"),
+            resolver,
+            apply_batch_size: 1024,
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        };
+
+        // Sync should succeed on the second attempt after the first corrupted pinned nodes
+        // are rejected.
+        let synced_db: H::Db = sync::sync(config).await.unwrap();
+        assert_eq!(synced_db.root(), sync_root);
+        synced_db.destroy().await.unwrap();
+    });
+}
+
+/// A resolver wrapper that replays the first fresh boundary request against the retained
+/// historical root, then blocks the retry until the test releases it.
+#[derive(Clone)]
+struct ReplayFreshBoundaryResolver<R: Resolver<Digest = Digest>> {
+    inner: R,
+    historical_target_size: Location<R::Family>,
+    boundary_start: Location<R::Family>,
+    release_historical_gap: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
+    release_boundary_retry: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
+    boundary_attempts: Arc<AtomicUsize>,
+}
+
+impl<R: Resolver<Digest = Digest>> Resolver for ReplayFreshBoundaryResolver<R> {
+    type Family = R::Family;
+    type Digest = Digest;
+    type Op = R::Op;
+    type Error = R::Error;
+
+    async fn get_operations(
+        &self,
+        op_count: Location<Self::Family>,
+        start_loc: Location<Self::Family>,
+        max_ops: NonZeroU64,
+        include_pinned_nodes: bool,
+        cancel_rx: oneshot::Receiver<()>,
+    ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
+        if op_count == self.historical_target_size {
+            if include_pinned_nodes {
+                let _ = cancel_rx.await;
+                return self
+                    .inner
+                    .get_operations(
+                        op_count,
+                        start_loc,
+                        max_ops,
+                        include_pinned_nodes,
+                        oneshot::channel().1,
+                    )
+                    .await;
+            }
+
+            let release = self.release_historical_gap.lock().take();
+            if let Some(release) = release {
+                let _ = release.await;
+            }
+        }
+
+        if include_pinned_nodes && start_loc == self.boundary_start {
+            let attempt = self.boundary_attempts.fetch_add(1, Ordering::Relaxed);
+            if attempt == 0 {
+                let mut result = self
+                    .inner
+                    .get_operations(
+                        self.historical_target_size,
+                        start_loc,
+                        max_ops,
+                        false,
+                        oneshot::channel().1,
+                    )
+                    .await?;
+                result.pinned_nodes = None;
+                return Ok(result);
+            }
+
+            let release = self.release_boundary_retry.lock().take();
+            if let Some(release) = release {
+                let _ = release.await;
+            }
+        }
+
+        self.inner
+            .get_operations(
+                op_count,
+                start_loc,
+                max_ops,
+                include_pinned_nodes,
+                cancel_rx,
+            )
+            .await
+    }
+}
+
+/// Test that reaching the journal target does not report completion while the pruned
+/// boundary retry is still outstanding.
+pub(crate) fn test_sync_waits_for_boundary_retry_after_target_update<H: SyncTestHarness>()
+where
+    Arc<DbOf<H>>: Resolver<Family = H::Family, Op = OpOf<H>, Digest = Digest>,
+    OpOf<H>: Encode,
+    JournalOf<H>: Contiguous,
+{
+    let executor = deterministic::Runner::default();
+    executor.start(|mut context| async move {
+        let mut target_db = H::init_db(context.child("target")).await;
+
+        let mut seed = 0;
+        loop {
+            target_db = H::apply_ops(target_db, H::create_ops_seeded(32, seed)).await;
+            target_db
+                .prune(target_db.sync_boundary().await)
+                .await
+                .unwrap();
+
+            if target_db.inactivity_floor_loc().await > Location::new(0) {
+                break;
+            }
+
+            seed += 1;
+            assert!(seed < 8, "expected prune floor to advance");
+        }
+
+        let old_target = H::target(
+            qmdb::sync::Database::root(&target_db),
+            qmdb::sync::Database::ops_root(&target_db),
+            non_empty_range!(
+                target_db.inactivity_floor_loc().await,
+                target_db.bounds().await.end
+            ),
+        );
+
+        target_db = H::apply_ops(target_db, H::create_ops_seeded(3, seed + 1)).await;
+        let new_target = H::target(
+            qmdb::sync::Database::root(&target_db),
+            qmdb::sync::Database::ops_root(&target_db),
+            non_empty_range!(
+                target_db.inactivity_floor_loc().await,
+                target_db.bounds().await.end
+            ),
+        );
+        let verification_root = target_db.root();
+
+        assert!(old_target.range().start() > Location::new(0));
+        assert!(new_target.range().end() > old_target.range().end());
+
+        let (release_historical_gap_tx, release_historical_gap_rx) = oneshot::channel();
+        let (release_boundary_retry_tx, release_boundary_retry_rx) = oneshot::channel();
+        let target_db = Arc::new(target_db);
+        let resolver = ReplayFreshBoundaryResolver {
+            inner: target_db.clone(),
+            historical_target_size: old_target.range().end(),
+            boundary_start: new_target.range().start(),
+            release_historical_gap: Arc::new(Mutex::new(Some(release_historical_gap_rx))),
+            release_boundary_retry: Arc::new(Mutex::new(Some(release_boundary_retry_rx))),
+            boundary_attempts: Arc::new(AtomicUsize::new(0)),
+        };
+
+        let (update_sender, update_receiver) = mpsc::channel(1);
+        let (finish_sender, finish_receiver) = mpsc::channel(1);
+        let (reached_sender, mut reached_receiver) = mpsc::channel(1);
+
+        let config = Config {
+            context: context.child("client"),
+            db_config: H::config(&context.next_u64().to_string(), &context),
+            fetch_batch_size: NZU64!(1),
+            target: old_target.clone(),
+            resolver,
+            apply_batch_size: 1024,
+            max_outstanding_requests: 2,
+            update_rx: Some(update_receiver),
+            finish_rx: Some(finish_receiver),
+            reached_target_tx: Some(reached_sender),
+            max_retained_roots: 1,
+        };
+
+        let mut engine: Engine<H::Db, _, TargetOf<H>> = Engine::new(config).await.unwrap();
+
+        update_sender.send(new_target.clone()).await.unwrap();
+        finish_sender.send(()).await.unwrap();
+
+        engine = match engine.step().await.unwrap() {
+            NextStep::Continue(engine) => engine,
+            NextStep::Complete(..) => panic!("target update should not complete sync"),
+        };
+
+        let _ = release_historical_gap_tx.send(());
+
+        let journal_start = engine.journal().size().await;
+        for step_idx in 0..4 {
+            let next_step = engine.step();
+            pin_mut!(next_step);
+
+            select! {
+                result = next_step.as_mut() => {
+                    engine = match result.unwrap() {
+                        NextStep::Continue(engine) => engine,
+                        NextStep::Complete(..) => panic!("boundary retry should still be required"),
+                    };
+                    assert_eq!(
+                        engine.journal().size().await,
+                        journal_start,
+                        "replayed fresh boundary responses must not advance the journal"
+                    );
+                },
+                _ = context.sleep(Duration::from_millis(100)) => {
+                    panic!(
+                        "engine should keep processing fetch results while the boundary retry is blocked: step={step_idx}"
+                    );
+                },
+            }
+        }
+        assert!(
+            reached_receiver.recv().now_or_never().is_none(),
+            "engine should not report reached-target while boundary state is missing"
+        );
+
+        let _ = release_boundary_retry_tx.send(());
+
+        let synced_db = engine.sync().await.unwrap();
+
+        let reached = reached_receiver.recv().await.unwrap();
+        assert_eq!(reached, new_target);
+        assert_eq!(synced_db.root(), verification_root);
+
+        synced_db.destroy().await.unwrap();
+        Arc::try_unwrap(target_db)
+            .unwrap_or_else(|_| panic!("failed to unwrap Arc"))
+            .destroy()
+            .await
+            .unwrap();
+    });
+}


### PR DESCRIPTION
- Add a `current::sync` wrapper path that verifies each `OpsRootWitness`, forwards authenticated ops-root targets to the shared sync engine, plus the database root, and verifies the database root derived from sync matches.
- Update the sync example to support moving `current` sync targets without trusting server-provided ops roots directly.
- Add regression coverage for `current` target updates and simplify duplicated sync target tests.

Resolves: https://github.com/commonwarexyz/monorepo/issues/3788
