### PR TITLE
[storage/index] Move pointer into cursor state

### DIFF
--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -38,39 +38,50 @@ const MUST_CALL_NEXT: &str = "must call Cursor::next()";
 /// Panic message shown when `update()` or `delete()` is called after [Cursor] has returned `None`.
 const NO_ACTIVE_ITEM: &str = "no active item in Cursor";
 
-#[derive(PartialEq, Eq)]
-enum State {
+/// Position of the [Cursor] within the linked list owned by its entry.
+enum State<V: Eq + Send + Sync> {
     /// Before first `next()` call, or immediately after `insert()`/`delete()`.
-    NeedNext,
-    /// `next()` returned a value; `update()`/`delete()` are valid.
-    Active,
-    /// `next()` returned `None`; only `insert()` is valid.
-    Done,
+    ///
+    /// `from` is the node the next `next()` will step from; `None` means start at the entry head.
+    NeedNext { from: Option<NonNull<Record<V>>> },
+    /// `next()` returned `current`; `update()`/`delete()`/`insert()` are valid.
+    ///
+    /// `prev` is the predecessor live node, `None` when `current` is the entry head.
+    Active {
+        current: NonNull<Record<V>>,
+        prev: Option<NonNull<Record<V>>>,
+    },
+    /// `next()` returned `None`; only `insert()` (which appends) is valid.
+    ///
+    /// `tail` is the final node of the chain, used by `insert` to append.
+    Done { tail: NonNull<Record<V>> },
     /// The sole element was deleted; the entry will be removed on Drop.
     EntryRemoved,
 }
 
+// Manual `Copy`/`Clone` to avoid deriving an unnecessary `V: Copy` bound: the enum only contains
+// `NonNull<Record<V>>` (always `Copy`) and `Option<NonNull<...>>` (also `Copy`).
+impl<V: Eq + Send + Sync> Clone for State<V> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<V: Eq + Send + Sync> Copy for State<V> {}
+
 /// A cursor that traverses and mutates a linked list of [Record]s in place using raw pointers.
-///
-/// Tracks `prev` (for relinking on delete) and `current` (last item returned by `next`).
-/// The next element to visit is derived from `current.next` (or the entry head when
-/// `current` is `None`), so no separate `upcoming` pointer is needed.
 ///
 /// Invariants:
 /// - `entry` owns the linked list and keeps it exclusively borrowed for the cursor's lifetime.
-/// - `prev` and `current`, when present, point into that list.
-/// - `prev` and `current` are created only from exclusive references through `record_ptr`.
-/// - When both are present, `prev.next` owns `current`.
-/// - After deleting a node, `current` is moved back to the previous live node or cleared.
+/// - All pointers stored inside `state` were created from exclusive references via `record_ptr`
+///   and refer to nodes owned by `entry`.
+/// - In [`State::Active`], when `prev` is `Some`, `prev.next` owns the node at `current`.
+/// - After a non-head delete, the [`State::NeedNext`] `from` is the surviving predecessor;
+///   after a head delete, it is `None` so the next `next()` re-reads the entry head.
 pub(super) struct Cursor<'a, V: Eq + Send + Sync, E: IndexEntry<V>> {
     // The occupied index entry that owns the linked list while the cursor exists.
     entry: Option<E>,
-    // The live record immediately before `current`, used to relink on non-head deletes.
-    prev: Option<NonNull<Record<V>>>,
-    // The last record returned by `next()`.
-    current: Option<NonNull<Record<V>>>,
-    // The current position/state of the cursor.
-    state: State,
+    // The current position/state of the cursor, including any live pointers into the chain.
+    state: State<V>,
 
     // Metrics.
     keys: &'a Gauge,
@@ -88,9 +99,7 @@ impl<'a, V: Eq + Send + Sync, E: IndexEntry<V>> Cursor<'a, V, E> {
     ) -> Self {
         Self {
             entry: Some(entry),
-            prev: None,
-            current: None,
-            state: State::NeedNext,
+            state: State::NeedNext { from: None },
             keys,
             items,
             pruned,
@@ -113,17 +122,18 @@ impl<V: Eq + Send + Sync, E: IndexEntry<V>> CursorTrait for Cursor<'_, V, E> {
     type Value = V;
 
     fn next(&mut self) -> Option<&V> {
-        match self.state {
-            State::Done | State::EntryRemoved => return None,
-            State::NeedNext | State::Active => {}
-        }
+        let from = match self.state {
+            State::Done { .. } | State::EntryRemoved => return None,
+            State::NeedNext { from } => from,
+            State::Active { current, .. } => Some(current),
+        };
 
-        // Derive the next record from `current.next` or the entry head.
-        let next_ptr = if let Some(current) = self.current {
-            match self.record_mut(current).next.as_deref_mut() {
+        // Derive the next pointer from `from.next`, or the entry head when `from` is `None`.
+        let next_ptr = if let Some(from) = from {
+            match self.record_mut(from).next.as_deref_mut() {
                 Some(next) => Self::record_ptr(next),
                 None => {
-                    self.state = State::Done;
+                    self.state = State::Done { tail: from };
                     return None;
                 }
             }
@@ -131,30 +141,28 @@ impl<V: Eq + Send + Sync, E: IndexEntry<V>> CursorTrait for Cursor<'_, V, E> {
             Self::record_ptr(self.entry.as_mut().unwrap().get_mut())
         };
 
-        self.prev = self.current;
-        self.current = Some(next_ptr);
-        self.state = State::Active;
+        self.state = State::Active {
+            current: next_ptr,
+            prev: from,
+        };
         Some(&self.record_mut(next_ptr).value)
     }
 
     fn update(&mut self, v: V) {
         match self.state {
-            State::NeedNext => panic!("{MUST_CALL_NEXT}"),
-            State::Done | State::EntryRemoved => panic!("{NO_ACTIVE_ITEM}"),
-            State::Active => {}
+            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
+            State::Done { .. } | State::EntryRemoved => panic!("{NO_ACTIVE_ITEM}"),
+            State::Active { current, .. } => {
+                self.record_mut(current).value = v;
+            }
         }
-        assert!(self.current.is_some(), "Active state requires current");
-        let current = self.current.unwrap();
-        self.record_mut(current).value = v;
     }
 
     fn insert(&mut self, v: V) {
         match self.state {
-            State::NeedNext => panic!("{MUST_CALL_NEXT}"),
-            State::Active => {
+            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
+            State::Active { current, .. } => {
                 self.items.inc();
-                assert!(self.current.is_some(), "Active state requires current");
-                let current = self.current.unwrap();
                 let inserted = {
                     let current_record = self.record_mut(current);
                     let new = Box::new(Record {
@@ -165,9 +173,9 @@ impl<V: Eq + Send + Sync, E: IndexEntry<V>> CursorTrait for Cursor<'_, V, E> {
                     Self::record_ptr(current_record.next.as_deref_mut().unwrap())
                 };
                 // Advance past the inserted node so next() returns the element after it.
-                self.prev = self.current;
-                self.current = Some(inserted);
-                self.state = State::NeedNext;
+                self.state = State::NeedNext {
+                    from: Some(inserted),
+                };
             }
             State::EntryRemoved => {
                 // Re-populate the entry that was emptied by delete.
@@ -175,48 +183,39 @@ impl<V: Eq + Send + Sync, E: IndexEntry<V>> CursorTrait for Cursor<'_, V, E> {
                 let entry_record = self.entry.as_mut().unwrap().get_mut();
                 entry_record.value = v;
                 entry_record.next = None;
-                self.prev = None;
-                self.current = Some(Self::record_ptr(entry_record));
-                self.state = State::Done;
+                self.state = State::Done {
+                    tail: Self::record_ptr(entry_record),
+                };
             }
-            State::Done => {
+            State::Done { tail } => {
                 self.items.inc();
-                let last = self.current.or(self.prev);
-                assert!(last.is_some(), "Done state requires current or prev");
                 let inserted = {
-                    let last_record = self.record_mut(last.unwrap());
-                    last_record.next = Some(Box::new(Record {
+                    let tail_record = self.record_mut(tail);
+                    tail_record.next = Some(Box::new(Record {
                         value: v,
                         next: None,
                     }));
-                    Self::record_ptr(last_record.next.as_deref_mut().unwrap())
+                    Self::record_ptr(tail_record.next.as_deref_mut().unwrap())
                 };
-                self.prev = last;
-                self.current = Some(inserted);
-                self.state = State::Done;
+                self.state = State::Done { tail: inserted };
             }
         }
     }
 
     fn delete(&mut self) {
-        match self.state {
-            State::NeedNext => panic!("{MUST_CALL_NEXT}"),
-            State::Done | State::EntryRemoved => panic!("{NO_ACTIVE_ITEM}"),
-            State::Active => {}
-        }
+        let (current, prev) = match self.state {
+            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
+            State::Done { .. } | State::EntryRemoved => panic!("{NO_ACTIVE_ITEM}"),
+            State::Active { current, prev } => (current, prev),
+        };
         self.pruned.inc();
         self.items.dec();
 
-        assert!(self.current.is_some(), "Active state requires current");
-        let current = self.current.unwrap();
-
-        if let Some(prev) = self.prev {
+        if let Some(prev) = prev {
             // Deleting a non-head node: relink prev.next to current.next.
             let next = self.record_mut(current).next.take();
             self.record_mut(prev).next = next;
-            self.current = self.prev;
-            self.prev = None;
-            self.state = State::NeedNext;
+            self.state = State::NeedNext { from: Some(prev) };
         } else {
             // Deleting the head node (the entry record itself).
             let head = self.record_mut(current);
@@ -224,11 +223,9 @@ impl<V: Eq + Send + Sync, E: IndexEntry<V>> CursorTrait for Cursor<'_, V, E> {
                 // Promote the next record into the head position.
                 head.value = next.value;
                 head.next = next.next;
-                self.current = None;
-                self.state = State::NeedNext;
+                self.state = State::NeedNext { from: None };
             } else {
                 // Sole element deleted.
-                self.current = None;
                 self.state = State::EntryRemoved;
             }
         }
@@ -244,9 +241,10 @@ impl<V: Eq + Send + Sync, E: IndexEntry<V>> CursorTrait for Cursor<'_, V, E> {
     }
 }
 
-// SAFETY: `NonNull` is not `Send`, so this cannot be derived automatically. `prev` and `current`
-// are only bookkeeping pointers into the linked list owned by `entry`. Moving the cursor to another
-// thread also moves `entry`, keeping the list alive and exclusively borrowed by the cursor.
+// SAFETY: `NonNull` is not `Send`, so this cannot be derived automatically. The pointers stored
+// inside `state` are only bookkeeping pointers into the linked list owned by `entry`. Moving the
+// cursor to another thread also moves `entry`, keeping the list alive and exclusively borrowed by
+// the cursor.
 unsafe impl<V: Eq + Send + Sync, E: IndexEntry<V>> Send for Cursor<'_, V, E> {}
 // SAFETY: `NonNull` is not `Sync`, so this cannot be derived automatically. Sharing a cursor does
 // not grant access to the records without `&mut self`, and `entry` keeps the list alive and
@@ -255,7 +253,7 @@ unsafe impl<V: Eq + Send + Sync, E: IndexEntry<V>> Sync for Cursor<'_, V, E> {}
 
 impl<V: Eq + Send + Sync, E: IndexEntry<V>> Drop for Cursor<'_, V, E> {
     fn drop(&mut self) {
-        if self.state == State::EntryRemoved {
+        if matches!(self.state, State::EntryRemoved) {
             self.keys.dec();
             self.entry.take().unwrap().remove();
         }


### PR DESCRIPTION
Follow up to #3760.

## Summary

Refines the in-place `Cursor` rewrite from #3760 by lifting the `prev` and `current` pointers into the `State` enum. Each state variant now owns exactly the pointers it needs, so the contract previously enforced by runtime asserts becomes compile-time.

## Motivation

The post-#3760 `Cursor` encodes "do I have a live record under the cursor?" in three correlated places:

```rust
struct Cursor { state: State, prev: Option<NonNull<_>>, current: Option<NonNull<_>>, ... }
enum State { NeedNext, Active, Done, EntryRemoved }
```

with `update`/`insert`/`delete` each containing the same pattern:

```rust
match self.state { State::Active => {}, _ => panic!(...) }
assert!(self.current.is_some(), "Active state requires current");
let current = self.current.unwrap();
self.record_mut(current). …
```

The invariant *"`Active` implies `current.is_some()`"* is documented, asserted at runtime, and unwrapped — the compiler could enforce these checks on its own. Likewise the `insert(Done)` branch guards with `self.current.or(self.prev)`, even though every path into `Done` leaves `current` populated, so the `.or` fallback is dead code.

## Changes

Move the pointers into the variants:

```rust
enum State<V> {
    NeedNext { from: Option<NonNull<Record<V>>> },
    Active   { current: NonNull<Record<V>>, prev: Option<NonNull<Record<V>>> },
    Done     { tail: NonNull<Record<V>> },
    EntryRemoved,
}
```

and drop the standalone `prev` / `current` struct fields. Each variant carries only the pointers meaningful to that state, and `Active`'s `current` is a non-Option `NonNull` — the type system now enforces what the assert was checking.