### PR TITLE
[runtime] append page-size shrink crash safety fix

### DIFF
--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -822,11 +822,8 @@ impl<B: Blob> Append<B> {
             0
         };
         let staged_slot = Self::checksum_slot_bytes(0, new_crc);
-        blob.write_at(
-            crc_start + new_slot_start as u64,
-            staged_slot.to_vec(),
-        )
-        .await?;
+        blob.write_at(crc_start + new_slot_start as u64, staged_slot.to_vec())
+            .await?;
         blob.sync().await?;
 
         blob.write_at(
@@ -963,6 +960,11 @@ impl<B: Blob> Append<B> {
             return Ok(());
         }
 
+        self.shrink(size).await
+    }
+
+    /// Coordinate the locking and dispatch logic for shrinking the blob.
+    async fn shrink(&self, target_size: u64) -> Result<(), Error> {
         let logical_page_size = self.cache_ref.page_size();
         let physical_page_size = logical_page_size + CHECKSUM_SIZE;
 
@@ -974,8 +976,8 @@ impl<B: Blob> Append<B> {
         let mut blob_guard = self.blob_state.write().await;
 
         // Calculate the physical size needed for the new logical size.
-        let full_pages = size / logical_page_size;
-        let partial_bytes = size % logical_page_size;
+        let full_pages = target_size / logical_page_size;
+        let partial_bytes = target_size % logical_page_size;
         let new_physical_size = if partial_bytes > 0 {
             // We need full_pages + 1 physical pages to hold the partial data.
             // The partial page will be padded to full physical page size.
@@ -985,94 +987,99 @@ impl<B: Blob> Append<B> {
             full_pages * physical_page_size
         };
 
-        let protected_partial_shrink = size < current_size
-            && partial_bytes > 0
-            && (full_pages < blob_guard.current_page
-                || (full_pages == blob_guard.current_page
-                    && blob_guard.partial_page_state.is_some()));
-
-        if protected_partial_shrink {
-            blob_guard.blob.resize(new_physical_size).await?;
-
-            // Evict cached pages at or beyond the new full-page boundary. The page at
-            // `full_pages` is now owned by the tip buffer, and anything above is beyond the new
-            // logical size.
-            self.cache_ref.invalidate_from(self.id, full_pages);
-
-            // Update blob state and buffer based on the desired logical size. The page data is
-            // read with CRC validation, then durably rewritten below with a shorter CRC.
-            blob_guard.current_page = full_pages;
-            buf_guard.offset = full_pages * logical_page_size;
-
-            let (page_data, old_crc) = super::get_page_with_checksum_from_blob(
-                &blob_guard.blob,
+        if partial_bytes > 0 {
+            self.shrink_protected_partial(
+                &mut buf_guard,
+                &mut blob_guard,
+                new_physical_size,
                 full_pages,
+                partial_bytes,
                 logical_page_size,
             )
-            .await?;
-
-            // Ensure the validated data covers what we need.
-            if (page_data.len() as u64) < partial_bytes {
-                return Err(Error::InvalidChecksum);
-            }
-
-            buf_guard.clear();
-            let new_data = &page_data.as_ref()[..partial_bytes as usize];
-            let over_capacity = buf_guard.append(new_data);
-            assert!(!over_capacity);
-
-            let final_record = Self::sync_partial_page_shrink(
-                &blob_guard.blob,
+            .await
+        } else {
+            self.shrink_standard(
+                &mut buf_guard,
+                &mut blob_guard,
+                new_physical_size,
                 full_pages,
-                logical_page_size,
-                partial_bytes as u16,
-                Crc32::checksum(new_data),
-                &old_crc,
             )
-            .await?;
-            blob_guard.partial_page_state = Some(final_record);
-            return Ok(());
+            .await
+        }
+    }
+
+    /// Perform a safe, torn-write-resistant shrink to a new partial page tip.
+    async fn shrink_protected_partial(
+        &self,
+        buf_guard: &mut Buffer,
+        blob_guard: &mut BlobState<B>,
+        new_physical_size: u64,
+        full_pages: u64,
+        partial_bytes: u64,
+        logical_page_size: u64,
+    ) -> Result<(), Error> {
+        blob_guard.blob.resize(new_physical_size).await?;
+
+        // Evict cached pages at or beyond the new full-page boundary. The page at
+        // `full_pages` is now owned by the tip buffer, and anything above is beyond the new
+        // logical size.
+        self.cache_ref.invalidate_from(self.id, full_pages);
+
+        // Update blob state and buffer based on the desired logical size. The page data is
+        // read with CRC validation, then durably rewritten below with a shorter CRC.
+        blob_guard.current_page = full_pages;
+        buf_guard.offset = full_pages * logical_page_size;
+
+        let (page_data, old_crc) = super::get_page_with_checksum_from_blob(
+            &blob_guard.blob,
+            full_pages,
+            logical_page_size,
+        )
+        .await?;
+
+        // Ensure the validated data covers what we need.
+        if (page_data.len() as u64) < partial_bytes {
+            return Err(Error::InvalidChecksum);
         }
 
+        buf_guard.clear();
+        let new_data = &page_data.as_ref()[..partial_bytes as usize];
+        let over_capacity = buf_guard.append(new_data);
+        assert!(!over_capacity);
+
+        let final_record = Self::sync_partial_page_shrink(
+            &blob_guard.blob,
+            full_pages,
+            logical_page_size,
+            partial_bytes as u16,
+            Crc32::checksum(new_data),
+            &old_crc,
+        )
+        .await?;
+        blob_guard.partial_page_state = Some(final_record);
+        Ok(())
+    }
+
+    /// Perform a standard shrink to a page boundary.
+    async fn shrink_standard(
+        &self,
+        buf_guard: &mut Buffer,
+        blob_guard: &mut BlobState<B>,
+        new_physical_size: u64,
+        full_pages: u64,
+    ) -> Result<(), Error> {
         // Resize the underlying blob.
         blob_guard.blob.resize(new_physical_size).await?;
         blob_guard.partial_page_state = None;
 
-        // Evict cached pages at or beyond the new full-page boundary. The page at `full_pages` (if
-        // partial) is now owned by the tip buffer, and anything above is beyond the new logical
-        // size. Leaving their pre-resize contents in the cache lets `try_read_sync` (which bypasses
-        // the tip buffer) observe stale bytes once the tip is repopulated.
+        // Evict cached pages at or beyond the new full-page boundary. Leaving pre-resize contents
+        // in the cache lets `try_read_sync` observe stale bytes once the tip is repopulated.
         self.cache_ref.invalidate_from(self.id, full_pages);
 
-        // Update blob state and buffer based on the desired logical size. The partial page data is
-        // read with CRC validation; the validated length may exceed partial_bytes (reflecting the
-        // old data length), but we only load the prefix we need. The next sync will write the
-        // correct CRC for the new length.
-        //
-        // Note: This updates state before validation completes, which could leave state
-        // inconsistent if validation fails. This is acceptable because failures from mutable
-        // methods are fatal - callers must not use the blob after any error.
-
+        // Update blob state and buffer based on the desired logical size.
         blob_guard.current_page = full_pages;
-        buf_guard.offset = full_pages * logical_page_size;
-
-        if partial_bytes > 0 {
-            // There's a partial page. Read its data from disk with CRC validation.
-            let page_data =
-                super::get_page_from_blob(&blob_guard.blob, full_pages, logical_page_size).await?;
-
-            // Ensure the validated data covers what we need.
-            if (page_data.len() as u64) < partial_bytes {
-                return Err(Error::InvalidChecksum);
-            }
-
-            buf_guard.clear();
-            let over_capacity = buf_guard.append(&page_data.as_ref()[..partial_bytes as usize]);
-            assert!(!over_capacity);
-        } else {
-            // No partial page - all pages are full or blob is empty.
-            buf_guard.clear();
-        }
+        buf_guard.offset = full_pages * self.cache_ref.page_size();
+        buf_guard.clear();
 
         Ok(())
     }
@@ -2945,7 +2952,9 @@ mod tests {
                 .open("test_partition", b"same_page_shrink_fallback_slot")
                 .await
                 .unwrap();
-            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref).await.unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
             assert_eq!(append.size().await, 50);
             let read = append.read_at(0, 50).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), &data[..50]);
@@ -2983,11 +2992,7 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(append.size().await, target);
-            let read = append
-                .read_at(0, target as usize)
-                .await
-                .unwrap()
-                .coalesce();
+            let read = append.read_at(0, target as usize).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), &data[..target as usize]);
         });
     }

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -759,6 +759,7 @@ impl<B: Blob> Append<B> {
         (write_buffer, Some(crc_record))
     }
 
