### PR TITLE
[storage/journal/contiguous] Avoid fsync on blob transition

### DIFF
--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -1003,10 +1003,7 @@ impl<B: Blob> Append<B> {
             NonZeroU16::new(logical_page_size as u16).expect("page_size is non-zero");
 
         // Flush any buffered data (without fsync) so the reader sees all written data.
-        {
-            let buf_guard = self.buffer.write().await;
-            self.flush_internal(buf_guard, true, false).await?;
-        }
+        self.flush().await?;
 
         // Convert buffer size (bytes) to page count
         let physical_page_size = logical_page_size + CHECKSUM_SIZE;
@@ -1047,6 +1044,16 @@ impl<B: Blob> Append<B> {
 }
 
 impl<B: Blob> Append<B> {
+    /// Flushes buffered data without making it durable.
+    ///
+    /// This makes buffered data visible through the underlying blob and page cache. Call
+    /// [`sync`](Self::sync) if the data must survive a crash.
+    pub async fn flush(&self) -> Result<(), Error> {
+        let buf_guard = self.buffer.write().await;
+        self.flush_internal(buf_guard, true, false).await?;
+        Ok(())
+    }
+
     /// Flushes buffered data and makes all pending mutations durable.
     ///
     /// A single physical write can be persisted with [`Blob::write_at_sync`]. If there

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -48,11 +48,11 @@ hash = "13b3e99a8c74b50dc18150194a92306de670b94e6642758feb6d9b6e9881f827"
 
 ["commonware_storage::journal::conformance::ContiguousFixed"]
 n_cases = 512
-hash = "b193d460f527eb5e6f54e6bfc0819aefac1e7b58367464e10e45f0c14d5805e9"
+hash = "d4c3aeded82350fb18f684f0230df7caf572daafe6c36d473e03e103d8b23205"
 
 ["commonware_storage::journal::conformance::ContiguousVariable"]
 n_cases = 512
-hash = "4345d35c8fe6fbfb3b76d6a487a864085637163f6a70a7eaa288bea469e842ed"
+hash = "51cb628503f330195abe1e51420bb2a1c40c76592b15cbe158c14ca90cfc74a5"
 
 ["commonware_storage::journal::conformance::SegmentedFixed"]
 n_cases = 512
@@ -344,4 +344,4 @@ hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
 
 ["commonware_storage::queue::conformance::QueueConformance"]
 n_cases = 512
-hash = "718a6b9f3905c146aa0d95b2b32ea1557680940c3fe2a293b73a19a56a3ac000"
+hash = "cede6ef8241f11e9d7d8d401ad5c753fc41d197e338ee593c1edcc110ebfe7c9"

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -73,6 +73,41 @@ use tracing::warn;
 
 /// Metadata key for storing the pruning boundary.
 const PRUNING_BOUNDARY_KEY: u64 = 1;
+/// Metadata key marking journals that require length-walking recovery.
+const LENGTH_RECOVERY_KEY: u64 = 2;
+/// Metadata key for the highest logical size durably synced as a recovery checkpoint.
+const RECOVERY_SIZE_KEY: u64 = 3;
+
+/// Return the first retained logical position in `section`.
+#[inline]
+fn first_in_section(
+    pruning_boundary: u64,
+    section: u64,
+    items_per_blob: u64,
+) -> Result<u64, Error> {
+    let start = section
+        .checked_mul(items_per_blob)
+        .ok_or(Error::OffsetOverflow)?;
+    Ok(pruning_boundary.max(start))
+}
+
+/// Maximum number of retained items that can be stored in `section`.
+#[inline]
+fn section_capacity(
+    pruning_boundary: u64,
+    section: u64,
+    items_per_blob: u64,
+) -> Result<u64, Error> {
+    let start = section
+        .checked_mul(items_per_blob)
+        .ok_or(Error::OffsetOverflow)?;
+    let skipped = first_in_section(pruning_boundary, section, items_per_blob)?
+        .checked_sub(start)
+        .ok_or(Error::OffsetOverflow)?;
+    items_per_blob
+        .checked_sub(skipped)
+        .ok_or(Error::OffsetOverflow)
+}
 
 /// Configuration for `Journal` storage.
 #[derive(Clone)]
@@ -115,6 +150,16 @@ struct Inner<E: Context, A: CodecFixedShared> {
 
     /// The position before which all items have been pruned.
     pruning_boundary: u64,
+
+    /// The earliest section modified since the last successful sync.
+    dirty_from_section: Option<u64>,
+
+    /// Whether recovery must walk section lengths instead of relying on the legacy rollover-sync
+    /// invariant.
+    length_recovery: bool,
+
+    /// The last logical size synced as a recovery checkpoint.
+    recovery_size: Option<u64>,
 }
 
 impl<E: Context, A: CodecFixedShared> Inner<E, A> {
@@ -412,6 +457,23 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Size of each entry in bytes (as u64).
     pub const CHUNK_SIZE_U64: u64 = Self::CHUNK_SIZE as u64;
 
+    fn parse_metadata_u64(
+        metadata: &Metadata<E, u64, Vec<u8>>,
+        key: u64,
+        name: &'static str,
+    ) -> Result<Option<u64>, Error> {
+        metadata
+            .get(&key)
+            .map(|bytes| {
+                let bytes = bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| Error::Corruption(format!("invalid {name} metadata")))?;
+                Ok(u64::from_be_bytes(bytes))
+            })
+            .transpose()
+    }
+
     /// Scan a partition and return blob names, treating a missing partition as empty.
     async fn scan_partition(context: &E, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
         match context.scan(partition).await {
@@ -472,16 +534,21 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             Metadata::<_, u64, Vec<u8>>::init(context.child("meta"), meta_cfg).await?;
 
         // Parse metadata if present
-        let meta_pruning_boundary = match metadata.get(&PRUNING_BOUNDARY_KEY) {
-            Some(bytes) => Some(u64::from_be_bytes(bytes.as_slice().try_into().map_err(
-                |_| Error::Corruption("invalid pruning_boundary metadata".into()),
-            )?)),
-            None => None,
-        };
+        let meta_pruning_boundary =
+            Self::parse_metadata_u64(&metadata, PRUNING_BOUNDARY_KEY, "pruning_boundary")?;
+        let recovery_size =
+            Self::parse_metadata_u64(&metadata, RECOVERY_SIZE_KEY, "recovery_size")?;
+        let length_recovery = metadata.get(&LENGTH_RECOVERY_KEY).is_some();
 
         // Recover bounds from metadata and/or blobs
-        let (pruning_boundary, size, needs_metadata_update) =
-            Self::recover_bounds(&journal, items_per_blob, meta_pruning_boundary).await?;
+        let (pruning_boundary, size, needs_metadata_update) = Self::recover_bounds(
+            &mut journal,
+            items_per_blob,
+            meta_pruning_boundary,
+            length_recovery,
+            recovery_size,
+        )
+        .await?;
 
         // Persist metadata if needed
         if needs_metadata_update {
@@ -513,6 +580,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                 size,
                 metadata,
                 pruning_boundary,
+                dirty_from_section: None,
+                length_recovery,
+                recovery_size,
             }),
             items_per_blob,
             metrics,
@@ -530,9 +600,11 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     ///
     /// If `meta_pruning_boundary` is `None`, computes bounds purely from blobs.
     async fn recover_bounds(
-        inner: &SegmentedJournal<E, A>,
+        inner: &mut SegmentedJournal<E, A>,
         items_per_blob: u64,
         meta_pruning_boundary: Option<u64>,
+        length_recovery: bool,
+        recovery_size: Option<u64>,
     ) -> Result<(u64, u64, bool), Error> {
         // Blob-based boundary is always section-aligned
         let blob_boundary = inner.oldest_section().map_or(0, |o| o * items_per_blob);
@@ -581,41 +653,42 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             None => (blob_boundary, false),
         };
 
-        // Validate oldest section before computing size.
-        Self::validate_oldest_section(inner, items_per_blob, pruning_boundary).await?;
+        let recovery_size = if needs_update && inner.oldest_section().is_none() {
+            None
+        } else {
+            recovery_size
+        };
 
-        let size = Self::compute_size(inner, items_per_blob, pruning_boundary).await?;
+        let size = if length_recovery {
+            Self::recover_by_walking_lengths(inner, items_per_blob, pruning_boundary, recovery_size)
+                .await?
+        } else {
+            Self::validate_oldest_section(inner, items_per_blob, pruning_boundary).await?;
+            Self::compute_size(inner, items_per_blob, pruning_boundary).await?
+        };
         Ok((pruning_boundary, size, needs_update))
     }
 
     /// Validate that the oldest section has the expected number of items.
     ///
-    /// Non-tail sections must be full from their logical start. The tail section
-    /// (oldest == newest) can be partially filled.
+    /// Legacy journals synced historical sections on rollover, so a short oldest non-tail section is
+    /// corruption unless length-walking recovery was explicitly enabled.
     async fn validate_oldest_section(
         inner: &SegmentedJournal<E, A>,
         items_per_blob: u64,
         pruning_boundary: u64,
     ) -> Result<(), Error> {
         let (Some(oldest), Some(newest)) = (inner.oldest_section(), inner.newest_section()) else {
-            return Ok(()); // No sections to validate
+            return Ok(());
         };
 
         if oldest == newest {
-            return Ok(()); // Tail section, can be partial
+            return Ok(());
         }
 
-        let oldest_len = inner.section_len(oldest).await?;
-        let oldest_start = oldest * items_per_blob;
-
-        let expected = if pruning_boundary > oldest_start {
-            // Mid-section boundary: items from pruning_boundary to section end
-            items_per_blob - (pruning_boundary - oldest_start)
-        } else {
-            // Section-aligned boundary: full section
-            items_per_blob
-        };
-
+        let (oldest_len, expected) =
+            Self::section_len_within_capacity(inner, items_per_blob, pruning_boundary, oldest)
+                .await?;
         if oldest_len != expected {
             return Err(Error::Corruption(format!(
                 "oldest section {oldest} has wrong size: expected {expected} items, got {oldest_len}"
@@ -625,7 +698,23 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok(())
     }
 
-    /// Returns the total number of items ever appended (size), computed from the blobs.
+    async fn section_len_within_capacity(
+        inner: &SegmentedJournal<E, A>,
+        items_per_blob: u64,
+        pruning_boundary: u64,
+        section: u64,
+    ) -> Result<(u64, u64), Error> {
+        let len = inner.section_len(section).await?;
+        let capacity = section_capacity(pruning_boundary, section, items_per_blob)?;
+        if len > capacity {
+            return Err(Error::Corruption(format!(
+                "section {section} has too many items: expected at most {capacity}, got {len}"
+            )));
+        }
+        Ok((len, capacity))
+    }
+
+    /// Returns the total number of items ever appended (size), computed using legacy invariants.
     async fn compute_size(
         inner: &SegmentedJournal<E, A>,
         items_per_blob: u64,
@@ -639,20 +728,75 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         };
 
         if oldest == newest {
-            // Single section: count from pruning boundary
             let tail_len = inner.section_len(newest).await?;
-            return Ok(pruning_boundary + tail_len);
+            return pruning_boundary
+                .checked_add(tail_len)
+                .ok_or(Error::OffsetOverflow);
         }
 
-        // Multiple sections: sum actual item counts
         let oldest_len = inner.section_len(oldest).await?;
         let tail_len = inner.section_len(newest).await?;
+        let middle_sections = newest
+            .checked_sub(oldest + 1)
+            .ok_or(Error::OffsetOverflow)?;
+        let middle_items = middle_sections
+            .checked_mul(items_per_blob)
+            .ok_or(Error::OffsetOverflow)?;
 
-        // Middle sections are assumed full
-        let middle_sections = newest - oldest - 1;
-        let middle_items = middle_sections * items_per_blob;
+        pruning_boundary
+            .checked_add(oldest_len)
+            .and_then(|size| size.checked_add(middle_items))
+            .and_then(|size| size.checked_add(tail_len))
+            .ok_or(Error::OffsetOverflow)
+    }
 
-        Ok(pruning_boundary + oldest_len + middle_items + tail_len)
+    /// Recover by walking section lengths until the first short non-tail section.
+    async fn recover_by_walking_lengths(
+        inner: &mut SegmentedJournal<E, A>,
+        items_per_blob: u64,
+        pruning_boundary: u64,
+        recovery_size: Option<u64>,
+    ) -> Result<u64, Error> {
+        let oldest = inner.oldest_section();
+        let newest = inner.newest_section();
+
+        let (Some(oldest), Some(newest)) = (oldest, newest) else {
+            return Ok(pruning_boundary);
+        };
+
+        let mut size = pruning_boundary;
+        for section in oldest..=newest {
+            let (len, capacity) =
+                Self::section_len_within_capacity(inner, items_per_blob, pruning_boundary, section)
+                    .await?;
+            let first = first_in_section(pruning_boundary, section, items_per_blob)?;
+            size = first.checked_add(len).ok_or(Error::OffsetOverflow)?;
+
+            if len < capacity {
+                if section != newest {
+                    if let Some(checkpoint) = recovery_size {
+                        if size < checkpoint {
+                            return Err(Error::Corruption(format!(
+                                "recovered size {size} is before recovery checkpoint {checkpoint}"
+                            )));
+                        }
+                    }
+                }
+                if section != newest {
+                    let byte_offset = len
+                        .checked_mul(Self::CHUNK_SIZE_U64)
+                        .ok_or(Error::OffsetOverflow)?;
+                    warn!(
+                        section,
+                        len, capacity, "crash repair: truncating journal after short section"
+                    );
+                    inner.rewind(section, byte_offset).await?;
+                }
+                return Ok(size);
+            }
+        }
+
+        Ok(size)
     }
 
     /// Initialize a new `Journal` instance in a pruned state at a given size.
@@ -717,6 +861,13 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             metadata.remove(&PRUNING_BOUNDARY_KEY);
             metadata.sync().await?;
         }
+        let reset_recovery_metadata = metadata.get(&LENGTH_RECOVERY_KEY).is_some()
+            || metadata.get(&RECOVERY_SIZE_KEY).is_some();
+        if reset_recovery_metadata {
+            metadata.remove(&LENGTH_RECOVERY_KEY);
+            metadata.remove(&RECOVERY_SIZE_KEY);
+            metadata.sync().await?;
+        }
 
         let metrics = Metrics::new(context);
         metrics.update(size, size, items_per_blob);
@@ -727,6 +878,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                 size,
                 metadata,
                 pruning_boundary: size, // No data exists yet
+                dirty_from_section: None,
+                length_recovery: false,
+                recovery_size: None,
             }),
             items_per_blob,
             metrics,
@@ -741,10 +895,59 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         (section, pos_in_section)
     }
 
+    async fn enable_length_recovery_inner(inner: &mut Inner<E, A>) -> Result<(), Error> {
+        if inner.length_recovery {
+            return Ok(());
+        }
+        inner.metadata.put(LENGTH_RECOVERY_KEY, vec![1]);
+        if inner.recovery_size.is_none() {
+            inner
+                .metadata
+                .put(RECOVERY_SIZE_KEY, inner.size.to_be_bytes().to_vec());
+            inner.recovery_size = Some(inner.size);
+        }
+        inner.metadata.sync().await?;
+        inner.length_recovery = true;
+        Ok(())
+    }
+
+    pub(crate) async fn enable_length_recovery(&self) -> Result<(), Error> {
+        let mut inner = self.inner.write().await;
+        Self::enable_length_recovery_inner(&mut inner).await
+    }
+
+    pub(crate) async fn length_recovery_enabled(&self) -> bool {
+        self.inner.read().await.length_recovery
+    }
+
+    fn stage_recovery_size(inner: &mut Inner<E, A>, size: u64) {
+        if inner.recovery_size == Some(size) {
+            return;
+        }
+        inner
+            .metadata
+            .put(RECOVERY_SIZE_KEY, size.to_be_bytes().to_vec());
+        inner.recovery_size = Some(size);
+    }
+
+    async fn lower_recovery_size(inner: &mut Inner<E, A>, size: u64) -> Result<(), Error> {
+        if inner.length_recovery
+            && inner
+                .recovery_size
+                .is_some_and(|checkpoint| checkpoint > size)
+        {
+            inner
+                .metadata
+                .put_sync(RECOVERY_SIZE_KEY, size.to_be_bytes().to_vec())
+                .await?;
+            inner.recovery_size = Some(size);
+        }
+        Ok(())
+    }
+
     /// Sync any pending updates to disk.
     ///
-    /// Only the tail section can have pending updates since historical sections are synced
-    /// when they become full.
+    /// Syncs every section modified since the last successful sync.
     pub async fn sync(&self) -> Result<(), Error> {
         let _timer = self.metrics.sync_timer();
         self.metrics.sync_calls.inc();
@@ -752,44 +955,61 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // concurrent readers.
         let inner = self.inner.upgradable_read().await;
 
-        // Sync the tail section
-        let tail_section = inner.size / self.items_per_blob;
-
-        // The tail section may not exist yet if the previous section was just filled, but syncing a
-        // non-existent section is safe (returns Ok).
-        inner.journal.sync(tail_section).await?;
+        if let Some(start_section) = inner.dirty_from_section {
+            let start_section = inner
+                .journal
+                .oldest_section()
+                .map_or(start_section, |oldest| start_section.max(oldest));
+            let tail_section = inner.size / self.items_per_blob;
+            for section in start_section..=tail_section {
+                inner.journal.sync(section).await?;
+            }
+        }
 
         // Persist metadata only when pruning_boundary is mid-section.
         let pruning_boundary = inner.pruning_boundary;
         let pruning_boundary_from_metadata = inner.metadata.get(&PRUNING_BOUNDARY_KEY).cloned();
-        let put = if !pruning_boundary.is_multiple_of(self.items_per_blob) {
+        let metadata_update = if !pruning_boundary.is_multiple_of(self.items_per_blob) {
             let needs_update = pruning_boundary_from_metadata
                 .is_none_or(|bytes| bytes.as_slice() != pruning_boundary.to_be_bytes());
 
             if needs_update {
-                true
+                Some(true)
             } else {
-                return Ok(());
+                None
             }
         } else if pruning_boundary_from_metadata.is_some() {
-            false
+            Some(false)
         } else {
-            return Ok(());
+            None
         };
+        let recovery_update = inner.length_recovery && inner.recovery_size != Some(inner.size);
+        let size = inner.size;
 
-        // Upgrade only for the metadata mutation; reads were allowed while syncing
-        // the tail section above. Downgrade before the metadata fsync to unblock readers.
+        if inner.dirty_from_section.is_none() && metadata_update.is_none() && !recovery_update {
+            return Ok(());
+        }
+
+        // Upgrade only for bookkeeping/metadata mutation. Reads were allowed while syncing blobs.
         let mut inner = inner.upgrade().await;
-        if put {
-            inner.metadata.put(
-                PRUNING_BOUNDARY_KEY,
-                pruning_boundary.to_be_bytes().to_vec(),
-            );
-        } else {
-            inner.metadata.remove(&PRUNING_BOUNDARY_KEY);
+        inner.dirty_from_section = None;
+        if let Some(put) = metadata_update {
+            if put {
+                inner.metadata.put(
+                    PRUNING_BOUNDARY_KEY,
+                    pruning_boundary.to_be_bytes().to_vec(),
+                );
+            } else {
+                inner.metadata.remove(&PRUNING_BOUNDARY_KEY);
+            }
+        }
+        if recovery_update {
+            Self::stage_recovery_size(&mut inner, size);
         }
         let inner = inner.downgrade_to_upgradable();
-        inner.metadata.sync().await?;
+        if metadata_update.is_some() || recovery_update {
+            inner.metadata.sync().await?;
+        }
 
         Ok(())
     }
@@ -858,6 +1078,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
         // Mutating operations are serialized by taking the write guard.
         let mut inner = self.inner.write().await;
+        Self::enable_length_recovery_inner(&mut inner).await?;
         let mut written = 0;
         while written < items_count {
             let (section, pos_in_section) = self.position_to_section(inner.size);
@@ -866,6 +1087,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             let start = written * A::SIZE;
             let end = start + batch_count * A::SIZE;
 
+            if inner.dirty_from_section.is_none() {
+                inner.dirty_from_section = Some(section);
+            }
             inner
                 .journal
                 .append_raw(section, &items_buf[start..end])
@@ -874,12 +1098,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             written += batch_count;
 
             if inner.size.is_multiple_of(self.items_per_blob) {
-                // The section was filled and must be synced. Downgrade so readers can continue
-                // during the sync, but keep mutators blocked. After sync, upgrade again to
-                // create the next tail section before any append can proceed.
-                let inner_ref = inner.downgrade_to_upgradable();
-                inner_ref.journal.sync(section).await?;
-                inner = inner_ref.upgrade().await;
+                inner.journal.flush(section).await?;
                 inner.journal.ensure_section_exists(section + 1).await?;
             }
         }
@@ -918,8 +1137,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let pos_in_section = size - first_in_section;
         let byte_offset = pos_in_section * Self::CHUNK_SIZE_U64;
 
+        Self::lower_recovery_size(&mut inner, size).await?;
         inner.journal.rewind(section, byte_offset).await?;
         inner.size = size;
+        inner.dirty_from_section = Some(
+            inner
+                .dirty_from_section
+                .map_or(section, |dirty_from| dirty_from.min(section)),
+        );
         self.metrics
             .update(inner.size, inner.pruning_boundary, self.items_per_blob);
 
@@ -961,6 +1186,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             // Pruning boundary only moves forward
             assert!(inner.pruning_boundary < new_oldest * self.items_per_blob);
             inner.pruning_boundary = new_oldest * self.items_per_blob;
+            if let Some(dirty_from) = inner.dirty_from_section {
+                inner.dirty_from_section = Some(dirty_from.max(new_oldest));
+            }
             self.metrics
                 .update(inner.size, inner.pruning_boundary, self.items_per_blob);
         }
@@ -995,12 +1223,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // - Crash after create: old metadata triggers "metadata ahead" warning,
         //   recovery falls back to blob state
         let mut inner = self.inner.write().await;
+        Self::lower_recovery_size(&mut inner, new_size).await?;
         inner.journal.clear().await?;
         let tail_section = new_size / self.items_per_blob;
         inner.journal.ensure_section_exists(tail_section).await?;
 
         inner.size = new_size;
         inner.pruning_boundary = new_size; // No data exists
+        inner.dirty_from_section = None;
 
         // Persist metadata only when pruning_boundary is mid-section.
         if !inner.pruning_boundary.is_multiple_of(self.items_per_blob) {
@@ -1138,6 +1368,16 @@ mod tests {
     /// Generate a SHA-256 digest for the given value.
     fn test_digest(value: u64) -> Digest {
         Sha256::hash(&value.to_be_bytes())
+    }
+
+    async fn sync_dirty_blobs<E: crate::Context>(journal: &Journal<E, Digest>) {
+        let inner = journal.inner.read().await;
+        if let Some(start) = inner.dirty_from_section {
+            let tail = inner.size / journal.items_per_blob;
+            for section in start..=tail {
+                inner.journal.sync(section).await.unwrap();
+            }
+        }
     }
 
     fn test_cfg(pooler: &impl BufferPooler, items_per_blob: NonZeroU64) -> Config {
@@ -1574,29 +1814,8 @@ mod tests {
             blob.resize(size - 1).await.expect("Failed to corrupt blob");
             blob.sync().await.expect("Failed to sync blob");
 
-            // The segmented journal will trim the incomplete blob on init, resulting in the blob
-            // missing one item. This should be detected as corruption during replay.
-            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
-                .await
-                .expect("failed to initialize journal");
-
-            // Journal size is computed from the tail section, so it's unchanged
-            // despite the corruption in section 40.
-            let expected_size = ITEMS_PER_BLOB.get() * 100 + ITEMS_PER_BLOB.get() / 2;
-            assert_eq!(journal.size().await, expected_size);
-
-            // Replay should detect corruption (incomplete section) in section 40
-            let reader = journal.reader().await;
-            match reader.replay(NZUsize!(1024), 0).await {
-                Err(Error::Corruption(msg)) => {
-                    assert!(
-                        msg.contains("section 40"),
-                        "Error should mention section 40, got: {msg}"
-                    );
-                }
-                Err(e) => panic!("Expected Corruption error for section 40, got: {:?}", e),
-                Ok(_) => panic!("Expected replay to fail with corruption"),
-            };
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
         });
     }
 
@@ -1622,25 +1841,8 @@ mod tests {
                 .await
                 .expect("failed to remove blob");
 
-            // Init won't detect the corruption.
-            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
-                .await
-                .expect("init shouldn't fail");
-
-            // But replay will.
-            let reader = result.reader().await;
-            match reader.replay(NZUsize!(1024), 0).await {
-                Err(Error::Corruption(_)) => {}
-                Err(err) => panic!("expected Corruption, got: {err}"),
-                Ok(_) => panic!("expected Corruption, got ok"),
-            };
-
-            // As will trying to read an item that was in the deleted blob.
-            match result.read(2).await {
-                Err(Error::Corruption(_)) => {}
-                Err(err) => panic!("expected Corruption, got: {err}"),
-                Ok(_) => panic!("expected Corruption, got ok"),
-            };
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
         });
     }
 
@@ -2655,10 +2857,7 @@ mod tests {
             for i in 0..5u64 {
                 journal.append(&test_digest(i)).await.unwrap();
             }
-            let inner = journal.inner.read().await;
-            let tail_section = inner.size / journal.items_per_blob;
-            inner.journal.sync(tail_section).await.unwrap();
-            drop(inner);
+            sync_dirty_blobs(&journal).await;
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -2720,10 +2919,7 @@ mod tests {
             for i in 0..3u64 {
                 journal.append(&test_digest(i)).await.unwrap();
             }
-            let inner = journal.inner.read().await;
-            let tail_section = inner.size / journal.items_per_blob;
-            inner.journal.sync(tail_section).await.unwrap();
-            drop(inner);
+            sync_dirty_blobs(&journal).await;
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -2751,10 +2947,7 @@ mod tests {
             assert_eq!(journal.size().await, 17);
             journal.prune(10).await.unwrap();
 
-            let inner = journal.inner.read().await;
-            let tail_section = inner.size / journal.items_per_blob;
-            inner.journal.sync(tail_section).await.unwrap();
-            drop(inner);
+            sync_dirty_blobs(&journal).await;
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -481,7 +481,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .transpose()
     }
 
-    fn stage_length_recovery_metadata(
+    fn install_recovery_metadata_if_needed(
         metadata: &mut Metadata<E, u64, Vec<u8>>,
         length_recovery: &mut bool,
         recovery_size: &mut Option<u64>,
@@ -591,12 +591,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             }
             metadata_dirty = true;
         }
-        metadata_dirty |= Self::stage_length_recovery_metadata(
+        if Self::install_recovery_metadata_if_needed(
             &mut metadata,
             &mut length_recovery,
             &mut recovery_size,
             size,
-        );
+        ) {
+            metadata_dirty = true;
+        }
         if metadata_dirty {
             metadata.sync().await?;
         }
@@ -899,12 +901,16 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
         let mut length_recovery = false;
         let mut recovery_size = None;
-        metadata_dirty |= Self::stage_length_recovery_metadata(
+        // A state-synced journal starts under the no-rollover-fsync recovery model immediately.
+        // The checkpoint is the synthetic pruned size because no retained data exists before it.
+        if Self::install_recovery_metadata_if_needed(
             &mut metadata,
             &mut length_recovery,
             &mut recovery_size,
             size,
-        );
+        ) {
+            metadata_dirty = true;
+        }
         if metadata_dirty {
             metadata.sync().await?;
         }
@@ -935,10 +941,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         (section, pos_in_section)
     }
 
-    pub(crate) async fn length_recovery_enabled(&self) -> bool {
-        self.inner.read().await.length_recovery
-    }
-
     fn stage_recovery_size(inner: &mut Inner<E, A>, size: u64) {
         if inner.recovery_size == Some(size) {
             return;
@@ -955,6 +957,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                 .recovery_size
                 .is_some_and(|checkpoint| checkpoint > size)
         {
+            // Persist the lowered checkpoint before destructive blob changes so recovery after a
+            // crash does not reject the intentionally shortened journal.
             inner
                 .metadata
                 .put_sync(RECOVERY_SIZE_KEY, size.to_be_bytes().to_vec())
@@ -1388,7 +1392,7 @@ mod tests {
         Sha256::hash(&value.to_be_bytes())
     }
 
-    async fn sync_dirty_blobs<E: crate::Context>(journal: &Journal<E, Digest>) {
+    async fn sync_dirty_blobs_without_checkpoint<E: crate::Context>(journal: &Journal<E, Digest>) {
         let inner = journal.inner.read().await;
         if let Some(start) = inner.dirty_from_section {
             let tail = inner.size / journal.items_per_blob;
@@ -1419,7 +1423,7 @@ mod tests {
             let journal = Journal::<_, Digest>::init(context.child("init"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
-            assert!(journal.length_recovery_enabled().await);
+            assert!(journal.inner.read().await.length_recovery);
             journal.destroy().await.expect("failed to destroy journal");
         });
     }
@@ -1433,11 +1437,17 @@ mod tests {
                 .await
                 .expect("failed to initialize journal");
 
-            let item_count = cfg.items_per_blob.get() * 2 + 3;
-            for i in 0..item_count {
+            let checkpoint = cfg.items_per_blob.get();
+            for i in 0..checkpoint {
                 journal.append(&test_digest(i)).await.unwrap();
             }
-            sync_dirty_blobs(&journal).await;
+            journal.sync().await.expect("failed to sync checkpoint");
+
+            let item_count = checkpoint * 2 + 3;
+            for i in checkpoint..item_count {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            sync_dirty_blobs_without_checkpoint(&journal).await;
             drop(journal);
 
             let (blob, size) = context
@@ -1458,10 +1468,40 @@ mod tests {
                 "short non-tail section should truncate unsynced suffix"
             );
             assert!(
-                recovered >= cfg.items_per_blob.get(),
+                recovered >= checkpoint,
                 "recovery should keep the full prefix before the short section"
             );
             journal.destroy().await.expect("failed to destroy journal");
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_length_recovery_rejects_checkpoint_violation() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(7));
+            let journal = Journal::init(context.child("first"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+
+            let item_count = cfg.items_per_blob.get() * 2 + 3;
+            for i in 0..item_count {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.expect("failed to sync journal");
+            drop(journal);
+
+            let (blob, size) = context
+                .open(&blob_partition(&cfg), &1u64.to_be_bytes())
+                .await
+                .expect("failed to open section");
+            blob.resize(size - 1)
+                .await
+                .expect("failed to truncate section");
+            blob.sync().await.expect("failed to sync section");
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
         });
     }
 
@@ -2929,7 +2969,7 @@ mod tests {
             for i in 0..5u64 {
                 journal.append(&test_digest(i)).await.unwrap();
             }
-            sync_dirty_blobs(&journal).await;
+            sync_dirty_blobs_without_checkpoint(&journal).await;
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -2991,7 +3031,7 @@ mod tests {
             for i in 0..3u64 {
                 journal.append(&test_digest(i)).await.unwrap();
             }
-            sync_dirty_blobs(&journal).await;
+            sync_dirty_blobs_without_checkpoint(&journal).await;
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -3019,7 +3059,7 @@ mod tests {
             assert_eq!(journal.size().await, 17);
             journal.prune(10).await.unwrap();
 
-            sync_dirty_blobs(&journal).await;
+            sync_dirty_blobs_without_checkpoint(&journal).await;
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1116,6 +1116,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         }
 
         // Upgrade only for bookkeeping/metadata mutation. Reads were allowed while syncing blobs.
+        // If metadata sync fails after this point, the journal must be discarded like any other
+        // failed mutable operation.
         let mut inner = inner.upgrade().await;
         inner.dirty_from_section = None;
         if let Some(put) = metadata_update {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -647,7 +647,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // Blob-based boundary is always section-aligned
         let blob_boundary = inner.oldest_section().map_or(0, |o| o * items_per_blob);
 
-        let (pruning_boundary, needs_update) = match meta_pruning_boundary {
+        let (pruning_boundary, needs_update, discard_recovery_size) = match meta_pruning_boundary {
             // Mid-section metadata: validate against blobs
             Some(meta_pruning_boundary)
                 if !meta_pruning_boundary.is_multiple_of(items_per_blob) =>
@@ -662,14 +662,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                             meta_oldest_section,
                             "crash repair: no blobs exist, ignoring stale metadata"
                         );
-                        (blob_boundary, true)
+                        (blob_boundary, true, true)
                     }
                     Some(oldest_section) if meta_oldest_section < oldest_section => {
                         warn!(
                             meta_oldest_section,
                             oldest_section, "crash repair: metadata stale, computing from blobs"
                         );
-                        (blob_boundary, true)
+                        (blob_boundary, true, false)
                     }
                     Some(oldest_section) if meta_oldest_section > oldest_section => {
                         // Metadata references a section ahead of the oldest blob. This can happen
@@ -680,18 +680,24 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                             oldest_section,
                             "crash repair: metadata ahead of blobs, computing from blobs"
                         );
-                        (blob_boundary, true)
+                        (blob_boundary, true, true)
                     }
-                    Some(_) => (meta_pruning_boundary, false), // valid mid-section metadata
+                    Some(_) => (meta_pruning_boundary, false, false), // valid mid-section metadata
                 }
             }
-            // Section-aligned metadata: unnecessary, use blob-based
-            Some(_) => (blob_boundary, true),
+            // Section-aligned metadata: unnecessary, use blob-based.
+            Some(meta_pruning_boundary) => {
+                let meta_oldest_section = meta_pruning_boundary / items_per_blob;
+                let discard_recovery_size = inner
+                    .oldest_section()
+                    .is_none_or(|oldest_section| meta_oldest_section > oldest_section);
+                (blob_boundary, true, discard_recovery_size)
+            }
             // No metadata: use blob-based, no update needed
-            None => (blob_boundary, false),
+            None => (blob_boundary, false, false),
         };
 
-        let recovery_size = if needs_update && inner.oldest_section().is_none() {
+        let recovery_size = if discard_recovery_size {
             None
         } else {
             recovery_size
@@ -752,6 +758,17 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok((len, capacity))
     }
 
+    fn validate_recovery_checkpoint(size: u64, recovery_size: Option<u64>) -> Result<(), Error> {
+        if let Some(checkpoint) = recovery_size {
+            if size < checkpoint {
+                return Err(Error::Corruption(format!(
+                    "recovered size {size} is before recovery checkpoint {checkpoint}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Returns the total number of items ever appended (size), computed using legacy invariants.
     async fn compute_size(
         inner: &SegmentedJournal<E, A>,
@@ -799,26 +816,22 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let newest = inner.newest_section();
 
         let (Some(oldest), Some(newest)) = (oldest, newest) else {
+            Self::validate_recovery_checkpoint(pruning_boundary, recovery_size)?;
             return Ok(pruning_boundary);
         };
 
-        let mut size = pruning_boundary;
+        let mut size = None;
         for section in oldest..=newest {
             let (len, capacity) =
                 Self::section_len_within_capacity(inner, items_per_blob, pruning_boundary, section)
                     .await?;
             let first = first_in_section(pruning_boundary, section, items_per_blob)?;
-            size = first.checked_add(len).ok_or(Error::OffsetOverflow)?;
+            let recovered_size = first.checked_add(len).ok_or(Error::OffsetOverflow)?;
+            size = Some(recovered_size);
 
             if len < capacity {
+                Self::validate_recovery_checkpoint(recovered_size, recovery_size)?;
                 if section != newest {
-                    if let Some(checkpoint) = recovery_size {
-                        if size < checkpoint {
-                            return Err(Error::Corruption(format!(
-                                "recovered size {size} is before recovery checkpoint {checkpoint}"
-                            )));
-                        }
-                    }
                     let byte_offset = len
                         .checked_mul(Self::CHUNK_SIZE_U64)
                         .ok_or(Error::OffsetOverflow)?;
@@ -828,10 +841,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                     );
                     inner.rewind(section, byte_offset).await?;
                 }
-                return Ok(size);
+                return Ok(recovered_size);
             }
         }
 
+        let size = size.expect("non-empty section range should set recovered size");
+        Self::validate_recovery_checkpoint(size, recovery_size)?;
         Ok(size)
     }
 
@@ -951,6 +966,11 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         inner.recovery_size = Some(size);
     }
 
+    pub(crate) async fn validate_recovered_size(&self, size: u64) -> Result<(), Error> {
+        let inner = self.inner.read().await;
+        Self::validate_recovery_checkpoint(size, inner.recovery_size)
+    }
+
     async fn lower_recovery_size(inner: &mut Inner<E, A>, size: u64) -> Result<(), Error> {
         if inner.length_recovery
             && inner
@@ -989,7 +1009,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             }
         }
 
-        // Persist metadata only when pruning_boundary is mid-section.
+        // Persist pruning metadata and advance the recovery checkpoint when needed.
         let pruning_boundary = inner.pruning_boundary;
         let pruning_boundary_from_metadata = inner.metadata.get(&PRUNING_BOUNDARY_KEY).cloned();
         let metadata_update = if !pruning_boundary.is_multiple_of(self.items_per_blob) {
@@ -1415,6 +1435,17 @@ mod tests {
         format!("{}-blobs", cfg.partition)
     }
 
+    fn assert_corruption_contains<T>(result: Result<T, Error>, needle: &str) {
+        match result {
+            Err(Error::Corruption(msg)) => assert!(
+                msg.contains(needle),
+                "corruption message {msg:?} did not contain {needle:?}"
+            ),
+            Err(err) => panic!("expected corruption containing {needle:?}, got {err:?}"),
+            Ok(_) => panic!("expected corruption containing {needle:?}, got success"),
+        }
+    }
+
     #[test_traced]
     fn test_fixed_journal_init_installs_length_recovery() {
         let executor = deterministic::Runner::default();
@@ -1501,7 +1532,96 @@ mod tests {
             blob.sync().await.expect("failed to sync section");
 
             let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
-            assert!(matches!(result, Err(Error::Corruption(_))));
+            assert_corruption_contains(result, "recovered size");
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_length_recovery_rejects_tail_checkpoint_violation() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(7));
+            let journal = Journal::init(context.child("first"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+
+            let item_count = cfg.items_per_blob.get() + 3;
+            for i in 0..item_count {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.expect("failed to sync journal");
+            drop(journal);
+
+            let (blob, size) = context
+                .open(&blob_partition(&cfg), &1u64.to_be_bytes())
+                .await
+                .expect("failed to open tail section");
+            blob.resize(size - 1)
+                .await
+                .expect("failed to truncate tail section");
+            blob.sync().await.expect("failed to sync tail section");
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_length_recovery_rejects_missing_synced_blobs() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(7));
+            let journal = Journal::init(context.child("first"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+
+            for i in 0..10 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.expect("failed to sync journal");
+            drop(journal);
+
+            context
+                .remove(&blob_partition(&cfg), None)
+                .await
+                .expect("failed to remove blobs");
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_keeps_checkpoint_with_stale_pruning_metadata() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let journal =
+                Journal::<_, Digest>::init_at_size(context.child("first"), cfg.clone(), 2)
+                    .await
+                    .expect("failed to initialize journal");
+
+            for i in 0..18 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            assert_eq!(journal.size().await, 20);
+            journal.sync().await.expect("failed to sync journal");
+
+            journal.prune(10).await.expect("failed to prune journal");
+            assert_eq!(journal.bounds().await.start, 10);
+            drop(journal);
+
+            let (blob, size) = context
+                .open(&blob_partition(&cfg), &2u64.to_be_bytes())
+                .await
+                .expect("failed to open stale-metadata section");
+            blob.resize(size - 1)
+                .await
+                .expect("failed to truncate section");
+            blob.sync().await.expect("failed to sync section");
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
         });
     }
 
@@ -1927,7 +2047,7 @@ mod tests {
             blob.sync().await.expect("Failed to sync blob");
 
             let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
-            assert!(matches!(result, Err(Error::Corruption(_))));
+            assert_corruption_contains(result, "recovered size");
         });
     }
 
@@ -1992,16 +2112,8 @@ mod tests {
             blob.resize(size - 1).await.expect("Failed to corrupt blob");
             blob.sync().await.expect("Failed to sync blob");
 
-            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
-                .await
-                .unwrap();
-
-            // The truncation invalidates the last page (bad checksum), which is removed.
-            // This loses one item.
-            assert_eq!(journal.size().await, item_count - 1);
-
-            // Cleanup.
-            journal.destroy().await.expect("Failed to destroy journal");
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
         });
     }
 
@@ -2102,28 +2214,8 @@ mod tests {
             blob.resize(size - 1).await.expect("Failed to corrupt blob");
             blob.sync().await.expect("Failed to sync blob");
 
-            // Re-initialize the journal to simulate a restart
-            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
-                .await
-                .expect("Failed to re-initialize journal");
-            // The truncation invalidates the last page, which is removed. This loses one item.
-            assert_eq!(journal.pruning_boundary().await, 0);
-            assert_eq!(journal.size().await, 4);
-            drop(journal);
-
-            // Delete the second blob and re-init
-            context
-                .remove(&blob_partition(&cfg), Some(&1u64.to_be_bytes()))
-                .await
-                .expect("Failed to remove blob");
-
-            let journal = Journal::<_, Digest>::init(context.child("third"), cfg.clone())
-                .await
-                .expect("Failed to re-initialize journal");
-            // Only the first blob remains
-            assert_eq!(journal.size().await, 3);
-
-            journal.destroy().await.unwrap();
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
         });
     }
 
@@ -2158,7 +2250,7 @@ mod tests {
             blob.sync().await.expect("failed to sync blob");
 
             let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
-            assert!(matches!(result, Err(Error::Corruption(_))));
+            assert_corruption_contains(result, "recovered size");
         });
     }
 
@@ -2189,24 +2281,8 @@ mod tests {
             blob.resize(size - 1).await.expect("Failed to corrupt blob");
             blob.sync().await.expect("Failed to sync blob");
 
-            // Re-initialize the journal to simulate a restart
-            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
-                .await
-                .expect("Failed to re-initialize journal");
-
-            // Since there was only a single item appended which we then corrupted, recovery should
-            // leave us in the state of an empty journal.
-            let bounds = journal.bounds().await;
-            assert_eq!(bounds.end, 0);
-            assert!(bounds.is_empty());
-            // Make sure journal still works for appending.
-            journal
-                .append(&test_digest(0))
-                .await
-                .expect("failed to append data");
-            assert_eq!(journal.size().await, 1);
-
-            journal.destroy().await.unwrap();
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
         });
     }
 
@@ -2414,34 +2490,8 @@ mod tests {
                 .expect("Failed to truncate blob");
             blob.sync().await.expect("Failed to sync blob");
 
-            // Re-initialize the journal - it should recover by truncating to valid data
-            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
-                .await
-                .expect("Failed to re-initialize journal after page truncation");
-
-            // The journal should have fewer items now (those that fit in the remaining pages).
-            // With logical page size 44 and item size 32:
-            // - After truncating to (full_pages-1) physical pages, we have (full_pages-1)*44 logical bytes
-            // - Number of complete items = floor(logical_bytes / 32)
-            let remaining_logical_bytes = (full_pages - 1) * PAGE_SIZE.get() as u64;
-            let expected_items = remaining_logical_bytes / 32; // 32 = Digest::SIZE
-            assert_eq!(
-                journal.size().await,
-                expected_items,
-                "Journal should recover to {} items after truncation",
-                expected_items
-            );
-
-            // Verify we can still read the remaining items
-            for i in 0..expected_items {
-                let item = journal
-                    .read(i)
-                    .await
-                    .expect("failed to read recovered item");
-                assert_eq!(item, test_digest(i), "item {} mismatch after recovery", i);
-            }
-
-            journal.destroy().await.expect("Failed to destroy journal");
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
         });
     }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -84,6 +84,8 @@ const LENGTH_RECOVERY_KEY: u64 = 2;
 /// Length-walking recovery may truncate an unsynced suffix, but it must not recover before this
 /// checkpoint. Destructive operations lower the checkpoint before mutating data.
 const RECOVERY_SIZE_KEY: u64 = 3;
+/// Metadata key marking an in-progress destructive reset to a logical size.
+const RESET_SIZE_KEY: u64 = 4;
 
 /// Return the first retained logical position in `section`.
 #[inline]
@@ -167,6 +169,15 @@ struct Inner<E: Context, A: CodecFixedShared> {
 
     /// The last logical size synced as a recovery checkpoint.
     recovery_size: Option<u64>,
+}
+
+struct RecoveredBounds {
+    pruning_boundary: u64,
+    size: u64,
+    needs_metadata_update: bool,
+    remove_reset_marker: bool,
+    recovery_size: Option<u64>,
+    repaired_from_section: Option<u64>,
 }
 
 impl<E: Context, A: CodecFixedShared> Inner<E, A> {
@@ -565,22 +576,39 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             Self::parse_metadata_u64(&metadata, PRUNING_BOUNDARY_KEY, "pruning_boundary")?;
         let mut recovery_size =
             Self::parse_metadata_u64(&metadata, RECOVERY_SIZE_KEY, "recovery_size")?;
+        let reset_size = Self::parse_metadata_u64(&metadata, RESET_SIZE_KEY, "reset_size")?;
         let mut length_recovery = metadata.get(&LENGTH_RECOVERY_KEY).is_some();
 
         // Recover bounds from metadata and/or blobs
-        let (pruning_boundary, size, needs_metadata_update) = Self::recover_bounds(
+        let recovered = Self::recover_bounds(
             &mut journal,
             items_per_blob,
             meta_pruning_boundary,
+            reset_size,
             length_recovery,
             recovery_size,
         )
         .await?;
+        let pruning_boundary = recovered.pruning_boundary;
+        let size = recovered.size;
+        recovery_size = recovered.recovery_size;
+
+        if let Some(start_section) = recovered.repaired_from_section {
+            let tail_section = size / items_per_blob;
+            for section in start_section..=tail_section {
+                journal.sync(section).await?;
+            }
+        }
+
+        // Re-establish the tail before persisting metadata cleanup. If recovery consumed a reset
+        // marker, a crash after marker removal can still recover from the replacement tail.
+        let tail_section = size / items_per_blob;
+        journal.ensure_section_exists(tail_section).await?;
 
         // Persist metadata if needed, and install length-recovery metadata after the legacy
         // recovery pass so future appends do not need an append-time metadata sync.
         let mut metadata_dirty = false;
-        if needs_metadata_update {
+        if recovered.needs_metadata_update {
             if pruning_boundary.is_multiple_of(items_per_blob) {
                 metadata.remove(&PRUNING_BOUNDARY_KEY);
             } else {
@@ -589,6 +617,10 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                     pruning_boundary.to_be_bytes().to_vec(),
                 );
             }
+            metadata_dirty = true;
+        }
+        if recovered.remove_reset_marker {
+            metadata.remove(&RESET_SIZE_KEY);
             metadata_dirty = true;
         }
         if Self::install_recovery_metadata_if_needed(
@@ -602,12 +634,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         if metadata_dirty {
             metadata.sync().await?;
         }
-
-        // Invariant: Tail blob must exist, even if empty. This ensures we can reconstruct size on
-        // reopen even after pruning all items. The tail blob is at `size / items_per_blob` (where
-        // the next append would go).
-        let tail_section = size / items_per_blob;
-        journal.ensure_section_exists(tail_section).await?;
 
         let metrics = Metrics::new(context);
         metrics.update(size, pruning_boundary, items_per_blob);
@@ -641,11 +667,25 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         inner: &mut SegmentedJournal<E, A>,
         items_per_blob: u64,
         meta_pruning_boundary: Option<u64>,
+        reset_size: Option<u64>,
         length_recovery: bool,
         recovery_size: Option<u64>,
-    ) -> Result<(u64, u64, bool), Error> {
+    ) -> Result<RecoveredBounds, Error> {
         // Blob-based boundary is always section-aligned
         let blob_boundary = inner.oldest_section().map_or(0, |o| o * items_per_blob);
+        let remove_reset_marker = reset_size.is_some();
+        if let Some(reset_size) = reset_size {
+            if Self::reset_marker_matches(inner, items_per_blob, reset_size).await? {
+                return Ok(RecoveredBounds {
+                    pruning_boundary: reset_size,
+                    size: reset_size,
+                    needs_metadata_update: true,
+                    remove_reset_marker,
+                    recovery_size: None,
+                    repaired_from_section: None,
+                });
+            }
+        }
 
         let (pruning_boundary, needs_update, discard_recovery_size) = match meta_pruning_boundary {
             // Mid-section metadata: validate against blobs
@@ -685,13 +725,25 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                     Some(_) => (meta_pruning_boundary, false, false), // valid mid-section metadata
                 }
             }
-            // Section-aligned metadata: unnecessary, use blob-based.
+            // Section-aligned metadata is normally unnecessary. During aligned destructive resets,
+            // it is also used as a temporary marker until the replacement tail exists.
             Some(meta_pruning_boundary) => {
                 let meta_oldest_section = meta_pruning_boundary / items_per_blob;
-                let discard_recovery_size = inner
-                    .oldest_section()
-                    .is_none_or(|oldest_section| meta_oldest_section > oldest_section);
-                (blob_boundary, true, discard_recovery_size)
+                match inner.oldest_section() {
+                    None => (meta_pruning_boundary, false, true),
+                    Some(oldest_section) if meta_oldest_section > oldest_section => {
+                        (blob_boundary, true, true)
+                    }
+                    Some(oldest_section) if meta_oldest_section == oldest_section => {
+                        let empty_reset_tail = inner.section_len(oldest_section).await? == 0;
+                        if empty_reset_tail {
+                            (meta_pruning_boundary, false, false)
+                        } else {
+                            (blob_boundary, true, false)
+                        }
+                    }
+                    Some(_) => (blob_boundary, true, false),
+                }
             }
             // No metadata: use blob-based, no update needed
             None => (blob_boundary, false, false),
@@ -703,14 +755,39 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             recovery_size
         };
 
-        let size = if length_recovery {
+        let (size, repaired_from_section) = if length_recovery {
             Self::recover_by_walking_lengths(inner, items_per_blob, pruning_boundary, recovery_size)
                 .await?
         } else {
             Self::validate_oldest_section(inner, items_per_blob, pruning_boundary).await?;
-            Self::compute_size(inner, items_per_blob, pruning_boundary).await?
+            (
+                Self::compute_size(inner, items_per_blob, pruning_boundary).await?,
+                None,
+            )
         };
-        Ok((pruning_boundary, size, needs_update))
+        Ok(RecoveredBounds {
+            pruning_boundary,
+            size,
+            needs_metadata_update: needs_update,
+            remove_reset_marker,
+            recovery_size,
+            repaired_from_section,
+        })
+    }
+
+    async fn reset_marker_matches(
+        inner: &SegmentedJournal<E, A>,
+        items_per_blob: u64,
+        reset_size: u64,
+    ) -> Result<bool, Error> {
+        let reset_section = reset_size / items_per_blob;
+        let (Some(oldest), Some(newest)) = (inner.oldest_section(), inner.newest_section()) else {
+            return Ok(true);
+        };
+        if oldest != reset_section || newest != reset_section {
+            return Ok(false);
+        }
+        Ok(inner.section_len(reset_section).await? == 0)
     }
 
     /// Validate that the oldest section has the expected number of items.
@@ -811,13 +888,13 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         items_per_blob: u64,
         pruning_boundary: u64,
         recovery_size: Option<u64>,
-    ) -> Result<u64, Error> {
+    ) -> Result<(u64, Option<u64>), Error> {
         let oldest = inner.oldest_section();
         let newest = inner.newest_section();
 
         let (Some(oldest), Some(newest)) = (oldest, newest) else {
             Self::validate_recovery_checkpoint(pruning_boundary, recovery_size)?;
-            return Ok(pruning_boundary);
+            return Ok((pruning_boundary, None));
         };
 
         let mut size = None;
@@ -840,14 +917,15 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                         len, capacity, "crash repair: truncating journal after short section"
                     );
                     inner.rewind(section, byte_offset).await?;
+                    return Ok((recovered_size, Some(section)));
                 }
-                return Ok(recovered_size);
+                return Ok((recovered_size, None));
             }
         }
 
         let size = size.expect("non-empty section range should set recovered size");
         Self::validate_recovery_checkpoint(size, recovery_size)?;
-        Ok(size)
+        Ok((size, None))
     }
 
     /// Initialize a new `Journal` instance in a pruned state at a given size.
