### PR TITLE
Simplify byzantine first network implementation and fix send calls

### DIFF
--- a/consensus/fuzz/src/byzzfuzz/injector.rs
+++ b/consensus/fuzz/src/byzzfuzz/injector.rs
@@ -155,9 +155,7 @@ where
             variant,
             item.targets.len(),
         ));
-        let _ = vote_sender
-            .send(commonware_p2p::Recipients::Some(item.targets), bytes, true)
-            .await;
+        let _ = vote_sender.send(commonware_p2p::Recipients::Some(item.targets), bytes, true);
     }
 
     /// True per-message mutate: take the actual decoded `Vote`, run the

--- a/consensus/fuzz/src/network.rs
+++ b/consensus/fuzz/src/network.rs
@@ -20,11 +20,7 @@ use commonware_p2p::{simulated::SplitTarget, Message, Receiver};
 use commonware_utils::sync::Mutex;
 use rand::Rng;
 use rand_core::CryptoRngCore;
-use std::{
-    collections::HashSet,
-    fmt::{self, Debug},
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 /// Shared cell holding the currently-active honest-message drop rate (0..=90).
 /// Updated by the `FaultyMessaging` scheduler on view boundaries; read on every
@@ -89,6 +85,7 @@ impl<P: PublicKey, E: CryptoRngCore + Send + 'static> Clone for Router<P, E> {
 }
 
 /// A receiver that preferentially yields messages from the "primary" (Byzantine) lane.
+#[derive(Debug)]
 pub struct ByzantineFirstReceiver<P, R>
 where
     P: PublicKey,
@@ -96,21 +93,6 @@ where
 {
     primary: R,
     secondary: R,
-    primary_closed: bool,
-    secondary_closed: bool,
-}
-
-impl<P, R> Debug for ByzantineFirstReceiver<P, R>
-where
-    P: PublicKey,
-    R: Receiver<PublicKey = P> + Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ByzantineFirstReceiver")
-            .field("primary_closed", &self.primary_closed)
-            .field("secondary_closed", &self.secondary_closed)
-            .finish_non_exhaustive()
-    }
 }
 
 impl<P, R> ByzantineFirstReceiver<P, R>
@@ -119,12 +101,7 @@ where
     R: Receiver<PublicKey = P>,
 {
     pub const fn new(primary: R, secondary: R) -> Self {
-        Self {
-            primary,
-            secondary,
-            primary_closed: false,
-            secondary_closed: false,
-        }
+        Self { primary, secondary }
     }
 }
 
@@ -138,35 +115,9 @@ where
     type PublicKey = P;
 
     async fn recv(&mut self) -> Result<Message<Self::PublicKey>, Self::Error> {
-        loop {
-            match (self.primary_closed, self.secondary_closed) {
-                (true, true) => {
-                    return self.primary.recv().await;
-                }
-                (false, true) => return self.primary.recv().await,
-                (true, false) => return self.secondary.recv().await,
-                (false, false) => {
-                    let result = select! {
-                        msg = self.primary.recv() => (true, msg),
-                        msg = self.secondary.recv() => (false, msg),
-                    };
-
-                    let (was_primary, msg) = result;
-                    match msg {
-                        Ok(m) => return Ok(m),
-                        Err(e) => {
-                            if was_primary {
-                                self.primary_closed = true;
-                            } else {
-                                self.secondary_closed = true;
-                            }
-                            if self.primary_closed && self.secondary_closed {
-                                return Err(e);
-                            }
-                        }
-                    }
-                }
-            }
+        select! {
+            msg = self.primary.recv() => msg,
+            msg = self.secondary.recv() => msg,
         }
     }
 }

--- a/consensus/fuzz/src/simplex_node.rs
+++ b/consensus/fuzz/src/simplex_node.rs
@@ -831,9 +831,11 @@ where
         } else {
             default_response
         };
-        let _ = self.resolver_senders[receiver_idx]
-            .send(Recipients::One(self.honest.clone()), response, true)
-            .await;
+        let _ = self.resolver_senders[receiver_idx].send(
+            Recipients::One(self.honest.clone()),
+            response,
+            true,
+        );
     }
 
     fn handle_honest_certificates(&mut self, sender: &S::PublicKey, bytes: Vec<u8>) {
@@ -1133,9 +1135,7 @@ where
     }
 
     async fn send_vote_bytes(&mut self, signer_idx: usize, msg: Bytes) {
-        let _ = self.vote_senders[signer_idx]
-            .send(Recipients::One(self.honest.clone()), msg, true)
-            .await;
+        let _ = self.vote_senders[signer_idx].send(Recipients::One(self.honest.clone()), msg, true);
     }
 
     async fn send_malformed_vote(&mut self, signer_idx: usize) {
@@ -1165,9 +1165,11 @@ where
 
     async fn send_certificate_bytes(&mut self, msg: Bytes) {
         let sender_idx = self.next_sender();
-        let _ = self.certificate_senders[sender_idx]
-            .send(Recipients::One(self.honest.clone()), msg, true)
-            .await;
+        let _ = self.certificate_senders[sender_idx].send(
+            Recipients::One(self.honest.clone()),
+            msg,
+            true,
+        );
     }
 
     async fn send_malformed_certificate(&mut self) {


### PR DESCRIPTION
This PR:
-  simplifies `recv` to just the biased select
- fixes `send` calls after refactoring