### PR TITLE
[storage/journal] fix recovery with multiple empty trailing data sections

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -99,7 +99,7 @@ use commonware_utils::{
     sequence::VecU64,
     sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard},
 };
-use futures::{stream::Stream, StreamExt};
+use futures::{future::try_join_all, stream::Stream, StreamExt};
 use std::{
     future::Future,
     num::{NonZeroU64, NonZeroUsize},
@@ -1084,8 +1084,13 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         (section, pos_in_section)
     }
 
-    /// Fsync dirty sections under the read lock, allowing concurrent reads.
-    async fn fsync_dirty_sections(&self) -> Result<(), Error> {
+    /// Flush dirty sections to storage under the read lock, allowing concurrent reads.
+    ///
+    /// Sections are synced concurrently. Ordering is not required for recovery: appends only add
+    /// data, so committed sections are never at risk, and recovery truncates at the first short or
+    /// missing section, so a crash that leaves a gap still recovers a contiguous prefix no shorter
+    /// than the last completed commit.
+    async fn flush_dirty_sections(&self) -> Result<(), Error> {
         let inner = self.inner.read().await;
         if let Some(start_section) = inner.dirty_from_section {
             let tail_section = inner.size / self.items_per_blob;
@@ -1096,9 +1101,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                 // With no retained blobs, any earlier dirty section was cleared or pruned.
                 // Syncing the tail section is harmless when it does not exist.
                 .unwrap_or(tail_section);
-            for section in start_section..=tail_section {
-                inner.journal.sync(section).await?;
-            }
+            try_join_all((start_section..=tail_section).map(|section| inner.journal.sync(section)))
+                .await?;
         }
         Ok(())
     }
@@ -1112,7 +1116,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let _timer = self.metrics.commit_timer();
         self.metrics.record_commit();
         let _op_guard = self.op_lock.lock().await;
-        self.fsync_dirty_sections().await?;
+        self.flush_dirty_sections().await?;
 
         let mut inner = self.inner.write().await;
         inner.dirty_from_section = None;
@@ -1127,7 +1131,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let _timer = self.metrics.sync_timer();
         self.metrics.sync_calls.inc();
         let _op_guard = self.op_lock.lock().await;
-        self.fsync_dirty_sections().await?;
+        self.flush_dirty_sections().await?;
 
         let mut inner = self.inner.write().await;
         inner.dirty_from_section = None;
@@ -3291,13 +3295,13 @@ mod tests {
         });
     }
 
-    /// Test that a crash partway through the ascending per-section sync loop leaves a contiguous
-    /// durable prefix that recovery preserves.
+    /// Test that a crash partway through a multi-section sync leaves a contiguous durable prefix
+    /// that recovery preserves.
     ///