@@ -895,15 +973,19 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             Metadata::<_, u64, Vec<u8>>::init(context.child("meta"), meta_cfg).await?;
         let mut journal = SegmentedJournal::init(context.child("blobs"), segmented_cfg).await?;
 
-        // Clear blobs before updating metadata.
-        // This ordering is critical for crash safety:
-        // - Crash after clear: no blobs, recovery returns (0, 0), metadata ignored
-        // - Crash after create: old metadata triggers "metadata ahead" warning,
-        //   recovery falls back to blob state.
+        // The reset marker lets recovery distinguish an interrupted destructive reset from
+        // ordinary blob loss. If old data is still present, recovery ignores the marker.
+        metadata
+            .put_sync(RESET_SIZE_KEY, size.to_be_bytes().to_vec())
+            .await?;
+
+        // Clear blobs before updating pruning metadata. If a crash interrupts the reset after
+        // this point, the reset marker recovers the intended pruned size.
         journal.clear().await?;
         journal.ensure_section_exists(tail_section).await?;
 
-        let mut metadata_dirty = false;
+        let mut metadata_dirty = true;
+        metadata.remove(&RESET_SIZE_KEY);
 
         // Persist metadata if pruning_boundary is mid-section.
         if !size.is_multiple_of(items_per_blob) {
@@ -1259,13 +1341,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// If a crash occurs during this operation, `init()` will recover to a consistent state
     /// (though possibly different from the intended `new_size`).
     pub(crate) async fn clear_to_size(&self, new_size: u64) -> Result<(), Error> {
-        // Clear blobs before updating metadata.
-        // This ordering is critical for crash safety:
-        // - Crash after clear: no blobs, recovery returns (0, 0), metadata ignored
-        // - Crash after create: old metadata triggers "metadata ahead" warning,
-        //   recovery falls back to blob state
         let mut inner = self.inner.write().await;
         Self::lower_recovery_size(&mut inner, new_size).await?;
+        // The reset marker lets recovery distinguish an interrupted destructive reset from
+        // ordinary blob loss. If old data is still present, recovery ignores the marker.
+        inner
+            .metadata
+            .put_sync(RESET_SIZE_KEY, new_size.to_be_bytes().to_vec())
+            .await?;
         inner.journal.clear().await?;
         let tail_section = new_size / self.items_per_blob;
         inner.journal.ensure_section_exists(tail_section).await?;
@@ -1275,11 +1358,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         inner.dirty_from_section = None;
 
         // Persist metadata only when pruning_boundary is mid-section.
+        inner.metadata.remove(&RESET_SIZE_KEY);
         if !inner.pruning_boundary.is_multiple_of(self.items_per_blob) {
             let value = inner.pruning_boundary.to_be_bytes().to_vec();
             inner.metadata.put_sync(PRUNING_BOUNDARY_KEY, value).await?;
         } else if inner.metadata.get(&PRUNING_BOUNDARY_KEY).is_some() {
             inner.metadata.remove(&PRUNING_BOUNDARY_KEY);
+            inner.metadata.sync().await?;
+        } else {
             inner.metadata.sync().await?;
         }
 
@@ -1622,6 +1708,148 @@ mod tests {
 
             let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
             assert_corruption_contains(result, "recovered size");
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_recovers_aligned_reset_after_clear_crash() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let journal = Journal::init(context.child("first"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+            for i in 0..12 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.expect("failed to sync journal");
+            drop(journal);
+
+            let reset_size = 10u64;
+            let meta_cfg = MetadataConfig {
+                partition: format!("{}-metadata", cfg.partition),
+                codec_config: ((0..).into(), ()),
+            };
+            let mut metadata =
+                Metadata::<_, u64, Vec<u8>>::init(context.child("metadata"), meta_cfg)
+                    .await
+                    .unwrap();
+            metadata
+                .put_sync(RECOVERY_SIZE_KEY, reset_size.to_be_bytes().to_vec())
+                .await
+                .unwrap();
+            metadata
+                .put_sync(RESET_SIZE_KEY, reset_size.to_be_bytes().to_vec())
+                .await
+                .unwrap();
+
+            context
+                .remove(&blob_partition(&cfg), None)
+                .await
+                .expect("failed to remove blobs");
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("failed to recover reset journal");
+            assert_eq!(journal.bounds().await, reset_size..reset_size);
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("third"), cfg.clone())
+                .await
+                .expect("failed to reopen recovered reset journal");
+            assert_eq!(journal.bounds().await, reset_size..reset_size);
+            journal.destroy().await.expect("failed to destroy journal");
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_ignores_reset_marker_before_clear() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let journal = Journal::init(context.child("first"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+            for i in 0..12 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.expect("failed to sync journal");
+            drop(journal);
+
+            let reset_size = 10u64;
+            let meta_cfg = MetadataConfig {
+                partition: format!("{}-metadata", cfg.partition),
+                codec_config: ((0..).into(), ()),
+            };
+            let mut metadata =
+                Metadata::<_, u64, Vec<u8>>::init(context.child("metadata"), meta_cfg)
+                    .await
+                    .unwrap();
+            metadata
+                .put_sync(RECOVERY_SIZE_KEY, reset_size.to_be_bytes().to_vec())
+                .await
+                .unwrap();
+            metadata
+                .put_sync(RESET_SIZE_KEY, reset_size.to_be_bytes().to_vec())
+                .await
+                .unwrap();
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("failed to ignore reset marker");
+            assert_eq!(journal.size().await, 12);
+            assert_eq!(journal.read(11).await.unwrap(), test_digest(11));
+            journal.destroy().await.expect("failed to destroy journal");
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_recovers_reset_marker_with_old_checkpoint() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let journal = Journal::init(context.child("first"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+            for i in 0..12 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.expect("failed to sync journal");
+            drop(journal);
+
+            let reset_size = 10u64;
+            let meta_cfg = MetadataConfig {
+                partition: format!("{}-metadata", cfg.partition),
+                codec_config: ((0..).into(), ()),
+            };
+            let mut metadata =
+                Metadata::<_, u64, Vec<u8>>::init(context.child("metadata"), meta_cfg)
+                    .await
+                    .unwrap();
+            metadata
+                .put_sync(RESET_SIZE_KEY, reset_size.to_be_bytes().to_vec())
+                .await
+                .unwrap();
+            context
+                .remove(&blob_partition(&cfg), None)
+                .await
+                .expect("failed to remove blobs");
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("failed to recover reset marker");
+            assert_eq!(journal.bounds().await, reset_size..reset_size);
+            journal
+                .sync()
+                .await
+                .expect("failed to sync recovered journal");
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("third"), cfg.clone())
+                .await
+                .expect("failed to reopen reset marker journal");
+            assert_eq!(journal.bounds().await, reset_size..reset_size);
+            journal.destroy().await.expect("failed to destroy journal");
         });
     }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -73,9 +73,16 @@ use tracing::warn;
 
 /// Metadata key for storing the pruning boundary.
 const PRUNING_BOUNDARY_KEY: u64 = 1;
-/// Metadata key marking journals that require length-walking recovery.
+/// Metadata key marking journals that require length-walking recovery on startup.
+///
+/// Legacy journals without this key are recovered with the historical invariant that all non-tail
+/// sections were synced on rollover. After a successful initialization, the key is installed so
+/// future appends can avoid rollover fsyncs without doing an append-time metadata sync.
 const LENGTH_RECOVERY_KEY: u64 = 2;
 /// Metadata key for the highest logical size durably synced as a recovery checkpoint.
+///
+/// Length-walking recovery may truncate an unsynced suffix, but it must not recover before this
+/// checkpoint. Destructive operations lower the checkpoint before mutating data.
 const RECOVERY_SIZE_KEY: u64 = 3;
 
 /// Return the first retained logical position in `section`.
@@ -474,6 +481,26 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .transpose()
     }
 
+    fn stage_length_recovery_metadata(
+        metadata: &mut Metadata<E, u64, Vec<u8>>,
+        length_recovery: &mut bool,
+        recovery_size: &mut Option<u64>,
+        size: u64,
+    ) -> bool {
+        let mut dirty = false;
+        if !*length_recovery {
+            metadata.put(LENGTH_RECOVERY_KEY, vec![1]);
+            *length_recovery = true;
+            dirty = true;
+        }
+        if recovery_size.is_none() {
+            metadata.put(RECOVERY_SIZE_KEY, size.to_be_bytes().to_vec());
+            *recovery_size = Some(size);
+            dirty = true;
+        }
+        dirty
+    }
+
     /// Scan a partition and return blob names, treating a missing partition as empty.
     async fn scan_partition(context: &E, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
         match context.scan(partition).await {
@@ -536,9 +563,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // Parse metadata if present
         let meta_pruning_boundary =
             Self::parse_metadata_u64(&metadata, PRUNING_BOUNDARY_KEY, "pruning_boundary")?;
-        let recovery_size =
+        let mut recovery_size =
             Self::parse_metadata_u64(&metadata, RECOVERY_SIZE_KEY, "recovery_size")?;
-        let length_recovery = metadata.get(&LENGTH_RECOVERY_KEY).is_some();
+        let mut length_recovery = metadata.get(&LENGTH_RECOVERY_KEY).is_some();
 
         // Recover bounds from metadata and/or blobs
         let (pruning_boundary, size, needs_metadata_update) = Self::recover_bounds(
@@ -550,19 +577,28 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         )
         .await?;
 
-        // Persist metadata if needed
+        // Persist metadata if needed, and install length-recovery metadata after the legacy
+        // recovery pass so future appends do not need an append-time metadata sync.
+        let mut metadata_dirty = false;
         if needs_metadata_update {
             if pruning_boundary.is_multiple_of(items_per_blob) {
                 metadata.remove(&PRUNING_BOUNDARY_KEY);
-                metadata.sync().await?;
             } else {
-                metadata
-                    .put_sync(
-                        PRUNING_BOUNDARY_KEY,
-                        pruning_boundary.to_be_bytes().to_vec(),
-                    )
-                    .await?;
+                metadata.put(
+                    PRUNING_BOUNDARY_KEY,
+                    pruning_boundary.to_be_bytes().to_vec(),
+                );
             }
+            metadata_dirty = true;
+        }
+        metadata_dirty |= Self::stage_length_recovery_metadata(
+            &mut metadata,
+            &mut length_recovery,
+            &mut recovery_size,
+            size,
+        );
+        if metadata_dirty {
+            metadata.sync().await?;
         }
 
         // Invariant: Tail blob must exist, even if empty. This ensures we can reconstruct size on
@@ -781,8 +817,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                             )));
                         }
                     }
