### PR TITLE
[build] trim dev debuginfo to line tables for faster builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,6 +220,9 @@ debug = true
 # Although overflow checks are enabled by default in "test", we explicitly
 # enable them here for clarity.
 overflow-checks = true
+# Keep line tables for file:line in panics and backtraces, but skip variable-level
+# debuginfo to speed up codegen and linking. Use `debug = 2` for debugger sessions.
+debug = "line-tables-only"
 
 [profile.test.package.curve25519-dalek]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,13 +194,16 @@ zeroize = "1.5.7"
 zstd = "0.13.2"
 
 [profile.bench]
-# Because we enable overflow checks in "release," we should benchmark with them.
+# Because we enable overflow checks in "release", we should benchmark with them.
 overflow-checks = true
 
 [profile.dev]
 # Although overflow checks are enabled by default in "dev", we explicitly
 # enable them here for clarity.
 overflow-checks = true
+# Keep line tables for file:line in panics and backtraces, but skip variable-level
+# debuginfo to speed up codegen and linking. Use `debug = 2` for debugger sessions.
+debug = "line-tables-only"
 
 [profile.release]
 # To guard against unexpected behavior in production, we enable overflow checks in


### PR DESCRIPTION
This PR sets `debug = "line-tables-only"` for the `dev` profile. This shrinks the DWARF emitted by every dev/test build to just the line-number tables instead of the full variable-level debuginfo that cargo defaults to.

  Generating and writing full DWARF is a meaningful chunk of both codegen and link time, especially on Linux where ELF traditionally bundles debuginfo into the final binary. Panics, `RUST_BACKTRACE=1`, and tracing output continue to resolve to `file:line:column` exactly as before, since line tables are all that machinery needs.

  The only thing lost is variable and struct-field inspection in `lldb` / `gdb` sessions. For the rare cases where stepping through a debugger is needed, building with `-C debuginfo=2` is enough to get full fidelity back.

### Results

| Command              | Before | After | Δ           |
|----------------------|--------|-------|-------------|
| `cargo build`        | 40s    | 29s   | -11s (-28%) |
| `cargo test --no-run`| 79s    | 70s   | -9s (-11%)  |
