### PR TITLE
[cryptography] bump aws-lc-rs to 1.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.3"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.36.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ suspicious_op_assign_impl = "allow"
 anyhow = { version = "1.0.99", default-features = false }
 arbitrary = "1.4.1"
 aws-config = "1.8.12"
-aws-lc-rs = "1.15.2"
+aws-lc-rs = "1.16.3"
 aws-sdk-ec2 = "1.200.0"
 aws-sdk-s3 = "1.91.0"
 axum = "0.8.1"


### PR DESCRIPTION
This includes support for compiling with cranelift (`AWS_LC_SYS_NO_U1_BINDINGS=1`).