### PR TITLE
[storage/index] Deduplicate `Cursor`

### DIFF
--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -41,49 +41,8 @@ impl<K: Ord + Send + Sync, V: Eq + Send + Sync> IndexEntry<V>
     }
 }
 
-/// A cursor for the ordered [Index] that wraps the shared implementation.
-pub struct Cursor<'a, K: Ord + Send + Sync, V: Eq + Send + Sync> {
-    inner: CursorImpl<'a, V, BTreeOccupiedEntry<'a, K, Record<V>>>,
-}
-
-impl<'a, K: Ord + Send + Sync, V: Eq + Send + Sync> Cursor<'a, K, V> {
-    const fn new(
-        entry: BTreeOccupiedEntry<'a, K, Record<V>>,
-        keys: &'a Gauge,
-        items: &'a Gauge,
-        pruned: &'a Counter,
-    ) -> Self {
-        Self {
-            inner: CursorImpl::<'a, V, BTreeOccupiedEntry<'a, K, Record<V>>>::new(
-                entry, keys, items, pruned,
-            ),
-        }
-    }
-}
-
-impl<K: Ord + Send + Sync, V: Eq + Send + Sync> CursorTrait for Cursor<'_, K, V> {
-    type Value = V;
-
-    fn update(&mut self, v: V) {
-        self.inner.update(v)
-    }
-
-    fn next(&mut self) -> Option<&V> {
-        self.inner.next()
-    }
-
-    fn insert(&mut self, v: V) {
-        self.inner.insert(v)
-    }
-
-    fn delete(&mut self) {
-        self.inner.delete()
-    }
-
-    fn prune(&mut self, predicate: &impl Fn(&V) -> bool) {
-        self.inner.prune(predicate)
-    }
-}
+/// A [crate::index::Cursor] over the values associated with a translated key.
+pub type Cursor<'a, K, V> = CursorImpl<'a, V, BTreeOccupiedEntry<'a, K, Record<V>>>;
 
 /// A memory-efficient index that uses an ordered map internally to map translated keys to arbitrary
 /// values.

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -12,12 +12,12 @@ use commonware_runtime::telemetry::metrics::{Counter, Gauge};
 /// Again optimizing for the common case, we store the first value directly in the [Record] to avoid
 /// indirection (heap jumping).
 #[derive(PartialEq, Eq)]
-pub(super) struct Record<V: Eq + Send + Sync> {
+pub struct Record<V: Eq + Send + Sync> {
     pub(super) value: V,
     pub(super) next: Option<Box<Self>>,
 }
 
-pub(super) trait IndexEntry<V: Eq + Send + Sync>: Send + Sync {
+pub trait IndexEntry<V: Eq + Send + Sync>: Send + Sync {
     fn get(&self) -> &V;
     fn get_mut(&mut self) -> &mut Record<V>;
     fn remove(self);
@@ -57,7 +57,7 @@ enum Phase<V: Eq + Send + Sync> {
 }
 
 /// A cursor for [crate::index] types that can be instantiated with any [IndexEntry] implementation.
-pub(super) struct Cursor<'a, V: Eq + Send + Sync, E: IndexEntry<V>> {
+pub struct Cursor<'a, V: Eq + Send + Sync, E: IndexEntry<V>> {
     // The current phase of the cursor.
     phase: Phase<V>,
 

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -36,49 +36,8 @@ impl<K: Send + Sync, V: Eq + Send + Sync> IndexEntry<V> for OccupiedEntry<'_, K,
     }
 }
 
-/// A cursor for the unordered [Index] that wraps the shared implementation.
-pub struct Cursor<'a, K: Send + Sync, V: Eq + Send + Sync> {
-    inner: CursorImpl<'a, V, OccupiedEntry<'a, K, Record<V>>>,
-}
-
-impl<'a, K: Send + Sync, V: Eq + Send + Sync> Cursor<'a, K, V> {
-    const fn new(
-        entry: OccupiedEntry<'a, K, Record<V>>,
-        keys: &'a Gauge,
-        items: &'a Gauge,
-        pruned: &'a Counter,
-    ) -> Self {
-        Self {
-            inner: CursorImpl::<'a, V, OccupiedEntry<'a, K, Record<V>>>::new(
-                entry, keys, items, pruned,
-            ),
-        }
-    }
-}
-
-impl<K: Send + Sync, V: Eq + Send + Sync> CursorTrait for Cursor<'_, K, V> {
-    type Value = V;
-
-    fn next(&mut self) -> Option<&V> {
-        self.inner.next()
-    }
-
-    fn insert(&mut self, value: V) {
-        self.inner.insert(value)
-    }
-
-    fn delete(&mut self) {
-        self.inner.delete()
-    }
-
-    fn update(&mut self, value: V) {
-        self.inner.update(value)
-    }
-
-    fn prune(&mut self, predicate: &impl Fn(&V) -> bool) {
-        self.inner.prune(predicate)
-    }
-}
+/// A [crate::index::Cursor] over the values associated with a translated key.
+pub type Cursor<'a, K, V> = CursorImpl<'a, V, OccupiedEntry<'a, K, Record<V>>>;
 
 /// A memory-efficient index that uses an unordered map internally to map translated keys to
 /// arbitrary values.


### PR DESCRIPTION
`storage::index::unordered` and `storage::index::ordered` each define a `pub struct Cursor<'a, K, V>` newtype around the shared `storage::Cursor` implementation. Each newtype carries a `new` constructor and a five-method `CursorTrait` impl whose every method is a single-line delegation to `self.inner.<method>()`.

This PR replaces both newtypes with `pub type` aliases. The aliases name the same concrete type the wrappers used to wrap; the trait impl already exists on the underlying `storage::Cursor` and applies through the alias.