### PR TITLE
[ci] Bump performance benchmark samples

### DIFF
--- a/.github/benchmark-tracking.toml
+++ b/.github/benchmark-tracking.toml
@@ -49,7 +49,7 @@ cargo_flags = ["--features", "test-traits"]
 
 [[packages.benchmarks]]
 name = "qmdb"
-criterion_args = ["--sample-size", "100", "--significance-level", "0.01"]
+criterion_args = ["--sample-size", "500", "--significance-level", "0.01"]
 variants = [
   "qmdb::merkleize/variant=any::unordered::fixed::mmr keys=10000 ch=false sync=false",
   "qmdb::merkleize/variant=current::ordered::fixed::mmb chunk=256 keys=10000 ch=true sync=false",


### PR DESCRIPTION
## Overview

Bumps benchmark samples to 500 for the QMDB benchmarks tracked in the performance regression job, lowering the likelihood that noise on the runner will trip a false regression.