+    /// Encode one checksum slot as `[len: u16][crc: u32]`, matching `Checksum::write`.
     fn checksum_slot_bytes(len: u16, crc: u32) -> [u8; CHECKSUM_SLOT_SIZE] {
         let mut bytes = [0u8; CHECKSUM_SLOT_SIZE];
         bytes[..2].copy_from_slice(&len.to_be_bytes());

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -8,7 +8,8 @@
 //! pages have a [Checksum] at the end. If no CRC record existed before for the page being written,
 //! then one of the checksums will be all zero. If a checksum already existed for the page being
 //! written, then the write will overwrite only the checksum with the lesser length value. Should
-//! this write fail, the previously committed page state can still be recovered.
+//! this write fail, the previously committed page state can still be recovered. Same-page shrink
+//! makes the shorter checksum durable before invalidating the old longer checksum.
 //!
 //! During initialization, the wrapper will back up over any page that is not accompanied by a
 //! valid CRC, treating it as the result of an incomplete write that may be invalid.
@@ -16,7 +17,7 @@
 use super::read::{PageReader, Replay};
 use crate::{
     buffer::{
-        paged::{CacheRef, Checksum, CHECKSUM_SIZE},
+        paged::{CacheRef, Checksum, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE},
         tip::Buffer,
     },
     Blob, Error, IoBuf, IoBufMut, IoBufs,
@@ -786,6 +787,72 @@ impl<B: Blob> Append<B> {
         }
     }
 
+    /// Durably rewrite a committed partial page to a shorter length in the same physical page.
+    ///
+    /// Since larger valid lengths are authoritative, a shorter CRC cannot simply be written next to
+    /// the old CRC. We first make the shorter CRC durable in the alternate slot, then invalidate
+    /// the old longer slot. A crash during either phase recovers either the old longer page or the
+    /// new shorter page, but never loses the whole page.
+    async fn sync_same_page_shrink(
+        blob: &B,
+        page: u64,
+        logical_page_size: u64,
+        new_len: u16,
+        new_crc: u32,
+        old_crc: &Checksum,
+    ) -> Result<Checksum, Error> {
+        let physical_page_size = logical_page_size
+            .checked_add(CHECKSUM_SIZE)
+            .ok_or(Error::OffsetOverflow)?;
+        let crc_start = page
+            .checked_mul(physical_page_size)
+            .and_then(|start| start.checked_add(logical_page_size))
+            .ok_or(Error::OffsetOverflow)?;
+
+        let staged_record = Self::build_crc_record_preserving_old(new_len, new_crc, old_crc);
+        let staged_bytes = staged_record.to_bytes();
+        let new_slot_start = if old_crc.len1 >= old_crc.len2 {
+            CHECKSUM_SLOT_SIZE
+        } else {
+            0
+        };
+        blob.write_at(
+            crc_start + new_slot_start as u64,
+            staged_bytes[new_slot_start..new_slot_start + CHECKSUM_SLOT_SIZE].to_vec(),
+        )
+        .await?;
+        blob.sync().await?;
+
+        let old_slot_start = if new_slot_start == 0 {
+            CHECKSUM_SLOT_SIZE
+        } else {
+            0
+        };
+        blob.write_at(
+            crc_start + old_slot_start as u64,
+            vec![0u8; CHECKSUM_SLOT_SIZE],
+        )
+        .await?;
+        blob.sync().await?;
+
+        let final_record = if new_slot_start == 0 {
+            Checksum {
+                len1: new_len,
+                crc1: new_crc,
+                len2: 0,
+                crc2: 0,
+            }
+        } else {
+            Checksum {
+                len1: 0,
+                crc1: 0,
+                len2: new_len,
+                crc2: new_crc,
+            }
+        };
+        Ok(final_record)
+    }
+
     /// Flushes any buffered data, then returns a [Replay] for the underlying blob.
     ///
     /// The returned replay can be used to sequentially read all pages from the blob while ensuring
@@ -864,6 +931,9 @@ impl<B: Blob> Append<B> {
     /// - The resize is not guaranteed durable until the next sync.
     pub async fn resize(&self, size: u64) -> Result<(), Error> {
         let current_size = self.size().await;
+        if size == current_size {
+            return Ok(());
+        }
 
         // Handle growing by appending zero bytes.
         if size > current_size {
@@ -895,6 +965,52 @@ impl<B: Blob> Append<B> {
             // No partial page needed.
             full_pages * physical_page_size
         };
+
+        let old_partial_page_state = blob_guard.partial_page_state.clone();
+        let same_page_partial_shrink = size < current_size
+            && partial_bytes > 0
+            && full_pages == blob_guard.current_page
+            && old_partial_page_state.is_some();
+
+        if same_page_partial_shrink {
+            let old_crc =
+                old_partial_page_state.expect("same-page shrink requires old partial CRC");
+
+            // Evict cached pages at or beyond the new full-page boundary. The page at
+            // `full_pages` is now owned by the tip buffer, and anything above is beyond the new
+            // logical size.
+            self.cache_ref.invalidate_from(self.id, full_pages);
+
+            // Update blob state and buffer based on the desired logical size. The page data is
+            // read with CRC validation, then durably rewritten below with a shorter CRC.
+            blob_guard.current_page = full_pages;
+            buf_guard.offset = full_pages * logical_page_size;
+
+            let page_data =
+                super::get_page_from_blob(&blob_guard.blob, full_pages, logical_page_size).await?;
+
+            // Ensure the validated data covers what we need.
+            if (page_data.len() as u64) < partial_bytes {
+                return Err(Error::InvalidChecksum);
+            }
+
+            buf_guard.clear();
+            let new_data = &page_data.as_ref()[..partial_bytes as usize];
+            let over_capacity = buf_guard.append(new_data);
+            assert!(!over_capacity);
+
+            let final_record = Self::sync_same_page_shrink(
+                &blob_guard.blob,
+                full_pages,
+                logical_page_size,
+                partial_bytes as u16,
+                Crc32::checksum(new_data),
+                &old_crc,
+            )
+            .await?;
+            blob_guard.partial_page_state = Some(final_record);
+            return Ok(());
+        }
 
         // Resize the underlying blob.
         blob_guard.blob.resize(new_physical_size).await?;
@@ -944,13 +1060,19 @@ impl<B: Blob> Append<B> {
 mod tests {
     use super::*;
     use crate::{
-        deterministic, telemetry::metrics::Registry, BufferPool, BufferPoolConfig, Runner as _,
-        Storage as _,
+        deterministic, telemetry::metrics::Registry, BufferPool, BufferPoolConfig, IoBufsMut,
+        Runner as _, Storage as _,
     };
     use commonware_codec::ReadExt;
     use commonware_macros::test_traced;
     use commonware_utils::{NZUsize, NZU16, NZU32};
-    use std::num::NonZeroU16;
+    use std::{
+        num::NonZeroU16,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(103); // janky size to ensure we test page alignment
     const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;
@@ -1483,6 +1605,76 @@ mod tests {
     fn read_crc_record_from_page(page_bytes: &[u8]) -> Checksum {
         let crc_start = page_bytes.len() - CHECKSUM_SIZE as usize;
         Checksum::read(&mut &page_bytes[crc_start..]).unwrap()
+    }
+
+    /// Blob wrapper that turns one write into a durable partial write followed by an error.
+    #[derive(Clone)]
+    struct PartialWriteBlob<B: Blob> {
+        inner: B,
+        writes: Arc<AtomicUsize>,
+        failed_write_len: Arc<AtomicUsize>,
+        fail_on: usize,
+        partial_len: usize,
+    }
+
+    impl<B: Blob> PartialWriteBlob<B> {
+        fn new(inner: B, fail_on: usize, partial_len: usize) -> Self {
+            Self {
+                inner,
+                writes: Arc::new(AtomicUsize::new(0)),
+                failed_write_len: Arc::new(AtomicUsize::new(0)),
+                fail_on,
+                partial_len,
+            }
+        }
+
+        fn failed_write_len(&self) -> Arc<AtomicUsize> {
+            self.failed_write_len.clone()
+        }
+
+        fn write_count(&self) -> Arc<AtomicUsize> {
+            self.writes.clone()
+        }
+    }
+
+    impl<B: Blob> crate::Blob for PartialWriteBlob<B> {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            bufs: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, bufs).await
+        }
+
+        async fn write_at(&self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
+            let bufs = bufs.into();
+            let write = self.writes.fetch_add(1, Ordering::SeqCst) + 1;
+            if write == self.fail_on {
+                let bytes = bufs.coalesce();
+                self.failed_write_len.store(bytes.len(), Ordering::SeqCst);
+                let partial_len = self.partial_len.min(bytes.len());
+                self.inner
+                    .write_at(offset, bytes.slice(..partial_len))
+                    .await?;
+                self.inner.sync().await?;
+                return Err(Error::Io(std::io::Error::other("injected partial write")));
+            }
+
+            self.inner.write_at(offset, bufs).await
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            self.inner.sync().await
+        }
     }
 
     /// Dummy marker bytes with len=0 so the mangled slot is never authoritative.
@@ -2503,6 +2695,186 @@ mod tests {
                 !hit || probe == new_bytes,
                 "try_read_sync served stale pre-resize bytes: {probe:?}"
             );
+        });
+    }
+
+    #[test]
+    fn test_resize_same_size_is_noop() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let (blob, blob_size) = context
+                .open("test_partition", b"resize_same_size")
+                .await
+                .unwrap();
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            append.append(b"hello world").await.unwrap();
+            assert_eq!(append.size().await, 11);
+
+            // Resize to same size. Should succeed.
+            append.resize(11).await.unwrap();
+            assert_eq!(append.size().await, 11);
+
+            // Verify content is still readable and intact.
+            let read = append.read_at(0, 11).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"hello world");
+        });
+    }
+
+    #[test]
+    fn test_resize_same_page_shrink_reopens_at_shorter_size() {
+        let executor = deterministic::Runner::default();
+
+        executor.start(|context| async move {
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let data: Vec<u8> = (0..50).collect();
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Create a partial page whose authoritative CRC is in the first slot. The interrupted
+            // tests below exercise the opposite slot orientation.
+            append.append(&data).await.unwrap();
+            append.sync().await.unwrap();
+
+            append.resize(45).await.unwrap();
+            drop(append);
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 45);
+            let read = append.read_at(0, 45).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data[..45]);
+        });
+    }
+
+    #[test]
+    fn test_resize_same_page_shrink_survives_interrupted_crc_stage() {
+        let executor = deterministic::Runner::default();
+
+        executor.start(|context| async move {
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let data: Vec<u8> = (0..50).collect();
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink_interrupted")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            append.append(&data[..40]).await.unwrap();
+            append.sync().await.unwrap();
+            append.append(&data[40..]).await.unwrap();
+            append.sync().await.unwrap();
+            drop(append);
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink_interrupted")
+                .await
+                .unwrap();
+            let faulty_blob = PartialWriteBlob::new(blob, 1, 3);
+            let write_count = faulty_blob.write_count();
+            let failed_write_len = faulty_blob.failed_write_len();
+            let append = Append::new(faulty_blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            assert!(
+                append.resize(45).await.is_err(),
+                "phase-1 partial write should fail"
+            );
+            assert_eq!(write_count.load(Ordering::SeqCst), 1);
+            assert_eq!(failed_write_len.load(Ordering::SeqCst), CHECKSUM_SLOT_SIZE);
+            drop(append);
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink_interrupted")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 50);
+            let read = append.read_at(0, 50).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data);
+        });
+    }
+
+    #[test]
+    fn test_resize_same_page_shrink_survives_interrupted_crc_invalidation() {
+        let executor = deterministic::Runner::default();
+
+        executor.start(|context| async move {
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let data: Vec<u8> = (0..50).collect();
+
+            let (blob, size) = context
+                .open(
+                    "test_partition",
+                    b"same_page_shrink_interrupted_invalidation",
+                )
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            // Put the old authoritative CRC in slot 1, so the shorter CRC will be staged in slot
+            // 0. Phase 1 is the new-slot write; phase 2 only invalidates the old slot.
+            append.append(&data[..40]).await.unwrap();
+            append.sync().await.unwrap();
+            append.append(&data[40..]).await.unwrap();
+            append.sync().await.unwrap();
+            drop(append);
+
+            let (blob, size) = context
+                .open(
+                    "test_partition",
+                    b"same_page_shrink_interrupted_invalidation",
+                )
+                .await
+                .unwrap();
+            let faulty_blob = PartialWriteBlob::new(blob, 2, 3);
+            let write_count = faulty_blob.write_count();
+            let failed_write_len = faulty_blob.failed_write_len();
+            let append = Append::new(faulty_blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            assert!(
+                append.resize(45).await.is_err(),
+                "phase-2 partial write should fail"
+            );
+            assert_eq!(write_count.load(Ordering::SeqCst), 2);
+            assert_eq!(failed_write_len.load(Ordering::SeqCst), CHECKSUM_SLOT_SIZE);
+            drop(append);
+
+            let (blob, size) = context
+                .open(
+                    "test_partition",
+                    b"same_page_shrink_interrupted_invalidation",
+                )
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 45);
+            let read = append.read_at(0, 45).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data[..45]);
         });
     }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -815,18 +815,17 @@ impl<B: Blob> Append<B> {
             .checked_mul(physical_page_size)
             .and_then(|start| start.checked_add(logical_page_size))
             .ok_or(Error::OffsetOverflow)?;
-
         let (new_slot_start, old_slot_start) = if old_crc.len1 >= old_crc.len2 {
             (CHECKSUM_SLOT_SIZE, 0)
         } else {
             (0, CHECKSUM_SLOT_SIZE)
         };
-        let new_slot_offset = crc_start
-            .checked_add(new_slot_start as u64)
-            .ok_or(Error::OffsetOverflow)?;
 
         // Stage the new slot with a 0 length and the shrunken page CRC. A crash here leaves the
         // old slot as the only non-zero valid slot.
+        let new_slot_offset = crc_start
+            .checked_add(new_slot_start as u64)
+            .ok_or(Error::OffsetOverflow)?;
         let staged_slot = Self::checksum_slot_bytes(0, new_crc);
         blob.write_at(new_slot_offset, staged_slot.to_vec()).await?;
         blob.sync().await?;
@@ -837,14 +836,13 @@ impl<B: Blob> Append<B> {
             .await?;
         blob.sync().await?;
 
+        // Clear only the old slot's length bytes. Rewriting the whole footer here could tear across
+        // both slots and lose the already-durable shorter checksum. Once this lands, length 0 is
+        // never authoritative, so the shrunken slot wins.
         let old_slot_offset = crc_start
             .checked_add(old_slot_start as u64)
             .ok_or(Error::OffsetOverflow)?;
         let len_size = std::mem::size_of::<u16>();
-
-        // Clear only the old slot's length bytes. Rewriting the whole footer here could tear across
-        // both slots and lose the already-durable shorter checksum. Once this lands, length 0 is
-        // never authoritative, so the shrunken slot wins.
         blob.write_at(old_slot_offset, vec![0u8; len_size]).await?;
         blob.sync().await?;
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -8,8 +8,8 @@
 //! pages have a [Checksum] at the end. If no CRC record existed before for the page being written,
 //! then one of the checksums will be all zero. If a checksum already existed for the page being
 //! written, then the write will overwrite only the checksum with the lesser length value. Should
-//! this write fail, the previously committed page state can still be recovered. Same-page shrink
-//! makes the shorter checksum durable before invalidating the old longer checksum.
+//! this write fail, the previously committed page state can still be recovered. Partial-page
+//! shrink makes the shorter checksum durable before invalidating the old longer checksum.
 //!
 //! During initialization, the wrapper will back up over any page that is not accompanied by a
 //! valid CRC, treating it as the result of an incomplete write that may be invalid.
@@ -759,6 +759,13 @@ impl<B: Blob> Append<B> {
         (write_buffer, Some(crc_record))
     }
 
+    fn checksum_slot_bytes(len: u16, crc: u32) -> [u8; CHECKSUM_SLOT_SIZE] {
+        let mut bytes = [0u8; CHECKSUM_SLOT_SIZE];
+        bytes[..2].copy_from_slice(&len.to_be_bytes());
+        bytes[2..].copy_from_slice(&crc.to_be_bytes());
+        bytes
+    }
+
     /// Build a CRC record that preserves the old CRC in its original slot and places
     /// the new CRC in the other slot.
     const fn build_crc_record_preserving_old(
@@ -787,13 +794,13 @@ impl<B: Blob> Append<B> {
         }
     }
 
-    /// Durably rewrite a committed partial page to a shorter length in the same physical page.
+    /// Durably rewrite a committed page to a shorter partial length.
     ///
     /// Since larger valid lengths are authoritative, a shorter CRC cannot simply be written next to
-    /// the old CRC. We first make the shorter CRC durable in the alternate slot, then invalidate
-    /// the old longer slot. A crash during either phase recovers either the old longer page or the
-    /// new shorter page, but never loses the whole page.
-    async fn sync_same_page_shrink(
+    /// the old CRC. We first stage the shorter slot with length 0, then make its length durable,
+    /// then invalidate the old longer slot. A crash during any phase recovers either the old longer
+    /// page or the new shorter page, but never loses the whole page or fabricates a larger length.
+    async fn sync_partial_page_shrink(
         blob: &B,
         page: u64,
         logical_page_size: u64,
@@ -809,16 +816,22 @@ impl<B: Blob> Append<B> {
             .and_then(|start| start.checked_add(logical_page_size))
             .ok_or(Error::OffsetOverflow)?;
 
-        let staged_record = Self::build_crc_record_preserving_old(new_len, new_crc, old_crc);
-        let staged_bytes = staged_record.to_bytes();
         let new_slot_start = if old_crc.len1 >= old_crc.len2 {
             CHECKSUM_SLOT_SIZE
         } else {
             0
         };
+        let staged_slot = Self::checksum_slot_bytes(0, new_crc);
         blob.write_at(
             crc_start + new_slot_start as u64,
-            staged_bytes[new_slot_start..new_slot_start + CHECKSUM_SLOT_SIZE].to_vec(),
+            staged_slot.to_vec(),
+        )
+        .await?;
+        blob.sync().await?;
+
+        blob.write_at(
+            crc_start + new_slot_start as u64,
+            new_len.to_be_bytes().to_vec(),
         )
         .await?;
         blob.sync().await?;
@@ -828,11 +841,17 @@ impl<B: Blob> Append<B> {
         } else {
             0
         };
+        let len_size = std::mem::size_of::<u16>();
+        let crc_size = CHECKSUM_SLOT_SIZE - len_size;
         blob.write_at(
-            crc_start + old_slot_start as u64,
-            vec![0u8; CHECKSUM_SLOT_SIZE],
+            crc_start + old_slot_start as u64 + len_size as u64,
+            vec![0u8; crc_size],
         )
         .await?;
+        blob.sync().await?;
+
+        blob.write_at(crc_start + old_slot_start as u64, vec![0u8; len_size])
+            .await?;
         blob.sync().await?;
 
         let final_record = if new_slot_start == 0 {
@@ -966,15 +985,14 @@ impl<B: Blob> Append<B> {
             full_pages * physical_page_size
         };
 
-        let old_partial_page_state = blob_guard.partial_page_state.clone();
-        let same_page_partial_shrink = size < current_size
+        let protected_partial_shrink = size < current_size
             && partial_bytes > 0
-            && full_pages == blob_guard.current_page
-            && old_partial_page_state.is_some();
+            && (full_pages < blob_guard.current_page
+                || (full_pages == blob_guard.current_page
+                    && blob_guard.partial_page_state.is_some()));
 
-        if same_page_partial_shrink {
-            let old_crc =
-                old_partial_page_state.expect("same-page shrink requires old partial CRC");
+        if protected_partial_shrink {
+            blob_guard.blob.resize(new_physical_size).await?;
 
             // Evict cached pages at or beyond the new full-page boundary. The page at
             // `full_pages` is now owned by the tip buffer, and anything above is beyond the new
@@ -986,8 +1004,12 @@ impl<B: Blob> Append<B> {
             blob_guard.current_page = full_pages;
             buf_guard.offset = full_pages * logical_page_size;
 
-            let page_data =
-                super::get_page_from_blob(&blob_guard.blob, full_pages, logical_page_size).await?;
+            let (page_data, old_crc) = super::get_page_with_checksum_from_blob(
+                &blob_guard.blob,
+                full_pages,
+                logical_page_size,
+            )
+            .await?;
 
             // Ensure the validated data covers what we need.
             if (page_data.len() as u64) < partial_bytes {
@@ -999,7 +1021,7 @@ impl<B: Blob> Append<B> {
             let over_capacity = buf_guard.append(new_data);
             assert!(!over_capacity);
 
-            let final_record = Self::sync_same_page_shrink(
+            let final_record = Self::sync_partial_page_shrink(
                 &blob_guard.blob,
                 full_pages,
                 logical_page_size,
@@ -2815,6 +2837,219 @@ mod tests {
     }
 
     #[test]
+    fn test_resize_same_page_shrink_survives_interrupted_len_stage() {
+        let executor = deterministic::Runner::default();
+
+        executor.start(|context| async move {
+            const LARGE_PAGE_SIZE: NonZeroU16 = NZU16!(600);
+            const LARGE_BUFFER_SIZE: usize = 1_200;
+
+            let cache_ref =
+                CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(LARGE_BUFFER_SIZE));
+            let data: Vec<u8> = (0..300).map(|i| (i % 251) as u8).collect();
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink_len_stage")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, LARGE_BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            append.append(&data[..255]).await.unwrap();
+            append.sync().await.unwrap();
+            append.append(&data[255..]).await.unwrap();
+            append.sync().await.unwrap();
+            drop(append);
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink_len_stage")
+                .await
+                .unwrap();
+            let faulty_blob = PartialWriteBlob::new(blob, 2, 1);
+            let write_count = faulty_blob.write_count();
+            let failed_write_len = faulty_blob.failed_write_len();
+            let append = Append::new(faulty_blob, size, LARGE_BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            assert!(
+                append.resize(257).await.is_err(),
+                "length-stage partial write should fail"
+            );
+            assert_eq!(write_count.load(Ordering::SeqCst), 2);
+            assert_eq!(failed_write_len.load(Ordering::SeqCst), 2);
+            drop(append);
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink_len_stage")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, LARGE_BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 300);
+            let read = append.read_at(0, 300).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data);
+        });
+    }
+
+    #[test]
+    fn test_resize_same_page_shrink_preserves_validated_fallback_slot() {
+        let executor = deterministic::Runner::default();
+
+        executor.start(|context| async move {
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let data: Vec<u8> = (0..52).collect();
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink_fallback_slot")
+                .await
+                .unwrap();
+            let faulty_blob = PartialWriteBlob::new(blob.clone(), 5, 3);
+            let write_count = faulty_blob.write_count();
+            let failed_write_len = faulty_blob.failed_write_len();
+            let append = Append::new(faulty_blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            append.append(&data[..48]).await.unwrap();
+            append.sync().await.unwrap();
+            assert_eq!(write_count.load(Ordering::SeqCst), 1);
+
+            append.append(&data[48..50]).await.unwrap();
+            append.sync().await.unwrap();
+            assert_eq!(write_count.load(Ordering::SeqCst), 3);
+
+            append.append(&data[50..]).await.unwrap();
+            append.sync().await.unwrap();
+            assert_eq!(write_count.load(Ordering::SeqCst), 4);
+
+            // Corrupt the newer authoritative slot. The older slot still covers the shrink target.
+            // `resize()` first syncs the live buffer, which writes a valid fallback slot but leaves
+            // the cached footer stale. A torn phase-1 shrink write must preserve that validated
+            // fallback slot.
+            let slot0_offset = PAGE_SIZE.get() as u64;
+            blob.write_at(slot0_offset, DUMMY_MARKER.to_vec())
+                .await
+                .unwrap();
+            blob.sync().await.unwrap();
+
+            assert!(
+                append.resize(45).await.is_err(),
+                "phase-1 partial write should fail"
+            );
+            assert_eq!(write_count.load(Ordering::SeqCst), 5);
+            assert_eq!(failed_write_len.load(Ordering::SeqCst), CHECKSUM_SLOT_SIZE);
+            drop(append);
+
+            let (blob, size) = context
+                .open("test_partition", b"same_page_shrink_fallback_slot")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref).await.unwrap();
+            assert_eq!(append.size().await, 50);
+            let read = append.read_at(0, 50).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data[..50]);
+        });
+    }
+
+    #[test]
+    fn test_resize_full_page_to_partial_reopens_at_shorter_size() {
+        let executor = deterministic::Runner::default();
+
+        executor.start(|context| async move {
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let page_size = PAGE_SIZE.get() as u64;
+            let target = page_size + 45;
+            let data: Vec<u8> = (0..page_size * 2).map(|i| (i % 251) as u8).collect();
+
+            let (blob, size) = context
+                .open("test_partition", b"full_page_to_partial")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            append.append(&data).await.unwrap();
+            append.sync().await.unwrap();
+
+            append.resize(target).await.unwrap();
+            drop(append);
+
+            let (blob, size) = context
+                .open("test_partition", b"full_page_to_partial")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, target);
+            let read = append
+                .read_at(0, target as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..target as usize]);
+        });
+    }
+
+    #[test]
+    fn test_resize_full_page_to_partial_survives_interrupted_crc_stage() {
+        let executor = deterministic::Runner::default();
+
+        executor.start(|context| async move {
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let page_size = PAGE_SIZE.get() as u64;
+            let target = page_size + 45;
+            let data: Vec<u8> = (0..page_size * 3).map(|i| (i % 251) as u8).collect();
+
+            let (blob, size) = context
+                .open("test_partition", b"full_page_to_partial_interrupted")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            append.append(&data).await.unwrap();
+            append.sync().await.unwrap();
+            drop(append);
+
+            let (blob, size) = context
+                .open("test_partition", b"full_page_to_partial_interrupted")
+                .await
+                .unwrap();
+            let faulty_blob = PartialWriteBlob::new(blob, 1, 3);
+            let write_count = faulty_blob.write_count();
+            let failed_write_len = faulty_blob.failed_write_len();
+            let append = Append::new(faulty_blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            assert!(
+                append.resize(target).await.is_err(),
+                "phase-1 partial write should fail"
+            );
+            assert_eq!(write_count.load(Ordering::SeqCst), 1);
+            assert_eq!(failed_write_len.load(Ordering::SeqCst), CHECKSUM_SLOT_SIZE);
+            drop(append);
+
+            let (blob, size) = context
+                .open("test_partition", b"full_page_to_partial_interrupted")
+                .await
+                .unwrap();
+            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, page_size * 2);
+            let read = append
+                .read_at(0, (page_size * 2) as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..(page_size * 2) as usize]);
+        });
+    }
+
+    #[test]
     fn test_resize_same_page_shrink_survives_interrupted_crc_invalidation() {
         let executor = deterministic::Runner::default();
 
@@ -2833,7 +3068,7 @@ mod tests {
                 .await
                 .unwrap();
             // Put the old authoritative CRC in slot 1, so the shorter CRC will be staged in slot
-            // 0. Phase 1 is the new-slot write; phase 2 only invalidates the old slot.
+            // 0. The old slot is invalidated only after the shorter slot is durable.
             append.append(&data[..40]).await.unwrap();
             append.sync().await.unwrap();
             append.append(&data[40..]).await.unwrap();
@@ -2847,7 +3082,7 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            let faulty_blob = PartialWriteBlob::new(blob, 2, 3);
+            let faulty_blob = PartialWriteBlob::new(blob, 3, 3);
             let write_count = faulty_blob.write_count();
             let failed_write_len = faulty_blob.failed_write_len();
             let append = Append::new(faulty_blob, size, BUFFER_SIZE, cache_ref.clone())
@@ -2856,10 +3091,13 @@ mod tests {
 
             assert!(
                 append.resize(45).await.is_err(),
-                "phase-2 partial write should fail"
+                "old-slot invalidation should fail"
             );
-            assert_eq!(write_count.load(Ordering::SeqCst), 2);
-            assert_eq!(failed_write_len.load(Ordering::SeqCst), CHECKSUM_SLOT_SIZE);
+            assert_eq!(write_count.load(Ordering::SeqCst), 3);
+            assert_eq!(
+                failed_write_len.load(Ordering::SeqCst),
+                CHECKSUM_SLOT_SIZE - std::mem::size_of::<u16>()
+            );
             drop(append);
 
             let (blob, size) = context

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -795,12 +795,6 @@ impl<B: Blob> Append<B> {
     }
 
     /// Durably rewrite a committed page to a shorter partial length.
-    ///
-    /// Since larger valid lengths are authoritative, a shorter CRC cannot simply be written next to
-    /// the old CRC. We first stage the shorter slot with length 0, then make its length durable,
-    /// then clear the old slot's length bytes. A crash during any phase recovers either the old
-    /// longer page or the new shorter page, but never loses the whole page or fabricates a larger
-    /// length.
     async fn sync_partial_page_shrink(
         blob: &B,
         page: u64,
@@ -809,6 +803,9 @@ impl<B: Blob> Append<B> {
         new_crc: u32,
         old_crc: &Checksum,
     ) -> Result<Checksum, Error> {
+        // Since larger valid lengths are authoritative, a shorter slot cannot simply be written
+        // next to the old slot. We stage the shorter slot with length 0, make its length durable,
+        // then clear the previous slot's length bytes.
         let physical_page_size = logical_page_size
             .checked_add(CHECKSUM_SIZE)
             .ok_or(Error::OffsetOverflow)?;
@@ -817,33 +814,33 @@ impl<B: Blob> Append<B> {
             .and_then(|start| start.checked_add(logical_page_size))
             .ok_or(Error::OffsetOverflow)?;
 
-        let new_slot_start = if old_crc.len1 >= old_crc.len2 {
-            CHECKSUM_SLOT_SIZE
+        let (new_slot_start, old_slot_start) = if old_crc.len1 >= old_crc.len2 {
+            (CHECKSUM_SLOT_SIZE, 0)
         } else {
-            0
+            (0, CHECKSUM_SLOT_SIZE)
         };
         let new_slot_offset = crc_start
             .checked_add(new_slot_start as u64)
             .ok_or(Error::OffsetOverflow)?;
+
+        // Stage the new slot with a 0 length and the shrunken page CRC.
         let staged_slot = Self::checksum_slot_bytes(0, new_crc);
         blob.write_at(new_slot_offset, staged_slot.to_vec()).await?;
         blob.sync().await?;
 
+        // Make the new shrunken length durable. We cannot write the CRC and new length in one go
+        // without introducing crash safety concerns due to partial writes.
         blob.write_at(new_slot_offset, new_len.to_be_bytes().to_vec())
             .await?;
         blob.sync().await?;
 
-        let old_slot_start = if new_slot_start == 0 {
-            CHECKSUM_SLOT_SIZE
-        } else {
-            0
-        };
         let old_slot_offset = crc_start
             .checked_add(old_slot_start as u64)
             .ok_or(Error::OffsetOverflow)?;
         let len_size = std::mem::size_of::<u16>();
 
-        // A slot with length 0 is invalid regardless of its CRC.
+        // Clear the old slot's length. A slot with length 0 is never authoritative, so the slot
+        // representing the shrunken page becomes authoritative.
         blob.write_at(old_slot_offset, vec![0u8; len_size]).await?;
         blob.sync().await?;
 
@@ -983,44 +980,41 @@ impl<B: Blob> Append<B> {
             full_pages * physical_page_size
         };
 
+        // Drop cached pages at or beyond the new tail. Future appends may reuse those logical
+        // offsets, and cache-only reads must not see pre-shrink bytes there.
+        blob_guard.blob.resize(new_physical_size).await?;
+        self.cache_ref.invalidate_from(self.id, full_pages);
+
         if partial_bytes > 0 {
-            self.shrink_protected_partial(
-                &mut buf_guard,
-                &mut blob_guard,
-                new_physical_size,
-                full_pages,
-                partial_bytes,
-                logical_page_size,
-            )
-            .await
-        } else {
-            self.shrink_standard(
-                &mut buf_guard,
-                &mut blob_guard,
-                new_physical_size,
-                full_pages,
-            )
-            .await
+            return self
+                .shrink_to_partial(
+                    &mut buf_guard,
+                    &mut blob_guard,
+                    full_pages,
+                    partial_bytes,
+                    logical_page_size,
+                )
+                .await;
         }
+
+        // Shrink the blob to a page boundary, which requires no CRC-slot rewrite.
+        blob_guard.partial_page_state = None;
+        blob_guard.current_page = full_pages;
+        buf_guard.offset = full_pages * logical_page_size;
+        buf_guard.clear();
+
+        Ok(())
     }
 
-    /// Perform a safe, torn-write-resistant shrink to a new partial page tip.
-    async fn shrink_protected_partial(
+    /// Perform a shrink to a partial page tip and make the shorter CRC slot authoritative.
+    async fn shrink_to_partial(
         &self,
         buf_guard: &mut Buffer,
         blob_guard: &mut BlobState<B>,
-        new_physical_size: u64,
         full_pages: u64,
         partial_bytes: u64,
         logical_page_size: u64,
     ) -> Result<(), Error> {
-        blob_guard.blob.resize(new_physical_size).await?;
-
-        // Evict cached pages at or beyond the new full-page boundary. The page at
-        // `full_pages` is now owned by the tip buffer, and anything above is beyond the new
-        // logical size.
-        self.cache_ref.invalidate_from(self.id, full_pages);
-
         // Update blob state and buffer based on the desired logical size. The page data is
         // read with CRC validation, then durably rewritten below with a shorter CRC.
         blob_guard.current_page = full_pages;
@@ -1053,29 +1047,6 @@ impl<B: Blob> Append<B> {
         )
         .await?;
         blob_guard.partial_page_state = Some(final_record);
-        Ok(())
-    }
-
-    /// Perform a standard shrink to a page boundary.
-    async fn shrink_standard(
-        &self,
-        buf_guard: &mut Buffer,
-        blob_guard: &mut BlobState<B>,
-        new_physical_size: u64,
-        full_pages: u64,
-    ) -> Result<(), Error> {
-        // Resize the underlying blob.
-        blob_guard.blob.resize(new_physical_size).await?;
-        blob_guard.partial_page_state = None;
-
-        // Evict cached pages at or beyond the new full-page boundary. Leaving pre-resize contents
-        // in the cache lets `try_read_sync` observe stale bytes once the tip is repopulated.
-        self.cache_ref.invalidate_from(self.id, full_pages);
-
-        // Update blob state and buffer based on the desired logical size.
-        blob_guard.current_page = full_pages;
-        buf_guard.offset = full_pages * self.cache_ref.page_size();
-        buf_guard.clear();
 
         Ok(())
     }

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -1664,6 +1664,26 @@ mod tests {
             self.inner.write_at(offset, bufs).await
         }
 
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            let bufs = bufs.into();
+            let write = self.writes.fetch_add(1, Ordering::SeqCst) + 1;
+            if write == self.fail_on {
+                let bytes = bufs.coalesce();
+                self.failed_write_len.store(bytes.len(), Ordering::SeqCst);
+                let partial_len = self.partial_len.min(bytes.len());
+                self.inner
+                    .write_at_sync(offset, bytes.slice(..partial_len))
+                    .await?;
+                return Err(Error::Io(std::io::Error::other("injected partial write")));
+            }
+
+            self.inner.write_at_sync(offset, bufs).await
+        }
+
         async fn resize(&self, len: u64) -> Result<(), Error> {
             self.inner.resize(len).await
         }

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -803,9 +803,10 @@ impl<B: Blob> Append<B> {
         new_crc: u32,
         old_crc: &Checksum,
     ) -> Result<Checksum, Error> {
-        // Since larger valid lengths are authoritative, a shorter slot cannot simply be written
-        // next to the old slot. We stage the shorter slot with length 0, make its length durable,
-        // then clear the previous slot's length bytes.
+        // Recovery chooses the valid slot with the larger length. While shrinking, the new
+        // checksum must be made durable without becoming authoritative until the old longer slot
+        // can be disabled. The sequence below therefore lets recovery observe either the old page
+        // or the new shorter page, but not a footer where both slots were damaged by one torn write.
         let physical_page_size = logical_page_size
             .checked_add(CHECKSUM_SIZE)
             .ok_or(Error::OffsetOverflow)?;
@@ -823,13 +824,14 @@ impl<B: Blob> Append<B> {
             .checked_add(new_slot_start as u64)
             .ok_or(Error::OffsetOverflow)?;
 
-        // Stage the new slot with a 0 length and the shrunken page CRC.
+        // Stage the new slot with a 0 length and the shrunken page CRC. A crash here leaves the
+        // old slot as the only non-zero valid slot.
         let staged_slot = Self::checksum_slot_bytes(0, new_crc);
         blob.write_at(new_slot_offset, staged_slot.to_vec()).await?;
         blob.sync().await?;
 
-        // Make the new shrunken length durable. We cannot write the CRC and new length in one go
-        // without introducing crash safety concerns due to partial writes.
+        // Publish the new shrunken length. If a crash happens before the old slot is invalidated,
+        // both slots may be valid, but recovery still chooses the old longer length.
         blob.write_at(new_slot_offset, new_len.to_be_bytes().to_vec())
             .await?;
         blob.sync().await?;
@@ -839,8 +841,9 @@ impl<B: Blob> Append<B> {
             .ok_or(Error::OffsetOverflow)?;
         let len_size = std::mem::size_of::<u16>();
 
-        // Clear the old slot's length. A slot with length 0 is never authoritative, so the slot
-        // representing the shrunken page becomes authoritative.
+        // Clear only the old slot's length bytes. Rewriting the whole footer here could tear across
+        // both slots and lose the already-durable shorter checksum. Once this lands, length 0 is
+        // never authoritative, so the shrunken slot wins.
         blob.write_at(old_slot_offset, vec![0u8; len_size]).await?;
         blob.sync().await?;
 
@@ -959,7 +962,9 @@ impl<B: Blob> Append<B> {
     /// Coordinate the locking and dispatch logic for shrinking the blob.
     async fn shrink(&self, target_size: u64) -> Result<(), Error> {
         let logical_page_size = self.cache_ref.page_size();
-        let physical_page_size = logical_page_size + CHECKSUM_SIZE;
+        let physical_page_size = logical_page_size
+            .checked_add(CHECKSUM_SIZE)
+            .ok_or(Error::OffsetOverflow)?;
 
         // Flush any buffered data first to ensure we have a consistent state on disk.
         self.sync().await?;
@@ -971,14 +976,15 @@ impl<B: Blob> Append<B> {
         // Calculate the physical size needed for the new logical size.
         let full_pages = target_size / logical_page_size;
         let partial_bytes = target_size % logical_page_size;
-        let new_physical_size = if partial_bytes > 0 {
-            // We need full_pages + 1 physical pages to hold the partial data.
-            // The partial page will be padded to full physical page size.
-            (full_pages + 1) * physical_page_size
-        } else {
-            // No partial page needed.
-            full_pages * physical_page_size
-        };
+        let physical_pages = full_pages
+            .checked_add(u64::from(partial_bytes > 0))
+            .ok_or(Error::OffsetOverflow)?;
+        let new_physical_size = physical_pages
+            .checked_mul(physical_page_size)
+            .ok_or(Error::OffsetOverflow)?;
+        let tail_offset = full_pages
+            .checked_mul(logical_page_size)
+            .ok_or(Error::OffsetOverflow)?;
 
         // Drop cached pages at or beyond the new tail. Future appends may reuse those logical
         // offsets, and cache-only reads must not see pre-shrink bytes there.
@@ -993,6 +999,7 @@ impl<B: Blob> Append<B> {
                     full_pages,
                     partial_bytes,
                     logical_page_size,
+                    tail_offset,
                 )
                 .await;
         }
@@ -1000,7 +1007,7 @@ impl<B: Blob> Append<B> {
         // Shrink the blob to a page boundary, which requires no CRC-slot rewrite.
         blob_guard.partial_page_state = None;
         blob_guard.current_page = full_pages;
-        buf_guard.offset = full_pages * logical_page_size;
+        buf_guard.offset = tail_offset;
         buf_guard.clear();
 
         Ok(())
@@ -1014,11 +1021,12 @@ impl<B: Blob> Append<B> {
         full_pages: u64,
         partial_bytes: u64,
         logical_page_size: u64,
+        tail_offset: u64,
     ) -> Result<(), Error> {
         // Update blob state and buffer based on the desired logical size. The page data is
         // read with CRC validation, then durably rewritten below with a shorter CRC.
         blob_guard.current_page = full_pages;
-        buf_guard.offset = full_pages * logical_page_size;
+        buf_guard.offset = tail_offset;
 
         let (page_data, old_crc) = super::get_page_with_checksum_from_blob(
             &blob_guard.blob,

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -798,9 +798,9 @@ impl<B: Blob> Append<B> {
     ///
     /// Since larger valid lengths are authoritative, a shorter CRC cannot simply be written next to
     /// the old CRC. We first stage the shorter slot with length 0, then make its length durable,
-    /// then clear the old slot's CRC bytes before clearing its length bytes. A crash during any
-    /// phase recovers either the old longer page or the new shorter page, but never loses the whole
-    /// page or fabricates a larger length.
+    /// then clear the old slot's length bytes. A crash during any phase recovers either the old
+    /// longer page or the new shorter page, but never loses the whole page or fabricates a larger
+    /// length.
     async fn sync_partial_page_shrink(
         blob: &B,
         page: u64,
@@ -842,15 +842,8 @@ impl<B: Blob> Append<B> {
             .checked_add(old_slot_start as u64)
             .ok_or(Error::OffsetOverflow)?;
         let len_size = std::mem::size_of::<u16>();
-        let crc_size = CHECKSUM_SLOT_SIZE - len_size;
-        let old_crc_offset = old_slot_offset
-            .checked_add(len_size as u64)
-            .ok_or(Error::OffsetOverflow)?;
 
-        // Clear CRC bytes before length bytes so torn invalidation cannot create a new valid slot.
-        blob.write_at(old_crc_offset, vec![0u8; crc_size]).await?;
-        blob.sync().await?;
-
+        // A slot with length 0 is invalid regardless of its CRC.
         blob.write_at(old_slot_offset, vec![0u8; len_size]).await?;
         blob.sync().await?;
 
@@ -3058,69 +3051,73 @@ mod tests {
     }
 
     #[test]
-    fn test_resize_same_page_shrink_survives_interrupted_crc_invalidation() {
+    fn test_resize_same_page_shrink_survives_interrupted_length_invalidation() {
         let executor = deterministic::Runner::default();
 
         executor.start(|context| async move {
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let data: Vec<u8> = (0..50).collect();
+            const LARGE_PAGE_SIZE: NonZeroU16 = NZU16!(600);
+            const LARGE_BUFFER_SIZE: usize = 1_200;
+
+            let cache_ref =
+                CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(LARGE_BUFFER_SIZE));
+            let data: Vec<u8> = (0..300).map(|i| (i % 251) as u8).collect();
 
             let (blob, size) = context
                 .open(
                     "test_partition",
-                    b"same_page_shrink_interrupted_invalidation",
+                    b"same_page_shrink_interrupted_len_invalidation",
                 )
                 .await
                 .unwrap();
-            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref.clone())
+            let append = Append::new(blob, size, LARGE_BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
             // Put the old authoritative CRC in slot 1, so the shorter CRC will be staged in slot
-            // 0. The old slot is invalidated only after the shorter slot is durable.
-            append.append(&data[..40]).await.unwrap();
+            // 0. The old length is above 255, so a one-byte tear changes the decoded length.
+            append.append(&data[..255]).await.unwrap();
             append.sync().await.unwrap();
-            append.append(&data[40..]).await.unwrap();
+            append.append(&data[255..]).await.unwrap();
             append.sync().await.unwrap();
             drop(append);
 
             let (blob, size) = context
                 .open(
                     "test_partition",
-                    b"same_page_shrink_interrupted_invalidation",
+                    b"same_page_shrink_interrupted_len_invalidation",
                 )
                 .await
                 .unwrap();
-            let faulty_blob = PartialWriteBlob::new(blob, 3, 3);
+            let faulty_blob = PartialWriteBlob::new(blob, 3, 1);
             let write_count = faulty_blob.write_count();
             let failed_write_len = faulty_blob.failed_write_len();
-            let append = Append::new(faulty_blob, size, BUFFER_SIZE, cache_ref.clone())
+            let append = Append::new(faulty_blob, size, LARGE_BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
 
             assert!(
-                append.resize(45).await.is_err(),
-                "old-slot invalidation should fail"
+                append.resize(40).await.is_err(),
+                "old-slot length invalidation should fail"
             );
             assert_eq!(write_count.load(Ordering::SeqCst), 3);
             assert_eq!(
                 failed_write_len.load(Ordering::SeqCst),
-                CHECKSUM_SLOT_SIZE - std::mem::size_of::<u16>()
+                std::mem::size_of::<u16>()
             );
             drop(append);
 
             let (blob, size) = context
                 .open(
                     "test_partition",
-                    b"same_page_shrink_interrupted_invalidation",
+                    b"same_page_shrink_interrupted_len_invalidation",
                 )
                 .await
                 .unwrap();
-            let append = Append::new(blob, size, BUFFER_SIZE, cache_ref)
+            let append = Append::new(blob, size, LARGE_BUFFER_SIZE, cache_ref)
                 .await
                 .unwrap();
-            assert_eq!(append.size().await, 45);
-            let read = append.read_at(0, 45).await.unwrap().coalesce();
-            assert_eq!(read.as_ref(), &data[..45]);
+            assert_eq!(append.size().await, 40);
+            let read = append.read_at(0, 40).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data[..40]);
         });
     }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -798,8 +798,9 @@ impl<B: Blob> Append<B> {
     ///
     /// Since larger valid lengths are authoritative, a shorter CRC cannot simply be written next to
     /// the old CRC. We first stage the shorter slot with length 0, then make its length durable,
-    /// then invalidate the old longer slot. A crash during any phase recovers either the old longer
-    /// page or the new shorter page, but never loses the whole page or fabricates a larger length.
+    /// then clear the old slot's CRC bytes before clearing its length bytes. A crash during any
+    /// phase recovers either the old longer page or the new shorter page, but never loses the whole
+    /// page or fabricates a larger length.
     async fn sync_partial_page_shrink(
         blob: &B,
         page: u64,
@@ -821,16 +822,15 @@ impl<B: Blob> Append<B> {
         } else {
             0
         };
+        let new_slot_offset = crc_start
+            .checked_add(new_slot_start as u64)
+            .ok_or(Error::OffsetOverflow)?;
         let staged_slot = Self::checksum_slot_bytes(0, new_crc);
-        blob.write_at(crc_start + new_slot_start as u64, staged_slot.to_vec())
-            .await?;
+        blob.write_at(new_slot_offset, staged_slot.to_vec()).await?;
         blob.sync().await?;
 
-        blob.write_at(
-            crc_start + new_slot_start as u64,
-            new_len.to_be_bytes().to_vec(),
-        )
-        .await?;
+        blob.write_at(new_slot_offset, new_len.to_be_bytes().to_vec())
+            .await?;
         blob.sync().await?;
 
         let old_slot_start = if new_slot_start == 0 {
@@ -838,17 +838,20 @@ impl<B: Blob> Append<B> {
         } else {
             0
         };
+        let old_slot_offset = crc_start
+            .checked_add(old_slot_start as u64)
+            .ok_or(Error::OffsetOverflow)?;
         let len_size = std::mem::size_of::<u16>();
         let crc_size = CHECKSUM_SLOT_SIZE - len_size;
-        blob.write_at(
-            crc_start + old_slot_start as u64 + len_size as u64,
-            vec![0u8; crc_size],
-        )
-        .await?;
+        let old_crc_offset = old_slot_offset
+            .checked_add(len_size as u64)
+            .ok_or(Error::OffsetOverflow)?;
+
+        // Clear CRC bytes before length bytes so torn invalidation cannot create a new valid slot.
+        blob.write_at(old_crc_offset, vec![0u8; crc_size]).await?;
         blob.sync().await?;
 
-        blob.write_at(crc_start + old_slot_start as u64, vec![0u8; len_size])
-            .await?;
+        blob.write_at(old_slot_offset, vec![0u8; len_size]).await?;
         blob.sync().await?;
 
         let final_record = if new_slot_start == 0 {

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -13,11 +13,11 @@
 //!
 //! Two checksums are stored so that partial pages can be re-written without overwriting a valid
 //! checksum for its previously committed contents. A checksum over a page is computed over the
-//! first [0,len) bytes in the page, with all other bytes in the page ignored. New partial-page
-//! writes 0-pad the range [len, page_size), but recovery does not depend on those bytes. A checksum
-//! with length 0 is never considered valid. If both checksums are valid for the page, the one with
-//! the larger `len` is considered authoritative. Same-page shrink first makes the shorter checksum
-//! durable in the alternate slot, then invalidates the old longer checksum.
+//! first [0,len) bytes in the page, with all other bytes in the page ignored. Ordinary partial-page
+//! payload writes 0-pad the range [len, page_size), but recovery does not depend on bytes outside
+//! [0,len). A checksum with length 0 is never considered valid. If both checksums are valid for the
+//! page, the one with the larger `len` is considered authoritative. Partial-page shrink first makes
+//! the shorter checksum durable in the alternate slot, then invalidates the old longer checksum.
 //!
 //! A _full_ page is one whose crc stores a len equal to the logical page size. Otherwise the page
 //! is called _partial_. All pages in a blob are full except for the very last page, which can be
@@ -48,6 +48,16 @@ async fn get_page_from_blob(
     page_num: u64,
     logical_page_size: u64,
 ) -> Result<IoBuf, Error> {
+    let (page, _) = get_page_with_checksum_from_blob(blob, page_num, logical_page_size).await?;
+    Ok(page)
+}
+
+/// Read the designated page and return both its logical bytes and validated checksum record.
+async fn get_page_with_checksum_from_blob(
+    blob: &impl Blob,
+    page_num: u64,
+    logical_page_size: u64,
+) -> Result<(IoBuf, Checksum), Error> {
     let physical_page_size = logical_page_size + CHECKSUM_SIZE;
     let physical_page_start = page_num * physical_page_size;
 
@@ -61,7 +71,7 @@ async fn get_page_from_blob(
     };
     let (len, _) = record.get_crc();
 
-    Ok(page.freeze().slice(..len as usize))
+    Ok((page.freeze().slice(..len as usize), record))
 }
 
 /// Describes a CRC record stored at the end of a page.

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -13,15 +13,15 @@
 //!
 //! Two checksums are stored so that partial pages can be re-written without overwriting a valid
 //! checksum for its previously committed contents. A checksum over a page is computed over the
-//! first [0,len) bytes in the page, with all other bytes in the page ignored. This implementation
-//! always 0-pads the range [len, page_size). A checksum with length 0 is never considered
-//! valid. If both checksums are valid for the page, the one with the larger `len` is considered
-//! authoritative.
+//! first [0,len) bytes in the page, with all other bytes in the page ignored. New partial-page
+//! writes 0-pad the range [len, page_size), but recovery does not depend on those bytes. A checksum
+//! with length 0 is never considered valid. If both checksums are valid for the page, the one with
+//! the larger `len` is considered authoritative. Same-page shrink first makes the shorter checksum
+//! durable in the alternate slot, then invalidates the old longer checksum.
 //!
 //! A _full_ page is one whose crc stores a len equal to the logical page size. Otherwise the page
 //! is called _partial_. All pages in a blob are full except for the very last page, which can be
-//! full or partial. A partial page's logical bytes are immutable on commit, and if it's re-written,
-//! it's only to add more bytes after the existing ones.
+//! full or partial. A partial page's committed prefix remains recoverable while it is rewritten.
 
 use crate::{Blob, Buf, BufMut, Error, IoBuf};
 use commonware_codec::{EncodeFixed, FixedSize, Read as CodecRead, ReadExt, Write};
@@ -36,8 +36,9 @@ pub use cache::CacheRef;
 pub use read::Replay;
 use tracing::{debug, error};
 
-// A checksum record contains two u16 lengths and two CRCs (each 4 bytes).
+// A checksum record contains two slots. Each slot stores one u16 length and one CRC.
 const CHECKSUM_SIZE: u64 = Checksum::SIZE as u64;
+const CHECKSUM_SLOT_SIZE: usize = u16::SIZE + crc32::Digest::SIZE;
 
 /// Read the designated page from the underlying blob and return its logical bytes as a vector if it
 /// passes the integrity check, returning error otherwise. Safely handles partial pages. Caller can

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -58,8 +58,12 @@ async fn get_page_with_checksum_from_blob(
     page_num: u64,
     logical_page_size: u64,
 ) -> Result<(IoBuf, Checksum), Error> {
-    let physical_page_size = logical_page_size + CHECKSUM_SIZE;
-    let physical_page_start = page_num * physical_page_size;
+    let physical_page_size = logical_page_size
+        .checked_add(CHECKSUM_SIZE)
+        .ok_or(Error::OffsetOverflow)?;
+    let physical_page_start = page_num
+        .checked_mul(physical_page_size)
+        .ok_or(Error::OffsetOverflow)?;
 
     let page = blob
         .read_at(physical_page_start, physical_page_size as usize)

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -402,7 +402,13 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
                                                     new_size = state.valid_offset,
                                                     "trailing bytes detected: truncating"
                                                 );
-                                                state.blob.resize(state.valid_offset).await.ok()?;
+                                                if let Err(err) =
+                                                    state.blob.resize(state.valid_offset).await
+                                                {
+                                                    batch.push(Err(err.into()));
+                                                    state.done = true;
+                                                    return Some((batch, state));
+                                                }
                                             }
                                             state.done = true;
                                             return if batch.is_empty() {
@@ -428,7 +434,11 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
                                         new_size = state.valid_offset,
                                         "incomplete item at end: truncating"
                                     );
-                                    state.blob.resize(state.valid_offset).await.ok()?;
+                                    if let Err(err) = state.blob.resize(state.valid_offset).await {
+                                        batch.push(Err(err.into()));
+                                        state.done = true;
+                                        return Some((batch, state));
+                                    }
                                     state.done = true;
                                     return if batch.is_empty() {
                                         None

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -1404,7 +1404,9 @@ mod tests {
 
             match stream.next().await {
                 Some(Err(_)) => {}
-                other => panic!("expected resize error while repairing trailing bytes, got {other:?}"),
+                other => {
+                    panic!("expected resize error while repairing trailing bytes, got {other:?}")
+                }
             }
             assert!(stream.next().await.is_none());
         });

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -1354,6 +1354,63 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_journal_replay_reports_resize_error_on_trailing_bytes() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-partition".into(),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
+            };
+            let section = 1u64;
+            let item = 10u64;
+
+            let mut journal = Journal::init(context.child("first"), cfg.clone())
+                .await
+                .expect("Failed to initialize journal");
+            journal
+                .append(section, &item)
+                .await
+                .expect("Failed to append item");
+            journal
+                .append_raw(section, &[0xFF, 0xFF])
+                .await
+                .expect("Failed to append trailing bytes");
+            journal.sync(section).await.expect("Failed to sync journal");
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg)
+                .await
+                .expect("Failed to re-initialize journal");
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                resize_rate: Some(1.0),
+                ..Default::default()
+            };
+
+            let stream = journal
+                .replay(0, 0, NZUsize!(1024))
+                .await
+                .expect("unable to setup replay");
+            pin_mut!(stream);
+
+            let first = stream
+                .next()
+                .await
+                .expect("expected item before trailing bytes")
+                .expect("failed to replay valid item");
+            assert_eq!(first, (section, 0, item.encode_size() as u32, item));
+
+            match stream.next().await {
+                Some(Err(_)) => {}
+                other => panic!("expected resize error while repairing trailing bytes, got {other:?}"),
+            }
+            assert!(stream.next().await.is_none());
+        });
+    }
+
+    #[test_traced]
     fn test_journal_read_item_missing() {
         // Initialize the deterministic context
         let executor = deterministic::Runner::default();


### PR DESCRIPTION
## Summary

Fix crash safety for `runtime::utils::buffer::paged::Append::resize()` when shrinking a committed page to a shorter partial page, without changing the on-disk CRC format.

The paged append layer stores two `(len, crc)` slots per page. Because `len` is not covered by the CRC, shrink rewrites must be careful not to let a torn footer write fabricate a larger authoritative length or destroy the only recoverable footer. This PR makes partial-page shrink use a staged footer update so recovery observes either the old committed page or the new shorter page.

## Detailed Summary

- Add a validated page+checksum read helper so shrink decisions use the checksum record recovered from disk, not potentially stale cached `partial_page_state`.
- Protect both same-page partial shrink and full-page-to-partial shrink.
- Stage the shorter checksum before publishing its length, then invalidate the old longer slot only after the shorter slot is durable.
- Invalidate the old slot CRC-first so a torn invalidation cannot create a valid larger length.
- Preserve recovery fallback behavior if a crash happens during any shrink footer phase.
- Add a no-op fast path for `resize(current_size)`.
- Clarify paged-buffer documentation around partial-page shrink and ignored bytes past `len`.

This keeps the storage format unchanged. It hardens the torn-write states created by this implementation, but arbitrary length-field corruption remains a format-level limitation because `len` is still not included in the CRC.

## Tests

- Add regression coverage for interrupted shrink footer writes during:
  - new checksum staging
  - length publication
  - old-slot invalidation
- Add coverage for shrink after recovery falls back to the non-authoritative checksum slot.
- Add coverage for full-page-to-partial shrink, including interrupted footer staging.
- Add coverage for `resize()` to the current size as a no-op.

Validated with:

```bash
cargo fmt -p commonware-runtime
git diff --check -- runtime/src/utils/buffer/paged/append.rs runtime/src/utils/buffer/paged/mod.rs
just test -p commonware-runtime utils::buffer::paged::append

Towards: https://github.com/commonwarexyz/monorepo/issues/1432
