### PR TITLE
[runtime/fuzz] cap max cache size to 64MB

### DIFF
--- a/runtime/fuzz/fuzz_targets/buffer.rs
+++ b/runtime/fuzz/fuzz_targets/buffer.rs
@@ -12,6 +12,7 @@ use commonware_utils::{NZUsize, NZU16};
 use libfuzzer_sys::fuzz_target;
 
 const MAX_SIZE: usize = 1024 * 1024;
+const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
 const SHARED_BLOB: &[u8] = b"buffer_blob";
 const MAX_OPERATIONS: usize = 50;
 
@@ -33,7 +34,7 @@ enum FuzzOperation {
     },
     CreateAppend {
         initial_size: u16,
-        buffer_size: u16,
+        buffer_size: u32,
         cache_page_size: u16,
         cache_capacity: u16,
     },
@@ -160,7 +161,10 @@ fn fuzz(input: FuzzInput) {
                     cache_capacity,
                 } => {
                     let buffer_size = (buffer_size as usize).clamp(0, MAX_SIZE);
-                    let cache_capacity = NZUsize!((cache_capacity as usize).clamp(1, MAX_SIZE));
+                    let cache_page_size = cache_page_size.max(1);
+                    let max_cache_capacity = (MAX_CACHE_BYTES / cache_page_size as usize).max(1);
+                    let cache_capacity =
+                        NZUsize!((cache_capacity as usize).clamp(1, max_cache_capacity));
 
                     let (blob, _) = context
                         .open("test_partition", b"append_blob")
@@ -171,7 +175,6 @@ fn fuzz(input: FuzzInput) {
                     // a different page size would corrupt reads since page size is embedded
                     // in the CRC records.
                     if cache_ref.is_none() {
-                        let cache_page_size = cache_page_size.clamp(1, u16::MAX);
                         cache_ref = Some(CacheRef::from_pooler(
                             &context,
                             NZU16!(cache_page_size),

--- a/runtime/fuzz/fuzz_targets/buffer.rs
+++ b/runtime/fuzz/fuzz_targets/buffer.rs
@@ -162,8 +162,12 @@ fn fuzz(input: FuzzInput) {
                 } => {
                     let buffer_size = (buffer_size as usize).clamp(0, MAX_SIZE);
                     let cache_page_size = cache_page_size.max(1);
+                    // Cache slots are allocated from the storage pool, which rounds
+                    // requests up to a power-of-two size class. Cap capacity against that
+                    // actual allocation size rather than the requested page size.
                     let cache_slot_size = (cache_page_size as usize)
-                        .max(context.storage_buffer_pool().config().min_size.get());
+                        .max(context.storage_buffer_pool().config().min_size.get())
+                        .next_power_of_two();
                     let max_cache_capacity = (MAX_CACHE_BYTES / cache_slot_size).max(1);
                     let cache_capacity =
                         NZUsize!((cache_capacity as usize).clamp(1, max_cache_capacity));

--- a/runtime/fuzz/fuzz_targets/buffer.rs
+++ b/runtime/fuzz/fuzz_targets/buffer.rs
@@ -6,7 +6,7 @@ use commonware_runtime::{
         paged::{Append, CacheRef},
         Read, Write,
     },
-    deterministic, Blob, Runner, Storage,
+    deterministic, Blob, BufferPooler, Runner, Storage,
 };
 use commonware_utils::{NZUsize, NZU16};
 use libfuzzer_sys::fuzz_target;
@@ -162,7 +162,9 @@ fn fuzz(input: FuzzInput) {
                 } => {
                     let buffer_size = (buffer_size as usize).clamp(0, MAX_SIZE);
                     let cache_page_size = cache_page_size.max(1);
-                    let max_cache_capacity = (MAX_CACHE_BYTES / cache_page_size as usize).max(1);
+                    let cache_slot_size = (cache_page_size as usize)
+                        .max(context.storage_buffer_pool().config().min_size.get());
+                    let max_cache_capacity = (MAX_CACHE_BYTES / cache_slot_size).max(1);
                     let cache_capacity =
                         NZUsize!((cache_capacity as usize).clamp(1, max_cache_capacity));
 


### PR DESCRIPTION
Fixes https://github.com/commonwarexyz/monorepo/actions/runs/26500434353/job/78039175528?pr=3878.