### PR TITLE
[consensus/fuzz] avoid spinning on non-finalization

### DIFF
--- a/consensus/fuzz/src/disrupter.rs
+++ b/consensus/fuzz/src/disrupter.rs
@@ -261,6 +261,9 @@ where
                     self.send_random_message(&mut resolver_sender).await;
                 },
             }
+
+            // Keep non-finalizing configurations from spinning at one simulated timestamp.
+            self.context.sleep(TIMEOUT).await;
         }
     }
 


### PR DESCRIPTION
This fixes a consensus fuzz OOM where non-finalizing adversarial-majority inputs could keep the byzantine disrupter loop active at the same deterministic timestamp, continuously enqueueing simulated network messages before the harness timeout could advance. The disrupter now yields to deterministic time once per loop iteration, bounding message production in timeout-only scenarios while preserving adversarial behavior.

Fixes https://github.com/commonwarexyz/monorepo/actions/runs/26561333702/job/78244849819?pr=3878.