### PR TITLE
[storage/index] Rename `prune` to `retain`

### DIFF
--- a/storage/fuzz/fuzz_targets/ordered_index_operations.rs
+++ b/storage/fuzz/fuzz_targets/ordered_index_operations.rs
@@ -107,7 +107,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 IndexOperation::Prune { key, prune_value } => {
-                    index.prune(key, |v| *v == *prune_value);
+                    index.retain(key, |v| *v != *prune_value);
                 }
 
                 IndexOperation::InsertAndPrune {
@@ -115,7 +115,7 @@ fn fuzz(input: FuzzInput) {
                     value,
                     prune_value,
                 } => {
-                    index.insert_and_prune(key, *value, |v| *v == *prune_value);
+                    index.insert_and_retain(key, *value, |v| *v != *prune_value);
                 }
 
                 IndexOperation::InsertLargeKey { value } => {
@@ -133,7 +133,7 @@ fn fuzz(input: FuzzInput) {
 
                 IndexOperation::PruneAll { key } => {
                     // Remove all values for a key
-                    index.prune(key, |_| true);
+                    index.retain(key, |_| false);
                 }
 
                 IndexOperation::CursorIterate { key } => {

--- a/storage/fuzz/fuzz_targets/unordered_index_operations.rs
+++ b/storage/fuzz/fuzz_targets/unordered_index_operations.rs
@@ -107,7 +107,7 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 IndexOperation::Prune { key, prune_value } => {
-                    index.prune(key, |v| *v == *prune_value);
+                    index.retain(key, |v| *v != *prune_value);
                 }
 
                 IndexOperation::InsertAndPrune {
@@ -115,7 +115,7 @@ fn fuzz(input: FuzzInput) {
                     value,
                     prune_value,
                 } => {
-                    index.insert_and_prune(key, *value, |v| *v == *prune_value);
+                    index.insert_and_retain(key, *value, |v| *v != *prune_value);
                 }
 
                 IndexOperation::InsertLargeKey { value } => {
@@ -133,7 +133,7 @@ fn fuzz(input: FuzzInput) {
 
                 IndexOperation::PruneAll { key } => {
                     // Remove all values for a key
-                    index.prune(key, |_| true);
+                    index.retain(key, |_| false);
                 }
 
                 IndexOperation::CursorIterate { key } => {

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -338,7 +338,7 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
 
         // Insert and prune any useless keys
         self.keys
-            .insert_and_prune(&key, index, |v| *v < oldest_allowed);
+            .insert_and_retain(&key, index, |v| *v >= oldest_allowed);
 
         // Add section to pending
         self.pending.insert(section);

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -40,7 +40,7 @@ pub mod unordered;
 /// - Dropping the `Cursor` automatically restores the list structure by reattaching any detached
 ///   `next` nodes.
 ///
-/// _If you don't need advanced functionality, just use `insert()`, `insert_and_prune()`, or
+/// _If you don't need advanced functionality, just use `insert()`, `insert_and_retain()`, or
 /// `remove()` from [Unordered] instead._
 pub trait Cursor: Send + Sync {
     /// The type of values the cursor iterates over.
@@ -69,8 +69,9 @@ pub trait Cursor: Send + Sync {
     /// Panics if called before `next()` or after iteration is complete (`Status::Done` phase).
     fn update(&mut self, value: Self::Value);
 
-    /// Removes anything in the cursor that satisfies the predicate.
-    fn prune(&mut self, predicate: &impl Fn(&Self::Value) -> bool);
+    /// Retains only the values in the cursor for which `should_retain` returns `true`. All other
+    /// values are removed.
+    fn retain(&mut self, should_retain: &impl Fn(&Self::Value) -> bool);
 
     /// Advances the cursor until finding a value matching the predicate.
     ///
@@ -134,18 +135,20 @@ pub trait Unordered: Send + Sync {
     /// Inserts a new value at the current position.
     fn insert(&mut self, key: &[u8], value: Self::Value);
 
-    /// Insert a value at the given translated key, and prune any values that are no longer valid.
+    /// Insert a value at the given translated key, and remove any values for which
+    /// `should_retain` returns `false`.
     ///
-    /// If the value is prunable, it will not be inserted.
-    fn insert_and_prune(
+    /// If `should_retain` returns `false` for the new value, it will not be inserted.
+    fn insert_and_retain(
         &mut self,
         key: &[u8],
         value: Self::Value,
-        predicate: impl Fn(&Self::Value) -> bool,
+        should_retain: impl Fn(&Self::Value) -> bool,
     );
 
-    /// Remove all values associated with a translated key that match `predicate`.
-    fn prune(&mut self, key: &[u8], predicate: impl Fn(&Self::Value) -> bool);
+    /// Retain only the values associated with a translated key for which `should_retain` returns
+    /// `true`. All other values are removed.
+    fn retain(&mut self, key: &[u8], should_retain: impl Fn(&Self::Value) -> bool);
 
     /// Remove all values associated with a translated key.
     fn remove(&mut self, key: &[u8]);
@@ -254,9 +257,9 @@ mod tests {
         // Make sure we can remove keys with a predicate
         index.insert(key, 3);
         index.insert(key, 4);
-        index.prune(key, |i| *i == 3);
+        index.retain(key, |i| *i != 3);
         assert_eq!(index.get(key).copied().collect::<Vec<_>>(), vec![1, 4, 2]);
-        index.prune(key, |_| true);
+        index.retain(key, |_| false);
         // Try removing all of a keys values.
         assert_eq!(
             index.get(key).copied().collect::<Vec<_>>(),
@@ -267,7 +270,7 @@ mod tests {
         assert!(index.get_mut(key).is_none());
 
         // Removing a key that doesn't exist should be a no-op.
-        index.prune(key, |_| true);
+        index.retain(key, |_| false);
     }
 
     fn new_unordered(context: deterministic::Context) -> unordered::Index<TwoCap, u64> {
@@ -485,12 +488,12 @@ mod tests {
         assert_eq!(index.keys(), 2);
         assert_eq!(index.items(), 4);
 
-        index.prune(b"ab", |v| *v == 4);
+        index.retain(b"ab", |v| *v != 4);
         assert_eq!(index.get(b"ab").copied().collect::<Vec<_>>(), vec![2, 3]);
         assert_eq!(index.keys(), 2);
         assert_eq!(index.items(), 3);
 
-        index.prune(b"ab", |_| true);
+        index.retain(b"ab", |_| false);
         assert_eq!(
             index.get(b"ab").copied().collect::<Vec<_>>(),
             Vec::<u64>::new()
@@ -580,9 +583,9 @@ mod tests {
         index.insert(b"key", 1);
         index.insert(b"key", 2);
         index.insert(b"key", 3);
-        index.prune(b"key", |v| *v == 2);
+        index.retain(b"key", |v| *v != 2);
         assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![1, 3]);
-        index.prune(b"key", |v| *v == 1);
+        index.retain(b"key", |v| *v != 1);
         assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![3]);
     }
 
@@ -634,7 +637,7 @@ mod tests {
         values.sort();
         assert_eq!(values, vec![0, 1, 2]);
 
-        index.prune(b"", |v| *v == 1);
+        index.retain(b"", |v| *v != 1);
         let mut values = index.get(b"").copied().collect::<Vec<_>>();
         values.sort();
         assert_eq!(values, vec![0, 2]);
@@ -1080,8 +1083,8 @@ mod tests {
         });
     }
 
-    fn run_index_insert_and_prune_vacant<I: Unordered<Value = u64>>(index: &mut I) {
-        index.insert_and_prune(b"key", 1u64, |_| false);
+    fn run_index_insert_and_retain_vacant<I: Unordered<Value = u64>>(index: &mut I) {
+        index.insert_and_retain(b"key", 1u64, |_| true);
         assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![1]);
         assert_eq!(index.items(), 1);
         assert_eq!(index.keys(), 1);
@@ -1089,41 +1092,41 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_hash_index_insert_and_prune_vacant() {
+    fn test_hash_index_insert_and_retain_vacant() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_unordered(context);
-            run_index_insert_and_prune_vacant(&mut index);
+            run_index_insert_and_retain_vacant(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_ordered_index_insert_and_prune_vacant() {
+    fn test_ordered_index_insert_and_retain_vacant() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_ordered(context);
-            run_index_insert_and_prune_vacant(&mut index);
+            run_index_insert_and_retain_vacant(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_partitioned_index_insert_and_prune_vacant() {
+    fn test_partitioned_index_insert_and_retain_vacant() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             {
                 let mut index = new_partitioned_unordered(context.child("unordered"));
-                run_index_insert_and_prune_vacant(&mut index);
+                run_index_insert_and_retain_vacant(&mut index);
             }
             {
                 let mut index = new_partitioned_ordered(context.child("ordered"));
-                run_index_insert_and_prune_vacant(&mut index);
+                run_index_insert_and_retain_vacant(&mut index);
             }
         });
     }
 
-    fn run_index_insert_and_prune_replace_one<I: Unordered<Value = u64>>(index: &mut I) {
+    fn run_index_insert_and_retain_replace_one<I: Unordered<Value = u64>>(index: &mut I) {
         index.insert(b"key", 1u64);
-        index.insert_and_prune(b"key", 2u64, |v| *v == 1);
+        index.insert_and_retain(b"key", 2u64, |v| *v != 1);
         assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![2]);
         assert_eq!(index.items(), 1);
         assert_eq!(index.keys(), 1);
@@ -1131,42 +1134,42 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_hash_index_insert_and_prune_replace_one() {
+    fn test_hash_index_insert_and_retain_replace_one() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_unordered(context);
-            run_index_insert_and_prune_replace_one(&mut index);
+            run_index_insert_and_retain_replace_one(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_ordered_index_insert_and_prune_replace_one() {
+    fn test_ordered_index_insert_and_retain_replace_one() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_ordered(context);
-            run_index_insert_and_prune_replace_one(&mut index);
+            run_index_insert_and_retain_replace_one(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_partitioned_index_insert_and_prune_replace_one() {
+    fn test_partitioned_index_insert_and_retain_replace_one() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             {
                 let mut index = new_partitioned_unordered(context.child("unordered"));
-                run_index_insert_and_prune_replace_one(&mut index);
+                run_index_insert_and_retain_replace_one(&mut index);
             }
             {
                 let mut index = new_partitioned_ordered(context.child("ordered"));
-                run_index_insert_and_prune_replace_one(&mut index);
+                run_index_insert_and_retain_replace_one(&mut index);
             }
         });
     }
 
-    fn run_index_insert_and_prune_dead_insert<I: Unordered<Value = u64>>(index: &mut I) {
+    fn run_index_insert_and_retain_dead_insert<I: Unordered<Value = u64>>(index: &mut I) {
         index.insert(b"key", 10u64);
         index.insert(b"key", 20u64);
-        index.insert_and_prune(b"key", 30u64, |_| true);
+        index.insert_and_retain(b"key", 30u64, |_| false);
         assert_eq!(
             index.get(b"key").copied().collect::<Vec<u64>>(),
             Vec::<u64>::new()
@@ -1177,34 +1180,34 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_hash_index_insert_and_prune_dead_insert() {
+    fn test_hash_index_insert_and_retain_dead_insert() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_unordered(context);
-            run_index_insert_and_prune_dead_insert(&mut index);
+            run_index_insert_and_retain_dead_insert(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_ordered_index_insert_and_prune_dead_insert() {
+    fn test_ordered_index_insert_and_retain_dead_insert() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_ordered(context);
-            run_index_insert_and_prune_dead_insert(&mut index);
+            run_index_insert_and_retain_dead_insert(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_partitioned_index_insert_and_prune_dead_insert() {
+    fn test_partitioned_index_insert_and_retain_dead_insert() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             {
                 let mut index = new_partitioned_unordered(context.child("unordered"));
-                run_index_insert_and_prune_dead_insert(&mut index);
+                run_index_insert_and_retain_dead_insert(&mut index);
             }
             {
                 let mut index = new_partitioned_ordered(context.child("ordered"));
-                run_index_insert_and_prune_dead_insert(&mut index);
+                run_index_insert_and_retain_dead_insert(&mut index);
             }
         });
     }

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -80,8 +80,8 @@ impl<K: Ord + Send + Sync, V: Eq + Send + Sync> CursorTrait for Cursor<'_, K, V>
         self.inner.delete()
     }
 
-    fn prune(&mut self, predicate: &impl Fn(&V) -> bool) {
-        self.inner.prune(predicate)
+    fn retain(&mut self, should_retain: &impl Fn(&V) -> bool) {
+        self.inner.retain(should_retain)
     }
 }
 
@@ -263,7 +263,7 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
         }
     }
 
-    fn insert_and_prune(&mut self, key: &[u8], value: V, predicate: impl Fn(&V) -> bool) {
+    fn insert_and_retain(&mut self, key: &[u8], value: V, should_retain: impl Fn(&V) -> bool) {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             BTreeEntry::Occupied(entry) => {
@@ -271,11 +271,11 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
                 let mut cursor =
                     Cursor::<'_, T::Key, V>::new(entry, &self.keys, &self.items, &self.pruned);
 
-                // Remove anything that is prunable.
-                cursor.prune(&predicate);
+                // Drop anything that should not be retained.
+                cursor.retain(&should_retain);
 
-                // Add our new value (if not prunable).
-                if !predicate(&value) {
+                // Add the new value only if it should be retained.
+                if should_retain(&value) {
                     cursor.insert(value);
                 }
             }
@@ -285,7 +285,7 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
         }
     }
 
-    fn prune(&mut self, key: &[u8], predicate: impl Fn(&V) -> bool) {
+    fn retain(&mut self, key: &[u8], should_retain: impl Fn(&V) -> bool) {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             BTreeEntry::Occupied(entry) => {
@@ -293,8 +293,8 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
                 let mut cursor =
                     Cursor::<'_, T::Key, V>::new(entry, &self.keys, &self.items, &self.pruned);
 
-                // Remove anything that is prunable.
-                cursor.prune(&predicate);
+                // Drop anything that should not be retained.
+                cursor.retain(&should_retain);
             }
             BTreeEntry::Vacant(_) => {}
         }
@@ -303,7 +303,7 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
     fn remove(&mut self, key: &[u8]) {
         // To ensure metrics are accurate, we iterate over all conflicting values and remove them
         // one-by-one (rather than just removing the entire entry).
-        self.prune(key, |_| true);
+        self.retain(key, |_| false);
     }
 
     #[cfg(test)]

--- a/storage/src/index/partitioned/ordered.rs
+++ b/storage/src/index/partitioned/ordered.rs
@@ -94,21 +94,21 @@ impl<T: Translator, V: Eq + Send + Sync, const P: usize> UnorderedTrait for Inde
         partition.insert(sub_key, value);
     }
 
-    fn insert_and_prune(
+    fn insert_and_retain(
         &mut self,
         key: &[u8],
         value: Self::Value,
-        predicate: impl Fn(&Self::Value) -> bool,
+        should_retain: impl Fn(&Self::Value) -> bool,
     ) {
         let (partition, sub_key) = self.get_partition_mut(key);
 
-        partition.insert_and_prune(sub_key, value, predicate);
+        partition.insert_and_retain(sub_key, value, should_retain);
     }
 
-    fn prune(&mut self, key: &[u8], predicate: impl Fn(&Self::Value) -> bool) {
+    fn retain(&mut self, key: &[u8], should_retain: impl Fn(&Self::Value) -> bool) {
         let (partition, sub_key) = self.get_partition_mut(key);
 
-        partition.prune(sub_key, predicate);
+        partition.retain(sub_key, should_retain);
     }
 
     fn remove(&mut self, key: &[u8]) {

--- a/storage/src/index/partitioned/unordered.rs
+++ b/storage/src/index/partitioned/unordered.rs
@@ -94,21 +94,21 @@ impl<T: Translator, V: Eq + Send + Sync, const P: usize> UnorderedTrait for Inde
         partition.insert(sub_key, value);
     }
 
-    fn insert_and_prune(
+    fn insert_and_retain(
         &mut self,
         key: &[u8],
         value: Self::Value,
-        predicate: impl Fn(&Self::Value) -> bool,
+        should_retain: impl Fn(&Self::Value) -> bool,
     ) {
         let (partition, sub_key) = self.get_partition_mut(key);
 
-        partition.insert_and_prune(sub_key, value, predicate);
+        partition.insert_and_retain(sub_key, value, should_retain);
     }
 
-    fn prune(&mut self, key: &[u8], predicate: impl Fn(&Self::Value) -> bool) {
+    fn retain(&mut self, key: &[u8], should_retain: impl Fn(&Self::Value) -> bool) {
         let (partition, sub_key) = self.get_partition_mut(key);
 
-        partition.prune(sub_key, predicate);
+        partition.retain(sub_key, should_retain);
     }
 
     fn remove(&mut self, key: &[u8]) {

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -276,10 +276,10 @@ impl<V: Eq + Send + Sync, E: IndexEntry<V>> CursorTrait for Cursor<'_, V, E> {
         }
     }
 
-    /// Removes anything in the cursor that satisfies the predicate.
-    fn prune(&mut self, predicate: &impl Fn(&V) -> bool) {
+    /// Retains only the values for which `should_retain` returns `true`; removes the rest.
+    fn retain(&mut self, should_retain: &impl Fn(&V) -> bool) {
         while let Some(old) = self.next() {
-            if predicate(old) {
+            if !should_retain(old) {
                 self.delete();
             }
         }

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -75,8 +75,8 @@ impl<K: Send + Sync, V: Eq + Send + Sync> CursorTrait for Cursor<'_, K, V> {
         self.inner.update(value)
     }
 
-    fn prune(&mut self, predicate: &impl Fn(&V) -> bool) {
-        self.inner.prune(predicate)
+    fn retain(&mut self, should_retain: &impl Fn(&V) -> bool) {
+        self.inner.retain(should_retain)
     }
 }
 
@@ -183,7 +183,7 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
         }
     }
 
-    fn insert_and_prune(&mut self, key: &[u8], value: V, predicate: impl Fn(&V) -> bool) {
+    fn insert_and_retain(&mut self, key: &[u8], value: V, should_retain: impl Fn(&V) -> bool) {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             Entry::Occupied(entry) => {
@@ -191,10 +191,11 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
                 let mut cursor =
                     Cursor::<'_, T::Key, V>::new(entry, &self.keys, &self.items, &self.pruned);
 
-                cursor.prune(&predicate);
+                // Drop anything that should not be retained.
+                cursor.retain(&should_retain);
 
-                // Add our new value (if not prunable).
-                if !predicate(&value) {
+                // Add the new value only if it should be retained.
+                if should_retain(&value) {
                     cursor.insert(value);
                 }
             }
@@ -204,7 +205,7 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
         }
     }
 
-    fn prune(&mut self, key: &[u8], predicate: impl Fn(&V) -> bool) {
+    fn retain(&mut self, key: &[u8], should_retain: impl Fn(&V) -> bool) {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             Entry::Occupied(entry) => {
@@ -212,7 +213,8 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
                 let mut cursor =
                     Cursor::<'_, T::Key, V>::new(entry, &self.keys, &self.items, &self.pruned);
 
-                cursor.prune(&predicate);
+                // Drop anything that should not be retained.
+                cursor.retain(&should_retain);
             }
             Entry::Vacant(_) => {}
         }
@@ -221,7 +223,7 @@ impl<T: Translator, V: Eq + Send + Sync> Unordered for Index<T, V> {
     fn remove(&mut self, key: &[u8]) {
         // To ensure metrics are accurate, we iterate over all conflicting values and remove them
         // one-by-one (rather than just removing the entire entry).
-        self.prune(key, |_| true);
+        self.retain(key, |_| false);
     }
 
     #[cfg(test)]

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -580,7 +580,7 @@ where
         let rewind_loc = Location::<F>::new(rewind_size);
         for key in &rewound_keys {
             // Filter by location to make sure we don't also prune keys that happen to collide.
-            self.snapshot.prune(key, |loc| *loc >= rewind_loc);
+            self.snapshot.retain(key, |loc| *loc < rewind_loc);
         }
 
         // If the rewind target has a lower floor than the current snapshot was
@@ -702,7 +702,7 @@ where
         for (key, entry) in batch.diff.iter() {
             seen.insert(key.clone());
             self.snapshot
-                .insert_and_prune(key, entry.loc, |v| *v < bounds.start);
+                .insert_and_retain(key, entry.loc, |v| *v >= bounds.start);
         }
         for (i, ancestor_diff) in batch.ancestor_diffs.iter().enumerate() {
             if batch.bounds.ancestors[i].end <= db_size {
@@ -711,7 +711,7 @@ where
             for (key, entry) in ancestor_diff.iter() {
                 if seen.insert(key.clone()) {
                     self.snapshot
-                        .insert_and_prune(key, entry.loc, |v| *v < bounds.start);
+                        .insert_and_retain(key, entry.loc, |v| *v >= bounds.start);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Renames the in-place "remove items matching a predicate" API across the `storage::index` module to match Rust stdlib conventions:

- `Cursor::prune` → `Cursor::retain`
- `Unordered::prune` → `Unordered::retain`
- `Unordered::insert_and_prune` → `Unordered::insert_and_retain`

Predicate semantics flip everywhere from "true = remove" to "true = keep" (matching `Vec::retain` and friends). Parameter names change from `predicate` to `should_retain`. All call sites — internal, in `qmdb::immutable`, in `archive::prunable`, in fuzz targets, in tests — have their predicates negated so the behavior is preserved.

## Motivation

The stdlib's canonical name for "mutate a collection in place, keep items where the predicate is true" is **`retain`**. It exists on: `Vec`, `VecDeque`, `LinkedList`, `HashMap`, `BTreeMap`, `HashSet`, `BTreeSet`, `String`. 