### PR TITLE
[runtime] add Blob::write_at_sync

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -431,6 +431,30 @@ impl Handle {
             offset,
             written: 0,
             write: bufs.into(),
+            sync: false,
+            result: None,
+            sender: tx,
+        }))
+        .await
+        .map_err(|_| Error::WriteFailed)?;
+        rx.await.map_err(|_| Error::WriteFailed)?
+    }
+
+    /// Submit a logical positioned write with per-write sync and wait for its completion.
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    pub async fn write_at_sync(
+        &self,
+        file: Arc<File>,
+        offset: u64,
+        bufs: IoBufs,
+    ) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        self.enqueue(Request::WriteAt(WriteAtRequest {
+            file,
+            offset,
+            written: 0,
+            write: bufs.into(),
+            sync: true,
             result: None,
             sender: tx,
         }))

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -532,7 +532,7 @@ pub(super) struct WriteAtRequest {
 
 impl WriteAtRequest {
     /// Return the flags for this write request, setting `RWF_SYNC` when `sync` is set.
-    fn rw_flags(&self) -> i32 {
+    const fn rw_flags(&self) -> i32 {
         if self.sync {
             libc::RWF_SYNC
         } else {

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -522,6 +522,8 @@ pub(super) struct WriteAtRequest {
     pub(super) written: usize,
     /// Write cursor and buffers that still need to be written.
     pub(super) write: WriteBuffers,
+    /// Whether the write should be durably persisted before completion.
+    pub(super) sync: bool,
     /// Terminal result captured by `on_cqe` and delivered by `finish`.
     pub(super) result: Option<Result<(), Error>>,
     /// Completion channel for the top-level caller.
@@ -529,10 +531,20 @@ pub(super) struct WriteAtRequest {
 }
 
 impl WriteAtRequest {
+    /// Return the flags for this write request, setting `RWF_SYNC` when `sync` is set.
+    fn rw_flags(&self) -> i32 {
+        if self.sync {
+            libc::RWF_SYNC
+        } else {
+            0
+        }
+    }
+
     /// Build the next positioned write SQE for the remaining bytes.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.file.as_raw_fd());
         let offset = self.offset + self.written as u64;
+        let rw_flags = self.rw_flags();
         match &mut self.write {
             WriteBuffers::Single { buf } => {
                 let ptr = buf.as_ptr();
@@ -545,6 +557,7 @@ impl WriteAtRequest {
                         .expect("single-buffer SQE length exceeds u32"),
                 )
                 .offset(offset)
+                .rw_flags(rw_flags)
                 .build()
             }
             WriteBuffers::Vectored { bufs, iovecs } => {
@@ -563,6 +576,7 @@ impl WriteAtRequest {
 
                 opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len)
                     .offset(offset)
+                    .rw_flags(rw_flags)
                     .build()
             }
         }
@@ -1170,14 +1184,17 @@ mod tests {
 
         // Retryable CQEs should requeue the positioned write.
         let (tx, _rx) = oneshot::channel();
-        let mut request = Request::WriteAt(WriteAtRequest {
+        let write = WriteAtRequest {
             file: make_file_fd(),
             offset: 0,
             written: 0,
             write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            sync: false,
             result: None,
             sender: tx,
-        });
+        };
+        assert_eq!(write.rw_flags(), 0);
+        let mut request = Request::WriteAt(write);
         assert!(!request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EAGAIN));
 
         // Single-buffer writes should track partial progress until complete.
@@ -1187,6 +1204,7 @@ mod tests {
             offset: 0,
             written: 0,
             write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            sync: false,
             result: None,
             sender: tx,
         });
@@ -1207,6 +1225,7 @@ mod tests {
             offset: 0,
             written: 0,
             write: vectored.into(),
+            sync: false,
             result: None,
             sender: tx,
         });
@@ -1224,6 +1243,7 @@ mod tests {
             offset: 0,
             written: 0,
             write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            sync: false,
             result: None,
             sender: tx,
         });
@@ -1240,6 +1260,7 @@ mod tests {
             offset: 0,
             written: 0,
             write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            sync: false,
             result: None,
             sender: tx,
         });
@@ -1250,6 +1271,27 @@ mod tests {
             Err(Error::WriteFailed)
         ));
 
+        // Synchronous writes use the same logical error surface as regular
+        // writes, `sync` only changes the SQE flags.
+        let (tx, rx) = oneshot::channel();
+        let write = WriteAtRequest {
+            file: make_file_fd(),
+            offset: 0,
+            written: 0,
+            write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            sync: true,
+            result: None,
+            sender: tx,
+        };
+        assert_eq!(write.rw_flags(), libc::RWF_SYNC);
+        let mut request = Request::WriteAt(write);
+        assert!(request.on_cqe(WaiterState::Active { target_tick: None }, -libc::EINVAL));
+        request.complete();
+        assert!(matches!(
+            block_on(rx).expect("missing sync write failure"),
+            Err(Error::WriteFailed)
+        ));
+
         // Timeout cancellation should also surface as a write failure.
         let (tx, rx) = oneshot::channel();
         let mut request = Request::WriteAt(WriteAtRequest {
@@ -1257,6 +1299,7 @@ mod tests {
             offset: 0,
             written: 0,
             write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            sync: false,
             result: None,
             sender: tx,
         });
@@ -1408,6 +1451,7 @@ mod tests {
             offset: 0,
             written: 0,
             write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            sync: false,
             result: None,
             sender: tx,
         });
@@ -1492,6 +1536,7 @@ mod tests {
             offset: 0,
             written: 0,
             write: IoBufs::from(IoBuf::from(b"hello")).into(),
+            sync: false,
             result: None,
             sender: tx,
         });

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -773,6 +773,18 @@ stability_scope!(BETA {
             bufs: impl Into<IoBufs> + Send,
         ) -> impl Future<Output = Result<(), Error>> + Send;
 
+        /// Write `bufs` to the blob at the given offset and durably persist that write.
+        ///
+        /// This is not a durability barrier for previous operations. When it completes,
+        /// only the bytes submitted to this call are guaranteed durable. Earlier unsynced
+        /// [`Blob::write_at`] or [`Blob::resize`] calls require [`Blob::sync`] to become
+        /// durable.
+        fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+        ) -> impl Future<Output = Result<(), Error>> + Send;
+
         /// Resize the blob to the given length.
         ///
         /// If the length is greater than the current length, the blob is extended with zeros.

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -284,7 +284,8 @@ mod tests {
 
     #[derive(Clone)]
     struct RecordingBlob {
-        chunk_counts: Arc<Mutex<Vec<usize>>>,
+        write_chunk_counts: Arc<Mutex<Vec<usize>>>,
+        sync_write_chunk_counts: Arc<Mutex<Vec<usize>>>,
     }
 
     impl crate::Blob for RecordingBlob {
@@ -306,7 +307,20 @@ mod tests {
             _offset: u64,
             bufs: impl Into<IoBufs> + Send,
         ) -> Result<(), Error> {
-            self.chunk_counts.lock().push(bufs.into().chunk_count());
+            self.write_chunk_counts
+                .lock()
+                .push(bufs.into().chunk_count());
+            Ok(())
+        }
+
+        async fn write_at_sync(
+            &self,
+            _offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            self.sync_write_chunk_counts
+                .lock()
+                .push(bufs.into().chunk_count());
             Ok(())
         }
 
@@ -320,14 +334,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_audited_blob_write_preserves_chunking() {
-        let chunk_counts = Arc::new(Mutex::new(Vec::new()));
+    async fn test_audited_blob_writes_preserve_chunking() {
+        let write_chunk_counts = Arc::new(Mutex::new(Vec::new()));
+        let sync_write_chunk_counts = Arc::new(Mutex::new(Vec::new()));
         let blob = super::Blob {
             auditor: Arc::new(crate::deterministic::Auditor::default()),
             partition: "partition".into(),
             name: b"blob".to_vec(),
             inner: RecordingBlob {
-                chunk_counts: chunk_counts.clone(),
+                write_chunk_counts: write_chunk_counts.clone(),
+                sync_write_chunk_counts: sync_write_chunk_counts.clone(),
             },
         };
 
@@ -343,6 +359,22 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(*chunk_counts.lock(), vec![4]);
+        assert_eq!(*write_chunk_counts.lock(), vec![4]);
+        assert!(sync_write_chunk_counts.lock().is_empty());
+
+        blob.write_at_sync(
+            0,
+            IoBufs::from(vec![
+                IoBuf::from(b"a".to_vec()),
+                IoBuf::from(b"b".to_vec()),
+                IoBuf::from(b"c".to_vec()),
+                IoBuf::from(b"d".to_vec()),
+            ]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(*write_chunk_counts.lock(), vec![4]);
+        assert_eq!(*sync_write_chunk_counts.lock(), vec![4]);
     }
 }

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -115,6 +115,21 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         self.inner.write_at(offset, bufs).await
     }
 
+    async fn write_at_sync(
+        &self,
+        offset: u64,
+        bufs: impl Into<IoBufs> + Send,
+    ) -> Result<(), Error> {
+        let bufs = bufs.into();
+        self.auditor.event(b"write_at_sync", |hasher| {
+            hasher.update(self.partition.as_bytes());
+            hasher.update(&self.name);
+            hasher.update(&offset.to_be_bytes());
+            bufs.for_each_chunk(|chunk| hasher.update(chunk));
+        });
+        self.inner.write_at_sync(offset, bufs).await
+    }
+
     async fn resize(&self, len: u64) -> Result<(), Error> {
         self.auditor.event(b"resize", |hasher| {
             hasher.update(self.partition.as_bytes());

--- a/runtime/src/storage/benches/config.rs
+++ b/runtime/src/storage/benches/config.rs
@@ -21,6 +21,9 @@ pub enum Workload {
     /// Monotonic append writes to a growing file.
     #[value(name = "write_append")]
     WriteAppend,
+    /// Sequential durable positioned writes over a fixed-size file.
+    #[value(name = "write_sync")]
+    WriteSync,
     /// One append writer plus many random readers of the visible prefix.
     #[value(name = "read_write_append")]
     ReadWriteAppend,
@@ -31,7 +34,11 @@ impl Workload {
     pub const fn has_writes(self) -> bool {
         matches!(
             self,
-            Self::WriteSeq | Self::WriteRand | Self::WriteAppend | Self::ReadWriteAppend
+            Self::WriteSeq
+                | Self::WriteRand
+                | Self::WriteAppend
+                | Self::WriteSync
+                | Self::ReadWriteAppend
         )
     }
 
@@ -64,6 +71,17 @@ pub enum WriteShape {
     /// Four-buffer vectored write per operation.
     #[value(name = "vectored")]
     Vectored,
+}
+
+/// Durable write implementation for the `write_sync` workload.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum SyncMethod {
+    /// Call `write_at`, then call `sync`.
+    #[value(name = "write_then_sync")]
+    WriteThenSync,
+    /// Call `write_at_sync`.
+    #[value(name = "write_at_sync")]
+    WriteAtSync,
 }
 
 /// Write durability policy.
@@ -100,7 +118,7 @@ macro_rules! display_value_enum {
     )+};
 }
 
-display_value_enum!(Workload, CacheMode, WriteShape, OutputFormat);
+display_value_enum!(Workload, CacheMode, WriteShape, SyncMethod, OutputFormat);
 
 impl fmt::Display for SyncMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -164,6 +182,10 @@ pub struct Config {
     /// Write payload layout for write-heavy workloads.
     #[arg(long, value_enum, default_value = "contiguous")]
     pub write_shape: WriteShape,
+
+    /// Durable write method for the write_sync workload.
+    #[arg(long, value_enum, default_value = "write_then_sync")]
+    pub sync_method: SyncMethod,
 
     /// Durability cadence: `end` or a positive integer per writer stream.
     #[arg(long = "sync-every", default_value = "end", value_parser = parse_sync_mode)]
@@ -241,11 +263,22 @@ impl Config {
                 if !file_size.is_multiple_of(io_size) {
                     return Err("--file-size must be a multiple of --io-size".into());
                 }
-                if matches!(self.workload, Workload::WriteSeq | Workload::WriteRand) {
+                if matches!(
+                    self.workload,
+                    Workload::WriteSeq | Workload::WriteRand | Workload::WriteSync
+                ) {
                     let total_blocks = file_size / io_size;
                     if total_blocks < self.inflight as u64 {
                         return Err(
-                            "write_seq and write_rand require at least one non-overlapping block per worker"
+                            "write_seq, write_rand, and write_sync require at least one non-overlapping block per worker"
+                                .into(),
+                        );
+                    }
+                    if self.workload == Workload::WriteSync
+                        && !total_blocks.is_multiple_of(self.inflight as u64)
+                    {
+                        return Err(
+                            "write_sync requires --file-size / --io-size to be divisible by --inflight"
                                 .into(),
                         );
                     }
@@ -268,9 +301,18 @@ impl Config {
             if self.write_shape != WriteShape::Contiguous {
                 return Err("--write-shape is only valid for write-heavy workloads".into());
             }
+            if self.sync_method != SyncMethod::WriteThenSync {
+                return Err("--sync-method is only valid for write_sync".into());
+            }
             if self.sync_mode != SyncMode::End {
                 return Err("--sync-every is only valid for write-heavy workloads".into());
             }
+        } else if self.workload == Workload::WriteSync {
+            if self.sync_mode != SyncMode::End {
+                return Err("--sync-every is not used by write_sync".into());
+            }
+        } else if self.sync_method != SyncMethod::WriteThenSync {
+            return Err("--sync-method is only valid for write_sync".into());
         }
 
         Ok(())

--- a/runtime/src/storage/benches/main.rs
+++ b/runtime/src/storage/benches/main.rs
@@ -6,6 +6,7 @@
 //! - steady-state sequential reads and writes on fixed-size files
 //! - steady-state random reads and writes on fixed-size files
 //! - append-only writes on a growing file
+//! - durable positioned writes comparing sync strategies
 //! - mixed append-plus-read pressure with one writer and many readers
 
 mod config;

--- a/runtime/src/storage/benches/report.rs
+++ b/runtime/src/storage/benches/report.rs
@@ -1,6 +1,9 @@
 //! Statistics collection and reporting.
 
-use crate::{config::Config, filesystem::backend_name};
+use crate::{
+    config::{Config, Workload},
+    filesystem::backend_name,
+};
 use serde_json::json;
 use std::time::Duration;
 
@@ -161,10 +164,12 @@ impl Report {
             println!("cache={cache}");
         }
         if cfg.workload.has_writes() {
-            println!(
-                "write_shape={} sync_every={}",
-                cfg.write_shape, cfg.sync_mode
-            );
+            println!("write_shape={}", cfg.write_shape);
+            if cfg.workload == Workload::WriteSync {
+                println!("sync_method={}", cfg.sync_method);
+            } else {
+                println!("sync_every={}", cfg.sync_mode);
+            }
         }
 
         if let Some(read) = &self.read {
@@ -190,7 +195,10 @@ impl Report {
             "root": cfg.root,
             "cache": cfg.cache.map(|mode| mode.to_string()),
             "write_shape": cfg.workload.has_writes().then(|| cfg.write_shape.to_string()),
-            "sync_every": cfg.workload.has_writes().then(|| cfg.sync_mode.to_string()),
+            "sync_every": (cfg.workload.has_writes() && cfg.workload != Workload::WriteSync)
+                .then(|| cfg.sync_mode.to_string()),
+            "sync_method": (cfg.workload == Workload::WriteSync)
+                .then(|| cfg.sync_method.to_string()),
             "seed": cfg.seed,
             "elapsed_ns": self.elapsed.as_nanos() as u64,
             "read": self.read.as_ref().map(OperationReport::to_json),

--- a/runtime/src/storage/benches/runner.rs
+++ b/runtime/src/storage/benches/runner.rs
@@ -1,6 +1,10 @@
 //! Timed I/O loops and helpers.
 
-use crate::{config::SyncMode, error::Result, report::Stats};
+use crate::{
+    config::{SyncMethod, SyncMode},
+    error::Result,
+    report::Stats,
+};
 use commonware_runtime::{Blob, IoBufMut, IoBufs};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::time::Instant;
@@ -119,6 +123,35 @@ pub async fn run_write_loop(
         blob.sync().await?;
     }
 
+    Ok(stats)
+}
+
+/// Timed durable write loop with caller-defined offset selection.
+#[inline]
+pub async fn run_sync_write_loop(
+    blob: impl Blob,
+    deadline: Instant,
+    io_size: usize,
+    payload: IoBufs,
+    sync_method: SyncMethod,
+    mut next_block: impl FnMut() -> u64,
+) -> Result<Stats> {
+    let mut stats = Stats::default();
+    let io_size = io_size as u64;
+    while should_continue(deadline, stats.ops) {
+        let offset = next_block() * io_size;
+        let started = should_sample_latency(stats.ops).then(Instant::now);
+        match sync_method {
+            SyncMethod::WriteThenSync => {
+                blob.write_at(offset, payload.clone()).await?;
+                blob.sync().await?;
+            }
+            SyncMethod::WriteAtSync => {
+                blob.write_at_sync(offset, payload.clone()).await?;
+            }
+        }
+        stats.record(io_size, started.map(|s| s.elapsed()));
+    }
     Ok(stats)
 }
 

--- a/runtime/src/storage/benches/workload.rs
+++ b/runtime/src/storage/benches/workload.rs
@@ -5,7 +5,10 @@ use crate::{
     error::Result,
     filesystem::{drop_page_cache, prepare_blob, prepare_filled_blob, random_write_payload},
     report::Report,
-    runner::{random_blocks, run_read_loop, run_write_loop, sequential_blocks, warm_read_loop},
+    runner::{
+        random_blocks, run_read_loop, run_sync_write_loop, run_write_loop, sequential_blocks,
+        warm_read_loop,
+    },
 };
 use commonware_runtime::{tokio::Context, Blob as _, Storage as _};
 use futures::{stream::FuturesUnordered, TryStreamExt};
@@ -34,6 +37,7 @@ pub async fn run_benchmark(cfg: &Config, context: Context) -> Result<Report> {
         Workload::ReadSeq | Workload::ReadRand => run_read(cfg, &context).await,
         Workload::WriteSeq | Workload::WriteRand => run_overwrite(cfg, &context).await,
         Workload::WriteAppend => run_write_append(cfg, &context).await,
+        Workload::WriteSync => run_write_sync(cfg, &context).await,
         Workload::ReadWriteAppend => run_read_write_append(cfg, &context).await,
     };
     let _ = context.remove(PARTITION, None).await;
@@ -187,6 +191,45 @@ async fn run_write_append(cfg: &Config, context: &Context) -> Result<Report> {
         Some(vec![stats]),
         final_file_size,
     ))
+}
+
+/// Run sequential durable positioned writes on a fixed-size file.
+async fn run_write_sync(cfg: &Config, context: &Context) -> Result<Report> {
+    let file_size = cfg.file_size();
+    let total_blocks = file_size / cfg.io_size as u64;
+    let inflight = cfg.inflight as u64;
+
+    // Preallocate the blob so we measure steady-state write cost.
+    let blob = prepare_blob(context, &cfg.root, PARTITION, BLOB_NAME, file_size).await?;
+    let mut rng = StdRng::seed_from_u64(cfg.seed);
+    let payload = random_write_payload(&mut rng, cfg.io_size, cfg.write_shape);
+
+    let start = Instant::now();
+    let deadline = start + cfg.duration();
+
+    // Timed phase: drive multiple sequential durable write futures concurrently
+    // from the current task with `FuturesUnordered`.
+    let workers = (0..cfg.inflight)
+        .map(|worker| {
+            let blob = blob.clone();
+            let payload = payload.clone();
+            async move {
+                run_sync_write_loop(
+                    blob,
+                    deadline,
+                    cfg.io_size,
+                    payload,
+                    cfg.sync_method,
+                    sequential_blocks(worker as u64 % total_blocks, inflight, total_blocks),
+                )
+                .await
+            }
+        })
+        .collect::<FuturesUnordered<_>>()
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    Ok(Report::new(start.elapsed(), None, Some(workers), file_size))
 }
 
 /// Run one append writer plus concurrent random readers.

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -330,6 +330,43 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         Ok(())
     }
 
+    async fn write_at_sync(
+        &self,
+        offset: u64,
+        bufs: impl Into<IoBufs> + Send,
+    ) -> Result<(), Error> {
+        let bufs = bufs.into();
+        let total_bytes = bufs.remaining() as u64;
+        if total_bytes == 0 {
+            return Ok(());
+        }
+
+        let (should_fail, partial_rate) = self.ctx.check_write_fault();
+        if should_fail {
+            if let Some(bytes) = self.ctx.try_partial(partial_rate, 0, total_bytes) {
+                self.inner
+                    .write_at_sync(offset, bufs.coalesce().slice(..bytes as usize))
+                    .await?;
+                self.size
+                    .fetch_max(offset.saturating_add(bytes), Ordering::Relaxed);
+                return Err(Error::Io(injected_io_error()));
+            }
+            return Err(Error::Io(injected_io_error()));
+        }
+
+        if self.ctx.should_fail(Op::Sync) {
+            self.inner.write_at(offset, bufs).await?;
+            self.size
+                .fetch_max(offset.saturating_add(total_bytes), Ordering::Relaxed);
+            return Err(Error::Io(injected_io_error()));
+        }
+
+        self.inner.write_at_sync(offset, bufs).await?;
+        self.size
+            .fetch_max(offset.saturating_add(total_bytes), Ordering::Relaxed);
+        Ok(())
+    }
+
     async fn resize(&self, len: u64) -> Result<(), Error> {
         let (should_fail, partial_rate) = self.ctx.check_resize_fault();
         if should_fail {
@@ -424,6 +461,46 @@ mod tests {
             blob.write_at(0, b"data".to_vec()).await,
             Err(Error::Io(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn test_faulty_storage_write_at_sync_write_always_fails() {
+        let h = Harness::new(Config::default().write(1.0));
+
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+
+        assert!(matches!(
+            blob.write_at_sync(0, b"data".to_vec()).await,
+            Err(Error::Io(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_faulty_storage_write_at_sync_sync_failure_is_not_durable() {
+        let h = Harness::new(Config::default().sync(1.0));
+
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+
+        assert!(matches!(
+            blob.write_at_sync(0, b"data".to_vec()).await,
+            Err(Error::Io(_))
+        ));
+
+        let (_reopened, size) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(size, 0);
+    }
+
+    #[tokio::test]
+    async fn test_faulty_storage_empty_write_at_sync_does_not_sync_prior_write() {
+        let h = Harness::new(Config::default().sync(1.0));
+
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"data".to_vec()).await.unwrap();
+
+        blob.write_at_sync(4, Vec::<u8>::new()).await.unwrap();
+
+        let (_reopened, size) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(size, 0);
     }
 
     #[tokio::test]

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -342,6 +342,25 @@ impl crate::Blob for Blob {
             .await
     }
 
+    async fn write_at_sync(
+        &self,
+        offset: u64,
+        bufs: impl Into<IoBufs> + Send,
+    ) -> Result<(), Error> {
+        let bufs = bufs.into();
+        let offset = offset
+            .checked_add(Header::SIZE_U64)
+            .ok_or(Error::OffsetOverflow)?;
+
+        if !bufs.has_remaining() {
+            return Ok(());
+        }
+
+        self.io_handle
+            .write_at_sync(self.file.clone(), offset, bufs)
+            .await
+    }
+
     // TODO: Make this async. See https://github.com/commonwarexyz/monorepo/issues/831
     async fn resize(&self, len: u64) -> Result<(), Error> {
         let len = len

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,5 +1,5 @@
 use super::Header;
-use crate::{BufferPool, IoBufs, IoBufsMut};
+use crate::{Buf, BufferPool, IoBufs, IoBufsMut};
 use commonware_codec::Encode;
 use commonware_formatting::hex;
 use commonware_utils::sync::{Mutex, RwLock};
@@ -197,6 +197,20 @@ impl crate::Blob for Blob {
         }
         content[offset..offset + buf.len()].copy_from_slice(buf.as_ref());
         Ok(())
+    }
+
+    async fn write_at_sync(
+        &self,
+        offset: u64,
+        bufs: impl Into<IoBufs> + Send,
+    ) -> Result<(), crate::Error> {
+        let bufs = bufs.into();
+        if !bufs.has_remaining() {
+            return Ok(());
+        }
+
+        self.write_at(offset, bufs).await?;
+        self.sync().await
     }
 
     async fn resize(&self, len: u64) -> Result<(), crate::Error> {

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -156,6 +156,19 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         Ok(())
     }
 
+    async fn write_at_sync(
+        &self,
+        offset: u64,
+        bufs: impl Into<IoBufs> + Send,
+    ) -> Result<(), Error> {
+        let bufs = bufs.into();
+        let bufs_len = bufs.remaining();
+        self.inner.write_at_sync(offset, bufs).await?;
+        self.metrics.storage_writes.inc();
+        self.metrics.storage_write_bytes.inc_by(bufs_len as u64);
+        Ok(())
+    }
+
     async fn resize(&self, len: u64) -> Result<(), Error> {
         self.inner.resize(len).await
     }

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -291,6 +291,7 @@ pub(crate) mod tests {
         test_overwrite_data(&storage).await;
         test_read_beyond_bound(&storage).await;
         test_write_at_large_offset(&storage).await;
+        test_write_at_sync(&storage).await;
         test_append_data(&storage).await;
         test_vectored_write_at(&storage).await;
         test_vectored_write_at_large_offset(&storage).await;
@@ -492,6 +493,45 @@ pub(crate) mod tests {
         // Read back the data
         let read = blob.read_at(10_000, 11).await.unwrap().coalesce();
         assert_eq!(read, b"offset data", "Data at large offset is incorrect");
+    }
+
+    /// Test writing and syncing data in one operation.
+    async fn test_write_at_sync<S>(storage: &S)
+    where
+        S: Storage + Send + Sync,
+        S::Blob: Send + Sync,
+    {
+        let (blob, _) = storage
+            .open("test_write_at_sync", b"test_blob")
+            .await
+            .unwrap();
+
+        // Empty writes should be accepted without extending the blob.
+        blob.write_at_sync(1024, Vec::<u8>::new()).await.unwrap();
+        drop(blob);
+
+        let (blob, len) = storage
+            .open("test_write_at_sync", b"test_blob")
+            .await
+            .unwrap();
+        assert_eq!(len, 0);
+
+        // Non-empty writes must be visible after reopen without a separate sync call.
+        blob.write_at_sync(0, b"hello").await.unwrap();
+        blob.write_at_sync(5, vec![IoBuf::from(b" "), IoBuf::from(b"world")])
+            .await
+            .unwrap();
+        drop(blob);
+
+        // Reopening a blob in the same process may still observe dirty kernel
+        // page-cache state, so this doesn't really prove write durability.
+        let (blob, len) = storage
+            .open("test_write_at_sync", b"test_blob")
+            .await
+            .unwrap();
+        assert_eq!(len, 11);
+        let read = blob.read_at(0, 11).await.unwrap().coalesce();
+        assert_eq!(read.as_ref(), b"hello world");
     }
 
     /// Test appending data to a blob.

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -29,14 +29,33 @@ impl Blob {
         }
     }
 
-    async fn write_single_at(file: &mut fs::File, buf: &[u8]) -> Result<(), Error> {
-        file.write_all(buf).await.map_err(|_| Error::WriteFailed)
+    async fn write_at_inner(
+        file: &mut fs::File,
+        offset: u64,
+        bufs: &mut IoBufs,
+    ) -> Result<(), Error> {
+        let offset = offset
+            .checked_add(Header::SIZE_U64)
+            .ok_or(Error::OffsetOverflow)?;
+        file.seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|_| Error::WriteFailed)?;
+
+        if let Some(buf) = bufs.as_single() {
+            file.write_all(buf.as_ref())
+                .await
+                .map_err(|_| Error::WriteFailed)
+        } else {
+            file.write_all_buf(bufs)
+                .await
+                .map_err(|_| Error::WriteFailed)
+        }
     }
 
-    async fn write_vectored_at(file: &mut fs::File, bufs: &mut IoBufs) -> Result<(), Error> {
-        file.write_all_buf(bufs)
+    async fn sync_inner(&self, file: &fs::File) -> Result<(), Error> {
+        file.sync_all()
             .await
-            .map_err(|_| Error::WriteFailed)
+            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
     }
 }
 
@@ -83,18 +102,7 @@ impl crate::Blob for Blob {
     async fn write_at(&self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
         let mut bufs = bufs.into();
         let mut file = self.file.lock().await;
-        let offset = offset
-            .checked_add(Header::SIZE_U64)
-            .ok_or(Error::OffsetOverflow)?;
-        file.seek(SeekFrom::Start(offset))
-            .await
-            .map_err(|_| Error::WriteFailed)?;
-
-        if let Some(buf) = bufs.as_single() {
-            Self::write_single_at(&mut file, buf.as_ref()).await
-        } else {
-            Self::write_vectored_at(&mut file, &mut bufs).await
-        }
+        Self::write_at_inner(&mut file, offset, &mut bufs).await
     }
 
     async fn write_at_sync(
@@ -108,22 +116,8 @@ impl crate::Blob for Blob {
         }
 
         let mut file = self.file.lock().await;
-        let offset = offset
-            .checked_add(Header::SIZE_U64)
-            .ok_or(Error::OffsetOverflow)?;
-        file.seek(SeekFrom::Start(offset))
-            .await
-            .map_err(|_| Error::WriteFailed)?;
-
-        if let Some(buf) = bufs.as_single() {
-            Self::write_single_at(&mut file, buf.as_ref()).await?;
-        } else {
-            Self::write_vectored_at(&mut file, &mut bufs).await?;
-        }
-
-        file.sync_all()
-            .await
-            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
+        Self::write_at_inner(&mut file, offset, &mut bufs).await?;
+        self.sync_inner(&file).await
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {
@@ -139,8 +133,6 @@ impl crate::Blob for Blob {
 
     async fn sync(&self) -> Result<(), Error> {
         let file = self.file.lock().await;
-        file.sync_all()
-            .await
-            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
+        self.sync_inner(&file).await
     }
 }

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -1,5 +1,5 @@
 use super::Header;
-use crate::{BufferPool, Error, IoBufs, IoBufsMut};
+use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut};
 use commonware_formatting::hex;
 use std::{io::SeekFrom, sync::Arc};
 use tokio::{
@@ -95,6 +95,20 @@ impl crate::Blob for Blob {
         } else {
             Self::write_vectored_at(&mut file, &mut bufs).await
         }
+    }
+
+    async fn write_at_sync(
+        &self,
+        offset: u64,
+        bufs: impl Into<IoBufs> + Send,
+    ) -> Result<(), Error> {
+        let bufs = bufs.into();
+        if !bufs.has_remaining() {
+            return Ok(());
+        }
+
+        self.write_at(offset, bufs).await?;
+        self.sync().await
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -102,13 +102,28 @@ impl crate::Blob for Blob {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        let bufs = bufs.into();
+        let mut bufs = bufs.into();
         if !bufs.has_remaining() {
             return Ok(());
         }
 
-        self.write_at(offset, bufs).await?;
-        self.sync().await
+        let mut file = self.file.lock().await;
+        let offset = offset
+            .checked_add(Header::SIZE_U64)
+            .ok_or(Error::OffsetOverflow)?;
+        file.seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|_| Error::WriteFailed)?;
+
+        if let Some(buf) = bufs.as_single() {
+            Self::write_single_at(&mut file, buf.as_ref()).await?;
+        } else {
+            Self::write_vectored_at(&mut file, &mut bufs).await?;
+        }
+
+        file.sync_all()
+            .await
+            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -1,5 +1,6 @@
 use super::Header;
 use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut};
+use cfg_if::cfg_if;
 use commonware_formatting::hex;
 use std::{
     fs::File,
@@ -36,7 +37,12 @@ impl Blob {
         Ok(())
     }
 
-    fn write_vectored_at(file: &File, mut offset: u64, mut bufs: IoBufs) -> Result<(), Error> {
+    fn write_vectored_at(
+        file: &File,
+        mut offset: u64,
+        mut bufs: IoBufs,
+        flags: Option<libc::c_int>,
+    ) -> Result<(), Error> {
         while bufs.has_remaining() {
             let mut io_slices = [IoSlice::new(&[]); IOVEC_BATCH_SIZE];
             let io_slices_len = bufs.chunks_vectored(&mut io_slices);
@@ -45,18 +51,34 @@ impl Blob {
                 "chunks_vectored should produce at least one slice when bufs has remaining"
             );
 
-            // std::os::unix::fs::FileExt::write_vectored_at is unstable:
-            // https://doc.rust-lang.org/stable/std/os/unix/fs/trait.FileExt.html#method.write_vectored_at
-            // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
-            // `slices` points to valid readable buffers held alive for this syscall.
-            let ret = unsafe {
-                libc::pwritev(
-                    file.as_raw_fd(),
-                    io_slices.as_ptr().cast::<libc::iovec>(),
-                    io_slices_len as i32,
-                    offset.try_into().map_err(|_| Error::OffsetOverflow)?,
-                )
-            };
+            cfg_if! {
+                if #[cfg(target_os = "linux")] {
+                    // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
+                    // `io_slices` points to valid readable buffers held alive for this syscall.
+                    let ret = unsafe {
+                        libc::pwritev2(
+                            file.as_raw_fd(),
+                            io_slices.as_ptr().cast::<libc::iovec>(),
+                            io_slices_len as i32,
+                            offset.try_into().map_err(|_| Error::OffsetOverflow)?,
+                            flags.unwrap_or(0),
+                        )
+                    };
+                } else {
+                    assert!(flags.is_none(), "flags are only supported on Linux");
+
+                    // SAFETY: `IoSlice` is ABI-compatible with `libc::iovec` on Unix.
+                    // `io_slices` points to valid readable buffers held alive for this syscall.
+                    let ret = unsafe {
+                        libc::pwritev(
+                            file.as_raw_fd(),
+                            io_slices.as_ptr().cast::<libc::iovec>(),
+                            io_slices_len as i32,
+                            offset.try_into().map_err(|_| Error::OffsetOverflow)?,
+                        )
+                    };
+                }
+            }
 
             if ret < 0 {
                 let err = std::io::Error::last_os_error();
@@ -71,7 +93,9 @@ impl Blob {
                 return Err(Error::WriteFailed);
             }
             bufs.advance(bytes_written);
-            offset += bytes_written as u64;
+            offset = offset
+                .checked_add(bytes_written as u64)
+                .ok_or(Error::OffsetOverflow)?;
         }
 
         Ok(())
@@ -122,10 +146,47 @@ impl crate::Blob for Blob {
             .ok_or(Error::OffsetOverflow)?;
         task::spawn_blocking(move || match bufs.try_into_single() {
             Ok(buf) => Self::write_single_at(&file, offset, buf.as_ref()),
-            Err(bufs) => Self::write_vectored_at(&file, offset, bufs),
+            Err(bufs) => Self::write_vectored_at(&file, offset, bufs, None),
         })
         .await
         .map_err(|_| Error::WriteFailed)?
+    }
+
+    async fn write_at_sync(
+        &self,
+        offset: u64,
+        bufs: impl Into<IoBufs> + Send,
+    ) -> Result<(), Error> {
+        let bufs = bufs.into();
+        let file = self.file.clone();
+        let offset = offset
+            .checked_add(Header::SIZE_U64)
+            .ok_or(Error::OffsetOverflow)?;
+
+        if !bufs.has_remaining() {
+            return Ok(());
+        }
+
+        cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                task::spawn_blocking(move || {
+                    Self::write_vectored_at(&file, offset, bufs, Some(libc::RWF_SYNC))
+                })
+                .await
+                .map_err(|_| Error::WriteFailed)?
+            } else {
+                let partition = self.partition.clone();
+                let name = self.name.clone();
+                task::spawn_blocking(move || {
+                    Self::write_vectored_at(&file, offset, bufs, None)?;
+                    file.sync_all().map_err(|e| {
+                        Error::BlobSyncFailed(partition, hex(&name), e)
+                    })
+                })
+                .await
+                .map_err(|_| Error::WriteFailed)?
+            }
+        }
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -12,7 +12,7 @@ pub use write::Write;
 mod tests {
     use super::*;
     use crate::{
-        deterministic, Blob as _, BufMut, Clock, Error, IoBufMut, IoBufs, IoBufsMut, Runner,
+        deterministic, Blob as _, Buf, BufMut, Clock, Error, IoBufMut, IoBufs, IoBufsMut, Runner,
         Spawner, Storage, Supervisor as _,
     };
     use commonware_macros::test_traced;
@@ -101,6 +101,20 @@ mod tests {
             }
             data[start..end].copy_from_slice(buf.as_ref());
             Ok(())
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            let bufs = bufs.into();
+            if !bufs.has_remaining() {
+                return Ok(());
+            }
+
+            self.write_at(offset, bufs).await?;
+            self.sync().await
         }
 
         async fn resize(&self, len: u64) -> Result<(), Error> {

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -615,7 +615,7 @@ async fn fetch_cacheable_page(
 mod tests {
     use super::{super::Checksum, *};
     use crate::{
-        buffer::paged::CHECKSUM_SIZE, deterministic, telemetry::metrics::Registry, BufferPool,
+        buffer::paged::CHECKSUM_SIZE, deterministic, telemetry::metrics::Registry, Buf, BufferPool,
         BufferPoolConfig, Clock as _, IoBufsMut, Runner as _, Spawner as _, Storage as _,
         Supervisor as _,
     };
@@ -674,6 +674,20 @@ mod tests {
             _bufs: impl Into<crate::IoBufs> + Send,
         ) -> Result<(), Error> {
             Ok(())
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<crate::IoBufs> + Send,
+        ) -> Result<(), Error> {
+            let bufs = bufs.into();
+            if !bufs.has_remaining() {
+                return Ok(());
+            }
+
+            self.write_at(offset, bufs).await?;
+            self.sync().await
         }
 
         async fn resize(&self, _len: u64) -> Result<(), Error> {
@@ -739,6 +753,20 @@ mod tests {
             _bufs: impl Into<crate::IoBufs> + Send,
         ) -> Result<(), Error> {
             Ok(())
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<crate::IoBufs> + Send,
+        ) -> Result<(), Error> {
+            let bufs = bufs.into();
+            if !bufs.has_remaining() {
+                return Ok(());
+            }
+
+            self.write_at(offset, bufs).await?;
+            self.sync().await
         }
 
         async fn resize(&self, _len: u64) -> Result<(), Error> {


### PR DESCRIPTION
This PR adds `Blob::write_at_sync`, a storage API for writing a byte range and making that write durable as part of the same operation. On Linux-backed runtimes this uses per-I/O sync flags where available, while fallback implementations preserve the same logical contract with `write_at` followed by `sync`. Empty writes are accepted as no-ops and do not sync prior writes.

The storage benchmark harness now has a `write_sync` workload with a `--sync-method` switch for comparing `write_at + sync` against `write_at_sync`.

Replaces #3784.

# Benchmarks

Benchmarks ran on an AWS EC2 i8g.2xlarge node with local NVMe instance storage, Ubuntu 26.04, and Linux kernel 7.0.0. Each case ran the `write_sync` workload with contiguous writes, 30 seconds, a 256M fixed file, seed 0, and 8 runtime worker threads. Deltas compare `write_at_sync` against `write_at + sync`, positive throughput delta means `write_at_sync` is faster, and positive p95 delta means `write_at_sync` has lower p95 latency.

The concurrent-writer results need one caveat: `write_at + sync` is not a strict per-writer durable-write baseline when multiple writers share the same blob. Each `sync` can also flush dirty writes issued by other writers, so some writers may get credit for durability work already forced by a different writer. `write_at_sync` is range-scoped to the submitted write, so the 8-writer comparison is useful as a shared-blob workload measurement, but it is not a perfectly isolated per-operation comparison between the two durability methods.

## Summary

| Filesystem | Backend | Writers | 4K throughput | 64K throughput | 1M throughput | Notes |
|---|---|---:|---:|---:|---:|---|
| XFS | Tokio | 1 | +30.7% | +14.0% | -0.0% | `write_at_sync` helps small writes. |
| XFS | Tokio | 8 | +98.7% | -3.5% | -0.0% | Big 4K gain, neutral/regressive above that. |
| XFS | io_uring | 1 | +44.9% | +24.3% | -0.0% | Best single-writer gains. |
| XFS | io_uring | 8 | -43.0% | -3.4% | -0.1% | Concurrent 4K regresses sharply. |
| ext4 | Tokio | 1 | +30.2% | +16.2% | -0.0% | Similar to XFS single-writer Tokio. |
| ext4 | Tokio | 8 | +131.3% | -3.3% | +0.0% | Largest 4K gain. |
| ext4 | io_uring | 1 | +36.7% | +20.1% | -0.0% | Clear single-writer gain for 4K/64K. |
| ext4 | io_uring | 8 | -11.1% | -3.5% | -0.6% | No throughput win under concurrency. |

## XFS

### Tokio

#### Single Writer

| IO size | `write_at + sync` MiB/s | `write_at_sync` MiB/s | Throughput delta | `write_at + sync` p95 us | `write_at_sync` p95 us | p95 delta |
|---:|---:|---:|---:|---:|---:|---:|
| 4K | 104.3 | 136.3 | +30.7% | 118.1 | 52.9 | +55.2% |
| 64K | 1093.7 | 1247.1 | +14.0% | 81.3 | 76.1 | +6.4% |
| 1M | 1578.9 | 1578.5 | -0.0% | 719.4 | 727.7 | -1.2% |

#### Concurrent Writers (8)

| IO size | `write_at + sync` MiB/s | `write_at_sync` MiB/s | Throughput delta | `write_at + sync` p95 us | `write_at_sync` p95 us | p95 delta |
|---:|---:|---:|---:|---:|---:|---:|
| 4K | 321.4 | 638.6 | +98.7% | 163.0 | 97.7 | +40.1% |
| 64K | 1546.0 | 1491.7 | -3.5% | 601.0 | 640.9 | -6.6% |
| 1M | 1579.3 | 1579.3 | -0.0% | 5192.9 | 5158.7 | +0.7% |

### io_uring

#### Single Writer

| IO size | `write_at + sync` MiB/s | `write_at_sync` MiB/s | Throughput delta | `write_at + sync` p95 us | `write_at_sync` p95 us | p95 delta |
|---:|---:|---:|---:|---:|---:|---:|
| 4K | 107.4 | 155.6 | +44.9% | 114.6 | 48.7 | +57.4% |
| 64K | 1086.9 | 1351.4 | +24.3% | 83.1 | 74.3 | +10.6% |
| 1M | 1578.9 | 1578.6 | -0.0% | 726.2 | 727.4 | -0.2% |

#### Concurrent Writers (8)

| IO size | `write_at + sync` MiB/s | `write_at_sync` MiB/s | Throughput delta | `write_at + sync` p95 us | `write_at_sync` p95 us | p95 delta |
|---:|---:|---:|---:|---:|---:|---:|
| 4K | 305.6 | 174.1 | -43.0% | 178.5 | 286.1 | -60.3% |
| 64K | 1543.4 | 1491.1 | -3.4% | 457.1 | 630.7 | -38.0% |
| 1M | 1579.4 | 1578.6 | -0.1% | 5178.3 | 5141.0 | +0.7% |

## ext4

### Tokio

#### Single Writer

| IO size | `write_at + sync` MiB/s | `write_at_sync` MiB/s | Throughput delta | `write_at + sync` p95 us | `write_at_sync` p95 us | p95 delta |
|---:|---:|---:|---:|---:|---:|---:|
| 4K | 107.2 | 139.5 | +30.2% | 77.7 | 69.4 | +10.7% |
| 64K | 1064.1 | 1236.2 | +16.2% | 93.1 | 83.8 | +9.9% |
| 1M | 1568.6 | 1568.3 | -0.0% | 679.8 | 677.3 | +0.4% |

#### Concurrent Writers (8)

| IO size | `write_at + sync` MiB/s | `write_at_sync` MiB/s | Throughput delta | `write_at + sync` p95 us | `write_at_sync` p95 us | p95 delta |
|---:|---:|---:|---:|---:|---:|---:|
| 4K | 280.2 | 648.2 | +131.3% | 173.1 | 96.8 | +44.1% |
| 64K | 1531.6 | 1481.6 | -3.3% | 611.8 | 629.3 | -2.9% |
| 1M | 1577.6 | 1577.7 | +0.0% | 5150.0 | 5109.8 | +0.8% |

### io_uring

#### Single Writer

| IO size | `write_at + sync` MiB/s | `write_at_sync` MiB/s | Throughput delta | `write_at + sync` p95 us | `write_at_sync` p95 us | p95 delta |
|---:|---:|---:|---:|---:|---:|---:|
| 4K | 95.7 | 130.9 | +36.7% | 81.0 | 70.9 | +12.5% |
| 64K | 1028.5 | 1235.1 | +20.1% | 92.7 | 82.6 | +10.9% |
| 1M | 1568.7 | 1568.2 | -0.0% | 675.0 | 675.9 | -0.1% |

#### Concurrent Writers (8)

| IO size | `write_at + sync` MiB/s | `write_at_sync` MiB/s | Throughput delta | `write_at + sync` p95 us | `write_at_sync` p95 us | p95 delta |
|---:|---:|---:|---:|---:|---:|---:|
| 4K | 218.5 | 194.3 | -11.1% | 199.8 | 220.4 | -10.3% |
| 64K | 1533.2 | 1480.2 | -3.5% | 591.1 | 373.1 | +36.9% |
| 1M | 1577.6 | 1568.3 | -0.6% | 5104.8 | 5137.4 | -0.6% |

