### PR TITLE
[Storage] Use `Sealed` blob in fixed contiguous journal

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -655,39 +655,30 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         );
     }
 
-    /// Update pruning-boundary and recovery-watermark entries in metadata's in-memory state.
+    /// Stage pruning-boundary and recovery-watermark entries into `metadata`'s in-memory state.
     ///
-    /// Call `inner.metadata.sync()` separately to persist the updated entries.
-    fn update_metadata_entries(
-        inner: &mut Inner<E, A>,
+    /// Only writes when a value actually changes. The caller is responsible for syncing.
+    fn stage_metadata_entries(
+        metadata: &mut Metadata<E, u64, VecU64>,
         items_per_blob: u64,
         pruning_boundary: u64,
         recovery_watermark: u64,
     ) {
-        let current_pruning = inner
-            .metadata
-            .get(&PRUNING_BOUNDARY_KEY)
-            .copied()
-            .map(u64::from);
+        let current_pruning = metadata.get(&PRUNING_BOUNDARY_KEY).copied().map(u64::from);
         if !pruning_boundary.is_multiple_of(items_per_blob) {
             if current_pruning != Some(pruning_boundary) {
-                inner
-                    .metadata
-                    .put(PRUNING_BOUNDARY_KEY, pruning_boundary.into());
+                metadata.put(PRUNING_BOUNDARY_KEY, pruning_boundary.into());
             }
         } else if current_pruning.is_some() {
-            inner.metadata.remove(&PRUNING_BOUNDARY_KEY);
+            metadata.remove(&PRUNING_BOUNDARY_KEY);
         }
 
-        let current_watermark = inner
-            .metadata
+        let current_watermark = metadata
             .get(&RECOVERY_WATERMARK_KEY)
             .copied()
             .map(u64::from);
         if current_watermark != Some(recovery_watermark) {
-            inner
-                .metadata
-                .put(RECOVERY_WATERMARK_KEY, recovery_watermark.into());
+            metadata.put(RECOVERY_WATERMARK_KEY, recovery_watermark.into());
         }
     }
 
@@ -984,21 +975,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         pruning_boundary: u64,
         recovery_watermark: u64,
     ) -> Result<(), Error> {
-        let current_pruning = metadata.get(&PRUNING_BOUNDARY_KEY).copied().map(u64::from);
-        if !pruning_boundary.is_multiple_of(items_per_blob) {
-            if current_pruning != Some(pruning_boundary) {
-                metadata.put(PRUNING_BOUNDARY_KEY, pruning_boundary.into());
-            }
-        } else if current_pruning.is_some() {
-            metadata.remove(&PRUNING_BOUNDARY_KEY);
-        }
-        let current_watermark = metadata
-            .get(&RECOVERY_WATERMARK_KEY)
-            .copied()
-            .map(u64::from);
-        if current_watermark != Some(recovery_watermark) {
-            metadata.put(RECOVERY_WATERMARK_KEY, recovery_watermark.into());
-        }
+        Self::stage_metadata_entries(
+            metadata,
+            items_per_blob,
+            pruning_boundary,
+            recovery_watermark,
+        );
         metadata.sync().await?;
         Ok(())
     }
@@ -1400,7 +1382,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         inner.dirty_from_section = None;
         let pruning_boundary = inner.pruning_boundary;
         let size = inner.size;
-        Self::update_metadata_entries(&mut inner, self.items_per_blob, pruning_boundary, size);
+        Self::stage_metadata_entries(
+            &mut inner.metadata,
+            self.items_per_blob,
+            pruning_boundary,
+            size,
+        );
         drop(inner);
 
         let inner = self.inner.read().await;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -194,7 +194,7 @@ pub struct Config {
 
 /// Inner state protected by a single RwLock.
 struct Inner<E: Context, A: CodecFixedShared> {
-    /// The typed section store. Historical sections are sealed (immutable, no `RwLock`); only the
+    /// The underlying blobs. Historical sections are sealed (immutable, no `RwLock`); only the
     /// tail is writable.
     sections: Sections<E>,
 
@@ -524,8 +524,15 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
             }
         }
 
