### PR TITLE
[storage/qmdb/current] Add lookup-based sync target resolution

### DIFF
--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -235,42 +235,48 @@ where
             Resolver::<current::Operation, Key>::connect(context.child("resolver"), config.server)
                 .await?;
 
-        let initial_target = resolver.get_current_sync_target().await?;
+        // Simulate a consensus stream by polling the server's `GetSyncTargetRequest`
+        // endpoint, which for a `current` database returns the current canonical root via
+        // `Syncable::root()`. In a real deployment this stream would be driven by consensus
+        // finalization, not by polling the server.
+        let initial_canonical_target = resolver.get_sync_target().await?;
         info!(
-            root = %initial_target.root,
-            ops_root = %initial_target.ops_root,
-            range = ?initial_target.range,
-            "received current sync target"
+            root = %initial_canonical_target.root,
+            "received initial trusted canonical root (simulated consensus)"
         );
 
-        let (update_sender, update_receiver) = mpsc::channel(UPDATE_CHANNEL_SIZE);
+        let (trusted_root_tx, trusted_root_rx) = mpsc::channel(UPDATE_CHANNEL_SIZE);
+        trusted_root_tx
+            .clone()
+            .send(initial_canonical_target.root)
+            .await
+            .map_err(|err| Error::TargetUpdateChannel {
+                reason: err.to_string(),
+            })?;
 
         let target_update_handle = {
             let resolver = resolver.clone();
-            let mut current_target_root = initial_target.root;
             let target_update_interval = config.target_update_interval;
+            let mut last_root = initial_canonical_target.root;
             context
                 .child("target_update")
                 .spawn(move |context| async move {
                     loop {
                         context.sleep(target_update_interval).await;
-                        match resolver.get_current_sync_target().await {
+                        match resolver.get_sync_target().await {
                             Ok(new_target) => {
-                                if current_target_root != new_target.root {
+                                if new_target.root != last_root {
                                     let new_root = new_target.root;
-                                    match update_sender.clone().try_send(new_target) {
-                                        Ok(()) => {
-                                            info!("target updated");
-                                            current_target_root = new_root;
+                                    if let Err(err) = trusted_root_tx.clone().try_send(new_root) {
+                                        if matches!(err, mpsc::error::TrySendError::Closed(_)) {
+                                            return Ok(());
                                         }
-                                        Err(mpsc::error::TrySendError::Closed(_)) => return Ok(()),
-                                        Err(err) => {
-                                            warn!(?err, "failed to send target update");
-                                            return Err(Error::TargetUpdateChannel {
-                                                reason: err.to_string(),
-                                            });
-                                        }
+                                        warn!(?err, "failed to send trusted root");
+                                        return Err(Error::TargetUpdateChannel {
+                                            reason: err.to_string(),
+                                        });
                                     }
+                                    last_root = new_root;
                                 }
                             }
                             Err(err) => {
@@ -285,12 +291,13 @@ where
         let database: current::Database<_> = current_qmdb::sync::sync(current_qmdb::sync::Config {
             context: context.child("sync"),
             resolver,
-            target: initial_target,
+            trusted_root_rx,
+            trusted_root_buffer: std::num::NonZeroUsize::new(32).unwrap(),
+            target_poll_interval: std::time::Duration::from_millis(100),
             max_outstanding_requests: config.max_outstanding_requests,
             fetch_batch_size: config.batch_size,
             apply_batch_size: 1024,
             db_config,
-            update_rx: Some(update_receiver),
             finish_rx: None,
             reached_target_tx: None,
             max_retained_roots: 8,

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -219,8 +219,11 @@ where
 {
     state.request_counter.inc();
 
-    // Get the current database state
-    let (ops_root, sync_boundary, size) = {
+    // `Syncable::root()` returns the engine-facing root for this database type:
+    // - `any`: ops root (engine verifies directly against this)
+    // - `current`: canonical root (the value the chain commits to; the engine target
+    //   is derived separately via `GetCurrentTargetForRootsRequest`)
+    let (root, sync_boundary, size) = {
         let database = state.database.read().await;
         (
             database.root(),
@@ -230,7 +233,7 @@ where
     };
     let response = wire::GetSyncTargetResponse::<Key> {
         request_id: request.request_id,
-        target: Target::new(ops_root, non_empty_range!(sync_boundary, size)),
+        target: Target::new(root, non_empty_range!(sync_boundary, size)),
     };
 
     debug!(?response, "serving target update");
@@ -426,21 +429,27 @@ where
                 wire::Message::GetOperationsResponse,
                 handle_get_operations::<current::Database<E>>(state, request)
             ),
-            wire::Message::GetSyncTargetRequest(request) => {
+            // For `current`, `Syncable::root()` returns the canonical root. The example
+            // client uses this endpoint to obtain its trusted canonical root in place of
+            // a real consensus stream.
+            wire::Message::GetSyncTargetRequest(request) => dispatch_message!(
+                state,
+                request_id,
+                wire::Message::GetSyncTargetResponse,
+                handle_get_sync_target::<current::Database<E>>(state, request)
+            ),
+            wire::Message::GetCurrentTargetForRootsRequest(request) => {
                 state.request_counter.inc();
                 let database = state.database.read().await;
-                match current::current_sync_target(&*database).await {
-                    Ok(target) => {
-                        debug!(?target, "serving current sync target");
-                        wire::Message::GetCurrentSyncTargetResponse(
-                            wire::GetCurrentSyncTargetResponse {
-                                request_id: request.request_id,
-                                target,
-                            },
-                        )
-                    }
-                    Err(err) => error_message(state, request_id, err.into()),
-                }
+                let target = current::current_target_for_roots(&*database, &request.trusted_roots)
+                    .map(Into::into);
+                debug!(?target, "serving current target lookup");
+                wire::Message::GetCurrentTargetForRootsResponse(
+                    wire::GetCurrentTargetForRootsResponse {
+                        request_id: request.request_id,
+                        target,
+                    },
+                )
             }
             _ => unexpected_message(state, request_id),
         }

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -240,6 +240,27 @@ where
     Ok(response)
 }
 
+/// Handle a `current` target-for-roots lookup. The DB cache is consulted synchronously
+/// (a hash-map probe over `request.trusted_roots`); the result is always `Ok(...)` — a
+/// cache miss is encoded as `Some(target: None)`, not a server error.
+async fn handle_get_current_target_for_roots<E>(
+    state: &State<current::Database<E>>,
+    request: wire::GetCurrentTargetForRootsRequest<Key>,
+) -> Result<wire::GetCurrentTargetForRootsResponse<Key>, Error>
+where
+    E: Storage + Clock + Metrics + Send + Sync + 'static,
+{
+    state.request_counter.inc();
+    let database = state.database.read().await;
+    let target =
+        current::current_target_for_roots(&*database, &request.trusted_roots).map(Into::into);
+    debug!(?target, "serving current target lookup");
+    Ok(wire::GetCurrentTargetForRootsResponse {
+        request_id: request.request_id,
+        target,
+    })
+}
+
 /// Handle a request for compact-sync target.
 async fn handle_get_compact_sync_target<DB>(
     state: &State<DB>,
@@ -438,19 +459,12 @@ where
                 wire::Message::GetSyncTargetResponse,
                 handle_get_sync_target::<current::Database<E>>(state, request)
             ),
-            wire::Message::GetCurrentTargetForRootsRequest(request) => {
-                state.request_counter.inc();
-                let database = state.database.read().await;
-                let target = current::current_target_for_roots(&*database, &request.trusted_roots)
-                    .map(Into::into);
-                debug!(?target, "serving current target lookup");
-                wire::Message::GetCurrentTargetForRootsResponse(
-                    wire::GetCurrentTargetForRootsResponse {
-                        request_id: request.request_id,
-                        target,
-                    },
-                )
-            }
+            wire::Message::GetCurrentTargetForRootsRequest(request) => dispatch_message!(
+                state,
+                request_id,
+                wire::Message::GetCurrentTargetForRootsResponse,
+                handle_get_current_target_for_roots::<E>(state, request)
+            ),
             _ => unexpected_message(state, request_id),
         }
     }

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -27,11 +27,11 @@ use commonware_storage::{
     qmdb::{
         self,
         any::unordered::{fixed::Operation as FixedOperation, Update},
-        current::{self, sync::Target as CurrentTarget, FixedConfig as Config},
+        current::{self, FixedConfig as Config},
         operation::Committable,
     },
 };
-use commonware_utils::{non_empty_range, NZUsize, NZU16, NZU64};
+use commonware_utils::{NZUsize, NZU16, NZU64};
 use std::{future::Future, num::NonZeroU64};
 use tracing::error;
 
@@ -73,6 +73,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
         },
         grafted_metadata_partition: "grafted-mmr-metadata".into(),
         translator: Translator::default(),
+        witness_cache_size: 32,
     }
 }
 
@@ -186,19 +187,14 @@ where
     }
 }
 
-pub async fn current_sync_target<E: Storage + Clock + Metrics>(
+/// Return the first cached current target whose canonical root matches one of `trusted_roots`.
+/// The `current::Db` populates this cache at every commit and at init, so any recent root
+/// (up to `witness_cache_size`) is answerable.
+pub fn current_target_for_roots<E: Storage + Clock + Metrics>(
     db: &Database<E>,
-) -> Result<CurrentTarget<mmr::Family, Key>, qmdb::Error<mmr::Family>> {
-    let hasher = qmdb::hasher::<Hasher>();
-    let witness = db.ops_root_witness(&hasher).await?;
-    let sync_boundary = db.sync_boundary();
-    let size = db.bounds().await.end;
-    Ok(CurrentTarget::new(
-        db.root(),
-        db.ops_root(),
-        witness,
-        non_empty_range!(sync_boundary, size),
-    ))
+    trusted_roots: &[Key],
+) -> Option<commonware_storage::qmdb::current::db::CachedTarget<mmr::Family, Key>> {
+    db.cached_target(trusted_roots)
 }
 
 #[cfg(test)]

--- a/examples/sync/src/net/mod.rs
+++ b/examples/sync/src/net/mod.rs
@@ -229,4 +229,107 @@ mod tests {
             other => panic!("unexpected message variant: {other:?}"),
         }
     }
+
+    /// `GetCurrentTargetForRootsRequest` round-trips through encode/decode and clamps
+    /// per the configured `MAX_TRUSTED_ROOTS` only on the network-resolver side; the wire
+    /// codec itself accepts up to `MAX_TRUSTED_ROOTS` entries and rejects more.
+    #[test]
+    fn test_get_current_target_for_roots_request_roundtrip() {
+        let request_id = Generator::new().next();
+        let roots: Vec<sha256::Digest> = (0..3)
+            .map(|i| sha256::Digest::from([i as u8 + 1; 32]))
+            .collect();
+        let message: wire::Message<keyless_compact::Operation, sha256::Digest> =
+            wire::Message::GetCurrentTargetForRootsRequest(wire::GetCurrentTargetForRootsRequest {
+                request_id,
+                trusted_roots: roots.clone(),
+            });
+
+        let encoded = message.encode().to_vec();
+        let decoded =
+            wire::Message::<keyless_compact::Operation, sha256::Digest>::decode(&encoded[..])
+                .expect("failed to decode");
+
+        match decoded {
+            wire::Message::GetCurrentTargetForRootsRequest(req) => {
+                assert_eq!(req.request_id, request_id);
+                assert_eq!(req.trusted_roots, roots);
+            }
+            other => panic!("unexpected message variant: {other:?}"),
+        }
+    }
+
+    /// `GetCurrentTargetForRootsResponse` round-trips both `None` (cache miss) and
+    /// `Some(target)` (cache hit). The strict Option decode is exercised by these paths.
+    #[test]
+    fn test_get_current_target_for_roots_response_roundtrip_none() {
+        let request_id = Generator::new().next();
+        let message: wire::Message<keyless_compact::Operation, sha256::Digest> =
+            wire::Message::GetCurrentTargetForRootsResponse(
+                wire::GetCurrentTargetForRootsResponse {
+                    request_id,
+                    target: None,
+                },
+            );
+
+        let encoded = message.encode().to_vec();
+        let decoded =
+            wire::Message::<keyless_compact::Operation, sha256::Digest>::decode(&encoded[..])
+                .expect("failed to decode None response");
+
+        match decoded {
+            wire::Message::GetCurrentTargetForRootsResponse(resp) => {
+                assert_eq!(resp.request_id, request_id);
+                assert!(resp.target.is_none());
+            }
+            other => panic!("unexpected message variant: {other:?}"),
+        }
+    }
+
+    /// The wire decode caps `trusted_roots` at `MAX_TRUSTED_ROOTS`. A request encoded with
+    /// more than the cap must be rejected at decode — which is why the network resolver
+    /// clamps its slice before sending (see `Resolver::get_current_target_for_roots`).
+    #[test]
+    fn test_get_current_target_for_roots_request_rejects_oversize() {
+        let request_id = Generator::new().next();
+        let roots: Vec<sha256::Digest> = (0..=wire::MAX_TRUSTED_ROOTS)
+            .map(|i| sha256::Digest::from([(i & 0xFF) as u8; 32]))
+            .collect();
+        assert_eq!(roots.len(), wire::MAX_TRUSTED_ROOTS + 1);
+
+        let message: wire::Message<keyless_compact::Operation, sha256::Digest> =
+            wire::Message::GetCurrentTargetForRootsRequest(wire::GetCurrentTargetForRootsRequest {
+                request_id,
+                trusted_roots: roots,
+            });
+
+        let encoded = message.encode().to_vec();
+        let result =
+            wire::Message::<keyless_compact::Operation, sha256::Digest>::decode(&encoded[..]);
+        assert!(
+            result.is_err(),
+            "wire decode must reject more than MAX_TRUSTED_ROOTS entries, got {result:?}"
+        );
+    }
+
+    /// The Option discriminant in `GetCurrentTargetForRootsResponse` must accept ONLY 0
+    /// and 1. Any other byte value is a malformed encoding and should produce
+    /// `CodecError::Invalid`, not be silently interpreted as `Some`.
+    #[test]
+    fn test_get_current_target_for_roots_response_rejects_invalid_option_discriminant() {
+        use commonware_codec::Write as _;
+        // Construct the response bytes manually: message tag (10) + request_id + an
+        // invalid Option discriminant (2). Strict decode must reject.
+        let request_id = Generator::new().next();
+        let mut framed = vec![10u8];
+        request_id.write(&mut framed);
+        2u8.write(&mut framed); // illegal Option discriminant
+
+        let result =
+            wire::Message::<keyless_compact::Operation, sha256::Digest>::decode(&framed[..]);
+        assert!(
+            matches!(result, Err(commonware_codec::Error::Invalid(_, _))),
+            "strict decode must reject Option discriminant != 0/1, got {result:?}"
+        );
+    }
 }

--- a/examples/sync/src/net/resolver.rs
+++ b/examples/sync/src/net/resolver.rs
@@ -7,7 +7,7 @@ use commonware_storage::{
     mmr::{self, Location},
     qmdb::{
         any::sync::Target,
-        current::sync::Target as CurrentTarget,
+        current::sync::{self as current_sync, Target as CurrentTarget},
         sync::{self, compact},
     },
 };
@@ -75,13 +75,26 @@ where
         }
     }
 
-    /// Returns the current-database sync target (database root + witness).
-    pub async fn get_current_sync_target(
+    /// Ask the server for a current-database sync target whose canonical root matches one of
+    /// `trusted_roots`. Returns `None` if the server has no cached witness for any of them.
+    ///
+    /// If `trusted_roots.len() > wire::MAX_TRUSTED_ROOTS`, only the first
+    /// `MAX_TRUSTED_ROOTS` entries are sent over the wire. Callers should pass roots in
+    /// most-recent-first order so the freshest candidates are always queried.
+    pub async fn get_current_target_for_roots(
         &self,
-    ) -> Result<CurrentTarget<mmr::Family, D>, crate::Error> {
+        trusted_roots: &[D],
+    ) -> Result<Option<CurrentTarget<mmr::Family, D>>, crate::Error> {
         let request_id = self.request_id_generator.next();
+        // Clamp the request payload to the wire-format limit. The server would reject any
+        // larger payload at decode time; we honor the cap here so a misconfigured local
+        // trusted-root buffer doesn't break sync.
+        let send_count = trusted_roots.len().min(wire::MAX_TRUSTED_ROOTS);
         let request =
-            wire::Message::GetSyncTargetRequest(wire::GetSyncTargetRequest { request_id });
+            wire::Message::GetCurrentTargetForRootsRequest(wire::GetCurrentTargetForRootsRequest {
+                request_id,
+                trusted_roots: trusted_roots[..send_count].to_vec(),
+            });
         let (tx, rx) = oneshot::channel();
         self.request_tx
             .clone()
@@ -95,7 +108,7 @@ where
             .await
             .map_err(|_| crate::Error::ResponseChannelClosed { request_id })??;
         match response {
-            wire::Message::GetCurrentSyncTargetResponse(r) => Ok(r.target),
+            wire::Message::GetCurrentTargetForRootsResponse(r) => Ok(r.target),
             wire::Message::Error(err) => Err(crate::Error::Server {
                 code: err.error_code,
                 message: err.message,
@@ -223,6 +236,20 @@ where
             success_tx: tx,
             pinned_nodes,
         })
+    }
+}
+
+impl<Op, D> current_sync::CurrentResolver for Resolver<Op, D>
+where
+    Op: Clone + Read + EncodeShared,
+    Op::Cfg: IsUnit,
+    D: Digest,
+{
+    async fn target_for_roots(
+        &self,
+        trusted_roots: &[D],
+    ) -> Result<Option<CurrentTarget<mmr::Family, D>>, Self::Error> {
+        self.get_current_target_for_roots(trusted_roots).await
     }
 }
 

--- a/examples/sync/src/net/wire.rs
+++ b/examples/sync/src/net/wire.rs
@@ -58,15 +58,30 @@ where
     pub target: Target<mmr::Family, D>,
 }
 
-/// Response with current-database sync target (database root + witness).
+/// Request a current-database sync target whose canonical root matches one of the trusted
+/// roots the client received from consensus.
 #[derive(Debug)]
-pub struct GetCurrentSyncTargetResponse<D>
+pub struct GetCurrentTargetForRootsRequest<D>
 where
     D: Digest,
 {
     pub request_id: RequestId,
-    pub target: CurrentTarget<mmr::Family, D>,
+    pub trusted_roots: Vec<D>,
 }
+
+/// Response with a matching current-database sync target, or `None` if the server has no
+/// cached witness for any of the requested roots.
+#[derive(Debug)]
+pub struct GetCurrentTargetForRootsResponse<D>
+where
+    D: Digest,
+{
+    pub request_id: RequestId,
+    pub target: Option<CurrentTarget<mmr::Family, D>>,
+}
+
+/// Maximum trusted roots accepted per request.
+pub const MAX_TRUSTED_ROOTS: usize = 256;
 
 /// Request for compact authenticated state.
 #[derive(Debug)]
@@ -118,7 +133,8 @@ where
     GetCompactTargetResponse(GetCompactTargetResponse<D>),
     GetCompactStateRequest(GetCompactStateRequest<D>),
     GetCompactStateResponse(GetCompactStateResponse<Op, D>),
-    GetCurrentSyncTargetResponse(GetCurrentSyncTargetResponse<D>),
+    GetCurrentTargetForRootsRequest(GetCurrentTargetForRootsRequest<D>),
+    GetCurrentTargetForRootsResponse(GetCurrentTargetForRootsResponse<D>),
     Error(ErrorResponse),
 }
 
@@ -136,7 +152,8 @@ where
             Self::GetCompactTargetResponse(r) => r.request_id,
             Self::GetCompactStateRequest(r) => r.request_id,
             Self::GetCompactStateResponse(r) => r.request_id,
-            Self::GetCurrentSyncTargetResponse(r) => r.request_id,
+            Self::GetCurrentTargetForRootsRequest(r) => r.request_id,
+            Self::GetCurrentTargetForRootsResponse(r) => r.request_id,
             Self::Error(e) => e.request_id,
         }
     }