-                }
-                if section != newest {
                     let byte_offset = len
                         .checked_mul(Self::CHUNK_SIZE_U64)
                         .ok_or(Error::OffsetOverflow)?;
@@ -852,20 +886,26 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         journal.clear().await?;
         journal.ensure_section_exists(tail_section).await?;
 
+        let mut metadata_dirty = false;
+
         // Persist metadata if pruning_boundary is mid-section.
         if !size.is_multiple_of(items_per_blob) {
-            metadata
-                .put_sync(PRUNING_BOUNDARY_KEY, size.to_be_bytes().to_vec())
-                .await?;
+            metadata.put(PRUNING_BOUNDARY_KEY, size.to_be_bytes().to_vec());
+            metadata_dirty = true;
         } else if metadata.get(&PRUNING_BOUNDARY_KEY).is_some() {
             metadata.remove(&PRUNING_BOUNDARY_KEY);
-            metadata.sync().await?;
+            metadata_dirty = true;
         }
-        let reset_recovery_metadata = metadata.get(&LENGTH_RECOVERY_KEY).is_some()
-            || metadata.get(&RECOVERY_SIZE_KEY).is_some();
-        if reset_recovery_metadata {
-            metadata.remove(&LENGTH_RECOVERY_KEY);
-            metadata.remove(&RECOVERY_SIZE_KEY);
+
+        let mut length_recovery = false;
+        let mut recovery_size = None;
+        metadata_dirty |= Self::stage_length_recovery_metadata(
+            &mut metadata,
+            &mut length_recovery,
+            &mut recovery_size,
+            size,
+        );
+        if metadata_dirty {
             metadata.sync().await?;
         }
 
@@ -879,8 +919,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                 metadata,
                 pruning_boundary: size, // No data exists yet
                 dirty_from_section: None,
-                length_recovery: false,
-                recovery_size: None,
+                length_recovery,
+                recovery_size,
             }),
             items_per_blob,
             metrics,