+        // Concatenate the per-section replays into one stream of `(global position, item)` pairs in
+        // ascending position order. Each section is fully drained before the next one starts.
         let stream = stream::iter(per_section_replays).flat_map(
             move |(section, replay, initial_position)| {
+                // `unfold` repeatedly calls the closure below, threading `SectionReplayState`
+                // through each call, to turn one section's byte `Replay` into a stream of items.
+                // Each call returns a *batch* of items (decoding several buffered items per await is
+                // cheaper than one await per item); the trailing `flat_map(stream::iter)` then
+                // flattens those batches back into a stream of individual items.
                 stream::unfold(
                     SectionReplayState {
                         section,
@@ -534,14 +541,20 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                         done: false,
                     },
                     move |mut state| async move {
+                        // A previous call hit the section's end or an error and set `done`. Returning
+                        // `None` terminates this section's stream.
                         if state.done {
                             return None;
                         }
 
                         let mut batch: Vec<Result<(u64, A), Error>> = Vec::new();
                         loop {
+                            // Pull more bytes from the blob until at least one whole item is
+                            // buffered (or the section ends / a read fails).
                             match state.replay.ensure(chunk_size).await {
+                                // At least one item's worth of bytes is buffered; decode below.
                                 Ok(true) => {}
+                                // Section fully drained. Emit any items decoded so far, then stop.
                                 Ok(false) => {
                                     state.done = true;
                                     return if batch.is_empty() {
@@ -550,6 +563,7 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                                         Some((batch, state))
                                     };
                                 }
+                                // Read failure: surface it as the section's final item, then stop.
                                 Err(err) => {
                                     batch.push(Err(Error::Runtime(err)));
                                     state.done = true;
@@ -557,9 +571,12 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                                 }
                             }
 
+                            // Decode every whole item currently buffered.
                             while state.replay.remaining() >= chunk_size {
                                 match A::read(&mut state.replay) {
                                     Ok(item) => {
+                                        // Translate the item's index within this section into its
+                                        // absolute position in the journal.
                                         let global_pos = first_in_section(
                                             pruning_boundary,
                                             state.section,
@@ -575,6 +592,7 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                                                 batch.push(Ok((pos, item)));
                                                 state.position += 1;
                                             }
+                                            // Position overflow: emit the error and stop.
                                             Err(err) => {
                                                 batch.push(Err(err));
                                                 state.done = true;
@@ -582,6 +600,7 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                                             }
                                         }
                                     }
+                                    // Corrupt bytes: surface the decode error and stop the section.
                                     Err(err) => {
                                         batch.push(Err(Error::Codec(err)));
                                         state.done = true;
@@ -590,6 +609,9 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                                 }
                             }
 
+                            // Yield the decoded items. `ensure(chunk_size)` returning `Ok(true)`
+                            // guarantees we decoded at least one, so `batch` is non-empty here; the
+                            // guard simply keeps the loop from yielding an empty batch.
                             if !batch.is_empty() {
                                 return Some((batch, state));
                             }
@@ -604,11 +626,16 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
     }
 }
 
-/// State for replaying a single section's blob.
+/// State threaded through the `unfold` that replays a single section's blob.
 struct SectionReplayState<B: commonware_runtime::Blob> {
+    /// The section being replayed.
     section: u64,
+    /// Sequential reader over the section's logical bytes.
     replay: Replay<B>,
+    /// Index of the next item to emit, relative to the section's first retained item. Added to the
+    /// section's first position to recover the item's absolute journal position.
     position: u64,
+    /// Set once the section is exhausted or an error was emitted; the next call returns `None`.
     done: bool,
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -106,6 +106,7 @@ use commonware_utils::{
     sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard},
 };
 use futures::{
+    future::try_join_all,
     stream::{self, Stream},
     StreamExt,
 };
@@ -1319,10 +1320,10 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
     /// Flush dirty sections to storage under the read lock, allowing concurrent reads.
     ///
-    /// Sections are synced in section order. Ordering is not required for recovery: appends only
-    /// add data, so committed sections are never at risk, and recovery truncates at the first short
-    /// or missing section, so a crash that leaves a gap still recovers a contiguous prefix no
-    /// shorter than the last completed commit.
+    /// Sections are synced concurrently. Ordering is not required for recovery: appends only add
+    /// data, so committed sections are never at risk, and recovery truncates at the first short or
+    /// missing section, so a crash that leaves a gap still recovers a contiguous prefix no shorter
+    /// than the last completed commit.
     async fn flush_dirty_sections(&self) -> Result<(), Error> {
         let inner = self.inner.read().await;
         if let Some(start_section) = inner.dirty_from_section {
@@ -1334,9 +1335,10 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                 // With no retained blobs, any earlier dirty section was cleared or pruned.
                 // Syncing the tail section is harmless when it does not exist.
                 .unwrap_or(tail_section);
-            for section in start_section..=tail_section {
-                inner.sections.sync_section(section).await?;
-            }
+            try_join_all(
+                (start_section..=tail_section).map(|section| inner.sections.sync_section(section)),
+            )
+            .await?;
         }
         Ok(())
     }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -86,20 +86,29 @@
 use super::Reader as _;
 use crate::{
     journal::{
-        contiguous::{metrics::FixedMetrics as Metrics, Many, Mutable},
-        segmented::fixed::{Config as SegmentedConfig, Journal as SegmentedJournal},
+        contiguous::{
+            metrics::FixedMetrics as Metrics,
+            sections::{Config as SectionsConfig, Sections, SectionsInit},
+            Many, Mutable,
+        },
         Error,
     },
     metadata::{Config as MetadataConfig, Metadata},
     Context, Persistable,
 };
-use commonware_codec::CodecFixedShared;
-use commonware_runtime::buffer::paged::CacheRef;
+use commonware_codec::{CodecFixedShared, DecodeExt as _, ReadExt as _};
+use commonware_runtime::{
+    buffer::paged::{CacheRef, Replay},
+    Buf, Error as RuntimeError,
+};
 use commonware_utils::{
     sequence::VecU64,
     sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard},
 };
-use futures::{future::try_join_all, stream::Stream, StreamExt};
+use futures::{
+    stream::{self, Stream},
+    StreamExt,
+};
 use std::{
     future::Future,
     num::{NonZeroU64, NonZeroUsize},
@@ -184,8 +193,9 @@ pub struct Config {
 
 /// Inner state protected by a single RwLock.
 struct Inner<E: Context, A: CodecFixedShared> {
-    /// The underlying segmented journal.
-    journal: SegmentedJournal<E, A>,
+    /// The typed section store. Historical sections are sealed (immutable, no `RwLock`); only the
+    /// tail is writable.
+    sections: Sections<E>,
 
     /// Total number of items appended (not affected by pruning).
     size: u64,
@@ -205,6 +215,8 @@ struct Inner<E: Context, A: CodecFixedShared> {
 
     /// The earliest section modified since the last successful `commit()` or `sync()`.
     dirty_from_section: Option<u64>,
+
+    _phantom: std::marker::PhantomData<A>,
 }
 
 /// A deferred blob truncation to apply after metadata is persisted during init.
@@ -231,26 +243,26 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         let section = pos / items_per_blob;
         let pos_in_section =
             pos - first_in_section(self.pruning_boundary, section, items_per_blob)?;
+        let offset = pos_in_section
+            .checked_mul(Journal::<E, A>::CHUNK_SIZE_U64)
+            .ok_or(Error::OffsetOverflow)?;
 
-        self.journal
-            .get(section, pos_in_section)
+        let bufs = self
+            .sections
+            .read_at(section, offset, A::SIZE)
             .await
-            .map_err(|e| {
-                // Since we check bounds above, any failure here is unexpected.
-                match e {
-                    Error::SectionOutOfRange(e)
-                    | Error::AlreadyPrunedToSection(e)
-                    | Error::ItemOutOfRange(e) => {
-                        Error::Corruption(format!("section/item should be found, but got: {e}"))
-                    }
-                    other => other,
+            .map_err(|e| match e {
+                Error::SectionOutOfRange(e) | Error::AlreadyPrunedToSection(e) => {
+                    Error::Corruption(format!("section/item should be found, but got: {e}"))
                 }
-            })
+                other => other,
+            })?;
+        A::decode(bufs.coalesce()).map_err(Error::Codec)
     }
 
     /// Read an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
     fn try_read_sync(&self, pos: u64, items_per_blob: u64) -> Option<A> {
-        let mut buf = vec![0u8; SegmentedJournal::<E, A>::CHUNK_SIZE];
+        let mut buf = vec![0u8; A::SIZE];
         self.try_read_sync_into(pos, items_per_blob, &mut buf)
     }
 
@@ -262,14 +274,20 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         let section = pos / items_per_blob;
         let pos_in_section =
             pos - first_in_section(self.pruning_boundary, section, items_per_blob).ok()?;
-        self.journal.try_get_sync_into(section, pos_in_section, buf)
+        let offset = pos_in_section.checked_mul(Journal::<E, A>::CHUNK_SIZE_U64)?;
+        let buf = &mut buf[..A::SIZE];
+        if !self.sections.try_read_sync(section, offset, buf) {
+            return None;
+        }
+        A::decode(&buf[..]).ok()
     }
 }
 
 /// Implementation of `Journal` storage.
 ///
-/// This is implemented as a wrapper around [SegmentedJournal] that provides position-based access
-/// where positions are automatically mapped to (section, position_in_section) pairs.
+/// This is implemented on top of a typed section store that holds historical sections as
+/// immutable, sealed views and exposes a single writable tail. Positions are automatically mapped
+/// to (section, position_in_section) pairs.
 ///
 /// # Repair
 ///
@@ -278,10 +296,9 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
 /// and
 /// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
 /// the first invalid data read will be considered the new end of the journal (and the
-/// underlying blob will be truncated to the last valid item). Repair is performed
-/// by the underlying [SegmentedJournal] during init.
+/// underlying blob will be truncated to the last valid item). Repair is performed during init.
 pub struct Journal<E: Context, A: CodecFixedShared> {
-    /// Inner state with segmented journal and size.
+    /// Inner state with the section store and size.
     inner: AsyncRwLock<Inner<E, A>>,
 
     /// Serializes writers with `commit()` and `sync()` so a plain rwlock is sufficient.
@@ -343,7 +360,8 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
 
         let items_per_blob = self.items_per_blob;
         let pruning_boundary = self.guard.pruning_boundary;
-        let chunk_size = SegmentedJournal::<E, A>::CHUNK_SIZE;
+        let chunk_size = A::SIZE;
+        let chunk_size_u64 = Journal::<E, A>::CHUNK_SIZE_U64;
 
         // Phase 1: Drain page-cache hits synchronously.
         let mut result: Vec<Option<A>> = Vec::with_capacity(positions.len());
@@ -391,28 +409,31 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
 
             let group_len = group_end - group_start;
             let first_position = first_in_section(pruning_boundary, section, items_per_blob)?;
-            let section_positions: Vec<u64> = miss_positions[group_start..group_end]
+            let section_offsets: Vec<u64> = miss_positions[group_start..group_end]
                 .iter()
-                .map(|&pos| pos - first_position)
-                .collect();
+                .map(|&pos| {
+                    (pos - first_position)
+                        .checked_mul(chunk_size_u64)
+                        .ok_or(Error::OffsetOverflow)
+                })
+                .collect::<Result<_, _>>()?;
 
             let buf = &mut reusable_buf[..group_len * chunk_size];
-            let items = self
-                .guard
-                .journal
-                .get_many(section, &section_positions, buf)
+            self.guard
+                .sections
+                .read_many_into(section, buf, &section_offsets, chunk_size)
                 .await
                 .map_err(|e| match e {
-                    Error::SectionOutOfRange(e)
-                    | Error::AlreadyPrunedToSection(e)
-                    | Error::ItemOutOfRange(e) => {
+                    Error::SectionOutOfRange(e) | Error::AlreadyPrunedToSection(e) => {
                         Error::Corruption(format!("section/item should be found, but got: {e}"))
                     }
                     other => other,
                 })?;
 
-            for (item, &miss_idx) in items.into_iter().zip(&miss_indices[disk_offset..]) {
-                result[miss_idx] = Some(item);
+            for i in 0..group_len {
+                let slice = &buf[i * chunk_size..(i + 1) * chunk_size];
+                let item = A::decode(slice).map_err(Error::Codec)?;
+                result[miss_indices[disk_offset + i]] = Some(item);
             }
 
             disk_offset += group_len;
@@ -447,6 +468,8 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
         let items_per_blob = self.items_per_blob;
         let pruning_boundary = self.guard.pruning_boundary;
+        let chunk_size = A::SIZE;
+        let chunk_size_u64 = Journal::<E, A>::CHUNK_SIZE_U64;
 
         // Validate bounds.
         if start_pos > self.guard.size {
@@ -461,11 +484,14 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
             start_pos - first_in_section(pruning_boundary, start_section, items_per_blob)?;
 
         // Check all middle sections (not oldest, not tail) in range are complete.
-        let journal = &self.guard.journal;
-        if let (Some(oldest), Some(newest)) = (journal.oldest_section(), journal.newest_section()) {
-            let first_to_check = start_section.max(oldest + 1);
+        let sections = &self.guard.sections;
+        if let (Some(oldest), Some(newest)) = (sections.oldest_section(), sections.newest_section())
+        {
+            let first_to_check = oldest
+                .checked_add(1)
+                .map_or(newest, |after_oldest| start_section.max(after_oldest));
             for section in first_to_check..newest {
-                let len = journal.section_len(section).await?;
+                let len = sections.section_size(section).await? / chunk_size_u64;
                 if len < items_per_blob {
                     return Err(Error::Corruption(format!(
                         "section {section} incomplete: expected {items_per_blob} items, got {len}"
@@ -474,27 +500,120 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
             }
         }
 
-        let inner_stream = journal
-            .replay(start_section, start_pos_in_section, buffer)
-            .await?;
+        // Snapshot the sections to iterate over and seed each section's `Replay` upfront so the
+        // returned stream borrows nothing from `self` except via the per-section Replays.
+        let newest = sections.newest_section();
+        let mut per_section_replays: Vec<(u64, Replay<E::Blob>, u64)> = Vec::new();
+        if let Some(newest) = newest {
+            for section in start_section..=newest {
+                let (mut replay, section_size) = sections.replay_section(section, buffer).await?;
+                let initial_offset = if section == start_section {
+                    let start_byte = start_pos_in_section
+                        .checked_mul(chunk_size_u64)
+                        .ok_or(Error::OffsetOverflow)?;
+                    if start_byte > section_size {
+                        return Err(Error::ItemOutOfRange(start_pos));
+                    }
+                    replay.seek_to(start_byte).map_err(Error::Runtime)?;
+                    start_pos_in_section
+                } else {
+                    0
+                };
+                per_section_replays.push((section, replay, initial_offset));
+            }
+        }
 
-        // Transform (section, pos_in_section, item) to (global_pos, item).
-        let stream = inner_stream.map(move |result| {
-            result.and_then(|(section, pos_in_section, item)| {
-                let global_pos = first_in_section(pruning_boundary, section, items_per_blob)?
-                    .checked_add(pos_in_section)
-                    .ok_or(Error::OffsetOverflow)?;
-                Ok((global_pos, item))
-            })
-        });
+        let stream = stream::iter(per_section_replays).flat_map(
+            move |(section, replay, initial_position)| {
+                stream::unfold(
+                    SectionReplayState {
+                        section,
+                        replay,
+                        position: initial_position,
+                        done: false,
+                    },
+                    move |mut state| async move {
+                        if state.done {
+                            return None;
+                        }
+
+                        let mut batch: Vec<Result<(u64, A), Error>> = Vec::new();
+                        loop {
+                            match state.replay.ensure(chunk_size).await {
+                                Ok(true) => {}
+                                Ok(false) => {
+                                    state.done = true;
+                                    return if batch.is_empty() {
+                                        None
+                                    } else {
+                                        Some((batch, state))
+                                    };
+                                }
+                                Err(err) => {
+                                    batch.push(Err(Error::Runtime(err)));
+                                    state.done = true;
+                                    return Some((batch, state));
+                                }
+                            }
+
+                            while state.replay.remaining() >= chunk_size {
+                                match A::read(&mut state.replay) {
+                                    Ok(item) => {
+                                        let global_pos = first_in_section(
+                                            pruning_boundary,
+                                            state.section,
+                                            items_per_blob,
+                                        )
+                                        .and_then(|first| {
+                                            first
+                                                .checked_add(state.position)
+                                                .ok_or(Error::OffsetOverflow)
+                                        });
+                                        match global_pos {
+                                            Ok(pos) => {
+                                                batch.push(Ok((pos, item)));
+                                                state.position += 1;
+                                            }
+                                            Err(err) => {
+                                                batch.push(Err(err));
+                                                state.done = true;
+                                                return Some((batch, state));
+                                            }
+                                        }
+                                    }
+                                    Err(err) => {
+                                        batch.push(Err(Error::Codec(err)));
+                                        state.done = true;
+                                        return Some((batch, state));
+                                    }
+                                }
+                            }
+
+                            if !batch.is_empty() {
+                                return Some((batch, state));
+                            }
+                        }
+                    },
+                )
+                .flat_map(stream::iter)
+            },
+        );
 
         Ok(stream)
     }
 }
 
+/// State for replaying a single section's blob.
+struct SectionReplayState<B: commonware_runtime::Blob> {
+    section: u64,
+    replay: Replay<B>,
+    position: u64,
+    done: bool,
+}
+
 impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Size of each entry in bytes.
-    pub const CHUNK_SIZE: usize = SegmentedJournal::<E, A>::CHUNK_SIZE;
+    pub const CHUNK_SIZE: usize = A::SIZE;
 
     /// Size of each entry in bytes (as u64).
     pub const CHUNK_SIZE_U64: u64 = Self::CHUNK_SIZE as u64;
@@ -542,17 +661,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                 .metadata
                 .put(RECOVERY_WATERMARK_KEY, recovery_watermark.into());
         }
-    }
-
-    /// Update and persist pruning-boundary and recovery-watermark metadata entries.
-    async fn persist_metadata_entries(
-        inner: &mut Inner<E, A>,
-        items_per_blob: u64,
-        pruning_boundary: u64,
-        recovery_watermark: u64,
-    ) -> Result<(), Error> {
-        Self::update_metadata_entries(inner, items_per_blob, pruning_boundary, recovery_watermark);
-        inner.metadata.sync().await.map_err(Into::into)
     }
 
     /// Stage a recovery watermark no greater than `limit`.
@@ -606,16 +714,22 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             partition: format!("{}-metadata", cfg.partition),
             codec_config: (),
         };
-        Metadata::<_, u64, VecU64>::init(context, meta_cfg)
-            .await
-            .map_err(Into::into)
+        Ok(Metadata::<_, u64, VecU64>::init(context, meta_cfg).await?)
     }
 
     /// Scan a partition and return blob names, treating a missing partition as empty.
     async fn scan_partition(context: &E, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
         match context.scan(partition).await {
             Ok(blobs) => Ok(blobs),
-            Err(commonware_runtime::Error::PartitionMissing(_)) => Ok(Vec::new()),
+            Err(RuntimeError::PartitionMissing(_)) => Ok(Vec::new()),
+            Err(err) => Err(Error::Runtime(err)),
+        }
+    }
+
+    /// Remove a blob partition before completing a staged clear intent.
+    async fn remove_blob_partition(context: &E, partition: &str) -> Result<(), Error> {
+        match context.remove(partition, None).await {
+            Ok(()) | Err(RuntimeError::PartitionMissing(_)) => Ok(()),
             Err(err) => Err(Error::Runtime(err)),
         }
     }
@@ -664,17 +778,18 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// `CLEAR_TARGET_KEY`. Called both by `clear_to_size`/`init_at_size` and during init-time
     /// crash recovery when `CLEAR_TARGET_KEY` is present.
     async fn complete_clear_to_size(
-        journal: &mut SegmentedJournal<E, A>,
+        sections: &mut Sections<E>,
         metadata: &mut Metadata<E, u64, VecU64>,
         items_per_blob: u64,
         size: u64,
     ) -> Result<(), Error> {
-        journal.clear().await?;
-        journal.ensure_section_exists(size / items_per_blob).await?;
+        sections.clear().await?;
+        sections.install_tail(size / items_per_blob).await?;
         Self::stage_pruning_boundary_metadata(metadata, items_per_blob, size);
         metadata.put(RECOVERY_WATERMARK_KEY, size.into());
         metadata.remove(&CLEAR_TARGET_KEY);
-        metadata.sync().await.map_err(Into::into)
+        metadata.sync().await?;
+        Ok(())
     }
 
     /// Initialize a new `Journal` instance.
@@ -695,22 +810,71 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     ) -> Result<Self, Error> {
         let items_per_blob = cfg.items_per_blob.get();
 
+        // A staged clear intent means all old blob data is about to be discarded. Honor it before
+        // scanning or opening sections so corrupt stale blobs cannot block recovery of the reset.
+        if let Some(clear_target) = metadata.get(&CLEAR_TARGET_KEY).copied().map(u64::from) {
+            warn!(clear_target, "crash repair: completing interrupted clear");
+            let new_partition = format!("{}-blobs", cfg.partition);
+            Self::remove_blob_partition(&context, &cfg.partition).await?;
+            Self::remove_blob_partition(&context, &new_partition).await?;
+            let tail_section = clear_target / items_per_blob;
+            let sections_cfg = SectionsConfig {
+                partition: new_partition,
+                page_cache: cfg.page_cache,
+                write_buffer: cfg.write_buffer,
+            };
+            let init = SectionsInit::open(context.child("blobs"), sections_cfg).await?;
+            let sections = init.reset(tail_section).await?;
+            Self::stage_pruning_boundary_metadata(&mut metadata, items_per_blob, clear_target);
+            metadata.put(RECOVERY_WATERMARK_KEY, clear_target.into());
+            metadata.remove(&CLEAR_TARGET_KEY);
+            metadata.sync().await?;
+
+            let inner = Inner {
+                sections,
+                size: clear_target,
+                metadata,
+                pruning_boundary: clear_target,
+                dirty_from_section: None,
+                _phantom: std::marker::PhantomData,
+            };
+            let metrics = Metrics::new(context);
+            metrics.update(clear_target, clear_target, items_per_blob);
+            return Ok(Self {
+                inner: AsyncRwLock::new(inner),
+                op_lock: AsyncMutex::new(()),
+                items_per_blob,
+                metrics,
+            });
+        }
+
         let blob_partition = Self::select_blob_partition(&context, &cfg).await?;
-        let segmented_cfg = SegmentedConfig {
+        let sections_cfg = SectionsConfig {
             partition: blob_partition,
             page_cache: cfg.page_cache,
             write_buffer: cfg.write_buffer,
         };
 
-        let mut journal = SegmentedJournal::init(context.child("blobs"), segmented_cfg).await?;
+        let mut init = SectionsInit::open(context.child("blobs"), sections_cfg).await?;
 
-        // Complete any interrupted clear before recovering bounds. `complete_clear_to_size` also
-        // resets the recovery watermark to the clear target, so the subsequent bounds recovery
-        // sees fully consistent metadata.
-        if let Some(clear_target) = metadata.get(&CLEAR_TARGET_KEY).copied().map(u64::from) {
-            warn!(clear_target, "crash repair: completing interrupted clear");
-            Self::complete_clear_to_size(&mut journal, &mut metadata, items_per_blob, clear_target)
-                .await?;
+        // Truncate any trailing non-chunk-aligned bytes on every section before recovery. Items
+        // are fixed size, so a section ending in fewer than `CHUNK_SIZE` trailing bytes is junk
+        // from an incomplete write (Append's page-CRC layer surfaces it as a partial logical
+        // tail). `SectionsInit::truncate_section` syncs the repair before
+        // `recover_bounds` queries lengths.
+        let sections_to_check: Vec<u64> = init.sections();
+        for section in sections_to_check {
+            let size = init.section_size(section).await?;
+            if !size.is_multiple_of(Self::CHUNK_SIZE_U64) {
+                let valid_size = size - (size % Self::CHUNK_SIZE_U64);
+                warn!(
+                    section,
+                    invalid_size = size,
+                    new_size = valid_size,
+                    "trailing bytes detected: truncating"
+                );
+                init.truncate_section(section, valid_size).await?;
+            }
         }
 
         let meta_pruning_boundary = metadata.get(&PRUNING_BOUNDARY_KEY).copied().map(u64::from);
@@ -720,40 +884,58 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .map(u64::from);
 
         let (pruning_boundary, size, recovery_watermark, repair) = Self::recover_bounds(
-            &mut journal,
+            &init,
             items_per_blob,
             meta_pruning_boundary,
             meta_recovery_watermark,
         )
         .await?;
 
-        let mut inner = Inner {
-            journal,
-            size,
-            metadata,
-            pruning_boundary,
-            dirty_from_section: None,
-        };
         // Persist any lowered checkpoint before applying blob repairs that move recovered state
         // backward.
-        Self::persist_metadata_entries(
-            &mut inner,
+        Self::persist_metadata_entries_raw(
+            &mut metadata,
             items_per_blob,
             pruning_boundary,
             recovery_watermark,
         )
         .await?;
 
+        // Apply repair (if any). The repair section becomes the new tail; sections strictly newer
+        // than it are removed. `SectionsInit::truncate_section` (which calls `Append::resize`)
+        // syncs the section, so the repair is durable before `into_sections` runs.
+        let tail_section = size / items_per_blob;
         if let Some(repair) = repair {
-            inner
-                .journal
-                .rewind(repair.section, repair.byte_offset)
+            if repair.section != tail_section {
+                return Err(Error::Corruption(format!(
+                    "recovery repair target {} != tail section {tail_section}",
+                    repair.section
+                )));
+            }
+            // Remove any sections strictly newer than the repair section (newest-first).
+            let newer: Vec<u64> = init
+                .sections()
+                .into_iter()
+                .filter(|&s| s > repair.section)
+                .rev()
+                .collect();
+            for s in newer {
+                init.remove_section(s).await?;
+            }
+            init.truncate_section(repair.section, repair.byte_offset)
                 .await?;
-            inner.journal.sync(repair.section).await?;
         }
 
-        let tail_section = size / items_per_blob;
-        inner.journal.ensure_section_exists(tail_section).await?;
+        let sections = init.into_sections(Some(tail_section)).await?;
+
+        let inner = Inner {
+            sections,
+            size,
+            metadata,
+            pruning_boundary,
+            dirty_from_section: None,
+            _phantom: std::marker::PhantomData,
+        };
 
         let metrics = Metrics::new(context);
         metrics.update(size, pruning_boundary, items_per_blob);
@@ -766,18 +948,45 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         })
     }
 
+    /// Stage pruning-boundary and recovery-watermark entries directly into raw metadata and
+    /// persist them. Used by [`Self::init`] before constructing `Inner`.
+    async fn persist_metadata_entries_raw(
+        metadata: &mut Metadata<E, u64, VecU64>,
+        items_per_blob: u64,
+        pruning_boundary: u64,
+        recovery_watermark: u64,
+    ) -> Result<(), Error> {
+        let current_pruning = metadata.get(&PRUNING_BOUNDARY_KEY).copied().map(u64::from);
+        if !pruning_boundary.is_multiple_of(items_per_blob) {
+            if current_pruning != Some(pruning_boundary) {
+                metadata.put(PRUNING_BOUNDARY_KEY, pruning_boundary.into());
+            }
+        } else if current_pruning.is_some() {
+            metadata.remove(&PRUNING_BOUNDARY_KEY);
+        }
+        let current_watermark = metadata
+            .get(&RECOVERY_WATERMARK_KEY)
+            .copied()
+            .map(u64::from);
+        if current_watermark != Some(recovery_watermark) {
+            metadata.put(RECOVERY_WATERMARK_KEY, recovery_watermark.into());
+        }
+        metadata.sync().await?;
+        Ok(())
+    }
+
     /// Recover `(pruning_boundary, size, recovery_watermark, repair)` from metadata and blob state.
     ///
     /// Any in-progress `CLEAR_TARGET_KEY` is completed by the caller before this runs, so the
     /// remaining staleness modes are limited to mismatched pruning metadata. The `repair` is a
     /// blob truncation the caller applies after persisting the lowered checkpoint.
     async fn recover_bounds(
-        inner: &mut SegmentedJournal<E, A>,
+        init: &SectionsInit<E>,
         items_per_blob: u64,
         meta_pruning_boundary: Option<u64>,
         meta_recovery_watermark: Option<u64>,
     ) -> Result<(u64, u64, u64, Option<RecoveryRepair>), Error> {
-        let blob_boundary = match inner.oldest_section() {
+        let blob_boundary = match init.oldest_section() {
             Some(oldest) => oldest
                 .checked_mul(items_per_blob)
                 .ok_or(Error::OffsetOverflow)?,
@@ -801,7 +1010,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                 if !meta_pruning_boundary.is_multiple_of(items_per_blob) =>
             {
                 let meta_oldest_section = meta_pruning_boundary / items_per_blob;
-                match inner.oldest_section() {
+                match init.oldest_section() {
                     None => {
                         warn!(
                             meta_oldest_section,
@@ -835,20 +1044,20 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         };
 
         // Check oldest section for over-capacity corruption before recovery mode dispatch.
-        Self::validate_oldest_section(inner, items_per_blob, pruning_boundary).await?;
+        Self::validate_oldest_section(init, items_per_blob, pruning_boundary).await?;
 
         // Perform any recovery if needed, computing journal size and recovery watermark.
         let (size, repair) = match meta_recovery_watermark {
             Some(_) => {
-                Self::recover_by_walking_lengths(inner, items_per_blob, pruning_boundary).await?
+                Self::recover_by_walking_lengths(init, items_per_blob, pruning_boundary).await?
             }
             None if !pruning_metadata_stale => {
                 // No stale pruning metadata and no recovery watermark implies a legacy format.
-                Self::recover_legacy_size(inner, items_per_blob, pruning_boundary).await?
+                Self::recover_legacy_size(init, items_per_blob, pruning_boundary).await?
             }
             None => {
                 // Pruning metadata was stale, and there is no recovery watermark to preserve.
-                Self::recover_by_walking_lengths(inner, items_per_blob, pruning_boundary).await?
+                Self::recover_by_walking_lengths(init, items_per_blob, pruning_boundary).await?
             }
         };
         let recovery_watermark = meta_recovery_watermark.unwrap_or(size).min(size);
@@ -858,15 +1067,15 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
     /// Check that the oldest section does not exceed its logical capacity.
     async fn validate_oldest_section(
-        inner: &SegmentedJournal<E, A>,
+        init: &SectionsInit<E>,
         items_per_blob: u64,
         pruning_boundary: u64,
     ) -> Result<(), Error> {
-        let Some(oldest) = inner.oldest_section() else {
+        let Some(oldest) = init.oldest_section() else {
             return Ok(());
         };
 
-        let oldest_len = inner.section_len(oldest).await?;
+        let oldest_len = init.section_size(oldest).await? / Self::CHUNK_SIZE_U64;
         let expected = section_capacity(pruning_boundary, oldest, items_per_blob)?;
 
         if oldest_len > expected {
@@ -879,12 +1088,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     }
 
     async fn section_len_within_capacity(
-        inner: &SegmentedJournal<E, A>,
+        init: &SectionsInit<E>,
         items_per_blob: u64,
         pruning_boundary: u64,
         section: u64,
     ) -> Result<(u64, u64), Error> {
-        let len = inner.section_len(section).await?;
+        let len = init.section_size(section).await? / Self::CHUNK_SIZE_U64;
         let capacity = section_capacity(pruning_boundary, section, items_per_blob)?;
         if len > capacity {
             return Err(Error::Corruption(format!(
@@ -901,28 +1110,28 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// walking all retained sections. If the oldest non-tail section is already short, the legacy
     /// invariant is violated and recovery keeps only the contiguous prefix.
     async fn recover_legacy_size(
-        inner: &mut SegmentedJournal<E, A>,
+        init: &SectionsInit<E>,
         items_per_blob: u64,
         pruning_boundary: u64,
     ) -> Result<(u64, Option<RecoveryRepair>), Error> {
-        let Some(newest) = inner.newest_section() else {
+        let Some(newest) = init.newest_section() else {
             return Ok((pruning_boundary, None));
         };
-        let Some(oldest) = inner.oldest_section() else {
+        let Some(oldest) = init.oldest_section() else {
             return Ok((pruning_boundary, None));
         };
 
         let (oldest_len, oldest_capacity) =
-            Self::section_len_within_capacity(inner, items_per_blob, pruning_boundary, oldest)
+            Self::section_len_within_capacity(init, items_per_blob, pruning_boundary, oldest)
                 .await?;
         if oldest != newest && oldest_len < oldest_capacity {
             // This cannot be a valid legacy state under the old rollover-sync rule, but walking
             // lengths still recovers the contiguous prefix without trusting the stale size.
-            return Self::recover_by_walking_lengths(inner, items_per_blob, pruning_boundary).await;
+            return Self::recover_by_walking_lengths(init, items_per_blob, pruning_boundary).await;
         }
 
         let (tail_len, _) =
-            Self::section_len_within_capacity(inner, items_per_blob, pruning_boundary, newest)
+            Self::section_len_within_capacity(init, items_per_blob, pruning_boundary, newest)
                 .await?;
         let size = first_in_section(pruning_boundary, newest, items_per_blob)?
             .checked_add(tail_len)
@@ -935,19 +1144,19 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// This is the normal current-format crash-repair path. Legacy recovery uses it only when the
     /// old rollover invariant is already violated or pruning metadata was stale.
     async fn recover_by_walking_lengths(
-        inner: &mut SegmentedJournal<E, A>,
+        init: &SectionsInit<E>,
         items_per_blob: u64,
         pruning_boundary: u64,
     ) -> Result<(u64, Option<RecoveryRepair>), Error> {
-        let oldest = inner.oldest_section();
-        let newest = inner.newest_section();
+        let oldest = init.oldest_section();
+        let newest = init.newest_section();
 
         let (Some(oldest), Some(newest)) = (oldest, newest) else {
             return Ok((pruning_boundary, None));
         };
 
         // The oldest section's capacity was already checked before recovery mode dispatch.
-        let oldest_len = inner.section_len(oldest).await?;
+        let oldest_len = init.section_size(oldest).await? / Self::CHUNK_SIZE_U64;
         let expected_oldest = section_capacity(pruning_boundary, oldest, items_per_blob)?;
         let mut size = pruning_boundary
             .checked_add(oldest_len)
@@ -969,14 +1178,37 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             ));
         }
 
-        for section in oldest + 1..=newest {
+        let sections = init.sections();
+        let section_count = sections.len();
+        let mut expected = oldest.checked_add(1);
+        for (idx, section) in sections.into_iter().enumerate().skip(1) {
+            let Some(expected_section) = expected else {
+                return Err(Error::Corruption(format!(
+                    "section {section} follows terminal section {oldest}"
+                )));
+            };
+            if section < expected_section {
+                return Err(Error::Corruption(format!(
+                    "section ids out of order: expected at least {expected_section}, got {section}"
+                )));
+            }
+            if section > expected_section {
+                return Ok((
+                    size,
+                    Some(RecoveryRepair {
+                        section: expected_section,
+                        byte_offset: 0,
+                    }),
+                ));
+            }
+
             let (len, capacity) =
-                Self::section_len_within_capacity(inner, items_per_blob, pruning_boundary, section)
+                Self::section_len_within_capacity(init, items_per_blob, pruning_boundary, section)
                     .await?;
 
             size = size.checked_add(len).ok_or(Error::OffsetOverflow)?;
             if len < capacity {
-                if section == newest {
+                if idx + 1 == section_count {
                     return Ok((size, None));
                 }
                 return Ok((
@@ -989,6 +1221,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                     }),
                 ));
             }
+            expected = section.checked_add(1);
         }
 
         Ok((size, None))
@@ -1086,23 +1319,24 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
     /// Flush dirty sections to storage under the read lock, allowing concurrent reads.
     ///
-    /// Sections are synced concurrently. Ordering is not required for recovery: appends only add
-    /// data, so committed sections are never at risk, and recovery truncates at the first short or
-    /// missing section, so a crash that leaves a gap still recovers a contiguous prefix no shorter
-    /// than the last completed commit.
+    /// Sections are synced in section order. Ordering is not required for recovery: appends only
+    /// add data, so committed sections are never at risk, and recovery truncates at the first short
+    /// or missing section, so a crash that leaves a gap still recovers a contiguous prefix no
+    /// shorter than the last completed commit.
     async fn flush_dirty_sections(&self) -> Result<(), Error> {
         let inner = self.inner.read().await;
         if let Some(start_section) = inner.dirty_from_section {
             let tail_section = inner.size / self.items_per_blob;
             let start_section = inner
-                .journal
+                .sections
                 .oldest_section()
                 .map(|oldest| start_section.max(oldest))
                 // With no retained blobs, any earlier dirty section was cleared or pruned.
                 // Syncing the tail section is harmless when it does not exist.
                 .unwrap_or(tail_section);
-            try_join_all((start_section..=tail_section).map(|section| inner.journal.sync(section)))
-                .await?;
+            for section in start_section..=tail_section {
+                inner.sections.sync_section(section).await?;
+            }
         }
         Ok(())
     }
@@ -1230,16 +1464,27 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             let batch_count = remaining_space.min(items_count - written);
             let start = written * A::SIZE;
             let end = start + batch_count * A::SIZE;
+            let new_size = inner
+                .size
+                .checked_add(batch_count as u64)
+                .ok_or(Error::OffsetOverflow)?;
+            let next_section = if new_size.is_multiple_of(self.items_per_blob) {
+                Some(section.checked_add(1).ok_or(Error::OffsetOverflow)?)
+            } else {
+                None
+            };
 
             inner
-                .journal
-                .append_raw(section, &items_buf[start..end])
+                .sections
+                .append_to_tail(&items_buf[start..end])
                 .await?;
-            inner.size += batch_count as u64;
+            inner.size = new_size;
             written += batch_count;
 
-            if inner.size.is_multiple_of(self.items_per_blob) {
-                inner.journal.ensure_section_exists(section + 1).await?;
+            if let Some(next_section) = next_section {
+                // Seal the just-filled tail and open the next section as the new tail. This does
+                // NOT fsync the old section -- dirty tracking still covers it until commit/sync.
+                inner.sections.roll_tail(next_section).await?;
             }
         }
 
@@ -1287,7 +1532,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         }
 
         let mut inner = self.inner.write().await;
-        inner.journal.rewind(section, byte_offset).await?;
+        inner.sections.rewind(section, byte_offset).await?;
         inner.size = size;
         Self::mark_dirty_from(&mut inner, section);
         self.metrics
@@ -1321,17 +1566,25 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // Cap to tail section. The tail section is guaranteed to exist by our invariant.
         let min_section = std::cmp::min(target_section, tail_section);
 
-        let pruned = inner.journal.prune(min_section).await?;
+        let pruned = inner.sections.prune(min_section).await?;
 
         // After pruning, update pruning_boundary to the start of the oldest remaining section
         if pruned {
             let new_oldest = inner
-                .journal
+                .sections
                 .oldest_section()
                 .expect("all sections pruned - violates tail section invariant");
+            let new_boundary = new_oldest
+                .checked_mul(self.items_per_blob)
+                .ok_or(Error::OffsetOverflow)?;
             // Pruning boundary only moves forward
-            assert!(inner.pruning_boundary < new_oldest * self.items_per_blob);
-            inner.pruning_boundary = new_oldest * self.items_per_blob;
+            if inner.pruning_boundary >= new_boundary {
+                return Err(Error::Corruption(format!(
+                    "pruning boundary {} not before new oldest section boundary {new_boundary}",
+                    inner.pruning_boundary
+                )));
+            }
+            inner.pruning_boundary = new_boundary;
             if let Some(dirty_from) = inner.dirty_from_section {
                 inner.dirty_from_section = Some(dirty_from.max(new_oldest));
             }
@@ -1344,9 +1597,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
     /// Remove any persisted data created by the journal.
     pub async fn destroy(self) -> Result<(), Error> {
-        // Destroy inner journal
+        // Destroy section blobs and the blob partition itself.
         let inner = self.inner.into_inner();
-        inner.journal.destroy().await?;
+        inner.sections.destroy().await?;
 
         // Destroy metadata
         inner.metadata.destroy().await?;
@@ -1374,9 +1627,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         inner.metadata.sync().await?;
 
         let Inner {
-            journal, metadata, ..
+            sections, metadata, ..
         } = &mut *inner;
-        Self::complete_clear_to_size(journal, metadata, self.items_per_blob, new_size).await?;
+        Self::complete_clear_to_size(sections, metadata, self.items_per_blob, new_size).await?;
 
         inner.size = new_size;
         inner.pruning_boundary = new_size;
@@ -1400,7 +1653,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
         Self::lower_recovery_watermark(&mut inner, new_size);
         inner.metadata.put(CLEAR_TARGET_KEY, new_size.into());
-        inner.metadata.sync().await.map_err(Into::into)
+        inner.metadata.sync().await?;
+        Ok(())
     }
 
     /// Test helper: Read the item at the given position.
@@ -1415,18 +1669,18 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         self.reader().await.bounds()
     }
 
-    /// Test helper: Get the oldest section from the internal segmented journal.
+    /// Test helper: Get the oldest section from the section store.
     #[cfg(test)]
     pub(crate) async fn test_oldest_section(&self) -> Option<u64> {
         let inner = self.inner.read().await;
-        inner.journal.oldest_section()
+        inner.sections.oldest_section()
     }
 
-    /// Test helper: Get the newest section from the internal segmented journal.
+    /// Test helper: Get the newest section from the section store.
     #[cfg(test)]
     pub(crate) async fn test_newest_section(&self) -> Option<u64> {
         let inner = self.inner.read().await;
-        inner.journal.newest_section()
+        inner.sections.newest_section()
     }
 
     /// Test helper: Set and persist the recovery watermark directly.
@@ -1434,7 +1688,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     pub(crate) async fn test_set_recovery_watermark(&self, watermark: u64) -> Result<(), Error> {
         let mut inner = self.inner.write().await;
         inner.metadata.put(RECOVERY_WATERMARK_KEY, watermark.into());
-        inner.metadata.sync().await.map_err(Into::into)
+        inner.metadata.sync().await?;
+        Ok(())
     }
 }
 
@@ -1726,8 +1981,14 @@ mod tests {
 
             // Check no-op pruning
             journal.prune(0).await.expect("no-op pruning failed");
-            assert_eq!(journal.inner.read().await.journal.oldest_section(), Some(1));
-            assert_eq!(journal.inner.read().await.journal.newest_section(), Some(5));
+            assert_eq!(
+                journal.inner.read().await.sections.oldest_section(),
+                Some(1)
+            );
+            assert_eq!(
+                journal.inner.read().await.sections.newest_section(),
+                Some(5)
+            );
             assert_eq!(journal.bounds().await.start, 2);
 
             // Prune first 3 blobs (6 items)
@@ -1735,8 +1996,14 @@ mod tests {
                 .prune(3 * cfg.items_per_blob.get())
                 .await
                 .expect("failed to prune journal 2");
-            assert_eq!(journal.inner.read().await.journal.oldest_section(), Some(3));
-            assert_eq!(journal.inner.read().await.journal.newest_section(), Some(5));
+            assert_eq!(
+                journal.inner.read().await.sections.oldest_section(),
+                Some(3)
+            );
+            assert_eq!(
+                journal.inner.read().await.sections.newest_section(),
+                Some(5)
+            );
             assert_eq!(journal.bounds().await.start, 6);
 
             // Try pruning (more than) everything in the journal.
@@ -2254,31 +2521,28 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(5));
-            let segmented_cfg = SegmentedConfig {
-                partition: blob_partition(&cfg),
-                page_cache: cfg.page_cache.clone(),
-                write_buffer: cfg.write_buffer,
-            };
-            let mut inner =
-                SegmentedJournal::<_, Digest>::init(context.child("blobs"), segmented_cfg)
-                    .await
-                    .unwrap();
 
-            for i in 0..5 {
-                inner.append(0, &test_digest(i)).await.unwrap();
-            }
-            for i in 5..7 {
-                inner.append(1, &test_digest(i)).await.unwrap();
-            }
-            inner.sync(0).await.unwrap();
-            inner.sync(1).await.unwrap();
-
-            let (size, repair) = Journal::<_, Digest>::recover_by_walking_lengths(&mut inner, 5, 0)
+            // Set up via the public API: 5 items in section 0 (full) + 2 items in section 1
+            // (partial), then sync and drop.
+            let journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(size, 7);
-            assert!(repair.is_none());
-            inner.destroy().await.unwrap();
+            for i in 0..7 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Reopen and verify the size is exactly 7 with no repair (a clean short tail).
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.size().await, 7);
+            // Sections 0 and 1 exist and we can read every position.
+            for i in 0..7u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
         });
     }
 
@@ -2287,29 +2551,70 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(5));
-            let segmented_cfg = SegmentedConfig {
-                partition: blob_partition(&cfg),
-                page_cache: cfg.page_cache.clone(),
-                write_buffer: cfg.write_buffer,
-            };
-            let mut inner =
-                SegmentedJournal::<_, Digest>::init(context.child("blobs"), segmented_cfg)
-                    .await
-                    .unwrap();
 
-            for i in 0..5 {
-                inner.append(0, &test_digest(i)).await.unwrap();
-            }
-            inner.ensure_section_exists(1).await.unwrap();
-            inner.sync(0).await.unwrap();
-            inner.sync(1).await.unwrap();
-
-            let (size, repair) = Journal::<_, Digest>::recover_by_walking_lengths(&mut inner, 5, 0)
+            // Set up via the public API: 5 items in section 0 (full); rolling over implicitly
+            // creates an empty section 1 as the tail. Sync and drop.
+            let journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(size, 5);
-            assert!(repair.is_none());
-            inner.destroy().await.unwrap();
+            for i in 0..5 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Reopen: section 0 is full, section 1 is the empty tail. Size = 5, no repair.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.size().await, 5);
+            for i in 0..5u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            assert_eq!(journal.test_newest_section().await, Some(1));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_recover_sparse_section_ids_repairs_at_gap() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(1));
+            let blob_partition = blob_partition(&cfg);
+
+            let journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            journal.append(&test_digest(0)).await.unwrap();
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Add a far-future section directly. Recovery should inspect actual section ids and
+            // repair at the first missing boundary instead of walking the entire numeric range.
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+            let (blob, blob_size) = context
+                .open(&blob_partition, &u64::MAX.to_be_bytes())
+                .await
+                .unwrap();
+            let append = Append::new(blob, blob_size, 2048, cache_ref).await.unwrap();
+            let extra = test_digest(999);
+            append.append(extra.as_ref()).await.unwrap();
+            append.sync().await.unwrap();
+            drop(append);
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..1);
+            assert_eq!(journal.read(0).await.unwrap(), test_digest(0));
+            assert!(matches!(
+                journal.read(1).await,
+                Err(Error::ItemOutOfRange(1))
+            ));
+            assert_eq!(journal.test_newest_section().await, Some(1));
+
+            journal.destroy().await.unwrap();
         });
     }
 
@@ -2406,7 +2711,10 @@ mod tests {
                 Err(Error::ItemOutOfRange(9))
             ));
             assert_eq!(journal.test_oldest_section().await, Some(1));
-            assert_eq!(journal.inner.read().await.journal.newest_section(), Some(1));
+            assert_eq!(
+                journal.inner.read().await.sections.newest_section(),
+                Some(1)
+            );
 
             journal.destroy().await.unwrap();
         });
@@ -2431,18 +2739,10 @@ mod tests {
             journal.sync().await.expect("failed to sync journal");
             assert_eq!(journal.bounds().await, 7..17);
 
+            // Stage the stale forward-looking watermark while the journal is alive (so we go
+            // through the public metadata path), then drop and corrupt the underlying blob.
             {
                 let mut inner = journal.inner.write().await;
-                inner
-                    .journal
-                    .rewind_section(2, 2 * Digest::SIZE as u64)
-                    .await
-                    .expect("failed to shorten anchored section");
-                inner
-                    .journal
-                    .sync(2)
-                    .await
-                    .expect("failed to sync shortened anchored section");
                 inner.metadata.put(RECOVERY_WATERMARK_KEY, 12u64.into());
                 inner
                     .metadata
@@ -2451,6 +2751,24 @@ mod tests {
                     .expect("failed to sync recovery watermark");
             }
             drop(journal);
+
+            // Shorten section 2 to two items via Append::resize so the on-disk logical view
+            // matches the staged watermark of 12.
+            {
+                let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+                let (blob, blob_size) = context
+                    .open(&blob_partition(&cfg), &2u64.to_be_bytes())
+                    .await
+                    .expect("failed to open section 2");
+                let append = Append::new(blob, blob_size, 2048, cache_ref)
+                    .await
+                    .expect("failed to wrap section 2");
+                append
+                    .resize(2 * Digest::SIZE as u64)
+                    .await
+                    .expect("failed to shorten anchored section");
+                append.sync().await.expect("failed to sync section 2");
+            }
 
             // Remove the metadata's oldest section so PRUNING_BOUNDARY_KEY=7 is stale. The
             // watermark is preserved because length-based recovery ends at the same point.
@@ -2626,6 +2944,33 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_fixed_journal_commit_does_not_advance_recovery_watermark() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let journal = Journal::<_, Digest>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+
+            journal.append(&test_digest(0)).await.unwrap();
+            journal.sync().await.unwrap();
+            assert_eq!(journal.recovery_watermark().await, 1);
+
+            journal.append(&test_digest(1)).await.unwrap();
+            journal.commit().await.unwrap();
+            assert_eq!(
+                journal.recovery_watermark().await,
+                1,
+                "commit must make dirty sections durable without advancing the recovery watermark",
+            );
+
+            journal.sync().await.unwrap();
+            assert_eq!(journal.recovery_watermark().await, 2);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_fixed_journal_prune_to_blob_boundary_removes_pruning_metadata() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -2684,22 +3029,29 @@ mod tests {
                     .expect("failed to append data");
             }
             journal.sync().await.expect("failed to sync journal");
+            drop(journal);
 
+            // Inject an extra item into section 0 at the blob level so its length exceeds
+            // items_per_blob -- this is what `recover_bounds` validates and rejects as Corruption.
             {
                 let extra = test_digest(99);
-                let mut inner = journal.inner.write().await;
-                inner
-                    .journal
-                    .append_raw(0, extra.as_ref())
+                let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+                let (blob, blob_size) = context
+                    .open(&blob_partition(&cfg), &0u64.to_be_bytes())
+                    .await
+                    .expect("failed to open section 0");
+                let append = Append::new(blob, blob_size, 2048, cache_ref)
+                    .await
+                    .expect("failed to wrap section 0");
+                append
+                    .append(extra.as_ref())
                     .await
                     .expect("failed to append extra item");
-                inner
-                    .journal
-                    .sync(0)
+                append
+                    .sync()
                     .await
                     .expect("failed to sync corrupted section");
             }
-            drop(journal);
 
             let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
             assert!(matches!(result, Err(Error::Corruption(_))));
@@ -2723,21 +3075,27 @@ mod tests {
             }
             journal.sync().await.expect("failed to sync journal");
             assert_eq!(journal.recovery_watermark().await, 15);
+            drop(journal);
 
+            // Shorten section 1 to 4 items via blob-level Append::resize.
             {
-                let mut inner = journal.inner.write().await;
-                inner
-                    .journal
-                    .rewind_section(1, 4 * Digest::SIZE as u64)
+                let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+                let (blob, blob_size) = context
+                    .open(&blob_partition(&cfg), &1u64.to_be_bytes())
+                    .await
+                    .expect("failed to open section 1");
+                let append = Append::new(blob, blob_size, 2048, cache_ref)
+                    .await
+                    .expect("failed to wrap section 1");
+                append
+                    .resize(4 * Digest::SIZE as u64)
                     .await
                     .expect("failed to shorten middle section");
-                inner
-                    .journal
-                    .sync(1)
+                append
+                    .sync()
                     .await
                     .expect("failed to sync shortened middle section");
             }
-            drop(journal);
 
             // Remove the empty tail so the watermark points beyond newest. Recovery now keeps the
             // contiguous prefix up to the short section and lowers the watermark.
@@ -3321,8 +3679,8 @@ mod tests {
             // multi-section sync became durable.
             {
                 let inner = journal.inner.write().await;
-                inner.journal.sync(0).await.unwrap();
-                inner.journal.sync(1).await.unwrap();
+                inner.sections.sync_section(0).await.unwrap();
+                inner.sections.sync_section(1).await.unwrap();
             }
             drop(journal);
 
@@ -3390,7 +3748,7 @@ mod tests {
             }
             {
                 let inner = journal.inner.write().await;
-                inner.journal.sync(2).await.unwrap();
+                inner.sections.sync_section(2).await.unwrap();
             }
             drop(journal);
 
@@ -3846,6 +4204,25 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_fixed_journal_append_after_max_size_returns_overflow() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(1));
+            cfg.partition = "max-size-append-overflow".into();
+            let journal =
+                Journal::<_, Digest>::init_at_size(context.child("storage"), cfg.clone(), u64::MAX)
+                    .await
+                    .unwrap();
+
+            let err = journal.append(&test_digest(100)).await.unwrap_err();
+            assert!(matches!(err, Error::OffsetOverflow));
+            assert_eq!(journal.bounds().await, u64::MAX..u64::MAX);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_fixed_journal_init_at_size_section_boundary() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -4200,7 +4577,10 @@ mod tests {
             for i in 0..3u64 {
                 journal.append(&test_digest(i)).await.unwrap();
             }
-            assert_eq!(journal.inner.read().await.journal.newest_section(), Some(2));
+            assert_eq!(
+                journal.inner.read().await.sections.newest_section(),
+                Some(2)
+            );
             journal.sync().await.unwrap();
 
             // Simulate metadata deletion (corruption).
@@ -4294,6 +4674,29 @@ mod tests {
             // Prune to position 5 (section 1 start) should NOT move boundary back from 7 to 5
             journal.prune(5).await.unwrap();
             assert_eq!(journal.bounds().await.start, 7);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_prune_adjusts_dirty_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let journal = Journal::<_, Digest>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+
+            for i in 0..12 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+
+            journal.prune(5).await.unwrap();
+            journal
+                .commit()
+                .await
+                .expect("commit should not try to sync pruned dirty sections");
+            assert_eq!(journal.bounds().await, 5..12);
             journal.destroy().await.unwrap();
         });
     }
@@ -4554,6 +4957,38 @@ mod tests {
             assert_eq!(journal.bounds().await, 100..100);
             let pos = journal.append(&test_digest(100)).await.unwrap();
             assert_eq!(pos, 100);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_clear_intent_skips_corrupt_stale_blobs() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let blob_part = blob_partition(&cfg);
+            let meta_cfg = MetadataConfig {
+                partition: format!("{}-metadata", cfg.partition),
+                codec_config: (),
+            };
+            let mut metadata = Metadata::<_, u64, VecU64>::init(context.child("meta"), meta_cfg)
+                .await
+                .unwrap();
+            metadata.put(CLEAR_TARGET_KEY, 12u64.into());
+            metadata.sync().await.unwrap();
+            drop(metadata);
+
+            // This name would fail `SectionsInit::open` if init tried to parse stale blobs before
+            // honoring the clear intent.
+            let (blob, _) = context.open(&blob_part, b"not-u64").await.unwrap();
+            blob.write_at_sync(0, vec![1, 2, 3]).await.unwrap();
+            drop(blob);
+
+            let journal = Journal::<_, Digest>::init(context.child("recover"), cfg.clone())
+                .await
+                .expect("clear intent should discard stale corrupt blobs before section parsing");
+            assert_eq!(journal.bounds().await, 12..12);
+            assert_eq!(journal.recovery_watermark().await, 12);
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1529,8 +1529,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     ///
     /// * This operation is not guaranteed to survive restarts until `commit()` or `sync()` is
     ///   called.
-    /// * This operation is not atomic, but it will always leave the journal in a consistent state
-    ///   in the event of failure since blobs are always removed from newest to oldest.
+    /// * This operation is not atomic. Its on-disk updates are ordered (sections removed
+    ///   newest-to-oldest) so that restart recovery always rebuilds a contiguous retained prefix.
     pub async fn rewind(&self, size: u64) -> Result<(), Error> {
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;

--- a/storage/src/journal/contiguous/metrics.rs
+++ b/storage/src/journal/contiguous/metrics.rs
@@ -295,3 +295,23 @@ impl<E: Clock> Deref for VariableMetrics<E> {
         &self.common
     }
 }
+
+/// Metrics for the sealed-tail section store.
+pub(super) struct SectionsMetrics {
+    /// Number of sections (sealed + tail) currently held.
+    pub tracked: Gauge,
+    /// Number of underlying section blob syncs triggered by `Sections`.
+    pub synced: Counter,
+    /// Number of sections removed by `Sections::prune`.
+    pub pruned: Counter,
+}
+
+impl SectionsMetrics {
+    pub(super) fn new<E: RuntimeMetrics>(context: &E) -> Self {
+        Self {
+            tracked: context.gauge("tracked", "Number of sections held"),
+            synced: context.counter("synced", "Number of section sync calls"),
+            pruned: context.counter("pruned", "Number of sections pruned"),
+        }
+    }
+}

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -11,6 +11,7 @@ use tracing::warn;
 
 pub mod fixed;
 mod metrics;
+mod sections;
 pub mod variable;
 
 #[cfg(test)]

--- a/storage/src/journal/contiguous/sections.rs
+++ b/storage/src/journal/contiguous/sections.rs
@@ -1,0 +1,956 @@
+//! Typed section store for contiguous journals.
+//!
+//! Contiguous journals maintain a section lifecycle invariant: only the newest section (the tail)
+//! ever receives new bytes; every historical section is full and immutable. This module encodes
+//! that invariant in two types:
+//!
+//! - [`SectionsInit`] — opened during recovery, holds every section as a writable
+//!   [`Append`]. The caller can inspect sizes and truncate trailing bytes from any section before
+//!   transitioning to steady state.
+//! - [`Sections`] — steady state. Historical sections are [`Sealed`] (no `RwLock`, cheap clones);
+//!   at most one tail is [`Append`]. The type does not expose a method that would let the caller
+//!   mutate a sealed section.
+//!
+//! Both types embed a private [`SectionsCore`] that owns shared plumbing (the runtime context, the
+//! partition name, the page cache, metrics, and the in-process prune guard).
+//!
+//! # Durability
+//!
+//! Sealing a tail writes buffered bytes to the blob but does not fsync them.
+//! [`Sections::sync_section`] dispatches to either [`Sealed::sync`] or [`Append::sync`] and is what
+//! the journal's commit/sync loop calls to make a dirty (sealed or tail) section durable.
+//! Journal-level dirty tracking must therefore continue to cover a section after
+//! [`Sections::roll_tail`] seals it.
+
+use crate::{
+    journal::{contiguous::metrics::SectionsMetrics, Error},
+    Context,
+};
+use commonware_formatting::hex;
+use commonware_runtime::{
+    buffer::paged::{Append, CacheRef, Replay, Sealed},
+    telemetry::metrics::GaugeExt as _,
+    Blob, Error as RError, IoBufs,
+};
+use std::{collections::BTreeMap, num::NonZeroUsize};
+use tracing::debug;
+
+/// Configuration for [`SectionsInit`] / [`Sections`].
+#[derive(Clone)]
+pub(super) struct Config {
+    /// Partition where blobs live. Each section is one blob named by its `u64` big-endian bytes.
+    pub partition: String,
+    /// The page cache used for reads of full pages.
+    pub page_cache: CacheRef,
+    /// The capacity, in bytes, of the tail's write buffer.
+    pub write_buffer: NonZeroUsize,
+}
+
+/// Shared plumbing embedded in both [`SectionsInit`] and [`Sections`].
+struct SectionsCore<E: Context> {
+    context: E,
+    partition: String,
+    page_cache: CacheRef,
+    write_buffer: NonZeroUsize,
+
+    /// Sections pruned during the current process. Reads / syncs of any section below this return
+    /// [`Error::AlreadyPrunedToSection`]. Not persisted across restarts.
+    oldest_retained_section: u64,
+
+    metrics: SectionsMetrics,
+}
+
+impl<E: Context> SectionsCore<E> {
+    fn new(
+        context: E,
+        partition: String,
+        page_cache: CacheRef,
+        write_buffer: NonZeroUsize,
+        tracked: usize,
+    ) -> Self {
+        let metrics = SectionsMetrics::new(&context);
+        let _ = metrics.tracked.try_set(tracked);
+        Self {
+            context,
+            partition,
+            page_cache,
+            write_buffer,
+            oldest_retained_section: 0,
+            metrics,
+        }
+    }
+
+    /// Open `section`'s blob as a writable [`Append`]. Creates the blob if it does not exist.
+    async fn open_append(&self, section: u64) -> Result<Append<E::Blob>, Error> {
+        let name = section.to_be_bytes();
+        let (blob, size) = self
+            .context
+            .open(&self.partition, &name)
+            .await
+            .map_err(Error::Runtime)?;
+        Append::new(blob, size, self.write_buffer.get(), self.page_cache.clone())
+            .await
+            .map_err(Error::Runtime)
+    }
+
+    /// Remove `section`'s blob from storage.
+    async fn remove_blob(&self, section: u64) -> Result<(), Error> {
+        self.context
+            .remove(&self.partition, Some(&section.to_be_bytes()))
+            .await
+            .map_err(Error::Runtime)
+    }
+
+    /// Remove the partition itself, treating "already missing" as success.
+    async fn remove_partition(&self) -> Result<(), Error> {
+        match self.context.remove(&self.partition, None).await {
+            Ok(()) | Err(RError::PartitionMissing(_)) => Ok(()),
+            Err(err) => Err(Error::Runtime(err)),
+        }
+    }
+
+    /// Rejects reads / syncs of sections that were pruned during the current process.
+    const fn prune_guard(&self, section: u64) -> Result<(), Error> {
+        if section < self.oldest_retained_section {
+            Err(Error::AlreadyPrunedToSection(self.oldest_retained_section))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Recovery-phase section store. Every section is held as a writable [`Append`] so the caller can
+/// inspect sizes and apply truncations before transitioning to steady state.
+pub(super) struct SectionsInit<E: Context> {
+    core: SectionsCore<E>,
+    pending: BTreeMap<u64, Append<E::Blob>>,
+}
+
+impl<E: Context> SectionsInit<E> {
+    /// Scan the partition and open every existing blob as an [`Append`].
+    pub(super) async fn open(context: E, cfg: Config) -> Result<Self, Error> {
+        let stored = match context.scan(&cfg.partition).await {
+            Ok(names) => names,
+            Err(RError::PartitionMissing(_)) => Vec::new(),
+            Err(err) => return Err(Error::Runtime(err)),
+        };
+
+        let mut pending = BTreeMap::new();
+        for name in stored {
+            let hex_name = hex(&name);
+            let bytes: [u8; 8] = name
+                .clone()
+                .try_into()
+                .map_err(|_| Error::InvalidBlobName(hex_name.clone()))?;
+            let section = u64::from_be_bytes(bytes);
+            let (blob, size) = context
+                .open(&cfg.partition, &name)
+                .await
+                .map_err(Error::Runtime)?;
+            debug!(section, blob = hex_name, size, "loaded section");
+            let append = Append::new(blob, size, cfg.write_buffer.get(), cfg.page_cache.clone())
+                .await
+                .map_err(Error::Runtime)?;
+            pending.insert(section, append);
+        }
+
+        let core = SectionsCore::new(
+            context,
+            cfg.partition,
+            cfg.page_cache,
+            cfg.write_buffer,
+            pending.len(),
+        );
+        Ok(Self { core, pending })
+    }
+
+    /// All section numbers in ascending order.
+    pub(super) fn sections(&self) -> Vec<u64> {
+        self.pending.keys().copied().collect()
+    }
+
+    pub(super) fn oldest_section(&self) -> Option<u64> {
+        self.pending.keys().next().copied()
+    }
+
+    pub(super) fn newest_section(&self) -> Option<u64> {
+        self.pending.keys().next_back().copied()
+    }
+
+    /// Logical size, in bytes, of the given section. Returns 0 if the section does not exist.
+    pub(super) async fn section_size(&self, section: u64) -> Result<u64, Error> {
+        match self.pending.get(&section) {
+            Some(blob) => Ok(blob.size().await),
+            None => Ok(0),
+        }
+    }
+
+    /// Shrink the given section to `size` bytes. No-op if the section is absent or already at or
+    /// below the requested size. Shrinking is synced so init-time repairs are durable before
+    /// [`Self::into_sections`] runs.
+    pub(super) async fn truncate_section(&self, section: u64, size: u64) -> Result<(), Error> {
+        let Some(blob) = self.pending.get(&section) else {
+            return Ok(());
+        };
+        let current = blob.size().await;
+        if size < current {
+            blob.resize(size).await.map_err(Error::Runtime)?;
+            blob.sync().await.map_err(Error::Runtime)?;
+        }
+        Ok(())
+    }
+
+    /// Remove a single section (drop the handle, remove the blob).
+    pub(super) async fn remove_section(&mut self, section: u64) -> Result<(), Error> {
+        if let Some(blob) = self.pending.remove(&section) {
+            drop(blob);
+            self.core.remove_blob(section).await?;
+            self.core.metrics.tracked.dec();
+        }
+        Ok(())
+    }
+
+    /// Transition to steady state. Every section strictly less than `tail_section` becomes sealed,
+    /// and the section identified by `tail_section` becomes the tail. If no blob currently exists
+    /// for that section, a fresh empty one is opened. If `tail_section` is `None`, the resulting
+    /// store has no tail.
+    ///
+    /// Repair operations on [`SectionsInit`] sync their own mutations before this method runs.
+    /// Reopening an unchanged section as [`Sealed`] must not force startup fsyncs for every
+    /// historical blob.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Corruption`] if any pending section is strictly greater than the requested
+    /// `tail_section`. The caller must remove such sections first via [`Self::remove_section`].
+    pub(super) async fn into_sections(
+        self,
+        tail_section: Option<u64>,
+    ) -> Result<Sections<E>, Error> {
+        if let (Some(tail), Some(newest)) = (tail_section, self.pending.keys().next_back().copied())
+        {
+            if newest > tail {
+                return Err(Error::Corruption(format!(
+                    "into_sections: sections > tail_section {tail} exist (newest={newest})"
+                )));
+            }
+        }
+
+        let mut sealed = BTreeMap::new();
+        let mut tail_slot: Option<Tail<E::Blob>> = None;
+        let core = self.core;
+        for (section, blob) in self.pending {
+            if Some(section) == tail_section {
+                tail_slot = Some(Tail { section, blob });
+            } else {
+                let s = blob.seal().await.map_err(Error::Runtime)?;
+                sealed.insert(section, s);
+            }
+        }
+        // If the caller requested a tail that doesn't exist among the pending blobs, open it.
+        if let Some(tail) = tail_section {
+            if tail_slot.is_none() {
+                let blob = core.open_append(tail).await?;
+                core.metrics.tracked.inc();
+                tail_slot = Some(Tail {
+                    section: tail,
+                    blob,
+                });
+            }
+        }
+
+        Ok(Sections {
+            core,
+            sealed,
+            tail: tail_slot,
+        })
+    }
+
+    /// Remove all existing blobs and install a fresh empty tail at `tail_section`. Used by
+    /// `init_at_size`-style flows and crash-recovery for an interrupted clear.
+    pub(super) async fn reset(mut self, tail_section: u64) -> Result<Sections<E>, Error> {
+        let pending = std::mem::take(&mut self.pending);
+        for (section, blob) in pending {
+            drop(blob);
+            self.core.remove_blob(section).await?;
+        }
+        let _ = self.core.metrics.tracked.try_set(0);
+        self.core.oldest_retained_section = 0;
+
+        let blob = self.core.open_append(tail_section).await?;
+        self.core.metrics.tracked.inc();
+        Ok(Sections {
+            core: self.core,
+            sealed: BTreeMap::new(),
+            tail: Some(Tail {
+                section: tail_section,
+                blob,
+            }),
+        })
+    }
+}
+
+/// The writable tail. Holds the section index and the live [`Append`] handle.
+struct Tail<B: Blob> {
+    section: u64,
+    blob: Append<B>,
+}
+
+/// Steady-state section store. Historical sections are immutable [`Sealed`] views; at most one
+/// section is the writable [`Append`] tail. There is no API that mutates a sealed section.
+pub(super) struct Sections<E: Context> {
+    core: SectionsCore<E>,
+    sealed: BTreeMap<u64, Sealed<E::Blob>>,
+    tail: Option<Tail<E::Blob>>,
+}
+
+impl<E: Context> Sections<E> {
+    /// Oldest section in the store (sealed or tail).
+    pub(super) fn oldest_section(&self) -> Option<u64> {
+        let sealed_oldest = self.sealed.keys().next().copied();
+        let tail_section = self.tail.as_ref().map(|t| t.section);
+        match (sealed_oldest, tail_section) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        }
+    }
+
+    /// Newest section in the store (sealed or tail).
+    pub(super) fn newest_section(&self) -> Option<u64> {
+        let sealed_newest = self.sealed.keys().next_back().copied();
+        let tail_section = self.tail.as_ref().map(|t| t.section);
+        match (sealed_newest, tail_section) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        }
+    }
+
+    /// Section index of the tail, if a tail exists.
+    #[allow(dead_code)]
+    pub(super) fn tail_section(&self) -> Option<u64> {
+        self.tail.as_ref().map(|t| t.section)
+    }
+
+    /// Returns `true` if no sections exist.
+    #[allow(dead_code)]
+    pub(super) fn is_empty(&self) -> bool {
+        self.sealed.is_empty() && self.tail.is_none()
+    }
+
+    /// Logical size, in bytes, of the given section. Returns 0 if the section does not exist.
+    pub(super) async fn section_size(&self, section: u64) -> Result<u64, Error> {
+        self.core.prune_guard(section)?;
+        if let Some(s) = self.sealed.get(&section) {
+            return Ok(s.size());
+        }
+        if let Some(t) = &self.tail {
+            if t.section == section {
+                return Ok(t.blob.size().await);
+            }
+        }
+        // Missing unpruned sections are reported as zero-length so recovery code can distinguish an
+        // empty tail from an out-of-range read.
+        Ok(0)
+    }
+
+    /// Non-blocking variant of [`Self::section_size`]. Returns `None` for any section other than
+    /// the tail when it cannot be observed without waiting.
+    #[allow(dead_code)]
+    pub(super) fn try_section_size(&self, section: u64) -> Option<u64> {
+        if section < self.core.oldest_retained_section {
+            return None;
+        }
+        if let Some(s) = self.sealed.get(&section) {
+            return Some(s.size());
+        }
+        if let Some(t) = &self.tail {
+            if t.section == section {
+                return t.blob.try_size();
+            }
+        }
+        // Mirror `section_size`: absent-but-unpruned sections behave like empty sections for sizing.
+        Some(0)
+    }
+
+    /// Read exactly `len` bytes at `(section, offset)`.
+    pub(super) async fn read_at(
+        &self,
+        section: u64,
+        offset: u64,
+        len: usize,
+    ) -> Result<IoBufs, Error> {
+        self.core.prune_guard(section)?;
+        if let Some(s) = self.sealed.get(&section) {
+            return s.read_at(offset, len).await.map_err(Error::Runtime);
+        }
+        if let Some(t) = &self.tail {
+            if t.section == section {
+                return t.blob.read_at(offset, len).await.map_err(Error::Runtime);
+            }
+        }
+        Err(Error::SectionOutOfRange(section))
+    }
+
+    /// Read multiple disjoint, sorted, equally-sized items from one section into a contiguous
+    /// caller buffer.
+    pub(super) async fn read_many_into(
+        &self,
+        section: u64,
+        buf: &mut [u8],
+        offsets: &[u64],
+        item_size: usize,
+    ) -> Result<(), Error> {
+        self.core.prune_guard(section)?;
+        if let Some(s) = self.sealed.get(&section) {
+            return s
+                .read_many_into(buf, offsets, item_size)
+                .await
+                .map_err(Error::Runtime);
+        }
+        if let Some(t) = &self.tail {
+            if t.section == section {
+                return t
+                    .blob
+                    .read_many_into(buf, offsets, item_size)
+                    .await
+                    .map_err(Error::Runtime);
+            }
+        }
+        Err(Error::SectionOutOfRange(section))
+    }
+
+    /// Synchronous read from page cache / in-memory partial page. Returns `false` if any bytes
+    /// would require I/O.
+    pub(super) fn try_read_sync(&self, section: u64, offset: u64, buf: &mut [u8]) -> bool {
+        if self.core.prune_guard(section).is_err() {
+            return false;
+        }
+        if let Some(s) = self.sealed.get(&section) {
+            return s.try_read_sync(offset, buf);
+        }
+        if let Some(t) = &self.tail {
+            if t.section == section {
+                return t.blob.try_read_sync(offset, buf);
+            }
+        }
+        false
+    }
+
+    /// Return a [`Replay`] of the given section's logical bytes, plus the section's size.
+    pub(super) async fn replay_section(
+        &self,
+        section: u64,
+        buffer: NonZeroUsize,
+    ) -> Result<(Replay<E::Blob>, u64), Error> {
+        self.core.prune_guard(section)?;
+        if let Some(s) = self.sealed.get(&section) {
+            let replay = s.replay(buffer).map_err(Error::Runtime)?;
+            return Ok((replay, s.size()));
+        }
+        if let Some(t) = &self.tail {
+            if t.section == section {
+                let r = t.blob.replay(buffer).await.map_err(Error::Runtime)?;
+                let size = t.blob.size().await;
+                return Ok((r, size));
+            }
+        }
+        Err(Error::SectionOutOfRange(section))
+    }
+
+    /// Append `buf` to the tail. Requires a tail to exist.
+    pub(super) async fn append_to_tail(&self, buf: &[u8]) -> Result<(), Error> {
+        let tail = self
+            .tail
+            .as_ref()
+            .expect("append_to_tail requires an installed tail");
+        tail.blob.append(buf).await.map_err(Error::Runtime)
+    }
+
+    /// Make the given section durable. Dispatches to [`Sealed::sync`] for a historical section or
+    /// [`Append::sync`] for the tail. No-op (and no metric bump) if the section does not exist.
+    pub(super) async fn sync_section(&self, section: u64) -> Result<(), Error> {
+        self.core.prune_guard(section)?;
+        let synced = if let Some(s) = self.sealed.get(&section) {
+            s.sync().await.map_err(Error::Runtime)?;
+            true
+        } else if let Some(t) = &self.tail {
+            if t.section == section {
+                t.blob.sync().await.map_err(Error::Runtime)?;
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if synced {
+            self.core.metrics.synced.inc();
+        }
+        Ok(())
+    }
+
+    /// Open a fresh empty tail at `section`. Panics if a tail already exists.
+    pub(super) async fn install_tail(&mut self, section: u64) -> Result<(), Error> {
+        assert!(self.tail.is_none(), "install_tail requires no current tail");
+        let blob = self.core.open_append(section).await?;
+        self.core.metrics.tracked.inc();
+        self.tail = Some(Tail { section, blob });
+        Ok(())
+    }
+
+    /// Seal the current tail (no fsync) and open `next_section` as the new tail. Panics if no
+    /// tail exists.
+    pub(super) async fn roll_tail(&mut self, next_section: u64) -> Result<(), Error> {
+        let old = self
+            .tail
+            .take()
+            .expect("roll_tail requires an installed tail");
+        let s = old.blob.seal().await.map_err(Error::Runtime)?;
+        self.sealed.insert(old.section, s);
+        let blob = self.core.open_append(next_section).await?;
+        self.core.metrics.tracked.inc();
+        self.tail = Some(Tail {
+            section: next_section,
+            blob,
+        });
+        Ok(())
+    }
+
+    /// Prune all sections strictly less than `min`. Returns `true` if any section was removed.
+    ///
+    /// If the tail's section is below `min`, the tail is removed too — callers that maintain a
+    /// tail invariant must re-install one via [`Self::install_tail`].
+    pub(super) async fn prune(&mut self, min: u64) -> Result<bool, Error> {
+        let mut pruned = false;
+        // Drop sealed sections in ascending order.
+        while let Some((&section, _)) = self.sealed.first_key_value() {
+            if section >= min {
+                break;
+            }
+            let s = self.sealed.remove(&section).unwrap();
+            drop(s);
+            self.core.remove_blob(section).await?;
+            self.core.metrics.tracked.dec();
+            self.core.metrics.pruned.inc();
+            debug!(section, "pruned sealed section");
+            pruned = true;
+        }
+        // If the tail is below min, drop it too.
+        if let Some(tail) = self.tail.as_ref() {
+            if tail.section < min {
+                let old = self.tail.take().unwrap();
+                drop(old.blob);
+                self.core.remove_blob(old.section).await?;
+                self.core.metrics.tracked.dec();
+                self.core.metrics.pruned.inc();
+                debug!(section = old.section, "pruned tail section");
+                pruned = true;
+            }
+        }
+        if pruned {
+            self.core.oldest_retained_section = min;
+        }
+        Ok(pruned)
+    }
+
+    /// Rewind to `(section, size)`. Removes every section strictly greater than `section`
+    /// newest-first, ensures `section` is the tail (opening it if it is missing), and finally
+    /// resizes that tail to `size`.
+    ///
+    /// # Crash safety
+    ///
+    /// Sections are removed newest-first; a crash mid-rewind leaves a contiguous prefix. The
+    /// pre-demote sync runs before any destructive work — a sync failure leaves the in-memory
+    /// state matching the pre-rewind on-disk state.
+    pub(super) async fn rewind(&mut self, section: u64, size: u64) -> Result<(), Error> {
+        self.core.prune_guard(section)?;
+
+        // Step 1: make the target durable before destructive work. If demotion or newer-section
+        // removal later fails, recovery can still retain the target section.
+        let target_is_sealed = if let Some(s) = self.sealed.get(&section) {
+            s.sync().await.map_err(Error::Runtime)?;
+            self.core.metrics.synced.inc();
+            true
+        } else {
+            false
+        };
+
+        // Step 2: collect sections strictly newer than the target, newest-first. Drop the tail if
+        // it's above target.
+        if let Some(tail) = self.tail.as_ref() {
+            if tail.section > section {
+                let old = self.tail.take().unwrap();
+                drop(old.blob);
+                self.core.remove_blob(old.section).await?;
+                self.core.metrics.tracked.dec();
+            }
+        }
+        let to_remove: Vec<u64> = match section.checked_add(1) {
+            Some(after_section) => self
+                .sealed
+                .range(after_section..)
+                .rev()
+                .map(|(&s, _)| s)
+                .collect(),
+            None => Vec::new(),
+        };
+        for s in to_remove {
+            let sealed = self.sealed.remove(&s).unwrap();
+            drop(sealed);
+            self.core.remove_blob(s).await?;
+            self.core.metrics.tracked.dec();
+            debug!(section = s, "removed section during rewind");
+        }
+
+        // Step 3: ensure the target is the tail. If currently sealed, demote. If it was a missing
+        // gap that became exposed by dropping the newer tail, open an empty tail there.
+        if target_is_sealed {
+            // Remove the sealed handle to release its Arc + page-cache id before reopening.
+            // (Both Append::new and the prior Sealed reference the same Blob handle, but only one
+            // should be live at a time per the contiguous invariant.)
+            let _ = self.sealed.remove(&section);
+            self.core.metrics.tracked.dec();
+            let blob = self.core.open_append(section).await?;
+            self.core.metrics.tracked.inc();
+            self.tail = Some(Tail { section, blob });
+        }
+        if self.tail.is_none() {
+            let blob = self.core.open_append(section).await?;
+            self.core.metrics.tracked.inc();
+            self.tail = Some(Tail { section, blob });
+        }
+
+        // Step 4: resize the tail down to `size` (no-op if already shorter).
+        if let Some(tail) = self.tail.as_ref() {
+            if tail.section == section {
+                let current = tail.blob.size().await;
+                if size < current {
+                    tail.blob.resize(size).await.map_err(Error::Runtime)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Drop every section (sealed + tail) and remove all blobs. The store ends up empty.
+    pub(super) async fn clear(&mut self) -> Result<(), Error> {
+        if let Some(old) = self.tail.take() {
+            drop(old.blob);
+            self.core.remove_blob(old.section).await?;
+        }
+        let sealed = std::mem::take(&mut self.sealed);
+        for (section, s) in sealed {
+            drop(s);
+            self.core.remove_blob(section).await?;
+        }
+        let _ = self.core.metrics.tracked.try_set(0);
+        self.core.oldest_retained_section = 0;
+        Ok(())
+    }
+
+    /// Drop every section, remove all blobs AND the partition. Consumes `self`.
+    pub(super) async fn destroy(mut self) -> Result<(), Error> {
+        self.clear().await?;
+        self.core.remove_partition().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_macros::test_traced;
+    use commonware_runtime::{
+        buffer::paged::CacheRef, deterministic, BufferPooler, Runner as _, Supervisor as _,
+    };
+    use commonware_utils::{NZUsize, NZU16};
+    use rstest::rstest;
+    use std::num::NonZeroU16;
+
+    const PAGE_SIZE: NonZeroU16 = NZU16!(64);
+    const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(8);
+    const WRITE_BUFFER: NonZeroUsize = NZUsize!(256);
+
+    fn test_cfg(pooler: &impl BufferPooler, partition: &str) -> Config {
+        Config {
+            partition: partition.into(),
+            page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
+            write_buffer: WRITE_BUFFER,
+        }
+    }
+
+    #[rstest]
+    #[case::missing_section_is_a_noop(1, 2, 0)]
+    #[case::existing_section_can_be_shrunk(0, 2, 2)]
+    #[case::same_size_is_a_noop(0, 5, 5)]
+    #[case::larger_size_is_a_noop(0, 8, 5)]
+    fn test_sections_init_truncate_section(
+        #[case] section: u64,
+        #[case] truncate_to: u64,
+        #[case] expected_size: u64,
+    ) {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-truncate-init");
+
+            {
+                let init = SectionsInit::open(context.child("create"), cfg.clone())
+                    .await
+                    .unwrap();
+                let sections = init.into_sections(Some(0)).await.unwrap();
+                sections.append_to_tail(b"hello").await.unwrap();
+                sections.sync_section(0).await.unwrap();
+            }
+
+            let init = SectionsInit::open(context.child("repair"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Init-time truncation is a repair tool: it only shrinks existing sections and is a
+            // no-op for missing sections or requests at/above the current size.
+            init.truncate_section(section, truncate_to).await.unwrap();
+            drop(init);
+
+            let reopened = SectionsInit::open(context.child("verify"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(reopened.section_size(section).await.unwrap(), expected_size);
+        });
+    }
+
+    /// Empty partition → SectionsInit with no sections → Sections with just a tail.
+    #[test_traced]
+    fn test_sections_init_empty_then_install_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-empty");
+            let init = SectionsInit::open(context, cfg).await.unwrap();
+            assert!(init.sections().is_empty());
+            let sections = init.into_sections(Some(0)).await.unwrap();
+            assert_eq!(sections.tail_section(), Some(0));
+            assert!(sections.sealed.is_empty());
+        });
+    }
+
+    /// `roll_tail` seals the old tail and opens the next one without making the old tail durable.
+    ///
+    /// We assert this indirectly: after roll_tail the in-memory state contains a sealed section
+    /// AND a new tail, but Append::seal's contract guarantees no fsync. The runtime-level
+    /// `test_seal_no_fsync` (in `sealed.rs`) provides the direct proof.
+    #[test_traced]
+    fn test_sections_roll_tail_seals_old_into_sealed_map() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-roll");
+            let init = SectionsInit::open(context, cfg).await.unwrap();
+            let mut sections = init.into_sections(Some(0)).await.unwrap();
+
+            // Append some data into section 0.
+            sections.append_to_tail(b"hello").await.unwrap();
+            // Roll to section 1.
+            sections.roll_tail(1).await.unwrap();
+            assert_eq!(sections.tail_section(), Some(1));
+            assert!(sections.sealed.contains_key(&0));
+
+            // Sealed section 0 must be readable.
+            let bufs = sections.read_at(0, 0, 5).await.unwrap();
+            assert_eq!(bufs.coalesce().as_ref(), b"hello");
+        });
+    }
+
+    /// sync_section dispatches to the sealed handle (after rollover) and to the tail before
+    /// rollover.
+    #[test_traced]
+    fn test_sections_sync_section_dispatches_sealed_and_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-sync");
+            let init = SectionsInit::open(context, cfg).await.unwrap();
+            let mut sections = init.into_sections(Some(0)).await.unwrap();
+
+            sections.append_to_tail(b"a").await.unwrap();
+            // Sync the tail.
+            sections.sync_section(0).await.unwrap();
+            // Roll then sync the now-sealed section 0.
+            sections.roll_tail(1).await.unwrap();
+            sections.sync_section(0).await.unwrap();
+            // sync_section on a missing section is a no-op.
+            sections.sync_section(99).await.unwrap();
+        });
+    }
+
+    /// Rewinding into a sealed section promotes it back to the tail and removes newer sections
+    /// newest-first.
+    #[test_traced]
+    fn test_sections_rewind_promotes_sealed_to_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-rewind");
+            let init = SectionsInit::open(context, cfg).await.unwrap();
+            let mut sections = init.into_sections(Some(0)).await.unwrap();
+
+            // Build sections 0, 1, 2 with data.
+            sections.append_to_tail(b"sec0").await.unwrap();
+            sections.roll_tail(1).await.unwrap();
+            sections.append_to_tail(b"sec1").await.unwrap();
+            sections.roll_tail(2).await.unwrap();
+            sections.append_to_tail(b"sec2").await.unwrap();
+            assert_eq!(sections.tail_section(), Some(2));
+            assert!(sections.sealed.contains_key(&0));
+            assert!(sections.sealed.contains_key(&1));
+
+            // Rewind into sealed section 0.
+            sections.rewind(0, 2).await.unwrap();
+            assert_eq!(sections.tail_section(), Some(0));
+            assert!(sections.sealed.is_empty());
+            assert_eq!(sections.section_size(0).await.unwrap(), 2);
+
+            // Bytes are preserved.
+            let bufs = sections.read_at(0, 0, 2).await.unwrap();
+            assert_eq!(bufs.coalesce().as_ref(), b"se");
+        });
+    }
+
+    /// Rewinding to a missing target opens that section as an empty tail after newer sections are
+    /// removed.
+    #[test_traced]
+    fn test_sections_rewind_installs_missing_target_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-rewind-missing");
+            let init = SectionsInit::open(context, cfg).await.unwrap();
+            let mut sections = init.into_sections(Some(0)).await.unwrap();
+
+            sections.append_to_tail(b"sec0").await.unwrap();
+            sections.roll_tail(2).await.unwrap();
+            sections.append_to_tail(b"sec2").await.unwrap();
+
+            sections.rewind(1, 0).await.unwrap();
+            assert_eq!(sections.tail_section(), Some(1));
+            assert!(sections.sealed.contains_key(&0));
+            assert!(!sections.sealed.contains_key(&2));
+            assert_eq!(sections.section_size(1).await.unwrap(), 0);
+        });
+    }
+
+    /// Rewinding to `u64::MAX` has no newer sections to scan, so the removal range is empty.
+    #[test_traced]
+    fn test_sections_rewind_max_section_does_not_overflow() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-rewind-max");
+            let init = SectionsInit::open(context, cfg).await.unwrap();
+            let mut sections = init.into_sections(None).await.unwrap();
+
+            sections.rewind(u64::MAX, 0).await.unwrap();
+            assert_eq!(sections.tail_section(), Some(u64::MAX));
+            assert_eq!(sections.section_size(u64::MAX).await.unwrap(), 0);
+        });
+    }
+
+    /// Prune drops sections below `min` and updates the in-process retained boundary.
+    #[test_traced]
+    fn test_sections_prune_drops_below_min() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-prune");
+            let init = SectionsInit::open(context, cfg).await.unwrap();
+            let mut sections = init.into_sections(Some(0)).await.unwrap();
+
+            sections.append_to_tail(b"x").await.unwrap();
+            sections.roll_tail(1).await.unwrap();
+            sections.append_to_tail(b"y").await.unwrap();
+            sections.roll_tail(2).await.unwrap();
+
+            assert!(sections.prune(2).await.unwrap());
+            assert_eq!(sections.tail_section(), Some(2));
+            assert!(sections.sealed.is_empty());
+
+            // Read of pruned section returns AlreadyPrunedToSection.
+            let err = sections.section_size(0).await.unwrap_err();
+            assert!(matches!(err, Error::AlreadyPrunedToSection(2)));
+        });
+    }
+
+    /// reset clears all sections and installs a fresh tail.
+    #[test_traced]
+    fn test_sections_init_reset_clears_and_installs_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-reset");
+            // First create some sections.
+            {
+                let init = SectionsInit::open(context.child("a"), cfg.clone())
+                    .await
+                    .unwrap();
+                let mut sections = init.into_sections(Some(0)).await.unwrap();
+                sections.append_to_tail(b"x").await.unwrap();
+                sections.roll_tail(1).await.unwrap();
+                sections.append_to_tail(b"y").await.unwrap();
+                sections.sync_section(1).await.unwrap();
+            }
+
+            // Reopen and reset to a different tail.
+            let init = SectionsInit::open(context.child("b"), cfg).await.unwrap();
+            assert_eq!(init.sections(), vec![0, 1]);
+            let sections = init.reset(5).await.unwrap();
+            assert_eq!(sections.tail_section(), Some(5));
+            assert!(sections.sealed.is_empty());
+            assert_eq!(sections.section_size(5).await.unwrap(), 0);
+        });
+    }
+
+    /// destroy removes blobs AND the partition.
+    #[test_traced]
+    fn test_sections_destroy_removes_partition() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-destroy");
+            // Create state.
+            {
+                let init = SectionsInit::open(context.child("a"), cfg.clone())
+                    .await
+                    .unwrap();
+                let sections = init.into_sections(Some(0)).await.unwrap();
+                sections.append_to_tail(b"x").await.unwrap();
+                sections.sync_section(0).await.unwrap();
+                sections.destroy().await.unwrap();
+            }
+
+            // Reopen — partition is gone, no sections.
+            let init = SectionsInit::open(context.child("b"), cfg).await.unwrap();
+            assert!(init.sections().is_empty());
+        });
+    }
+
+    /// into_sections must reject a tail_section that is not the newest.
+    #[test_traced]
+    fn test_sections_into_sections_rejects_newer_sections() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let cfg = test_cfg(&context, "p-reject");
+            // Create sections 0, 1, 2.
+            {
+                let init = SectionsInit::open(context.child("a"), cfg.clone())
+                    .await
+                    .unwrap();
+                let mut sections = init.into_sections(Some(0)).await.unwrap();
+                sections.append_to_tail(b"x").await.unwrap();
+                sections.roll_tail(1).await.unwrap();
+                sections.append_to_tail(b"y").await.unwrap();
+                sections.roll_tail(2).await.unwrap();
+                sections.sync_section(2).await.unwrap();
+            }
+
+            // Try to claim section 1 is the tail with section 2 still present.
+            let init = SectionsInit::open(context.child("b"), cfg).await.unwrap();
+            assert_eq!(init.sections(), vec![0, 1, 2]);
+            let result = init.into_sections(Some(1)).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+        });
+    }
+}

