### PR TITLE
fix sync bug from journal crash

### DIFF
--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -602,6 +602,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             journal.prune(range.start).await?;
         }
 
+        // After a same-section crash during a previous clear_to_size, the journal may recover to a
+        // stale position ahead of the requested start.
+        let bounds = journal.reader().await.bounds();
+        if bounds.is_empty() && bounds.start > range.start {
+            journal.clear_to_size(range.start).await?;
+        }
+
         Ok(journal)
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -576,6 +576,14 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             }
         }
 
+        // After a same-section crash during a previous clear_to_size, the journal may recover to a
+        // stale position ahead of the requested start.
+        let bounds = journal.reader().await.bounds();
+        if bounds.is_empty() && bounds.start > range.start {
+            journal.clear_to_size(range.start).await?;
+            return Ok(journal);
+        }
+
         // Check if data exceeds the sync range
         if size > range.end {
             return Err(Error::ItemOutOfRange(size));
@@ -593,20 +601,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         }
 
         // Prune to lower bound if needed
-        let bounds = journal.reader().await.bounds();
         if !bounds.is_empty() && bounds.start < range.start {
             debug!(
                 oldest_pos = bounds.start,
                 range.start, "pruning journal to sync range start"
             );
             journal.prune(range.start).await?;
-        }
-
-        // After a same-section crash during a previous clear_to_size, the journal may recover to a
-        // stale position ahead of the requested start.
-        let bounds = journal.reader().await.bounds();
-        if bounds.is_empty() && bounds.start > range.start {
-            journal.clear_to_size(range.start).await?;
         }
 
         Ok(journal)
@@ -3017,6 +3017,103 @@ mod tests {
                 // Should return ItemOutOfRange error since data exists beyond upper_bound
                 assert!(matches!(result, Err(Error::ItemOutOfRange(_))));
             }
+        });
+    }
+
+    /// Test `init_sync` repairs an empty journal recovered at a stale position beyond the range.
+    #[test_traced]
+    fn test_init_sync_empty_stale_position_beyond_upper_bound() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-empty-stale-position".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                write_buffer: NZUsize!(1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
+            };
+
+            let stale_size = 30;
+            let journal = Journal::<deterministic::Context, u64>::init_at_size(
+                context.child("first"),
+                cfg.clone(),
+                stale_size,
+            )
+            .await
+            .expect("Failed to create stale empty journal");
+            assert_eq!(journal.size().await, stale_size);
+            assert!(journal.bounds().await.is_empty());
+            drop(journal);
+
+            let lower_bound = 10;
+            let upper_bound = 26;
+            let journal = Journal::<deterministic::Context, u64>::init_sync(
+                context.child("second"),
+                cfg.clone(),
+                lower_bound..upper_bound,
+            )
+            .await
+            .expect("Failed to repair stale empty journal");
+
+            assert_eq!(journal.size().await, lower_bound);
+            assert!(journal.bounds().await.is_empty());
+
+            let pos = journal.append(&999).await.unwrap();
+            assert_eq!(pos, lower_bound);
+            assert_eq!(journal.read(pos).await.unwrap(), 999);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Test `init_sync` repairs an empty journal recovered after a `clear_to_size` crash.
+    #[test_traced]
+    fn test_init_sync_recovers_from_stale_clear_to_size() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-stale-clear-to-size".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                write_buffer: NZUsize!(1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
+            };
+
+            let journal = Journal::<deterministic::Context, u64>::init_at_size(
+                context.child("first"),
+                cfg.clone(),
+                9,
+            )
+            .await
+            .expect("Failed to create stale empty journal");
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Simulate clear_to_size(7) crashing after clearing data, but before offsets were
+            // re-cleared. Recovery will initially see the old empty offsets boundary at 9.
+            match context.remove(&cfg.data_partition(), None).await {
+                Ok(()) | Err(commonware_runtime::Error::PartitionMissing(_)) => {}
+                Err(error) => panic!("failed to clear data partition: {error}"),
+            }
+
+            let lower_bound = 7;
+            let upper_bound = 20;
+            let journal = Journal::<deterministic::Context, u64>::init_sync(
+                context.child("second"),
+                cfg.clone(),
+                lower_bound..upper_bound,
+            )
+            .await
+            .expect("Failed to repair stale empty journal");
+
+            assert_eq!(journal.size().await, lower_bound);
+            let bounds = journal.bounds().await;
+            assert!(bounds.is_empty());
+            assert_eq!(bounds.start, lower_bound);
+
+            journal.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/qmdb/sync/journal.rs
+++ b/storage/src/qmdb/sync/journal.rs
@@ -1,5 +1,5 @@
 use crate::{
-    journal::contiguous::Contiguous,
+    journal::contiguous::{Contiguous, Reader as _},
     merkle::{Family, Location},
 };
 use commonware_utils::range::NonEmptyRange;
@@ -124,6 +124,14 @@ where
             journal.prune(*range.start()).await?;
         }
 
+        // After a same-section crash during a previous clear_to_size, the journal may recover to a
+        // stale position ahead of the requested start. Re-clear so the sync engine starts from the
+        // correct location.
+        let bounds = journal.reader().await.bounds();
+        if bounds.is_empty() && bounds.start > *range.start() {
+            journal.clear_to_size(*range.start()).await?;
+        }
+
         Ok(journal)
     }
 