-    /// `fsync_dirty_sections` syncs dirty sections in ascending order, and all mutating operations
-    /// serialize on `op_lock` so no concurrent sync can interleave. This reproduces a crash after
-    /// sections 0 and 1 were fsynced but before section 2, then asserts recovery keeps exactly the
-    /// contiguous prefix 0..20.
+    /// `flush_dirty_sections` syncs dirty sections, and all mutating operations serialize on
+    /// `op_lock` so no concurrent sync can interleave. This reproduces a crash after sections 0 and
+    /// 1 were synced but before section 2, then asserts recovery keeps exactly the contiguous
+    /// prefix 0..20.
     #[test_traced]
     fn test_fixed_recovery_partial_sync_loop_keeps_contiguous_prefix() {
         let executor = deterministic::Runner::default();
@@ -3313,8 +3317,8 @@ mod tests {
                 journal.append(&test_digest(i)).await.unwrap();
             }
 
-            // Replicate `fsync_dirty_sections`'s ascending loop, crashing after sections 0 and 1 are
-            // durable but before section 2 is synced.
+            // Sync sections 0 and 1 but not section 2, simulating a crash after part of a
+            // multi-section sync became durable.
             {
                 let inner = journal.inner.write().await;
                 inner.journal.sync(0).await.unwrap();
@@ -3359,7 +3363,7 @@ mod tests {
     /// Test that a durable section above the sync watermark, sitting beyond an empty intermediate
     /// section, is rolled back to the contiguous boundary during recovery.
     ///
-    /// Since #3790 removed the append-time fsync when crossing blob boundaries, a process crash can
+    /// Since #3790 removed the append-time sync when crossing blob boundaries, a process crash can
     /// leave a later section incidentally durable while an earlier section stayed buffered and was
     /// lost, producing a physical gap. Length-based recovery walks sections from oldest and
     /// truncates at the first short non-tail section, so the post-gap section is discarded and only
@@ -3379,7 +3383,7 @@ mod tests {
             }
             journal.sync().await.unwrap();
 
-            // Append section 1 and part of section 2 without committing. Manually fsync only section
+            // Append section 1 and part of section 2 without committing. Manually sync only section
             // 2 to mimic its writes surviving a crash, while section 1 stays buffered and is lost.
             for i in 10..28u64 {
                 journal.append(&test_digest(i)).await.unwrap();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -3234,6 +3234,16 @@ mod tests {
                 .unwrap();
             assert_eq!(journal.bounds().await, 0..1);
             assert_eq!(journal.read(0).await.unwrap(), test_digest(10));
+            drop(journal);
+
+            // Recovery should remove the empty trailing sections, leaving only the durable prefix's
+            // section and the recreated tail.
+            let blobs = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert_eq!(blobs.len(), 2);
+
+            let journal = Journal::<_, Digest>::init(context.child("recovered"), cfg.clone())
+                .await
+                .unwrap();
             assert_eq!(journal.append(&test_digest(42)).await.unwrap(), 1);
             assert_eq!(journal.read(1).await.unwrap(), test_digest(42));
             journal.destroy().await.unwrap();
@@ -3255,10 +3265,26 @@ mod tests {
             assert_eq!(journal.append(&test_digest(20)).await.unwrap(), 1);
             drop(journal);
 
+            let blobs = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert!(
+                blobs.len() > 1,
+                "expected multiple empty sections, got {}",
+                blobs.len()
+            );
+
             let journal = Journal::<_, Digest>::init(context.child("recovered"), cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(journal.bounds().await, 0..0);
+            drop(journal);
+
+            // Recovery should remove the extra empty sections, leaving only the recreated tail.
+            let blobs = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert_eq!(blobs.len(), 1);
+
+            let journal = Journal::<_, Digest>::init(context.child("recovered"), cfg.clone())
+                .await
+                .unwrap();
             assert_eq!(journal.append(&test_digest(42)).await.unwrap(), 0);
             assert_eq!(journal.read(0).await.unwrap(), test_digest(42));
             journal.destroy().await.unwrap();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -3205,6 +3205,66 @@ mod tests {
         });
     }
 
+    #[test_traced]
+    fn test_fixed_recovery_handles_multiple_empty_data_tail_sections() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(1));
+            let journal = Journal::<_, Digest>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Persist a prefix, then append across multiple section boundaries without syncing. The
+            // unsynced item bytes are lost on drop, but their section blobs remain visible.
+            assert_eq!(journal.append(&test_digest(10)).await.unwrap(), 0);
+            journal.sync().await.unwrap();
+            assert_eq!(journal.append(&test_digest(20)).await.unwrap(), 1);
+            assert_eq!(journal.append(&test_digest(30)).await.unwrap(), 2);
+            drop(journal);
+
+            let blobs = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert!(
+                blobs.len() > 2,
+                "expected multiple empty trailing sections, got {}",
+                blobs.len()
+            );
+
+            let journal = Journal::<_, Digest>::init(context.child("recovered"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..1);
+            assert_eq!(journal.read(0).await.unwrap(), test_digest(10));
+            assert_eq!(journal.append(&test_digest(42)).await.unwrap(), 1);
+            assert_eq!(journal.read(1).await.unwrap(), test_digest(42));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_recovery_handles_empty_data_with_no_durable_items() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(1));
+            let journal = Journal::<_, Digest>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Append across multiple section boundaries without ever syncing. No item bytes become
+            // durable, so recovery sees multiple empty sections and no durable data.
+            assert_eq!(journal.append(&test_digest(10)).await.unwrap(), 0);
+            assert_eq!(journal.append(&test_digest(20)).await.unwrap(), 1);
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("recovered"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..0);
+            assert_eq!(journal.append(&test_digest(42)).await.unwrap(), 0);
+            assert_eq!(journal.read(0).await.unwrap(), test_digest(42));
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test the contiguous fixed journal with items_per_blob: 1.
     ///
     /// This is an edge case where each item creates its own blob, and the

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -3291,6 +3291,143 @@ mod tests {
         });
     }
 
+    /// Test that a crash partway through the ascending per-section sync loop leaves a contiguous
+    /// durable prefix that recovery preserves.
+    ///
+    /// `fsync_dirty_sections` syncs dirty sections in ascending order, and all mutating operations
+    /// serialize on `op_lock` so no concurrent sync can interleave. This reproduces a crash after
+    /// sections 0 and 1 were fsynced but before section 2, then asserts recovery keeps exactly the
+    /// contiguous prefix 0..20.
+    #[test_traced]
+    fn test_fixed_recovery_partial_sync_loop_keeps_contiguous_prefix() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(10));
+            let journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Fill sections 0 and 1 and partially fill section 2 (positions 20..25). Nothing is
+            // synced yet, so only the created section blobs are durable, all still empty.
+            for i in 0..25u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+
+            // Replicate `fsync_dirty_sections`'s ascending loop, crashing after sections 0 and 1 are
+            // durable but before section 2 is synced.
+            {
+                let inner = journal.inner.write().await;
+                inner.journal.sync(0).await.unwrap();
+                inner.journal.sync(1).await.unwrap();
+            }
+            drop(journal);
+
+            // The durable data is exactly the contiguous prefix: sections 0 and 1 hold items and
+            // section 2 is an empty trailing blob.
+            let names = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert_eq!(names.len(), 3);
+            for (section, name) in names.iter().enumerate() {
+                let (_blob, size) = context.open(&blob_partition(&cfg), name).await.unwrap();
+                if section < 2 {
+                    assert!(size > 0, "section {section} should be durable");
+                } else {
+                    assert_eq!(size, 0, "section {section} should be empty");
+                }
+            }
+
+            // Recovery preserves exactly the contiguous prefix 0..20.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..20);
+            for i in 0..20u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            assert!(matches!(
+                journal.read(20).await,
+                Err(Error::ItemOutOfRange(20))
+            ));
+
+            // Appends resume cleanly from the recovered boundary.
+            assert_eq!(journal.append(&test_digest(999)).await.unwrap(), 20);
+            assert_eq!(journal.read(20).await.unwrap(), test_digest(999));
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Test that a durable section above the sync watermark, sitting beyond an empty intermediate
+    /// section, is rolled back to the contiguous boundary during recovery.
+    ///
+    /// Since #3790 removed the append-time fsync when crossing blob boundaries, a process crash can
+    /// leave a later section incidentally durable while an earlier section stayed buffered and was
+    /// lost, producing a physical gap. Length-based recovery walks sections from oldest and
+    /// truncates at the first short non-tail section, so the post-gap section is discarded and only
+    /// the synced prefix survives.
+    #[test_traced]
+    fn test_fixed_recovery_rolls_back_durable_section_after_gap() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(10));
+            let journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Durably commit section 0 (positions 0..10), advancing the recovery watermark to 10.
+            for i in 0..10u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+
+            // Append section 1 and part of section 2 without committing. Manually fsync only section
+            // 2 to mimic its writes surviving a crash, while section 1 stays buffered and is lost.
+            for i in 10..28u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            {
+                let inner = journal.inner.write().await;
+                inner.journal.sync(2).await.unwrap();
+            }
+            drop(journal);
+
+            // Durable state: section 0 (10 items), section 1 (empty gap), section 2 (8 items).
+            let names = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert_eq!(names.len(), 3);
+            let mut sizes = Vec::new();
+            for name in &names {
+                let (_blob, size) = context.open(&blob_partition(&cfg), name).await.unwrap();
+                sizes.push(size);
+            }
+            assert!(sizes[0] > 0, "section 0 should be durable");
+            assert_eq!(sizes[1], 0, "section 1 should be the gap");
+            assert!(sizes[2] > 0, "section 2 should be incidentally durable");
+
+            // Recovery rolls back to the watermark boundary: only the synced prefix survives and the
+            // gapped section 2 is truncated away.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..10);
+            for i in 0..10u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            assert!(matches!(
+                journal.read(10).await,
+                Err(Error::ItemOutOfRange(10))
+            ));
+
+            // The orphaned section 2 is gone; the truncated section 1 remains as the recovered tail.
+            let names = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert_eq!(names.len(), 2);
+
+            // Appends resume cleanly from the recovered boundary.
+            assert_eq!(journal.append(&test_digest(999)).await.unwrap(), 10);
+            assert_eq!(journal.read(10).await.unwrap(), test_digest(999));
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test the contiguous fixed journal with items_per_blob: 1.
     ///
     /// This is an edge case where each item creates its own blob, and the

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -977,9 +977,9 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 break items_in_last_section;
             }
 