@@ -192,8 +209,12 @@ where
                 7u8.write(buf);
                 resp.write(buf);
             }
-            Self::GetCurrentSyncTargetResponse(resp) => {
+            Self::GetCurrentTargetForRootsRequest(req) => {
                 9u8.write(buf);
+                req.write(buf);
+            }
+            Self::GetCurrentTargetForRootsResponse(resp) => {
+                10u8.write(buf);
                 resp.write(buf);
             }
             Self::Error(err) => {
@@ -219,7 +240,8 @@ where
             Self::GetCompactTargetResponse(resp) => resp.encode_size(),
             Self::GetCompactStateRequest(req) => req.encode_size(),
             Self::GetCompactStateResponse(resp) => resp.encode_size(),
-            Self::GetCurrentSyncTargetResponse(resp) => resp.encode_size(),
+            Self::GetCurrentTargetForRootsRequest(req) => req.encode_size(),
+            Self::GetCurrentTargetForRootsResponse(resp) => resp.encode_size(),
             Self::Error(err) => err.encode_size(),
         }
     }
@@ -256,8 +278,11 @@ where
                 GetCompactStateResponse::read(buf)?,
             )),
             8 => Ok(Self::Error(ErrorResponse::read(buf)?)),
-            9 => Ok(Self::GetCurrentSyncTargetResponse(
-                GetCurrentSyncTargetResponse::read(buf)?,
+            9 => Ok(Self::GetCurrentTargetForRootsRequest(
+                GetCurrentTargetForRootsRequest::read(buf)?,
+            )),
+            10 => Ok(Self::GetCurrentTargetForRootsResponse(
+                GetCurrentTargetForRootsResponse::read(buf)?,
             )),
             d => Err(CodecError::InvalidEnum(d)),
         }
@@ -439,24 +464,71 @@ where
     }
 }
 
-impl<D: Digest> Write for GetCurrentSyncTargetResponse<D> {
+impl<D: Digest> Write for GetCurrentTargetForRootsRequest<D> {
     fn write(&self, buf: &mut impl BufMut) {
         self.request_id.write(buf);
-        self.target.write(buf);
+        self.trusted_roots.write(buf);
     }
 }
 
-impl<D: Digest> EncodeSize for GetCurrentSyncTargetResponse<D> {
+impl<D: Digest> EncodeSize for GetCurrentTargetForRootsRequest<D> {
     fn encode_size(&self) -> usize {
-        self.request_id.encode_size() + self.target.encode_size()
+        self.request_id.encode_size() + self.trusted_roots.encode_size()
     }
 }
 
-impl<D: Digest> Read for GetCurrentSyncTargetResponse<D> {
+impl<D: Digest> Read for GetCurrentTargetForRootsRequest<D> {
     type Cfg = ();
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let request_id = RequestId::read_cfg(buf, &())?;
-        let target = CurrentTarget::<mmr::Family, D>::read_cfg(buf, &())?;
+        let trusted_roots = Vec::<D>::read_cfg(buf, &(RangeCfg::from(0..=MAX_TRUSTED_ROOTS), ()))?;
+        Ok(Self {
+            request_id,
+            trusted_roots,
+        })
+    }
+}
+
+impl<D: Digest> Write for GetCurrentTargetForRootsResponse<D> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.request_id.write(buf);
+        match &self.target {
+            Some(t) => {
+                1u8.write(buf);
+                t.write(buf);
+            }
+            None => {
+                0u8.write(buf);
+            }
+        }
+    }
+}
+
+impl<D: Digest> EncodeSize for GetCurrentTargetForRootsResponse<D> {
+    fn encode_size(&self) -> usize {
+        self.request_id.encode_size()
+            + 1u8.encode_size()
+            + self.target.as_ref().map_or(0, |t| t.encode_size())
+    }
+}
+
+impl<D: Digest> Read for GetCurrentTargetForRootsResponse<D> {
+    type Cfg = ();
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+        let request_id = RequestId::read_cfg(buf, &())?;
+        // Strict: accept only the canonical encoding (0 = None, 1 = Some). Other bytes
+        // could be interpreted as Some by a lax decoder and cause cross-instance
+        // ambiguity on bytes-to-value mappings.
+        let target = match u8::read(buf)? {
+            0 => None,
+            1 => Some(CurrentTarget::<mmr::Family, D>::read_cfg(buf, &())?),
+            _ => {
+                return Err(CodecError::Invalid(
+                    "GetCurrentTargetForRootsResponse",
+                    "Option discriminant must be 0 or 1",
+                ));
+            }
+        };
         Ok(Self { request_id, target })
     }
 }

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -120,6 +120,7 @@ fn make_config(
         },
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
+        witness_cache_size: 32,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -164,6 +164,7 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         },
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
+        witness_cache_size: 32,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -158,6 +158,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             },
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
+        witness_cache_size: 32,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -95,6 +95,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
+        witness_cache_size: 32,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -148,6 +148,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             },
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
+        witness_cache_size: 32,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/src/qmdb/benches/chained_growth.rs
+++ b/storage/src/qmdb/benches/chained_growth.rs
@@ -86,6 +86,7 @@ fn cur_fix_cfg(
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
+        witness_cache_size: 32,
     }
 }
 

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -156,6 +156,7 @@ pub fn cur_fix_cfg_with(
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_FIX}"),
         translator: EightCap,
+        witness_cache_size: 32,
     }
 }
 
@@ -193,6 +194,7 @@ pub fn cur_var_digest_cfg_with(
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
+        witness_cache_size: 32,
     }
 }
 
@@ -243,6 +245,7 @@ pub fn cur_var_vec_cfg_with(
         ),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
+        witness_cache_size: 32,
     }
 }
 

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -353,6 +353,7 @@ fn cur_fix_cfg(
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
+        witness_cache_size: 32,
     }
 }
 
@@ -366,6 +367,7 @@ fn cur_var_cfg(
         journal_config: var_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
+        witness_cache_size: 32,
     }
 }
 

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -212,6 +212,7 @@ fn current_fixed_config(
         journal_config: fixed_log_config(suffix, pc),
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
+        witness_cache_size: 32,
     }
 }
 
