### PR TITLE
[storage] Journal Recovery Nits

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1031,6 +1031,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Callers that key dependent state off this journal use this to discard that state atomically
     /// with the reset. A crash at any point leaves a durable intent that the next `init` (or
     /// [Self::init_cleared]) finishes.
+    #[commonware_macros::stability(ALPHA)]
     pub(super) async fn init_at_size_cleared<F, Fut>(
         context: E,
         cfg: Config,

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -111,7 +111,7 @@ const PRUNING_BOUNDARY_KEY: u64 = 1;
 ///
 /// This key is synced before destructive reset work starts. If recovery sees it, recovery
 /// completes the reset to the recorded target before normal bounds recovery.
-pub(crate) const CLEAR_TARGET_KEY: u64 = 2;
+pub(super) const CLEAR_TARGET_KEY: u64 = 2;
 
 /// Metadata key for storing the recovery watermark.
 const RECOVERY_WATERMARK_KEY: u64 = 3;
@@ -595,7 +595,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     ///
     /// This is used by `init_at_size` before it clears existing blobs, before an `Inner` exists.
     #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn update_metadata_watermark_before_clear(
+    pub(super) fn update_metadata_watermark_before_clear(
         metadata: &mut Metadata<E, u64, Vec<u8>>,
         limit: u64,
     ) -> Result<bool, Error> {
@@ -612,7 +612,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     }
 
     /// Open the metadata partition for `cfg`.
-    pub(crate) async fn open_metadata(
+    pub(super) async fn open_metadata(
         context: &E,
         cfg: &Config,
     ) -> Result<Metadata<E, u64, Vec<u8>>, Error> {
@@ -706,7 +706,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
     /// Finish initialization using an already-open metadata handle. Callers use this after
     /// `open_metadata` so the metadata partition is opened exactly once.
-    pub(crate) async fn init_with_metadata(
+    pub(super) async fn init_with_metadata(
         context: E,
         cfg: Config,
         mut metadata: Metadata<E, u64, Vec<u8>>,
@@ -1371,7 +1371,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// finish. If a crash interrupts the sequence, the next `init` completes the staged clear.
     /// The follow-up `clear_to_size` re-stages the same target idempotently.
     #[commonware_macros::stability(ALPHA)]
-    pub(crate) async fn stage_clear_intent(&self, new_size: u64) -> Result<(), Error> {
+    pub(super) async fn stage_clear_intent(&self, new_size: u64) -> Result<(), Error> {
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -97,10 +97,7 @@ use commonware_codec::CodecFixedShared;
 use commonware_runtime::buffer::paged::CacheRef;
 use commonware_utils::sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard};
 use futures::{stream::Stream, StreamExt};
-use std::{
-    future::Future,
-    num::{NonZeroU64, NonZeroUsize},
-};
+use std::num::{NonZeroU64, NonZeroUsize};
 use tracing::warn;
 
 /// Metadata key for a mid-section pruning boundary.
@@ -624,57 +621,25 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .map_err(Into::into)
     }
 
-    /// Stage a clear target in already-open metadata before external data is deleted.
-    async fn stage_clear_to_size_metadata(
-        metadata: &mut Metadata<E, u64, Vec<u8>>,
-        size: u64,
-    ) -> Result<(), Error> {
+    /// Durably stage a reset intent without opening the journal. The next `init` call will detect
+    /// the staged `CLEAR_TARGET_KEY` and complete the clear. Callers that own dependent state may
+    /// clear it between this call and the subsequent `init`; if a crash interrupts that window,
+    /// the same recovery path runs on restart.
+    pub(crate) async fn stage_reset(context: E, cfg: &Config, size: u64) -> Result<(), Error> {
+        // Fail before writing intent if existing blob partitions are already inconsistent.
+        Self::select_blob_partition(&context, cfg).await?;
+        let mut metadata = Self::open_metadata(&context, cfg).await?;
         // Lower the watermark before staging the clear intent so external consumers never see a
         // persisted recovery checkpoint beyond the eventual clear target.
-        Self::update_metadata_watermark_before_clear(metadata, size)?;
+        Self::update_metadata_watermark_before_clear(&mut metadata, size)?;
         metadata.put(CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
         metadata.sync().await.map_err(Into::into)
     }
 
-    /// Initialize while allowing a caller to clear external data before a staged clear is consumed.
-    pub(crate) async fn init_with_external_clear<F, Fut>(
-        context: E,
-        cfg: Config,
-        reset_target: Option<u64>,
-        external_clear: F,
-    ) -> Result<Self, Error>
-    where
-        F: FnOnce() -> Fut,
-        Fut: Future<Output = Result<(), Error>>,
-    {
-        let items_per_blob = cfg.items_per_blob.get();
-        let blob_partition = Self::select_blob_partition(&context, &cfg).await?;
-        let mut metadata = Self::open_metadata(&context, &cfg).await?;
-
-        if let Some(reset_target) = reset_target {
-            Self::stage_clear_to_size_metadata(&mut metadata, reset_target).await?;
-            external_clear().await?;
-        } else if let Some(clear_target) =
-            Self::parse_metadata_u64(&metadata, CLEAR_TARGET_KEY, "clear_target")?
-        {
-            warn!(
-                clear_target,
-                "crash repair: clearing external data for interrupted reset"
-            );
-            external_clear().await?;
-        }
-        Self::init_opened(context, cfg, items_per_blob, blob_partition, metadata).await
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn test_stage_clear_to_size_in_partition(
-        context: E,
-        cfg: &Config,
-        size: u64,
-    ) -> Result<(), Error> {
-        Self::select_blob_partition(&context, cfg).await?;
-        let mut metadata = Self::open_metadata(&context, cfg).await?;
-        Self::stage_clear_to_size_metadata(&mut metadata, size).await
+    /// Returns `Some(target)` when a `stage_reset` intent is durably staged for `cfg`.
+    pub(crate) async fn pending_reset(context: E, cfg: &Config) -> Result<Option<u64>, Error> {
+        let metadata = Self::open_metadata(&context, cfg).await?;
+        Self::parse_metadata_u64(&metadata, CLEAR_TARGET_KEY, "clear_target")
     }
 
     /// Scan a partition and return blob names, treating a missing partition as empty.
@@ -755,19 +720,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let items_per_blob = cfg.items_per_blob.get();
 
         let blob_partition = Self::select_blob_partition(&context, &cfg).await?;
-        let metadata = Self::open_metadata(&context, &cfg).await?;
-
-        Self::init_opened(context, cfg, items_per_blob, blob_partition, metadata).await
-    }
-
-    /// Finish initialization from an already-selected blob partition and open metadata handle.
-    async fn init_opened(
-        context: E,
-        cfg: Config,
-        items_per_blob: u64,
-        blob_partition: String,
-        mut metadata: Metadata<E, u64, Vec<u8>>,
-    ) -> Result<Self, Error> {
+        let mut metadata = Self::open_metadata(&context, &cfg).await?;
         let segmented_cfg = SegmentedConfig {
             partition: blob_partition,
             page_cache: cfg.page_cache,
@@ -1093,7 +1046,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// either still in its prior state, or has bounds `size..size`.
     #[commonware_macros::stability(ALPHA)]
     pub async fn init_at_size(context: E, cfg: Config, size: u64) -> Result<Self, Error> {
-        Self::init_with_external_clear(context, cfg, Some(size), || async { Ok(()) }).await
+        Self::stage_reset(context.child("intent"), &cfg, size).await?;
+        Self::init(context, cfg).await
     }
 
     /// Convert a global position to (section, position_in_section).
@@ -1381,41 +1335,17 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// In the event of a crash during this call, upon restart recovery will ensure the journal is
     /// either still in its prior state, or has bounds `new_size..new_size`.
     pub(crate) async fn clear_to_size(&self, new_size: u64) -> Result<(), Error> {
-        self.clear_to_size_with_dependent_clear(new_size, || async { Ok(()) })
-            .await
-    }
+        let _op_guard = self.op_lock.lock().await;
+        let mut inner = self.inner.write().await;
 
-    /// Stage a clear target while the caller holds the operation lock and write guard.
-    async fn stage_clear_to_size_locked(
-        inner: &mut Inner<E, A>,
-        new_size: u64,
-    ) -> Result<(), Error> {
         // Lower the watermark in-memory and stage the clear intent in the same metadata sync, so
         // external consumers never see a persisted recovery checkpoint beyond `new_size`.
-        Self::lower_recovery_watermark(inner, new_size)?;
+        Self::lower_recovery_watermark(&mut inner, new_size)?;
         inner
             .metadata
             .put(CLEAR_TARGET_KEY, new_size.to_be_bytes().to_vec());
-        inner.metadata.sync().await.map_err(Into::into)
-    }
+        inner.metadata.sync().await?;
 
-    /// Clear this journal, allowing a caller to clear dependent state after the intent is durable.
-    pub(crate) async fn clear_to_size_with_dependent_clear<F, Fut>(
-        &self,
-        new_size: u64,
-        external_clear: F,
-    ) -> Result<(), Error>
-    where
-        F: FnOnce() -> Fut,
-        Fut: Future<Output = Result<(), Error>>,
-    {
-        let _op_guard = self.op_lock.lock().await;
-        {
-            let mut inner = self.inner.write().await;
-            Self::stage_clear_to_size_locked(&mut inner, new_size).await?;
-        }
-        external_clear().await?;
-        let mut inner = self.inner.write().await;
         let Inner {
             journal, metadata, ..
         } = &mut *inner;
@@ -1428,6 +1358,19 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         self.metrics
             .update(inner.size, inner.pruning_boundary, self.items_per_blob);
         Ok(())
+    }
+
+    /// Runtime equivalent of `stage_reset`: durably stage `CLEAR_TARGET_KEY` so callers can clear
+    /// dependent sibling state before invoking `clear_to_size` to finish the operation. The
+    /// subsequent `clear_to_size` re-stages the same intent idempotently and then completes.
+    pub(crate) async fn stage_clear_intent(&self, new_size: u64) -> Result<(), Error> {
+        let _op_guard = self.op_lock.lock().await;
+        let mut inner = self.inner.write().await;
+        Self::lower_recovery_watermark(&mut inner, new_size)?;
+        inner
+            .metadata
+            .put(CLEAR_TARGET_KEY, new_size.to_be_bytes().to_vec());
+        inner.metadata.sync().await.map_err(Into::into)
     }
 
     /// Test helper: Read the item at the given position.

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -594,6 +594,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Stage a recovery-watermark entry no greater than `limit` in raw metadata.
     ///
     /// This is used by `init_at_size` before it clears existing blobs, before an `Inner` exists.
+    #[commonware_macros::stability(ALPHA)]
     pub(crate) fn update_metadata_watermark_before_clear(
         metadata: &mut Metadata<E, u64, Vec<u8>>,
         limit: u64,
@@ -1369,6 +1370,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Runtime equivalent of `stage_reset`: durably stage `CLEAR_TARGET_KEY` so callers can clear
     /// dependent sibling state before invoking `clear_to_size` to finish the operation. The
     /// subsequent `clear_to_size` re-stages the same intent idempotently and then completes.
+    #[commonware_macros::stability(ALPHA)]
     pub(crate) async fn stage_clear_intent(&self, new_size: u64) -> Result<(), Error> {
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -97,7 +97,10 @@ use commonware_codec::CodecFixedShared;
 use commonware_runtime::buffer::paged::CacheRef;
 use commonware_utils::sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard};
 use futures::{stream::Stream, StreamExt};
-use std::num::{NonZeroU64, NonZeroUsize};
+use std::{
+    future::Future,
+    num::{NonZeroU64, NonZeroUsize},
+};
 use tracing::warn;
 
 /// Metadata key for a mid-section pruning boundary.
@@ -1041,7 +1044,25 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     pub async fn init_at_size(context: E, cfg: Config, size: u64) -> Result<Self, Error> {
         // Fail before writing intent if existing blob partitions are already inconsistent.
         Self::select_blob_partition(&context, &cfg).await?;
+        Self::init_at_size_cleared(context, cfg, size, || async { Ok(()) }).await
+    }
 
+    /// Like [Self::init_at_size], but awaits `clear_dependents` after the reset intent is durably
+    /// staged and before it completes.
+    ///
+    /// Callers that key dependent state off this journal use this to discard that state atomically
+    /// with the reset. A crash at any point leaves a durable intent that the next `init` (or
+    /// [Self::init_cleared]) finishes.
+    pub(super) async fn init_at_size_cleared<F, Fut>(
+        context: E,
+        cfg: Config,
+        size: u64,
+        clear_dependents: F,
+    ) -> Result<Self, Error>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<(), Error>>,
+    {
         // Stage the reset intent durably. Lower the recovery watermark first so external
         // consumers never see a persisted checkpoint beyond `size`. `init_with_metadata` will
         // detect CLEAR_TARGET_KEY and complete the clear via complete_clear_to_size before
@@ -1050,7 +1071,29 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Self::update_metadata_watermark_before_clear(&mut metadata, size)?;
         metadata.put(CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
         metadata.sync().await?;
+        clear_dependents().await?;
+        Self::init_with_metadata(context, cfg, metadata).await
+    }
 
+    /// Like [Self::init], but awaits `clear_dependents` before completing a staged clear.
+    ///
+    /// If a prior (possibly crashed) [Self::init_at_size_cleared] or
+    /// [Self::stage_clear_intent] staged a `CLEAR_TARGET_KEY` reset, `clear_dependents` runs before
+    /// recovery so callers can discard dependent state that the staged clear must reconcile against.
+    /// With no staged reset this behaves exactly like [Self::init].
+    pub(super) async fn init_cleared<F, Fut>(
+        context: E,
+        cfg: Config,
+        clear_dependents: F,
+    ) -> Result<Self, Error>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<(), Error>>,
+    {
+        let metadata = Self::open_metadata(context.child("meta"), &cfg).await?;
+        if metadata.get(&CLEAR_TARGET_KEY).is_some() {
+            clear_dependents().await?;
+        }
         Self::init_with_metadata(context, cfg, metadata).await
     }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -111,7 +111,7 @@ const PRUNING_BOUNDARY_KEY: u64 = 1;
 ///
 /// This key is synced before destructive reset work starts. If recovery sees it, recovery
 /// completes the reset to the recorded target before normal bounds recovery.
-const CLEAR_TARGET_KEY: u64 = 2;
+pub(crate) const CLEAR_TARGET_KEY: u64 = 2;
 
 /// Metadata key for storing the recovery watermark.
 const RECOVERY_WATERMARK_KEY: u64 = 3;
@@ -594,7 +594,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Stage a recovery-watermark entry no greater than `limit` in raw metadata.
     ///
     /// This is used by `init_at_size` before it clears existing blobs, before an `Inner` exists.
-    fn update_metadata_watermark_before_clear(
+    pub(crate) fn update_metadata_watermark_before_clear(
         metadata: &mut Metadata<E, u64, Vec<u8>>,
         limit: u64,
     ) -> Result<bool, Error> {
@@ -610,8 +610,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok(true)
     }
 
-    /// Open the metadata partition for `cfg`.
-    async fn open_metadata(context: &E, cfg: &Config) -> Result<Metadata<E, u64, Vec<u8>>, Error> {
+    /// Open the metadata partition for `cfg`. Callers inspect or mutate it directly (via
+    /// `metadata.get(&CLEAR_TARGET_KEY)` or `update_metadata_watermark_before_clear` + `put` +
+    /// `sync`) and then hand it to `init_with_metadata` to finish initialization without
+    /// re-opening.
+    pub(crate) async fn open_metadata(
+        context: &E,
+        cfg: &Config,
+    ) -> Result<Metadata<E, u64, Vec<u8>>, Error> {
         let meta_cfg = MetadataConfig {
             partition: format!("{}-metadata", cfg.partition),
             codec_config: ((0..).into(), ()),
@@ -619,27 +625,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Metadata::<_, u64, Vec<u8>>::init(context.child("meta"), meta_cfg)
             .await
             .map_err(Into::into)
-    }
-
-    /// Durably stage a reset intent without opening the journal. The next `init` call will detect
-    /// the staged `CLEAR_TARGET_KEY` and complete the clear. Callers that own dependent state may
-    /// clear it between this call and the subsequent `init`; if a crash interrupts that window,
-    /// the same recovery path runs on restart.
-    pub(crate) async fn stage_reset(context: E, cfg: &Config, size: u64) -> Result<(), Error> {
-        // Fail before writing intent if existing blob partitions are already inconsistent.
-        Self::select_blob_partition(&context, cfg).await?;
-        let mut metadata = Self::open_metadata(&context, cfg).await?;
-        // Lower the watermark before staging the clear intent so external consumers never see a
-        // persisted recovery checkpoint beyond the eventual clear target.
-        Self::update_metadata_watermark_before_clear(&mut metadata, size)?;
-        metadata.put(CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
-        metadata.sync().await.map_err(Into::into)
-    }
-
-    /// Returns `Some(target)` when a `stage_reset` intent is durably staged for `cfg`.
-    pub(crate) async fn pending_reset(context: E, cfg: &Config) -> Result<Option<u64>, Error> {
-        let metadata = Self::open_metadata(&context, cfg).await?;
-        Self::parse_metadata_u64(&metadata, CLEAR_TARGET_KEY, "clear_target")
     }
 
     /// Scan a partition and return blob names, treating a missing partition as empty.
@@ -717,10 +702,20 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// All backing blobs are opened but not read during initialization. The `replay` method can be
     /// used to iterate over all items in the `Journal`.
     pub async fn init(context: E, cfg: Config) -> Result<Self, Error> {
+        let metadata = Self::open_metadata(&context, &cfg).await?;
+        Self::init_with_metadata(context, cfg, metadata).await
+    }
+
+    /// Finish initialization using an already-open metadata handle. Callers use this after
+    /// `open_metadata` + `stage_reset` / `pending_reset` so metadata is opened exactly once.
+    pub(crate) async fn init_with_metadata(
+        context: E,
+        cfg: Config,
+        mut metadata: Metadata<E, u64, Vec<u8>>,
+    ) -> Result<Self, Error> {
         let items_per_blob = cfg.items_per_blob.get();
 
         let blob_partition = Self::select_blob_partition(&context, &cfg).await?;
-        let mut metadata = Self::open_metadata(&context, &cfg).await?;
         let segmented_cfg = SegmentedConfig {
             partition: blob_partition,
             page_cache: cfg.page_cache,
@@ -1046,8 +1041,19 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// either still in its prior state, or has bounds `size..size`.
     #[commonware_macros::stability(ALPHA)]
     pub async fn init_at_size(context: E, cfg: Config, size: u64) -> Result<Self, Error> {
-        Self::stage_reset(context.child("intent"), &cfg, size).await?;
-        Self::init(context, cfg).await
+        // Fail before writing intent if existing blob partitions are already inconsistent.
+        Self::select_blob_partition(&context, &cfg).await?;
+
+        // Stage the reset intent durably. Lower the recovery watermark first so external
+        // consumers never see a persisted checkpoint beyond `size`. `init_with_metadata` will
+        // detect CLEAR_TARGET_KEY and complete the clear via complete_clear_to_size before
+        // recovering bounds.
+        let mut metadata = Self::open_metadata(&context, &cfg).await?;
+        Self::update_metadata_watermark_before_clear(&mut metadata, size)?;
+        metadata.put(CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
+        metadata.sync().await?;
+
+        Self::init_with_metadata(context, cfg, metadata).await
     }
 
     /// Convert a global position to (section, position_in_section).

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -597,7 +597,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Stage a recovery-watermark entry no greater than `limit` in raw metadata.
     ///
     /// This is used by `init_at_size` before it clears existing blobs, before an `Inner` exists.
-    #[commonware_macros::stability(ALPHA)]
     fn update_metadata_watermark_before_clear(
         metadata: &mut Metadata<E, u64, Vec<u8>>,
         limit: u64,
@@ -669,12 +668,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
     #[cfg(test)]
     pub(crate) async fn test_stage_clear_to_size_in_partition(
-        context: &E,
+        context: E,
         cfg: &Config,
         size: u64,
     ) -> Result<(), Error> {
-        Self::select_blob_partition(context, cfg).await?;
-        let mut metadata = Self::open_metadata(context, cfg).await?;
+        Self::select_blob_partition(&context, cfg).await?;
+        let mut metadata = Self::open_metadata(&context, cfg).await?;
         Self::stage_clear_to_size_metadata(&mut metadata, size).await
     }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -97,7 +97,10 @@ use commonware_codec::CodecFixedShared;
 use commonware_runtime::buffer::paged::CacheRef;
 use commonware_utils::sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard};
 use futures::{stream::Stream, StreamExt};
-use std::num::{NonZeroU64, NonZeroUsize};
+use std::{
+    future::Future,
+    num::{NonZeroU64, NonZeroUsize},
+};
 use tracing::warn;
 
 /// Metadata key for a mid-section pruning boundary.
@@ -611,6 +614,70 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok(true)
     }
 
+    /// Open the metadata partition for `cfg`.
+    async fn open_metadata(context: &E, cfg: &Config) -> Result<Metadata<E, u64, Vec<u8>>, Error> {
+        let meta_cfg = MetadataConfig {
+            partition: format!("{}-metadata", cfg.partition),
+            codec_config: ((0..).into(), ()),
+        };
+        Metadata::<_, u64, Vec<u8>>::init(context.child("meta"), meta_cfg)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Stage a clear target in already-open metadata before external data is deleted.
+    async fn stage_clear_to_size_metadata(
+        metadata: &mut Metadata<E, u64, Vec<u8>>,
+        size: u64,
+    ) -> Result<(), Error> {
+        // Lower the watermark before staging the clear intent so external consumers never see a
+        // persisted recovery checkpoint beyond the eventual clear target.
+        Self::update_metadata_watermark_before_clear(metadata, size)?;
+        metadata.put(CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
+        metadata.sync().await.map_err(Into::into)
+    }
+
+    /// Initialize while allowing a caller to clear external data before a staged clear is consumed.
+    pub(crate) async fn init_with_external_clear<F, Fut>(
+        context: E,
+        cfg: Config,
+        reset_target: Option<u64>,
+        external_clear: F,
+    ) -> Result<Self, Error>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<(), Error>>,
+    {
+        let items_per_blob = cfg.items_per_blob.get();
+        let blob_partition = Self::select_blob_partition(&context, &cfg).await?;
+        let mut metadata = Self::open_metadata(&context, &cfg).await?;
+
+        if let Some(reset_target) = reset_target {
+            Self::stage_clear_to_size_metadata(&mut metadata, reset_target).await?;
+            external_clear().await?;
+        } else if let Some(clear_target) =
+            Self::parse_metadata_u64(&metadata, CLEAR_TARGET_KEY, "clear_target")?
+        {
+            warn!(
+                clear_target,
+                "crash repair: clearing external data for interrupted reset"
+            );
+            external_clear().await?;
+        }
+        Self::init_opened(context, cfg, items_per_blob, blob_partition, metadata).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn test_stage_clear_to_size_in_partition(
+        context: &E,
+        cfg: &Config,
+        size: u64,
+    ) -> Result<(), Error> {
+        Self::select_blob_partition(context, cfg).await?;
+        let mut metadata = Self::open_metadata(context, cfg).await?;
+        Self::stage_clear_to_size_metadata(&mut metadata, size).await
+    }
+
     /// Scan a partition and return blob names, treating a missing partition as empty.
     async fn scan_partition(context: &E, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
         match context.scan(partition).await {
@@ -689,6 +756,19 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let items_per_blob = cfg.items_per_blob.get();
 
         let blob_partition = Self::select_blob_partition(&context, &cfg).await?;
+        let metadata = Self::open_metadata(&context, &cfg).await?;
+
+        Self::init_opened(context, cfg, items_per_blob, blob_partition, metadata).await
+    }
+
+    /// Finish initialization from an already-selected blob partition and open metadata handle.
+    async fn init_opened(
+        context: E,
+        cfg: Config,
+        items_per_blob: u64,
+        blob_partition: String,
+        mut metadata: Metadata<E, u64, Vec<u8>>,
+    ) -> Result<Self, Error> {
         let segmented_cfg = SegmentedConfig {
             partition: blob_partition,
             page_cache: cfg.page_cache,
@@ -696,13 +776,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         };
 
         let mut journal = SegmentedJournal::init(context.child("blobs"), segmented_cfg).await?;
-        let meta_cfg = MetadataConfig {
-            partition: format!("{}-metadata", cfg.partition),
-            codec_config: ((0..).into(), ()),
-        };
-
-        let mut metadata =
-            Metadata::<_, u64, Vec<u8>>::init(context.child("meta"), meta_cfg).await?;
 
         // Complete any interrupted clear before recovering bounds. `complete_clear_to_size` also
         // resets the recovery watermark to the clear target, so the subsequent bounds recovery
@@ -1021,23 +1094,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// either still in its prior state, or has bounds `size..size`.
     #[commonware_macros::stability(ALPHA)]
     pub async fn init_at_size(context: E, cfg: Config, size: u64) -> Result<Self, Error> {
-        // Fail before writing clear intent if existing blob partitions are already inconsistent.
-        Self::select_blob_partition(&context, &cfg).await?;
-
-        let meta_cfg = MetadataConfig {
-            partition: format!("{}-metadata", cfg.partition),
-            codec_config: ((0..).into(), ()),
-        };
-        let mut metadata =
-            Metadata::<_, u64, Vec<u8>>::init(context.child("intent"), meta_cfg).await?;
-        // Lower the watermark before staging the clear intent so external consumers never see a
-        // persisted recovery checkpoint beyond the eventual clear target.
-        Self::update_metadata_watermark_before_clear(&mut metadata, size)?;
-        metadata.put(CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
-        metadata.sync().await?;
-        drop(metadata);
-
-        Self::init(context, cfg).await
+        Self::init_with_external_clear(context, cfg, Some(size), || async { Ok(()) }).await
     }
 
     /// Convert a global position to (section, position_in_section).
@@ -1325,16 +1382,41 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// In the event of a crash during this call, upon restart recovery will ensure the journal is
     /// either still in its prior state, or has bounds `new_size..new_size`.
     pub(crate) async fn clear_to_size(&self, new_size: u64) -> Result<(), Error> {
-        let _op_guard = self.op_lock.lock().await;
-        let mut inner = self.inner.write().await;
+        self.clear_to_size_with_external_clear(new_size, || async { Ok(()) })
+            .await
+    }
 
+    /// Stage a clear target while the caller holds the operation lock and write guard.
+    async fn stage_clear_to_size_locked(
+        inner: &mut Inner<E, A>,
+        new_size: u64,
+    ) -> Result<(), Error> {
         // Lower the watermark in-memory and stage the clear intent in the same metadata sync, so
         // external consumers never see a persisted recovery checkpoint beyond `new_size`.
-        Self::lower_recovery_watermark(&mut inner, new_size)?;
+        Self::lower_recovery_watermark(inner, new_size)?;
         inner
             .metadata
             .put(CLEAR_TARGET_KEY, new_size.to_be_bytes().to_vec());
-        inner.metadata.sync().await?;
+        inner.metadata.sync().await.map_err(Into::into)
+    }
+
+    /// Clear this journal, allowing a caller to clear dependent state after the intent is durable.
+    pub(crate) async fn clear_to_size_with_external_clear<F, Fut>(
+        &self,
+        new_size: u64,
+        external_clear: F,
+    ) -> Result<(), Error>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<(), Error>>,
+    {
+        let _op_guard = self.op_lock.lock().await;
+        {
+            let mut inner = self.inner.write().await;
+            Self::stage_clear_to_size_locked(&mut inner, new_size).await?;
+        }
+        external_clear().await?;
+        let mut inner = self.inner.write().await;
         let Inner {
             journal, metadata, ..
         } = &mut *inner;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -613,14 +613,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
     /// Open the metadata partition for `cfg`.
     pub(super) async fn open_metadata(
-        context: &E,
+        context: E,
         cfg: &Config,
     ) -> Result<Metadata<E, u64, Vec<u8>>, Error> {
         let meta_cfg = MetadataConfig {
             partition: format!("{}-metadata", cfg.partition),
             codec_config: ((0..).into(), ()),
         };
-        Metadata::<_, u64, Vec<u8>>::init(context.child("meta"), meta_cfg)
+        Metadata::<_, u64, Vec<u8>>::init(context, meta_cfg)
             .await
             .map_err(Into::into)
     }
@@ -700,7 +700,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// All backing blobs are opened but not read during initialization. The `replay` method can be
     /// used to iterate over all items in the `Journal`.
     pub async fn init(context: E, cfg: Config) -> Result<Self, Error> {
-        let metadata = Self::open_metadata(&context, &cfg).await?;
+        let metadata = Self::open_metadata(context.child("meta"), &cfg).await?;
         Self::init_with_metadata(context, cfg, metadata).await
     }
 
@@ -1046,7 +1046,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // consumers never see a persisted checkpoint beyond `size`. `init_with_metadata` will
         // detect CLEAR_TARGET_KEY and complete the clear via complete_clear_to_size before
         // recovering bounds.
-        let mut metadata = Self::open_metadata(&context, &cfg).await?;
+        let mut metadata = Self::open_metadata(context.child("meta"), &cfg).await?;
         Self::update_metadata_watermark_before_clear(&mut metadata, size)?;
         metadata.put(CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
         metadata.sync().await?;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -552,8 +552,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         recovery_watermark: u64,
     ) -> Result<(), Error> {
         Self::update_metadata_entries(inner, items_per_blob, pruning_boundary, recovery_watermark);
-        inner.metadata.sync().await?;
-        Ok(())
+        inner.metadata.sync().await.map_err(Into::into)
     }
 
     /// Stage a recovery watermark no greater than `limit`.
@@ -675,8 +674,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Self::stage_pruning_boundary_metadata(metadata, items_per_blob, size);
         metadata.put(RECOVERY_WATERMARK_KEY, size.into());
         metadata.remove(&CLEAR_TARGET_KEY);
-        metadata.sync().await?;
-        Ok(())
+        metadata.sync().await.map_err(Into::into)
     }
 
     /// Initialize a new `Journal` instance.
@@ -1431,8 +1429,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     pub(crate) async fn test_set_recovery_watermark(&self, watermark: u64) -> Result<(), Error> {
         let mut inner = self.inner.write().await;
         inner.metadata.put(RECOVERY_WATERMARK_KEY, watermark.into());
-        inner.metadata.sync().await?;
-        Ok(())
+        inner.metadata.sync().await.map_err(Into::into)
     }
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1382,7 +1382,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// In the event of a crash during this call, upon restart recovery will ensure the journal is
     /// either still in its prior state, or has bounds `new_size..new_size`.
     pub(crate) async fn clear_to_size(&self, new_size: u64) -> Result<(), Error> {
-        self.clear_to_size_with_external_clear(new_size, || async { Ok(()) })
+        self.clear_to_size_with_dependent_clear(new_size, || async { Ok(()) })
             .await
     }
 
@@ -1401,7 +1401,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     }
 
     /// Clear this journal, allowing a caller to clear dependent state after the intent is durable.
-    pub(crate) async fn clear_to_size_with_external_clear<F, Fut>(
+    pub(crate) async fn clear_to_size_with_dependent_clear<F, Fut>(
         &self,
         new_size: u64,
         external_clear: F,

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -95,7 +95,10 @@ use crate::{
 };
 use commonware_codec::CodecFixedShared;
 use commonware_runtime::buffer::paged::CacheRef;
-use commonware_utils::sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard};
+use commonware_utils::{
+    sequence::VecU64,
+    sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard},
+};
 use futures::{stream::Stream, StreamExt};
 use std::{
     future::Future,
@@ -195,8 +198,7 @@ struct Inner<E: Context, A: CodecFixedShared> {
     /// the blob state it describes is durable. A lower recovery watermark is always safe to persist
     /// because it only expands the suffix external consumers may replay. If pruning metadata
     /// disagrees with the oldest blob during recovery, the blob state wins.
-    // TODO(#2939): Remove metadata
-    metadata: Metadata<E, u64, Vec<u8>>,
+    metadata: Metadata<E, u64, VecU64>,
 
     /// The position before which all items have been pruned.
     pruning_boundary: u64,
@@ -506,23 +508,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         );
     }
 
-    /// Parse an optional u64 value from metadata.
-    fn parse_metadata_u64(
-        metadata: &Metadata<E, u64, Vec<u8>>,
-        key: u64,
-        label: &'static str,
-    ) -> Result<Option<u64>, Error> {
-        match metadata.get(&key) {
-            Some(bytes) => Ok(Some(u64::from_be_bytes(
-                bytes
-                    .as_slice()
-                    .try_into()
-                    .map_err(|_| Error::Corruption(format!("invalid {label} metadata")))?,
-            ))),
-            None => Ok(None),
-        }
-    }
-
     /// Update pruning-boundary and recovery-watermark entries in metadata's in-memory state.
     ///
     /// Call `inner.metadata.sync()` separately to persist the updated entries.
@@ -531,33 +516,32 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         items_per_blob: u64,
         pruning_boundary: u64,
         recovery_watermark: u64,
-    ) -> Result<(), Error> {
-        let current_pruning =
-            Self::parse_metadata_u64(&inner.metadata, PRUNING_BOUNDARY_KEY, "pruning_boundary")?;
+    ) {
+        let current_pruning = inner
+            .metadata
+            .get(&PRUNING_BOUNDARY_KEY)
+            .copied()
+            .map(u64::from);
         if !pruning_boundary.is_multiple_of(items_per_blob) {
             if current_pruning != Some(pruning_boundary) {
-                inner.metadata.put(
-                    PRUNING_BOUNDARY_KEY,
-                    pruning_boundary.to_be_bytes().to_vec(),
-                );
+                inner
+                    .metadata
+                    .put(PRUNING_BOUNDARY_KEY, pruning_boundary.into());
             }
         } else if current_pruning.is_some() {
             inner.metadata.remove(&PRUNING_BOUNDARY_KEY);
         }
 
-        let current_watermark = Self::parse_metadata_u64(
-            &inner.metadata,
-            RECOVERY_WATERMARK_KEY,
-            "recovery_watermark",
-        )?;
+        let current_watermark = inner
+            .metadata
+            .get(&RECOVERY_WATERMARK_KEY)
+            .copied()
+            .map(u64::from);
         if current_watermark != Some(recovery_watermark) {
-            inner.metadata.put(
-                RECOVERY_WATERMARK_KEY,
-                recovery_watermark.to_be_bytes().to_vec(),
-            );
+            inner
+                .metadata
+                .put(RECOVERY_WATERMARK_KEY, recovery_watermark.into());
         }
-
-        Ok(())
     }
 
     /// Update and persist pruning-boundary and recovery-watermark metadata entries.
@@ -567,7 +551,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         pruning_boundary: u64,
         recovery_watermark: u64,
     ) -> Result<(), Error> {
-        Self::update_metadata_entries(inner, items_per_blob, pruning_boundary, recovery_watermark)?;
+        Self::update_metadata_entries(inner, items_per_blob, pruning_boundary, recovery_watermark);
         inner.metadata.sync().await?;
         Ok(())
     }
@@ -576,22 +560,20 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     ///
     /// This is used before blob state moves backward so external consumers never see a persisted
     /// recovery checkpoint beyond the rewind/clear target.
-    fn lower_recovery_watermark(inner: &mut Inner<E, A>, limit: u64) -> Result<bool, Error> {
-        let current_watermark = Self::parse_metadata_u64(
-            &inner.metadata,
-            RECOVERY_WATERMARK_KEY,
-            "recovery_watermark",
-        )?;
-        let Some(current) = current_watermark else {
-            return Ok(false);
+    fn lower_recovery_watermark(inner: &mut Inner<E, A>, limit: u64) -> bool {
+        let Some(current) = inner
+            .metadata
+            .get(&RECOVERY_WATERMARK_KEY)
+            .copied()
+            .map(u64::from)
+        else {
+            return false;
         };
         if current <= limit {
-            return Ok(false);
+            return false;
         }
-        inner
-            .metadata
-            .put(RECOVERY_WATERMARK_KEY, limit.to_be_bytes().to_vec());
-        Ok(true)
+        inner.metadata.put(RECOVERY_WATERMARK_KEY, limit.into());
+        true
     }
 
     /// Stage a recovery-watermark entry no greater than `limit` in raw metadata.
@@ -599,31 +581,33 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// This is used by `init_at_size` before it clears existing blobs, before an `Inner` exists.
     #[commonware_macros::stability(ALPHA)]
     pub(super) fn update_metadata_watermark_before_clear(
-        metadata: &mut Metadata<E, u64, Vec<u8>>,
+        metadata: &mut Metadata<E, u64, VecU64>,
         limit: u64,
-    ) -> Result<bool, Error> {
-        let Some(current_watermark) =
-            Self::parse_metadata_u64(metadata, RECOVERY_WATERMARK_KEY, "recovery_watermark")?
+    ) -> bool {
+        let Some(current_watermark) = metadata
+            .get(&RECOVERY_WATERMARK_KEY)
+            .copied()
+            .map(u64::from)
         else {
-            return Ok(false);
+            return false;
         };
         if current_watermark <= limit {
-            return Ok(false);
+            return false;
         }
-        metadata.put(RECOVERY_WATERMARK_KEY, limit.to_be_bytes().to_vec());
-        Ok(true)
+        metadata.put(RECOVERY_WATERMARK_KEY, limit.into());
+        true
     }
 
     /// Open the metadata partition for `cfg`.
     pub(super) async fn open_metadata(
         context: E,
         cfg: &Config,
-    ) -> Result<Metadata<E, u64, Vec<u8>>, Error> {
+    ) -> Result<Metadata<E, u64, VecU64>, Error> {
         let meta_cfg = MetadataConfig {
             partition: format!("{}-metadata", cfg.partition),
-            codec_config: ((0..).into(), ()),
+            codec_config: (),
         };
-        Metadata::<_, u64, Vec<u8>>::init(context, meta_cfg)
+        Metadata::<_, u64, VecU64>::init(context, meta_cfg)
             .await
             .map_err(Into::into)
     }
@@ -666,15 +650,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Stage `PRUNING_BOUNDARY_KEY` in metadata, putting the mid-section boundary or removing the
     /// entry when section-aligned.
     fn stage_pruning_boundary_metadata(
-        metadata: &mut Metadata<E, u64, Vec<u8>>,
+        metadata: &mut Metadata<E, u64, VecU64>,
         items_per_blob: u64,
         pruning_boundary: u64,
     ) {
         if !pruning_boundary.is_multiple_of(items_per_blob) {
-            metadata.put(
-                PRUNING_BOUNDARY_KEY,
-                pruning_boundary.to_be_bytes().to_vec(),
-            );
+            metadata.put(PRUNING_BOUNDARY_KEY, pruning_boundary.into());
         } else {
             metadata.remove(&PRUNING_BOUNDARY_KEY);
         }
@@ -685,14 +666,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// crash recovery when `CLEAR_TARGET_KEY` is present.
     async fn complete_clear_to_size(
         journal: &mut SegmentedJournal<E, A>,
-        metadata: &mut Metadata<E, u64, Vec<u8>>,
+        metadata: &mut Metadata<E, u64, VecU64>,
         items_per_blob: u64,
         size: u64,
     ) -> Result<(), Error> {
         journal.clear().await?;
         journal.ensure_section_exists(size / items_per_blob).await?;
         Self::stage_pruning_boundary_metadata(metadata, items_per_blob, size);
-        metadata.put(RECOVERY_WATERMARK_KEY, size.to_be_bytes().to_vec());
+        metadata.put(RECOVERY_WATERMARK_KEY, size.into());
         metadata.remove(&CLEAR_TARGET_KEY);
         metadata.sync().await?;
         Ok(())
@@ -712,7 +693,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     pub(super) async fn init_with_metadata(
         context: E,
         cfg: Config,
-        mut metadata: Metadata<E, u64, Vec<u8>>,
+        mut metadata: Metadata<E, u64, VecU64>,
     ) -> Result<Self, Error> {
         let items_per_blob = cfg.items_per_blob.get();
 
@@ -728,18 +709,17 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // Complete any interrupted clear before recovering bounds. `complete_clear_to_size` also
         // resets the recovery watermark to the clear target, so the subsequent bounds recovery
         // sees fully consistent metadata.
-        if let Some(clear_target) =
-            Self::parse_metadata_u64(&metadata, CLEAR_TARGET_KEY, "clear_target")?
-        {
+        if let Some(clear_target) = metadata.get(&CLEAR_TARGET_KEY).copied().map(u64::from) {
             warn!(clear_target, "crash repair: completing interrupted clear");
             Self::complete_clear_to_size(&mut journal, &mut metadata, items_per_blob, clear_target)
                 .await?;
         }
 
-        let meta_pruning_boundary =
-            Self::parse_metadata_u64(&metadata, PRUNING_BOUNDARY_KEY, "pruning_boundary")?;
-        let meta_recovery_watermark =
-            Self::parse_metadata_u64(&metadata, RECOVERY_WATERMARK_KEY, "recovery_watermark")?;
+        let meta_pruning_boundary = metadata.get(&PRUNING_BOUNDARY_KEY).copied().map(u64::from);
+        let meta_recovery_watermark = metadata
+            .get(&RECOVERY_WATERMARK_KEY)
+            .copied()
+            .map(u64::from);
 
         let (pruning_boundary, size, recovery_watermark, repair) = Self::recover_bounds(
             &mut journal,
@@ -1068,8 +1048,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // detect CLEAR_TARGET_KEY and complete the clear via complete_clear_to_size before
         // recovering bounds.
         let mut metadata = Self::open_metadata(context.child("meta"), &cfg).await?;
-        Self::update_metadata_watermark_before_clear(&mut metadata, size)?;
-        metadata.put(CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
+        Self::update_metadata_watermark_before_clear(&mut metadata, size);
+        metadata.put(CLEAR_TARGET_KEY, size.into());
         metadata.sync().await?;
         clear_dependents().await?;
         Self::init_with_metadata(context, cfg, metadata).await
@@ -1154,7 +1134,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         inner.dirty_from_section = None;
         let pruning_boundary = inner.pruning_boundary;
         let size = inner.size;
-        Self::update_metadata_entries(&mut inner, self.items_per_blob, pruning_boundary, size)?;
+        Self::update_metadata_entries(&mut inner, self.items_per_blob, pruning_boundary, size);
         drop(inner);
 
         let inner = self.inner.read().await;
@@ -1175,13 +1155,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Return the recovery watermark.
     pub(crate) async fn recovery_watermark(&self) -> u64 {
         let inner = self.inner.read().await;
-        Self::parse_metadata_u64(
-            &inner.metadata,
-            RECOVERY_WATERMARK_KEY,
-            "recovery_watermark",
-        )
-        .expect("valid recovery watermark metadata")
-        .expect("recovery watermark must exist after init")
+        inner
+            .metadata
+            .get(&RECOVERY_WATERMARK_KEY)
+            .copied()
+            .map(u64::from)
+            .expect("recovery watermark must exist after init")
     }
 
     /// Return the total number of items in the journal, irrespective of pruning. The next value
@@ -1296,7 +1275,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .checked_mul(Self::CHUNK_SIZE_U64)
             .ok_or(Error::OffsetOverflow)?;
 
-        let should_sync_metadata = Self::lower_recovery_watermark(&mut inner, size)?;
+        let should_sync_metadata = Self::lower_recovery_watermark(&mut inner, size);
         drop(inner);
 
         if should_sync_metadata {
@@ -1387,10 +1366,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
         // Lower the watermark in-memory and stage the clear intent in the same metadata sync, so
         // external consumers never see a persisted recovery checkpoint beyond `new_size`.
-        Self::lower_recovery_watermark(&mut inner, new_size)?;
-        inner
-            .metadata
-            .put(CLEAR_TARGET_KEY, new_size.to_be_bytes().to_vec());
+        Self::lower_recovery_watermark(&mut inner, new_size);
+        inner.metadata.put(CLEAR_TARGET_KEY, new_size.into());
         inner.metadata.sync().await?;
 
         let Inner {
@@ -1418,10 +1395,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;
 
-        Self::lower_recovery_watermark(&mut inner, new_size)?;
-        inner
-            .metadata
-            .put(CLEAR_TARGET_KEY, new_size.to_be_bytes().to_vec());
+        Self::lower_recovery_watermark(&mut inner, new_size);
+        inner.metadata.put(CLEAR_TARGET_KEY, new_size.into());
         inner.metadata.sync().await.map_err(Into::into)
     }
 
@@ -1455,9 +1430,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     #[cfg(test)]
     pub(crate) async fn test_set_recovery_watermark(&self, watermark: u64) -> Result<(), Error> {
         let mut inner = self.inner.write().await;
-        inner
-            .metadata
-            .put(RECOVERY_WATERMARK_KEY, watermark.to_be_bytes().to_vec());
+        inner.metadata.put(RECOVERY_WATERMARK_KEY, watermark.into());
         inner.metadata.sync().await?;
         Ok(())
     }
@@ -2404,9 +2377,7 @@ mod tests {
 
             {
                 let mut inner = journal.inner.write().await;
-                inner
-                    .metadata
-                    .put(RECOVERY_WATERMARK_KEY, 6u64.to_be_bytes().to_vec());
+                inner.metadata.put(RECOVERY_WATERMARK_KEY, 6u64.into());
                 inner
                     .metadata
                     .sync()
@@ -2470,9 +2441,7 @@ mod tests {
                     .sync(2)
                     .await
                     .expect("failed to sync shortened anchored section");
-                inner
-                    .metadata
-                    .put(RECOVERY_WATERMARK_KEY, 12u64.to_be_bytes().to_vec());
+                inner.metadata.put(RECOVERY_WATERMARK_KEY, 12u64.into());
                 inner
                     .metadata
                     .sync()
@@ -2594,16 +2563,16 @@ mod tests {
 
             let meta_cfg = MetadataConfig {
                 partition: format!("{}-metadata", cfg.partition),
-                codec_config: ((0..).into(), ()),
+                codec_config: (),
             };
-            let metadata = Metadata::<_, u64, Vec<u8>>::init(context.child("metadata"), meta_cfg)
+            let metadata = Metadata::<_, u64, VecU64>::init(context.child("metadata"), meta_cfg)
                 .await
                 .expect("failed to reopen metadata");
-            let raw_watermark = metadata
+            let persisted_watermark = metadata
                 .get(&RECOVERY_WATERMARK_KEY)
+                .copied()
+                .map(u64::from)
                 .expect("missing recovery watermark after legacy recovery");
-            let persisted_watermark =
-                u64::from_be_bytes(raw_watermark.as_slice().try_into().unwrap());
             assert_eq!(persisted_watermark, 12);
             drop(metadata);
 
@@ -2624,34 +2593,32 @@ mod tests {
             let cfg = test_cfg(&context, NZU64!(5));
             let meta_cfg = MetadataConfig {
                 partition: format!("{}-metadata", cfg.partition),
-                codec_config: ((0..).into(), ()),
+                codec_config: (),
             };
             let mut metadata =
-                Metadata::<_, u64, Vec<u8>>::init(context.child("metadata"), meta_cfg)
+                Metadata::<_, u64, VecU64>::init(context.child("metadata"), meta_cfg)
                     .await
                     .expect("failed to initialize metadata");
-            metadata.put(RECOVERY_WATERMARK_KEY, 7u64.to_be_bytes().to_vec());
+            metadata.put(RECOVERY_WATERMARK_KEY, 7u64.into());
 
             let changed =
-                Journal::<_, Digest>::update_metadata_watermark_before_clear(&mut metadata, 9)
-                    .expect("failed to update metadata watermark");
+                Journal::<_, Digest>::update_metadata_watermark_before_clear(&mut metadata, 9);
             assert!(!changed);
-            let raw_watermark = metadata
+            let persisted_watermark = metadata
                 .get(&RECOVERY_WATERMARK_KEY)
+                .copied()
+                .map(u64::from)
                 .expect("missing recovery watermark");
-            let persisted_watermark =
-                u64::from_be_bytes(raw_watermark.as_slice().try_into().unwrap());
             assert_eq!(persisted_watermark, 7);
 
             let changed =
-                Journal::<_, Digest>::update_metadata_watermark_before_clear(&mut metadata, 5)
-                    .expect("failed to update metadata watermark");
+                Journal::<_, Digest>::update_metadata_watermark_before_clear(&mut metadata, 5);
             assert!(changed);
-            let raw_watermark = metadata
+            let persisted_watermark = metadata
                 .get(&RECOVERY_WATERMARK_KEY)
+                .copied()
+                .map(u64::from)
                 .expect("missing recovery watermark");
-            let persisted_watermark =
-                u64::from_be_bytes(raw_watermark.as_slice().try_into().unwrap());
             assert_eq!(persisted_watermark, 5);
         });
     }
@@ -2682,9 +2649,9 @@ mod tests {
 
             let meta_cfg = MetadataConfig {
                 partition: format!("{}-metadata", cfg.partition),
-                codec_config: ((0..).into(), ()),
+                codec_config: (),
             };
-            let metadata = Metadata::<_, u64, Vec<u8>>::init(context.child("metadata"), meta_cfg)
+            let metadata = Metadata::<_, u64, VecU64>::init(context.child("metadata"), meta_cfg)
                 .await
                 .expect("failed to reopen metadata");
             assert!(metadata.get(&PRUNING_BOUNDARY_KEY).is_none());
@@ -3051,16 +3018,16 @@ mod tests {
 
             let meta_cfg = MetadataConfig {
                 partition: format!("{}-metadata", cfg.partition),
-                codec_config: ((0..).into(), ()),
+                codec_config: (),
             };
-            let metadata = Metadata::<_, u64, Vec<u8>>::init(context.child("metadata"), meta_cfg)
+            let metadata = Metadata::<_, u64, VecU64>::init(context.child("metadata"), meta_cfg)
                 .await
                 .expect("failed to reopen metadata");
-            let raw_watermark = metadata
+            let persisted_watermark = metadata
                 .get(&RECOVERY_WATERMARK_KEY)
+                .copied()
+                .map(u64::from)
                 .expect("missing recovery watermark after rewind");
-            let persisted_watermark =
-                u64::from_be_bytes(raw_watermark.as_slice().try_into().unwrap());
             assert_eq!(persisted_watermark, 7);
             drop(metadata);
 
@@ -3090,9 +3057,7 @@ mod tests {
 
             {
                 let mut inner = journal.inner.write().await;
-                inner
-                    .metadata
-                    .put(RECOVERY_WATERMARK_KEY, 7u64.to_be_bytes().to_vec());
+                inner.metadata.put(RECOVERY_WATERMARK_KEY, 7u64.into());
                 inner
                     .metadata
                     .sync()
@@ -4057,13 +4022,13 @@ mod tests {
             let blob_part = blob_partition(&cfg);
             let meta_cfg = MetadataConfig {
                 partition: format!("{}-metadata", cfg.partition),
-                codec_config: ((0..).into(), ()),
+                codec_config: (),
             };
             let mut metadata =
-                Metadata::<_, u64, Vec<u8>>::init(context.child("intent_meta"), meta_cfg.clone())
+                Metadata::<_, u64, VecU64>::init(context.child("intent_meta"), meta_cfg.clone())
                     .await
                     .unwrap();
-            metadata.put(CLEAR_TARGET_KEY, 12u64.to_be_bytes().to_vec());
+            metadata.put(CLEAR_TARGET_KEY, 12u64.into());
             metadata.sync().await.unwrap();
             drop(metadata);
             context.remove(&blob_part, None).await.unwrap();
@@ -4082,11 +4047,11 @@ mod tests {
 
             // Restore metadata for next scenario (it might have been removed by init)
             let mut metadata =
-                Metadata::<_, u64, Vec<u8>>::init(context.child("restore_meta"), meta_cfg.clone())
+                Metadata::<_, u64, VecU64>::init(context.child("restore_meta"), meta_cfg.clone())
                     .await
                     .unwrap();
-            metadata.put(PRUNING_BOUNDARY_KEY, 7u64.to_be_bytes().to_vec());
-            metadata.put(CLEAR_TARGET_KEY, 2u64.to_be_bytes().to_vec());
+            metadata.put(PRUNING_BOUNDARY_KEY, 7u64.into());
+            metadata.put(CLEAR_TARGET_KEY, 2u64.into());
             metadata.sync().await.unwrap();
             drop(metadata);
 
@@ -4132,12 +4097,12 @@ mod tests {
             let blob_part = blob_partition(&cfg);
             let meta_cfg = MetadataConfig {
                 partition: format!("{}-metadata", cfg.partition),
-                codec_config: ((0..).into(), ()),
+                codec_config: (),
             };
-            let mut metadata = Metadata::<_, u64, Vec<u8>>::init(context.child("meta"), meta_cfg)
+            let mut metadata = Metadata::<_, u64, VecU64>::init(context.child("meta"), meta_cfg)
                 .await
                 .unwrap();
-            metadata.put(CLEAR_TARGET_KEY, 2u64.to_be_bytes().to_vec());
+            metadata.put(CLEAR_TARGET_KEY, 2u64.into());
             metadata.sync().await.unwrap();
             drop(metadata);
 
@@ -4172,12 +4137,12 @@ mod tests {
 
             let meta_cfg = MetadataConfig {
                 partition: format!("{}-metadata", cfg.partition),
-                codec_config: ((0..).into(), ()),
+                codec_config: (),
             };
-            let mut metadata = Metadata::<_, u64, Vec<u8>>::init(context.child("meta"), meta_cfg)
+            let mut metadata = Metadata::<_, u64, VecU64>::init(context.child("meta"), meta_cfg)
                 .await
                 .unwrap();
-            metadata.put(CLEAR_TARGET_KEY, 100u64.to_be_bytes().to_vec());
+            metadata.put(CLEAR_TARGET_KEY, 100u64.into());
             metadata.sync().await.unwrap();
             drop(metadata);
             drop(journal);
@@ -4210,12 +4175,12 @@ mod tests {
 
             let meta_cfg = MetadataConfig {
                 partition: format!("{}-metadata", cfg.partition),
-                codec_config: ((0..).into(), ()),
+                codec_config: (),
             };
-            let mut metadata = Metadata::<_, u64, Vec<u8>>::init(context.child("meta"), meta_cfg)
+            let mut metadata = Metadata::<_, u64, VecU64>::init(context.child("meta"), meta_cfg)
                 .await
                 .unwrap();
-            metadata.put(CLEAR_TARGET_KEY, 15u64.to_be_bytes().to_vec());
+            metadata.put(CLEAR_TARGET_KEY, 15u64.into());
             metadata.sync().await.unwrap();
             drop(metadata);
             drop(journal);

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -611,10 +611,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok(true)
     }
 
-    /// Open the metadata partition for `cfg`. Callers inspect or mutate it directly (via
-    /// `metadata.get(&CLEAR_TARGET_KEY)` or `update_metadata_watermark_before_clear` + `put` +
-    /// `sync`) and then hand it to `init_with_metadata` to finish initialization without
-    /// re-opening.
+    /// Open the metadata partition for `cfg`.
     pub(crate) async fn open_metadata(
         context: &E,
         cfg: &Config,
@@ -708,7 +705,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     }
 
     /// Finish initialization using an already-open metadata handle. Callers use this after
-    /// `open_metadata` + `stage_reset` / `pending_reset` so metadata is opened exactly once.
+    /// `open_metadata` so the metadata partition is opened exactly once.
     pub(crate) async fn init_with_metadata(
         context: E,
         cfg: Config,
@@ -1367,13 +1364,17 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok(())
     }
 
-    /// Runtime equivalent of `stage_reset`: durably stage `CLEAR_TARGET_KEY` so callers can clear
-    /// dependent sibling state before invoking `clear_to_size` to finish the operation. The
-    /// subsequent `clear_to_size` re-stages the same intent idempotently and then completes.
+    /// Durably stage a clear to `new_size` without completing it.
+    ///
+    /// This lowers the recovery watermark and persists `CLEAR_TARGET_KEY`, leaving a recoverable
+    /// intent so a caller can clear dependent sibling state before calling `clear_to_size` to
+    /// finish. If a crash interrupts the sequence, the next `init` completes the staged clear.
+    /// The follow-up `clear_to_size` re-stages the same target idempotently.
     #[commonware_macros::stability(ALPHA)]
     pub(crate) async fn stage_clear_intent(&self, new_size: u64) -> Result<(), Error> {
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;
+
         Self::lower_recovery_watermark(&mut inner, new_size)?;
         inner
             .metadata

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -463,12 +463,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             page_cache: cfg.page_cache,
             write_buffer: cfg.write_buffer,
         };
-        let mut offsets = fixed::Journal::<E, u64>::init_cleared(
-            context.child("offsets"),
-            offsets_cfg,
-            || data.clear(),
-        )
-        .await?;
+        let mut offsets =
+            fixed::Journal::<E, u64>::init_cleared(context.child("offsets"), offsets_cfg, || {
+                data.clear()
+            })
+            .await?;
 
         // Validate and align offsets journal to match data journal
         let (pruning_boundary, size) =
@@ -3236,9 +3235,8 @@ mod tests {
                 fixed::Journal::<_, u64>::update_metadata_watermark_before_clear(
                     &mut intent_metadata,
                     7,
-                )
-                .unwrap();
-                intent_metadata.put(fixed::CLEAR_TARGET_KEY, 7u64.to_be_bytes().to_vec());
+                );
+                intent_metadata.put(fixed::CLEAR_TARGET_KEY, 7u64.into());
                 intent_metadata.sync().await.unwrap();
                 drop(intent_metadata);
 
@@ -3318,9 +3316,11 @@ mod tests {
                 fixed::Journal::<_, u64>::open_metadata(stale_ctx.child("meta"), &offsets_cfg)
                     .await
                     .unwrap();
-            fixed::Journal::<_, u64>::update_metadata_watermark_before_clear(&mut stale_metadata, 5)
-                .unwrap();
-            stale_metadata.put(fixed::CLEAR_TARGET_KEY, 5u64.to_be_bytes().to_vec());
+            fixed::Journal::<_, u64>::update_metadata_watermark_before_clear(
+                &mut stale_metadata,
+                5,
+            );
+            stale_metadata.put(fixed::CLEAR_TARGET_KEY, 5u64.into());
             stale_metadata.sync().await.unwrap();
             drop(stale_metadata);
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -454,27 +454,19 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         )
         .await?;
 
-        // If offsets has a pending reset from a prior crashed `init_at_size` or `clear_to_size`,
-        // CLEAR_TARGET_KEY is present in its metadata. Clear data first so the staged clear that
-        // `init_with_metadata` runs (via `complete_clear_to_size`) reconciles both sides.
-        // Metadata stays open and is handed to `init_with_metadata` so we only open it once.
+        // If a prior `init_at_size`/`clear_to_size` crashed mid-reset, the offsets journal carries
+        // a staged clear. `init_cleared` discards data before finishing that reset so the two sides
+        // are reconciled and stale data is never replayed past the reset size.
         let offsets_cfg = fixed::Config {
             partition: offsets_partition,
             items_per_blob: cfg.items_per_section,
             page_cache: cfg.page_cache,
             write_buffer: cfg.write_buffer,
         };
-        let offsets_ctx = context.child("offsets");
-        let offsets_metadata =
-            fixed::Journal::<E, u64>::open_metadata(offsets_ctx.child("meta"), &offsets_cfg)
-                .await?;
-        if offsets_metadata.get(&fixed::CLEAR_TARGET_KEY).is_some() {
-            data.clear().await?;
-        }
-        let mut offsets = fixed::Journal::<E, u64>::init_with_metadata(
-            offsets_ctx,
+        let mut offsets = fixed::Journal::<E, u64>::init_cleared(
+            context.child("offsets"),
             offsets_cfg,
-            offsets_metadata,
+            || data.clear(),
         )
         .await?;
 
@@ -528,27 +520,14 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         )
         .await?;
 
-        // Stage the offsets reset intent durably before clearing data. Lower the recovery
-        // watermark first so external consumers never see a persisted checkpoint beyond `size`.
-        // After data is cleared, `init_with_metadata` detects CLEAR_TARGET_KEY and completes the
-        // clear. A crash at any point in this sequence leaves a durable intent that the next
-        // `init` (via `init_with_metadata`) will finish. Metadata stays open across stage / clear
-        // / init so it's only opened once.
-        let offsets_ctx = context.child("offsets");
-        let mut offsets_metadata =
-            fixed::Journal::<E, u64>::open_metadata(offsets_ctx.child("meta"), &offsets_cfg)
-                .await?;
-        fixed::Journal::<E, u64>::update_metadata_watermark_before_clear(
-            &mut offsets_metadata,
-            size,
-        )?;
-        offsets_metadata.put(fixed::CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
-        offsets_metadata.sync().await?;
-        data.clear().await?;
-        let offsets = fixed::Journal::<E, u64>::init_with_metadata(
-            offsets_ctx,
+        // `init_at_size_cleared` durably stages the offsets reset, clears data, then completes the
+        // reset. A crash at any point leaves a staged clear that the next `init` (via
+        // `init_cleared`) finishes, so stale data can never outlive the reset.
+        let offsets = fixed::Journal::<E, u64>::init_at_size_cleared(
+            context.child("offsets"),
             offsets_cfg,
-            offsets_metadata,
+            size,
+            || data.clear(),
         )
         .await?;
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -454,15 +454,18 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         )
         .await?;
 
+        let offsets_cfg = fixed::Config {
+            partition: offsets_partition,
+            items_per_blob: cfg.items_per_section,
+            page_cache: cfg.page_cache,
+            write_buffer: cfg.write_buffer,
+        };
         // Initialize offsets journal
-        let mut offsets = fixed::Journal::init(
+        let mut offsets = fixed::Journal::init_with_external_clear(
             context.child("offsets"),
-            fixed::Config {
-                partition: offsets_partition,
-                items_per_blob: cfg.items_per_section,
-                page_cache: cfg.page_cache,
-                write_buffer: cfg.write_buffer,
-            },
+            offsets_cfg,
+            None,
+            || async { data.clear().await },
         )
         .await?;
 
@@ -490,16 +493,20 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
     /// Initialize an empty [Journal] at the given logical `size`.
     ///
-    /// This discards any existing data and offsets. The data journal is cleared before the offsets
-    /// journal is reset because normal recovery treats data as the source of truth; stale data must
-    /// not be replayed against freshly reset offsets.
+    /// This discards any existing data and offsets. The offsets reset intent is staged before the
+    /// data journal is cleared so recovery can complete the requested reset if a crash interrupts
+    /// the operation.
     ///
     /// Returns a journal with journal.bounds() == Range{start: size, end: size}
     /// and next append at position `size`.
     #[commonware_macros::stability(ALPHA)]
     pub async fn init_at_size(context: E, cfg: Config<V::Cfg>, size: u64) -> Result<Self, Error> {
-        // Initialize and clear the data journal. Offsets alone are not enough to reset the
-        // journal because stale data sections can otherwise break the next recovery.
+        let offsets_cfg = fixed::Config {
+            partition: cfg.offsets_partition(),
+            items_per_blob: cfg.items_per_section,
+            page_cache: cfg.page_cache.clone(),
+            write_buffer: cfg.write_buffer,
+        };
         let mut data = variable::Journal::init(
             context.child("data"),
             variable::Config {
@@ -511,18 +518,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             },
         )
         .await?;
-        data.clear().await?;
-
-        // Initialize offsets journal at the target size
-        let offsets = fixed::Journal::init_at_size(
+        let offsets = fixed::Journal::<E, u64>::init_with_external_clear(
             context.child("offsets"),
-            fixed::Config {
-                partition: cfg.offsets_partition(),
-                items_per_blob: cfg.items_per_section,
-                page_cache: cfg.page_cache,
-                write_buffer: cfg.write_buffer,
-            },
-            size,
+            offsets_cfg,
+            Some(size),
+            || async { data.clear().await },
         )
         .await?;
 
@@ -909,15 +909,15 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// Unlike `destroy`, this keeps the journal alive so it can be reused.
     /// After clearing, the journal will behave as if initialized with `init_at_size(new_size)`.
-    /// The data journal is cleared before the offsets journal is reset to preserve the recovery
-    /// rule that data is the source of truth.
+    /// The offsets reset intent is staged before the data journal is cleared so recovery can
+    /// complete the requested reset if a crash interrupts the operation.
     #[commonware_macros::stability(ALPHA)]
     pub(crate) async fn clear_to_size(&self, new_size: u64) -> Result<(), Error> {
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;
-        inner.data.clear().await?;
-
-        self.offsets.clear_to_size(new_size).await?;
+        self.offsets
+            .clear_to_size_with_external_clear(new_size, || async { inner.data.clear().await })
+            .await?;
         inner.size = new_size;
         inner.pruning_boundary = new_size;
         inner.dirty_from_section = None;
@@ -3065,6 +3065,147 @@ mod tests {
             ));
 
             journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_init_at_size_stages_reset_before_clearing_data() {
+        let partition = "init-at-size-stage-before-clear-failure".to_string();
+        let executor = deterministic::Runner::default();
+        let ((), checkpoint) = executor.start_and_recover({
+            let partition = partition.clone();
+            |context| async move {
+                let cfg = Config {
+                    partition,
+                    items_per_section: NZU64!(5),
+                    compression: None,
+                    codec_config: (),
+                    page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                    write_buffer: NZUsize!(1024),
+                };
+
+                let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+                for i in 0..12u64 {
+                    journal.append(&(100 + i)).await.unwrap();
+                }
+                journal.sync().await.unwrap();
+                drop(journal);
+
+                *context.storage_fault_config().write() = deterministic::FaultConfig {
+                    sync_rate: Some(1.0),
+                    ..Default::default()
+                };
+                assert!(
+                    Journal::<_, u64>::init_at_size(context.child("reset"), cfg, 7)
+                        .await
+                        .is_err()
+                );
+            }
+        });
+
+        deterministic::Runner::from(checkpoint).start(move |context| async move {
+            *context.storage_fault_config().write() = deterministic::FaultConfig::default();
+            let cfg = Config {
+                partition,
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("recover"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..12);
+            for i in 0..12u64 {
+                assert_eq!(journal.read(i).await.unwrap(), 100 + i);
+            }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_init_at_size_recovers_staged_reset_crash_points() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            for (index, clear_data) in [false, true].into_iter().enumerate() {
+                let cfg = Config {
+                    partition: format!("init-at-size-staged-reset-crash-{index}"),
+                    items_per_section: NZU64!(5),
+                    compression: None,
+                    codec_config: (),
+                    page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                    write_buffer: NZUsize!(1024),
+                };
+
+                let journal = Journal::<_, u64>::init(
+                    context.child("first").with_attribute("index", index),
+                    cfg.clone(),
+                )
+                .await
+                .unwrap();
+                for i in 0..12u64 {
+                    journal.append(&(100 + i)).await.unwrap();
+                }
+                journal.sync().await.unwrap();
+                drop(journal);
+
+                let offsets_cfg = fixed::Config {
+                    partition: cfg.offsets_partition(),
+                    items_per_blob: cfg.items_per_section,
+                    page_cache: cfg.page_cache.clone(),
+                    write_buffer: cfg.write_buffer,
+                };
+                fixed::Journal::<_, u64>::test_stage_clear_to_size_in_partition(
+                    &context.child("intent").with_attribute("index", index),
+                    &offsets_cfg,
+                    7,
+                )
+                .await
+                .unwrap();
+
+                if clear_data {
+                    let mut data = variable::Journal::<_, u64>::init(
+                        context.child("data").with_attribute("index", index),
+                        variable::Config {
+                            partition: cfg.data_partition(),
+                            compression: cfg.compression,
+                            codec_config: cfg.codec_config,
+                            page_cache: cfg.page_cache.clone(),
+                            write_buffer: cfg.write_buffer,
+                        },
+                    )
+                    .await
+                    .unwrap();
+                    data.clear().await.unwrap();
+                }
+
+                let journal = Journal::<_, u64>::init(
+                    context.child("recover").with_attribute("index", index),
+                    cfg.clone(),
+                )
+                .await
+                .unwrap();
+                assert_eq!(journal.bounds().await, 7..7);
+                assert_eq!(journal.append(&700).await.unwrap(), 7);
+                journal.sync().await.unwrap();
+                drop(journal);
+
+                let journal = Journal::<_, u64>::init(
+                    context.child("reopen").with_attribute("index", index),
+                    cfg.clone(),
+                )
+                .await
+                .unwrap();
+                assert_eq!(journal.bounds().await, 7..8);
+                assert_eq!(journal.read(7).await.unwrap(), 700);
+
+                journal.destroy().await.unwrap();
+            }
         });
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -501,12 +501,6 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// and next append at position `size`.
     #[commonware_macros::stability(ALPHA)]
     pub async fn init_at_size(context: E, cfg: Config<V::Cfg>, size: u64) -> Result<Self, Error> {
-        let offsets_cfg = fixed::Config {
-            partition: cfg.offsets_partition(),
-            items_per_blob: cfg.items_per_section,
-            page_cache: cfg.page_cache.clone(),
-            write_buffer: cfg.write_buffer,
-        };
         let mut data = variable::Journal::init(
             context.child("data"),
             variable::Config {
@@ -524,7 +518,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // `init_cleared`) finishes, so stale data can never outlive the reset.
         let offsets = fixed::Journal::<E, u64>::init_at_size_cleared(
             context.child("offsets"),
-            offsets_cfg,
+            fixed::Config {
+                partition: cfg.offsets_partition(),
+                items_per_blob: cfg.items_per_section,
+                page_cache: cfg.page_cache.clone(),
+                write_buffer: cfg.write_buffer,
+            },
             size,
             || data.clear(),
         )

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -454,16 +454,16 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         )
         .await?;
 
+        // If offsets has a pending reset from a prior crashed `init_at_size` or `clear_to_size`,
+        // CLEAR_TARGET_KEY is present in its metadata. Clear data first so the staged clear that
+        // `init_with_metadata` runs (via `complete_clear_to_size`) reconciles both sides.
+        // Metadata stays open and is handed to `init_with_metadata` so we only open it once.
         let offsets_cfg = fixed::Config {
             partition: offsets_partition,
             items_per_blob: cfg.items_per_section,
             page_cache: cfg.page_cache,
             write_buffer: cfg.write_buffer,
         };
-        // If offsets has a pending reset from a prior crashed `init_at_size` or `clear_to_size`,
-        // CLEAR_TARGET_KEY is present in its metadata. Clear data first so the staged clear that
-        // `init_with_metadata` runs (via `complete_clear_to_size`) reconciles both sides.
-        // Metadata stays open and is handed to `init_with_metadata` so we only open it once.
         let offsets_ctx = context.child("offsets");
         let offsets_metadata =
             fixed::Journal::<E, u64>::open_metadata(&offsets_ctx, &offsets_cfg).await?;
@@ -526,6 +526,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             },
         )
         .await?;
+
         // Stage the offsets reset intent durably before clearing data. Lower the recovery
         // watermark first so external consumers never see a persisted checkpoint beyond `size`.
         // After data is cleared, `init_with_metadata` detects CLEAR_TARGET_KEY and completes the
@@ -938,6 +939,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     pub(crate) async fn clear_to_size(&self, new_size: u64) -> Result<(), Error> {
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;
+
         // Stage in offsets first so a crash mid-clear leaves an intent that recovery completes.
         // `clear_to_size` re-stages the same target idempotently before completing.
         self.offsets.stage_clear_intent(new_size).await?;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -3137,6 +3137,63 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_clear_to_size_stages_reset_before_clearing_data() {
+        let partition = "clear-to-size-stage-before-clear-failure".to_string();
+        let executor = deterministic::Runner::default();
+        let ((), checkpoint) = executor.start_and_recover({
+            let partition = partition.clone();
+            |context| async move {
+                let cfg = Config {
+                    partition,
+                    items_per_section: NZU64!(5),
+                    compression: None,
+                    codec_config: (),
+                    page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                    write_buffer: NZUsize!(1024),
+                };
+
+                let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+                for i in 0..12u64 {
+                    journal.append(&(100 + i)).await.unwrap();
+                }
+                journal.sync().await.unwrap();
+
+                // Fail the offsets metadata sync inside `stage_clear_intent` so `clear_to_size`
+                // aborts before any data is cleared. The reset intent never becomes durable.
+                *context.storage_fault_config().write() = deterministic::FaultConfig {
+                    sync_rate: Some(1.0),
+                    ..Default::default()
+                };
+                assert!(journal.clear_to_size(7).await.is_err());
+            }
+        });
+
+        deterministic::Runner::from(checkpoint).start(move |context| async move {
+            *context.storage_fault_config().write() = deterministic::FaultConfig::default();
+            let cfg = Config {
+                partition,
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("recover"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..12);
+            for i in 0..12u64 {
+                assert_eq!(journal.read(i).await.unwrap(), 100 + i);
+            }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_init_at_size_recovers_staged_reset_crash_points() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -3223,6 +3280,67 @@ mod tests {
 
                 journal.destroy().await.unwrap();
             }
+        });
+    }
+
+    #[test_traced]
+    fn test_init_at_size_overwrites_pending_clear_target() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "init-at-size-overwrites-pending-target".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..12u64 {
+                journal.append(&(100 + i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Simulate a prior `clear_to_size(5)` that crashed after staging its intent: the offsets
+            // metadata carries CLEAR_TARGET_KEY=5 while the data journal still holds all 12 items.
+            let offsets_cfg = fixed::Config {
+                partition: cfg.offsets_partition(),
+                items_per_blob: cfg.items_per_section,
+                page_cache: cfg.page_cache.clone(),
+                write_buffer: cfg.write_buffer,
+            };
+            let stale_ctx = context.child("stale");
+            let mut stale_metadata =
+                fixed::Journal::<_, u64>::open_metadata(stale_ctx.child("meta"), &offsets_cfg)
+                    .await
+                    .unwrap();
+            fixed::Journal::<_, u64>::update_metadata_watermark_before_clear(&mut stale_metadata, 5)
+                .unwrap();
+            stale_metadata.put(fixed::CLEAR_TARGET_KEY, 5u64.to_be_bytes().to_vec());
+            stale_metadata.sync().await.unwrap();
+            drop(stale_metadata);
+
+            // init_at_size(10) overwrites the pending target of 5 and resets to 10.
+            let journal = Journal::<_, u64>::init_at_size(context.child("reset"), cfg.clone(), 10)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 10..10);
+            assert_eq!(journal.append(&700).await.unwrap(), 10);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Reopen: target 10 (not 5) persisted and no stale data was replayed.
+            let journal = Journal::<_, u64>::init(context.child("reopen"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 10..11);
+            assert_eq!(journal.read(10).await.unwrap(), 700);
+
+            journal.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -470,9 +470,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         if offsets_metadata.get(&fixed::CLEAR_TARGET_KEY).is_some() {
             data.clear().await?;
         }
-        let mut offsets =
-            fixed::Journal::<E, u64>::init_with_metadata(offsets_ctx, offsets_cfg, offsets_metadata)
-                .await?;
+        let mut offsets = fixed::Journal::<E, u64>::init_with_metadata(
+            offsets_ctx,
+            offsets_cfg,
+            offsets_metadata,
+        )
+        .await?;
 
         // Validate and align offsets journal to match data journal
         let (pruning_boundary, size) =

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -3161,7 +3161,7 @@ mod tests {
                     write_buffer: cfg.write_buffer,
                 };
                 fixed::Journal::<_, u64>::test_stage_clear_to_size_in_partition(
-                    &context.child("intent").with_attribute("index", index),
+                    context.child("intent").with_attribute("index", index),
                     &offsets_cfg,
                     7,
                 )

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -916,7 +916,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;
         self.offsets
-            .clear_to_size_with_external_clear(new_size, || async { inner.data.clear().await })
+            .clear_to_size_with_dependent_clear(new_size, || async { inner.data.clear().await })
             .await?;
         inner.size = new_size;
         inner.pruning_boundary = new_size;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -457,17 +457,17 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // If a prior `init_at_size`/`clear_to_size` crashed mid-reset, the offsets journal carries
         // a staged clear. `init_cleared` discards data before finishing that reset so the two sides
         // are reconciled and stale data is never replayed past the reset size.
-        let offsets_cfg = fixed::Config {
-            partition: offsets_partition,
-            items_per_blob: cfg.items_per_section,
-            page_cache: cfg.page_cache,
-            write_buffer: cfg.write_buffer,
-        };
-        let mut offsets =
-            fixed::Journal::<E, u64>::init_cleared(context.child("offsets"), offsets_cfg, || {
-                data.clear()
-            })
-            .await?;
+        let mut offsets = fixed::Journal::<E, u64>::init_cleared(
+            context.child("offsets"),
+            fixed::Config {
+                partition: offsets_partition,
+                items_per_blob: cfg.items_per_section,
+                page_cache: cfg.page_cache,
+                write_buffer: cfg.write_buffer,
+            },
+            || data.clear(),
+        )
+        .await?;
 
         // Validate and align offsets journal to match data journal
         let (pruning_boundary, size) =

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -460,14 +460,15 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             page_cache: cfg.page_cache,
             write_buffer: cfg.write_buffer,
         };
-        // Initialize offsets journal
-        let mut offsets = fixed::Journal::init_with_external_clear(
-            context.child("offsets"),
-            offsets_cfg,
-            None,
-            || async { data.clear().await },
-        )
-        .await?;
+        // If offsets has a pending reset from a prior crashed `init_at_size` or `clear_to_size`,
+        // clear data first so the staged clear inside offsets init reconciles both sides.
+        if fixed::Journal::<E, u64>::pending_reset(context.child("offsets"), &offsets_cfg)
+            .await?
+            .is_some()
+        {
+            data.clear().await?;
+        }
+        let mut offsets = fixed::Journal::init(context.child("offsets"), offsets_cfg).await?;
 
         // Validate and align offsets journal to match data journal
         let (pruning_boundary, size) =
@@ -518,13 +519,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             },
         )
         .await?;
-        let offsets = fixed::Journal::<E, u64>::init_with_external_clear(
-            context.child("offsets"),
-            offsets_cfg,
-            Some(size),
-            || async { data.clear().await },
-        )
-        .await?;
+        // Stage the offsets reset, then clear data, then let offsets init complete the clear. A
+        // crash at any point leaves the staged intent for `init` to finish.
+        fixed::Journal::<E, u64>::stage_reset(context.child("offsets"), &offsets_cfg, size).await?;
+        data.clear().await?;
+        let offsets = fixed::Journal::<E, u64>::init(context.child("offsets"), offsets_cfg).await?;
 
         let items_per_section = cfg.items_per_section.get();
         let metrics = Metrics::new(context);
@@ -915,9 +914,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     pub(crate) async fn clear_to_size(&self, new_size: u64) -> Result<(), Error> {
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;
-        self.offsets
-            .clear_to_size_with_dependent_clear(new_size, || async { inner.data.clear().await })
-            .await?;
+        // Stage in offsets first so a crash mid-clear leaves an intent that recovery completes.
+        // `clear_to_size` re-stages the same target idempotently before completing.
+        self.offsets.stage_clear_intent(new_size).await?;
+        inner.data.clear().await?;
+        self.offsets.clear_to_size(new_size).await?;
         inner.size = new_size;
         inner.pruning_boundary = new_size;
         inner.dirty_from_section = None;
@@ -3160,7 +3161,7 @@ mod tests {
                     page_cache: cfg.page_cache.clone(),
                     write_buffer: cfg.write_buffer,
                 };
-                fixed::Journal::<_, u64>::test_stage_clear_to_size_in_partition(
+                fixed::Journal::<_, u64>::stage_reset(
                     context.child("intent").with_attribute("index", index),
                     &offsets_cfg,
                     7,

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -490,12 +490,17 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
     /// Initialize an empty [Journal] at the given logical `size`.
     ///
+    /// This discards any existing data and offsets. The data journal is cleared before the offsets
+    /// journal is reset because normal recovery treats data as the source of truth; stale data must
+    /// not be replayed against freshly reset offsets.
+    ///
     /// Returns a journal with journal.bounds() == Range{start: size, end: size}
     /// and next append at position `size`.
     #[commonware_macros::stability(ALPHA)]
     pub async fn init_at_size(context: E, cfg: Config<V::Cfg>, size: u64) -> Result<Self, Error> {
-        // Initialize empty data journal
-        let data = variable::Journal::init(
+        // Initialize and clear the data journal. Offsets alone are not enough to reset the
+        // journal because stale data sections can otherwise break the next recovery.
+        let mut data = variable::Journal::init(
             context.child("data"),
             variable::Config {
                 partition: cfg.data_partition(),
@@ -506,6 +511,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             },
         )
         .await?;
+        data.clear().await?;
 
         // Initialize offsets journal at the target size
         let offsets = fixed::Journal::init_at_size(
@@ -903,6 +909,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// Unlike `destroy`, this keeps the journal alive so it can be reused.
     /// After clearing, the journal will behave as if initialized with `init_at_size(new_size)`.
+    /// The data journal is cleared before the offsets journal is reset to preserve the recovery
+    /// rule that data is the source of truth.
     #[commonware_macros::stability(ALPHA)]
     pub(crate) async fn clear_to_size(&self, new_size: u64) -> Result<(), Error> {
         let _op_guard = self.op_lock.lock().await;
@@ -3010,6 +3018,105 @@ mod tests {
             let pos = journal.append(&1500).await.unwrap();
             assert_eq!(pos, 15);
             assert_eq!(journal.read(15).await.unwrap(), 1500);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_init_at_size_clears_existing_data() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "init-at-size-clears-existing".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..12u64 {
+                journal.append(&(100 + i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init_at_size(context.child("reset"), cfg.clone(), 7)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 7..7);
+            assert_eq!(journal.append(&700).await.unwrap(), 7);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 7..8);
+            assert_eq!(journal.read(7).await.unwrap(), 700);
+            assert!(matches!(journal.read(6).await, Err(Error::ItemPruned(6))));
+            assert!(matches!(
+                journal.read(8).await,
+                Err(Error::ItemOutOfRange(8))
+            ));
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_init_at_size_discards_same_section_stale_data() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "init-at-size-discards-same-section-stale-data".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init_at_size(context.child("first"), cfg.clone(), 5)
+                .await
+                .unwrap();
+            for i in 0..4u64 {
+                assert_eq!(journal.append(&(500 + i)).await.unwrap(), 5 + i);
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init_at_size(context.child("reset"), cfg.clone(), 7)
+                .await
+                .unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("after_reset"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 7..7);
+            assert!(matches!(
+                journal.read(7).await,
+                Err(Error::ItemOutOfRange(7))
+            ));
+
+            assert_eq!(journal.append(&700).await.unwrap(), 7);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("after_append"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 7..8);
+            assert_eq!(journal.read(7).await.unwrap(), 700);
+            assert!(matches!(
+                journal.read(8).await,
+                Err(Error::ItemOutOfRange(8))
+            ));
 
             journal.destroy().await.unwrap();
         });

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -3192,6 +3192,72 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_clear_to_size_crash_after_staging_completes_on_init() {
+        let partition = "clear-to-size-crash-after-staging".to_string();
+        let executor = deterministic::Runner::default();
+        let ((), checkpoint) = executor.start_and_recover({
+            let partition = partition.clone();
+            |context| async move {
+                let cfg = Config {
+                    partition,
+                    items_per_section: NZU64!(5),
+                    compression: None,
+                    codec_config: (),
+                    page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                    write_buffer: NZUsize!(1024),
+                };
+
+                let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+                for i in 0..12u64 {
+                    journal.append(&(100 + i)).await.unwrap();
+                }
+                journal.sync().await.unwrap();
+
+                // Let `stage_clear_intent` (a metadata sync) persist the reset intent, but fail the
+                // subsequent `data.clear()` (a blob remove) so `clear_to_size` aborts after the
+                // intent is durable but before the data is cleared.
+                *context.storage_fault_config().write() = deterministic::FaultConfig {
+                    remove_rate: Some(1.0),
+                    ..Default::default()
+                };
+                assert!(journal.clear_to_size(7).await.is_err());
+            }
+        });
+
+        deterministic::Runner::from(checkpoint).start(move |context| async move {
+            *context.storage_fault_config().write() = deterministic::FaultConfig::default();
+            let cfg = Config {
+                partition,
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            // `init` finds the staged intent, discards the stale data, and completes the reset.
+            let journal = Journal::<_, u64>::init(context.child("recover"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 7..7);
+            assert_eq!(journal.append(&700).await.unwrap(), 7);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Reopen: the completed reset persists and no stale data was replayed.
+            let journal = Journal::<_, u64>::init(context.child("reopen"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 7..8);
+            assert_eq!(journal.read(7).await.unwrap(), 700);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_init_at_size_recovers_staged_reset_crash_points() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -461,14 +461,18 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             write_buffer: cfg.write_buffer,
         };
         // If offsets has a pending reset from a prior crashed `init_at_size` or `clear_to_size`,
-        // clear data first so the staged clear inside offsets init reconciles both sides.
-        if fixed::Journal::<E, u64>::pending_reset(context.child("offsets"), &offsets_cfg)
-            .await?
-            .is_some()
-        {
+        // CLEAR_TARGET_KEY is present in its metadata. Clear data first so the staged clear that
+        // `init_with_metadata` runs (via `complete_clear_to_size`) reconciles both sides.
+        // Metadata stays open and is handed to `init_with_metadata` so we only open it once.
+        let offsets_ctx = context.child("offsets");
+        let offsets_metadata =
+            fixed::Journal::<E, u64>::open_metadata(&offsets_ctx, &offsets_cfg).await?;
+        if offsets_metadata.get(&fixed::CLEAR_TARGET_KEY).is_some() {
             data.clear().await?;
         }
-        let mut offsets = fixed::Journal::init(context.child("offsets"), offsets_cfg).await?;
+        let mut offsets =
+            fixed::Journal::<E, u64>::init_with_metadata(offsets_ctx, offsets_cfg, offsets_metadata)
+                .await?;
 
         // Validate and align offsets journal to match data journal
         let (pruning_boundary, size) =
@@ -519,11 +523,28 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             },
         )
         .await?;
-        // Stage the offsets reset, then clear data, then let offsets init complete the clear. A
-        // crash at any point leaves the staged intent for `init` to finish.
-        fixed::Journal::<E, u64>::stage_reset(context.child("offsets"), &offsets_cfg, size).await?;
+        // Stage the offsets reset intent durably before clearing data. Lower the recovery
+        // watermark first so external consumers never see a persisted checkpoint beyond `size`.
+        // After data is cleared, `init_with_metadata` detects CLEAR_TARGET_KEY and completes the
+        // clear. A crash at any point in this sequence leaves a durable intent that the next
+        // `init` (via `init_with_metadata`) will finish. Metadata stays open across stage / clear
+        // / init so it's only opened once.
+        let offsets_ctx = context.child("offsets");
+        let mut offsets_metadata =
+            fixed::Journal::<E, u64>::open_metadata(&offsets_ctx, &offsets_cfg).await?;
+        fixed::Journal::<E, u64>::update_metadata_watermark_before_clear(
+            &mut offsets_metadata,
+            size,
+        )?;
+        offsets_metadata.put(fixed::CLEAR_TARGET_KEY, size.to_be_bytes().to_vec());
+        offsets_metadata.sync().await?;
         data.clear().await?;
-        let offsets = fixed::Journal::<E, u64>::init(context.child("offsets"), offsets_cfg).await?;
+        let offsets = fixed::Journal::<E, u64>::init_with_metadata(
+            offsets_ctx,
+            offsets_cfg,
+            offsets_metadata,
+        )
+        .await?;
 
         let items_per_section = cfg.items_per_section.get();
         let metrics = Metrics::new(context);
@@ -3161,13 +3182,22 @@ mod tests {
                     page_cache: cfg.page_cache.clone(),
                     write_buffer: cfg.write_buffer,
                 };
-                fixed::Journal::<_, u64>::stage_reset(
-                    context.child("intent").with_attribute("index", index),
-                    &offsets_cfg,
+                // Simulate a crash mid-`init_at_size`: stage CLEAR_TARGET_KEY in offsets metadata
+                // but leave data untouched (clear_data=false) or also clear data (clear_data=true)
+                // so we cover both crash points.
+                let intent_ctx = context.child("intent").with_attribute("index", index);
+                let mut intent_metadata =
+                    fixed::Journal::<_, u64>::open_metadata(&intent_ctx, &offsets_cfg)
+                        .await
+                        .unwrap();
+                fixed::Journal::<_, u64>::update_metadata_watermark_before_clear(
+                    &mut intent_metadata,
                     7,
                 )
-                .await
                 .unwrap();
+                intent_metadata.put(fixed::CLEAR_TARGET_KEY, 7u64.to_be_bytes().to_vec());
+                intent_metadata.sync().await.unwrap();
+                drop(intent_metadata);
 
                 if clear_data {
                     let mut data = variable::Journal::<_, u64>::init(

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -466,7 +466,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         };
         let offsets_ctx = context.child("offsets");
         let offsets_metadata =
-            fixed::Journal::<E, u64>::open_metadata(&offsets_ctx, &offsets_cfg).await?;
+            fixed::Journal::<E, u64>::open_metadata(offsets_ctx.child("meta"), &offsets_cfg)
+                .await?;
         if offsets_metadata.get(&fixed::CLEAR_TARGET_KEY).is_some() {
             data.clear().await?;
         }
@@ -535,7 +536,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // / init so it's only opened once.
         let offsets_ctx = context.child("offsets");
         let mut offsets_metadata =
-            fixed::Journal::<E, u64>::open_metadata(&offsets_ctx, &offsets_cfg).await?;
+            fixed::Journal::<E, u64>::open_metadata(offsets_ctx.child("meta"), &offsets_cfg)
+                .await?;
         fixed::Journal::<E, u64>::update_metadata_watermark_before_clear(
             &mut offsets_metadata,
             size,
@@ -3192,7 +3194,7 @@ mod tests {
                 // so we cover both crash points.
                 let intent_ctx = context.child("intent").with_attribute("index", index);
                 let mut intent_metadata =
-                    fixed::Journal::<_, u64>::open_metadata(&intent_ctx, &offsets_cfg)
+                    fixed::Journal::<_, u64>::open_metadata(intent_ctx.child("meta"), &offsets_cfg)
                         .await
                         .unwrap();
                 fixed::Journal::<_, u64>::update_metadata_watermark_before_clear(

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -472,6 +472,54 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
+    /// Test that a commit after an older sync boundary is recovered without another sync.
+    pub(crate) async fn test_any_db_commit_after_sync_recovery<F: Family, D, V>(
+        context: Context,
+        mut db: D,
+        reopen_db: impl Fn(Context) -> Pin<Box<dyn Future<Output = D> + Send>>,
+        make_value: impl Fn(u64) -> V,
+    ) where
+        D: DbAny<F, Key = Digest, Value = V, Digest = Digest>,
+        V: Clone + CodecShared + Eq + std::fmt::Debug,
+    {
+        let key0 = Sha256::hash(&0u64.to_be_bytes());
+        let key1 = Sha256::hash(&1u64.to_be_bytes());
+        let value0 = make_value(100);
+        let value1 = make_value(200);
+
+        // Establish a synced baseline so recovery starts before the later commit.
+        let merkleized = db
+            .new_batch()
+            .write(key0, Some(value0.clone()))
+            .merkleize(&db, None)
+            .await
+            .unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        db.sync().await.unwrap();
+
+        // Commit a second batch without syncing; reopen must replay it from the journal.
+        let merkleized = db
+            .new_batch()
+            .write(key1, Some(value1.clone()))
+            .merkleize(&db, None)
+            .await
+            .unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        let committed_root = db.root();
+        let committed_size = db.size().await;
+        drop(db);
+
+        let db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
+        assert_eq!(db.root(), committed_root);
+        assert_eq!(db.size().await, committed_size);
+        assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
+        assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
+
+        db.destroy().await.unwrap();
+    }
+
     /// Test rewinding to a prior committed state and recovering that state after reopen.
     pub(crate) async fn test_any_db_rewind_recovery<D, V>(
         context: Context,
@@ -1414,6 +1462,12 @@ pub(crate) mod test {
     #[test_traced("WARN")]
     fn test_all_variants_empty_recovery() {
         for_all_variants!("er", with_reopen: test_any_db_empty_recovery);
+    }
+
+    #[test_group("slow")]
+    #[test_traced("WARN")]
+    fn test_all_variants_commit_after_sync_recovery() {
+        for_all_variants!("casr", with_reopen: test_any_db_commit_after_sync_recovery);
     }
 
     #[test_group("slow")]

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -747,6 +747,50 @@ pub mod tests {
         assert_eq!(state1, state2);
     }
 
+    /// Run `test_commit_after_sync_recovery` against a database factory.
+    pub fn test_commit_after_sync_recovery<M, C, F, Fut>(mut open_db: F)
+    where
+        M: merkle::Graftable + 'static,
+        C: DbAny<M> + 'static,
+        C::Key: TestKey,
+        <C as DbAny<M>>::Value: TestValue,
+        F: FnMut(Context, String) -> Fut + Clone,
+        Fut: Future<Output = C>,
+    {
+        let executor = deterministic::Runner::default();
+        let mut open_db_clone = open_db.clone();
+        executor.start(|context| async move {
+            let partition = "commit-after-sync".to_string();
+            let mut db: C = open_db_clone(context.child("first"), partition.clone()).await;
+            let key0 = <<C as DbAny<M>>::Key as TestKey>::from_seed(0);
+            let key1 = <<C as DbAny<M>>::Key as TestKey>::from_seed(1);
+            let value0 = <C as DbAny<M>>::Value::from_seed(100);
+            let value1 = <C as DbAny<M>>::Value::from_seed(200);
+
+            // Establish a synced baseline so metadata and journal recovery start from it.
+            commit_writes::<M, C>(&mut db, [(key0, Some(value0.clone()))])
+                .await
+                .unwrap();
+            db.sync().await.unwrap();
+
+            // Commit a later batch without syncing metadata; reopen must rebuild it from the log.
+            commit_writes::<M, C>(&mut db, [(key1, Some(value1.clone()))])
+                .await
+                .unwrap();
+            let committed_root = db.root();
+            let committed_size = db.size().await;
+            drop(db);
+
+            let db: C = open_db(context.child("second"), partition).await;
+            assert_eq!(db.root(), committed_root);
+            assert_eq!(db.size().await, committed_size);
+            assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
+            assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// Run `test_simulate_write_failures` against a database factory.
     ///
     /// This test builds a random database and simulates recovery from different types of
@@ -1487,6 +1531,15 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|_context| async move {
             for_all_variants!(simple: test_sync_persists_bitmap_pruning_boundary);
+        });
+    }
+
+    #[test_group("slow")]
+    #[test_traced("WARN")]
+    fn test_all_variants_commit_after_sync_recovery() {
+        let executor = deterministic::Runner::default();
+        executor.start(|_context| async move {
+            for_all_variants!(simple: test_commit_after_sync_recovery);
         });
     }
 

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -267,6 +267,14 @@ mod tests {
         });
     }
 
+    #[test_traced("WARN")]
+    fn test_fixed_commit_after_sync_recovery() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            test::test_immutable_commit_after_sync_recovery(ctx, open::<mmr::Family>).await;
+        });
+    }
+
     #[test_traced("DEBUG")]
     fn test_fixed_build_basic() {
         let executor = deterministic::Runner::default();

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -806,6 +806,41 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
+    pub(crate) async fn test_immutable_commit_after_sync_recovery<F: Family, V, C>(
+        context: deterministic::Context,
+        open_db: impl Fn(
+            deterministic::Context,
+        ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
+    ) where
+        V: ValueEncoding<Value = Digest>,
+        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C::Item: EncodeShared,
+    {
+        let mut db = open_db(context.child("first")).await;
+        let k1 = Sha256::fill(1u8);
+        let k2 = Sha256::fill(2u8);
+        let v1 = Sha256::fill(3u8);
+        let v2 = Sha256::fill(4u8);
+
+        // Commit and sync the first key so recovery has an older persisted boundary.
+        commit_sets(&mut db, [(k1, v1)], None).await;
+        db.sync().await.unwrap();
+
+        // Commit a second key without syncing; reopen must replay it from journal data.
+        commit_sets(&mut db, [(k2, v2)], None).await;
+        let committed_bounds = db.bounds().await;
+        let committed_root = db.root();
+        drop(db);
+
+        let db = open_db(context.child("second")).await;
+        assert_eq!(db.bounds().await, committed_bounds);
+        assert_eq!(db.root(), committed_root);
+        assert_eq!(db.get(&k1).await.unwrap(), Some(v1));
+        assert_eq!(db.get(&k2).await.unwrap(), Some(v2));
+
+        db.destroy().await.unwrap();
+    }
+
     pub(crate) async fn test_immutable_build_basic<F: Family, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -241,6 +241,14 @@ mod tests {
         });
     }
 
+    #[test_traced("WARN")]
+    fn test_variable_commit_after_sync_recovery() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            test::test_immutable_commit_after_sync_recovery(ctx, open::<mmr::Family>).await;
+        });
+    }
+
     #[test_traced("DEBUG")]
     fn test_variable_build_basic() {
         let executor = deterministic::Runner::default();

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -201,6 +201,15 @@ mod test {
         });
     }
 
+    #[test_traced("INFO")]
+    fn test_keyless_fixed_commit_after_sync_recovery() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let db = open_db::<mmr::Family>(ctx.child("db").with_attribute("index", 1)).await;
+            tests::test_keyless_db_commit_after_sync_recovery(ctx, db, reopen::<mmr::Family>())
+                .await;
+        });
+    }
+
     #[test_traced("WARN")]
     fn test_keyless_fixed_build_basic() {
         deterministic::Runner::default().start(|ctx| async move {

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -641,6 +641,56 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
+    pub(crate) async fn test_keyless_db_commit_after_sync_recovery<
+        F: Family,
+        V,
+        C,
+        H,
+        S: Strategy,
+    >(
+        context: deterministic::Context,
+        mut db: TestKeyless<F, V, C, H, S>,
+        reopen: Reopen<TestKeyless<F, V, C, H, S>>,
+    ) where
+        V: ValueEncoding<Value: TestValue>,
+        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        H: Hasher,
+        Operation<F, V>: EncodeShared,
+    {
+        let value0 = V::Value::make(10);
+        let value1 = V::Value::make(20);
+
+        // Commit and sync the first append so recovery has an older durable boundary.
+        let first_loc = Location::new(1);
+        let merkleized =
+            db.new_batch()
+                .append(value0.clone())
+                .merkleize(&db, None, db.inactivity_floor_loc());
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        db.sync().await.unwrap();
+
+        // Commit the next append without syncing; reopen must replay it from the journal.
+        let second_loc = db.bounds().await.end;
+        let merkleized =
+            db.new_batch()
+                .append(value1.clone())
+                .merkleize(&db, None, db.inactivity_floor_loc());
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        let committed_bounds = db.bounds().await;
+        let committed_root = db.root();
+        drop(db);
+
+        let db = reopen(context.child("db").with_attribute("index", 2)).await;
+        assert_eq!(db.bounds().await, committed_bounds);
+        assert_eq!(db.root(), committed_root);
+        assert_eq!(db.get(first_loc).await.unwrap(), Some(value0));
+        assert_eq!(db.get(second_loc).await.unwrap(), Some(value1));
+
+        db.destroy().await.unwrap();
+    }
+
     pub(crate) async fn test_keyless_db_build_basic<F: Family, V, C, H, S: Strategy>(
         context: deterministic::Context,
         mut db: TestKeyless<F, V, C, H, S>,

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -171,6 +171,15 @@ mod test {
         });
     }
 
+    #[test_traced("INFO")]
+    fn test_keyless_db_commit_after_sync_recovery() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let db = open_db::<mmr::Family>(ctx.child("db").with_attribute("index", 1)).await;
+            tests::test_keyless_db_commit_after_sync_recovery(ctx, db, reopen::<mmr::Family>())
+                .await;
+        });
+    }
+
     #[test_traced("WARN")]
     fn test_keyless_db_build_basic() {
         deterministic::Runner::default().start(|ctx| async move {

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -975,6 +975,38 @@ mod test {
         });
     }
 
+    #[test_traced("WARN")]
+    pub fn test_store_commit_after_sync_recovers_without_second_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut db = create_test_store(context.child("store").with_attribute("index", 0)).await;
+            let key0 = Blake3::hash(&0u64.to_be_bytes());
+            let key1 = Blake3::hash(&1u64.to_be_bytes());
+            let value0 = vec![0, 1, 2];
+            let value1 = vec![3, 4, 5, 6];
+
+            // Commit and sync an initial update so restart recovery has an older watermark.
+            apply_entries(&mut db, [(key0, Some(value0.clone()))]).await;
+            db.commit().await.unwrap();
+            db.sync().await.unwrap();
+
+            // Persist a later commit without syncing; recovery must replay it after reopen.
+            apply_entries(&mut db, [(key1, Some(value1.clone()))]).await;
+            db.commit().await.unwrap();
+            let committed_end = db.bounds().await.end;
+            let committed_floor = db.inactivity_floor_loc();
+            drop(db);
+
+            let db = create_test_store(context.child("store").with_attribute("index", 1)).await;
+            assert_eq!(db.bounds().await.end, committed_end);
+            assert_eq!(db.inactivity_floor_loc(), committed_floor);
+            assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
+            assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     #[test_traced("DEBUG")]
     fn test_store_batch() {
         let executor = deterministic::Runner::default();

--- a/storage/src/queue/storage.rs
+++ b/storage/src/queue/storage.rs
@@ -502,6 +502,46 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_commit_after_sync_recovers_without_second_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config("test_commit_after_sync_recovery", &context);
+
+            {
+                let mut queue = Queue::<_, Vec<u8>>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+
+                // Establish a synced baseline so the recovery watermark is behind the next commit.
+                queue.append(b"synced".to_vec()).await.unwrap();
+                queue.commit().await.unwrap();
+                queue.sync().await.unwrap();
+
+                // Commit later data without syncing; reopen must replay it from the old watermark.
+                queue.append(b"committed-a".to_vec()).await.unwrap();
+                queue.append(b"committed-b".to_vec()).await.unwrap();
+                queue.commit().await.unwrap();
+            }
+
+            let mut queue = Queue::<_, Vec<u8>>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(queue.size().await, 3);
+            for (expected_pos, expected_item) in [
+                (0, b"synced".to_vec()),
+                (1, b"committed-a".to_vec()),
+                (2, b"committed-b".to_vec()),
+            ] {
+                let (pos, item) = queue.dequeue().await.unwrap().unwrap();
+                assert_eq!(pos, expected_pos);
+                assert_eq!(item, expected_item);
+            }
+
+            queue.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_sequential_ack() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/utils/conformance.toml
+++ b/utils/conformance.toml
@@ -82,6 +82,10 @@ hash = "73102c8e2c269bbe2afd67158252c90a683a347e7ba623e8a1b383197c0d848a"
 n_cases = 65536
 hash = "07854d2fef297a06ba81685e660c332de36d5d18d546927d30daad6d7fda1541"
 
+["commonware_utils::sequence::vec_u64::tests::conformance::CodecConformance<VecU64>"]
+n_cases = 65536
+hash = "b2714bf2d181f332a44e9701d501d0f2d1cadd38d3bd87634c175fcefd8640fc"
+
 ["commonware_utils::tests::conformance::CodecConformance<Participant>"]
 n_cases = 65536
 hash = "f0b66ee345e9e295c50b522d9cf3501d95cd70cecfe7bfd315c970ffa78ede40"

--- a/utils/src/sequence/mod.rs
+++ b/utils/src/sequence/mod.rs
@@ -13,6 +13,8 @@ pub use fixed_bytes::FixedBytes;
 pub mod u64;
 pub use u64::U64;
 pub mod prefixed_u64;
+pub mod vec_u64;
+pub use vec_u64::VecU64;
 pub mod u32;
 pub use u32::U32;
 pub mod unit;

--- a/utils/src/sequence/vec_u64.rs
+++ b/utils/src/sequence/vec_u64.rs
@@ -1,0 +1,91 @@
+//! A `u64` encoded with the same framing as a `Vec<u8>` of its big-endian bytes.
+
+use bytes::{Buf, BufMut};
+use commonware_codec::{EncodeSize, Error as CodecError, FixedSize, Read, Write};
+
+/// A `u64` encoded with the same framing as a `Vec<u8>` of its big-endian bytes.
+///
+/// The encoding is a varint length of 8 followed by the 8 big-endian bytes, byte-identical to the
+/// codec encoding of a `Vec<u8>` holding those bytes. This lets a typed `u64` share an on-disk
+/// format with a value historically stored as a `Vec<u8>`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct VecU64(u64);
+
+impl VecU64 {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<u64> for VecU64 {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<VecU64> for u64 {
+    fn from(value: VecU64) -> Self {
+        value.0
+    }
+}
+
+impl From<&VecU64> for u64 {
+    fn from(value: &VecU64) -> Self {
+        value.0
+    }
+}
+
+impl Write for VecU64 {
+    fn write(&self, buf: &mut impl BufMut) {
+        let bytes = self.0.to_be_bytes();
+        bytes.len().write(buf);
+        buf.put_slice(&bytes);
+    }
+}
+
+impl EncodeSize for VecU64 {
+    fn encode_size(&self) -> usize {
+        let bytes = self.0.to_be_bytes();
+        bytes.len().encode_size() + bytes.len()
+    }
+}
+
+impl Read for VecU64 {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _: &Self::Cfg) -> Result<Self, CodecError> {
+        let len = usize::read_cfg(buf, &(u64::SIZE..=u64::SIZE).into())?;
+        if buf.remaining() < len {
+            return Err(CodecError::EndOfBuffer);
+        }
+        let mut bytes = [0u8; u64::SIZE];
+        buf.copy_to_slice(&mut bytes);
+        Ok(Self(u64::from_be_bytes(bytes)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_codec::{DecodeExt, Encode};
+
+    #[test]
+    fn test_vec_u64_matches_vec_encoding() {
+        for value in [0u64, 1, 42, u64::MAX] {
+            let encoded = VecU64(value).encode();
+            assert_eq!(encoded, value.to_be_bytes().to_vec().encode());
+            assert_eq!(u64::from(VecU64::decode(encoded).unwrap()), value);
+        }
+    }
+
+    #[cfg(feature = "arbitrary")]
+    mod conformance {
+        use super::*;
+        use commonware_codec::conformance::CodecConformance;
+
+        commonware_conformance::conformance_tests! {
+            CodecConformance<VecU64>,
+        }
+    }
+}

--- a/utils/src/sequence/vec_u64.rs
+++ b/utils/src/sequence/vec_u64.rs
@@ -68,14 +68,22 @@ impl Read for VecU64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use commonware_codec::{DecodeExt, Encode};
+    use commonware_codec::{DecodeExt, DecodeRangeExt, Encode};
 
     #[test]
     fn test_vec_u64_matches_vec_encoding() {
-        for value in [0u64, 1, 42, u64::MAX] {
-            let encoded = VecU64(value).encode();
-            assert_eq!(encoded, value.to_be_bytes().to_vec().encode());
-            assert_eq!(u64::from(VecU64::decode(encoded).unwrap()), value);
+        for value in [0u64, 1, 8, 42, 255, 256, u64::MAX - 1, u64::MAX] {
+            let vec = value.to_be_bytes().to_vec();
+            let vec_u64 = VecU64(value);
+
+            // `VecU64` encodes byte-identically to a `Vec<u8>` of the big-endian bytes.
+            assert_eq!(vec_u64.encode(), vec.encode());
+
+            // A `Vec<u8>` reader decodes the bytes written by `VecU64`.
+            assert_eq!(Vec::<u8>::decode_range(vec_u64.encode(), ..).unwrap(), vec);
+
+            // A `VecU64` reader decodes the bytes written as a `Vec<u8>`.
+            assert_eq!(VecU64::decode(vec.encode()).unwrap(), vec_u64);
         }
     }
 


### PR DESCRIPTION
## Related PRs

- https://github.com/commonwarexyz/monorepo/pull/3790 - changes contiguous journal durability so `commit()` persists data without requiring `sync()`/fsync on blob-boundary transitions.
- https://github.com/commonwarexyz/monorepo/pull/3809 - fixes fixed-journal crash recovery for `clear_to_size` / `init_at_size` reset paths.

## Summary

This is a follow-up to the journal recovery work above.

While reviewing the variable journal reset path, I found that `init_at_size()` could reset the offsets journal while leaving old variable-length data sections intact. On the next open, recovery treats the data journal as authoritative enough to rebuild offsets, so stale data in the same section could be replayed past the requested logical reset size.

This PR:

- Clears the variable journal data when `init_at_size()` resets the logical size.
- Documents why reset paths must discard stale data rather than relying only on offset metadata.
- Adds regression tests for stale variable data after `init_at_size()`, including same-section stale entries.
- Adds consumer-level recovery coverage for the `commit()` vs `sync()` contract across queue storage and QMDB users. These tests sync a baseline, commit later data without another sync, reopen, and verify the committed post-watermark data is recovered.

## Verification

- `just test -p commonware-storage commit_after_sync`
- `just test -p commonware-storage --profile slow commit_after_sync`
- `just test -p commonware-storage`
- `just clippy -p commonware-storage`
- `rustfmt +nightly --edition 2021 --check ...`
- `git diff --check`