### PR TITLE
[actor] (Re)introduce `Rejected`

### DIFF
--- a/actor/src/benches/mailbox.rs
+++ b/actor/src/benches/mailbox.rs
@@ -258,7 +258,7 @@ fn bench_overflow_drop(c: &mut Criterion) {
             |(sender, _receiver)| {
                 for _ in 0..MESSAGES {
                     let result = sender.enqueue(black_box(Message::drop()));
-                    assert_eq!(result, Feedback::Dropped);
+                    assert_eq!(result, Feedback::Rejected);
                     black_box(result);
                 }
             },

--- a/actor/src/benches/mailbox.rs
+++ b/actor/src/benches/mailbox.rs
@@ -92,11 +92,12 @@ impl Message {
 impl mailbox::Policy for Message {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+    fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
         match message.policy {
-            Policy::Drop => {}
+            Policy::Drop => false,
             Policy::Spill => {
                 overflow.push_back(message);
+                true
             }
             Policy::Replace => {
                 if let Some(pending) = overflow
@@ -108,6 +109,7 @@ impl mailbox::Policy for Message {
                 } else {
                     overflow.push_back(message);
                 }
+                true
             }
         }
     }
@@ -256,7 +258,7 @@ fn bench_overflow_drop(c: &mut Criterion) {
             |(sender, _receiver)| {
                 for _ in 0..MESSAGES {
                     let result = sender.enqueue(black_box(Message::drop()));
-                    assert_eq!(result, Feedback::Backoff);
+                    assert_eq!(result, Feedback::Dropped);
                     black_box(result);
                 }
             },

--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -15,9 +15,9 @@ commonware_macros::stability_scope!(BETA {
     pub enum Feedback {
         /// The work was accepted within the configured capacity.
         Ok,
-        /// The submission exceeded ready capacity but was handled by the overflow policy.
+        /// The submission exceeded configured capacity but was handled by the overflow policy.
         Backoff,
-        /// The submission exceeded ready capacity and was rejected by the overflow policy.
+        /// The submission exceeded configured capacity and was rejected by the overflow policy.
         Rejected,
         /// The endpoint is closed.
         Closed,
@@ -25,9 +25,6 @@ commonware_macros::stability_scope!(BETA {
 
     impl Feedback {
         /// Returns `true` when the endpoint handled the submission.
-        ///
-        /// This does not guarantee eventual delivery. Handled work may still be coalesced,
-        /// superseded, or fail later inside the receiver.
         pub const fn accepted(self) -> bool {
             matches!(self, Self::Ok | Self::Backoff)
         }

--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -15,16 +15,19 @@ commonware_macros::stability_scope!(BETA {
     pub enum Feedback {
         /// The work was accepted within the configured capacity.
         Ok,
-        /// The submission exceeded the configured capacity and requests sender backoff.
+        /// The submission exceeded ready capacity but was handled by the overflow policy.
         Backoff,
-        /// The submission exceeded the configured capacity and was dropped.
-        Dropped,
+        /// The submission exceeded ready capacity and was rejected by the overflow policy.
+        Rejected,
         /// The endpoint is closed.
         Closed,
     }
 
     impl Feedback {
         /// Returns `true` when the endpoint handled the submission.
+        ///
+        /// This does not guarantee eventual delivery. Handled work may still be coalesced,
+        /// superseded, or fail later inside the receiver.
         pub const fn accepted(self) -> bool {
             matches!(self, Self::Ok | Self::Backoff)
         }

--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -17,6 +17,8 @@ commonware_macros::stability_scope!(BETA {
         Ok,
         /// The submission exceeded the configured capacity and requests sender backoff.
         Backoff,
+        /// The submission exceeded the configured capacity and was dropped.
+        Dropped,
         /// The endpoint is closed.
         Closed,
     }

--- a/actor/src/mailbox.rs
+++ b/actor/src/mailbox.rs
@@ -93,10 +93,6 @@ pub trait Policy: Sized {
 
     /// Handle `message` when it cannot enter the bounded ready queue immediately.
     ///
-    /// Messages already in the ready queue are not provided here. Policy changes only apply to
-    /// overflow retained beyond ready capacity. Policies may append, remove, replace, reorder, or
-    /// clear overflow, and are responsible for bounding it when a hard memory limit is required.
-    ///
     /// Returns `true` when the policy considered the message's effects. This includes
     /// retaining the message, coalescing it with retained work, replacing older retained work,
     /// or deliberately doing no work because the message is already satisfied, superseded, or no

--- a/actor/src/mailbox.rs
+++ b/actor/src/mailbox.rs
@@ -97,6 +97,10 @@ pub trait Policy: Sized {
     /// overflow retained beyond ready capacity. Policies may append, remove, replace, reorder, or
     /// clear overflow, and are responsible for bounding it when a hard memory limit is required.
     ///
+    /// Returns `true` when the message's effects were considered, including when a policy
+    /// coalesces it with retained work or ignores it as a no-op. Returns `false` only when the
+    /// message's effects were dropped.
+    ///
     /// # Warning
     ///
     /// Do not enqueue into the same mailbox from this method or from destructors triggered by
@@ -106,7 +110,7 @@ pub trait Policy: Sized {
     /// This method should not unwind after mutating `overflow`. A panic, including one from a
     /// destructor triggered while editing `overflow`, can leave retained overflow data stranded in
     /// the mailbox.
-    fn handle(overflow: &mut Self::Overflow, message: Self);
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool;
 }
 
 // `activity` packs the published overflow state and in-flight overflow
@@ -299,9 +303,13 @@ impl<T: Policy> OverflowState<T> {
         };
 
         // Preserve overflow order, or handle a still-full ready queue.
-        T::handle(&mut queue, message);
+        let handled = T::handle(&mut queue, message);
         mutation.publish(queue.is_empty());
-        Feedback::Backoff
+        if handled {
+            Feedback::Backoff
+        } else {
+            Feedback::Dropped
+        }
     }
 
     fn refill(&self, ready: &Ready<T>) {
@@ -445,10 +453,10 @@ impl<T: Policy> Sender<T> {
             self.state.backoff.inc();
         }
 
-        // Wake on any handled enqueue because a receiver may have skipped
-        // refill while this overflow mutation was active. By the time we wake,
-        // the mutation has published its overflow state. Spurious wakes are
-        // acceptable.
+        // Wake after any non-closed slow-path enqueue because a receiver may
+        // have skipped refill while this overflow mutation was active. By the
+        // time we wake, the mutation has published its overflow state. Spurious
+        // wakes are acceptable.
         if feedback != Feedback::Closed {
             self.state.waker.wake();
         }
@@ -631,7 +639,7 @@ mod tests {
     impl Policy for Message {
         type Overflow = VecDeque<Self>;
 
-        fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+        fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
             match message {
                 Self::Update(value) => {
                     if let Some(index) = overflow
@@ -641,21 +649,24 @@ mod tests {
                         overflow.remove(index);
                     }
                     overflow.push_back(Self::Update(value));
+                    true
                 }
                 Self::Required(_) | Self::Buffered(_) => {
                     overflow.push_back(message);
+                    true
                 }
                 Self::Hint(value) => {
                     let Some(index) = overflow
                         .iter()
                         .rposition(|pending| matches!(pending, Self::Update(_)))
                     else {
-                        return;
+                        return true;
                     };
                     overflow.remove(index);
                     overflow.push_back(Self::Hint(value));
+                    true
                 }
-                Self::Vote(_) => {}
+                Self::Vote(_) => false,
             }
         }
     }
@@ -667,8 +678,9 @@ mod tests {
     impl Policy for Ack {
         type Overflow = VecDeque<Self>;
 
-        fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+        fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
             overflow.push_back(message);
+            true
         }
     }
 
@@ -738,7 +750,7 @@ mod tests {
     async fn full_inbox_rejects_non_replaceable_message() {
         let (sender, mut receiver) = new(NZUsize!(1));
         assert_eq!(sender.enqueue(Message::Vote(1)), Feedback::Ok);
-        assert_eq!(sender.enqueue(Message::Vote(2)), Feedback::Backoff);
+        assert_eq!(sender.enqueue(Message::Vote(2)), Feedback::Dropped);
 
         assert_eq!(receiver.recv().await, Some(Message::Vote(1)));
     }
@@ -776,6 +788,25 @@ mod tests {
             assert!(
                 buffer.contains("mailbox_backoff_total 2"),
                 "missing backoff count in metrics: {buffer}"
+            );
+        });
+    }
+
+    #[test]
+    fn dropped_feedback_is_not_accepted_or_counted_as_backoff() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (sender, _receiver) = super::new(context.child("mailbox"), NZUsize!(1));
+            assert_eq!(sender.enqueue(Message::Vote(1)), Feedback::Ok);
+            let feedback = sender.enqueue(Message::Vote(2));
+
+            assert_eq!(feedback, Feedback::Dropped);
+            assert!(!feedback.accepted());
+
+            let buffer = context.encode();
+            assert!(
+                buffer.contains("mailbox_backoff_total 0"),
+                "unexpected backoff count in metrics: {buffer}"
             );
         });
     }
@@ -1007,9 +1038,10 @@ mod tests {
     impl Policy for ClearingMessage {
         type Overflow = VecDeque<Self>;
 
-        fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+        fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
             overflow.push_back(message);
             overflow.clear();
+            true
         }
     }
 
@@ -1038,8 +1070,9 @@ mod tests {
     impl Policy for SpillMessage {
         type Overflow = VecDeque<Self>;
 
-        fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+        fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
             overflow.push_back(message);
+            true
         }
     }
 
@@ -1131,11 +1164,12 @@ mod loom_tests {
     impl Policy for Message {
         type Overflow = VecDeque<Self>;
 
-        fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+        fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
             match message {
-                Self::Drop(_) => {}
+                Self::Drop(_) => false,
                 Self::Spill(_) => {
                     overflow.push_back(message);
+                    true
                 }
             }
         }
@@ -1144,7 +1178,7 @@ mod loom_tests {
     impl Policy for OrderedMessage {
         type Overflow = VecDeque<Self>;
 
-        fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+        fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
             let gate = match &message {
                 Self::Item(_) => None,
                 Self::Coordinated(_, gate) => Some(gate.clone()),
@@ -1156,15 +1190,16 @@ mod loom_tests {
                     thread::yield_now();
                 }
             }
+            true
         }
     }
 
     impl Policy for ReplacingMessage {
         type Overflow = VecDeque<Self>;
 
-        fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+        fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
             match message {
-                Self::FillReady => {}
+                Self::FillReady => false,
                 Self::Replace(_) => {
                     if let Some(pending) = overflow
                         .iter_mut()
@@ -1175,6 +1210,7 @@ mod loom_tests {
                     } else {
                         overflow.push_back(message);
                     }
+                    true
                 }
             }
         }
@@ -1183,16 +1219,18 @@ mod loom_tests {
     impl Policy for TrackedMessage {
         type Overflow = VecDeque<Self>;
 
-        fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+        fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
             overflow.push_back(message);
+            true
         }
     }
 
     impl Policy for CyclicMessage {
         type Overflow = VecDeque<Self>;
 
-        fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+        fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
             overflow.push_back(message);
+            true
         }
     }
 

--- a/actor/src/mailbox.rs
+++ b/actor/src/mailbox.rs
@@ -97,9 +97,15 @@ pub trait Policy: Sized {
     /// overflow retained beyond ready capacity. Policies may append, remove, replace, reorder, or
     /// clear overflow, and are responsible for bounding it when a hard memory limit is required.
     ///
-    /// Returns `true` when the message's effects were considered, including when a policy
-    /// coalesces it with retained work or ignores it as a no-op. Returns `false` only when the
-    /// message's effects were dropped.
+    /// Returns `true` when the policy considered the message's effects. This includes
+    /// retaining the message, coalescing it with retained work, replacing older retained work,
+    /// or deliberately doing no work because the message is already satisfied, superseded, or no
+    /// longer needed (for example, a request whose response channel is already closed). These
+    /// no-op cases are still handled: there is no remaining work, so there is no loss to report.
+    ///
+    /// Returns `false` only when the policy rejects the message under backpressure. This is the
+    /// lossy case: the submitted work was not semantically handled, and callers that care should
+    /// retry or treat the submission as failed.
     ///
     /// # Warning
     ///
@@ -308,7 +314,7 @@ impl<T: Policy> OverflowState<T> {
         if handled {
             Feedback::Backoff
         } else {
-            Feedback::Dropped
+            Feedback::Rejected
         }
     }
 
@@ -750,7 +756,7 @@ mod tests {
     async fn full_inbox_rejects_non_replaceable_message() {
         let (sender, mut receiver) = new(NZUsize!(1));
         assert_eq!(sender.enqueue(Message::Vote(1)), Feedback::Ok);
-        assert_eq!(sender.enqueue(Message::Vote(2)), Feedback::Dropped);
+        assert_eq!(sender.enqueue(Message::Vote(2)), Feedback::Rejected);
 
         assert_eq!(receiver.recv().await, Some(Message::Vote(1)));
     }
@@ -793,14 +799,14 @@ mod tests {
     }
 
     #[test]
-    fn dropped_feedback_is_not_accepted_or_counted_as_backoff() {
+    fn rejected_feedback_is_not_accepted_or_counted_as_backoff() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (sender, _receiver) = super::new(context.child("mailbox"), NZUsize!(1));
             assert_eq!(sender.enqueue(Message::Vote(1)), Feedback::Ok);
             let feedback = sender.enqueue(Message::Vote(2));
 
-            assert_eq!(feedback, Feedback::Dropped);
+            assert_eq!(feedback, Feedback::Rejected);
             assert!(!feedback.accepted());
 
             let buffer = context.encode();

--- a/broadcast/src/buffered/ingress.rs
+++ b/broadcast/src/buffered/ingress.rs
@@ -79,7 +79,7 @@ impl<P: PublicKey, M: Digestible> Policy for Message<P, M> {
 
     fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         if message.response_closed() {
-            return false;
+            return true;
         }
 
         overflow.0.push_back(message);

--- a/broadcast/src/buffered/ingress.rs
+++ b/broadcast/src/buffered/ingress.rs
@@ -77,12 +77,13 @@ impl<P: PublicKey, M: Digestible> Overflow<Message<P, M>> for Pending<P, M> {
 impl<P: PublicKey, M: Digestible> Policy for Message<P, M> {
     type Overflow = Pending<P, M>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         if message.response_closed() {
-            return;
+            return false;
         }
 
         overflow.0.push_back(message);
+        true
     }
 }
 

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -148,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    fn policy_drops_closed_responders() {
+    fn policy_handles_closed_responders() {
         let mut overflow = <Message<PublicKey, TestMessage> as Policy>::Overflow::default();
         let pending_subscribe = TestMessage::shared(b"pending_subscribe");
         let pending_get = TestMessage::shared(b"pending_get");
@@ -196,13 +196,13 @@ mod tests {
 
         let (current_responder, current_receiver) = commonware_utils::channel::oneshot::channel();
         drop(current_receiver);
-        <Message<PublicKey, TestMessage> as Policy>::handle(
+        assert!(<Message<PublicKey, TestMessage> as Policy>::handle(
             &mut overflow,
             Message::Get {
                 digest: current_get.digest(),
                 responder: current_responder,
             },
-        );
+        ));
 
         let mut drained = VecDeque::new();
         overflow.drain(|message| {

--- a/collector/src/p2p/ingress.rs
+++ b/collector/src/p2p/ingress.rs
@@ -28,30 +28,12 @@ impl<P: PublicKey, R: Committable + Digestible + Codec> Policy for Message<P, R>
                 request,
                 recipients,
             } => {
-                // The actor tracks outbound requests by commitment, so overflow coalesces sends
-                // with the same key. Keep the first queued payload and union later recipients into
-                // that send.
-                let commitment = request.commitment();
-                if let Some(existing) = overflow.iter_mut().find(|message| {
-                    matches!(
-                        message,
-                        Self::Send { request, .. } if request.commitment() == commitment
-                    )
-                }) {
-                    let Self::Send {
-                        recipients: existing,
-                        ..
-                    } = existing
-                    else {
-                        unreachable!("matched send");
-                    };
-                    merge_recipients(existing, recipients);
-                } else {
-                    overflow.push_back(Self::Send {
-                        request,
-                        recipients,
-                    });
-                }
+                // Commitment identifies the collection, not necessarily the encoded request.
+                // Keep payloads separate so peers never receive bytes intended for another send.
+                overflow.push_back(Self::Send {
+                    request,
+                    recipients,
+                });
             }
             Self::Cancel { commitment } => {
                 // Drop queued sends that this cancel supersedes. Keep the cancel itself because
@@ -66,46 +48,6 @@ impl<P: PublicKey, R: Committable + Digestible + Codec> Policy for Message<P, R>
             }
         }
         true
-    }
-}
-
-/// Merges recipients into an existing queued send without duplicating peers.
-fn merge_recipients<P: PublicKey>(existing: &mut Recipients<P>, incoming: Recipients<P>) {
-    if matches!(existing, Recipients::All) {
-        return;
-    }
-    if matches!(incoming, Recipients::All) {
-        *existing = Recipients::All;
-        return;
-    }
-
-    let previous = std::mem::replace(existing, Recipients::All);
-    *existing = union_recipients(previous, incoming);
-}
-
-/// Returns the sorted, deduplicated union of two non-`All` recipient sets.
-fn union_recipients<P: PublicKey>(
-    existing: Recipients<P>,
-    incoming: Recipients<P>,
-) -> Recipients<P> {
-    let mut peers = match existing {
-        Recipients::All => unreachable!("handled above"),
-        Recipients::One(peer) => vec![peer],
-        Recipients::Some(peers) => peers,
-    };
-
-    match incoming {
-        Recipients::All => unreachable!("handled above"),
-        Recipients::One(peer) => peers.push(peer),
-        Recipients::Some(incoming) => peers.extend(incoming),
-    }
-
-    peers.sort();
-    peers.dedup();
-    if peers.len() == 1 {
-        Recipients::One(peers.pop().expect("single peer"))
-    } else {
-        Recipients::Some(peers)
     }
 }
 
@@ -171,11 +113,10 @@ mod tests {
     }
 
     #[test]
-    fn send_merges_recipients_for_same_commitment() {
+    fn send_same_request_keeps_recipients_separate() {
         let request = Request { id: 1, data: 10 };
         let peer1 = peer(1);
         let peer2 = peer(2);
-        let peer3 = peer(3);
         let mut overflow = VecDeque::new();
 
         handle(
@@ -189,31 +130,25 @@ mod tests {
             &mut overflow,
             Message::Send {
                 request: request.clone(),
-                recipients: Recipients::Some(vec![peer2.clone(), peer1.clone()]),
-            },
-        );
-        handle(
-            &mut overflow,
-            Message::Send {
-                request,
-                recipients: Recipients::One(peer3.clone()),
+                recipients: Recipients::One(peer2.clone()),
             },
         );
 
-        assert_eq!(overflow.len(), 1);
-        let Message::Send { recipients, .. } = &overflow[0] else {
-            panic!("expected send");
-        };
-        let Recipients::Some(peers) = recipients else {
-            panic!("expected merged recipient set");
-        };
-        let mut expected = vec![peer1, peer2, peer3];
-        expected.sort();
-        assert_eq!(peers, &expected);
+        assert_eq!(overflow.len(), 2);
+        assert!(matches!(
+            &overflow[0],
+            Message::Send { request: queued, recipients: Recipients::One(peer), .. }
+                if queued == &request && peer == &peer1
+        ));
+        assert!(matches!(
+            &overflow[1],
+            Message::Send { request: queued, recipients: Recipients::One(peer), .. }
+                if queued == &request && peer == &peer2
+        ));
     }
 
     #[test]
-    fn send_merges_same_commitment_with_different_digest() {
+    fn send_same_commitment_different_digest_keeps_payloads_separate() {
         let request1 = Request { id: 1, data: 10 };
         let request2 = Request { id: 1, data: 20 };
         let peer1 = peer(1);
@@ -230,30 +165,26 @@ mod tests {
         handle(
             &mut overflow,
             Message::Send {
-                request: request2,
+                request: request2.clone(),
                 recipients: Recipients::One(peer2.clone()),
             },
         );
 
-        assert_eq!(overflow.len(), 1);
-        let Message::Send {
-            request,
-            recipients,
-        } = &overflow[0]
-        else {
-            panic!("expected send");
-        };
-        assert_eq!(request, &request1);
-        let Recipients::Some(peers) = recipients else {
-            panic!("expected merged recipient set");
-        };
-        let mut expected = vec![peer1, peer2];
-        expected.sort();
-        assert_eq!(peers, &expected);
+        assert_eq!(overflow.len(), 2);
+        assert!(matches!(
+            &overflow[0],
+            Message::Send { request, recipients: Recipients::One(peer), .. }
+                if request == &request1 && peer == &peer1
+        ));
+        assert!(matches!(
+            &overflow[1],
+            Message::Send { request, recipients: Recipients::One(peer), .. }
+                if request == &request2 && peer == &peer2
+        ));
     }
 
     #[test]
-    fn send_merge_with_all_recipients_supersedes_specific_recipients() {
+    fn send_with_all_recipients_keeps_payloads_separate() {
         let request = Request { id: 1, data: 10 };
         let mut overflow = VecDeque::new();
 
@@ -272,9 +203,16 @@ mod tests {
             },
         );
 
-        assert_eq!(overflow.len(), 1);
+        assert_eq!(overflow.len(), 2);
         assert!(matches!(
             &overflow[0],
+            Message::Send {
+                recipients: Recipients::One(_),
+                ..
+            }
+        ));
+        assert!(matches!(
+            &overflow[1],
             Message::Send {
                 recipients: Recipients::All,
                 ..

--- a/collector/src/p2p/ingress.rs
+++ b/collector/src/p2p/ingress.rs
@@ -22,7 +22,7 @@ pub enum Message<P: PublicKey, R: Committable + Digestible + Codec> {
 impl<P: PublicKey, R: Committable + Digestible + Codec> Policy for Message<P, R> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         match message {
             Self::Send {
                 request,
@@ -65,6 +65,7 @@ impl<P: PublicKey, R: Committable + Digestible + Codec> Policy for Message<P, R>
                 overflow.push_back(Self::Cancel { commitment });
             }
         }
+        true
     }
 }
 

--- a/consensus/src/aggregation/mocks/reporter.rs
+++ b/consensus/src/aggregation/mocks/reporter.rs
@@ -30,8 +30,9 @@ enum Message<S: Scheme, D: Digest> {
 impl<S: Scheme, D: Digest> Policy for Message<S, D> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+    fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
         overflow.push_back(message);
+        true
     }
 }
 

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -168,7 +168,7 @@ where
 
     fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         if message.response_closed() {
-            return false;
+            return true;
         }
 
         overflow.0.push_back(message);

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -166,12 +166,13 @@ where
 {
     type Overflow = Pending<B, C, H, P>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         if message.response_closed() {
-            return;
+            return false;
         }
 
         overflow.0.push_back(message);
+        true
     }
 }
 

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -411,10 +411,10 @@ impl<S: Scheme, V: Variant> Overflow<Message<S, V>> for Pending<S, V> {
 impl<S: Scheme, V: Variant> Policy for Message<S, V> {
     type Overflow = Pending<S, V>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         // A closed responder cannot be served
         if message.response_closed() {
-            return;
+            return false;
         }
         match message {
             // Coalesce hints: a single entry per height with a unioned target set
@@ -431,13 +431,14 @@ impl<S: Scheme, V: Variant> Policy for Message<S, V> {
             // Queue if the new message is still useful
             message => {
                 if message.stale(overflow.height()) {
-                    return;
+                    return true;
                 }
                 overflow
                     .messages
                     .push_back(PendingMessage::Message(message));
             }
         }
+        true
     }
 }
 

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -414,7 +414,7 @@ impl<S: Scheme, V: Variant> Policy for Message<S, V> {
     fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         // A closed responder cannot be served
         if message.response_closed() {
-            return false;
+            return true;
         }
         match message {
             // Coalesce hints: a single entry per height with a unioned target set
@@ -943,7 +943,7 @@ mod tests {
     }
 
     #[test]
-    fn policy_drops_closed_subscriptions() {
+    fn policy_handles_closed_subscriptions() {
         let mut overflow = pending();
 
         let (pending_closed, pending_closed_rx) = subscribe_by_digest(1);
@@ -959,7 +959,7 @@ mod tests {
 
         let (current_closed, current_closed_rx) = subscribe_by_digest(3);
         drop(current_closed_rx);
-        <TestMessage as Policy>::handle(&mut overflow, current_closed);
+        assert!(<TestMessage as Policy>::handle(&mut overflow, current_closed));
 
         assert!(!has_subscription(&overflow, 1));
         assert!(has_subscription(&overflow, 2));
@@ -971,7 +971,7 @@ mod tests {
     }
 
     #[test]
-    fn policy_drops_closed_responses() {
+    fn policy_handles_closed_responses() {
         let mut overflow = pending();
 
         let (pending_closed, pending_closed_rx) = get_block(1);
@@ -987,7 +987,7 @@ mod tests {
 
         let (current_closed, current_closed_rx) = get_finalization(3);
         drop(current_closed_rx);
-        <TestMessage as Policy>::handle(&mut overflow, current_closed);
+        assert!(<TestMessage as Policy>::handle(&mut overflow, current_closed));
 
         assert!(!has_get_block(&overflow, 1));
         assert!(has_get_info(&overflow, 2));

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -959,7 +959,10 @@ mod tests {
 
         let (current_closed, current_closed_rx) = subscribe_by_digest(3);
         drop(current_closed_rx);
-        assert!(<TestMessage as Policy>::handle(&mut overflow, current_closed));
+        assert!(<TestMessage as Policy>::handle(
+            &mut overflow,
+            current_closed
+        ));
 
         assert!(!has_subscription(&overflow, 1));
         assert!(has_subscription(&overflow, 2));
@@ -987,7 +990,10 @@ mod tests {
 
         let (current_closed, current_closed_rx) = get_finalization(3);
         drop(current_closed_rx);
-        assert!(<TestMessage as Policy>::handle(&mut overflow, current_closed));
+        assert!(<TestMessage as Policy>::handle(
+            &mut overflow,
+            current_closed
+        ));
 
         assert!(!has_get_block(&overflow, 1));
         assert!(has_get_info(&overflow, 2));

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -84,7 +84,7 @@ impl<D: Digest> Policy for Message<D> {
 
     fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         if message.response_closed() {
-            return false;
+            return true;
         }
         overflow.0.push_back(message);
         true

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -82,11 +82,12 @@ impl<D: Digest> Overflow<Message<D>> for Pending<D> {
 impl<D: Digest> Policy for Message<D> {
     type Overflow = Pending<D>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         if message.response_closed() {
-            return;
+            return false;
         }
         overflow.0.push_back(message);
+        true
     }
 }
 

--- a/consensus/src/ordered_broadcast/mocks/reporter.rs
+++ b/consensus/src/ordered_broadcast/mocks/reporter.rs
@@ -29,8 +29,9 @@ enum Message<C: PublicKey, S: Scheme, D: Digest> {
 impl<C: PublicKey, S: Scheme, D: Digest> Policy for Message<C, S, D> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+    fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
         overflow.push_back(message);
+        true
     }
 }
 

--- a/consensus/src/reporter.rs
+++ b/consensus/src/reporter.rs
@@ -51,6 +51,7 @@ const fn combine(a: Feedback, b: Feedback) -> Feedback {
     match (a, b) {
         (Feedback::Closed, _) | (_, Feedback::Closed) => Feedback::Closed,
         (Feedback::Backoff, _) | (_, Feedback::Backoff) => Feedback::Backoff,
+        (Feedback::Dropped, _) | (_, Feedback::Dropped) => Feedback::Dropped,
         (Feedback::Ok, Feedback::Ok) => Feedback::Ok,
     }
 }
@@ -145,6 +146,11 @@ mod tests {
             Feedback::Closed
         );
         assert_eq!(combine(Feedback::Backoff, Feedback::Ok), Feedback::Backoff);
+        assert_eq!(combine(Feedback::Dropped, Feedback::Ok), Feedback::Dropped);
+        assert_eq!(
+            combine(Feedback::Dropped, Feedback::Backoff),
+            Feedback::Backoff
+        );
         assert_eq!(combine(Feedback::Ok, Feedback::Ok), Feedback::Ok);
     }
 }

--- a/consensus/src/reporter.rs
+++ b/consensus/src/reporter.rs
@@ -51,7 +51,7 @@ const fn combine(a: Feedback, b: Feedback) -> Feedback {
     match (a, b) {
         (Feedback::Closed, _) | (_, Feedback::Closed) => Feedback::Closed,
         (Feedback::Backoff, _) | (_, Feedback::Backoff) => Feedback::Backoff,
-        (Feedback::Dropped, _) | (_, Feedback::Dropped) => Feedback::Dropped,
+        (Feedback::Rejected, _) | (_, Feedback::Rejected) => Feedback::Rejected,
         (Feedback::Ok, Feedback::Ok) => Feedback::Ok,
     }
 }
@@ -146,9 +146,9 @@ mod tests {
             Feedback::Closed
         );
         assert_eq!(combine(Feedback::Backoff, Feedback::Ok), Feedback::Backoff);
-        assert_eq!(combine(Feedback::Dropped, Feedback::Ok), Feedback::Dropped);
+        assert_eq!(combine(Feedback::Rejected, Feedback::Ok), Feedback::Rejected);
         assert_eq!(
-            combine(Feedback::Dropped, Feedback::Backoff),
+            combine(Feedback::Rejected, Feedback::Backoff),
             Feedback::Backoff
         );
         assert_eq!(combine(Feedback::Ok, Feedback::Ok), Feedback::Ok);

--- a/consensus/src/reporter.rs
+++ b/consensus/src/reporter.rs
@@ -50,8 +50,8 @@ where
 const fn combine(a: Feedback, b: Feedback) -> Feedback {
     match (a, b) {
         (Feedback::Closed, _) | (_, Feedback::Closed) => Feedback::Closed,
-        (Feedback::Backoff, _) | (_, Feedback::Backoff) => Feedback::Backoff,
         (Feedback::Rejected, _) | (_, Feedback::Rejected) => Feedback::Rejected,
+        (Feedback::Backoff, _) | (_, Feedback::Backoff) => Feedback::Backoff,
         (Feedback::Ok, Feedback::Ok) => Feedback::Ok,
     }
 }
@@ -152,7 +152,7 @@ mod tests {
         );
         assert_eq!(
             combine(Feedback::Rejected, Feedback::Backoff),
-            Feedback::Backoff
+            Feedback::Rejected
         );
         assert_eq!(combine(Feedback::Ok, Feedback::Ok), Feedback::Ok);
     }

--- a/consensus/src/reporter.rs
+++ b/consensus/src/reporter.rs
@@ -146,7 +146,10 @@ mod tests {
             Feedback::Closed
         );
         assert_eq!(combine(Feedback::Backoff, Feedback::Ok), Feedback::Backoff);
-        assert_eq!(combine(Feedback::Rejected, Feedback::Ok), Feedback::Rejected);
+        assert_eq!(
+            combine(Feedback::Rejected, Feedback::Ok),
+            Feedback::Rejected
+        );
         assert_eq!(
             combine(Feedback::Rejected, Feedback::Backoff),
             Feedback::Backoff

--- a/consensus/src/simplex/actors/batcher/ingress.rs
+++ b/consensus/src/simplex/actors/batcher/ingress.rs
@@ -90,7 +90,7 @@ impl<S: Scheme, D: Digest> Overflow<Message<S, D>> for Pending<S, D> {
 impl<S: Scheme, D: Digest> Policy for Message<S, D> {
     type Overflow = Pending<S, D>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         match message {
             update @ Self::Update {
                 current: new_current,
@@ -107,7 +107,7 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
                     let old = (*old_current, *old_finalized);
                     let new = (new_current, new_finalized);
                     if new <= old {
-                        return;
+                        return true;
                     }
                 }
                 overflow.update = Some(update);
@@ -124,7 +124,7 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
                     Some(Self::Update { current: old_current, finalized: old_finalized, .. })
                         if Self::prunes(*old_current, *old_finalized, &new_vote)
                 ) {
-                    return;
+                    return true;
                 }
 
                 // Ignore the constructed vote if it is a duplicate
@@ -133,11 +133,12 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
                     .iter()
                     .any(|old_vote| Self::similar(old_vote, &new_vote))
                 {
-                    return;
+                    return true;
                 }
                 overflow.constructed.push_back(new_vote);
             }
         }
+        true
     }
 }
 

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -196,7 +196,7 @@ impl Policy for HandlerMessage {
 
     fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         if message.response_closed() {
-            return false;
+            return true;
         }
         overflow.0.push_back(message);
         true

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -67,7 +67,7 @@ impl<S: Scheme, D: Digest> Overflow<MailboxMessage<S, D>> for Pending<S, D> {
 impl<S: Scheme, D: Digest> Policy for MailboxMessage<S, D> {
     type Overflow = Pending<S, D>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         // Ignore the message if there exists a queued finalization
         // with a view greater than or equal to the new view
         let new_view = message.view();
@@ -76,7 +76,7 @@ impl<S: Scheme, D: Digest> Policy for MailboxMessage<S, D> {
             Some(Self::Certificate(Certificate::Finalization(old_finalized)))
                 if old_finalized.view() >= new_view
         ) {
-            return;
+            return true;
         }
 
         // Retain only the highest-view finalization and any messages with a view greater than the new view
@@ -85,7 +85,7 @@ impl<S: Scheme, D: Digest> Policy for MailboxMessage<S, D> {
                 .messages
                 .retain(|old_message| old_message.view() > new_view);
             overflow.finalization = Some(message);
-            return;
+            return true;
         }
 
         // Ignore the message if it is a duplicate
@@ -109,9 +109,10 @@ impl<S: Scheme, D: Digest> Policy for MailboxMessage<S, D> {
                 _ => false,
             })
         {
-            return;
+            return true;
         }
         overflow.messages.push_back(message);
+        true
     }
 }
 
@@ -193,11 +194,12 @@ impl Overflow<HandlerMessage> for HandlerPending {
 impl Policy for HandlerMessage {
     type Overflow = HandlerPending;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         if message.response_closed() {
-            return;
+            return false;
         }
         overflow.0.push_back(message);
+        true
     }
 }
 

--- a/consensus/src/simplex/actors/voter/ingress.rs
+++ b/consensus/src/simplex/actors/voter/ingress.rs
@@ -77,7 +77,7 @@ impl<S: Scheme, D: Digest> Overflow<Message<S, D>> for Pending<S, D> {
 impl<S: Scheme, D: Digest> Policy for Message<S, D> {
     type Overflow = Pending<S, D>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         // Ignore the message if there exists a queued finalization
         // with a view greater than or equal to the new view
         let new_view = message.view();
@@ -86,7 +86,7 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
             Some(Self::Verified(Certificate::Finalization(old_finalized), _))
                 if old_finalized.view() >= new_view
         ) {
-            return;
+            return true;
         }
 
         // Retain only the highest-view finalization and any messages with a view greater than the new view
@@ -95,7 +95,7 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
                 .messages
                 .retain(|old_message| old_message.view() > new_view);
             overflow.finalization = Some(message);
-            return;
+            return true;
         }
 
         // Ignore the message if it is a duplicate
@@ -119,9 +119,10 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
                 _ => false,
             })
         {
-            return;
+            return true;
         }
         overflow.messages.push_back(message);
+        true
     }
 }
 

--- a/examples/bridge/src/application/ingress.rs
+++ b/examples/bridge/src/application/ingress.rs
@@ -37,8 +37,9 @@ pub enum Message<D: Digest> {
 impl<D: Digest> Policy for Message<D> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+    fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
         overflow.push_back(message);
+        true
     }
 }
 

--- a/examples/log/src/application/ingress.rs
+++ b/examples/log/src/application/ingress.rs
@@ -27,8 +27,9 @@ pub enum Message<D: Digest> {
 impl<D: Digest> Policy for Message<D> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+    fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
         overflow.push_back(message);
+        true
     }
 }
 

--- a/examples/reshare/src/dkg/ingress.rs
+++ b/examples/reshare/src/dkg/ingress.rs
@@ -47,8 +47,9 @@ where
 {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut VecDeque<Self>, message: Self) {
+    fn handle(overflow: &mut VecDeque<Self>, message: Self) -> bool {
         overflow.push_back(message);
+        true
     }
 }
 

--- a/p2p/src/authenticated/discovery/actors/peer/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/ingress.rs
@@ -20,10 +20,13 @@ pub enum Message<C: PublicKey> {
 impl<C: PublicKey> Policy for Message<C> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         if matches!(message, Self::Kill) {
             overflow.clear();
             overflow.push_back(message);
+            true
+        } else {
+            false
         }
     }
 }

--- a/p2p/src/authenticated/discovery/actors/router/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/router/ingress.rs
@@ -42,10 +42,13 @@ pub enum Message<P: PublicKey> {
 impl<P: PublicKey> Policy for Message<P> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         match message {
-            Self::Content { .. } => {}
-            message => overflow.push_back(message),
+            Self::Content { .. } => false,
+            message => {
+                overflow.push_back(message);
+                true
+            }
         }
     }
 }
@@ -174,7 +177,7 @@ mod tests {
             );
             assert_eq!(
                 messenger.content(Recipients::One(peer), 7, IoBuf::from(b"two").into(), false),
-                Feedback::Backoff
+                Feedback::Dropped
             );
             assert_eq!(
                 mailbox.release(PrivateKey::from_seed(2).public_key()),

--- a/p2p/src/authenticated/discovery/actors/router/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/router/ingress.rs
@@ -154,7 +154,7 @@ mod tests {
     };
 
     #[test]
-    fn test_overflow_drops_content_but_retains_control() {
+    fn test_overflow_rejects_content_but_retains_control() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (control_sender, mut receiver) =
@@ -177,7 +177,7 @@ mod tests {
             );
             assert_eq!(
                 messenger.content(Recipients::One(peer), 7, IoBuf::from(b"two").into(), false),
-                Feedback::Dropped
+                Feedback::Rejected
             );
             assert_eq!(
                 mailbox.release(PrivateKey::from_seed(2).public_key()),

--- a/p2p/src/authenticated/discovery/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/spawner/ingress.rs
@@ -21,10 +21,11 @@ pub enum Message<O: Sink, I: Stream, P: PublicKey> {
 impl<P: PublicKey, O: Sink, I: Stream> Policy for Message<O, I, P> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(_overflow: &mut Self::Overflow, _message: Self) {
+    fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
         // We drop spawn requests when we are backlogged because it is more likely
         // than not that by the time we get around to handling it the peer connection
         // will have already timed out (and closed).
+        false
     }
 }
 
@@ -156,7 +157,7 @@ mod tests {
             assert_eq!(spawner.spawn(connection_1, reservation_1), Feedback::Ok);
             assert_eq!(
                 spawner.spawn(connection_2, reservation_2),
-                Feedback::Backoff
+                Feedback::Dropped
             );
 
             let release = tracker_receiver

--- a/p2p/src/authenticated/discovery/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/spawner/ingress.rs
@@ -131,7 +131,7 @@ mod tests {
     }
 
     #[test]
-    fn spawn_overflow_drops_message_and_releases_reservation() {
+    fn spawn_overflow_rejects_message_and_releases_reservation() {
         deterministic::Runner::default().start(|context| async move {
             let (connection_1, connection_2) =
                 connections(&context, PrivateKey::from_seed(1), PrivateKey::from_seed(2)).await;
@@ -157,7 +157,7 @@ mod tests {
             assert_eq!(spawner.spawn(connection_1, reservation_1), Feedback::Ok);
             assert_eq!(
                 spawner.spawn(connection_2, reservation_2),
-                Feedback::Dropped
+                Feedback::Rejected
             );
 
             let release = tracker_receiver

--- a/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
@@ -143,8 +143,9 @@ pub enum Message<C: PublicKey> {
 impl<C: PublicKey> Policy for Message<C> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         overflow.push_back(message);
+        true
     }
 }
 

--- a/p2p/src/authenticated/discovery/channels.rs
+++ b/p2p/src/authenticated/discovery/channels.rs
@@ -21,7 +21,9 @@ pub(crate) struct Inbound<P: PublicKey>(pub(crate) NetworkMessage<P>);
 impl<P: PublicKey> Policy for Inbound<P> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(_overflow: &mut Self::Overflow, _message: Self) {}
+    fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
+        false
+    }
 }
 
 /// An interior sender that enforces message size limits and

--- a/p2p/src/authenticated/discovery/config.rs
+++ b/p2p/src/authenticated/discovery/config.rs
@@ -53,9 +53,9 @@ pub struct Config<C: Signer> {
 
     /// Message backlog allowed for internal actors.
     ///
-    /// When there are more messages in a mailbox than this value, messages may be
-    /// dropped mailboxes are processed. Refer to [`commonware_actor::Feedback`] and/or metrics
-    /// on [`commonware_actor::mailbox`] for a signal this is occurring.
+    /// When there are more messages in a mailbox than this value, messages may be rejected before
+    /// they are processed. Refer to [`commonware_actor::Feedback`] and/or metrics on
+    /// [`commonware_actor::mailbox`] for a signal this is occurring.
     pub mailbox_size: NonZeroUsize,
 
     /// Maximum number of already-queued outbound messages to combine into one connection write.

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -147,8 +147,8 @@
 //!
 //! ## Message Delivery
 //!
-//! Outgoing messages are dropped when a peer's send buffer is full, preventing slow peers
-//! from blocking sends to other peers. Incoming messages are dropped when the application's
+//! Outgoing message submissions can be rejected when a peer's send buffer is full, preventing slow
+//! peers from blocking sends to other peers. Incoming messages are dropped when the application's
 //! receive buffer is full, ensuring protocol messages (BitVec, Peers) continue to flow and
 //! connections remain healthy.
 //!

--- a/p2p/src/authenticated/lookup/actors/router/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/router/ingress.rs
@@ -42,10 +42,13 @@ pub enum Message<P: PublicKey> {
 impl<P: PublicKey> Policy for Message<P> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         match message {
-            Self::Content { .. } => {}
-            message => overflow.push_back(message),
+            Self::Content { .. } => false,
+            message => {
+                overflow.push_back(message);
+                true
+            }
         }
     }
 }

--- a/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
@@ -21,10 +21,11 @@ pub enum Message<Si: Sink, St: Stream, P: PublicKey> {
 impl<Si: Sink, St: Stream, P: PublicKey> Policy for Message<Si, St, P> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(_overflow: &mut Self::Overflow, _message: Self) {
+    fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
         // We drop spawn requests when we are backlogged because it is more likely
         // than not that by the time we get around to handling it the peer connection
         // will have already timed out (and closed).
+        false
     }
 }
 
@@ -156,7 +157,7 @@ mod tests {
             assert_eq!(spawner.spawn(connection_1, reservation_1), Feedback::Ok);
             assert_eq!(
                 spawner.spawn(connection_2, reservation_2),
-                Feedback::Backoff
+                Feedback::Dropped
             );
 
             let release = tracker_receiver

--- a/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
@@ -131,7 +131,7 @@ mod tests {
     }
 
     #[test]
-    fn spawn_overflow_drops_message_and_releases_reservation() {
+    fn spawn_overflow_rejects_message_and_releases_reservation() {
         deterministic::Runner::default().start(|context| async move {
             let (connection_1, connection_2) =
                 connections(&context, PrivateKey::from_seed(1), PrivateKey::from_seed(2)).await;
@@ -157,7 +157,7 @@ mod tests {
             assert_eq!(spawner.spawn(connection_1, reservation_1), Feedback::Ok);
             assert_eq!(
                 spawner.spawn(connection_2, reservation_2),
-                Feedback::Dropped
+                Feedback::Rejected
             );
 
             let release = tracker_receiver

--- a/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
@@ -117,8 +117,9 @@ pub enum Message<C: PublicKey> {
 impl<C: PublicKey> Policy for Message<C> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(overflow: &mut Self::Overflow, message: Self) {
+    fn handle(overflow: &mut Self::Overflow, message: Self) -> bool {
         overflow.push_back(message);
+        true
     }
 }
 

--- a/p2p/src/authenticated/lookup/channels.rs
+++ b/p2p/src/authenticated/lookup/channels.rs
@@ -22,7 +22,9 @@ pub(crate) struct Inbound<P: PublicKey>(pub(crate) NetworkMessage<P>);
 impl<P: PublicKey> Policy for Inbound<P> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(_overflow: &mut Self::Overflow, _message: Self) {}
+    fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
+        false
+    }
 }
 
 /// An interior sender that enforces message size limits and

--- a/p2p/src/authenticated/lookup/config.rs
+++ b/p2p/src/authenticated/lookup/config.rs
@@ -46,9 +46,9 @@ pub struct Config<C: Signer> {
 
     /// Message backlog allowed for internal actors.
     ///
-    /// When there are more messages in a mailbox than this value, messages may be
-    /// dropped mailboxes are processed. Refer to [`commonware_actor::Feedback`] and/or metrics
-    /// on [`commonware_actor::mailbox`] for a signal this is occurring.
+    /// When there are more messages in a mailbox than this value, messages may be rejected before
+    /// they are processed. Refer to [`commonware_actor::Feedback`] and/or metrics on
+    /// [`commonware_actor::mailbox`] for a signal this is occurring.
     pub mailbox_size: NonZeroUsize,
 
     /// Maximum number of already-queued outbound messages to combine into one connection write.

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -101,10 +101,9 @@
 //!
 //! ## Message Delivery
 //!
-//! Outgoing messages are dropped when a peer's send buffer is full, preventing slow peers
-//! from blocking sends to other peers. Incoming messages are dropped when the application's
-//! receive buffer is full, ensuring ping messages continue to flow and connections remain
-//! healthy.
+//! Outgoing message submissions can be rejected when a peer's send buffer is full, preventing slow
+//! peers from blocking sends to other peers. Incoming messages are dropped when the application's
+//! receive buffer is full, ensuring ping messages continue to flow and connections remain healthy.
 //!
 //! # Example
 //!

--- a/p2p/src/authenticated/relay.rs
+++ b/p2p/src/authenticated/relay.rs
@@ -52,8 +52,8 @@ impl<T> Relay<T> {
 
     /// Submits `message` to the priority channel selected by `priority`.
     ///
-    /// This never waits for capacity. [`Feedback::Dropped`] means the selected
-    /// channel was full, and [`Feedback::Closed`] means the receiver is gone.
+    /// This never waits for capacity. [`Feedback::Rejected`] means the selected channel was full
+    /// and did not handle the message, and [`Feedback::Closed`] means the receiver is gone.
     pub fn send(&self, message: T, priority: bool) -> Feedback {
         let sender = if priority { &self.high } else { &self.low };
         sender.enqueue(Message(message))
@@ -120,11 +120,11 @@ mod tests {
     }
 
     #[test]
-    fn test_relay_drops_on_overflow() {
+    fn test_relay_rejects_on_overflow() {
         let (relay, mut receivers) = Relay::new(Metrics, NZUsize!(1));
 
         assert_eq!(relay.send(1, false), Feedback::Ok);
-        assert_eq!(relay.send(2, false), Feedback::Dropped);
+        assert_eq!(relay.send(2, false), Feedback::Rejected);
         assert_eq!(receivers.low.try_recv().map(Message::into_inner), Ok(1));
         assert!(receivers.low.try_recv().is_err());
     }

--- a/p2p/src/authenticated/relay.rs
+++ b/p2p/src/authenticated/relay.rs
@@ -17,7 +17,9 @@ impl<T> Message<T> {
 impl<T> Policy for Message<T> {
     type Overflow = VecDeque<Self>;
 
-    fn handle(_overflow: &mut Self::Overflow, _message: Self) {}
+    fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
+        false
+    }
 }
 
 pub(crate) struct Receivers<T> {
@@ -50,7 +52,7 @@ impl<T> Relay<T> {
 
     /// Submits `message` to the priority channel selected by `priority`.
     ///
-    /// This never waits for capacity. [`Feedback::Backoff`] means the selected
+    /// This never waits for capacity. [`Feedback::Dropped`] means the selected
     /// channel was full, and [`Feedback::Closed`] means the receiver is gone.
     pub fn send(&self, message: T, priority: bool) -> Feedback {
         let sender = if priority { &self.high } else { &self.low };
@@ -122,7 +124,7 @@ mod tests {
         let (relay, mut receivers) = Relay::new(Metrics, NZUsize!(1));
 
         assert_eq!(relay.send(1, false), Feedback::Ok);
-        assert_eq!(relay.send(2, false), Feedback::Backoff);
+        assert_eq!(relay.send(2, false), Feedback::Dropped);
         assert_eq!(receivers.low.try_recv().map(Message::into_inner), Ok(1));
         assert!(receivers.low.try_recv().is_err());
     }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -61,8 +61,8 @@ stability_scope!(BETA {
         ///
         /// # Returns
         ///
-        /// Feedback from submitting the message for delivery. [`Feedback::accepted`]
-        /// does not guarantee that the recipient will receive the message.
+        /// Feedback from submitting the message to the local send path.
+        /// [`Feedback::accepted`] does not guarantee that the recipient will receive the message.
         fn send(
             &mut self,
             recipients: Recipients<Self::PublicKey>,
@@ -119,8 +119,8 @@ stability_scope!(BETA {
         ///
         /// # Returns
         ///
-        /// Feedback from submitting the message for delivery. [`Feedback::accepted`]
-        /// does not guarantee that the recipient will receive the message.
+        /// Feedback from submitting the message to the local send path.
+        /// [`Feedback::accepted`] does not guarantee that the recipient will receive the message.
         fn send(
             self,
             message: impl Into<IoBufs> + Send,
@@ -145,9 +145,9 @@ stability_scope!(BETA {
         ///
         /// # Returns
         ///
-        /// The recipients retained by the synchronous check. Returns an empty
-        /// list if all recipients are rate-limited, the sender has closed, or
-        /// the send is not accepted.
+        /// The recipients retained by the synchronous check and local submission. Returns an
+        /// empty list if all recipients are rate-limited, the sender has closed, or the send is
+        /// not accepted.
         ///
         /// [`Feedback::accepted`] does not guarantee that the recipient will receive
         /// the message.

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -61,7 +61,7 @@ stability_scope!(BETA {
         ///
         /// # Returns
         ///
-        /// Feedback from submitting the message to the local send path.
+        /// Feedback from submitting the message for delivery.
         /// [`Feedback::accepted`] does not guarantee that the recipient will receive the message.
         fn send(
             &mut self,
@@ -119,7 +119,7 @@ stability_scope!(BETA {
         ///
         /// # Returns
         ///
-        /// Feedback from submitting the message to the local send path.
+        /// Feedback from submitting the message for delivery.
         /// [`Feedback::accepted`] does not guarantee that the recipient will receive the message.
         fn send(
             self,
@@ -145,12 +145,9 @@ stability_scope!(BETA {
         ///
         /// # Returns
         ///
-        /// The recipients retained by the synchronous check and local submission. Returns an
+        /// The recipients we will attempt to send to. Returns an
         /// empty list if all recipients are rate-limited, the sender has closed, or the send is
         /// not accepted.
-        ///
-        /// [`Feedback::accepted`] does not guarantee that the recipient will receive
-        /// the message.
         fn send(
             &mut self,
             recipients: Recipients<Self::PublicKey>,

--- a/p2p/src/utils/mocks/mod.rs
+++ b/p2p/src/utils/mocks/mod.rs
@@ -127,14 +127,14 @@ mod tests {
     use commonware_utils::test_rng;
 
     #[derive(Clone)]
-    struct DroppingSender<P: PublicKey> {
+    struct RejectingSender<P: PublicKey> {
         peer: P,
     }
 
-    impl<P: PublicKey> LimitedSender for DroppingSender<P> {
+    impl<P: PublicKey> LimitedSender for RejectingSender<P> {
         type PublicKey = P;
         type Checked<'a>
-            = DroppingSender<P>
+            = RejectingSender<P>
         where
             Self: 'a;
 
@@ -146,7 +146,7 @@ mod tests {
         }
     }
 
-    impl<P: PublicKey> CheckedSender for DroppingSender<P> {
+    impl<P: PublicKey> CheckedSender for RejectingSender<P> {
         type PublicKey = P;
 
         fn recipients(&self) -> Vec<Self::PublicKey> {
@@ -154,7 +154,7 @@ mod tests {
         }
 
         fn send(self, _message: impl Into<IoBufs> + Send, _priority: bool) -> Feedback {
-            Feedback::Dropped
+            Feedback::Rejected
         }
     }
 
@@ -173,10 +173,10 @@ mod tests {
     }
 
     #[test]
-    fn sender_returns_no_recipients_when_checked_send_drops() {
+    fn sender_returns_no_recipients_when_checked_send_rejects() {
         let mut rng = test_rng();
         let peer = PrivateKey::random(&mut rng).public_key();
-        let mut sender = DroppingSender { peer: peer.clone() };
+        let mut sender = RejectingSender { peer: peer.clone() };
 
         let sent = Sender::send(&mut sender, Recipients::One(peer), b"hello".to_vec(), false);
 

--- a/p2p/src/utils/mocks/mod.rs
+++ b/p2p/src/utils/mocks/mod.rs
@@ -126,6 +126,38 @@ mod tests {
     use commonware_math::algebra::Random;
     use commonware_utils::test_rng;
 
+    #[derive(Clone)]
+    struct DroppingSender<P: PublicKey> {
+        peer: P,
+    }
+
+    impl<P: PublicKey> LimitedSender for DroppingSender<P> {
+        type PublicKey = P;
+        type Checked<'a>
+            = DroppingSender<P>
+        where
+            Self: 'a;
+
+        fn check(
+            &mut self,
+            _recipients: Recipients<Self::PublicKey>,
+        ) -> Result<Self::Checked<'_>, SystemTime> {
+            Ok(self.clone())
+        }
+    }
+
+    impl<P: PublicKey> CheckedSender for DroppingSender<P> {
+        type PublicKey = P;
+
+        fn recipients(&self) -> Vec<Self::PublicKey> {
+            vec![self.peer.clone()]
+        }
+
+        fn send(self, _message: impl Into<IoBufs> + Send, _priority: bool) -> Feedback {
+            Feedback::Dropped
+        }
+    }
+
     #[test]
     fn inert_sender_expands_all_recipients() {
         let mut rng = test_rng();
@@ -138,5 +170,16 @@ mod tests {
         let (mut sender, _) = inert_channel(peers.as_slice());
         let sent = sender.send(Recipients::All, b"hello".to_vec(), false);
         assert_eq!(sent, peers);
+    }
+
+    #[test]
+    fn sender_returns_no_recipients_when_checked_send_drops() {
+        let mut rng = test_rng();
+        let peer = PrivateKey::random(&mut rng).public_key();
+        let mut sender = DroppingSender { peer: peer.clone() };
+
+        let sent = Sender::send(&mut sender, Recipients::One(peer), b"hello".to_vec(), false);
+
+        assert!(sent.is_empty());
     }
 }

--- a/p2p/src/utils/mocks/mod.rs
+++ b/p2p/src/utils/mocks/mod.rs
@@ -134,7 +134,7 @@ mod tests {
     impl<P: PublicKey> LimitedSender for RejectingSender<P> {
         type PublicKey = P;
         type Checked<'a>
-            = RejectingSender<P>
+            = Self
         where
             Self: 'a;
 

--- a/resolver/src/p2p/fetcher.rs
+++ b/resolver/src/p2p/fetcher.rs
@@ -310,10 +310,10 @@ where
                         self.key_to_id.insert(key, id);
                         return;
                     }
-                    Feedback::Closed => {
+                    feedback @ (Feedback::Dropped | Feedback::Closed) => {
                         // Peer dropped message, try next peer
                         self.requests_sent.inc(Status::Dropped);
-                        debug!(?peer, "send closed");
+                        debug!(?peer, ?feedback, "send failed");
                         self.update_performance(&peer, self.timeout);
                     }
                 }

--- a/resolver/src/p2p/fetcher.rs
+++ b/resolver/src/p2p/fetcher.rs
@@ -310,8 +310,8 @@ where
                         self.key_to_id.insert(key, id);
                         return;
                     }
-                    feedback @ (Feedback::Dropped | Feedback::Closed) => {
-                        // Peer dropped message, try next peer
+                    feedback @ (Feedback::Rejected | Feedback::Closed) => {
+                        // Send was not handled, try next peer.
                         self.requests_sent.inc(Status::Dropped);
                         debug!(?peer, ?feedback, "send failed");
                         self.update_performance(&peer, self.timeout);
@@ -605,7 +605,7 @@ mod tests {
             _message: impl Into<IoBufs> + Send,
             _priority: bool,
         ) -> Feedback {
-            Feedback::Closed
+            Feedback::Rejected
         }
     }
 

--- a/resolver/src/p2p/fetcher.rs
+++ b/resolver/src/p2p/fetcher.rs
@@ -311,7 +311,7 @@ where
                         return;
                     }
                     feedback @ (Feedback::Rejected | Feedback::Closed) => {
-                        // Send was not handled, try next peer.
+                        // Send was not handled, try next peer
                         self.requests_sent.inc(Status::Dropped);
                         debug!(?peer, ?feedback, "send failed");
                         self.update_performance(&peer, self.timeout);

--- a/resolver/src/p2p/ingress.rs
+++ b/resolver/src/p2p/ingress.rs
@@ -139,7 +139,7 @@ fn merge_targets<P: Eq>(existing: &mut Option<NonEmptyVec<P>>, incoming: Option<
 impl<K: Eq, P: Eq> Policy for Message<K, P> {
     type Overflow = Pending<K, P>;
 
-    fn handle(overflow: &mut Pending<K, P>, message: Self) {
+    fn handle(overflow: &mut Pending<K, P>, message: Self) -> bool {
         match message {
             Self::Fetch(requests) => {
                 for request in requests {
@@ -186,6 +186,7 @@ impl<K: Eq, P: Eq> Policy for Message<K, P> {
                     .push_back(Modification::Retain { predicate });
             }
         }
+        true
     }
 }
 


### PR DESCRIPTION
To keep handling trait-agnostic in downstream actors, we need upstream actors to be more specific about their behavior.