### PR TITLE
[consensus/simplex] support targeted mock payload broadcasts

### DIFF
--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -81,7 +81,10 @@ mod tests {
         Hasher as _, Sha256,
     };
     use commonware_macros::{select, test_collect_traces, test_traced};
-    use commonware_p2p::simulated::{Config as NConfig, Link, Network, Oracle};
+    use commonware_p2p::{
+        simulated::{Config as NConfig, Link, Network, Oracle},
+        Recipients,
+    };
     use commonware_parallel::Sequential;
     use commonware_runtime::{
         deterministic, telemetry::traces::collector::TraceStorage, Clock, Metrics as _, Quota,
@@ -2812,7 +2815,7 @@ mod tests {
                     .as_slice(),
             );
             let contents = (proposal.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal);
 
             // Wait for nullify vote for target_view. Since timeouts are 10s, receiving it
@@ -3365,7 +3368,7 @@ mod tests {
                 7u64,
             )
                 .encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal);
 
             // With 10s timeouts, seeing nullify within 1s proves we fast-pathed on dropped verify.
@@ -3780,7 +3783,11 @@ mod tests {
                 11u64,
             )
                 .encode();
-            relay.broadcast(&target_leader, (proposal.payload, contents));
+            relay.broadcast(
+                &target_leader,
+                Recipients::All,
+                (proposal.payload, contents),
+            );
             mailbox.proposal(proposal);
 
             // We should still broadcast for target_view (typically a nullify after timeout).