@@ -225,6 +226,7 @@ fn current_variable_config(
         journal_config: variable_log_config(suffix, pc, ((), ())),
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
+        witness_cache_size: 32,
     }
 }
 

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -309,6 +309,14 @@ pub struct MerkleizedBatch<
 
     /// The canonical root (ops root + grafted root + partial chunk).
     pub(crate) canonical_root: D,
+
+    /// The `(ops_root, OpsRootWitness)` pair that authenticates `canonical_root` against
+    /// the ops tree. Present when this batch was produced by [`UnmerkleizedBatch::merkleize`]
+    /// (the components are already computed inline with `canonical_root`). `None` for batches
+    /// constructed via [`super::db::Db::to_batch`], which represent the current committed
+    /// state and have no in-flight commit to authenticate; the DB's witness cache already
+    /// holds an equivalent entry from when that state was committed.
+    pub(crate) ops_root_witness: Option<(D, crate::qmdb::current::proof::OpsRootWitness<F, D>)>,
 }
 
 impl<F, H, U, const N: usize, S: Strategy> UnmerkleizedBatch<F, H, U, N, S>
@@ -675,7 +683,10 @@ where
             Some((chunk, rem))
         }
     };
-    let canonical_root = compute_db_root::<F, H, _, _, N>(
+    let crate::qmdb::current::db::ComputedRoot {
+        root: canonical_root,
+        witness: ops_root_witness,
+    } = compute_db_root::<F, H, _, _, N>(
         &hasher,
         &bitmap_batch,
         &grafted_storage,
@@ -691,6 +702,7 @@ where
         grafted: grafted_batch,
         bitmap: bitmap_batch,
         canonical_root,
+        ops_root_witness: Some((ops_root, ops_root_witness)),
     }))
 }
 
@@ -910,6 +922,7 @@ where
             grafted,
             bitmap: BitmapBatch::Base(Arc::clone(&self.any.bitmap)),
             canonical_root: self.root,
+            ops_root_witness: None,
         })
     }
 }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -41,12 +41,16 @@ use commonware_runtime::telemetry::metrics::{
 };
 use commonware_utils::{
     bitmap::{self, Readable as _},
+    range::NonEmptyRange,
     sequence::prefixed_u64::U64,
     sync::AsyncMutex,
 };
 use core::{num::NonZeroU64, ops::Range};
 use futures::future::try_join_all;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    sync::Arc,
+};
 use tracing::{error, warn};
 
 /// Prefix used for the metadata key for grafted tree pinned nodes.
@@ -128,6 +132,93 @@ impl<E: Context> Metrics<E> {
     }
 }
 
+/// A recent committed target: the four pieces a sync client needs to bridge a trusted
+/// canonical root to a verified ops root. Constructed at commit time when the witness
+/// components are already computed for the canonical root.
+#[derive(Clone, Debug)]
+pub struct CachedTarget<F: merkle::Graftable, D: Digest> {
+    /// The canonical database root.
+    pub root: D,
+    /// The ops-tree root committed by `root`.
+    pub ops_root: D,
+    /// Witness binding `ops_root` to `root`.
+    pub witness: OpsRootWitness<F, D>,
+    /// Range of operation locations a sync client should request to reach this target.
+    pub range: NonEmptyRange<Location<F>>,
+}
+
+/// Bounded ring buffer mapping canonical roots to their authenticated sync targets.
+///
+/// Populated at every commit so a sync server can answer "do you have a witness for any
+/// of these trusted roots?" without recomputing historical state. The cache is a liveness
+/// optimization, not a trust anchor: clients verify each target's witness against their
+/// own trusted root before using it.
+#[derive(Debug)]
+pub(crate) struct WitnessCache<F: merkle::Graftable, D: Digest> {
+    by_root: HashMap<D, CachedTarget<F, D>>,
+    order: VecDeque<D>,
+    capacity: usize,
+}
+
+impl<F: merkle::Graftable, D: Digest> WitnessCache<F, D> {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            by_root: HashMap::with_capacity(capacity),
+            order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Insert (or refresh) a target. No-op when capacity is zero.
+    pub(crate) fn insert(&mut self, target: CachedTarget<F, D>) {
+        if self.capacity == 0 {
+            return;
+        }
+        let root = target.root;
+        if self.by_root.insert(root, target).is_none() {
+            self.order.push_back(root);
+        }
+        while self.order.len() > self.capacity {
+            if let Some(evicted) = self.order.pop_front() {
+                self.by_root.remove(&evicted);
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Return the first cached target whose root appears in `roots`, if any.
+    pub(crate) fn lookup(&self, roots: &[D]) -> Option<CachedTarget<F, D>> {
+        roots.iter().find_map(|r| self.by_root.get(r).cloned())
+    }
+
+    /// Drop every cached entry. Called on rewind: the chain forked, so older targets
+    /// describe a state that is no longer reachable on this branch.
+    pub(crate) fn clear(&mut self) {
+        self.by_root.clear();
+        self.order.clear();
+    }
+
+    /// Drop every cached entry whose `range.start` is below `boundary`. Called after pruning:
+    /// the server can no longer serve operations below `boundary`, so any cached target
+    /// pointing at a `start` below it is unservable.
+    pub(crate) fn evict_before(&mut self, boundary: Location<F>) {
+        let stale: Vec<D> = self
+            .by_root
+            .iter()
+            .filter(|(_, t)| t.range.start() < boundary)
+            .map(|(root, _)| *root)
+            .collect();
+        if stale.is_empty() {
+            return;
+        }
+        for root in &stale {
+            self.by_root.remove(root);
+        }
+        self.order.retain(|root| self.by_root.contains_key(root));
+    }
+}
+
 /// A Current QMDB implementation generic over ordered/unordered keys and variable/fixed values.
 pub struct Db<
     F: merkle::Graftable,
@@ -163,6 +254,10 @@ pub struct Db<
     /// The cached canonical root.
     /// See the [Root structure](super) section in the module documentation.
     pub(super) root: DigestOf<H>,
+
+    /// Bounded cache of `(canonical_root, ops_root, witness, range)` entries, populated at
+    /// every commit and at init. Sync clients query this cache via [`Db::cached_target`].
+    pub(super) witness_cache: WitnessCache<F, H::Digest>,
 
     /// Metrics for the Current layer.
     pub(super) metrics: Metrics<E>,
@@ -250,6 +345,17 @@ where
     /// Return a reference to the merkleization strategy.
     pub const fn strategy(&self) -> &S {
         &self.strategy
+    }
+
+    /// Return the first cached sync target whose canonical root appears in `trusted_roots`,
+    /// or `None` if no cached entry matches.
+    ///
+    /// This is the server-side entrypoint for sync clients that hold trusted canonical roots
+    /// from consensus. The cache holds the last `witness_cache_size` committed targets, plus
+    /// the current target seeded at init. Callers must still verify each returned target's
+    /// witness against the trusted root before driving sync.
+    pub fn cached_target(&self, trusted_roots: &[H::Digest]) -> Option<CachedTarget<F, H::Digest>> {
+        self.witness_cache.lookup(trusted_roots)
     }
 
     /// Returns the ops tree root.
@@ -460,6 +566,30 @@ where
         Location::new(pruned_chunks * chunk_bits)
     }
 
+    /// Insert the current `(root, ops_root, witness)` triple into the witness cache, using
+    /// the database's current `[sync_boundary, bounds.end)` as the target range.
+    ///
+    /// No-op when the cache capacity is zero or the range would be empty (e.g. an empty
+    /// database before any commits).
+    pub(crate) async fn cache_current_target(
+        &mut self,
+        ops_root: H::Digest,
+        witness: OpsRootWitness<F, H::Digest>,
+    ) {
+        let lower = self.sync_boundary();
+        let upper = self.bounds().await.end;
+        let Ok(range) = NonEmptyRange::new(lower..upper) else {
+            return;
+        };
+        let target = CachedTarget {
+            root: self.root,
+            ops_root,
+            witness,
+            range,
+        };
+        self.witness_cache.insert(target);
+    }
+
     /// Update Current-specific state gauges.
     pub(super) fn update_metrics(&self) {
         self.metrics.update(
@@ -572,6 +702,11 @@ where
         // Prune the bitmap to the sync boundary (most aggressive safe location).
         self.any.prune_bitmap(sync_boundary);
         self.prune_grafted_tree_to_bitmap()?;
+
+        // Drop cached sync targets that point at operations below the new prune boundary.
+        // The server can no longer serve those ranges, so handing them to a sync client
+        // would set up a `target_for_roots` hit that the engine immediately fails on.
+        self.witness_cache.evict_before(prune_loc);
 
         // Persist grafted tree pruning state before pruning the ops log. If the subsequent
         // `any.prune_log` fails, the metadata is ahead of the log, which is safe: on recovery,
@@ -691,7 +826,7 @@ where
         );
         let partial_chunk = partial_chunk(self.any.bitmap.as_ref());
         let ops_root = self.any.root();
-        let root = compute_db_root(
+        let ComputedRoot { root, witness } = compute_db_root(
             &hasher,
             self.any.bitmap.as_ref(),
             &storage,
@@ -704,6 +839,11 @@ where
 
         self.grafted_tree = grafted_tree;
         self.root = root;
+        // Rewind discards forward-of-rewind state: cached targets newer than the rewound
+        // size now describe a fork the server can no longer reach. Drop all of them; the
+        // call below re-seeds with the post-rewind current target.
+        self.witness_cache.clear();
+        self.cache_current_target(ops_root, witness).await;
         self.update_metrics();
 
         Ok(())
@@ -805,6 +945,9 @@ where
         let range = self.any.apply_batch(Arc::clone(&batch.inner)).await?;
         self.grafted_tree.apply_batch(&batch.grafted)?;
         self.root = batch.canonical_root;
+        if let Some((ops_root, witness)) = batch.ops_root_witness.clone() {
+            self.cache_current_target(ops_root, witness).await;
+        }
         self.update_metrics();
         Ok(range)
     }
@@ -944,7 +1087,14 @@ pub(super) fn combine_roots<H: Hasher>(
     }
 }
 
-/// Compute the canonical root digest of a [Db].
+/// The canonical root of a [Db], plus the witness binding it to the ops root.
+pub(super) struct ComputedRoot<F: merkle::Graftable, D: Digest> {
+    pub root: D,
+    pub witness: OpsRootWitness<F, D>,
+}
+
+/// Compute the canonical root digest of a [Db], along with the witness that authenticates
+/// `ops_root` against that root.
 ///
 /// See the [Root structure](super) section in the module documentation.
 ///
@@ -968,7 +1118,7 @@ pub(super) async fn compute_db_root<
     partial_chunk: Option<([u8; N], u64)>,
     inactivity_floor: Location<F>,
     ops_root: &H::Digest,
-) -> Result<H::Digest, Error<F>> {
+) -> Result<ComputedRoot<F, H::Digest>, Error<F>> {
     let grafted_root =
         compute_grafted_root(hasher, status, storage, ops_leaves, inactivity_floor).await?;
     let pending = pending_chunk::<F, B, N>(status, ops_leaves, grafting::height::<N>())?
@@ -977,13 +1127,22 @@ pub(super) async fn compute_db_root<
         let digest = hasher.digest(&chunk);
         (next_bit, digest)
     });
-    Ok(combine_roots(
+    let root = combine_roots(
         hasher,
         ops_root,
         &grafted_root,
         pending.as_ref(),
         partial.as_ref().map(|(nb, d)| (*nb, d)),
-    ))
+    );
+    let pending_chunk_digest: F::PendingChunk<H::Digest> = pending
+        .try_into()
+        .expect("pending_chunk must be consistent with family");
+    let witness = OpsRootWitness {
+        grafted_root,
+        pending_chunk_digest,
+        partial_chunk: partial,
+    };
+    Ok(ComputedRoot { root, witness })
 }
 
 /// Compute the root of the grafted structure represented by `storage`.

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -133,8 +133,8 @@ impl<E: Context> Metrics<E> {
 }
 
 /// A recent committed target: the four pieces a sync client needs to bridge a trusted
