### PR TITLE
[broadcast/fuzz] fix subscribe deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,6 +1238,7 @@ dependencies = [
  "commonware-p2p",
  "commonware-runtime",
  "commonware-utils",
+ "futures",
  "libfuzzer-sys",
  "rand 0.8.5",
 ]

--- a/broadcast/fuzz/Cargo.toml
+++ b/broadcast/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ commonware-cryptography = { workspace = true, features = ["arbitrary"] }
 commonware-p2p.workspace = true
 commonware-runtime.workspace = true
 commonware-utils.workspace = true
+futures.workspace = true
 libfuzzer-sys.workspace = true
 rand.workspace = true
 

--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -12,10 +12,8 @@ use commonware_cryptography::{
     Digestible, Hasher, Sha256, Signer,
 };
 use commonware_p2p::{simulated::Network, Recipients};
-use commonware_runtime::{
-    deterministic, Buf, BufMut, Clock, Quota, Runner, Spawner, Supervisor as _,
-};
-use commonware_utils::NZUsize;
+use commonware_runtime::{deterministic, Buf, BufMut, Clock, Quota, Runner, Supervisor as _};
+use commonware_utils::{channel::oneshot, NZUsize};
 use libfuzzer_sys::fuzz_target;
 use rand::{seq::SliceRandom, SeedableRng};
 use std::{
@@ -36,7 +34,7 @@ const MAX_SLEEP_DURATION_MS: u64 = 1000;
 /// Maximum number of recently broadcast digests tracked for `Recent` lookups.
 ///
 /// Indexed by `u8` modulo length, so a larger buffer would leave entries past 255
-/// unreachable via `DigestSource::Recent`.
+/// unreachable via `Source::Recent`.
 const MAX_RECENT_DIGESTS: usize = (u8::MAX as usize) + 1;
 
 #[derive(Clone, Debug, Arbitrary)]
@@ -86,21 +84,21 @@ impl commonware_codec::Read for FuzzMessage {
 
 /// Source for the digest used by `Subscribe`/`Get` actions.
 #[derive(Clone, Debug, Arbitrary)]
-enum DigestSource {
+enum Source {
     /// A random message.
     Random(FuzzMessage),
     /// Index into messages broadcast earlier in this run.
     Recent(u8),
 }
 
-impl DigestSource {
+impl Source {
     /// Resolve to a concrete digest. Returns `None` when `Recent` is selected
     /// before any messages have been broadcast.
     fn resolve(self, recent: &VecDeque<Digest>) -> Option<Digest> {
         match self {
-            DigestSource::Random(message) => Some(message.digest()),
-            DigestSource::Recent(_) if recent.is_empty() => None,
-            DigestSource::Recent(idx) => Some(recent[(idx as usize) % recent.len()]),
+            Source::Random(message) => Some(message.digest()),
+            Source::Recent(_) if recent.is_empty() => None,
+            Source::Recent(idx) => Some(recent[(idx as usize) % recent.len()]),
         }
     }
 }
@@ -114,11 +112,11 @@ enum BroadcastAction {
     },
     Subscribe {
         peer_index: usize,
-        source: DigestSource,
+        digest: Source,
     },
     Get {
         peer_index: usize,
-        source: DigestSource,
+        digest: Source,
     },
     Sleep {
         duration_ms: u64,
@@ -136,11 +134,11 @@ impl<'a> Arbitrary<'a> for BroadcastAction {
             }),
             1 => Ok(BroadcastAction::Subscribe {
                 peer_index: u.arbitrary()?,
-                source: u.arbitrary()?,
+                digest: u.arbitrary()?,
             }),
             2 => Ok(BroadcastAction::Get {
                 peer_index: u.arbitrary()?,
-                source: u.arbitrary()?,
+                digest: u.arbitrary()?,
             }),
             _ => Ok(BroadcastAction::Sleep {
                 duration_ms: u.int_in_range(0..=MAX_SLEEP_DURATION_MS)?,
@@ -199,6 +197,23 @@ fn resolve_recipients(pattern: &RecipientPattern, peers: &[PublicKey]) -> Recipi
             let count = ((seed % peers.len() as u64) as usize).max(1);
             let peer_slice = shuffled_peers.into_iter().take(count).collect();
             Recipients::Some(peer_slice)
+        }
+    }
+}
+
+// Keep subscriptions alive without spawning one task per receiver. Ready
+// subscriptions are validated, while unresolved ones remain pending.
+fn drain_ready_subscriptions(pending: &mut VecDeque<(Digest, oneshot::Receiver<FuzzMessage>)>) {
+    for _ in 0..pending.len() {
+        let (digest, mut receiver) = pending.pop_front().unwrap();
+        match receiver.try_recv() {
+            Ok(message) => {
+                assert_eq!(message.digest(), digest);
+            }
+            Err(oneshot::error::TryRecvError::Empty) => {
+                pending.push_back((digest, receiver));
+            }
+            Err(oneshot::error::TryRecvError::Closed) => {}
         }
     }
 }
@@ -271,6 +286,8 @@ fn fuzz(input: FuzzInput) {
 
         // Execute fuzzed actions
         let mut recent_digests: VecDeque<Digest> = VecDeque::with_capacity(MAX_RECENT_DIGESTS);
+        let mut pending_subscriptions: VecDeque<(Digest, oneshot::Receiver<FuzzMessage>)> =
+            VecDeque::with_capacity(MAX_RECENT_DIGESTS);
         for action in input.actions {
             match action {
                 BroadcastAction::SendMessage {
@@ -290,38 +307,41 @@ fn fuzz(input: FuzzInput) {
                         let _ = mailbox.broadcast(resolved_recipients, message);
                     }
                 }
-                BroadcastAction::Subscribe { peer_index, source } => {
-                    let Some(digest) = source.resolve(&recent_digests) else {
-                        continue;
-                    };
-                    let clamped_peer_idx = peer_index % peers.len();
-                    let peer = peers[clamped_peer_idx].clone();
+                BroadcastAction::Subscribe {
+                    peer_index,
+                    digest: source,
+                } => {
+                    if let Some(digest) = source.resolve(&recent_digests) {
+                        let clamped_peer_idx = peer_index % peers.len();
+                        let peer = peers[clamped_peer_idx].clone();
 
-                    if let Some(mailbox) = mailboxes.get(&peer).cloned() {
-                        // Spawn the await so the responder stays live and the
-                        // engine actually wakes it when a matching message
-                        // arrives.
-                        let receiver = mailbox.subscribe(digest);
-                        context.child("subscriber").spawn(|_| async move {
-                            let _ = receiver.await;
-                        });
+                        if let Some(mailbox) = mailboxes.get(&peer).cloned() {
+                            let receiver = mailbox.subscribe(digest);
+                            pending_subscriptions.push_back((digest, receiver));
+                            if pending_subscriptions.len() > MAX_RECENT_DIGESTS {
+                                pending_subscriptions.pop_front();
+                            }
+                        }
                     }
                 }
-                BroadcastAction::Get { peer_index, source } => {
-                    let Some(digest) = source.resolve(&recent_digests) else {
-                        continue;
-                    };
-                    let clamped_peer_idx = peer_index % peers.len();
-                    let peer = peers[clamped_peer_idx].clone();
+                BroadcastAction::Get {
+                    peer_index,
+                    digest: source,
+                } => {
+                    if let Some(digest) = source.resolve(&recent_digests) {
+                        let clamped_peer_idx = peer_index % peers.len();
+                        let peer = peers[clamped_peer_idx].clone();
 
-                    if let Some(mailbox) = mailboxes.get(&peer).cloned() {
-                        drop(mailbox.get(digest).await);
+                        if let Some(mailbox) = mailboxes.get(&peer).cloned() {
+                            drop(mailbox.get(digest).await);
+                        }
                     }
                 }
                 BroadcastAction::Sleep { duration_ms } => {
                     context.sleep(Duration::from_millis(duration_ms)).await;
                 }
             }
+            drain_ready_subscriptions(&mut pending_subscriptions);
         }
     });
 }

--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -311,16 +311,17 @@ fn fuzz(input: FuzzInput) {
                     peer_index,
                     digest: source,
                 } => {
-                    if let Some(digest) = source.resolve(&recent_digests) {
-                        let clamped_peer_idx = peer_index % peers.len();
-                        let peer = peers[clamped_peer_idx].clone();
+                    let Some(digest) = source.resolve(&recent_digests) else {
+                        continue;
+                    };
+                    let clamped_peer_idx = peer_index % peers.len();
+                    let peer = peers[clamped_peer_idx].clone();
 
-                        if let Some(mailbox) = mailboxes.get(&peer).cloned() {
-                            let receiver = mailbox.subscribe(digest);
-                            pending_subscriptions.push_back((digest, receiver));
-                            if pending_subscriptions.len() > MAX_RECENT_DIGESTS {
-                                pending_subscriptions.pop_front();
-                            }
+                    if let Some(mailbox) = mailboxes.get(&peer).cloned() {
+                        let receiver = mailbox.subscribe(digest);
+                        pending_subscriptions.push_back((digest, receiver));
+                        if pending_subscriptions.len() > MAX_RECENT_DIGESTS {
+                            pending_subscriptions.pop_front();
                         }
                     }
                 }
@@ -328,13 +329,14 @@ fn fuzz(input: FuzzInput) {
                     peer_index,
                     digest: source,
                 } => {
-                    if let Some(digest) = source.resolve(&recent_digests) {
-                        let clamped_peer_idx = peer_index % peers.len();
-                        let peer = peers[clamped_peer_idx].clone();
+                    let Some(digest) = source.resolve(&recent_digests) else {
+                        continue;
+                    };
+                    let clamped_peer_idx = peer_index % peers.len();
+                    let peer = peers[clamped_peer_idx].clone();
 
-                        if let Some(mailbox) = mailboxes.get(&peer).cloned() {
-                            drop(mailbox.get(digest).await);
-                        }
+                    if let Some(mailbox) = mailboxes.get(&peer).cloned() {
+                        drop(mailbox.get(digest).await);
                     }
                 }
                 BroadcastAction::Sleep { duration_ms } => {

--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -13,7 +13,8 @@ use commonware_cryptography::{
 };
 use commonware_p2p::{simulated::Network, Recipients};
 use commonware_runtime::{deterministic, Buf, BufMut, Clock, Quota, Runner, Supervisor as _};
-use commonware_utils::{channel::oneshot, NZUsize};
+use commonware_utils::{channel::oneshot, futures::Pool as FuturesPool, NZUsize};
+use futures::FutureExt as _;
 use libfuzzer_sys::fuzz_target;
 use rand::{seq::SliceRandom, SeedableRng};
 use std::{
@@ -36,6 +37,8 @@ const MAX_SLEEP_DURATION_MS: u64 = 1000;
 /// Indexed by `u8` modulo length, so a larger buffer would leave entries past 255
 /// unreachable via `Source::Recent`.
 const MAX_RECENT_DIGESTS: usize = (u8::MAX as usize) + 1;
+
+type Subscription = (Digest, Result<FuzzMessage, oneshot::error::RecvError>);
 
 #[derive(Clone, Debug, Arbitrary)]
 pub enum RecipientPattern {
@@ -203,17 +206,13 @@ fn resolve_recipients(pattern: &RecipientPattern, peers: &[PublicKey]) -> Recipi
 
 // Keep subscriptions alive without spawning one task per receiver. Ready
 // subscriptions are validated, while unresolved ones remain pending.
-fn drain_ready_subscriptions(pending: &mut VecDeque<(Digest, oneshot::Receiver<FuzzMessage>)>) {
-    for _ in 0..pending.len() {
-        let (digest, mut receiver) = pending.pop_front().unwrap();
-        match receiver.try_recv() {
+fn drain_ready_subscriptions(pending: &mut FuturesPool<Subscription>) {
+    while let Some((digest, result)) = pending.next_completed().now_or_never() {
+        match result {
             Ok(message) => {
                 assert_eq!(message.digest(), digest);
             }
-            Err(oneshot::error::TryRecvError::Empty) => {
-                pending.push_back((digest, receiver));
-            }
-            Err(oneshot::error::TryRecvError::Closed) => {}
+            Err(_) => {}
         }
     }
 }
@@ -286,8 +285,7 @@ fn fuzz(input: FuzzInput) {
 
         // Execute fuzzed actions
         let mut recent_digests: VecDeque<Digest> = VecDeque::with_capacity(MAX_RECENT_DIGESTS);
-        let mut pending_subscriptions: VecDeque<(Digest, oneshot::Receiver<FuzzMessage>)> =
-            VecDeque::with_capacity(MAX_RECENT_DIGESTS);
+        let mut pending_subscriptions = FuturesPool::default();
         for action in input.actions {
             match action {
                 BroadcastAction::SendMessage {
@@ -319,10 +317,7 @@ fn fuzz(input: FuzzInput) {
 
                     if let Some(mailbox) = mailboxes.get(&peer).cloned() {
                         let receiver = mailbox.subscribe(digest);
-                        pending_subscriptions.push_back((digest, receiver));
-                        if pending_subscriptions.len() > MAX_RECENT_DIGESTS {
-                            pending_subscriptions.pop_front();
-                        }
+                        pending_subscriptions.push(async move { (digest, receiver.await) });
                     }
                 }
                 BroadcastAction::Get {

--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -13,15 +13,11 @@ use commonware_cryptography::{
 };
 use commonware_p2p::{simulated::Network, Recipients};
 use commonware_runtime::{deterministic, Buf, BufMut, Clock, Quota, Runner, Supervisor as _};
-use commonware_utils::{channel::oneshot, futures::Pool as FuturesPool, NZUsize};
+use commonware_utils::{channel::oneshot, futures::Pool, vec::Bounded, NZUsize};
 use futures::FutureExt as _;
 use libfuzzer_sys::fuzz_target;
 use rand::{seq::SliceRandom, SeedableRng};
-use std::{
-    collections::{BTreeMap, VecDeque},
-    num::NonZeroU32,
-    time::Duration,
-};
+use std::{collections::BTreeMap, num::NonZeroU32, time::Duration};
 
 /// Default rate limit set high enough to not interfere with normal operation
 const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
@@ -38,6 +34,7 @@ const MAX_SLEEP_DURATION_MS: u64 = 1000;
 /// unreachable via `Source::Recent`.
 const MAX_RECENT_DIGESTS: usize = (u8::MAX as usize) + 1;
 
+/// Subscription result paired with the digest requested so completions can be validated.
 type Subscription = (Digest, Result<FuzzMessage, oneshot::error::RecvError>);
 
 #[derive(Clone, Debug, Arbitrary)]
@@ -97,11 +94,11 @@ enum Source {
 impl Source {
     /// Resolve to a concrete digest. Returns `None` when `Recent` is selected
     /// before any messages have been broadcast.
-    fn resolve(self, recent: &VecDeque<Digest>) -> Option<Digest> {
+    fn resolve(self, recent: &Bounded<Digest>) -> Option<Digest> {
         match self {
             Source::Random(message) => Some(message.digest()),
             Source::Recent(_) if recent.is_empty() => None,
-            Source::Recent(idx) => Some(recent[(idx as usize) % recent.len()]),
+            Source::Recent(idx) => recent.get((idx as usize) % recent.len()).cloned(),
         }
     }
 }
@@ -206,7 +203,7 @@ fn resolve_recipients(pattern: &RecipientPattern, peers: &[PublicKey]) -> Recipi
 
 // Keep subscriptions alive without spawning one task per receiver. Ready
 // subscriptions are validated, while unresolved ones remain pending.
-fn drain_ready_subscriptions(pending: &mut FuturesPool<Subscription>) {
+fn drain_ready_subscriptions(pending: &mut Pool<Subscription>) {
     while let Some((digest, result)) = pending.next_completed().now_or_never() {
         match result {
             Ok(message) => {
@@ -284,8 +281,8 @@ fn fuzz(input: FuzzInput) {
         }
 
         // Execute fuzzed actions
-        let mut recent_digests: VecDeque<Digest> = VecDeque::with_capacity(MAX_RECENT_DIGESTS);
-        let mut pending_subscriptions = FuturesPool::default();
+        let mut recent_digests = Bounded::new(NZUsize!(MAX_RECENT_DIGESTS));
+        let mut pending_subscriptions = Pool::default();
         for action in input.actions {
             match action {
                 BroadcastAction::SendMessage {
@@ -298,10 +295,7 @@ fn fuzz(input: FuzzInput) {
 
                     if let Some(mailbox) = mailboxes.get(&peer).cloned() {
                         let resolved_recipients = resolve_recipients(&recipients, &peers);
-                        if recent_digests.len() == MAX_RECENT_DIGESTS {
-                            recent_digests.pop_front();
-                        }
-                        recent_digests.push_back(message.digest());
+                        recent_digests.push(message.digest());
                         let _ = mailbox.broadcast(resolved_recipients, message);
                     }
                 }

--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -325,7 +325,9 @@ fn fuzz(input: FuzzInput) {
                     let peer = peers[clamped_peer_idx].clone();
 
                     if let Some(mailbox) = mailboxes.get(&peer).cloned() {
-                        drop(mailbox.get(digest).await);
+                        if let Some(message) = mailbox.get(digest).await {
+                            assert_eq!(message.digest(), digest);
+                        }
                     }
                 }
                 BroadcastAction::Sleep { duration_ms } => {

--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -12,11 +12,17 @@ use commonware_cryptography::{
     Digestible, Hasher, Sha256, Signer,
 };
 use commonware_p2p::{simulated::Network, Recipients};
-use commonware_runtime::{deterministic, Buf, BufMut, Clock, Quota, Runner, Supervisor as _};
+use commonware_runtime::{
+    deterministic, Buf, BufMut, Clock, Quota, Runner, Spawner, Supervisor as _,
+};
 use commonware_utils::NZUsize;
 use libfuzzer_sys::fuzz_target;
 use rand::{seq::SliceRandom, SeedableRng};
-use std::{collections::BTreeMap, num::NonZeroU32, time::Duration};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    num::NonZeroU32,
+    time::Duration,
+};
 
 /// Default rate limit set high enough to not interfere with normal operation
 const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
@@ -26,6 +32,12 @@ const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 /// Capped to avoid overflow in governor rate limiter which uses nanoseconds internally
 /// and can only represent durations up to ~584 years.
 const MAX_SLEEP_DURATION_MS: u64 = 1000;
+
+/// Maximum number of recently broadcast digests tracked for `Recent` lookups.
+///
+/// Indexed by `u8` modulo length, so a larger buffer would leave entries past 255
+/// unreachable via `DigestSource::Recent`.
+const MAX_RECENT_DIGESTS: usize = (u8::MAX as usize) + 1;
 
 #[derive(Clone, Debug, Arbitrary)]
 pub enum RecipientPattern {
@@ -72,6 +84,27 @@ impl commonware_codec::Read for FuzzMessage {
     }
 }
 
+/// Source for the digest used by `Subscribe`/`Get` actions.
+#[derive(Clone, Debug, Arbitrary)]
+enum DigestSource {
+    /// A random message.
+    Random(FuzzMessage),
+    /// Index into messages broadcast earlier in this run.
+    Recent(u8),
+}
+
+impl DigestSource {
+    /// Resolve to a concrete digest. Returns `None` when `Recent` is selected
+    /// before any messages have been broadcast.
+    fn resolve(self, recent: &VecDeque<Digest>) -> Option<Digest> {
+        match self {
+            DigestSource::Random(message) => Some(message.digest()),
+            DigestSource::Recent(_) if recent.is_empty() => None,
+            DigestSource::Recent(idx) => Some(recent[(idx as usize) % recent.len()]),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 enum BroadcastAction {
     SendMessage {
@@ -81,11 +114,11 @@ enum BroadcastAction {
     },
     Subscribe {
         peer_index: usize,
-        digest: Digest,
+        source: DigestSource,
     },
     Get {
         peer_index: usize,
-        digest: Digest,
+        source: DigestSource,
     },
     Sleep {
         duration_ms: u64,
@@ -103,11 +136,11 @@ impl<'a> Arbitrary<'a> for BroadcastAction {
             }),
             1 => Ok(BroadcastAction::Subscribe {
                 peer_index: u.arbitrary()?,
-                digest: u.arbitrary()?,
+                source: u.arbitrary()?,
             }),
             2 => Ok(BroadcastAction::Get {
                 peer_index: u.arbitrary()?,
-                digest: u.arbitrary()?,
+                source: u.arbitrary()?,
             }),
             _ => Ok(BroadcastAction::Sleep {
                 duration_ms: u.int_in_range(0..=MAX_SLEEP_DURATION_MS)?,
@@ -237,6 +270,7 @@ fn fuzz(input: FuzzInput) {
         }
 
         // Execute fuzzed actions
+        let mut recent_digests: VecDeque<Digest> = VecDeque::with_capacity(MAX_RECENT_DIGESTS);
         for action in input.actions {
             match action {
                 BroadcastAction::SendMessage {
@@ -249,18 +283,34 @@ fn fuzz(input: FuzzInput) {
 
                     if let Some(mailbox) = mailboxes.get(&peer).cloned() {
                         let resolved_recipients = resolve_recipients(&recipients, &peers);
+                        if recent_digests.len() == MAX_RECENT_DIGESTS {
+                            recent_digests.pop_front();
+                        }
+                        recent_digests.push_back(message.digest());
                         let _ = mailbox.broadcast(resolved_recipients, message);
                     }
                 }
-                BroadcastAction::Subscribe { peer_index, digest } => {
+                BroadcastAction::Subscribe { peer_index, source } => {
+                    let Some(digest) = source.resolve(&recent_digests) else {
+                        continue;
+                    };
                     let clamped_peer_idx = peer_index % peers.len();
                     let peer = peers[clamped_peer_idx].clone();
 
                     if let Some(mailbox) = mailboxes.get(&peer).cloned() {
-                        drop(mailbox.subscribe(digest).await);
+                        // Spawn the await so the responder stays live and the
+                        // engine actually wakes it when a matching message
+                        // arrives.
+                        let receiver = mailbox.subscribe(digest);
+                        context.child("subscriber").spawn(|_| async move {
+                            let _ = receiver.await;
+                        });
                     }
                 }
-                BroadcastAction::Get { peer_index, digest } => {
+                BroadcastAction::Get { peer_index, source } => {
+                    let Some(digest) = source.resolve(&recent_digests) else {
+                        continue;
+                    };
                     let clamped_peer_idx = peer_index % peers.len();
                     let peer = peers[clamped_peer_idx].clone();
 

--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -205,11 +205,8 @@ fn resolve_recipients(pattern: &RecipientPattern, peers: &[PublicKey]) -> Recipi
 // subscriptions are validated, while unresolved ones remain pending.
 fn drain_ready_subscriptions(pending: &mut Pool<Subscription>) {
     while let Some((digest, result)) = pending.next_completed().now_or_never() {
-        match result {
-            Ok(message) => {
-                assert_eq!(message.digest(), digest);
-            }
-            Err(_) => {}
+        if let Ok(message) = result {
+            assert_eq!(message.digest(), digest);
         }
     }
 }

--- a/utils/src/vec.rs
+++ b/utils/src/vec.rs
@@ -1,15 +1,82 @@
-//! A vector type that guarantees at least one element.
+//! Vector-backed collection types with additional invariants.
 
 use crate::TryFromIterator;
 #[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::{collections::VecDeque, vec, vec::Vec};
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, RangeCfg, Read, Write};
 use core::{
     num::NonZeroUsize,
     ops::{Deref, DerefMut},
 };
+#[cfg(feature = "std")]
+use std::collections::VecDeque;
 use thiserror::Error;
+
+/// A [`VecDeque`] that keeps at most `capacity` items.
+///
+/// Pushing past capacity evicts the oldest item.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Bounded<T> {
+    deque: VecDeque<T>,
+    capacity: NonZeroUsize,
+}
+
+impl<T> Bounded<T> {
+    /// Creates an empty [`Bounded`] with the given capacity.
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            deque: VecDeque::with_capacity(capacity.get()),
+            capacity,
+        }
+    }
+
+    /// Returns the maximum number of items retained.
+    pub const fn capacity(&self) -> NonZeroUsize {
+        self.capacity
+    }
+
+    /// Pushes an item, evicting the oldest item if full.
+    pub fn push(&mut self, value: T) -> Option<T> {
+        let evicted = if self.deque.len() == self.capacity.get() {
+            self.deque.pop_front()
+        } else {
+            None
+        };
+        self.deque.push_back(value);
+        evicted
+    }
+
+    /// Removes the oldest item.
+    pub fn pop_front(&mut self) -> Option<T> {
+        self.deque.pop_front()
+    }
+
+    /// Consumes the bounded deque and returns the underlying [`VecDeque`].
+    pub fn into_inner(self) -> VecDeque<T> {
+        self.deque
+    }
+}
+
+impl<T> Deref for Bounded<T> {
+    type Target = VecDeque<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.deque
+    }
+}
+
+impl<T> AsRef<VecDeque<T>> for Bounded<T> {
+    fn as_ref(&self) -> &VecDeque<T> {
+        &self.deque
+    }
+}
+
+impl<T> From<Bounded<T>> for VecDeque<T> {
+    fn from(deque: Bounded<T>) -> Self {
+        deque.deque
+    }
+}
 
 /// Errors that can occur when creating a [`NonEmptyVec`].
 #[derive(Error, Debug, PartialEq, Eq)]
@@ -445,6 +512,44 @@ mod tests {
     use crate::{NZUsize, TryCollect};
     use commonware_codec::{EncodeSize, Error as CodecError, RangeCfg, Read, Write};
     use std::num::NonZeroUsize;
+
+    #[test]
+    fn test_bounded_push_evicts_oldest() {
+        let mut deque = Bounded::new(NZUsize!(3));
+
+        assert_eq!(deque.push(1), None);
+        assert_eq!(deque.push(2), None);
+        assert_eq!(deque.push(3), None);
+        assert_eq!(deque.push(4), Some(1));
+
+        assert_eq!(deque.capacity().get(), 3);
+        assert_eq!(deque.iter().copied().collect::<Vec<_>>(), vec![2, 3, 4]);
+    }
+
+    #[test]
+    fn test_bounded_pop_front_reuses_capacity() {
+        let mut deque = Bounded::new(NZUsize!(2));
+
+        assert_eq!(deque.push(1), None);
+        assert_eq!(deque.push(2), None);
+        assert_eq!(deque.pop_front(), Some(1));
+        assert_eq!(deque.push(3), None);
+
+        assert_eq!(deque.iter().copied().collect::<Vec<_>>(), vec![2, 3]);
+    }
+
+    #[test]
+    fn test_bounded_into_inner() {
+        let mut deque = Bounded::new(NZUsize!(2));
+
+        deque.push(1);
+        deque.push(2);
+
+        assert_eq!(
+            deque.into_inner().into_iter().collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+    }
 
     #[test]
     fn test_new() {


### PR DESCRIPTION
`Mailbox::subscribe` was made synchronous in #3785, but the fuzz target still did `drop(mailbox.subscribe(digest).await)`. Before #3785, `.await` resolved the `async fn` to a `Receiver` and `drop` discarded it, fire-and-forget. Post-change, the same expression awaits the `Receiver` directly, which only resolves when a matching message arrives, which with random 32-byte digests it almost never does, so the action loop blocks and the deterministic runtime trips its liveness check. 

The deadlock fix alone would still leave `Subscribe` and `Get` doing very little, since random 32-byte digests almost never match broadcast traffic and the engine's wakeup and cache-hit paths stay cold. To fix that, this PR introduces `DigestSource { Random(FuzzMessage), Recent(u8) }` plus a bounded FIFO ring of broadcast digests. `Recent` indexes into the ring, so the fuzzer now actually hits cache-hit, cache-miss-after-eviction, and live-subscriber-wakeup paths.