@@ -893,27 +933,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let section = position / self.items_per_blob;
         let pos_in_section = position % self.items_per_blob;
         (section, pos_in_section)
-    }
-
-    async fn enable_length_recovery_inner(inner: &mut Inner<E, A>) -> Result<(), Error> {
-        if inner.length_recovery {
-            return Ok(());
-        }
-        inner.metadata.put(LENGTH_RECOVERY_KEY, vec![1]);
-        if inner.recovery_size.is_none() {
-            inner
-                .metadata
-                .put(RECOVERY_SIZE_KEY, inner.size.to_be_bytes().to_vec());
-            inner.recovery_size = Some(inner.size);
-        }
-        inner.metadata.sync().await?;
-        inner.length_recovery = true;
-        Ok(())
-    }
-
-    pub(crate) async fn enable_length_recovery(&self) -> Result<(), Error> {
-        let mut inner = self.inner.write().await;
-        Self::enable_length_recovery_inner(&mut inner).await
     }
 
     pub(crate) async fn length_recovery_enabled(&self) -> bool {
@@ -1078,7 +1097,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
         // Mutating operations are serialized by taking the write guard.
         let mut inner = self.inner.write().await;
-        Self::enable_length_recovery_inner(&mut inner).await?;
         let mut written = 0;
         while written < items_count {
             let (section, pos_in_section) = self.position_to_section(inner.size);
@@ -1391,6 +1409,60 @@ mod tests {
 
     fn blob_partition(cfg: &Config) -> String {
         format!("{}-blobs", cfg.partition)
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_init_installs_length_recovery() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(7));
+            let journal = Journal::<_, Digest>::init(context.child("init"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+            assert!(journal.length_recovery_enabled().await);
+            journal.destroy().await.expect("failed to destroy journal");
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_length_recovery_truncates_unsynced_short_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(7));
+            let journal = Journal::init(context.child("first"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+
+            let item_count = cfg.items_per_blob.get() * 2 + 3;
+            for i in 0..item_count {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            sync_dirty_blobs(&journal).await;
+            drop(journal);
+
+            let (blob, size) = context
+                .open(&blob_partition(&cfg), &1u64.to_be_bytes())
+                .await
+                .expect("failed to open section");
+            blob.resize(size - 1)
+                .await
+                .expect("failed to truncate section");
+            blob.sync().await.expect("failed to sync section");
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("failed to recover journal");
+            let recovered = journal.size().await;
+            assert!(
+                recovered < item_count,
+                "short non-tail section should truncate unsynced suffix"
+            );
+            assert!(
+                recovered >= cfg.items_per_blob.get(),
+                "recovery should keep the full prefix before the short section"
+            );
+            journal.destroy().await.expect("failed to destroy journal");
+        });
     }
 
     async fn scan_partition(context: &Context, partition: &str) -> Vec<Vec<u8>> {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -725,8 +725,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                     Some(_) => (meta_pruning_boundary, false, false), // valid mid-section metadata
                 }
             }
-            // Section-aligned metadata is normally unnecessary. During aligned destructive resets,
-            // it is also used as a temporary marker until the replacement tail exists.
+            // Section-aligned metadata is normally unnecessary. Keep accepting it as a reset
+            // compatibility marker for journals that crashed while older versions of this patch
+            // were installing aligned replacement tails.
             Some(meta_pruning_boundary) => {
                 let meta_oldest_section = meta_pruning_boundary / items_per_blob;
                 match inner.oldest_section() {
@@ -782,6 +783,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     ) -> Result<bool, Error> {
         let reset_section = reset_size / items_per_blob;
         let (Some(oldest), Some(newest)) = (inner.oldest_section(), inner.newest_section()) else {
+            // No blobs is exactly the crash window that the reset marker exists to cover: the reset
+            // was durably marked, but blob clearing completed before the replacement tail survived.
             return Ok(true);
         };
         if oldest != reset_section || newest != reset_section {
@@ -1828,6 +1831,10 @@ mod tests {
                 Metadata::<_, u64, Vec<u8>>::init(context.child("metadata"), meta_cfg)
                     .await
                     .unwrap();
+            // This state cannot be produced by the current reset path, which lowers
+            // RECOVERY_SIZE before writing RESET_SIZE_KEY. It protects recovery against older WIP
+            // states and manually constructed metadata where the reset marker is the only reliable
+            // indication of the intended clear target.
             metadata
                 .put_sync(RESET_SIZE_KEY, reset_size.to_be_bytes().to_vec())
                 .await

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -929,8 +929,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let stream = data.replay(section, 0, REPLAY_BUFFER_SIZE).await?;
         futures::pin_mut!(stream);
         let mut count = 0u64;
+        // Recovery is fail-fast: partial counts are not useful once replay reports corruption.
         while let Some(result) = stream.next().await {
-            // Recovery is fail-fast: partial counts are not useful once replay reports corruption.
             let (item_section, _, _, _) = result?;
             if item_section != section {
                 break;
@@ -1019,18 +1019,16 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         offsets: &mut fixed::Journal<E, u64>,
         items_per_section: u64,
     ) -> Result<(u64, u64), Error> {
-        if offsets.length_recovery_enabled().await {
-            let initial_offsets_bounds = {
-                let offsets_reader = offsets.reader().await;
-                offsets_reader.bounds()
-            };
-            Self::recover_data_by_walking_lengths(
-                data,
-                initial_offsets_bounds.start,
-                items_per_section,
-            )
-            .await?;
-        }
+        let initial_offsets_bounds = {
+            let offsets_reader = offsets.reader().await;
+            offsets_reader.bounds()
+        };
+        Self::recover_data_by_walking_lengths(
+            data,
+            initial_offsets_bounds.start,
+            items_per_section,
+        )
+        .await?;
 
         // === Handle empty data journal case ===
         let items_in_last_section = match data.newest_section() {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1,7 +1,8 @@
 //! Position-based journal for variable-length items.
 //!
-//! This journal enforces section fullness: all non-final sections are full and synced.
-//! On init, only the last section needs to be replayed to determine the exact size.
+//! This journal assigns appended items to fixed-capacity sections. Full sections are flushed for
+//! visibility at rollover, while `commit()` and `sync()` provide durability. On init, recovery may
+//! walk retained data sections to distinguish an unsynced suffix from checkpointed data.
 
 use super::Reader as _;
 use crate::{
@@ -68,7 +69,7 @@ pub struct Config<C> {
     /// The number of items to store in each section.
     ///
     /// Once set, this value cannot be changed across restarts.
-    /// All non-final sections will be full and persisted.
+    /// All non-final sections should be full during normal operation.
     pub items_per_section: NonZeroU64,
 
     /// Optional compression level for stored items.
@@ -196,8 +197,8 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 ///
 /// ## 1. Section Fullness
 ///
-/// All non-final sections are full (`items_per_section` items) and persisted. This ensures
-/// that on `init()`, we only need to replay the last section to determine the exact size.
+/// All non-final sections are full (`items_per_section` items) during normal operation. Recovery
+/// walks retained data sections to repair uncheckpointed suffixes and reject checkpoint violations.
 ///
 /// ## 2. Data Journal is Source of Truth
 ///
@@ -945,10 +946,10 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         offsets: &fixed::Journal<E, u64>,
         offsets_start: u64,
         items_per_section: u64,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<u64>, Error> {
         let sections: Vec<u64> = data.sections().collect();
         if sections.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         let last_section = *sections.last().expect("sections is non-empty");
 
@@ -964,7 +965,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                         section, "crash repair: truncating data journal before section gap"
                     );
                     data.rewind(previous, byte_offset).await?;
-                    return Ok(());
+                    return Ok(Some(previous));
                 }
             }
 
@@ -1003,7 +1004,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             if count < capacity {
                 offsets.validate_recovered_size(recovered_size).await?;
                 if section == last_section {
-                    return Ok(());
+                    return Ok(None);
                 }
                 let byte_offset = data.size(section).await?;
                 warn!(
@@ -1011,13 +1012,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                     count, capacity, "crash repair: truncating data journal after short section"
                 );
                 data.rewind(section, byte_offset).await?;
-                return Ok(());
+                return Ok(Some(section));
             }
 
             previous = Some(section);
         }
         offsets.validate_recovered_size(recovered_size).await?;
-        Ok(())
+        Ok(None)
     }
 
     /// Align the offsets journal and data journal to be consistent in case a crash occurred
@@ -1038,7 +1039,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             let offsets_reader = offsets.reader().await;
             offsets_reader.bounds()
         };
-        Self::recover_data_by_walking_lengths(
+        let repaired_from_section = Self::recover_data_by_walking_lengths(
             data,
             offsets,
             initial_offsets_bounds.start,
@@ -1201,6 +1202,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             offsets_bounds.start
         };
 
+        if let (Some(start_section), Some(last_section)) =
+            (repaired_from_section, data.newest_section())
+        {
+            for section in start_section..=last_section {
+                data.sync(section).await?;
+            }
+        }
         offsets.sync().await?;
         Ok((pruning_boundary, data_size))
     }
@@ -1612,6 +1620,65 @@ mod tests {
 
             let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
             assert_corruption_contains(result, "recovered size");
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_recovery_truncates_unsynced_short_data_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "unsynced-short-data-section".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..10u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+
+            let item_count = 25;
+            for i in 10..item_count {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            {
+                let inner = journal.inner.read().await;
+                inner.data.sync(1).await.unwrap();
+            }
+            drop(journal);
+
+            let (blob, size) = context
+                .open(&cfg.data_partition(), &1u64.to_be_bytes())
+                .await
+                .expect("failed to open data section");
+            blob.resize(size - 1)
+                .await
+                .expect("failed to truncate data section");
+            blob.sync().await.expect("failed to sync data section");
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("failed to recover journal");
+            let recovered = journal.size().await;
+            assert!(
+                recovered >= 10,
+                "recovery should preserve synced prefix before short section"
+            );
+            assert!(
+                recovered < item_count,
+                "short unsynced data section should truncate suffix"
+            );
+            for i in 0..recovered {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            journal.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -117,6 +117,9 @@ struct Inner<E: Context, V: Codec> {
     ///
     /// Never decreases (pruning only moves forward).
     pruning_boundary: u64,
+
+    /// Earliest data section modified since the last successful commit or sync.
+    dirty_from_section: Option<u64>,
 }
 
 impl<E: Context, V: CodecShared> Inner<E, V> {
@@ -459,6 +462,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 data,
                 size,
                 pruning_boundary,
+                dirty_from_section: None,
             }),
             offsets,
             items_per_section,
@@ -508,6 +512,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 data,
                 size,
                 pruning_boundary: size,
+                dirty_from_section: None,
             }),
             offsets,
             items_per_section,
@@ -655,6 +660,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
         // Update our size
         inner.size = size;
+        inner.dirty_from_section = Some(
+            inner
+                .dirty_from_section
+                .map_or(discard_section, |dirty_from| {
+                    dirty_from.min(discard_section)
+                }),
+        );
         self.metrics
             .update(inner.size, inner.pruning_boundary, self.items_per_section);
 
@@ -721,6 +733,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             }
         }
 
+        self.offsets.enable_length_recovery().await?;
+
         // Mutating operations are serialized by taking the write guard.
         let mut inner = self.inner.write().await;
 
@@ -738,6 +752,9 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
             // Append pre-encoded data to the data journal, then convert relative item starts
             // into absolute offsets.
+            if inner.dirty_from_section.is_none() {
+                inner.dirty_from_section = Some(section);
+            }
             let base_offset = inner
                 .data
                 .append_raw(section, &encoded[batch_start..batch_end])
@@ -762,20 +779,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             inner.size += batch_count as u64;
             written += batch_count;
 
-            // The section was filled and must be synced. Downgrade so readers can continue
-            // during the sync while mutators remain blocked.
             if inner.size.is_multiple_of(self.items_per_section) {
-                let inner_ref = inner.downgrade_to_upgradable();
-                futures::try_join!(inner_ref.data.sync(section), self.offsets.sync())?;
-                if written == items_count {
-                    self.metrics.update(
-                        inner_ref.size,
-                        inner_ref.pruning_boundary,
-                        self.items_per_section,
-                    );
-                    return Ok(inner_ref.size - 1);
-                }
-                inner = inner_ref.upgrade().await;
+                inner.data.flush(section).await?;
             }
         }
 
@@ -827,6 +832,9 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         if pruned {
             let new_oldest = (min_section * self.items_per_section).max(inner.pruning_boundary);
             inner.pruning_boundary = new_oldest;
+            if let Some(dirty_from) = inner.dirty_from_section {
+                inner.dirty_from_section = Some(dirty_from.max(min_section));
+            }
             self.offsets.prune(new_oldest).await?;
             self.metrics
                 .update(inner.size, inner.pruning_boundary, self.items_per_section);
@@ -845,8 +853,18 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // concurrent readers.
         let inner = self.inner.upgradable_read().await;
 
-        let section = position_to_section(inner.size, self.items_per_section);
-        inner.data.sync(section).await?;
+        if let Some(start_section) = inner.dirty_from_section {
+            let start_section = inner
+                .data
+                .oldest_section()
+                .map_or(start_section, |oldest| start_section.max(oldest));
+            let tail_section = position_to_section(inner.size, self.items_per_section);
+            for section in start_section..=tail_section {
+                inner.data.sync(section).await?;
+            }
+            let mut inner = inner.upgrade().await;
+            inner.dirty_from_section = None;
+        }
         Ok(())
     }
 
@@ -860,13 +878,21 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // concurrent readers.
         let inner = self.inner.upgradable_read().await;
 
-        // Persist only the current (final) section of the data journal.
-        // All non-final sections are already persisted per Invariant #1.
-        let section = position_to_section(inner.size, self.items_per_section);
-
-        // Persist both journals concurrently. These journals may not exist yet if the
-        // previous section was just filled. This is checked internally.
-        futures::try_join!(inner.data.sync(section), self.offsets.sync())?;
+        if let Some(start_section) = inner.dirty_from_section {
+            let start_section = inner
+                .data
+                .oldest_section()
+                .map_or(start_section, |oldest| start_section.max(oldest));
+            let tail_section = position_to_section(inner.size, self.items_per_section);
+            for section in start_section..=tail_section {
+                inner.data.sync(section).await?;
+            }
+        }
+        self.offsets.sync().await?;
+        if inner.dirty_from_section.is_some() {
+            let mut inner = inner.upgrade().await;
+            inner.dirty_from_section = None;
+        }
 
         Ok(())
     }
@@ -892,8 +918,86 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         self.offsets.clear_to_size(new_size).await?;
         inner.size = new_size;
         inner.pruning_boundary = new_size;
+        inner.dirty_from_section = None;
         self.metrics
             .update(inner.size, inner.pruning_boundary, self.items_per_section);
+        Ok(())
+    }
+
+    async fn count_section_items(
+        data: &variable::Journal<E, V>,
+        section: u64,
+    ) -> Result<u64, Error> {
+        let stream = data.replay(section, 0, REPLAY_BUFFER_SIZE).await?;
+        futures::pin_mut!(stream);
+        let mut count = 0u64;
+        while let Some(result) = stream.next().await {
+            let (item_section, _, _, _) = result?;
+            if item_section != section {
+                break;
+            }
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    async fn recover_data_by_walking_lengths(
+        data: &mut variable::Journal<E, V>,
+        offsets_start: u64,
+        items_per_section: u64,
+    ) -> Result<(), Error> {
+        let sections: Vec<u64> = data.sections().collect();
+        let Some(&first_section) = sections.first() else {
+            return Ok(());
+        };
+
+        let mut previous = None;
+        for (idx, section) in sections.iter().copied().enumerate() {
+            if let Some(previous) = previous {
+                if section != previous + 1 {
+                    let size = data.size(previous).await?;
+                    warn!(
+                        previous,
+                        section, "crash repair: truncating data journal before section gap"
+                    );
+                    data.rewind(previous, size).await?;
+                    return Ok(());
+                }
+            }
+
+            let count = Self::count_section_items(data, section).await?;
+
+            let section_start = section
+                .checked_mul(items_per_section)
+                .ok_or(Error::OffsetOverflow)?;
+            let capacity = if idx == 0 && offsets_start > section_start {
+                let skipped = offsets_start
+                    .checked_sub(section_start)
+                    .ok_or(Error::OffsetOverflow)?;
+                items_per_section
+                    .checked_sub(skipped)
+                    .ok_or(Error::OffsetOverflow)?
+            } else {
+                items_per_section
+            };
+            if count > capacity {
+                return Err(Error::Corruption(format!(
+                    "data section {section} has too many items: expected at most {capacity}, got {count}"
+                )));
+            }
+
+            if count < capacity && section != *sections.last().unwrap_or(&first_section) {
+                let size = data.size(section).await?;
+                warn!(
+                    section,
+                    count, capacity, "crash repair: truncating data journal after short section"
+                );
+                data.rewind(section, size).await?;
+                return Ok(());
+            }
+
+            previous = Some(section);
+        }
         Ok(())
     }
 
@@ -911,18 +1015,22 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         offsets: &mut fixed::Journal<E, u64>,
         items_per_section: u64,
     ) -> Result<(u64, u64), Error> {
+        if offsets.length_recovery_enabled().await {
+            let initial_offsets_bounds = {
+                let offsets_reader = offsets.reader().await;
+                offsets_reader.bounds()
+            };
+            Self::recover_data_by_walking_lengths(
+                data,
+                initial_offsets_bounds.start,
+                items_per_section,
+            )
+            .await?;
+        }
+
         // === Handle empty data journal case ===
         let items_in_last_section = match data.newest_section() {
-            Some(last_section) => {
-                let stream = data.replay(last_section, 0, REPLAY_BUFFER_SIZE).await?;
-                futures::pin_mut!(stream);
-                let mut count = 0u64;
-                while let Some(result) = stream.next().await {
-                    result?; // Propagate replay errors (corruption, etc.)
-                    count += 1;
-                }
-                count
-            }
+            Some(last_section) => Self::count_section_items(data, last_section).await?,
             None => 0,
         };
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -490,7 +490,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     #[commonware_macros::stability(ALPHA)]
     pub async fn init_at_size(context: E, cfg: Config<V::Cfg>, size: u64) -> Result<Self, Error> {
         // Initialize empty data journal
-        let data = variable::Journal::init(
+        let mut data = variable::Journal::init(
             context.child("data"),
             variable::Config {
                 partition: cfg.data_partition(),
@@ -501,6 +501,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             },
         )
         .await?;
+        data.clear().await?;
 
         // Initialize offsets journal at the target size
         let offsets = fixed::Journal::init_at_size(
@@ -1155,6 +1156,14 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             return Ok((size, size));
         }
 
+        if let (Some(start_section), Some(last_section)) =
+            (data_recovery.repaired_from_section, data.newest_section())
+        {
+            for section in start_section..=last_section {
+                data.sync(section).await?;
+            }
+        }
+
         // === Handle non-empty data journal case ===
         let data_first_section = data.oldest_section().unwrap();
         let data_last_section = data.newest_section().unwrap();
@@ -1261,13 +1270,6 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             offsets_bounds.start
         };
 
-        if let (Some(start_section), Some(last_section)) =
-            (data_recovery.repaired_from_section, data.newest_section())
-        {
-            for section in start_section..=last_section {
-                data.sync(section).await?;
-            }
-        }
         offsets.sync().await?;
         Ok((pruning_boundary, data_size))
     }
@@ -2820,6 +2822,45 @@ mod tests {
             assert_eq!(pos, 15);
             assert_eq!(journal.read(15).await.unwrap(), 1500);
 
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_init_at_size_clears_residual_data() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "init-at-size-clears-residual-data".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..10u64 {
+                journal.append(&i).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init_at_size(context.child("second"), cfg.clone(), 7)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 7..7);
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("third"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 7..7);
+            let pos = journal.append(&99).await.unwrap();
+            assert_eq!(pos, 7);
+            assert_eq!(journal.read(7).await.unwrap(), 99);
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -733,8 +733,6 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             }
         }
 
-        self.offsets.enable_length_recovery().await?;
-
         // Mutating operations are serialized by taking the write guard.
         let mut inner = self.inner.write().await;
 
@@ -932,6 +930,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         futures::pin_mut!(stream);
         let mut count = 0u64;
         while let Some(result) = stream.next().await {
+            // Recovery is fail-fast: partial counts are not useful once replay reports corruption.
             let (item_section, _, _, _) = result?;
             if item_section != section {
                 break;
@@ -974,6 +973,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 let skipped = offsets_start
                     .checked_sub(section_start)
                     .ok_or(Error::OffsetOverflow)?;
+                if skipped > items_per_section {
+                    return Err(Error::Corruption(format!(
+                        "offsets start {offsets_start} is beyond data section {section}"
+                    )));
+                }
                 items_per_section
                     .checked_sub(skipped)
                     .ok_or(Error::OffsetOverflow)?

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -942,24 +942,28 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
     async fn recover_data_by_walking_lengths(
         data: &mut variable::Journal<E, V>,
+        offsets: &fixed::Journal<E, u64>,
         offsets_start: u64,
         items_per_section: u64,
     ) -> Result<(), Error> {
         let sections: Vec<u64> = data.sections().collect();
-        let Some(&first_section) = sections.first() else {
+        if sections.is_empty() {
             return Ok(());
-        };
+        }
+        let last_section = *sections.last().expect("sections is non-empty");
 
         let mut previous = None;
+        let mut recovered_size = offsets_start;
         for (idx, section) in sections.iter().copied().enumerate() {
             if let Some(previous) = previous {
                 if section != previous + 1 {
-                    let size = data.size(previous).await?;
+                    offsets.validate_recovered_size(recovered_size).await?;
+                    let byte_offset = data.size(previous).await?;
                     warn!(
                         previous,
                         section, "crash repair: truncating data journal before section gap"
                     );
-                    data.rewind(previous, size).await?;
+                    data.rewind(previous, byte_offset).await?;
                     return Ok(());
                 }
             }
@@ -969,7 +973,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             let section_start = section
                 .checked_mul(items_per_section)
                 .ok_or(Error::OffsetOverflow)?;
-            let capacity = if idx == 0 && offsets_start > section_start {
+            let (first_position, capacity) = if idx == 0 && offsets_start > section_start {
                 let skipped = offsets_start
                     .checked_sub(section_start)
                     .ok_or(Error::OffsetOverflow)?;
@@ -978,11 +982,14 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                         "offsets start {offsets_start} is beyond data section {section}"
                     )));
                 }
-                items_per_section
-                    .checked_sub(skipped)
-                    .ok_or(Error::OffsetOverflow)?
+                (
+                    offsets_start,
+                    items_per_section
+                        .checked_sub(skipped)
+                        .ok_or(Error::OffsetOverflow)?,
+                )
             } else {
-                items_per_section
+                (section_start, items_per_section)
             };
             if count > capacity {
                 return Err(Error::Corruption(format!(
@@ -990,18 +997,26 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 )));
             }
 
-            if count < capacity && section != *sections.last().unwrap_or(&first_section) {
-                let size = data.size(section).await?;
+            recovered_size = first_position
+                .checked_add(count)
+                .ok_or(Error::OffsetOverflow)?;
+            if count < capacity {
+                offsets.validate_recovered_size(recovered_size).await?;
+                if section == last_section {
+                    return Ok(());
+                }
+                let byte_offset = data.size(section).await?;
                 warn!(
                     section,
                     count, capacity, "crash repair: truncating data journal after short section"
                 );
-                data.rewind(section, size).await?;
+                data.rewind(section, byte_offset).await?;
                 return Ok(());
             }
 
             previous = Some(section);
         }
+        offsets.validate_recovered_size(recovered_size).await?;
         Ok(())
     }
 
@@ -1025,6 +1040,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         };
         Self::recover_data_by_walking_lengths(
             data,
+            offsets,
             initial_offsets_bounds.start,
             items_per_section,
         )
@@ -1057,6 +1073,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 let data_first_section = data.oldest_section().unwrap();
                 let data_section_start = data_first_section * items_per_section;
                 let target_pos = data_section_start.max(offsets_bounds.start);
+                offsets.validate_recovered_size(target_pos).await?;
 
                 warn!("crash repair: clearing offsets to {target_pos} (empty section crash)");
                 offsets.clear_to_size(target_pos).await?;
@@ -1151,6 +1168,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             };
             (offsets_bounds, data_size)
         };