-/// canonical root to a verified ops root. Constructed at commit time when the witness
-/// components are already computed for the canonical root.
+/// canonical root to a verified ops root. Constructed whenever the database produces a
+/// canonical root — init (when non-empty), `apply_batch`, `rewind`, and the sync builder.
 #[derive(Clone, Debug)]
 pub struct CachedTarget<F: merkle::Graftable, D: Digest> {
     /// The canonical database root.
@@ -351,9 +351,10 @@ where
     /// or `None` if no cached entry matches.
     ///
     /// This is the server-side entrypoint for sync clients that hold trusted canonical roots
-    /// from consensus. The cache holds the last `witness_cache_size` committed targets, plus
-    /// the current target seeded at init. Callers must still verify each returned target's
-    /// witness against the trusted root before driving sync.
+    /// from consensus. The cache holds up to `witness_cache_size` recent committed targets,
+    /// including the init-seeded entry (when the database is non-empty). The init seed
+    /// counts against capacity and may be evicted by later commits. Callers must still
+    /// verify each returned target's witness against the trusted root before driving sync.
     pub fn cached_target(&self, trusted_roots: &[H::Digest]) -> Option<CachedTarget<F, H::Digest>> {
         self.witness_cache.lookup(trusted_roots)
     }
@@ -569,8 +570,11 @@ where
     /// Insert the current `(root, ops_root, witness)` triple into the witness cache, using
     /// the database's current `[sync_boundary, bounds.end)` as the target range.
     ///
-    /// No-op when the cache capacity is zero or the range would be empty (e.g. an empty
-    /// database before any commits).
+    /// No-op in either of two cases:
+    /// - The cache capacity is zero.
+    /// - The range would be empty (`sync_boundary == bounds.end`). This happens for a
+    ///   fresh database with no operations: there is nothing for a sync client to fetch,
+    ///   so no target is meaningful. The cache stays empty until the first commit.
     pub(crate) async fn cache_current_target(
         &mut self,
         ops_root: H::Digest,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -375,6 +375,12 @@ pub struct Config<T: Translator, J, S: Strategy> {
 
     /// The translator used by the compressed index.
     pub translator: T,
+
+    /// Number of recent `(canonical_root, target)` entries to retain in memory so a sync
+    /// server can answer queries against a trusted root the client received from consensus.
+    ///
+    /// Set to `0` to disable. Default `32`.
+    pub witness_cache_size: usize,
 }
 
 impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S> {
@@ -425,6 +431,7 @@ where
 
     let strategy = config.merkle_config.strategy.clone();
     let metadata_partition = config.grafted_metadata_partition.clone();
+    let witness_cache_size = config.witness_cache_size;
 
     // Load bitmap metadata (pruned_chunks + pinned nodes for the grafted tree).
     let (metadata, pruned_chunks, pinned_nodes) =
@@ -462,7 +469,7 @@ where
     );
     let partial_chunk = db::partial_chunk(any.bitmap.as_ref());
     let ops_root = any.root();
-    let root = db::compute_db_root(
+    let db::ComputedRoot { root, witness } = db::compute_db_root(
         &hasher,
         any.bitmap.as_ref(),
         &storage,
@@ -474,14 +481,17 @@ where
     .await?;
 
     let metrics = Metrics::new(context);
-    let db = db::Db {
+    let witness_cache = db::WitnessCache::new(witness_cache_size);
+    let mut db = db::Db {
         any,
         grafted_tree,
         metadata: AsyncMutex::new(metadata),
         strategy,
         root,
+        witness_cache,
         metrics,
     };
+    db.cache_current_target(ops_root, witness).await;
     db.update_metrics();
     Ok(db)
 }
@@ -563,6 +573,7 @@ pub mod tests {
             },
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
+            witness_cache_size: 32,
         }
     }
 
@@ -591,6 +602,7 @@ pub mod tests {
             },
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
+            witness_cache_size: 32,
         }
     }
 

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -971,7 +971,8 @@ mod tests {
             &ops_root,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .root;
 
         let loc = mmb::Location::new(BitMap::<N>::CHUNK_SIZE_BITS + 4);
         let proof = RangeProof::new(
@@ -1075,7 +1076,8 @@ mod tests {
             &ops_root,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .root;
         let proof = RangeProof::new(
             &hasher,
             &status,
@@ -1184,7 +1186,8 @@ mod tests {
             &ops_root,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .root;
 
         let leaves_loc = mmb::Location::new(leaf_count);
         let proof = RangeProof::new(
@@ -1282,7 +1285,8 @@ mod tests {
             &ops_root,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .root;
 
         let loc = mmb::Location::new(0);
         let mut proof = RangeProof::new(
@@ -1378,7 +1382,8 @@ mod tests {
             &ops_root,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .root;
 
         let proof = RangeProof::new(
             &hasher,
@@ -1765,7 +1770,8 @@ mod tests {
             &ops_root,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .root;
         let proof = RangeProof::new(
             &hasher,
             &status,
@@ -1906,7 +1912,8 @@ mod tests {
                 &ops_root,
             )
             .await
-            .unwrap();
+            .unwrap()
+            .root;
 
             // OpsRootWitness round-trip
             let pending_chunk_digest =
@@ -2073,7 +2080,8 @@ mod tests {
             &ops_root_pre,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .root;
 
         // Post-state canonical root.
         let mut status_post = BitMap::<N>::new();
@@ -2119,7 +2127,8 @@ mod tests {
             &ops_root_post,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .root;
 
         assert_ne!(
             canonical_pre, canonical_post,
@@ -2204,7 +2213,8 @@ mod tests {
             &ops_root,
         )
         .await
-        .unwrap();
+        .unwrap()
+        .root;
 
         let loc = mmb::Location::new(chunk_bits - 1);
         let proof = RangeProof::new(

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -129,11 +129,12 @@ impl<F: Graftable, D: Digest> From<db::CachedTarget<F, D>> for Target<F, D> {
 /// Resolver extension for `current` databases: query the server for a sync target whose
 /// canonical root appears in a set of trusted roots.
 ///
-/// The server's witness cache holds the last `witness_cache_size` committed targets plus
-/// the current target seeded at init. The client passes its recent trusted-root buffer
-/// (e.g., from consensus) and the server returns the first match, if any. Callers must
-/// still verify each returned target's witness against the trusted root before driving
-/// sync; the helper [`sync()`] in this module performs both checks.
+/// The server's witness cache holds up to `witness_cache_size` recent committed targets,
+/// including the init-seeded entry when the database is non-empty (the seed counts
+/// against capacity and may be evicted by later commits). The client passes its recent
+/// trusted-root buffer (e.g., from consensus) and the server returns the first match, if
+/// any. Callers must still verify each returned target's witness against the trusted
+/// root before driving sync; the helper [`sync()`] in this module performs both checks.
 pub trait CurrentResolver: qmdb_sync::Resolver
 where
     Self::Family: Graftable,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -1,32 +1,54 @@
 //! Synchronization logic for [crate::qmdb::current] databases.
 //!
-//! Contains implementation of the sync `Database` trait for all
+//! Contains the sync `Database` and `Resolver` trait implementations for all
 //! [Db](crate::qmdb::current::db::Db) variants (ordered/unordered, fixed/variable), plus a
-//! [sync()] wrapper for targets anchored by trusted database roots.
+//! [sync()] wrapper that drives the shared sync engine from a stream of trusted canonical
+//! roots.
 //!
-//! The database root of a `current` database combines the ops root, grafted root, and optional
-//! pending and partial chunk digests into a single hash (see the [Root structure](super) section in
-//! the module documentation). The shared sync engine operates on the **ops root** internally,
-//! downloading operations and verifying each batch against the ops root using ops-tree range proofs
-//! (identical to `any` sync).
+//! # Why this wrapper exists
 //!
-//! Callers that only trust a database root (e.g., from consensus) should use [sync()] with a
-//! [Target] that includes an [OpsRootWitness]. The wrapper verifies each target's witness before
-//! forwarding its ops root to the shared sync engine, then checks the reconstructed database root
-//! for the target the engine finishes on.
+//! A `current` database's canonical root commits to the ops root, the grafted root, and
+//! optional pending/partial chunk digests (see the [Root structure](super) section in the
+//! module documentation). The shared sync engine, however, verifies each operation batch
+//! against the **ops root** alone — not the canonical root — because the ops-tree range
+//! proof format is shared with `any` sync.
 //!
-//! After all operations are synced, the bitmap and grafted tree are reconstructed deterministically
-//! from the operations. The database root is then computed from the ops root, the reconstructed
-//! grafted root, and any pending or partial chunk digests.
+//! That leaves a gap: a client that only trusts a canonical root from consensus cannot
+//! drive the engine directly. It needs the ops root that the trusted canonical root
+//! commits to, plus an [`OpsRootWitness`] proving the binding. Only a node holding the
+//! live database state can produce that witness, and only for states it has committed.
 //!
-//! `Database::ops_root()` returns the ops root because that is what the sync engine verifies
-//! against. `Database::root()` returns the full database root.
+//! # API shape
 //!
-//! For pruned databases (`range.start > 0`), grafted pinned nodes for the pruned region are read
-//! directly from the ops tree after it is built. This works because of the zero-chunk identity: for
-//! all-zero bitmap chunks (which all pruned chunks are), the grafted leaf equals the ops subtree
-//! root, making the grafted tree structurally identical to the ops tree at and above the grafting
-//! height.
+//! - [`CurrentResolver`] extends [`qmdb_sync::Resolver`] with `target_for_roots`: the
+//!   client passes a set of trusted canonical roots and the server answers from a small
+//!   per-commit cache populated at [`Db::cache_current_target`](crate::qmdb::current::db::Db).
+//! - [`sync()`] takes a `trusted_root_rx: mpsc::Receiver<Digest>` (e.g., a stream of
+//!   finalized roots from consensus) and a `CurrentResolver`. It buffers recent trusted
+//!   roots and polls the resolver until a verified target is returned, then drives the
+//!   shared engine and continues forwarding matching updates as the chain advances.
+//! - Every returned target passes two gates before reaching the engine: **membership**
+//!   (target root is in the trusted buffer) and **witness verification**
+//!   (witness commits `ops_root` to `target.root`).
+//!
+//! # Liveness model
+//!
+//! Discovery and forward loops wake on either a new trusted root or a `target_poll_interval`
+//! tick. Polling guarantees progress under a quiet trusted-root stream: if the resolver's
+//! cache lags behind a buffered root, the wrapper retries on each tick. Closing the
+//! trusted-root stream while the buffer is non-empty switches the wrapper to poll-only
+//! mode; closing while the buffer is empty returns `TrustedStreamClosed`.
+//!
+//! # Engine completion
+//!
+//! After the engine downloads all operations, the bitmap and grafted tree are reconstructed
+//! deterministically. The wrapper recomputes the canonical root and rejects with
+//! `RootMismatch` if it differs from the latest accepted target's `root`.
+//!
+//! For pruned targets (`range.start > 0`), grafted pinned nodes for the pruned region are
+//! read directly from the ops tree via the zero-chunk identity: all-zero bitmap chunks
+//! produce a grafted leaf equal to the ops subtree root, making the grafted tree
+//! structurally identical to the ops tree at and above the grafting height.
 
 use crate::{
     index::Factory as IndexFactory,
@@ -69,7 +91,7 @@ use crate::{
         operation::{Committable, Key, Operation as _},
         sync::{
             self as qmdb_sync, engine::Config as EngineConfig, Database, DatabaseConfig,
-            DbResolver, EngineError,
+            EngineError,
         },
     },
     translator::Translator,
@@ -78,6 +100,7 @@ use crate::{
 use commonware_codec::{Codec, CodecShared, Encode, Read as CodecRead, ReadExt as _};
 use commonware_cryptography::{Digest, DigestOf, Hasher};
 use commonware_parallel::Strategy;
+use commonware_runtime::{Clock, Supervisor};
 use commonware_utils::{
     bitmap::Prunable as BitMap,
     channel::{mpsc, oneshot},
@@ -86,10 +109,43 @@ use commonware_utils::{
     Array,
 };
 use futures::future::{select, Either};
-use std::{num::NonZeroU64, sync::Arc};
+use std::{
+    collections::VecDeque,
+    future::Future,
+    num::{NonZeroU64, NonZeroUsize},
+    sync::Arc,
+    time::Duration,
+};
 
 #[cfg(test)]
 pub(crate) mod tests;
+
+impl<F: Graftable, D: Digest> From<db::CachedTarget<F, D>> for Target<F, D> {
+    fn from(t: db::CachedTarget<F, D>) -> Self {
+        Self::new(t.root, t.ops_root, t.witness, t.range)
+    }
+}
+
+/// Resolver extension for `current` databases: query the server for a sync target whose
+/// canonical root appears in a set of trusted roots.
+///
+/// The server's witness cache holds the last `witness_cache_size` committed targets plus
+/// the current target seeded at init. The client passes its recent trusted-root buffer
+/// (e.g., from consensus) and the server returns the first match, if any. Callers must
+/// still verify each returned target's witness against the trusted root before driving
+/// sync; the helper [`sync()`] in this module performs both checks.
+pub trait CurrentResolver: qmdb_sync::Resolver
+where
+    Self::Family: Graftable,
+{
+    /// Return the first cached target whose canonical root appears in `trusted_roots`,
+    /// or `None` if no entry matches. A cache miss is not an error.
+    #[allow(clippy::type_complexity)]
+    fn target_for_roots<'a>(
+        &'a self,
+        trusted_roots: &'a [Self::Digest],
+    ) -> impl Future<Output = Result<Option<Target<Self::Family, Self::Digest>>, Self::Error>> + Send + 'a;
+}
 
 /// Sync target for `current` databases, anchored by a trusted database root.
 ///
@@ -203,18 +259,41 @@ impl<F: Graftable, D: Digest> commonware_codec::Read for Target<F, D> {
     }
 }
 
-/// Configuration for syncing a `current` database from trusted database-root targets.
-pub struct Config<DB: Database, R: DbResolver<DB>>
-where
+/// Configuration for syncing a `current` database from trusted canonical roots.
+///
+/// The caller feeds a stream of canonical roots from consensus (or another trust source) via
+/// [`Config::trusted_root_rx`]. The wrapper buffers the most recent
+/// [`Config::trusted_root_buffer`] roots and queries `resolver` for a matching target on
+/// every new trusted root **and** on every `target_poll_interval` tick. The first match
+/// starts the engine; subsequent matches are forwarded as in-flight target updates.
+///
+/// Polling on a fixed interval guarantees progress even when the trusted-root stream goes
+/// silent (e.g., consensus is finalized but no new roots arrive) — without it, a resolver
+/// that lags behind the client's trusted set could stall sync indefinitely.
+pub struct Config<
+    DB: Database,
+    R: CurrentResolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
+> where
     DB::Family: Graftable,
     DB::Op: Encode,
 {
     /// Runtime context.
     pub context: DB::Context,
-    /// Resolver for fetching operations and proofs.
+    /// Resolver for fetching operations, proofs, and sync targets.
     pub resolver: R,
-    /// Sync target with trusted database root and witness.
-    pub target: Target<DB::Family, DB::Digest>,
+    /// Stream of trusted canonical roots (e.g., from consensus finalization).
+    pub trusted_root_rx: mpsc::Receiver<DB::Digest>,
+    /// Number of recent trusted roots to retry against on each resolver query. Must be > 0.
+    ///
+    /// Network resolvers silently cap the per-request payload at the wire-format limit
+    /// (typically 256). Setting this larger than the wire cap still works for local
+    /// resolvers but only the most-recent wire-cap entries are sent over the network on
+    /// each query.
+    pub trusted_root_buffer: NonZeroUsize,
+    /// Backoff between resolver queries when the trusted-root stream is idle. Queries are
+    /// also triggered immediately on every new trusted root. Must be > 0 to avoid a
+    /// busy-loop. Very small values may be quantized by the runtime scheduler.
+    pub target_poll_interval: Duration,
     /// Maximum parallel outstanding requests.
     pub max_outstanding_requests: usize,
     /// Maximum operations per fetch batch.
@@ -223,10 +302,6 @@ where
     pub apply_batch_size: usize,
     /// Database-specific configuration.
     pub db_config: DB::Config,
-    /// Channel for receiving target updates during sync.
-    ///
-    /// Each update must include a witness authenticating its ops root against its trusted root.
-    pub update_rx: Option<mpsc::Receiver<Target<DB::Family, DB::Digest>>>,
     /// Channel that requests sync completion once the current target is reached.
     pub finish_rx: Option<mpsc::Receiver<()>>,
     /// Channel to notify an observer when the current target is reached.
@@ -235,10 +310,99 @@ where
     pub max_retained_roots: usize,
 }
 
-/// Sync a `current` database from a trusted database root.
+/// Bounded FIFO of recent trusted canonical roots plus a `HashSet` for O(1) membership.
+struct TrustedRootBuffer<D: Digest> {
+    order: VecDeque<D>,
+    set: std::collections::HashSet<D>,
+    capacity: NonZeroUsize,
+}
+
+impl<D: Digest> TrustedRootBuffer<D> {
+    fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            order: VecDeque::with_capacity(capacity.get()),
+            set: std::collections::HashSet::with_capacity(capacity.get()),
+            capacity,
+        }
+    }
+
+    /// Insert `root`. Evicts the oldest entry when capacity is exceeded. No-op if already
+    /// present.
+    fn insert(&mut self, root: D) {
+        if !self.set.insert(root) {
+            return;
+        }
+        self.order.push_back(root);
+        while self.order.len() > self.capacity.get() {
+            if let Some(evicted) = self.order.pop_front() {
+                self.set.remove(&evicted);
+            }
+        }
+    }
+
+    fn contains(&self, root: &D) -> bool {
+        self.set.contains(root)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+
+    fn as_slice_vec(&self) -> Vec<D> {
+        // Most-recent first so resolvers honoring caller order check the freshest first.
+        self.order.iter().rev().copied().collect()
+    }
+}
+
+/// Ask `resolver` for a target whose root is in `trusted` and verify it.
 ///
-/// Verifies the initial target and any target update witnesses before giving them to the shared
-/// sync engine, then checks the reconstructed database root for the target the engine finishes on.
+/// Returns `Ok(Some(target))` only after passing two checks:
+/// 1. **Membership**: `target.root` is in `trusted`. A malicious resolver may return a
+///    self-consistent target for an untrusted root; the engine's end-of-sync `RootMismatch`
+///    check does not catch this, so the wrapper must.
+/// 2. **Witness**: `target.verify(&hasher)` succeeds (cryptographically binds `ops_root`).
+///
+/// A resolver `None` is `Ok(None)` (cache miss). A resolver error propagates.
+/// A returned target failing either check returns `Err(OpsRootWitnessInvalid)`.
+async fn next_verified_target<F, D, R, H>(
+    resolver: &R,
+    trusted: &TrustedRootBuffer<D>,
+    hasher: &StandardHasher<H>,
+) -> Result<Option<Target<F, D>>, qmdb_sync::Error<F, R::Error, D>>
+where
+    F: Graftable,
+    D: Digest,
+    H: commonware_cryptography::Hasher<Digest = D>,
+    R: CurrentResolver<Family = F, Digest = D>,
+{
+    let roots = trusted.as_slice_vec();
+    if roots.is_empty() {
+        return Ok(None);
+    }
+    let target = match resolver
+        .target_for_roots(&roots)
+        .await
+        .map_err(qmdb_sync::Error::Resolver)?
+    {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+    if !trusted.contains(&target.root) {
+        tracing::warn!("resolver returned target for untrusted root");
+        return Err(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid));
+    }
+    if !target.verify(hasher) {
+        tracing::warn!("resolver returned target with invalid witness");
+        return Err(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid));
+    }
+    Ok(Some(target))
+}
+
+/// Sync a `current` database from a stream of trusted canonical roots.
+///
+/// The wrapper buffers recent trusted roots and queries `resolver` for matches. The first
+/// verified match (passing membership + witness checks) starts the engine; subsequent matches
+/// that strictly advance the current target are forwarded as engine updates.
 pub async fn sync<DB, R>(
     config: Config<DB, R>,
 ) -> Result<DB, qmdb_sync::Error<DB::Family, R::Error, DB::Digest>>
@@ -246,34 +410,73 @@ where
     DB: Database,
     DB::Family: Graftable,
     DB::Op: Encode,
-    R: DbResolver<DB>,
+    R: CurrentResolver<Family = DB::Family, Op = DB::Op, Digest = DB::Digest>,
 {
     let hasher = qmdb::hasher::<DB::Hasher>();
-
-    if !config.target.verify(&hasher) {
-        return Err(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid));
+    let mut trusted_root_rx = config.trusted_root_rx;
+    let resolver = config.resolver;
+    if config.target_poll_interval.is_zero() {
+        return Err(qmdb_sync::Error::Engine(EngineError::InvalidConfig(
+            "target_poll_interval must be > 0",
+        )));
     }
-    let update_rx = config.update_rx;
+    let poll_interval = config.target_poll_interval;
 
-    // The caller controls the public update channel capacity. Once updates reach this wrapper,
-    // keep the internal queue shallow so verified current targets cannot get far ahead of the
-    // target the shared sync engine has consumed.
-    let (engine_update_tx, engine_update_rx) = if update_rx.is_some() {
-        let (tx, rx) = mpsc::channel(1);
-        (Some(tx), Some(rx))
-    } else {
-        (None, None)
+    // Take an owned clock handle BEFORE moving `config.context` into the engine. Both the
+    // discovery loop (this function's body) and the forward task (spawned later via
+    // `select` in the same task) need to call `sleep`, but the engine consumes the
+    // primary context. `Supervisor::child` (via `Metrics: Supervisor`) returns a fresh
+    // child handle from `&self`, so we get a clock without requiring `Context: Clone`.
+    let poll_clock = config.context.child("current_sync_poll");
+
+    // Discovery phase: pull trusted roots, queried on each new root or `poll_interval`
+    // tick (whichever first), until the resolver returns a matching target.
+    //
+    // Channel-close handling: if the trusted-root stream closes while the buffer already
+    // holds roots, switch to poll-only mode — the resolver may catch up later and produce
+    // a match against the buffered roots. Only return `TrustedStreamClosed` when the
+    // channel closes AND the buffer is empty (we have nothing to match against).
+    let mut trusted = TrustedRootBuffer::<DB::Digest>::new(config.trusted_root_buffer);
+    let mut stream_closed = false;
+    let initial_target = loop {
+        if stream_closed {
+            // Buffer is non-empty (we checked at close); just poll.
+            poll_clock.sleep(poll_interval).await;
+        } else {
+            let recv_fut = trusted_root_rx.recv();
+            let sleep_fut = poll_clock.sleep(poll_interval);
+            futures::pin_mut!(recv_fut);
+            futures::pin_mut!(sleep_fut);
+            match select(recv_fut, sleep_fut).await {
+                Either::Left((Some(root), _)) => trusted.insert(root),
+                Either::Left((None, _)) => {
+                    if trusted.is_empty() {
+                        return Err(qmdb_sync::Error::Engine(EngineError::TrustedStreamClosed));
+                    }
+                    stream_closed = true;
+                }
+                Either::Right(_) => {} // poll tick: re-query the resolver with the current buffer
+            }
+        }
+        if let Some(t) =
+            next_verified_target::<_, _, _, DB::Hasher>(&resolver, &trusted, &hasher).await?
+        {
+            break t;
+        }
     };
 
-    let engine_config = EngineConfig {
+    // Build the engine, with an internal update channel of capacity 1: the wrapper-side
+    // discovery loop will push at most one in-flight target ahead of the engine at any time.
+    let (engine_update_tx, engine_update_rx) = mpsc::channel::<Target<DB::Family, DB::Digest>>(1);
+    let engine_config: EngineConfig<DB, R, Target<DB::Family, DB::Digest>> = EngineConfig {
         context: config.context,
-        resolver: config.resolver,
-        target: config.target,
+        resolver: resolver.clone(),
+        target: initial_target.clone(),
         max_outstanding_requests: config.max_outstanding_requests,
         fetch_batch_size: config.fetch_batch_size,
         apply_batch_size: config.apply_batch_size,
         db_config: config.db_config,
-        update_rx: engine_update_rx,
+        update_rx: Some(engine_update_rx),
         finish_rx: config.finish_rx,
         reached_target_tx: config.reached_target_tx,
         max_retained_roots: config.max_retained_roots,
@@ -282,31 +485,78 @@ where
     let engine = qmdb_sync::Engine::new(engine_config).await?;
     let engine_fut = Box::pin(engine.sync_with_target());
 
-    let (database, final_target) = if let Some(mut update_rx) = update_rx {
-        let update_tx = engine_update_tx.expect("engine update sender must exist");
-        let forward_fut = Box::pin(async {
-            let update_tx = update_tx;
-            while let Some(current_target) = update_rx.recv().await {
-                if !current_target.verify(&hasher) {
-                    tracing::warn!("target update witness verification failed");
-                    return Err(qmdb_sync::Error::Engine(EngineError::OpsRootWitnessInvalid));
-                }
-                if update_tx.send(current_target).await.is_err() {
-                    break;
+    // Continue feeding trusted roots and forwarding strictly-forward matches as engine
+    // updates while the engine runs.
+    //
+    // Channel-close handling mirrors the discovery loop: if the stream closes while the
+    // buffer holds roots, keep polling — a buffered trusted root may still match a future
+    // resolver state and produce a forward update. The forward task exits naturally when
+    // (a) the engine completes and the wrapping `select` drops this future, or (b) the
+    // engine update channel is closed (`engine_update_tx.send` returns Err).
+    let mut last_accepted = initial_target;
+    let forward_fut = Box::pin(async move {
+        type ForwardResult<DB, R> = Result<
+            (),
+            qmdb_sync::Error<
+                <DB as Database>::Family,
+                <R as qmdb_sync::Resolver>::Error,
+                <DB as Database>::Digest,
+            >,
+        >;
+        let result: ForwardResult<DB, R> = loop {
+            if stream_closed {
+                poll_clock.sleep(poll_interval).await;
+            } else {
+                let recv_fut = trusted_root_rx.recv();
+                let sleep_fut = poll_clock.sleep(poll_interval);
+                futures::pin_mut!(recv_fut);
+                futures::pin_mut!(sleep_fut);
+                match select(recv_fut, sleep_fut).await {
+                    Either::Left((Some(root), _)) => trusted.insert(root),
+                    Either::Left((None, _)) => {
+                        if trusted.is_empty() {
+                            break Ok(()); // nothing more to forward
+                        }
+                        stream_closed = true;
+                    }
+                    Either::Right(_) => {} // poll tick: re-query and continue
                 }
             }
-            Ok(())
-        });
-        let result = match select(engine_fut, forward_fut).await {
-            Either::Left((result, _)) => result?,
-            Either::Right((forward_result, engine_fut)) => {
-                forward_result?;
-                engine_fut.await?
+            let candidate =
+                match next_verified_target::<_, _, _, DB::Hasher>(&resolver, &trusted, &hasher)
+                    .await
+                {
+                    Ok(Some(t)) => t,
+                    Ok(None) => continue,
+                    Err(e) => break Err(e),
+                };
+            // Wrapper-level non-forward filter: mirror `qmdb_sync::target::validate_update`
+            // and drop anything that would fail it, so the engine never sees a hard error
+            // from a stale-but-valid target. The conditions match validate_update exactly:
+            //   - start moves backward
+            //   - end fails to strictly advance
+            //   - ops_root is unchanged
+            if candidate.range.start() < last_accepted.range.start()
+                || candidate.range.end() <= last_accepted.range.end()
+                || candidate.ops_root == last_accepted.ops_root
+            {
+                continue;
             }
+            if engine_update_tx.send(candidate.clone()).await.is_err() {
+                // Engine dropped its receiver: it has finished. Stop forwarding.
+                break Ok(());
+            }
+            last_accepted = candidate;
         };
         result
-    } else {
-        engine_fut.await?
+    });
+
+    let (database, final_target) = match select(engine_fut, forward_fut).await {
+        Either::Left((result, _)) => result?,
+        Either::Right((forward_result, engine_fut)) => {
+            forward_result?;
+            engine_fut.await?
+        }
     };
 
     let expected = final_target.root;
@@ -347,6 +597,7 @@ async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
     apply_batch_size: usize,
     metadata_partition: String,
     strategy: S,
+    witness_cache_size: usize,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, qmdb::Error<F>>
 where
     F: Graftable,
@@ -434,8 +685,8 @@ where
     )
     .await?;
 
-    // Compute the database root. The grafted root is deterministic from the ops
-    // (which are authenticated by the engine) and the bitmap (which is deterministic
+    // Compute the database root and the witness binding the ops root to it. The grafted root
+    // is deterministic from the ops (authenticated by the engine) and the bitmap (deterministic
     // from the ops).
     let storage = grafting::Storage::new(
         &grafted_tree,
@@ -444,29 +695,17 @@ where
         hasher.clone(),
     );
     let partial = db::partial_chunk(any.bitmap.as_ref());
-    let grafted_root = db::compute_grafted_root(
+    let ops_root = any.root();
+    let db::ComputedRoot { root, witness } = db::compute_db_root::<F, H, _, _, N>(
         &hasher,
         any.bitmap.as_ref(),
         &storage,
         ops_leaves,
+        partial,
         any.inactivity_floor_loc,
+        &ops_root,
     )
     .await?;
-    let ops_root = any.root();
-    let partial_digest = partial.map(|(chunk, next_bit)| {
-        let digest = hasher.digest(&chunk);
-        (next_bit, digest)
-    });
-    let pending_digest =
-        db::pending_chunk::<F, _, N>(any.bitmap.as_ref(), ops_leaves, grafting::height::<N>())?
-            .map(|chunk| hasher.digest(&chunk));
-    let root = db::combine_roots(
-        &hasher,
-        &ops_root,
-        &grafted_root,
-        pending_digest.as_ref(),
-        partial_digest.as_ref().map(|(nb, d)| (*nb, d)),
-    );
 
     // Initialize metadata store and construct the Db.
     let (metadata, _, _) =
@@ -474,14 +713,17 @@ where
             .await?;
 
     let metrics = db::Metrics::new(context);
-    let current_db = db::Db {
+    let witness_cache = db::WitnessCache::new(witness_cache_size);
+    let mut current_db = db::Db {
         any,
         grafted_tree,
         metadata: AsyncMutex::new(metadata),
         strategy,
         root,
+        witness_cache,
         metrics,
     };
+    current_db.cache_current_target(ops_root, witness).await;
     current_db.update_metrics();
 
     // Persist metadata so the db can be reopened with init_fixed/init_variable.
@@ -528,6 +770,7 @@ macro_rules! impl_current_sync_database {
                 let metadata_partition = config.grafted_metadata_partition.clone();
                 let strategy = config.merkle_config.strategy.clone();
                 let translator = config.translator.clone();
+                let witness_cache_size = config.witness_cache_size;
                 build_db::<F, _, $update<K, V>, _, H, _, T, N, _>(
                     context,
                     merkle_config,
@@ -538,6 +781,7 @@ macro_rules! impl_current_sync_database {
                     apply_batch_size,
                     metadata_partition,
                     strategy,
+                    witness_cache_size,
                 )
                 .await
             }
@@ -773,6 +1017,95 @@ macro_rules! impl_current_resolver {
                     success_tx: oneshot::channel().0,
                     pinned_nodes,
                 })
+            }
+        }
+
+        impl<F, E, K, V, H, T, const N: usize, S> CurrentResolver
+            for std::sync::Arc<$db<F, E, K, V, H, T, N, S>>
+        where
+            F: Graftable,
+            E: Context,
+            K: $key_bound,
+            V: $val_bound + Send + Sync + 'static,
+            H: Hasher,
+            T: Translator + Send + Sync + 'static,
+            T::Key: Send + Sync,
+            S: Strategy,
+            $($($where_extra)+)?
+        {
+            fn target_for_roots<'a>(
+                &'a self,
+                trusted_roots: &'a [H::Digest],
+            ) -> impl std::future::Future<
+                    Output = Result<Option<Target<F, H::Digest>>, qmdb::Error<F>>,
+                > + Send
+                  + 'a {
+                async move {
+                    Ok(self.cached_target(trusted_roots).map(Into::into))
+                }
+            }
+        }
+
+        impl<F, E, K, V, H, T, const N: usize, S> CurrentResolver
+            for std::sync::Arc<
+                commonware_utils::sync::AsyncRwLock<
+                    $db<F, E, K, V, H, T, N, S>,
+                >,
+            >
+        where
+            F: Graftable,
+            E: Context,
+            K: $key_bound,
+            V: $val_bound + Send + Sync + 'static,
+            H: Hasher,
+            T: Translator + Send + Sync + 'static,
+            T::Key: Send + Sync,
+            S: Strategy,
+            $($($where_extra)+)?
+        {
+            fn target_for_roots<'a>(
+                &'a self,
+                trusted_roots: &'a [H::Digest],
+            ) -> impl std::future::Future<
+                    Output = Result<Option<Target<F, H::Digest>>, qmdb::Error<F>>,
+                > + Send
+                  + 'a {
+                async move {
+                    let db = self.read().await;
+                    Ok(db.cached_target(trusted_roots).map(Into::into))
+                }
+            }
+        }
+
+        impl<F, E, K, V, H, T, const N: usize, S> CurrentResolver
+            for std::sync::Arc<
+                commonware_utils::sync::AsyncRwLock<
+                    Option<$db<F, E, K, V, H, T, N, S>>,
+                >,
+            >
+        where
+            F: Graftable,
+            E: Context,
+            K: $key_bound,
+            V: $val_bound + Send + Sync + 'static,
+            H: Hasher,
+            T: Translator + Send + Sync + 'static,
+            T::Key: Send + Sync,
+            S: Strategy,
+            $($($where_extra)+)?
+        {
+            fn target_for_roots<'a>(
+                &'a self,
+                trusted_roots: &'a [H::Digest],
+            ) -> impl std::future::Future<
+                    Output = Result<Option<Target<F, H::Digest>>, qmdb::Error<F>>,
+                > + Send
+                  + 'a {
+                async move {
+                    let guard = self.read().await;
+                    let db = guard.as_ref().ok_or(qmdb::Error::<F>::KeyNotFound)?;
+                    Ok(db.cached_target(trusted_roots).map(Into::into))
+                }
             }
         }
     };

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -1463,8 +1463,11 @@ mod root_sync {
             let init_root = target_db.root();
             assert!(target_db.cached_target(&[init_root]).is_some());
 
-            // Apply enough distinct writes so multiple chunks complete and sync_boundary > 0.
-            // CHUNK_SIZE_BITS is N * 8 = 256 here.
+            // Apply enough operations so multiple bitmap chunks complete and the
+            // `sync_boundary` advances past zero. CHUNK_SIZE_BITS is `N * 8 = 256`, so
+            // ~400 commits is comfortably more than one full chunk. Keys cycle through
+            // 256 distinct u8 patterns (rounds 256..399 overwrite earlier keys) — fine
+            // for the test, which only cares about the operation count.
             for round in 0..400u64 {
                 let key = Digest::from([(round & 0xFF) as u8; 32]);
                 apply_round(&mut target_db, key, round).await;

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -904,23 +904,27 @@ mod root_sync {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
             let target_db = build_target_db(&mut context).await;
-            let target = make_current_target(&target_db).await;
-            let root = target.root;
+            let root = target_db.root();
 
             let client_suffix = context.next_u64().to_string();
             let client_config =
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
 
             let target_db = std::sync::Arc::new(target_db);
+            let (trusted_tx, trusted_rx) = commonware_utils::channel::mpsc::channel(4);
+            trusted_tx.send(root).await.unwrap();
+            drop(trusted_tx);
+
             let synced_db: Db = current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
-                target,
+                trusted_root_rx: trusted_rx,
+                trusted_root_buffer: std::num::NonZeroUsize::new(8).unwrap(),
+                target_poll_interval: std::time::Duration::from_millis(1),
                 max_outstanding_requests: 4,
                 fetch_batch_size: NZU64!(64),
                 apply_batch_size: 1024,
                 db_config: client_config,
-                update_rx: None,
                 finish_rx: None,
                 reached_target_tx: None,
                 max_retained_roots: 8,
@@ -941,20 +945,20 @@ mod root_sync {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
             let mut target_db = build_target_db(&mut context).await;
-            let initial_target = make_current_target(&target_db).await;
+            let initial_root = target_db.root();
 
             let key = Digest::from([7u8; 32]);
             for round in 10..20u64 {
                 apply_round(&mut target_db, key, round).await;
             }
             target_db.sync().await.unwrap();
-            let updated_target = make_current_target(&target_db).await;
-            let expected_root = updated_target.root;
+            let updated_root = target_db.root();
 
-            let (update_sender, update_receiver) = commonware_utils::channel::mpsc::channel(1);
+            let (trusted_tx, trusted_rx) = commonware_utils::channel::mpsc::channel(4);
             let (finish_sender, finish_receiver) = commonware_utils::channel::mpsc::channel(1);
-            update_sender.send(updated_target).await.unwrap();
-            drop(update_sender);
+            trusted_tx.send(initial_root).await.unwrap();
+            trusted_tx.send(updated_root).await.unwrap();
+            drop(trusted_tx);
             context.child("finish").spawn(move |context| async move {
                 context.sleep(std::time::Duration::from_millis(1)).await;
                 finish_sender.send(()).await.unwrap();
@@ -968,12 +972,13 @@ mod root_sync {
             let synced_db: Db = current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
-                target: initial_target,
+                trusted_root_rx: trusted_rx,
+                trusted_root_buffer: std::num::NonZeroUsize::new(8).unwrap(),
+                target_poll_interval: std::time::Duration::from_millis(1),
                 max_outstanding_requests: 1,
                 fetch_batch_size: NZU64!(1),
                 apply_batch_size: 1024,
                 db_config: client_config,
-                update_rx: Some(update_receiver),
                 finish_rx: Some(finish_receiver),
                 reached_target_tx: None,
                 max_retained_roots: 8,
@@ -981,12 +986,133 @@ mod root_sync {
             .await
             .unwrap();
 
-            assert_eq!(synced_db.root(), expected_root);
+            assert_eq!(synced_db.root(), updated_root);
 
             synced_db.destroy().await.unwrap();
             let target_db = std::sync::Arc::into_inner(target_db).unwrap();
             target_db.destroy().await.unwrap();
         });
+    }
+
+    /// A resolver wrapper that delegates `get_operations` to an inner `Arc<Db>` but lets the
+    /// test inject a custom `target_for_roots` response. Useful for testing the wrapper's
+    /// trust gates (membership + witness checks) against malicious resolver behavior.
+    #[derive(Clone)]
+    struct AdversarialResolver {
+        inner: std::sync::Arc<Db>,
+        /// What to return from `target_for_roots`. `None` reflects a real cache miss; `Some`
+        /// is what the adversary serves regardless of the trusted roots passed in.
+        served: std::sync::Arc<
+            commonware_utils::sync::AsyncMutex<
+                Option<crate::qmdb::current::sync::Target<mmr::Family, Digest>>,
+            >,
+        >,
+    }
+
+    impl crate::qmdb::sync::Resolver for AdversarialResolver {
+        type Family = mmr::Family;
+        type Digest = Digest;
+        type Op = <std::sync::Arc<Db> as crate::qmdb::sync::Resolver>::Op;
+        type Error = qmdb::Error<mmr::Family>;
+
+        async fn get_operations(
+            &self,
+            op_count: crate::merkle::Location<mmr::Family>,
+            start_loc: crate::merkle::Location<mmr::Family>,
+            max_ops: std::num::NonZeroU64,
+            include_pinned_nodes: bool,
+            cancel_rx: commonware_utils::channel::oneshot::Receiver<()>,
+        ) -> Result<crate::qmdb::sync::FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error>
+        {
+            crate::qmdb::sync::Resolver::get_operations(
+                &self.inner,
+                op_count,
+                start_loc,
+                max_ops,
+                include_pinned_nodes,
+                cancel_rx,
+            )
+            .await
+        }
+    }
+
+    impl current_sync::CurrentResolver for AdversarialResolver {
+        async fn target_for_roots(
+            &self,
+            _trusted_roots: &[Digest],
+        ) -> Result<Option<crate::qmdb::current::sync::Target<mmr::Family, Digest>>, Self::Error>
+        {
+            let guard = self.served.lock().await;
+            Ok(guard.clone())
+        }
+    }
+
+    /// Resolver that returns `None` from `target_for_roots` for the first `lag` calls,
+    /// then delegates to the inner `Arc<Db>`'s real cache. Simulates a resolver whose
+    /// commit cache is behind the client's trusted-root buffer — exactly what
+    /// `target_poll_interval` is meant to handle.
+    #[derive(Clone)]
+    struct LaggingResolver {
+        inner: std::sync::Arc<Db>,
+        remaining_lag: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl LaggingResolver {
+        fn new(inner: std::sync::Arc<Db>, lag: usize) -> Self {
+            Self {
+                inner,
+                remaining_lag: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(lag)),
+            }
+        }
+    }
+
+    impl crate::qmdb::sync::Resolver for LaggingResolver {
+        type Family = mmr::Family;
+        type Digest = Digest;
+        type Op = <std::sync::Arc<Db> as crate::qmdb::sync::Resolver>::Op;
+        type Error = qmdb::Error<mmr::Family>;
+
+        async fn get_operations(
+            &self,
+            op_count: crate::merkle::Location<mmr::Family>,
+            start_loc: crate::merkle::Location<mmr::Family>,
+            max_ops: std::num::NonZeroU64,
+            include_pinned_nodes: bool,
+            cancel_rx: commonware_utils::channel::oneshot::Receiver<()>,
+        ) -> Result<crate::qmdb::sync::FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error>
+        {
+            crate::qmdb::sync::Resolver::get_operations(
+                &self.inner,
+                op_count,
+                start_loc,
+                max_ops,
+                include_pinned_nodes,
+                cancel_rx,
+            )
+            .await
+        }
+    }
+
+    impl current_sync::CurrentResolver for LaggingResolver {
+        async fn target_for_roots(
+            &self,
+            trusted_roots: &[Digest],
+        ) -> Result<Option<crate::qmdb::current::sync::Target<mmr::Family, Digest>>, Self::Error>
+        {
+            // Decrement and probe atomically; non-zero means we're still lagging.
+            let prev = self
+                .remaining_lag
+                .fetch_update(
+                    std::sync::atomic::Ordering::Relaxed,
+                    std::sync::atomic::Ordering::Relaxed,
+                    |v| if v > 0 { Some(v - 1) } else { Some(0) },
+                )
+                .unwrap_or(0);
+            if prev > 0 {
+                return Ok(None);
+            }
+            Ok(self.inner.cached_target(trusted_roots).map(Into::into))
+        }
     }
 
     #[test_traced("INFO")]
@@ -1005,16 +1131,29 @@ mod root_sync {
             let client_config =
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
 
-            let target_db = std::sync::Arc::new(target_db);
+            let target_db_arc = std::sync::Arc::new(target_db);
+            // Trust the (tampered) target's root: the witness check should still reject the
+            // returned target because the witness no longer hashes to that root.
+            let trusted_root = target.root;
+            let resolver = AdversarialResolver {
+                inner: target_db_arc.clone(),
+                served: std::sync::Arc::new(commonware_utils::sync::AsyncMutex::new(Some(target))),
+            };
+
+            let (trusted_tx, trusted_rx) = commonware_utils::channel::mpsc::channel(4);
+            trusted_tx.send(trusted_root).await.unwrap();
+            drop(trusted_tx);
+
             let result: Result<Db, _> = current_sync::sync(current_sync::Config {
                 context: context.child("client"),
-                resolver: target_db.clone(),
-                target,
+                resolver,
+                trusted_root_rx: trusted_rx,
+                trusted_root_buffer: std::num::NonZeroUsize::new(8).unwrap(),
+                target_poll_interval: std::time::Duration::from_millis(1),
                 max_outstanding_requests: 4,
                 fetch_batch_size: NZU64!(64),
                 apply_batch_size: 1024,
                 db_config: client_config,
-                update_rx: None,
                 finish_rx: None,
                 reached_target_tx: None,
                 max_retained_roots: 8,
@@ -1028,49 +1167,52 @@ mod root_sync {
                 ))
             ));
 
-            let target_db = std::sync::Arc::into_inner(target_db).unwrap();
+            let target_db = std::sync::Arc::into_inner(target_db_arc).unwrap();
             target_db.destroy().await.unwrap();
         });
     }
 
     #[test_traced("INFO")]
-    fn test_root_sync_rejects_invalid_update_witness() {
+    fn test_root_sync_rejects_untrusted_root() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
-            let mut target_db = build_target_db(&mut context).await;
-            let initial_target = make_current_target(&target_db).await;
-
-            let key = Digest::from([7u8; 32]);
-            for round in 10..20u64 {
-                apply_round(&mut target_db, key, round).await;
-            }
-            target_db.sync().await.unwrap();
-            let mut updated_target = make_current_target(&target_db).await;
-            updated_target.witness = OpsRootWitness {
-                grafted_root: Digest::from([0xFFu8; 32]),
-                ..updated_target.witness
-            };
-
-            let (update_sender, update_receiver) = commonware_utils::channel::mpsc::channel(1);
-            let (_finish_sender, finish_receiver) = commonware_utils::channel::mpsc::channel(1);
-            update_sender.send(updated_target).await.unwrap();
-            drop(update_sender);
+            let target_db = build_target_db(&mut context).await;
+            let real_target = make_current_target(&target_db).await;
 
             let client_suffix = context.next_u64().to_string();
             let client_config =
                 variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
-            let target_db = std::sync::Arc::new(target_db);
+
+            let target_db_arc = std::sync::Arc::new(target_db);
+
+            // Adversary returns a self-consistent target (witness valid against its own root),
+            // but the root is NOT in the client's trusted set. The wrapper must reject this
+            // via the membership check; the engine's end-of-sync `RootMismatch` check is too
+            // late to catch it (the engine would happily sync to the resolver's root).
+            let resolver = AdversarialResolver {
+                inner: target_db_arc.clone(),
+                served: std::sync::Arc::new(commonware_utils::sync::AsyncMutex::new(Some(
+                    real_target.clone(),
+                ))),
+            };
+
+            // Trust a completely different root.
+            let trusted_root = Digest::from([0xAAu8; 32]);
+            let (trusted_tx, trusted_rx) = commonware_utils::channel::mpsc::channel(4);
+            trusted_tx.send(trusted_root).await.unwrap();
+            drop(trusted_tx);
 
             let result: Result<Db, _> = current_sync::sync(current_sync::Config {
                 context: context.child("client"),
-                resolver: target_db.clone(),
-                target: initial_target,
-                max_outstanding_requests: 1,
-                fetch_batch_size: NZU64!(1),
+                resolver,
+                trusted_root_rx: trusted_rx,
+                trusted_root_buffer: std::num::NonZeroUsize::new(8).unwrap(),
+                target_poll_interval: std::time::Duration::from_millis(1),
+                max_outstanding_requests: 4,
+                fetch_batch_size: NZU64!(64),
                 apply_batch_size: 1024,
                 db_config: client_config,
-                update_rx: Some(update_receiver),
-                finish_rx: Some(finish_receiver),
+                finish_rx: None,
                 reached_target_tx: None,
                 max_retained_roots: 8,
             })
@@ -1082,19 +1224,121 @@ mod root_sync {
                     crate::qmdb::sync::EngineError::OpsRootWitnessInvalid
                 ))
             ));
+            assert_ne!(real_target.root, trusted_root);
+
+            let target_db = std::sync::Arc::into_inner(target_db_arc).unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    /// `target_poll_interval = 0` must be rejected at sync entry rather than busy-looping.
+    #[test_traced("INFO")]
+    fn test_sync_rejects_zero_poll_interval() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let target_db = build_target_db(&mut context).await;
+            let target_db = std::sync::Arc::new(target_db);
+            let (_trusted_tx, trusted_rx) = commonware_utils::channel::mpsc::channel(1);
+            let client_suffix = context.next_u64().to_string();
+            let client_config =
+                variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+
+            let result: Result<Db, _> = current_sync::sync(current_sync::Config {
+                context: context.child("client"),
+                resolver: target_db.clone(),
+                trusted_root_rx: trusted_rx,
+                trusted_root_buffer: std::num::NonZeroUsize::new(8).unwrap(),
+                target_poll_interval: std::time::Duration::ZERO,
+                max_outstanding_requests: 4,
+                fetch_batch_size: NZU64!(64),
+                apply_batch_size: 1024,
+                db_config: client_config,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            })
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(crate::qmdb::sync::Error::Engine(
+                    crate::qmdb::sync::EngineError::InvalidConfig(_)
+                ))
+            ));
 
             let target_db = std::sync::Arc::into_inner(target_db).unwrap();
             target_db.destroy().await.unwrap();
         });
     }
 
-    /// Verify that closing the caller's update channel while the engine is waiting
-    /// for updates (with finish_rx) allows the engine to eventually complete.
-    /// This exercises the Either::Right path in the forwarding select: the forward
-    /// future exits, update_tx must be dropped so the engine sees
-    /// UpdateChannelClosed, and then finish completes sync.
+    /// Closing the trusted-root stream before any match yields `TrustedStreamClosed`,
+    /// not the previous (misleading) `OpsRootWitnessInvalid`.
     #[test_traced("INFO")]
-    fn test_root_sync_update_channel_close_unblocks_engine() {
+    fn test_sync_closed_trusted_stream_returns_dedicated_error() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let target_db = build_target_db(&mut context).await;
+            let target_db = std::sync::Arc::new(target_db);
+            let (trusted_tx, trusted_rx) = commonware_utils::channel::mpsc::channel(1);
+            drop(trusted_tx); // close immediately
+
+            let client_suffix = context.next_u64().to_string();
+            let client_config =
+                variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+
+            let result: Result<Db, _> = current_sync::sync(current_sync::Config {
+                context: context.child("client"),
+                resolver: target_db.clone(),
+                trusted_root_rx: trusted_rx,
+                trusted_root_buffer: std::num::NonZeroUsize::new(8).unwrap(),
+                target_poll_interval: std::time::Duration::from_millis(1),
+                max_outstanding_requests: 4,
+                fetch_batch_size: NZU64!(64),
+                apply_batch_size: 1024,
+                db_config: client_config,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            })
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(crate::qmdb::sync::Error::Engine(
+                    crate::qmdb::sync::EngineError::TrustedStreamClosed
+                ))
+            ));
+
+            let target_db = std::sync::Arc::into_inner(target_db).unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    /// Init seeding: a freshly opened DB exposes its current root via `cached_target`
+    /// without any subsequent commits. Restart liveness: closing and reopening the DB
+    /// re-seeds the cache so the current root remains answerable.
+    #[test_traced("INFO")]
+    fn test_witness_cache_seeded_at_init() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let target_db = build_target_db(&mut context).await;
+            let root = target_db.root();
+            let cached = target_db.cached_target(&[root]);
+            assert!(cached.is_some(), "init should seed the current target");
+            let cached = cached.unwrap();
+            assert_eq!(cached.root, root);
+            assert_eq!(cached.ops_root, target_db.ops_root());
+
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    /// Verify that closing the trusted-root channel while the engine is waiting allows the
+    /// engine to eventually complete via `finish_rx`. The wrapper's forward task exits when
+    /// the channel closes, the engine sees `UpdateChannelClosed`, and `finish_rx` lets it
+    /// complete.
+    #[test_traced("INFO")]
+    fn test_root_sync_trusted_channel_close_unblocks_engine() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context: Context| async move {
             let target_db = build_target_db(&mut context).await;
@@ -1107,31 +1351,299 @@ mod root_sync {
 
             let target_db = std::sync::Arc::new(target_db);
 
-            let (update_tx, update_rx) = commonware_utils::channel::mpsc::channel(1);
+            let (trusted_tx, trusted_rx) = commonware_utils::channel::mpsc::channel(4);
             let (finish_tx, finish_rx) = commonware_utils::channel::mpsc::channel(1);
+
+            // Send the initial trusted root, then close the channel. The engine then waits
+            // on finish_rx; sending the finish signal lets it complete.
+            trusted_tx.send(root).await.unwrap();
+            drop(trusted_tx);
 
             let sync_fut = current_sync::sync(current_sync::Config {
                 context: context.child("client"),
                 resolver: target_db.clone(),
-                target,
+                trusted_root_rx: trusted_rx,
+                trusted_root_buffer: std::num::NonZeroUsize::new(8).unwrap(),
+                target_poll_interval: std::time::Duration::from_millis(1),
                 max_outstanding_requests: 4,
                 fetch_batch_size: NZU64!(64),
                 apply_batch_size: 1024,
                 db_config: client_config,
-                update_rx: Some(update_rx),
                 finish_rx: Some(finish_rx),
                 reached_target_tx: None,
                 max_retained_roots: 8,
             });
 
-            // Drop the update sender to close the channel while the engine is
-            // waiting for updates or a finish signal.
-            drop(update_tx);
-
-            // Send the finish signal so the engine can complete.
             finish_tx.send(()).await.unwrap();
 
             let synced_db: Db = sync_fut.await.unwrap();
+            assert_eq!(synced_db.root(), root);
+
+            synced_db.destroy().await.unwrap();
+            let target_db = std::sync::Arc::into_inner(target_db).unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    /// Verify cache grows across commits up to capacity, evicts FIFO, and serves any
+    /// retained root.
+    #[test_traced("INFO")]
+    fn test_witness_cache_fifo_eviction() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            // Build a DB with witness_cache_size = 3.
+            let suffix = context.next_u64().to_string();
+            let mut cfg = variable_config::<crate::translator::TwoCap>(&suffix, &context);
+            cfg.witness_cache_size = 3;
+            let mut db: Db = Db::init(context.child("cache"), cfg).await.unwrap();
+
+            let key = Digest::from([1u8; 32]);
+            let mut roots = Vec::new();
+            roots.push(db.root());
+            // Five commits produce five new roots; only the most recent 3 should remain
+            // (plus the init-seeded entry, which gets evicted by the 3rd commit).
+            for round in 0..5u64 {
+                apply_round(&mut db, key, round).await;
+                roots.push(db.root());
+            }
+
+            // Oldest roots: evicted.
+            for old_root in &roots[..roots.len() - 3] {
+                assert!(
+                    db.cached_target(&[*old_root]).is_none(),
+                    "old root should be evicted"
+                );
+            }
+            // Newest 3 roots: retained.
+            for recent_root in &roots[roots.len() - 3..] {
+                assert!(
+                    db.cached_target(&[*recent_root]).is_some(),
+                    "recent root should be cached"
+                );
+            }
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// `witness_cache_size = 0` disables the cache entirely. All lookups return `None`.
+    #[test_traced("INFO")]
+    fn test_witness_cache_disabled() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let suffix = context.next_u64().to_string();
+            let mut cfg = variable_config::<crate::translator::TwoCap>(&suffix, &context);
+            cfg.witness_cache_size = 0;
+            let mut db: Db = Db::init(context.child("cache"), cfg).await.unwrap();
+
+            let initial_root = db.root();
+            assert!(db.cached_target(&[initial_root]).is_none());
+
+            let key = Digest::from([1u8; 32]);
+            apply_round(&mut db, key, 0).await;
+            assert!(db.cached_target(&[db.root()]).is_none());
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Pruning the DB evicts cache entries whose `range.start` is below the new boundary.
+    /// Newer entries (range.start >= boundary) stay.
+    #[test_traced("INFO")]
+    fn test_witness_cache_evicted_by_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            // Larger cache so early roots aren't evicted by FIFO before we prune.
+            let suffix = context.next_u64().to_string();
+            let mut cfg = variable_config::<crate::translator::TwoCap>(&suffix, &context);
+            cfg.witness_cache_size = 1024;
+            let mut target_db: Db = Db::init(context.child("target"), cfg).await.unwrap();
+
+            // The init-seed entry has range.start = 0 (empty DB).
+            let init_root = target_db.root();
+            assert!(target_db.cached_target(&[init_root]).is_some());
+
+            // Apply enough distinct writes so multiple chunks complete and sync_boundary > 0.
+            // CHUNK_SIZE_BITS is N * 8 = 256 here.
+            for round in 0..400u64 {
+                let key = Digest::from([(round & 0xFF) as u8; 32]);
+                apply_round(&mut target_db, key, round).await;
+            }
+            target_db.sync().await.unwrap();
+
+            let prune_loc = target_db.sync_boundary();
+            assert!(*prune_loc > 0, "test relies on a non-zero prune boundary");
+            // init_root's entry has range.start = 0, which is below prune_loc.
+            assert!(target_db.cached_target(&[init_root]).is_some());
+
+            target_db.prune(prune_loc).await.unwrap();
+
+            // The init-seed entry (range.start = 0 < prune_loc) is evicted.
+            assert!(
+                target_db.cached_target(&[init_root]).is_none(),
+                "entry with range.start below prune boundary should be evicted"
+            );
+            // The current target entry (range.start = sync_boundary = prune_loc) survives.
+            let current_root = target_db.root();
+            let post = target_db.cached_target(&[current_root]).unwrap();
+            assert!(
+                post.range.start() >= prune_loc,
+                "surviving entries must have range.start >= prune boundary"
+            );
+
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    /// Rewinding the DB drops every previously cached target (fork happened), and the
+    /// post-rewind seed re-seeds with the rewound state's target.
+    #[test_traced("INFO")]
+    fn test_witness_cache_cleared_by_rewind() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let mut target_db = build_target_db(&mut context).await;
+            let pre_rewind_size = target_db.bounds().await.end;
+            let pre_rewind_root = target_db.root();
+
+            // Advance further, then rewind back to the pre-rewind size. The post-rewind
+            // root will match `pre_rewind_root` (deterministic), but cache entries from
+            // the discarded-after-rewind branch should be gone.
+            let key = Digest::from([3u8; 32]);
+            for round in 200..210u64 {
+                apply_round(&mut target_db, key, round).await;
+            }
+            target_db.sync().await.unwrap();
+            let advanced_root = target_db.root();
+            assert_ne!(advanced_root, pre_rewind_root);
+            assert!(target_db.cached_target(&[advanced_root]).is_some());
+
+            target_db.rewind(pre_rewind_size).await.unwrap();
+
+            // After rewind: the advanced-branch entry is gone, only the (re-seeded)
+            // current target remains.
+            assert!(target_db.cached_target(&[advanced_root]).is_none());
+            assert!(target_db.cached_target(&[target_db.root()]).is_some());
+
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    /// `cached_target` honors the order of the caller's slice — first matching root wins.
+    #[test_traced("INFO")]
+    fn test_witness_cache_lookup_multiple_roots() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let target_db = build_target_db(&mut context).await;
+            let real_root = target_db.root();
+            let unknown_root = Digest::from([0xCDu8; 32]);
+
+            // Real root present in [unknown, unknown, real]: returns the real one.
+            let hit = target_db.cached_target(&[unknown_root, unknown_root, real_root]);
+            assert!(hit.is_some());
+            assert_eq!(hit.unwrap().root, real_root);
+
+            // All roots unknown: None.
+            assert!(target_db
+                .cached_target(&[unknown_root, Digest::from([0xEFu8; 32])])
+                .is_none());
+
+            // Empty slice: None.
+            assert!(target_db.cached_target(&[]).is_none());
+
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    /// The resolver returns `None` for the first few `target_for_roots` calls (its commit
+    /// cache lags the client's trusted-root buffer), then catches up. The wrapper must keep
+    /// polling on the `target_poll_interval` cadence and succeed once the resolver returns
+    /// a matching target. This is the primary liveness guarantee of `target_poll_interval`.
+    #[test_traced("INFO")]
+    fn test_sync_polls_resolver_until_match() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let target_db = build_target_db(&mut context).await;
+            let root = target_db.root();
+            let target_db = std::sync::Arc::new(target_db);
+
+            // Resolver returns None for the first 3 queries, then serves the real target.
+            let resolver = LaggingResolver::new(target_db.clone(), 3);
+
+            let (trusted_tx, trusted_rx) = commonware_utils::channel::mpsc::channel(4);
+            trusted_tx.send(root).await.unwrap();
+            // Keep the channel open: progress must come from polling, not from new roots.
+
+            let client_suffix = context.next_u64().to_string();
+            let client_config =
+                variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+
+            let synced_db: Db = current_sync::sync(current_sync::Config {
+                context: context.child("client"),
+                resolver,
+                trusted_root_rx: trusted_rx,
+                trusted_root_buffer: std::num::NonZeroUsize::new(8).unwrap(),
+                target_poll_interval: std::time::Duration::from_millis(1),
+                max_outstanding_requests: 4,
+                fetch_batch_size: NZU64!(64),
+                apply_batch_size: 1024,
+                db_config: client_config,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(synced_db.root(), root);
+            drop(trusted_tx);
+
+            synced_db.destroy().await.unwrap();
+            let target_db = std::sync::Arc::into_inner(target_db).unwrap();
+            target_db.destroy().await.unwrap();
+        });
+    }
+
+    /// Closing the trusted-root channel while the buffer already holds roots must NOT
+    /// abort sync. The wrapper switches to poll-only mode and keeps querying the resolver
+    /// until a buffered root produces a match.
+    #[test_traced("INFO")]
+    fn test_sync_continues_polling_after_stream_close_with_buffered_roots() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context: Context| async move {
+            let target_db = build_target_db(&mut context).await;
+            let root = target_db.root();
+            let target_db = std::sync::Arc::new(target_db);
+
+            // Resolver lags by 5 calls. The trusted-root channel is closed immediately
+            // after the first send — so all subsequent polling must happen against an
+            // already-closed channel.
+            let resolver = LaggingResolver::new(target_db.clone(), 5);
+
+            let (trusted_tx, trusted_rx) = commonware_utils::channel::mpsc::channel(4);
+            trusted_tx.send(root).await.unwrap();
+            drop(trusted_tx);
+
+            let client_suffix = context.next_u64().to_string();
+            let client_config =
+                variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
+
+            let synced_db: Db = current_sync::sync(current_sync::Config {
+                context: context.child("client"),
+                resolver,
+                trusted_root_rx: trusted_rx,
+                trusted_root_buffer: std::num::NonZeroUsize::new(8).unwrap(),
+                target_poll_interval: std::time::Duration::from_millis(1),
+                max_outstanding_requests: 4,
+                fetch_batch_size: NZU64!(64),
+                apply_batch_size: 1024,
+                db_config: client_config,
+                finish_rx: None,
+                reached_target_tx: None,
+                max_retained_roots: 8,
+            })
+            .await
+            .unwrap();
+
             assert_eq!(synced_db.root(), root);
 
             synced_db.destroy().await.unwrap();

--- a/storage/src/qmdb/sync/error.rs
+++ b/storage/src/qmdb/sync/error.rs
@@ -54,6 +54,13 @@ pub enum EngineError<F: Family, D: Digest> {
     /// Witness for the `ops_root` failed verification against the root commitment.
     #[error("ops root witness failed verification")]
     OpsRootWitnessInvalid,
+    /// The trusted-root stream supplying canonical roots was closed before the resolver
+    /// produced a matching target.
+    #[error("trusted-root stream closed before any cached target matched")]
+    TrustedStreamClosed,
+    /// A user-provided sync configuration value was invalid.
+    #[error("invalid sync configuration: {0}")]
+    InvalidConfig(&'static str),
 }
 
 /// Errors that can occur during database synchronization.


### PR DESCRIPTION
## Summary

This PR updates `qmdb::current` state sync so clients can start from only a trusted canonical root, while fetching the ops-root witness and sync range from an untrusted resolver.

Unlike `qmdb::any`, a `current` canonical root is not the same root used by the shared sync engine. The engine verifies operation proofs against the ops root, while the canonical `current` root also commits to grafted bitmap state and optional pending/partial chunk digests. That means a client with only a trusted root from consensus needs auxiliary data before it can sync safely:

- the ops root,
- an `OpsRootWitness` binding that ops root to the trusted canonical root,
- and the operation range to sync.

Previously, callers had to supply a full `current::sync::Target` up front. This pushed target discovery and witness fetching outside the sync API. This PR moves that discovery into the `current` sync wrapper and makes the resolver API explicitly lookup-based.

## What Changed

- Added a `CurrentResolver::target_for_roots(&[Digest]) -> Option<Target>` extension API for `qmdb::current` sync.
- Changed `current::sync::sync()` to take a stream of trusted canonical roots instead of an initial full target plus target-update channel.
- Added a bounded in-memory witness cache to `current::Db`, populated at init and on committed batches.
- Changed canonical root computation to also return the `OpsRootWitness` material it already computes.
- Updated the sync wrapper to:
  - buffer recent trusted roots,
  - poll the resolver for a matching cached target,
  - verify trusted-root membership,
  - verify the ops-root witness,
  - and then drive the existing shared sync engine with the authenticated ops root.
- Added cache invalidation for prune and rewind paths.
- Updated the sync example wire protocol with `GetCurrentTargetForRoots`.

The generic QMDB sync engine remains ops-root based and does not learn about `current` witnesses or trusted-root streams.

## Protocol Shape

The new flow is:

1. A trusted source, such as consensus, provides canonical `current` roots.
2. The sync client buffers recent trusted roots.
3. The client asks the resolver for a target matching any buffered root.
4. The resolver scans its local witness cache and returns `Some(Target)` if it has one.
5. The client verifies that the target root is trusted and that the witness binds `ops_root` to that root.
6. The shared sync engine fetches and verifies operation ranges against the authenticated `ops_root`.
7. The rebuilt `current` DB root must match the trusted canonical root.

This adds a target lookup step relative to putting the witness directly in the block header, but keeps block headers smaller and treats resolver-provided witness data as untrusted.