--- a/storage/src/journal/contiguous/sections.rs
+++ b/storage/src/journal/contiguous/sections.rs
@@ -557,20 +557,31 @@ impl<E: Context> Sections<E> {
         Ok(pruned)
     }
 
-    /// Rewind to `(section, size)`. Removes every section strictly greater than `section`
-    /// newest-first, ensures `section` is the tail (opening it if it is missing), and finally
-    /// resizes that tail to `size`.
+    /// Rewind so that `section` becomes the tail, truncated to `size` bytes, discarding every
+    /// section newer than it.
+    ///
+    /// The target `section` can be in one of three states, all handled here:
+    /// - it is already the tail: just shrink it to `size`;
+    /// - it is a sealed historical section: demote it back to a writable tail, then shrink it;
+    /// - it does not exist (a gap that newer sections were hiding): open a fresh empty tail there.
+    ///
+    /// In steady state the tail is always the newest section and every sealed section is older, so
+    /// "sections newer than the target" means the tail (if above the target) plus any sealed
+    /// sections above it.
     ///
     /// # Crash safety
     ///
-    /// Sections are removed newest-first; a crash mid-rewind leaves a contiguous prefix. The
-    /// pre-demote sync runs before any destructive work — a sync failure leaves the in-memory
-    /// state matching the pre-rewind on-disk state.
+    /// Newer sections are removed newest-first, so a crash at any point leaves a contiguous prefix
+    /// on disk. When the target is a sealed section it is fsynced before those removals begin, so a
+    /// crash partway through still recovers a size no shorter than `(section, size)`. That sync is
+    /// the only fallible step before destructive work; if it fails, nothing has been removed and
+    /// in-memory state still matches disk.
     pub(super) async fn rewind(&mut self, section: u64, size: u64) -> Result<(), Error> {
         self.core.prune_guard(section)?;
 
-        // Step 1: make the target durable before destructive work. If demotion or newer-section
-        // removal later fails, recovery can still retain the target section.
+        // Step 1: if the target is a sealed section, fsync it before touching anything else, so the
+        // bytes we intend to keep are durable if a later removal crashes. Safe to fail here: no
+        // destructive work has run yet.
         let target_is_sealed = if let Some(s) = self.sealed.get(&section) {
             s.sync().await.map_err(Error::Runtime)?;
             self.core.metrics.synced.inc();
@@ -579,8 +590,10 @@ impl<E: Context> Sections<E> {
             false
         };
 
-        // Step 2: collect sections strictly newer than the target, newest-first. Drop the tail if
-        // it's above target.
+        // Step 2: remove every section strictly newer than the target, newest-first. The tail (when
+        // it sits above the target) is the newest of all, so drop it first, then the sealed sections
+        // above the target in descending order. Removing newest-first keeps the on-disk prefix
+        // contiguous at every step.
         if let Some(tail) = self.tail.as_ref() {
             if tail.section > section {
                 let old = self.tail.take().unwrap();
@@ -589,16 +602,17 @@ impl<E: Context> Sections<E> {
                 self.core.metrics.tracked.dec();
             }
         }
-        let to_remove: Vec<u64> = match section.checked_add(1) {
-            Some(after_section) => self
+        let newer_sealed: Vec<u64> = match section.checked_add(1) {
+            Some(first_newer) => self
                 .sealed
-                .range(after_section..)
+                .range(first_newer..)
                 .rev()
                 .map(|(&s, _)| s)
                 .collect(),
+            // `section == u64::MAX`: nothing can be newer.
             None => Vec::new(),
         };
-        for s in to_remove {
+        for s in newer_sealed {
             let sealed = self.sealed.remove(&s).unwrap();
             drop(sealed);
             self.core.remove_blob(s).await?;
@@ -606,25 +620,26 @@ impl<E: Context> Sections<E> {
             debug!(section = s, "removed section during rewind");
         }
 
-        // Step 3: ensure the target is the tail. If currently sealed, demote. If it was a missing
-        // gap that became exposed by dropping the newer tail, open an empty tail there.
+        // Step 3: make the target the tail. Exactly one branch applies; the third state (target is
+        // already the tail) needs no work here and falls through to the resize below.
         if target_is_sealed {
-            // Remove the sealed handle to release its Arc + page-cache id before reopening.
-            // (Both Append::new and the prior Sealed reference the same Blob handle, but only one
-            // should be live at a time per the contiguous invariant.)
+            // Demote the sealed target. Drop the Sealed handle before reopening as an Append: both
+            // wrap the same blob, but only one handle (and one page-cache id) may be live at a time
+            // per the contiguous invariant.
             let _ = self.sealed.remove(&section);
             self.core.metrics.tracked.dec();
             let blob = self.core.open_append(section).await?;
             self.core.metrics.tracked.inc();
             self.tail = Some(Tail { section, blob });
-        }
-        if self.tail.is_none() {
+        } else if self.tail.is_none() {
+            // The target is a gap exposed by dropping the newer tail in Step 2; open it empty.
             let blob = self.core.open_append(section).await?;
             self.core.metrics.tracked.inc();
             self.tail = Some(Tail { section, blob });
         }
 
-        // Step 4: resize the tail down to `size` (no-op if already shorter).
+        // Step 4: shrink the tail to `size`. No-op when it is already at or below `size` (e.g. a
+        // freshly opened gap tail, which starts empty).
         if let Some(tail) = self.tail.as_ref() {
             if tail.section == section {
                 let current = tail.blob.size().await;

--- a/storage/src/journal/contiguous/sections.rs
+++ b/storage/src/journal/contiguous/sections.rs
@@ -330,15 +330,9 @@ impl<E: Context> Sections<E> {
     }
 
     /// Section index of the tail, if a tail exists.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(super) fn tail_section(&self) -> Option<u64> {
         self.tail.as_ref().map(|t| t.section)
-    }
-
-    /// Returns `true` if no sections exist.
-    #[allow(dead_code)]
-    pub(super) fn is_empty(&self) -> bool {
-        self.sealed.is_empty() && self.tail.is_none()
     }
 
     /// Logical size, in bytes, of the given section. Returns 0 if the section does not exist.
@@ -355,25 +349,6 @@ impl<E: Context> Sections<E> {
         // Missing unpruned sections are reported as zero-length so recovery code can distinguish an
         // empty tail from an out-of-range read.
         Ok(0)
-    }
-
-    /// Non-blocking variant of [`Self::section_size`]. Returns `None` for any section other than
-    /// the tail when it cannot be observed without waiting.
-    #[allow(dead_code)]
-    pub(super) fn try_section_size(&self, section: u64) -> Option<u64> {
-        if section < self.core.oldest_retained_section {
-            return None;
-        }
-        if let Some(s) = self.sealed.get(&section) {
-            return Some(s.size());
-        }
-        if let Some(t) = &self.tail {
-            if t.section == section {
-                return t.blob.try_size();
-            }
-        }
-        // Mirror `section_size`: absent-but-unpruned sections behave like empty sections for sizing.
-        Some(0)
     }
 
     /// Read exactly `len` bytes at `(section, offset)`.

--- a/storage/src/journal/contiguous/sections.rs
+++ b/storage/src/journal/contiguous/sections.rs
@@ -712,7 +712,7 @@ mod tests {
         });
     }
 
-    /// Empty partition → SectionsInit with no sections → Sections with just a tail.
+    /// Empty partition -> SectionsInit with no sections -> Sections with just a tail.
     #[test_traced]
     fn test_sections_init_empty_then_install_tail() {
         let executor = deterministic::Runner::default();

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -137,26 +137,6 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         Ok(position)
     }
 
-    /// Append pre-encoded bytes to the given section.
-    ///
-    /// The buffer must contain one or more encoded items with size [Self::CHUNK_SIZE] each.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `buf` is empty or not a multiple of [Self::CHUNK_SIZE].
-    pub(crate) async fn append_raw(&mut self, section: u64, buf: &[u8]) -> Result<(), Error> {
-        assert!(!buf.is_empty());
-        assert!(buf.len().is_multiple_of(Self::CHUNK_SIZE));
-        let blob = self.manager.get_or_create(section).await?;
-        blob.append(buf).await?;
-        trace!(
-            section,
-            count = buf.len() / Self::CHUNK_SIZE,
-            "appended items"
-        );
-        Ok(())
-    }
-
     /// Read the item at the given section and position.
     ///
     /// # Errors
@@ -435,15 +415,6 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     /// Unlike `destroy`, this keeps the journal alive so it can be reused.
     pub async fn clear(&mut self) -> Result<(), Error> {
         self.manager.clear().await
-    }
-
-    /// Ensure a section exists, creating an empty blob if needed.
-    ///
-    /// This is used to maintain the invariant that at least one blob always exists
-    /// (the "tail" blob), which allows reconstructing journal size on reopen.
-    pub(crate) async fn ensure_section_exists(&mut self, section: u64) -> Result<(), Error> {
-        self.manager.get_or_create(section).await?;
-        Ok(())
     }
 }
 

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -478,15 +478,24 @@ where
 
         // Create two databases with their own configs
         let target_config = H::config(&context.next_u64().to_string(), &context);
-        let mut target_db = H::init_db_with_config(context.child("target"), target_config).await;
+        // Heap-pin large sub-futures so their state machines don't inflate this test's outer
+        // state machine and overflow the test thread stack.
+        let mut target_db = Box::pin(H::init_db_with_config(
+            context.child("target"),
+            target_config,
+        ))
+        .await;
         let sync_config = H::config(&context.next_u64().to_string(), &context);
         let client_context = context.child("client");
-        let mut sync_db =
-            H::init_db_with_config(client_context.child("client"), sync_config.clone()).await;
+        let mut sync_db = Box::pin(H::init_db_with_config(
+            client_context.child("client"),
+            sync_config.clone(),
+        ))
+        .await;
 
         // Apply the same operations to both databases
-        target_db = H::apply_ops(target_db, target_ops.clone()).await;
-        sync_db = H::apply_ops(sync_db, target_ops.clone()).await;
+        target_db = Box::pin(H::apply_ops(target_db, target_ops.clone())).await;
+        sync_db = Box::pin(H::apply_ops(sync_db, target_ops.clone())).await;
         // commit already done in apply_ops
         // commit already done in apply_ops
 
@@ -525,7 +534,7 @@ where
             reached_target_tx: None,
             max_retained_roots: 8,
         };
-        let synced_db: H::Db = sync::sync(config).await.unwrap();
+        let synced_db: H::Db = Box::pin(sync::sync(config)).await.unwrap();
 
         // Verify database state
         let bounds = synced_db.bounds().await;

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -704,23 +704,26 @@ pub mod tests {
         let state1 = {
             let partition = "build-random".to_string();
             let rng_seed = context.next_u64();
-            let mut db: C = open_db_clone(context.child("first"), partition.clone()).await;
+            // Heap-pin large generic sub-futures so generated DB variants do not inflate this
+            // test future enough to overflow the smaller Windows test thread stack.
+            let mut db: C =
+                Box::pin(open_db_clone(context.child("first"), partition.clone())).await;
             db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
                 .await
                 .unwrap();
-            let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.sync().await.unwrap();
+            let merkleized = Box::pin(db.new_batch().merkleize(&db, None)).await.unwrap();
+            Box::pin(db.apply_batch(merkleized)).await.unwrap();
+            Box::pin(db.sync()).await.unwrap();
 
             // Drop and reopen the db
             let root = db.root();
             drop(db);
-            let db: C = open_db_clone(context.child("second"), partition).await;
+            let db: C = Box::pin(open_db_clone(context.child("second"), partition)).await;
 
             // Ensure the root matches
             assert_eq!(db.root(), root);
 
-            db.destroy().await.unwrap();
+            Box::pin(db.destroy()).await.unwrap();
             context.auditor().state()
         };
 
@@ -729,20 +732,20 @@ pub mod tests {
         let state2 = executor.start(|mut context| async move {
             let partition = "build-random".to_string();
             let rng_seed = context.next_u64();
-            let mut db: C = open_db(context.child("first"), partition.clone()).await;
+            let mut db: C = Box::pin(open_db(context.child("first"), partition.clone())).await;
             db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
                 .await
                 .unwrap();
-            let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.sync().await.unwrap();
+            let merkleized = Box::pin(db.new_batch().merkleize(&db, None)).await.unwrap();
+            Box::pin(db.apply_batch(merkleized)).await.unwrap();
+            Box::pin(db.sync()).await.unwrap();
 
             let root = db.root();
             drop(db);
-            let db: C = open_db(context.child("second"), partition).await;
+            let db: C = Box::pin(open_db(context.child("second"), partition)).await;
             assert_eq!(db.root(), root);
 
-            db.destroy().await.unwrap();
+            Box::pin(db.destroy()).await.unwrap();
             context.auditor().state()
         });
 


### PR DESCRIPTION
## Summary

Moves the fixed contiguous journal onto a typed section store that encodes the section lifecycle directly: historical sections are `Sealed`, and only the tail remains writable.

This keeps the existing journal API and section layout, but makes the "only the tail receives writes" invariant explicit in the storage layer instead of relying on every caller to preserve it manually.

## Changes

- Adds `contiguous::sections`, with two states:
  - `SectionsInit` for recovery/open, where every section is writable so init can inspect and repair blobs.
  - `Sections` for steady state, where historical sections are sealed and at most one tail is an `Append`.
- Refactors the fixed contiguous journal to route reads, replay, append, sync, prune, rewind, clear, and destroy through `Sections`.
- Rolls a full tail by sealing it without fsyncing, then opening the next tail; journal commit/sync continues to make dirty sections durable.
- Tracks dirty work by earliest dirty section so a section remains eligible for sync after it rolls from tail to sealed history.
- Keeps recovery repair in the init phase, then transitions to sealed steady state after trailing bytes, gaps, and tail placement have been resolved.
- Adds section-store metrics for tracked, synced, and pruned sections.
- Removes the segmented fixed journal helper that existed only to force-create an empty section.