-            let previous_section = last_section.checked_sub(1).ok_or_else(|| {
-                Error::Corruption("multiple data sections with no previous section".into())
-            })?;
+            let previous_section = last_section
+                .checked_sub(1)
+                .expect("num_sections >= 2 implies newest_section >= 1");
             let previous_size = data.size(previous_section).await?;
             warn!(
                 section = last_section,

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2174,7 +2174,7 @@ mod tests {
             let data_blobs = context.scan(&data_partition).await.unwrap();
             assert_eq!(data_blobs.len(), 3);
             for name in &data_blobs[1..] {
-                let (_blob, size) = context.open(&data_partition, &name).await.unwrap();
+                let (_blob, size) = context.open(&data_partition, name).await.unwrap();
                 assert_eq!(size, 0);
             }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2145,6 +2145,56 @@ mod tests {
         });
     }
 
+    #[test_traced]
+    fn test_variable_recovery_handles_multiple_empty_data_tail_sections() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config::<()> {
+                partition: "recovery-empty-data-tail".into(),
+                items_per_section: NZU64!(1),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let journal = Journal::<_, u64>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+
+            // First persist a prefix, then append across multiple section
+            // boundaries without syncing. The unsynced item bytes are lost when
+            // the journal is dropped, but their section blobs remain visible.
+            assert_eq!(journal.append(&10).await.unwrap(), 0);
+            journal.sync().await.unwrap();
+            assert_eq!(journal.append(&20).await.unwrap(), 1);
+            assert_eq!(journal.append(&30).await.unwrap(), 2);
+            drop(journal);
+
+            let data_partition = cfg.data_partition();
+            let data_blobs = context.scan(&data_partition).await.unwrap();
+            assert_eq!(data_blobs.len(), 3);
+            for name in &data_blobs[1..] {
+                let (_blob, size) = context.open(&data_partition, &name).await.unwrap();
+                assert_eq!(size, 0);
+            }
+
+            // Recovery should trim only the empty trailing sections, preserving
+            // the durable prefix.
+            let cfg = Config {
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                ..cfg
+            };
+            let journal = Journal::<_, u64>::init(context.child("recovered"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..1);
+            assert_eq!(journal.read(0).await.unwrap(), 10);
+            assert_eq!(journal.append(&42).await.unwrap(), 1);
+            assert_eq!(journal.read(1).await.unwrap(), 42);
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test recovery from multiple prune operations with crash.
     #[test_traced]
     fn test_variable_recovery_multiple_prunes_crash() {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -20,7 +20,7 @@ use commonware_utils::{
 };
 #[commonware_macros::stability(ALPHA)]
 use core::ops::Range;
-use futures::{stream, Stream, StreamExt as _};
+use futures::{future::try_join_all, stream, Stream, StreamExt as _};
 use std::num::{NonZeroU64, NonZeroUsize};
 #[commonware_macros::stability(ALPHA)]
 use tracing::debug;
@@ -120,8 +120,8 @@ struct Inner<E: Context, V: Codec> {
 
     /// Earliest data section modified since the last `commit()` or `sync()`.
     ///
-    /// Tracks which sections need fsyncing. Reset by both `commit()` and `sync()` so
-    /// that repeated commit-without-sync cycles only fsync newly dirtied sections.
+    /// Tracks which sections need syncing. Reset by both `commit()` and `sync()` so
+    /// that repeated commit-without-sync cycles only sync newly dirtied sections.
     dirty_from_section: Option<u64>,
 }
 
@@ -856,8 +856,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok(pruned)
     }
 
-    /// Fsync dirty data sections under the read lock, allowing concurrent reads.
-    async fn fsync_dirty_data(&self) -> Result<(), Error> {
+    /// Flush dirty data sections to storage under the read lock, allowing concurrent reads.
+    ///
+    /// Sections are synced concurrently. Ordering is not required for recovery: appends only add
+    /// data, so committed sections are never at risk, and recovery replays the data journal as the
+    /// source of truth and truncates at the first short or missing section, so a crash that leaves a
+    /// gap still recovers a contiguous prefix no shorter than the last completed commit.
+    async fn flush_dirty_data(&self) -> Result<(), Error> {
         let inner = self.inner.read().await;
         if let Some(start_section) = inner.dirty_from_section {
             let tail_section = position_to_section(inner.size, self.items_per_section);
@@ -868,9 +873,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 // With no retained data blobs, any earlier dirty section was cleared or pruned.
                 // Syncing the tail section is harmless when it does not exist.
                 .unwrap_or(tail_section);
-            for section in start_section..=tail_section {
-                inner.data.sync(section).await?;
-            }
+            try_join_all((start_section..=tail_section).map(|section| inner.data.sync(section)))
+                .await?;
         }
         Ok(())
     }
@@ -880,7 +884,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let _timer = self.metrics.commit_timer();
         self.metrics.record_commit();
         let _op_guard = self.op_lock.lock().await;
-        self.fsync_dirty_data().await?;
+        self.flush_dirty_data().await?;
         self.offsets.commit().await?;
         let mut inner = self.inner.write().await;
         inner.dirty_from_section = None;
@@ -892,7 +896,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let _timer = self.metrics.sync_timer();
         self.metrics.sync_calls.inc();
         let _op_guard = self.op_lock.lock().await;
-        self.fsync_dirty_data().await?;
+        self.flush_dirty_data().await?;
         self.offsets.sync().await?;
         let mut inner = self.inner.write().await;
         inner.dirty_from_section = None;
@@ -2268,7 +2272,7 @@ mod tests {
     /// Test that a durable data section above the sync watermark, sitting beyond an empty
     /// intermediate section, is rolled back to the contiguous boundary during recovery.
     ///
-    /// Since #3790 removed the append-time fsync when crossing blob boundaries, a process crash can
+    /// Since #3790 removed the append-time sync when crossing blob boundaries, a process crash can
     /// leave a later data section incidentally durable (its page-cache writes survived) while an
     /// earlier section stayed buffered and was lost, producing a physical gap. Recovery anchors at
     /// the durable watermark and replays the data forward with a strict section-contiguity check, so
@@ -2296,7 +2300,7 @@ mod tests {
             }
             journal.sync().await.unwrap();
 
-            // Append sections 1 and 2 without committing. Manually fsync only section 2's data blob
+            // Append sections 1 and 2 without committing. Manually sync only section 2's data blob
             // to mimic its page-cache writes surviving a crash, while section 1 stays buffered and
             // the offsets journal is never advanced past position 10.
             for i in 10..30u64 {
@@ -2352,13 +2356,13 @@ mod tests {
         });
     }
 
-    /// Test that a crash partway through the ascending per-section sync loop leaves a contiguous
-    /// durable prefix that recovery preserves.
+    /// Test that a crash partway through a multi-section sync leaves a contiguous durable prefix
+    /// that recovery preserves.
     ///
-    /// `fsync_dirty_data` syncs dirty data sections in ascending order before syncing offsets, and
-    /// all mutating operations serialize on `op_lock` so no concurrent sync can interleave. This
-    /// reproduces a crash after sections 0 and 1 were fsynced but before section 2 and the offsets
-    /// journal were, then asserts recovery keeps exactly the contiguous prefix 0..20.
+    /// `flush_dirty_data` syncs dirty data sections before syncing offsets, and all mutating
+    /// operations serialize on `op_lock` so no concurrent sync can interleave. This reproduces a
+    /// crash after sections 0 and 1 were synced but before section 2 and the offsets journal were,
+    /// then asserts recovery keeps exactly the contiguous prefix 0..20.
     #[test_traced]
     fn test_variable_recovery_partial_sync_loop_keeps_contiguous_prefix() {
         let executor = deterministic::Runner::default();
@@ -2382,8 +2386,8 @@ mod tests {
                 journal.append(&(i * 100)).await.unwrap();
             }
 
-            // Replicate `fsync_dirty_data`'s ascending loop, crashing after sections 0 and 1 are
-            // durable but before section 2 (and before offsets) are synced.
+            // Sync sections 0 and 1 but not section 2 (and not offsets), simulating a crash after
+            // part of a multi-section sync became durable.
             {
                 let inner = journal.inner.write().await;
                 inner.data.sync(0).await.unwrap();

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2265,6 +2265,171 @@ mod tests {
         });
     }
 
+    /// Test that a durable data section above the sync watermark, sitting beyond an empty
+    /// intermediate section, is rolled back to the contiguous boundary during recovery.
+    ///
+    /// Since #3790 removed the append-time fsync when crossing blob boundaries, a process crash can
+    /// leave a later data section incidentally durable (its page-cache writes survived) while an
+    /// earlier section stayed buffered and was lost, producing a physical gap. Recovery anchors at
+    /// the durable watermark and replays the data forward with a strict section-contiguity check, so
+    /// the post-gap section is truncated and recovery returns only the synced prefix.
+    #[test_traced]
+    fn test_variable_recovery_rolls_back_durable_section_after_gap() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "recovery-rollback-after-gap".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Durably commit section 0 (positions 0..10), advancing the recovery watermark to 10.
+            for i in 0..10u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+
+            // Append sections 1 and 2 without committing. Manually fsync only section 2's data blob
+            // to mimic its page-cache writes surviving a crash, while section 1 stays buffered and
+            // the offsets journal is never advanced past position 10.
+            for i in 10..30u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            {
+                let inner = journal.inner.write().await;
+                inner.data.sync(2).await.unwrap();
+            }
+            drop(journal);
+
+            // Durable state: section 0 (10 items), section 1 (empty, lost), section 2 (10 items).
+            let data_partition = cfg.data_partition();
+            let mut names = context.scan(&data_partition).await.unwrap();
+            names.sort();
+            assert_eq!(names.len(), 3);
+            let sizes = {
+                let mut sizes = Vec::new();
+                for name in &names {
+                    let (_blob, size) = context.open(&data_partition, name).await.unwrap();
+                    sizes.push(size);
+                }
+                sizes
+            };
+            assert!(sizes[0] > 0, "section 0 should be durable");
+            assert_eq!(sizes[1], 0, "section 1 should be the gap");
+            assert!(sizes[2] > 0, "section 2 should be incidentally durable");
+
+            // Recovery rolls back to the watermark boundary: only the synced prefix survives and the
+            // gapped section 2 is truncated away.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..10);
+            for i in 0..10u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            assert!(matches!(
+                journal.read(10).await,
+                Err(Error::ItemOutOfRange(10))
+            ));
+
+            // The orphaned section 2 is gone. The repair truncates section 1 in place, so its
+            // emptied blob remains as the recovered tail.
+            let data_blobs = context.scan(&cfg.data_partition()).await.unwrap();
+            assert_eq!(data_blobs.len(), 2);
+
+            // Appends resume cleanly from the recovered boundary.
+            assert_eq!(journal.append(&1234).await.unwrap(), 10);
+            assert_eq!(journal.read(10).await.unwrap(), 1234);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Test that a crash partway through the ascending per-section sync loop leaves a contiguous
+    /// durable prefix that recovery preserves.
+    ///
+    /// `fsync_dirty_data` syncs dirty data sections in ascending order before syncing offsets, and
+    /// all mutating operations serialize on `op_lock` so no concurrent sync can interleave. This
+    /// reproduces a crash after sections 0 and 1 were fsynced but before section 2 and the offsets
+    /// journal were, then asserts recovery keeps exactly the contiguous prefix 0..20.
+    #[test_traced]
+    fn test_variable_recovery_partial_sync_loop_keeps_contiguous_prefix() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "recovery-partial-sync-loop".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Fill sections 0 and 1 and partially fill section 2 (positions 20..25). Nothing is
+            // synced yet, so only the created section blobs are durable, all still empty.
+            for i in 0..25u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+
+            // Replicate `fsync_dirty_data`'s ascending loop, crashing after sections 0 and 1 are
+            // durable but before section 2 (and before offsets) are synced.
+            {
+                let inner = journal.inner.write().await;
+                inner.data.sync(0).await.unwrap();
+                inner.data.sync(1).await.unwrap();
+            }
+            drop(journal);
+
+            // The durable data is exactly the contiguous prefix: sections 0 and 1 hold items,
+            // section 2 is an empty trailing blob, and offsets never synced.
+            let data_partition = cfg.data_partition();
+            let mut names = context.scan(&data_partition).await.unwrap();
+            names.sort();
+            assert_eq!(names.len(), 3);
+            for (section, name) in names.iter().enumerate() {
+                let (_blob, size) = context.open(&data_partition, name).await.unwrap();
+                if section < 2 {
+                    assert!(size > 0, "section {section} should be durable");
+                } else {
+                    assert_eq!(size, 0, "section {section} should be empty");
+                }
+            }
+
+            // Recovery trims the empty trailing section, rebuilds offsets from the durable data, and
+            // exposes exactly the contiguous prefix 0..20.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..20);
+            for i in 0..20u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            assert!(matches!(
+                journal.read(20).await,
+                Err(Error::ItemOutOfRange(20))
+            ));
+
+            // The trailing section is gone and appends continue from the recovered tail.
+            let data_blobs = context.scan(&cfg.data_partition()).await.unwrap();
+            assert_eq!(data_blobs.len(), 2);
+            assert_eq!(journal.append(&2000).await.unwrap(), 20);
+            assert_eq!(journal.read(20).await.unwrap(), 2000);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test recovery from multiple prune operations with crash.
     #[test_traced]
     fn test_variable_recovery_multiple_prunes_crash() {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2198,13 +2198,69 @@ mod tests {
                 page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
                 ..cfg
             };
-            let journal = Journal::<_, u64>::init(context.child("recovered"), cfg)
+            let journal = Journal::<_, u64>::init(context.child("recovered"), cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(journal.bounds().await, 0..1);
             assert_eq!(journal.read(0).await.unwrap(), 10);
             assert_eq!(journal.append(&42).await.unwrap(), 1);
             assert_eq!(journal.read(1).await.unwrap(), 42);
+            drop(journal);
+
+            // Recovery should have removed the empty trailing sections, leaving
+            // only the durable prefix's section and the one written above.
+            let data_blobs = context.scan(&cfg.data_partition()).await.unwrap();
+            assert_eq!(data_blobs.len(), 2);
+
+            let journal = Journal::<_, u64>::init(context.child("recovered"), cfg)
+                .await
+                .unwrap();
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_recovery_handles_empty_data_with_no_durable_items() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config::<()> {
+                partition: "recovery-empty-data-no-items".into(),
+                items_per_section: NZU64!(1),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let journal = Journal::<_, u64>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Append across multiple section boundaries without ever syncing. Each
+            // append opens a fresh section blob, but no item bytes (and no offsets)
+            // become durable, so recovery sees multiple empty sections and no
+            // durable data.
+            assert_eq!(journal.append(&10).await.unwrap(), 0);
+            assert_eq!(journal.append(&20).await.unwrap(), 1);
+            drop(journal);
+
+            let data_partition = cfg.data_partition();
+            let data_blobs = context.scan(&data_partition).await.unwrap();
+            assert_eq!(data_blobs.len(), 2);
+            for name in &data_blobs {
+                let (_blob, size) = context.open(&data_partition, name).await.unwrap();
+                assert_eq!(size, 0);
+            }
+
+            let cfg = Config {
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                ..cfg
+            };
+            let journal = Journal::<_, u64>::init(context.child("recovered"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..0);
+            assert_eq!(journal.append(&42).await.unwrap(), 0);
+            assert_eq!(journal.read(0).await.unwrap(), 42);
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -933,8 +933,14 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         items_per_section: u64,
     ) -> Result<(u64, u64), Error> {
         // === Handle empty data journal case ===
-        let items_in_last_section = match data.newest_section() {
-            Some(last_section) => {
+        // Count the newest data section, removing any empty trailing sections
+        // left by a crash before append buffers became durable.
+        let items_in_last_section = loop {
+            let Some(last_section) = data.newest_section() else {
+                break 0;
+            };
+
+            let items_in_last_section = {
                 let stream = data.replay(last_section, 0, REPLAY_BUFFER_SIZE).await?;
                 futures::pin_mut!(stream);
                 let mut count = 0u64;
@@ -943,20 +949,34 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                     count += 1;
                 }
                 count
-            }
-            None => 0,
-        };
-        if items_in_last_section > items_per_section {
-            return Err(Error::Corruption(format!(
-                "data section has too many items: expected at most {items_per_section}, got {items_in_last_section}"
-            )));
-        }
+            };
 
-        // Data journal is empty if there are no sections or if there is one section and it has no items.
-        // The latter should only occur if a crash occured after opening a data journal blob but
-        // before writing to it.
-        let data_empty =
-            data.is_empty() || (data.num_sections() == 1 && items_in_last_section == 0);
+            if items_in_last_section > items_per_section {
+                return Err(Error::Corruption(format!(
+                    "data section has too many items: expected at most {items_per_section}, got {items_in_last_section}"
+                )));
+            }
+
+            // Stop once we find replayable data or only one empty section
+            // remains for the existing empty-data repair path.
+            if items_in_last_section > 0 || data.num_sections() == 1 {
+                break items_in_last_section;
+            }
+
+            let previous_section = last_section.checked_sub(1).ok_or_else(|| {
+                Error::Corruption("multiple data sections with no previous section".into())
+            })?;
+            let previous_size = data.size(previous_section).await?;
+            warn!(
+                section = last_section,
+                "crash repair: removing empty trailing data section"
+            );
+            data.rewind(previous_section, previous_size).await?;
+        };
+
+        // After trimming empty trailing sections, a zero item count means the data journal is
+        // empty: either no sections remain, or one empty section remains for repair below.
+        let data_empty = data.is_empty() || items_in_last_section == 0;
         if data_empty {
             let offsets_bounds = {
                 let offsets_reader = offsets.reader().await;


### PR DESCRIPTION
Variable journal recovery could panic when normal append flow left multiple empty data section blobs behind after unsynced tail appends. Recovery now trims empty trailing data sections before deciding whether the data journal is empty or rebuilding offsets, so durable prefixes are preserved and empty tails are discarded.

Found by fuzzing in https://github.com/commonwarexyz/monorepo/actions/runs/26581984886/job/78317247546?pr=3878.