### PR TITLE
[stream/fuzz] fix connection target deadlock on large messages

### DIFF
--- a/stream/fuzz/fuzz_targets/connection.rs
+++ b/stream/fuzz/fuzz_targets/connection.rs
@@ -3,6 +3,7 @@
 use commonware_cryptography::{ed25519::PrivateKey, Signer};
 use commonware_runtime::{deterministic, mocks, Runner, Spawner, Supervisor as _};
 use commonware_stream::encrypted::{dial, listen, Config};
+use futures::join;
 use libfuzzer_sys::fuzz_target;
 use std::time::Duration;
 
@@ -146,8 +147,7 @@ fn fuzz(input: FuzzInput) {
             // Drive send and recv concurrently so the mock channel's
             // backpressure is satisfied while sending messages larger than that
             // buffer.
-            let (sent, received) =
-                futures::join!(dialer_sender.send(msg.clone()), listener_receiver.recv());
+            let (sent, received) = join!(dialer_sender.send(msg.clone()), listener_receiver.recv());
             sent.unwrap();
             let received = received.unwrap();
 
@@ -161,8 +161,7 @@ fn fuzz(input: FuzzInput) {
             }
 
             // Drive send and recv concurrently (same as above).
-            let (sent, received) =
-                futures::join!(listener_sender.send(msg.clone()), dialer_receiver.recv());
+            let (sent, received) = join!(listener_sender.send(msg.clone()), dialer_receiver.recv());
             sent.unwrap();
             let received = received.unwrap();
 

--- a/stream/fuzz/fuzz_targets/connection.rs
+++ b/stream/fuzz/fuzz_targets/connection.rs
@@ -143,8 +143,14 @@ fn fuzz(input: FuzzInput) {
                 continue;
             }
 
-            dialer_sender.send(msg.clone()).await.unwrap();
-            let received = listener_receiver.recv().await.unwrap();
+            // Drive send and recv concurrently so the mock channel's
+            // backpressure is satisfied while sending messages larger than that
+            // buffer.
+            let (sent, received) =
+                futures::join!(dialer_sender.send(msg.clone()), listener_receiver.recv());
+            let _ = sent.unwrap();
+            let received = received.unwrap();
+
             assert_eq!(received.coalesce(), &msg[..], "Message {i} mismatch");
         }
 
@@ -154,8 +160,12 @@ fn fuzz(input: FuzzInput) {
                 continue;
             }
 
-            listener_sender.send(msg.clone()).await.unwrap();
-            let received = dialer_receiver.recv().await.unwrap();
+            // Drive send and recv concurrently (same as above).
+            let (sent, received) =
+                futures::join!(listener_sender.send(msg.clone()), dialer_receiver.recv());
+            let _ = sent.unwrap();
+            let received = received.unwrap();
+
             assert_eq!(received.coalesce(), &msg[..], "Message {i} mismatch");
         }
     });

--- a/stream/fuzz/fuzz_targets/connection.rs
+++ b/stream/fuzz/fuzz_targets/connection.rs
@@ -148,7 +148,7 @@ fn fuzz(input: FuzzInput) {
             // buffer.
             let (sent, received) =
                 futures::join!(dialer_sender.send(msg.clone()), listener_receiver.recv());
-            let _ = sent.unwrap();
+            sent.unwrap();
             let received = received.unwrap();
 
             assert_eq!(received.coalesce(), &msg[..], "Message {i} mismatch");
@@ -163,7 +163,7 @@ fn fuzz(input: FuzzInput) {
             // Drive send and recv concurrently (same as above).
             let (sent, received) =
                 futures::join!(listener_sender.send(msg.clone()), dialer_receiver.recv());
-            let _ = sent.unwrap();
+            sent.unwrap();
             let received = received.unwrap();
 
             assert_eq!(received.coalesce(), &msg[..], "Message {i} mismatch");


### PR DESCRIPTION
The `stream` fuzz connection target drove each encrypted `send` and its matching `recv` sequentially on the same task. When a fuzz-generated message exceeded the mock channel's default 64 KiB backpressure threshold, `Sender::send` parked on a drain waiter that only the matching `recv` could release, but `recv` was the next line on the same task and was never reached, so the deterministic runtime caught the self-deadlock and panicked with runtime stalled. Wrapping each `send`/`recv` pair in `futures::join!` polls both halves cooperatively on the same task so the receiver drains the mock buffer while the sender is parked on backpressure, message-order assertions and fuzz coverage are unchanged.