@@ -145,5 +153,70 @@ where
 
     async fn append(&mut self, op: Self::Op) -> Result<(), Self::Error> {
         Self::append(self, &op).await.map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::journal::contiguous::fixed;
+    use commonware_cryptography::sha256::Digest;
+    use commonware_macros::test_traced;
+    use commonware_runtime::{
+        buffer::paged::CacheRef, deterministic, Blob, BufferPooler, Runner, Storage,
+        Supervisor as _,
+    };
+    use commonware_utils::{non_empty_range, NZUsize, NZU16, NZU64};
+
+    type FixedJournal = fixed::Journal<deterministic::Context, Digest>;
+    type F = crate::merkle::mmr::Family;
+
+    fn test_cfg(pooler: &impl BufferPooler) -> fixed::Config {
+        fixed::Config {
+            partition: "sync-journal-test".into(),
+            items_per_blob: NZU64!(5),
+            page_cache: CacheRef::from_pooler(pooler, NZU16!(44), NZUsize!(3)),
+            write_buffer: NZUsize!(2048),
+        }
+    }
+
+    #[test_traced]
+    fn test_sync_journal_new_recovers_from_stale_clear_to_size() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context);
+
+            // Create a journal at pruning_boundary=9 (mid-section in section 1).
+            let journal = FixedJournal::init_at_size(context.child("setup"), cfg.clone(), 9)
+                .await
+                .unwrap();
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Simulate clear_to_size(7) crash: blobs cleared, section 1 recreated
+            // empty, but metadata still says pruning_boundary=9.
+            let blob_part = format!("{}-blobs", cfg.partition);
+            context.remove(&blob_part, None).await.unwrap();
+            let (blob, _) = context.open(&blob_part, &1u64.to_be_bytes()).await.unwrap();
+            blob.sync().await.unwrap();
+
+            // Without the fix, this reopens at 9..9 and the sync engine skips
+            // locations 7-8. With the fix, it re-clears to 7.
+            let range = non_empty_range!(
+                crate::merkle::Location::<F>::new(7),
+                crate::merkle::Location::<F>::new(20)
+            );
+            let journal = <FixedJournal as Journal<F>>::new(context.child("sync"), cfg, range)
+                .await
+                .unwrap();
+
+            let size = Contiguous::size(&journal).await;
+            assert_eq!(size, 7);
+            let bounds = journal.reader().await.bounds();
+            assert!(bounds.is_empty());
+            assert_eq!(bounds.start, 7);
+
+            journal.destroy().await.unwrap();
+        });
     }
 }

--- a/storage/src/qmdb/sync/journal.rs
+++ b/storage/src/qmdb/sync/journal.rs
@@ -114,6 +114,15 @@ where
             return Ok(journal);
         }
 
+        // After a crash during a previous clear_to_size, the journal may recover empty at a stale
+        // position ahead of the requested start (possibly even beyond range.end). Re-clear so the
+        // sync engine starts from the correct location.
+        let bounds = journal.reader().await.bounds();
+        if bounds.is_empty() && bounds.start > *range.start() {
+            journal.clear_to_size(*range.start()).await?;
+            return Ok(journal);
+        }
+
         if size > *range.end() {
             return Err(crate::journal::Error::ItemOutOfRange(size));
         }
@@ -122,14 +131,6 @@ where
             journal.clear_to_size(*range.start()).await?;
         } else {
             journal.prune(*range.start()).await?;
-        }
-
-        // After a same-section crash during a previous clear_to_size, the journal may recover to a
-        // stale position ahead of the requested start. Re-clear so the sync engine starts from the
-        // correct location.
-        let bounds = journal.reader().await.bounds();
-        if bounds.is_empty() && bounds.start > *range.start() {
-            journal.clear_to_size(*range.start()).await?;
         }
 
         Ok(journal)
@@ -202,6 +203,39 @@ mod tests {
 
             // Without the fix, this reopens at 9..9 and the sync engine skips
             // locations 7-8. With the fix, it re-clears to 7.
+            let range = non_empty_range!(
+                crate::merkle::Location::<F>::new(7),
+                crate::merkle::Location::<F>::new(20)
+            );
+            let journal = <FixedJournal as Journal<F>>::new(context.child("sync"), cfg, range)
+                .await
+                .unwrap();
+
+            let size = Contiguous::size(&journal).await;
+            assert_eq!(size, 7);
+            let bounds = journal.reader().await.bounds();
+            assert!(bounds.is_empty());
+            assert_eq!(bounds.start, 7);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_sync_journal_new_stale_empty_position_beyond_range_end() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context);
+
+            // Create a journal at pruning_boundary=30, well beyond our intended range end.
+            let journal = FixedJournal::init_at_size(context.child("setup"), cfg.clone(), 30)
+                .await
+                .unwrap();
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Open via Journal::new with a range whose end < 30. Without the fix this would
+            // return ItemOutOfRange because size(30) > range.end(20).
             let range = non_empty_range!(
                 crate::merkle::Location::<F>::new(7),
                 crate::merkle::Location::<F>::new(20)


### PR DESCRIPTION
After a same-section crash during clear_to_size, the fixed and variable contiguous journals can recover to a stale pruning boundary ahead of the sync range start. The sync journal wrappers trusted size() without verifying it matched the requested range, causing the sync engine to skip the missing prefix and eventually fail with a root mismatch.

This adds a post-adjustment bounds check to both the fixed and variable sync journal new implementations that detects the stale position and re-clears to the correct start.