+        offsets.validate_recovered_size(data_size).await?;
 
         // Align sizes
         let offsets_size = offsets_bounds.end;
@@ -1390,7 +1408,8 @@ mod tests {
     use crate::journal::contiguous::tests::run_contiguous_tests;
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        buffer::paged::CacheRef, deterministic, Metrics as _, Runner, Storage, Supervisor as _,
+        buffer::paged::CacheRef, deterministic, Blob, Metrics as _, Runner, Storage,
+        Supervisor as _,
     };
     use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
     use futures::FutureExt as _;
@@ -1402,6 +1421,17 @@ mod tests {
     // Larger page sizes for tests that need more buffer space.
     const LARGE_PAGE_SIZE: NonZeroU16 = NZU16!(1024);
     const SMALL_PAGE_SIZE: NonZeroU16 = NZU16!(512);
+
+    fn assert_corruption_contains<T>(result: Result<T, Error>, needle: &str) {
+        match result {
+            Err(Error::Corruption(msg)) => assert!(
+                msg.contains(needle),
+                "corruption message {msg:?} did not contain {needle:?}"
+            ),
+            Err(err) => panic!("expected corruption containing {needle:?}, got {err:?}"),
+            Ok(_) => panic!("expected corruption containing {needle:?}, got success"),
+        }
+    }
 
     #[test_traced]
     fn test_variable_append_many_compressed() {
@@ -1510,6 +1540,78 @@ mod tests {
             drop(reader);
 
             journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_recovery_rejects_synced_short_data_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "synced-short-data-section".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..25u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let (blob, size) = context
+                .open(&cfg.data_partition(), &1u64.to_be_bytes())
+                .await
+                .expect("failed to open data section");
+            blob.resize(size - 1)
+                .await
+                .expect("failed to truncate data section");
+            blob.sync().await.expect("failed to sync data section");
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_recovery_rejects_synced_short_tail_data_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "synced-short-tail-data-section".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let (blob, size) = context
+                .open(&cfg.data_partition(), &1u64.to_be_bytes())
+                .await
+                .expect("failed to open data section");
+            blob.resize(size - 1)
+                .await
+                .expect("failed to truncate data section");
+            blob.sync().await.expect("failed to sync data section");
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
         });
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -123,6 +123,17 @@ struct Inner<E: Context, V: Codec> {
     dirty_from_section: Option<u64>,
 }
 
+struct SectionCount {
+    count: u64,
+    repaired: bool,
+}
+
+struct DataRecovery {
+    repaired_from_section: Option<u64>,
+    last_section: Option<u64>,
+    items_in_last_section: u64,
+}
+
 impl<E: Context, V: CodecShared> Inner<E, V> {
     /// Read the item at the given position using the provided offsets reader.
     ///
@@ -653,11 +664,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         };
         let discard_section = position_to_section(size, self.items_per_section);
 
+        self.offsets.rewind(size).await?;
         inner
             .data
             .rewind_to_offset(discard_section, discard_offset)
             .await?;
-        self.offsets.rewind(size).await?;
 
         // Update our size
         inner.size = size;
@@ -679,8 +690,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// The position returned is a stable, consecutively increasing value starting from 0.
     /// This position remains constant after pruning.
     ///
-    /// When a section becomes full, both the data journal and offsets journal are persisted
-    /// to maintain the invariant that all non-final sections are full and consistent.
+    /// When a section becomes full, the data section is flushed for visibility but not fsynced.
     ///
     /// # Errors
     ///
@@ -829,10 +839,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
         let pruned = inner.data.prune(min_section).await?;
         if pruned {
-            let new_oldest = (min_section * self.items_per_section).max(inner.pruning_boundary);
+            let new_oldest_section = inner.data.oldest_section().unwrap_or(min_section);
+            let new_oldest =
+                (new_oldest_section * self.items_per_section).max(inner.pruning_boundary);
             inner.pruning_boundary = new_oldest;
             if let Some(dirty_from) = inner.dirty_from_section {
-                inner.dirty_from_section = Some(dirty_from.max(min_section));
+                inner.dirty_from_section = Some(dirty_from.max(new_oldest_section));
             }
             self.offsets.prune(new_oldest).await?;
             self.metrics
@@ -926,11 +938,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     async fn count_section_items(
         data: &variable::Journal<E, V>,
         section: u64,
-    ) -> Result<u64, Error> {
+    ) -> Result<SectionCount, Error> {
+        let size_before = data.size(section).await?;
         let stream = data.replay(section, 0, REPLAY_BUFFER_SIZE).await?;
         futures::pin_mut!(stream);
         let mut count = 0u64;
-        // Recovery is fail-fast: partial counts are not useful once replay reports corruption.
+        // Replay can truncate trailing garbage as part of repair. Recovery tracks that side effect
+        // so the repaired section is synced before offsets are synced to the recovered state.
         while let Some(result) = stream.next().await {
             let (item_section, _, _, _) = result?;
             if item_section != section {
@@ -938,7 +952,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             }
             count += 1;
         }
-        Ok(count)
+        let size_after = data.size(section).await?;
+        Ok(SectionCount {
+            count,
+            repaired: size_after < size_before,
+        })
     }
 
     async fn recover_data_by_walking_lengths(
@@ -946,15 +964,21 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         offsets: &fixed::Journal<E, u64>,
         offsets_start: u64,
         items_per_section: u64,
-    ) -> Result<Option<u64>, Error> {
+    ) -> Result<DataRecovery, Error> {
         let sections: Vec<u64> = data.sections().collect();
         if sections.is_empty() {
-            return Ok(None);
+            return Ok(DataRecovery {
+                repaired_from_section: None,
+                last_section: None,
+                items_in_last_section: 0,
+            });
         }
         let last_section = *sections.last().expect("sections is non-empty");
 
         let mut previous = None;
+        let mut previous_count = 0;
         let mut recovered_size = offsets_start;
+        let mut repaired_from_section = None;
         for (idx, section) in sections.iter().copied().enumerate() {
             if let Some(previous) = previous {
                 if section != previous + 1 {
@@ -965,11 +989,24 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                         section, "crash repair: truncating data journal before section gap"
                     );
                     data.rewind(previous, byte_offset).await?;
-                    return Ok(Some(previous));
+                    repaired_from_section = Some(
+                        repaired_from_section
+                            .map_or(previous, |repaired: u64| repaired.min(previous)),
+                    );
+                    return Ok(DataRecovery {
+                        repaired_from_section,
+                        last_section: Some(previous),
+                        items_in_last_section: previous_count,
+                    });
                 }
             }
 
-            let count = Self::count_section_items(data, section).await?;
+            let SectionCount { count, repaired } = Self::count_section_items(data, section).await?;
+            if repaired {
+                repaired_from_section = Some(
+                    repaired_from_section.map_or(section, |repaired: u64| repaired.min(section)),
+                );
+            }
 
             let section_start = section
                 .checked_mul(items_per_section)
@@ -1004,7 +1041,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             if count < capacity {
                 offsets.validate_recovered_size(recovered_size).await?;
                 if section == last_section {
-                    return Ok(None);
+                    return Ok(DataRecovery {
+                        repaired_from_section,
+                        last_section: Some(section),
+                        items_in_last_section: count,
+                    });
                 }
                 let byte_offset = data.size(section).await?;
                 warn!(
@@ -1012,13 +1053,25 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                     count, capacity, "crash repair: truncating data journal after short section"
                 );
                 data.rewind(section, byte_offset).await?;
-                return Ok(Some(section));
+                repaired_from_section = Some(
+                    repaired_from_section.map_or(section, |repaired: u64| repaired.min(section)),
+                );
+                return Ok(DataRecovery {
+                    repaired_from_section,
+                    last_section: Some(section),
+                    items_in_last_section: count,
+                });
             }
 
             previous = Some(section);
+            previous_count = count;
         }
         offsets.validate_recovered_size(recovered_size).await?;
-        Ok(None)
+        Ok(DataRecovery {
+            repaired_from_section,
+            last_section: Some(last_section),
+            items_in_last_section: previous_count,
+        })
     }
 
     /// Align the offsets journal and data journal to be consistent in case a crash occurred
@@ -1039,7 +1092,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             let offsets_reader = offsets.reader().await;
             offsets_reader.bounds()
         };
