### PR TITLE
[ci] update dylint to 6.0.1

### DIFF
--- a/.github/dylints/borrowed_child_context/Cargo.lock
+++ b/.github/dylints/borrowed_child_context/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b795f98802f87352aab60584eea87f942c53ab30edcafab4b31a6cbdd9e8a3ac"
+checksum = "c738fb72ea7d248df2995a31b3698beb63d0f1f9ca5a5dc0188c4b64cd0e86e4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03ff51e671fceef87e50fef97ddc1569241af242d76e0b367dfcc812c860eb0"
+checksum = "9796d3441d7894cbaf4992640799efffc1661978f0cc1266ec788c32254fdfb3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3efcb9b741bccdd6f1ce701c4b17b452112e8c0cd045c8b894a112584ff5d55"
+checksum = "c213635b3eaa84f43b9b497377f17d9a8d4feb413bab1d82e03ad1c73e4f6d8c"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaa3ca6e1f740cd587630c321f61927b4cafdc2abf7c2fbacc3fca8635fcc48"
+checksum = "4f5f50ee06be9ebfb5b9538ba0d7bb08adc33e8f31c901e7d398de2a9b1ae290"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/.github/dylints/borrowed_child_context/Cargo.toml
+++ b/.github/dylints/borrowed_child_context/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "6.0.0"
+dylint_linting = "6.0.1"
 
 [dev-dependencies]
-dylint_testing = "6.0.0"
+dylint_testing = "6.0.1"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/.github/dylints/child_attribute_name_conflict/Cargo.lock
+++ b/.github/dylints/child_attribute_name_conflict/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "dylint"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b795f98802f87352aab60584eea87f942c53ab30edcafab4b31a6cbdd9e8a3ac"
+checksum = "c738fb72ea7d248df2995a31b3698beb63d0f1f9ca5a5dc0188c4b64cd0e86e4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_internal"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03ff51e671fceef87e50fef97ddc1569241af242d76e0b367dfcc812c860eb0"
+checksum = "9796d3441d7894cbaf4992640799efffc1661978f0cc1266ec788c32254fdfb3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_linting"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3efcb9b741bccdd6f1ce701c4b17b452112e8c0cd045c8b894a112584ff5d55"
+checksum = "c213635b3eaa84f43b9b497377f17d9a8d4feb413bab1d82e03ad1c73e4f6d8c"
 dependencies = [
  "cargo_metadata",
  "dylint_internal",
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "dylint_testing"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eaa3ca6e1f740cd587630c321f61927b4cafdc2abf7c2fbacc3fca8635fcc48"
+checksum = "4f5f50ee06be9ebfb5b9538ba0d7bb08adc33e8f31c901e7d398de2a9b1ae290"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/.github/dylints/child_attribute_name_conflict/Cargo.toml
+++ b/.github/dylints/child_attribute_name_conflict/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "6.0.0"
+dylint_linting = "6.0.1"
 
 [dev-dependencies]
-dylint_testing = "6.0.0"
+dylint_testing = "6.0.1"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -52,9 +52,10 @@ jobs:
         tool: just@1.43.0
     - name: Install Dylint
       if: matrix.os == 'ubuntu-latest' && matrix.flags == ''
-      run: |
-        cargo install cargo-dylint --version 6.0.0 --locked
-        cargo install dylint-link --version 6.0.0 --locked
+      uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
+      with:
+        tool: cargo-dylint@6.0.1,dylint-link@6.0.1
+        fallback: cargo-install
     - name: Fmt
       run: just check-fmt
     - name: Lint

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -55,7 +55,12 @@ jobs:
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
         tool: cargo-dylint@6.0.1,dylint-link@6.0.1
-        fallback: cargo-install
+    - name: Clone Dylint source
+      if: matrix.os == 'ubuntu-latest' && matrix.flags == ''
+      run: |
+        set -euo pipefail
+        mkdir -p /home/runner/work/dylint
+        git clone --depth 1 --branch v6.0.1 https://github.com/trailofbits/dylint.git /home/runner/work/dylint/dylint
     - name: Fmt
       run: just check-fmt
     - name: Lint


### PR DESCRIPTION
## Overview

Updates `cargo-dylint` and `dylint-link` to `v6.0.1`. Also takes advantage of the release artifacts published for these binaries rather than building them from source on every run: https://github.com/trailofbits/dylint/pull/1972