@@ -3966,7 +3973,7 @@ mod tests {
 
             // Broadcast payload and send proposal
             let contents = (proposal3.round, proposal2.payload, 0u64).encode();
-            relay.broadcast(&me, (digest3, contents));
+            relay.broadcast(&me, Recipients::All, (digest3, contents));
             mailbox.proposal(proposal3.clone());
 
             // Send notarization
@@ -4930,7 +4937,7 @@ mod tests {
                 Sha256::hash(b"follower_proposal"),
             );
             let contents = (proposal.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader_pk, (proposal.payload, contents));
+            relay.broadcast(&leader_pk, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             // Wait for our local notarize (journaled) so replay has something to restore.
@@ -5830,7 +5837,7 @@ mod tests {
 
             // Broadcast payload
             let contents = (proposal5.round, Sha256::hash(b"genesis"), 42u64).encode();
-            relay.broadcast(&me, (digest5, contents));
+            relay.broadcast(&me, Recipients::All, (digest5, contents));
 
             // Send proposal to verify
             mailbox.proposal(proposal5.clone());
@@ -6014,7 +6021,7 @@ mod tests {
 
             // Broadcast payload
             let contents = (proposal5.round, Sha256::hash(b"genesis"), 42u64).encode();
-            relay.broadcast(&me, (digest5, contents));
+            relay.broadcast(&me, Recipients::All, (digest5, contents));
 
             // Send proposal and notarization
             mailbox.proposal(proposal5.clone());
@@ -6361,7 +6368,7 @@ mod tests {
             );
             let leader = participants[1].clone();
             let contents = (proposal.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             // Wait for notarize vote
@@ -6647,7 +6654,7 @@ mod tests {
             let leader = participants[1].clone();
             let contents = (proposal.round, parent_payload, 0u64).encode();
             relay
-                .broadcast(&leader, (proposal.payload, contents));
+                .broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             // Build and send notarization so the voter tries to certify
@@ -6839,7 +6846,7 @@ mod tests {
             );
             let leader = participants[1].clone();
             let contents = (proposal.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             let (_, notarization) = build_notarization(&schemes, &proposal, quorum);
@@ -7062,7 +7069,7 @@ mod tests {
             );
             let leader = participants[1].clone();
             let contents = (proposal_4.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader, (proposal_4.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal_4.payload, contents));
             mailbox.proposal(proposal_4.clone());
 
             let (_, notarization_4) = build_notarization(&schemes, &proposal_4, quorum);
@@ -7256,7 +7263,7 @@ mod tests {
             );
             let leader = participants[1].clone();
             let contents = (proposal.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             // Wait for notarize vote first (verification passes)
@@ -7389,7 +7396,7 @@ mod tests {
             );
             let leader = participants[1].clone();
             let contents = (proposal.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             // Wait for notarize vote (verification passes).
@@ -7537,7 +7544,7 @@ mod tests {
             );
             let leader = participants[1].clone();
             let contents = (proposal.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             // Ensure proposal verification path ran.
@@ -7960,7 +7967,7 @@ mod tests {
                 Sha256::hash(b"first_view_progress_without_timeout"),
             );
             let contents = (proposal.round, genesis, 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             // The voter should notarize view 1 and must not nullify it.
@@ -8179,7 +8186,7 @@ mod tests {
             );
             let leader = participants[1].clone();
             let contents = (proposal.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             // Send notarization to trigger certification.
@@ -8448,7 +8455,7 @@ mod tests {
             );
             let leader = participants[1].clone();
             let contents = (proposal.round, parent_payload, 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
             // Send notarization to trigger certification.
@@ -8956,7 +8963,7 @@ mod tests {
             );
             let leader = participants[1].clone();
             let contents = (proposal.round, Sha256::hash(b"genesis"), 0u64).encode();
-            relay.broadcast(&leader, (proposal.payload, contents));
+            relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
             let (_, notarization) = build_notarization(&schemes, &proposal, quorum);
             mailbox.resolved(Certificate::Notarization(notarization));

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -388,26 +388,26 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
     }
 
     fn broadcast(&mut self, payload: H::Digest, plan: Plan<P>) {
-        let contents = match self.seen.get(&payload).cloned() {
-            Some(contents) => contents,
-            None => {
-                if matches!(&plan, Plan::Propose { .. }) {
-                    let contents = self.pending.remove(&payload).expect("missing payload");
-                    self.seen.insert(payload, contents.clone());
-                    contents
-                } else {
-                    let Some(contents) = self.pending.get(&payload).cloned() else {
-                        debug!("payload not found for forwarding");
-                        return;
-                    };
-                    self.seen.insert(payload, contents.clone());
-                    contents
-                }
+        let (contents, recipients) = match plan {
+            Plan::Propose { .. } => {
+                let contents = self.pending.remove(&payload).expect("missing payload");
+                self.seen.insert(payload, contents.clone());
+                (contents, Recipients::All)
             }
-        };
-        let recipients = match plan {
-            Plan::Propose { .. } => Recipients::All,
-            Plan::Forward { recipients, .. } => recipients,
+            Plan::Forward { recipients, .. } => {
+                let contents = match self.seen.get(&payload).cloned() {
+                    Some(contents) => contents,
+                    None => {
+                        let Some(contents) = self.pending.get(&payload).cloned() else {
+                            debug!("payload not found for forwarding");
+                            return;
+                        };
+                        self.seen.insert(payload, contents.clone());
+                        contents
+                    }
+                };
+                (contents, recipients)
+            }
         };
         self.relay
             .broadcast(&self.me, recipients, (payload, contents));

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -391,6 +391,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
         let (contents, recipients) = match plan {
             Plan::Propose { .. } => {
                 let contents = self.pending.remove(&payload).expect("missing payload");
+                self.seen.insert(payload, contents.clone());
                 (contents, Recipients::All)
             }
             Plan::Forward { recipients, .. } => {
@@ -401,13 +402,13 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                             debug!("payload not found for forwarding");
                             return;
                         };
+                        self.seen.insert(payload, contents.clone());
                         contents
                     }
                 };
                 (contents, recipients)
             }
         };
-        self.seen.insert(payload, contents.clone());
         self.relay
             .broadcast(&self.me, recipients, (payload, contents));
     }

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -391,7 +391,6 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
         let (contents, recipients) = match plan {
             Plan::Propose { .. } => {
                 let contents = self.pending.remove(&payload).expect("missing payload");
-                self.seen.insert(payload, contents.clone());
                 (contents, Recipients::All)
             }
             Plan::Forward { recipients, .. } => {
@@ -402,13 +401,13 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                             debug!("payload not found for forwarding");
                             return;
                         };
-                        self.seen.insert(payload, contents.clone());
                         contents
                     }
                 };
                 (contents, recipients)
             }
         };
+        self.seen.insert(payload, contents.clone());
         self.relay
             .broadcast(&self.me, recipients, (payload, contents));
     }

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -12,6 +12,7 @@ use commonware_actor::Feedback;
 use commonware_codec::{DecodeExt, Encode};
 use commonware_cryptography::{Digest, Hasher, PublicKey};
 use commonware_macros::select_loop;
+use commonware_p2p::Recipients;
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Spawner};
 use commonware_utils::channel::{
     fallible::{FallibleExt, OneshotExt},
@@ -43,6 +44,7 @@ pub enum Message<D: Digest, P: PublicKey> {
     },
     Broadcast {
         payload: D,
+        plan: Plan<P>,
     },
 }
 
@@ -100,8 +102,8 @@ impl<D: Digest, P: PublicKey> Re for Mailbox<D, P> {
     type PublicKey = P;
     type Plan = Plan<P>;
 
-    fn broadcast(&mut self, payload: Self::Digest, _plan: Plan<P>) -> Feedback {
-        if self.sender.send_lossy(Message::Broadcast { payload }) {
+    fn broadcast(&mut self, payload: Self::Digest, plan: Plan<P>) -> Feedback {
+        if self.sender.send_lossy(Message::Broadcast { payload, plan }) {
             Feedback::Ok
         } else {
             Feedback::Closed
@@ -185,6 +187,7 @@ pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
     should_certify: Certifier<H::Digest>,
 
     pending: HashMap<H::Digest, Bytes>,
+    seen: HashMap<H::Digest, Bytes>,
 
     verified: HashSet<H::Digest>,
 
@@ -240,6 +243,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                 should_certify: cfg.should_certify,
 
                 pending: HashMap::new(),
+                seen: HashMap::new(),
                 verified: HashSet::new(),
                 propose_observer: None,
                 verify_observer: None,
@@ -383,9 +387,30 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
         }
     }
 
-    fn broadcast(&mut self, payload: H::Digest) {
-        let contents = self.pending.remove(&payload).expect("missing payload");
-        self.relay.broadcast(&self.me, (payload, contents));
+    fn broadcast(&mut self, payload: H::Digest, plan: Plan<P>) {
+        let contents = match self.seen.get(&payload).cloned() {
+            Some(contents) => contents,
+            None => {
+                if matches!(&plan, Plan::Propose { .. }) {
+                    let contents = self.pending.remove(&payload).expect("missing payload");
+                    self.seen.insert(payload, contents.clone());
+                    contents
+                } else {
+                    let Some(contents) = self.pending.get(&payload).cloned() else {
+                        debug!("payload not found for forwarding");
+                        return;
+                    };
+                    self.seen.insert(payload, contents.clone());
+                    contents
+                }
+            }
+        };
+        let recipients = match plan {
+            Plan::Propose { .. } => Recipients::All,
+            Plan::Forward { recipients, .. } => recipients,
+        };
+        self.relay
+            .broadcast(&self.me, recipients, (payload, contents));
     }
 
     pub fn start(mut self) -> Handle<()> {
@@ -399,7 +424,6 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
             H::Digest,
             Vec<(Context<H::Digest, P>, oneshot::Sender<bool>)>,
         > = HashMap::new();
-        let mut seen: HashMap<H::Digest, Bytes> = HashMap::new();
 
         // Handle actions
         select_loop! {
@@ -434,7 +458,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                         if self.drop_verifications {
                             continue;
                         }
-                        if let Some(contents) = seen.get(&payload) {
+                        if let Some(contents) = self.seen.get(&payload) {
                             let verified = self.verify(context, payload, contents.clone()).await;
                             response.send_lossy(verified);
                         } else {
@@ -449,7 +473,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                         payload,
                         response,
                     } => {
-                        let contents = seen.get(&payload).cloned().unwrap_or_default();
+                        let contents = self.seen.get(&payload).cloned().unwrap_or_default();
                         if let Some(certified) = self.certify(round, payload, contents).await {
                             response.send_lossy(certified);
                         } else if matches!(self.should_certify, Certifier::Pending) {
@@ -460,14 +484,14 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
                         }
                         // Cancel: drop sender -> immediate RecvError on receiver.
                     }
-                    Message::Broadcast { payload } => {
-                        self.broadcast(payload);
+                    Message::Broadcast { payload, plan } => {
+                        self.broadcast(payload, plan);
                     }
                 }
             },
             Some((digest, contents)) = self.broadcast.recv() else break => {
                 // Record digest for future use
-                seen.insert(digest, contents.clone());
+                self.seen.insert(digest, contents.clone());
 
                 // Check if we have a waiter
                 if let Some(waiters) = waiters.remove(&digest) {

--- a/consensus/src/simplex/mocks/equivocator.rs
+++ b/consensus/src/simplex/mocks/equivocator.rs
@@ -143,8 +143,10 @@ impl<E: Clock + Rng + Spawner, S: Scheme<H::Digest>, L: ElectorConfig<S>, H: Has
                 .participants()
                 .key(self.scheme.me().unwrap())
                 .unwrap();
-            self.relay.broadcast(me, (digest_a, payload_a));
-            self.relay.broadcast(me, (digest_b, payload_b));
+            self.relay
+                .broadcast(me, Recipients::All, (digest_a, payload_a));
+            self.relay
+                .broadcast(me, Recipients::All, (digest_b, payload_b));
 
             // Notarize proposal A and send it to victim only
             let notarize_a = Notarize::<S, _>::sign(&self.scheme, proposal_a).expect("sign failed");

--- a/consensus/src/simplex/mocks/relay.rs
+++ b/consensus/src/simplex/mocks/relay.rs
@@ -2,6 +2,7 @@
 
 use bytes::Bytes;
 use commonware_cryptography::{Digest, PublicKey};
+use commonware_p2p::Recipients;
 use commonware_utils::{channel::mpsc, sync::Mutex};
 use std::collections::{btree_map::Entry, BTreeMap};
 use tracing::{error, warn};
@@ -45,17 +46,37 @@ impl<D: Digest, P: PublicKey> Relay<D, P> {
         receiver
     }
 
-    /// Broadcasts a payload to all registered recipients.
-    pub fn broadcast(&self, sender: &P, (payload, data): (D, Bytes)) {
-        // Send to all recipients
+    /// Broadcasts a payload to selected recipients.
+    pub fn broadcast(&self, sender: &P, recipients: Recipients<P>, (payload, data): (D, Bytes)) {
         let channels = {
             let mut channels = Vec::new();
-            let recipients = self.recipients.lock();
-            for (public_key, channel) in recipients.iter() {
-                if public_key == sender {
-                    continue;
+            let registered = self.recipients.lock();
+            match recipients {
+                Recipients::All => {
+                    for (public_key, channel) in registered.iter() {
+                        if public_key == sender {
+                            continue;
+                        }
+                        channels.push((public_key.clone(), channel.clone()));
+                    }
                 }
-                channels.push((public_key.clone(), channel.clone()));
+                Recipients::Some(peers) => {
+                    for public_key in peers {
+                        if &public_key == sender {
+                            continue;
+                        }
+                        if let Some(channel) = registered.get(&public_key) {
+                            channels.push((public_key, channel.clone()));
+                        }
+                    }
+                }
+                Recipients::One(public_key) => {
+                    if public_key != *sender {
+                        if let Some(channel) = registered.get(&public_key) {
+                            channels.push((public_key, channel.clone()));
+                        }
+                    }
+                }
             }
             channels
         };


### PR DESCRIPTION
Updates the simplex mock relay and application to preserve broadcast plans and route payloads to explicit recipients. This lets tests exercise the same targeted forwarding shape used by the consensus engine instead of treating every mock payload broadcast as all-to-all.