-        let repaired_from_section = Self::recover_data_by_walking_lengths(
+        let data_recovery = Self::recover_data_by_walking_lengths(
             data,
             offsets,
             initial_offsets_bounds.start,
@@ -1048,16 +1101,15 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         .await?;
 
         // === Handle empty data journal case ===
-        let items_in_last_section = match data.newest_section() {
-            Some(last_section) => Self::count_section_items(data, last_section).await?,
-            None => 0,
-        };
+        let items_in_last_section = data_recovery.items_in_last_section;
 
         // Data journal is empty if there are no sections or if there is one section and it has no items.
         // The latter should only occur if a crash occured after opening a data journal blob but
         // before writing to it.
-        let data_empty =
-            data.is_empty() || (data.num_sections() == 1 && items_in_last_section == 0);
+        let data_empty = data.is_empty()
+            || (data_recovery.last_section.is_some()
+                && data.num_sections() == 1
+                && items_in_last_section == 0);
         if data_empty {
             let offsets_bounds = {
                 let offsets_reader = offsets.reader().await;
@@ -1077,6 +1129,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 offsets.validate_recovered_size(target_pos).await?;
 
                 warn!("crash repair: clearing offsets to {target_pos} (empty section crash)");
+                if let (Some(start_section), Some(last_section)) =
+                    (data_recovery.repaired_from_section, data.newest_section())
+                {
+                    for section in start_section..=last_section {
+                        data.sync(section).await?;
+                    }
+                }
                 offsets.clear_to_size(target_pos).await?;
                 return Ok((target_pos, target_pos));
             }
@@ -1203,7 +1262,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         };
 
         if let (Some(start_section), Some(last_section)) =
-            (repaired_from_section, data.newest_section())
+            (data_recovery.repaired_from_section, data.newest_section())
         {
             for section in start_section..=last_section {
                 data.sync(section).await?;
@@ -1383,6 +1442,20 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// Test helper: Rewind the internal offsets journal directly (simulates crash scenario).
     pub(crate) async fn test_rewind_offsets(&self, position: u64) -> Result<(), Error> {
         self.offsets.rewind(position).await
+    }
+
+    /// Test helper: Rewind the internal data journal directly (simulates crash scenario).
+    pub(crate) async fn test_rewind_data(&self, position: u64) -> Result<(), Error> {
+        let discard_offset = {
+            let offsets_reader = self.offsets.reader().await;
+            offsets_reader.read(position).await?
+        };
+        let discard_section = position_to_section(position, self.items_per_section);
+        let mut inner = self.inner.write().await;
+        inner
+            .data
+            .rewind_to_offset(discard_section, discard_offset)
+            .await
     }
 
     /// Test helper: Get the size of the internal offsets journal.
@@ -2395,6 +2468,40 @@ mod tests {
             assert_eq!(variable.read(25).await.unwrap(), 2500);
 
             variable.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_recovery_rejects_data_first_rewind_crash() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "recovery-data-first-rewind-crash".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let variable = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..25u64 {
+                variable.append(&(i * 100)).await.unwrap();
+            }
+            variable.sync().await.unwrap();
+
+            variable.test_rewind_data(5).await.unwrap();
+            drop(variable);
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert_corruption_contains(result, "recovered size");
+            let _ = context.remove(&cfg.data_partition(), None).await;
+            let _ = context.remove(&cfg.offsets_partition(), None).await;
+            let _ = context
+                .remove(&format!("{}-metadata", cfg.offsets_partition()), None)
+                .await;
         });
     }
 

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -371,6 +371,15 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         self.manager.sync(section).await
     }
 
+    /// Flush the given section without fsyncing it.
+    pub(crate) async fn flush(&self, section: u64) -> Result<(), Error> {
+        let Some(blob) = self.manager.get(section)? else {
+            return Ok(());
+        };
+        blob.flush().await?;
+        Ok(())
+    }
+
     /// Sync all sections to storage.
     pub async fn sync_all(&self) -> Result<(), Error> {
         self.manager.sync_all().await

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -819,6 +819,15 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         self.manager.sync(section).await
     }
 
+    /// Flushes data in a given `section` without fsyncing it.
+    pub(crate) async fn flush(&self, section: u64) -> Result<(), Error> {
+        let Some(blob) = self.manager.get(section)? else {
+            return Ok(());
+        };
+        blob.flush().await?;
+        Ok(())
+    }
+
     /// Syncs all open sections.
     pub async fn sync_all(&self) -> Result<(), Error> {
         self.manager.sync_all().await
@@ -847,6 +856,11 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// Returns the number of sections.
     pub fn num_sections(&self) -> usize {
         self.manager.num_sections()
+    }
+
+    /// Returns an iterator over all section numbers.
+    pub fn sections(&self) -> impl Iterator<Item = u64> + '_ {
+        self.manager.sections()
     }
 
     /// Removes any underlying blobs created by the journal.


### PR DESCRIPTION
# PR Description: Avoid Rollover Fsyncs in Contiguous Journals

## Summary

This PR removes append-time fsyncs when contiguous journals cross section/blob boundaries.

Previously, fixed and variable contiguous journals durably synced a section as soon as that section became full. That made recovery straightforward because historical sections were expected to be complete, but it also put an fsync on the append path. In practice, an otherwise cheap append could occasionally pay the full cost of syncing a completed section.

This PR separates two concepts that were previously coupled:

- **Visibility**: completed sections must be readable and replayable after rollover.
- **Durability**: completed sections must survive a crash after an explicit durability request.

Rollover now flushes completed sections for visibility, while `sync()` and `commit()` are responsible for fsyncing the dirty sections that need durability.

## Design Overview

The new model is:

1. Appends write into the current section.
2. When a section becomes full, the journal flushes that section but does not fsync it.
3. The journal records the earliest dirty section since the last durability operation.
4. Explicit durability operations fsync all dirty sections through the current tail.
5. Recovery can truncate an unsynced suffix, but must not truncate below a synced recovery checkpoint.

This keeps append latency more predictable without giving up the ability to detect committed historical data loss.

## What Changed

### Runtime Buffering

`runtime/src/utils/buffer/paged/append.rs` now exposes:

```rust
pub async fn flush(&self) -> Result<(), Error>
```

`flush()` writes buffered data into the underlying blob/page layout and page cache without making it durable. This is the operation contiguous journals need at rollover: once a section is full, it should be visible to readers and replay, but it does not need to be fsynced until the user asks for durability.

`Append::replay()` now calls this helper instead of carrying its own flush logic. The semantics are unchanged for replay; the operation is just explicit and reusable.

### Segmented Journals

The segmented fixed and variable journals now have crate-private `flush(section)` helpers. They look up the section and call `Append::flush()` if the section exists.

These helpers intentionally do not fsync. They are used by contiguous journals during rollover as a replacement for `sync(section)`.

`segmented::variable::Journal` also exposes `sections()` so contiguous variable recovery can walk data sections in order.

### Fixed Contiguous Journal

The fixed journal now tracks three new pieces of state:

- `dirty_from_section`: earliest section modified since the last successful `sync()`.
- `length_recovery`: whether this journal is stored under the new length-walking recovery mode.
- `recovery_size`: the last logical size checkpointed by `sync()`.
- `reset_size`: a temporary metadata marker used only while destructive reset operations are in progress.

Append no longer fsyncs a full section. It marks the first modified section dirty, appends the data, flushes a section when it becomes full, and creates the next tail section.

`sync()` now fsyncs every dirty section from `dirty_from_section` through the current tail. It also updates the recovery checkpoint when length recovery is enabled.

Fixed recovery now has two modes:

- Legacy journals, without the length-recovery marker, keep the old invariant that historical sections are complete.
- New-format journals walk section lengths and may truncate an unsynced suffix, unless that would recover to a size before the last synced recovery checkpoint.

The format transition is explicit at initialization. A legacy journal first recovers using the old rollover-sync invariant, then `init()` persists a length-recovery marker and stores the recovered logical size as the initial recovery checkpoint. This protects data that existed before the journal started using no-rollover-fsync semantics without adding a metadata fsync to the first append.

If recovery truncates a section during initialization, the repaired section is synced before checkpoint metadata is persisted. This prevents init-time repair from leaving a durable checkpoint ahead of non-durable blob repair.

### Variable Contiguous Journal

The variable journal now tracks dirty data sections. It flushes a full data section on rollover instead of syncing it.

`commit()` syncs dirty data sections and clears the dirty marker. It does not sync the offsets journal, preserving the existing idea that `commit()` is cheaper and may require recovery on startup.

`sync()` syncs dirty data sections and then syncs the offsets journal. This remains the stronger durability boundary.

The offsets journal is a fixed contiguous journal, so offsets are initialized with the same recovery metadata before variable appends write under the new model.

During recovery, the variable journal still treats data as the source of truth. Variable recovery always walks retained data sections to detect gaps or short sections, validates the recovered data size against the offsets checkpoint, then runs the existing data/offset alignment logic. If the data walk truncates a section, that repair is synced before offsets are pruned, rewound, or synced to the recovered state.

## Recovery and Safety

The main risk in removing rollover fsyncs is ambiguity after a crash. If recovery sees a short historical section, it needs to know whether:

- the section was part of an unsynced suffix and may be truncated, or
- the section was already synced and its loss is corruption.

This PR handles that with two metadata values:

- A length-recovery marker says the journal was written under the new recovery rules.
- A recovery-size checkpoint records the logical size made durable by the last explicit `sync()`.
- A reset-size marker records an in-progress destructive reset until the replacement tail and pruning metadata have been installed.

Recovery may truncate an unsynced suffix. Recovery must not truncate below the checkpoint. If it would need to do that, it returns corruption.

This gives the fixed journal a conservative rule: incomplete data after the checkpoint can be discarded; incomplete data before the checkpoint is an error.

## Comparison With PR 3790

This PR and PR 3790 have the same core motivation: remove fsyncs from section/blob-boundary append paths and move durability work to explicit persistence operations.

They also share several concrete ideas:

- Both track dirty sections.
- Both remove rollover fsyncs from append paths.
- Both require explicit durability operations to fsync dirty data.
- Both make recovery responsible for handling partially durable suffixes.
- Both preserve the idea that variable-journal data is the source of truth and offsets can be rebuilt or corrected during recovery.

The main difference is the recovery model.

### PR 3790 Approach

PR 3790 uses a recovery watermark as a conservative replay boundary. In that design:

- Fixed journals persist `RECOVERY_WATERMARK_KEY`.
- The watermark is installed during initialization for journals that do not already have one.
- The watermark is advanced by `sync()`.
- The watermark is lowered before rewind and clear operations.
- Variable recovery uses the offsets watermark as a bounded replay anchor.
- Stale anchors are validated against retained data and recovered bounds.

PR 3790 also includes additional mechanical scope:

- an explicit operation mutex so mutators are serialized while fsync can avoid holding the journal write lock,
- init-time repair durability for tail truncations,
- fixed-journal commit metrics.

### This PR's Approach

This PR uses a smaller init-time checkpoint model:

- Fixed journals use legacy recovery for the initial recovery pass when the marker is absent.
- After a successful `init()`, fixed journals persist a length-recovery marker and an initial checkpoint at the recovered size.
- Later `sync()` calls advance that checkpoint.
- Rewind and clear lower the checkpoint when needed.
- Aligned destructive resets use a temporary reset marker so crashes after blob removal can recover without weakening ordinary data-loss checks.
- Variable recovery walks data sections unconditionally and checks recovered data size against the fixed offsets journal checkpoint.
- Variable `init_at_size()` and `clear_to_size()` use a variable-level reset marker so normal startup can complete an interrupted reset to the requested size. The marker is only honored after the fixed offsets checkpoint has been lowered to the reset target.

This keeps the append path free of metadata fsyncs while still making the storage-format transition explicit at initialization.

### Tradeoffs

The upside of this PR's approach is that it is smaller and localizes the compatibility transition to journal initialization. Legacy journals still recover with the old invariant first, then are upgraded before any new appends use the no-rollover-fsync behavior.

The tradeoff is that the recovery boundary is less explicit for layered users. PR 3790 gives the variable journal a persisted offsets watermark it can validate and use as a bounded replay anchor. This PR instead infers the recovery point by walking retained data sections against the fixed offsets journal bounds. That keeps the implementation smaller, but it means variable recovery has less persisted information about where a known-safe replay should begin and must derive more from the physical data layout at startup.

This PR also leaves concurrency and observability closer to the existing implementation. It does not add PR 3790's operation mutex, so the code still relies on the existing lock structure to serialize mutators while syncing dirty sections. It also does not add fixed-journal commit metrics, so it does not improve observability in that area.

Opening a legacy journal now performs a storage-format upgrade during initialization. That avoids a first-append metadata fsync, but it also means `init()` can modify metadata even if the caller only opens the journal to inspect it. There is no read-only open mode in this diff.

The upgrade can also surface pre-existing hidden corruption earlier. A legacy journal with a damaged middle section may have opened under the old invariant and only failed when the damaged item was read; after upgrade, length-walking recovery can reject the journal at initialization if the recovered size would fall below the installed checkpoint.

Rewind and clear also now lower the recovery checkpoint before destructive blob changes. That adds a metadata fsync to those operations when the checkpoint needs to move down. This is intentional for crash safety, but it means the fsync reduction is specifically on append rollover rather than on every mutating operation.

Variable data sections do not have a separate data-side checkpoint. The variable journal relies on the fixed offsets journal checkpoint and data-section walking during alignment, and rejects recovery if data walking would fall below the offsets checkpoint. Complete data-partition loss is still handled by the existing prune-all recovery model rather than by a new data-side checkpoint. That is smaller than PR 3790's explicit watermark model, but it is also less direct.

The conformance hash for `QueueConformance` changes as collateral because queues use variable journals internally, so queue storage now includes the new fixed and variable journal metadata even though queue source code is unchanged.

In short, this PR is an alternative implementation of the same append-path performance goal, but it accepts a narrower recovery and concurrency model than PR 3790. It implements no-rollover-fsync behavior with a compatible recovery story, but it does not provide the same explicit replay anchor, operation serialization, or metrics surface as PR 3790.

## Test Plan

- `cargo check -p commonware-runtime --lib`
- `cargo check -p commonware-storage --lib`
- `just test -p commonware-storage journal::contiguous --no-fail-fast`
- `just test-conformance -p commonware-storage`

The contiguous journal test suite passed `99/99` tests with these changes.
