### PR TITLE
[Storage] Use `Sealed` blob in contiguous variable journal

### DIFF
--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -13,6 +13,7 @@ pub mod fixed;
 mod metrics;
 mod sections;
 pub mod variable;
+mod variable_data;
 
 #[cfg(test)]
 mod tests;

--- a/storage/src/journal/contiguous/sections.rs
+++ b/storage/src/journal/contiguous/sections.rs
@@ -185,6 +185,13 @@ impl<E: Context> SectionsInit<E> {
         }
     }
 
+    /// Direct access to the [`Append`] handle for `section`, if it exists. Used by callers that
+    /// need to inspect section contents (e.g. replay the tail to find the last valid item
+    /// boundary) before transitioning to steady state.
+    pub(super) fn section(&self, section: u64) -> Option<&Append<E::Blob>> {
+        self.pending.get(&section)
+    }
+
     /// Shrink the given section to `size` bytes. No-op if the section is absent or already at or
     /// below the requested size. Shrinking is synced so init-time repairs are durable before
     /// [`Self::into_sections`] runs.
@@ -329,16 +336,34 @@ impl<E: Context> Sections<E> {
         }
     }
 
+    /// Existing section numbers greater than or equal to `start`, in ascending order.
+    pub(super) fn sections_from(&self, start: u64) -> Vec<u64> {
+        let mut sections: Vec<u64> = self
+            .sealed
+            .range(start..)
+            .map(|(&section, _)| section)
+            .collect();
+        if let Some(tail) = &self.tail {
+            if tail.section >= start {
+                sections.push(tail.section);
+            }
+        }
+        sections
+    }
+
     /// Section index of the tail, if a tail exists.
-    #[allow(dead_code)]
     pub(super) fn tail_section(&self) -> Option<u64> {
         self.tail.as_ref().map(|t| t.section)
     }
 
     /// Returns `true` if no sections exist.
-    #[allow(dead_code)]
     pub(super) fn is_empty(&self) -> bool {
         self.sealed.is_empty() && self.tail.is_none()
+    }
+
+    /// Number of existing sections.
+    pub(super) fn len(&self) -> usize {
+        self.sealed.len() + usize::from(self.tail.is_some())
     }
 
     /// Logical size, in bytes, of the given section. Returns 0 if the section does not exist.
@@ -359,7 +384,6 @@ impl<E: Context> Sections<E> {
 
     /// Non-blocking variant of [`Self::section_size`]. Returns `None` for any section other than
     /// the tail when it cannot be observed without waiting.
-    #[allow(dead_code)]
     pub(super) fn try_section_size(&self, section: u64) -> Option<u64> {
         if section < self.core.oldest_retained_section {
             return None;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -6,24 +6,25 @@
 use super::Reader as _;
 use crate::{
     journal::{
-        contiguous::{fixed, metrics::VariableMetrics as Metrics, Contiguous, Many, Mutable},
-        segmented::variable,
+        contiguous::{
+            fixed,
+            metrics::VariableMetrics as Metrics,
+            variable_data::{Config as VariableDataConfig, VariableData},
+            Contiguous, Many, Mutable,
+        },
+        variable_format::encode_item_into,
         Error,
     },
     Context, Persistable,
 };
 use commonware_codec::{Codec, CodecShared};
-use commonware_runtime::buffer::paged::CacheRef;
+use commonware_runtime::{buffer::paged::CacheRef, Error as RuntimeError};
 use commonware_utils::{
     sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard},
     NZUsize,
 };
-#[commonware_macros::stability(ALPHA)]
-use core::ops::Range;
 use futures::{future::try_join_all, stream, Stream, StreamExt as _};
 use std::num::{NonZeroU64, NonZeroUsize};
-#[commonware_macros::stability(ALPHA)]
-use tracing::debug;
 use tracing::warn;
 
 const REPLAY_BUFFER_SIZE: NonZeroUsize = NZUsize!(1024);
@@ -57,6 +58,21 @@ const OFFSETS_SUFFIX: &str = "_offsets";
 /// ```
 const fn position_to_section(position: u64, items_per_section: u64) -> u64 {
     position / items_per_section
+}
+
+fn section_start(section: u64, items_per_section: u64) -> Result<u64, Error> {
+    section
+        .checked_mul(items_per_section)
+        .ok_or(Error::OffsetOverflow)
+}
+
+fn logical_position(base: u64, delta: u64) -> Result<u64, Error> {
+    base.checked_add(delta).ok_or(Error::OffsetOverflow)
+}
+
+fn increment_logical_position(position: &mut u64) -> Result<(), Error> {
+    *position = position.checked_add(1).ok_or(Error::OffsetOverflow)?;
+    Ok(())
 }
 
 /// Configuration for a [Journal].
@@ -98,8 +114,8 @@ impl<C> Config<C> {
 
 /// Inner journal state protected by a lock for interior mutability.
 struct Inner<E: Context, V: Codec> {
-    /// The underlying variable-length data journal.
-    data: variable::Journal<E, V>,
+    /// The variable-item data backend built on top of the typed section store.
+    data: VariableData<E, V>,
 
     /// The next position to be assigned on append (total items appended).
     ///
@@ -192,8 +208,8 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 /// and
 /// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
 /// the first invalid data read will be considered the new end of the journal (and the
-/// underlying [Blob](commonware_runtime::Blob) will be truncated to the last valid item). Repair occurs during
-/// init via the underlying segmented journals.
+/// underlying [Blob](commonware_runtime::Blob) will be truncated to the last valid item). Repair
+/// occurs during init by replaying the data journal and realigning the offsets index.
 ///
 /// # Invariants
 ///
@@ -430,6 +446,14 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         );
     }
 
+    /// Remove the data partition, treating an already-missing partition as cleared.
+    async fn remove_data_partition(context: E, partition: String) -> Result<(), Error> {
+        match context.remove(&partition, None).await {
+            Ok(()) | Err(RuntimeError::PartitionMissing(_)) => Ok(()),
+            Err(err) => Err(Error::Runtime(err)),
+        }
+    }
+
     /// Initialize a contiguous variable journal.
     ///
     /// # Crash Recovery
@@ -441,31 +465,34 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let data_partition = cfg.data_partition();
         let offsets_partition = cfg.offsets_partition();
 
-        // Initialize underlying variable data journal
-        let mut data = variable::Journal::init(
+        // If a prior `init_at_size`/`clear_to_size` crashed mid-reset, the offsets journal carries
+        // a staged clear. `init_cleared` discards the raw data partition before `VariableData::init`
+        // parses it, so corrupt stale data cannot block the reset.
+        let clear_context = context.child("data_clear");
+        let clear_partition = data_partition.clone();
+        let mut offsets = fixed::Journal::<E, u64>::init_cleared(
+            context.child("offsets"),
+            fixed::Config {
+                partition: offsets_partition,
+                items_per_blob: cfg.items_per_section,
+                page_cache: cfg.page_cache.clone(),
+                write_buffer: cfg.write_buffer,
+            },
+            || Self::remove_data_partition(clear_context, clear_partition),
+        )
+        .await?;
+
+        // Initialize the section-backed variable data backend after any staged clear has been
+        // completed.
+        let mut data = VariableData::init(
             context.child("data"),
-            variable::Config {
+            VariableDataConfig {
                 partition: data_partition,
                 compression: cfg.compression,
                 codec_config: cfg.codec_config,
                 page_cache: cfg.page_cache.clone(),
                 write_buffer: cfg.write_buffer,
             },
-        )
-        .await?;
-
-        // If a prior `init_at_size`/`clear_to_size` crashed mid-reset, the offsets journal carries
-        // a staged clear. `init_cleared` discards data before finishing that reset so the two sides
-        // are reconciled and stale data is never replayed past the reset size.
-        let mut offsets = fixed::Journal::<E, u64>::init_cleared(
-            context.child("offsets"),
-            fixed::Config {
-                partition: offsets_partition,
-                items_per_blob: cfg.items_per_section,
-                page_cache: cfg.page_cache,
-                write_buffer: cfg.write_buffer,
-            },
-            || data.clear(),
         )
         .await?;
 
@@ -501,21 +528,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// and next append at position `size`.
     #[commonware_macros::stability(ALPHA)]
     pub async fn init_at_size(context: E, cfg: Config<V::Cfg>, size: u64) -> Result<Self, Error> {
-        let mut data = variable::Journal::init(
-            context.child("data"),
-            variable::Config {
-                partition: cfg.data_partition(),
-                compression: cfg.compression,
-                codec_config: cfg.codec_config.clone(),
-                page_cache: cfg.page_cache.clone(),
-                write_buffer: cfg.write_buffer,
-            },
-        )
-        .await?;
+        let data_partition = cfg.data_partition();
 
         // `init_at_size_cleared` durably stages the offsets reset, clears data, then completes the
         // reset. A crash at any point leaves a staged clear that the next `init` (via
         // `init_cleared`) finishes, so stale data can never outlive the reset.
+        let clear_context = context.child("data_clear");
+        let clear_partition = data_partition.clone();
         let offsets = fixed::Journal::<E, u64>::init_at_size_cleared(
             context.child("offsets"),
             fixed::Config {
@@ -525,7 +544,19 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 write_buffer: cfg.write_buffer,
             },
             size,
-            || data.clear(),
+            || Self::remove_data_partition(clear_context, clear_partition),
+        )
+        .await?;
+
+        let data = VariableData::init(
+            context.child("data"),
+            VariableDataConfig {
+                partition: data_partition,
+                compression: cfg.compression,
+                codec_config: cfg.codec_config.clone(),
+                page_cache: cfg.page_cache.clone(),
+                write_buffer: cfg.write_buffer,
+            },
         )
         .await?;
 
@@ -577,11 +608,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     pub(crate) async fn init_sync(
         context: E,
         cfg: Config<V::Cfg>,
-        range: Range<u64>,
+        range: std::ops::Range<u64>,
     ) -> Result<Self, Error> {
         assert!(!range.is_empty(), "range must not be empty");
 
-        debug!(
+        tracing::debug!(
             range.start,
             range.end,
             items_per_section = cfg.items_per_section.get(),
@@ -596,10 +627,10 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // No existing data - initialize at the start of the sync range if needed
         if size == 0 {
             if range.start == 0 {
-                debug!("no existing journal data, returning empty journal");
+                tracing::debug!("no existing journal data, returning empty journal");
                 return Ok(journal);
             } else {
-                debug!(
+                tracing::debug!(
                     range.start,
                     "no existing journal data, initializing at sync range start"
                 );
@@ -624,9 +655,10 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // If all existing data is before our sync range, destroy and recreate fresh
         if size <= range.start {
             // All data is stale (ends at or before range.start)
-            debug!(
+            tracing::debug!(
                 size,
-                range.start, "existing journal data is stale, re-initializing at start position"
+                range.start,
+                "existing journal data is stale, re-initializing at start position"
             );
             journal.destroy().await?;
             return Self::init_at_size(context, cfg, range.start).await;
@@ -634,9 +666,10 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
         // Prune to lower bound if needed
         if !bounds.is_empty() && bounds.start < range.start {
-            debug!(
+            tracing::debug!(
                 oldest_pos = bounds.start,
-                range.start, "pruning journal to sync range start"
+                range.start,
+                "pruning journal to sync range start"
             );
             journal.prune(range.start).await?;
         }
@@ -680,10 +713,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         };
         let discard_section = position_to_section(size, self.items_per_section);
 
-        inner
-            .data
-            .rewind_to_offset(discard_section, discard_offset)
-            .await?;
+        inner.data.rewind(discard_section, discard_offset).await?;
         self.offsets.rewind(size).await?;
 
         // Update our size
@@ -735,7 +765,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let mut item_starts = Vec::with_capacity(items_count);
         let mut encode = |item: &V| {
             item_starts.push(encoded.len());
-            variable::Journal::<E, V>::encode_item_into(self.compression, item, &mut encoded)
+            encode_item_into(self.compression, item, &mut encoded)
         };
         match &items {
             Many::Flat(items) => {
@@ -946,7 +976,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// Returns `(pruning_boundary, size)` for the contiguous journal.
     async fn align_journals(
-        data: &mut variable::Journal<E, V>,
+        data: &mut VariableData<E, V>,
         offsets: &mut fixed::Journal<E, u64>,
         items_per_section: u64,
     ) -> Result<(u64, u64), Error> {
@@ -977,14 +1007,16 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
             // Stop once we find replayable data or only one empty section
             // remains for the existing empty-data repair path.
-            if items_in_last_section > 0 || data.num_sections() == 1 {
+            if items_in_last_section > 0 || data.section_count() == 1 {
                 break items_in_last_section;
             }
 
             let previous_section = last_section
                 .checked_sub(1)
-                .expect("num_sections >= 2 implies newest_section >= 1");
-            let previous_size = data.size(previous_section).await?;
+                .expect("section_count >= 2 implies newest_section >= 1");
+            let previous_size = data
+                .valid_offset(previous_section, REPLAY_BUFFER_SIZE)
+                .await?;
             warn!(
                 section = last_section,
                 "crash repair: removing empty trailing data section"
@@ -1009,7 +1041,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 // In both cases, calculate target position from the first remaining section
                 // SAFETY: data is non-empty (checked above)
                 let data_first_section = data.oldest_section().unwrap();
-                let data_section_start = data_first_section * items_per_section;
+                let data_section_start = section_start(data_first_section, items_per_section)?;
                 let target_pos = data_section_start.max(offsets_bounds.start);
 
                 warn!("crash repair: clearing offsets to {target_pos} (empty section crash)");
@@ -1037,7 +1069,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
         // data_oldest_pos is ALWAYS section-aligned because it's computed from the section index.
         // This differs from offsets bounds start which can be mid-section after init_at_size.
-        let data_oldest_pos = data_first_section * items_per_section;
+        let data_oldest_pos = section_start(data_first_section, items_per_section)?;
 
         // Align pruning state
         // We always prune data before offsets, so offsets should never be "ahead" by a section.
@@ -1094,9 +1126,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let data_newest_section = data
             .newest_section()
             .expect("non-empty data journal should have newest section");
-        let data_newest_start = data_newest_section
-            .checked_mul(items_per_section)
-            .ok_or(Error::OffsetOverflow)?;
+        let data_newest_start = section_start(data_newest_section, items_per_section)?;
         let retained_data_end_bound = data_newest_start
             .max(offsets_bounds.start)
             .checked_add(items_in_last_section)
@@ -1185,7 +1215,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// an earlier point. If replay finds a short section after the anchor, recovery truncates newer
     /// data sections and returns the contiguous data-backed size.
     async fn rebuild_offsets_from_anchor(
-        data: &mut variable::Journal<E, V>,
+        data: &mut VariableData<E, V>,
         offsets: &mut fixed::Journal<E, u64>,
         items_per_section: u64,
         pruning_boundary: u64,
@@ -1209,7 +1239,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         }
 
         let start_section = position_to_section(anchor, items_per_section);
-        let first_position = pruning_boundary.max(start_section * items_per_section);
+        let first_position = pruning_boundary.max(section_start(start_section, items_per_section)?);
 
         let (size, repair) = {
             let skip = anchor - first_position;
@@ -1222,7 +1252,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                     return Ok(None);
                 };
                 let (section, _offset, _size, _item) = result?;
-                let position = first_position + skipped;
+                let position = logical_position(first_position, skipped)?;
                 let expected_section = position_to_section(position, items_per_section);
                 if section != expected_section {
                     if section > expected_section {
@@ -1232,7 +1262,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                         "data section {section} contains logical position {position}, expected section {expected_section}"
                     )));
                 }
-                skipped += 1;
+                increment_logical_position(&mut skipped)?;
             }
 
             let mut size = anchor;
@@ -1242,7 +1272,9 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 let expected_section = position_to_section(size, items_per_section);
                 if section != expected_section {
                     if section > expected_section {
-                        let byte_offset = data.size(expected_section).await?;
+                        let byte_offset = data
+                            .valid_offset(expected_section, REPLAY_BUFFER_SIZE)
+                            .await?;
                         repair = Some((expected_section, section, size, byte_offset));
                         break;
                     }
@@ -1251,7 +1283,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                     )));
                 }
                 offsets.append(&offset).await?;
-                size += 1;
+                increment_logical_position(&mut size)?;
             }
             (size, repair)
         };
@@ -1398,7 +1430,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         };
         let section = position_to_section(position, self.items_per_section);
         let mut inner = self.inner.write().await;
-        inner.data.rewind_to_offset(section, offset).await
+        inner.data.rewind(section, offset).await
     }
 
     /// Test helper: Append directly to the internal data journal (simulates crash scenario).
@@ -1407,8 +1439,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         section: u64,
         item: V,
     ) -> Result<(u64, u32), Error> {
+        let mut encoded = Vec::new();
+        let size = encode_item_into(self.compression, &item, &mut encoded)?;
         let mut inner = self.inner.write().await;
-        inner.data.append(section, &item).await
+        let offset = inner.data.append_raw(section, &encoded).await?;
+        Ok((offset, size))
     }
 
     /// Test helper: Sync the internal data journal.
@@ -1434,12 +1469,109 @@ mod tests {
     use futures::FutureExt as _;
     use std::num::NonZeroU16;
 
-    // Use some jank sizes to exercise boundary conditions.
+    // Use non-round page sizes to exercise boundary conditions.
     const PAGE_SIZE: NonZeroU16 = NZU16!(101);
     const PAGE_CACHE_SIZE: usize = 2;
     // Larger page sizes for tests that need more buffer space.
     const LARGE_PAGE_SIZE: NonZeroU16 = NZU16!(1024);
     const SMALL_PAGE_SIZE: NonZeroU16 = NZU16!(512);
+
+    #[test]
+    fn test_logical_position_overflow_helpers() {
+        assert!(matches!(
+            logical_position(u64::MAX, 1),
+            Err(Error::OffsetOverflow)
+        ));
+
+        let mut position = u64::MAX;
+        assert!(matches!(
+            increment_logical_position(&mut position),
+            Err(Error::OffsetOverflow)
+        ));
+        assert_eq!(position, u64::MAX);
+    }
+
+    /// Regression test: a valid item can be smaller than `MAX_U32_VARINT_SIZE` total bytes
+    /// (1-byte varint + small payload). Init-time tail truncation and replay must not drop
+    /// such items.
+    #[test_traced]
+    fn test_variable_replay_handles_small_items_below_varint_size() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "small-items".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+            // u8: 1-byte payload + 1-byte varint = 2 bytes total per item (< MAX_U32_VARINT_SIZE).
+            let journal = Journal::<_, u8>::init(context.child("j"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..3u8 {
+                journal.append(&i).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            assert_eq!(journal.size().await, 3);
+
+            // Reopen — exercises init-time find_valid_offset on small items.
+            drop(journal);
+            let journal = Journal::<_, u8>::init(context.child("j2"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(
+                journal.size().await,
+                3,
+                "no items should be dropped on reopen"
+            );
+
+            // Replay must emit all three items.
+            let reader = journal.reader().await;
+            let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
+            futures::pin_mut!(stream);
+            let mut emitted = Vec::new();
+            while let Some(result) = stream.next().await {
+                let (pos, item) = result.unwrap();
+                emitted.push((pos, item));
+            }
+            assert_eq!(emitted, vec![(0, 0u8), (1, 1u8), (2, 2u8)]);
+        });
+    }
+
+    /// Regression test for the qmdb-first-init pattern: append exactly one item to a fresh
+    /// journal, sync, then replay should emit exactly that one item.
+    #[test_traced]
+    fn test_variable_replay_emits_single_item_after_first_append() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "single-item-replay".into(),
+                items_per_section: NZU64!(7),
+                compression: None,
+                codec_config: ((0..=100).into(), ()),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+            let journal = Journal::<_, Vec<u8>>::init(context.child("j"), cfg)
+                .await
+                .unwrap();
+            journal.append(&vec![1u8, 2, 3]).await.unwrap();
+            journal.sync().await.unwrap();
+            assert_eq!(journal.size().await, 1);
+
+            let reader = journal.reader().await;
+            let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
+            futures::pin_mut!(stream);
+            let mut count = 0;
+            while let Some(result) = stream.next().await {
+                let (_pos, _item) = result.unwrap();
+                count += 1;
+            }
+            assert_eq!(count, 1, "replay should emit exactly one item");
+        });
+    }
 
     #[test_traced]
     fn test_variable_append_many_compressed() {
@@ -2358,6 +2490,66 @@ mod tests {
         });
     }
 
+    /// Test that recovery treats a completely missing middle data blob as a gap, not as permission
+    /// to skip ahead to newer data.
+    #[test_traced]
+    fn test_variable_recovery_rolls_back_durable_section_after_missing_blob_gap() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "recovery-rollback-missing-blob-gap".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            for i in 0..10u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+
+            for i in 10..30u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            {
+                let inner = journal.inner.write().await;
+                inner.data.sync(2).await.unwrap();
+            }
+            drop(journal);
+
+            let data_partition = cfg.data_partition();
+            let missing_section = 1u64.to_be_bytes();
+            context
+                .remove(&data_partition, Some(&missing_section))
+                .await
+                .unwrap();
+            let mut names = context.scan(&data_partition).await.unwrap();
+            names.sort();
+            assert_eq!(names, vec![0u64.to_be_bytes(), 2u64.to_be_bytes()]);
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..10);
+            for i in 0..10u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+
+            let data_blobs = context.scan(&cfg.data_partition()).await.unwrap();
+            assert_eq!(data_blobs.len(), 2);
+            assert_eq!(journal.append(&1234).await.unwrap(), 10);
+            assert_eq!(journal.read(10).await.unwrap(), 1234);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test recovery when the oldest data section is empty but a newer section still holds
     /// durable items and the offsets journal is gone.
     ///
@@ -2776,7 +2968,7 @@ mod tests {
     fn test_variable_rebuild_offsets_anchor_outside_bounds_returns_none() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let data_cfg = variable::Config {
+            let data_cfg = VariableDataConfig {
                 partition: "rebuild-anchor-outside-data".into(),
                 compression: None,
                 codec_config: (),
@@ -2790,14 +2982,17 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            let mut data = variable::Journal::<_, u64>::init(context.child("data"), data_cfg)
+            let mut data = VariableData::<_, u64>::init(context.child("data"), data_cfg)
                 .await
                 .unwrap();
             let mut offsets = fixed::Journal::<_, u64>::init(context.child("offsets"), offsets_cfg)
                 .await
                 .unwrap();
 
-            let (offset, _) = data.append(0, &100).await.unwrap();
+            // Encode and append a single item.
+            let mut buf = Vec::new();
+            encode_item_into(None, &100u64, &mut buf).unwrap();
+            let offset = data.append_raw(0, &buf).await.unwrap();
             offsets.append(&offset).await.unwrap();
 
             let result =
@@ -2856,6 +3051,9 @@ mod tests {
                 journal.read(12).await,
                 Err(Error::ItemOutOfRange(12))
             ));
+            let pos = journal.append(&999).await.unwrap();
+            assert_eq!(pos, 12);
+            assert_eq!(journal.read(12).await.unwrap(), 999);
 
             journal.destroy().await.unwrap();
         });
@@ -2979,13 +3177,20 @@ mod tests {
                 let offsets = journal.offsets.reader().await;
                 offsets.read(12).await.unwrap()
             };
-            {
-                let mut inner = journal.inner.write().await;
-                inner.data.rewind_section(1, offset).await.unwrap();
-                inner.data.sync(1).await.unwrap();
-                inner.data.sync(2).await.unwrap();
-            }
+            let data_partition = cfg.data_partition();
             drop(journal);
+
+            // Truncate one section directly at the blob level.
+            {
+                let cache_ref = CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10));
+                let (blob, size) = context
+                    .open(&data_partition, &1u64.to_be_bytes())
+                    .await
+                    .unwrap();
+                let append = Append::new(blob, size, 1024, cache_ref).await.unwrap();
+                append.resize(offset).await.unwrap();
+                append.sync().await.unwrap();
+            }
 
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
@@ -2999,6 +3204,126 @@ mod tests {
                 journal.read(12).await,
                 Err(Error::ItemOutOfRange(12))
             ));
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_recovery_truncates_short_data_section_to_item_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "recovery-short-section-mid-item-after-anchor".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..25u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            journal
+                .test_set_offsets_recovery_watermark(10)
+                .await
+                .unwrap();
+            let item_12_offset = {
+                let offsets = journal.offsets.reader().await;
+                offsets.read(12).await.unwrap()
+            };
+            drop(journal);
+
+            {
+                let cache_ref = CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10));
+                let (blob, size) = context
+                    .open(&cfg.data_partition(), &1u64.to_be_bytes())
+                    .await
+                    .unwrap();
+                let append = Append::new(blob, size, 1024, cache_ref).await.unwrap();
+                append.resize(item_12_offset + 1).await.unwrap();
+                append.sync().await.unwrap();
+            }
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..12);
+            let pos = journal.append(&999).await.unwrap();
+            assert_eq!(pos, 12);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("third"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..13);
+            assert_eq!(journal.read(12).await.unwrap(), 999);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_recovery_truncates_before_empty_trailing_section_to_item_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "recovery-short-section-mid-item-before-empty-tail".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            // Filling exactly two sections leaves an empty section 2 tail behind it.
+            for i in 0..20u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            let item_12_offset = {
+                let offsets = journal.offsets.reader().await;
+                offsets.read(12).await.unwrap()
+            };
+            drop(journal);
+
+            // Leave section 1 ending mid-item so the empty-tail repair must rewind to the last
+            // complete item boundary, not the raw blob size.
+            {
+                let cache_ref = CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10));
+                let (blob, size) = context
+                    .open(&cfg.data_partition(), &1u64.to_be_bytes())
+                    .await
+                    .unwrap();
+                let append = Append::new(blob, size, 1024, cache_ref).await.unwrap();
+                append.resize(item_12_offset + 1).await.unwrap();
+                append.sync().await.unwrap();
+            }
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..12);
+            // Appending and reopening catches stale bytes left after the valid boundary.
+            let pos = journal.append(&999).await.unwrap();
+            assert_eq!(pos, 12);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("third"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..13);
+            assert_eq!(journal.read(12).await.unwrap(), 999);
 
             journal.destroy().await.unwrap();
         });
@@ -3134,6 +3459,50 @@ mod tests {
             .await
             .unwrap();
             assert_eq!(append.size().await, expected_size);
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_init_reports_complete_corrupt_tail_item() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "data-init-corrupt-complete-tail".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: ((0..=3).into(), ()),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let data_partition = cfg.data_partition();
+
+            let journal = Journal::<_, Vec<u8>>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            journal.append(&vec![1, 2]).await.unwrap();
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let (blob, raw_size) = context
+                .open(&data_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            let append = Append::new(
+                blob,
+                raw_size,
+                2048,
+                CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+            )
+            .await
+            .unwrap();
+            let mut corrupt = Vec::new();
+            encode_item_into(None, &vec![1, 2, 3, 4], &mut corrupt).unwrap();
+            append.append(&corrupt).await.unwrap();
+            append.sync().await.unwrap();
+            drop(append);
+
+            let result = Journal::<_, Vec<u8>>::init(context.child("second"), cfg).await;
+            assert!(result.is_err(), "complete corrupt tail item must fail init");
         });
     }
 
@@ -3770,12 +4139,12 @@ mod tests {
                 drop(intent_metadata);
 
                 if clear_data {
-                    let mut data = variable::Journal::<_, u64>::init(
+                    let mut data = VariableData::<_, u64>::init(
                         context.child("data").with_attribute("index", index),
-                        variable::Config {
+                        VariableDataConfig {
                             partition: cfg.data_partition(),
                             compression: cfg.compression,
-                            codec_config: cfg.codec_config,
+                            codec_config: (),
                             page_cache: cfg.page_cache.clone(),
                             write_buffer: cfg.write_buffer,
                         },
@@ -3869,6 +4238,80 @@ mod tests {
             assert_eq!(journal.bounds().await, 10..11);
             assert_eq!(journal.read(10).await.unwrap(), 700);
 
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_init_clear_intent_skips_corrupt_stale_data() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "init-clear-intent-corrupt-stale-data".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let offsets_cfg = fixed::Config {
+                partition: cfg.offsets_partition(),
+                items_per_blob: cfg.items_per_section,
+                page_cache: cfg.page_cache.clone(),
+                write_buffer: cfg.write_buffer,
+            };
+            let mut metadata =
+                fixed::Journal::<_, u64>::open_metadata(context.child("meta"), &offsets_cfg)
+                    .await
+                    .unwrap();
+            metadata.put(fixed::CLEAR_TARGET_KEY, 7u64.into());
+            metadata.sync().await.unwrap();
+            drop(metadata);
+
+            // This stale data blob would fail `VariableData::init` if the staged clear intent were
+            // not honored first.
+            let (blob, _) = context
+                .open(&cfg.data_partition(), b"not-u64")
+                .await
+                .unwrap();
+            blob.write_at_sync(0, vec![1, 2, 3]).await.unwrap();
+            drop(blob);
+
+            let journal = Journal::<_, u64>::init(context.child("recover"), cfg.clone())
+                .await
+                .expect("staged clear should discard corrupt stale data before data init");
+            assert_eq!(journal.bounds().await, 7..7);
+            assert_eq!(journal.append(&700).await.unwrap(), 7);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_init_at_size_skips_corrupt_stale_data() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "init-at-size-corrupt-stale-data".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let (blob, _) = context
+                .open(&cfg.data_partition(), b"not-u64")
+                .await
+                .unwrap();
+            blob.write_at_sync(0, vec![1, 2, 3]).await.unwrap();
+            drop(blob);
+
+            let journal = Journal::<_, u64>::init_at_size(context.child("reset"), cfg.clone(), 9)
+                .await
+                .expect("init_at_size should discard corrupt stale data before data init");
+            assert_eq!(journal.bounds().await, 9..9);
+            assert_eq!(journal.append(&900).await.unwrap(), 9);
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1022,6 +1022,10 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 "crash repair: removing empty trailing data section"
             );
             data.rewind(previous_section, previous_size).await?;
+            // `rewind` shrinks the predecessor to its last valid item boundary but does not fsync
+            // that resize, and this repair is not dirty-tracked. Make it durable now so a later
+            // `sync()` is not required to re-truncate the predecessor on the next startup.
+            data.sync(previous_section).await?;
         };
 
         // After trimming empty trailing sections, a zero item count means the data journal is

--- a/storage/src/journal/contiguous/variable_data.rs
+++ b/storage/src/journal/contiguous/variable_data.rs
@@ -1,0 +1,446 @@
+//! Item-aware adapter for the contiguous variable journal's data backend.
+//!
+//! [`VariableData`] wraps a [`Sections`] store and adds the variable-length item primitives that
+//! `contiguous::variable::Journal` needs (varint-prefixed reads, multi-section item-stream
+//! replay, etc.). It owns section lifecycle through [`Sections`] but delegates item encoding and
+//! decoding to `variable_format`, keeping storage repair policy separate from wire-format parsing.
+//!
+//! # Invariants
+//!
+//! [`VariableData::init`] trims the newest data section to the last valid item boundary before the
+//! journal becomes readable. Cross-journal recovery in `contiguous::variable::Journal` handles
+//! short non-tail data sections and keeps the data journal aligned with the offsets index.
+
+use crate::{
+    journal::{
+        contiguous::sections::{Config as SectionsConfig, Sections, SectionsInit},
+        variable_format::{
+            read_item, read_many_consecutive, scan_replay_item, skip_replay, try_read_item_sync,
+            ReplayScan, SectionReader,
+        },
+        Error,
+    },
+    Context,
+};
+use commonware_codec::{varint::MAX_U32_VARINT_SIZE, Codec, CodecShared};
+use commonware_runtime::{
+    buffer::paged::{Append, CacheRef, Replay},
+    Blob, Buf, IoBuf,
+};
+use commonware_utils::NZUsize;
+use futures::stream::{self, Stream, StreamExt as _};
+use std::num::NonZeroUsize;
+
+/// Buffer size used for init-time tail replay.
+const INIT_REPLAY_BUFFER: NonZeroUsize = NZUsize!(1024);
+
+/// Configuration for [`VariableData`].
+#[derive(Clone)]
+pub(super) struct Config<C> {
+    /// Partition where data sections are stored.
+    pub partition: String,
+    /// Optional `zstd` compression level for item payloads.
+    pub compression: Option<u8>,
+    /// Codec configuration passed to item decoding.
+    pub codec_config: C,
+    /// Page cache used by the underlying section store.
+    pub page_cache: CacheRef,
+    /// Tail write-buffer capacity.
+    pub write_buffer: NonZeroUsize,
+}
+
+/// Variable-item view over a section store.
+pub(super) struct VariableData<E: Context, V: Codec> {
+    sections: Sections<E>,
+    compression: Option<u8>,
+    codec_config: V::Cfg,
+}
+
+/// Read-only adapter that exposes one section to shared variable-format helpers.
+struct SectionView<'a, E: Context> {
+    sections: &'a Sections<E>,
+    section: u64,
+}
+
+impl<E: Context> SectionReader for SectionView<'_, E> {
+    async fn size(&self) -> Result<u64, Error> {
+        self.sections.section_size(self.section).await
+    }
+
+    async fn read_prefix(&self, offset: u64, len: usize) -> Result<IoBuf, Error> {
+        let size = self.sections.section_size(self.section).await?;
+        let available = size
+            .saturating_sub(offset)
+            .min(len as u64)
+            .try_into()
+            .map_err(|_| Error::OffsetOverflow)?;
+        if available == 0 {
+            return Err(Error::Corruption(format!(
+                "no bytes available in data section {} at offset {offset}",
+                self.section
+            )));
+        }
+        Ok(self
+            .sections
+            .read_at(self.section, offset, available)
+            .await?
+            .coalesce())
+    }
+
+    async fn read_exact(&self, offset: u64, len: usize) -> Result<IoBuf, Error> {
+        Ok(self
+            .sections
+            .read_at(self.section, offset, len)
+            .await?
+            .coalesce())
+    }
+
+    fn try_size(&self) -> Option<u64> {
+        self.sections.try_section_size(self.section)
+    }
+
+    fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
+        self.sections.try_read_sync(self.section, offset, buf)
+    }
+}
+
+impl<E: Context, V: CodecShared> VariableData<E, V> {
+    /// Open the data backend and truncate any trailing partial-item bytes on the tail. The
+    /// contiguous-variable invariant guarantees only the tail can have such junk.
+    pub(super) async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
+        let sections_cfg = SectionsConfig {
+            partition: cfg.partition,
+            page_cache: cfg.page_cache,
+            write_buffer: cfg.write_buffer,
+        };
+        let init = SectionsInit::open(context, sections_cfg).await?;
+
+        let compressed = cfg.compression.is_some();
+        let tail_section = init.newest_section();
+        if let Some(tail) = tail_section {
+            let blob = init
+                .section(tail)
+                .expect("tail section exists per newest_section");
+            let valid_offset =
+                Self::find_valid_offset::<V>(blob, compressed, &cfg.codec_config).await?;
+            init.truncate_section(tail, valid_offset).await?;
+        }
+        let sections = init.into_sections(tail_section).await?;
+
+        Ok(Self {
+            sections,
+            compression: cfg.compression,
+            codec_config: cfg.codec_config,
+        })
+    }
+
+    /// Replay `blob` and return the byte offset just past the last successfully decoded item.
+    /// Stops at structural trailing bytes, treating them as junk. Complete items that fail decode
+    /// are returned as corruption rather than silently truncated.
+    async fn find_valid_offset<V2: CodecShared>(
+        blob: &Append<E::Blob>,
+        compressed: bool,
+        cfg: &V2::Cfg,
+    ) -> Result<u64, Error> {
+        let mut replay = blob
+            .replay(INIT_REPLAY_BUFFER)
+            .await
+            .map_err(Error::Runtime)?;
+        Self::valid_offset_from_replay::<_, V2>(&mut replay, compressed, cfg).await
+    }
+
+    /// Scan an already-open replay stream to the last structurally valid item boundary.
+    async fn valid_offset_from_replay<B: Blob, V2: CodecShared>(
+        replay: &mut Replay<B>,
+        compressed: bool,
+        cfg: &V2::Cfg,
+    ) -> Result<u64, Error> {
+        let mut offset = 0;
+        let mut valid_offset = 0;
+        loop {
+            match scan_replay_item::<_, V2>(replay, &mut offset, &mut valid_offset, cfg, compressed)
+                .await?
+            {
+                ReplayScan::Item(_) => {}
+                ReplayScan::End { valid_offset, .. } => return Ok(valid_offset),
+            }
+        }
+    }
+
+    /// Return the byte offset just past the last successfully decoded item in `section`.
+    pub(super) async fn valid_offset(
+        &self,
+        section: u64,
+        buffer_size: NonZeroUsize,
+    ) -> Result<u64, Error> {
+        if self.sections.section_size(section).await? == 0 {
+            return Ok(0);
+        }
+        let (mut replay, _) = self.sections.replay_section(section, buffer_size).await?;
+        Self::valid_offset_from_replay::<_, V>(
+            &mut replay,
+            self.compression.is_some(),
+            &self.codec_config,
+        )
+        .await
+    }
+
+    /// Borrow `section` as a [`SectionReader`] without exposing section lifecycle operations.
+    const fn section_view(&self, section: u64) -> SectionView<'_, E> {
+        SectionView {
+            sections: &self.sections,
+            section,
+        }
+    }
+
+    /// Oldest retained data section, if any.
+    pub(super) fn oldest_section(&self) -> Option<u64> {
+        self.sections.oldest_section()
+    }
+
+    /// Newest retained data section, if any.
+    pub(super) fn newest_section(&self) -> Option<u64> {
+        self.sections.newest_section()
+    }
+
+    /// Returns `true` when no data sections are retained.
+    pub(super) fn is_empty(&self) -> bool {
+        self.sections.is_empty()
+    }
+
+    /// Number of retained data sections.
+    pub(super) fn section_count(&self) -> usize {
+        self.sections.len()
+    }
+
+    /// Read the item at `(section, offset)`.
+    pub(super) async fn get(&self, section: u64, offset: u64) -> Result<V, Error> {
+        let view = self.section_view(section);
+        read_item(
+            &view,
+            offset,
+            &self.codec_config,
+            self.compression.is_some(),
+        )
+        .await
+        .map(|(_, _, item)| item)
+    }
+
+    /// Read multiple items from the same section that are byte-adjacent in storage.
+    ///
+    /// `offsets` must be strictly increasing. Returns [`Error::OffsetDataMismatch`] if the
+    /// on-disk varint at any offset disagrees with the gap to the next offset.
+    pub(super) async fn get_many_consecutive(
+        &self,
+        section: u64,
+        offsets: &[u64],
+    ) -> Result<Vec<V>, Error> {
+        let view = self.section_view(section);
+        read_many_consecutive(
+            section,
+            &view,
+            offsets,
+            &self.codec_config,
+            self.compression.is_some(),
+        )
+        .await
+    }
+
+    /// Try to read the item at `(section, offset)` synchronously.
+    pub(super) fn try_get_sync_into(
+        &self,
+        section: u64,
+        offset: u64,
+        buf: &mut Vec<u8>,
+    ) -> Option<V> {
+        let view = self.section_view(section);
+        try_read_item_sync(
+            &view,
+            offset,
+            &self.codec_config,
+            self.compression.is_some(),
+            buf,
+        )
+    }
+
+    /// Returns a stream of items starting at `(start_section, start_offset)`. Each emitted tuple
+    /// is `(section, offset, item_size, item)`.
+    pub(super) async fn replay(
+        &self,
+        start_section: u64,
+        start_offset: u64,
+        buffer_size: NonZeroUsize,
+    ) -> Result<impl Stream<Item = Result<(u64, u64, u32, V), Error>> + Send + '_, Error> {
+        let compressed = self.compression.is_some();
+        let cfg = self.codec_config.clone();
+
+        // Pre-create per-section replay handles so the stream owns no borrow back into `self`
+        // except via the page cache reachable through each Replay's underlying Blob handle.
+        let mut per_section: Vec<(u64, Replay<E::Blob>, u64)> = Vec::new();
+        if let Some(newest) = self.sections.newest_section() {
+            if start_section <= newest {
+                let oldest = self.sections.oldest_section().unwrap();
+                let first = start_section.max(oldest);
+                for section in self.sections.sections_from(first) {
+                    let (replay, _size) =
+                        self.sections.replay_section(section, buffer_size).await?;
+                    let skip = if section == start_section {
+                        start_offset
+                    } else {
+                        0
+                    };
+                    per_section.push((section, replay, skip));
+                }
+            }
+        }
+
+        let stream = stream::iter(per_section).flat_map(move |(section, replay, skip)| {
+            let cfg = cfg.clone();
+            stream::unfold(
+                ReplayState {
+                    section,
+                    replay,
+                    skip_bytes: skip,
+                    offset: 0,
+                    valid_offset: skip,
+                    cfg,
+                    compressed,
+                    done: false,
+                },
+                |mut state| async move {
+                    if state.done {
+                        return None;
+                    }
+                    let mut batch: Vec<Result<(u64, u64, u32, V), Error>> = Vec::new();
+                    loop {
+                        if state.skip_bytes > 0 {
+                            match skip_replay(
+                                &mut state.replay,
+                                &mut state.skip_bytes,
+                                &mut state.offset,
+                                &mut state.valid_offset,
+                            )
+                            .await
+                            {
+                                Ok(true) => {}
+                                Ok(false) => {
+                                    state.done = true;
+                                    return if batch.is_empty() {
+                                        None
+                                    } else {
+                                        Some((batch, state))
+                                    };
+                                }
+                                Err(err) => {
+                                    batch.push(Err(err));
+                                    state.done = true;
+                                    return Some((batch, state));
+                                }
+                            }
+                            continue;
+                        }
+
+                        match scan_replay_item::<_, V>(
+                            &mut state.replay,
+                            &mut state.offset,
+                            &mut state.valid_offset,
+                            &state.cfg,
+                            state.compressed,
+                        )
+                        .await
+                        {
+                            Ok(ReplayScan::Item(item)) => {
+                                batch.push(Ok((state.section, item.offset, item.size, item.item)));
+                            }
+                            Ok(ReplayScan::End { .. }) => {
+                                state.done = true;
+                                return if batch.is_empty() {
+                                    None
+                                } else {
+                                    Some((batch, state))
+                                };
+                            }
+                            Err(err) => {
+                                batch.push(Err(err));
+                                state.done = true;
+                                return Some((batch, state));
+                            }
+                        }
+
+                        if !batch.is_empty() && state.replay.remaining() < MAX_U32_VARINT_SIZE {
+                            return Some((batch, state));
+                        }
+                    }
+                },
+            )
+            .flat_map(stream::iter)
+            .boxed()
+        });
+
+        Ok(stream)
+    }
+
+    /// Append pre-encoded bytes to `section`. Returns the byte offset within `section` at which
+    /// the first byte was written.
+    ///
+    /// If `section` is ahead of the current tail, this rolls the tail forward. If no tail exists,
+    /// it installs `section` as the fresh tail. Panics if `section < tail_section`.
+    pub(super) async fn append_raw(&mut self, section: u64, buf: &[u8]) -> Result<u64, Error> {
+        match self.sections.tail_section() {
+            None => self.sections.install_tail(section).await?,
+            Some(tail) => {
+                assert!(
+                    section >= tail,
+                    "append_raw section {section} < tail {tail}"
+                );
+                let mut current = tail;
+                while current < section {
+                    self.sections.roll_tail(current + 1).await?;
+                    current += 1;
+                }
+            }
+        }
+        let base_offset = self.sections.section_size(section).await?;
+        self.sections.append_to_tail(buf).await?;
+        Ok(base_offset)
+    }
+
+    /// Make the given section durable. Dispatches to either `Sealed::sync` or `Append::sync`.
+    pub(super) async fn sync(&self, section: u64) -> Result<(), Error> {
+        self.sections.sync_section(section).await
+    }
+
+    /// Prune sections strictly less than `min_section`.
+    pub(super) async fn prune(&mut self, min_section: u64) -> Result<bool, Error> {
+        self.sections.prune(min_section).await
+    }
+
+    /// Rewind to `(section, byte_offset)`. Removes any sections strictly greater than `section`
+    /// (newest-first) and truncates `section` to `byte_offset` bytes.
+    pub(super) async fn rewind(&mut self, section: u64, byte_offset: u64) -> Result<(), Error> {
+        self.sections.rewind(section, byte_offset).await
+    }
+
+    /// Drop every section (sealed + tail) and remove all blobs.
+    #[commonware_macros::stability(ALPHA)]
+    pub(super) async fn clear(&mut self) -> Result<(), Error> {
+        self.sections.clear().await
+    }
+
+    /// Drop every section, remove all blobs AND the partition.
+    pub(super) async fn destroy(self) -> Result<(), Error> {
+        self.sections.destroy().await
+    }
+}
+
+/// State for replaying a single section's items.
+struct ReplayState<B: Blob, C> {
+    section: u64,
+    replay: Replay<B>,
+    skip_bytes: u64,
+    offset: u64,
+    valid_offset: u64,
+    cfg: C,
+    compressed: bool,
+    done: bool,
+}

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 commonware_macros::stability_mod!(ALPHA, pub mod authenticated);
 pub mod contiguous;
 pub mod segmented;
+pub(crate) mod variable_format;
 
 #[cfg(all(test, feature = "arbitrary"))]
 mod conformance;

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -81,19 +81,20 @@
 //! ```
 
 use super::manager::{AppendFactory, Config as ManagerConfig, Manager};
-use crate::journal::Error;
-use commonware_codec::{
-    varint::{UInt, MAX_U32_VARINT_SIZE},
-    Codec, CodecShared, EncodeSize, ReadExt, Write as CodecWrite,
+use crate::journal::{
+    variable_format::{
+        encode_item, read_item, scan_replay_item, skip_replay, try_read_item_sync, ReplayScan,
+    },
+    Error,
 };
+use commonware_codec::{varint::MAX_U32_VARINT_SIZE, Codec, CodecShared};
 use commonware_runtime::{
     buffer::paged::{Append, CacheRef, Replay},
-    Blob, Buf, IoBuf, IoBufMut, Metrics, Storage,
+    Blob, Buf, Metrics, Storage,
 };
 use futures::stream::{self, Stream, StreamExt};
-use std::{io::Cursor, num::NonZeroUsize};
+use std::num::NonZeroUsize;
 use tracing::{trace, warn};
-use zstd::{bulk::compress, decode_all};
 
 /// Configuration for `Journal` storage.
 #[derive(Clone)]
@@ -115,65 +116,6 @@ pub struct Config<C> {
     pub write_buffer: NonZeroUsize,
 }
 
-/// Decodes a varint length prefix from a buffer.
-/// Returns (item_size, varint_len).
-#[inline]
-fn decode_length_prefix(buf: &mut impl Buf) -> Result<(usize, usize), Error> {
-    let initial = buf.remaining();
-    let size = UInt::<u32>::read(buf)?.0 as usize;
-    let varint_len = initial - buf.remaining();
-    Ok((size, varint_len))
-}
-
-/// Result of finding an item in a buffer (offsets/lengths, not slices).
-enum ItemInfo {
-    /// All item data is available in the buffer.
-    Complete {
-        /// Length of the varint prefix.
-        varint_len: usize,
-        /// Length of the item data.
-        data_len: usize,
-    },
-    /// Only some item data is available.
-    Incomplete {
-        /// Length of the varint prefix.
-        varint_len: usize,
-        /// Bytes of item data available in buffer.
-        prefix_len: usize,
-        /// Full size of the item.
-        total_len: usize,
-    },
-}
-
-/// Find an item in a buffer by decoding its length prefix.
-///
-/// Returns (next_offset, item_info). The buffer is advanced past the varint.
-fn find_item(buf: &mut impl Buf, offset: u64) -> Result<(u64, ItemInfo), Error> {
-    let available = buf.remaining();
-    let (size, varint_len) = decode_length_prefix(buf)?;
-    let next_offset = offset
-        .checked_add(varint_len as u64)
-        .ok_or(Error::OffsetOverflow)?
-        .checked_add(size as u64)
-        .ok_or(Error::OffsetOverflow)?;
-    let buffered = available.saturating_sub(varint_len);
-
-    let item = if buffered >= size {
-        ItemInfo::Complete {
-            varint_len,
-            data_len: size,
-        }
-    } else {
-        ItemInfo::Incomplete {
-            varint_len,
-            prefix_len: buffered,
-            total_len: size,
-        }
-    };
-
-    Ok((next_offset, item))
-}
-
 /// State for replaying a single section's blob.
 struct ReplayState<B: Blob, C> {
     section: u64,
@@ -185,17 +127,6 @@ struct ReplayState<B: Blob, C> {
     codec_config: C,
     compressed: bool,
     done: bool,
-}
-
-/// Decode item data with optional decompression.
-fn decode_item<V: Codec>(item_data: impl Buf, cfg: &V::Cfg, compressed: bool) -> Result<V, Error> {
-    if compressed {
-        let decompressed =
-            decode_all(item_data.reader()).map_err(|_| Error::DecompressionFailed)?;
-        V::decode_cfg(decompressed.as_ref(), cfg).map_err(Error::Codec)
-    } else {
-        V::decode_cfg(item_data, cfg).map_err(Error::Codec)
-    }
 }
 
 /// A segmented journal with variable-size entries.
@@ -251,47 +182,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         blob: &Append<E::Blob>,
         offset: u64,
     ) -> Result<(u64, u32, V), Error> {
-        // Read varint header (max 5 bytes for u32)
-        let (buf, available) = blob
-            .read_up_to(
-                offset,
-                MAX_U32_VARINT_SIZE,
-                IoBufMut::with_capacity(MAX_U32_VARINT_SIZE),
-            )
-            .await?;
-        let buf = buf.freeze();
-        let mut cursor = Cursor::new(buf.slice(..available));
-        let (next_offset, item_info) = find_item(&mut cursor, offset)?;
-
-        // Decode item - either directly from buffer or by chaining prefix with remainder
-        let (item_size, decoded) = match item_info {
-            ItemInfo::Complete {
-                varint_len,
-                data_len,
-            } => {
-                // Data follows varint in buffer
-                let data = buf.slice(varint_len..varint_len + data_len);
-                let decoded = decode_item::<V>(data, cfg, compressed)?;
-                (data_len as u32, decoded)
-            }
-            ItemInfo::Incomplete {
-                varint_len,
-                prefix_len,
-                total_len,
-            } => {
-                // Read remainder and chain with prefix to avoid copying
-                let prefix = buf.slice(varint_len..varint_len + prefix_len);
-                let read_offset = offset + varint_len as u64 + prefix_len as u64;
-                let remainder_len = total_len - prefix_len;
-                let mut remainder = vec![0u8; remainder_len];
-                blob.read_into(&mut remainder, read_offset).await?;
-                let chained = prefix.chain(IoBuf::from(remainder));
-                let decoded = decode_item::<V>(chained, cfg, compressed)?;
-                (total_len as u32, decoded)
-            }
-        };
-
-        Ok((next_offset, item_size, decoded))
+        read_item(blob, offset, cfg, compressed).await
     }
 
     /// Returns an ordered stream of all items in the journal starting with the item at the given
@@ -348,14 +239,17 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
                         let blob_size = state.replay.blob_size();
                         let mut batch: Vec<Result<(u64, u64, u32, V), Error>> = Vec::new();
                         loop {
-                            // Ensure we have enough data for varint header.
-                            // ensure() returns Ok(false) if exhausted with fewer bytes,
-                            // but we still try to decode from remaining bytes.
-                            match state.replay.ensure(MAX_U32_VARINT_SIZE).await {
-                                Ok(true) => {}
-                                Ok(false) => {
-                                    // Reader exhausted - check if buffer is empty
-                                    if state.replay.remaining() == 0 {
+                            if state.skip_bytes > 0 {
+                                match skip_replay(
+                                    &mut state.replay,
+                                    &mut state.skip_bytes,
+                                    &mut state.offset,
+                                    &mut state.valid_offset,
+                                )
+                                .await
+                                {
+                                    Ok(true) => {}
+                                    Ok(false) => {
                                         state.done = true;
                                         return if batch.is_empty() {
                                             None
@@ -363,94 +257,56 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
                                             Some((batch, state))
                                         };
                                     }
-                                    // Buffer still has data - continue to try decoding
-                                }
-                                Err(err) => {
-                                    batch.push(Err(err.into()));
-                                    state.done = true;
-                                    return Some((batch, state));
-                                }
-                            }
-
-                            // Skip bytes if needed (for start_offset)
-                            if state.skip_bytes > 0 {
-                                let to_skip =
-                                    state.skip_bytes.min(state.replay.remaining() as u64) as usize;
-                                state.replay.advance(to_skip);
-                                state.skip_bytes -= to_skip as u64;
-                                state.offset += to_skip as u64;
-                                continue;
-                            }
-
-                            // Try to decode length prefix
-                            let before_remaining = state.replay.remaining();
-                            let (item_size, varint_len) =
-                                match decode_length_prefix(&mut state.replay) {
-                                    Ok(result) => result,
                                     Err(err) => {
-                                        // Could be incomplete varint - check if reader exhausted
-                                        if state.replay.is_exhausted()
-                                            || before_remaining < MAX_U32_VARINT_SIZE
-                                        {
-                                            // Treat as trailing bytes
-                                            if state.valid_offset < blob_size
-                                                && state.offset < blob_size
-                                            {
-                                                warn!(
-                                                    blob = state.section,
-                                                    bad_offset = state.offset,
-                                                    new_size = state.valid_offset,
-                                                    "trailing bytes detected: truncating"
-                                                );
-                                                // Tail repair is exceptional; make it durable
-                                                // immediately so callers do not need to track
-                                                // replay-time repaired sections separately.
-                                                if let Err(err) =
-                                                    state.blob.resize(state.valid_offset).await
-                                                {
-                                                    batch.push(Err(err.into()));
-                                                    state.done = true;
-                                                    return Some((batch, state));
-                                                }
-                                                if let Err(err) = state.blob.sync().await {
-                                                    batch.push(Err(err.into()));
-                                                    state.done = true;
-                                                    return Some((batch, state));
-                                                }
-                                            }
-                                            state.done = true;
-                                            return if batch.is_empty() {
-                                                None
-                                            } else {
-                                                Some((batch, state))
-                                            };
-                                        }
                                         batch.push(Err(err));
                                         state.done = true;
                                         return Some((batch, state));
                                     }
-                                };
+                                }
+                                continue;
+                            }
 
-                            // Ensure we have enough data for item body
-                            match state.replay.ensure(item_size).await {
-                                Ok(true) => {}
-                                Ok(false) => {
-                                    // Incomplete item at end - truncate
-                                    warn!(
-                                        blob = state.section,
-                                        bad_offset = state.offset,
-                                        new_size = state.valid_offset,
-                                        "incomplete item at end: truncating"
-                                    );
-                                    if let Err(err) = state.blob.resize(state.valid_offset).await {
-                                        batch.push(Err(err.into()));
-                                        state.done = true;
-                                        return Some((batch, state));
-                                    }
-                                    if let Err(err) = state.blob.sync().await {
-                                        batch.push(Err(err.into()));
-                                        state.done = true;
-                                        return Some((batch, state));
+                            match scan_replay_item::<_, V>(
+                                &mut state.replay,
+                                &mut state.offset,
+                                &mut state.valid_offset,
+                                &state.codec_config,
+                                state.compressed,
+                            )
+                            .await
+                            {
+                                Ok(ReplayScan::Item(item)) => {
+                                    batch.push(Ok((
+                                        state.section,
+                                        item.offset,
+                                        item.size,
+                                        item.item,
+                                    )));
+                                }
+                                Ok(ReplayScan::End {
+                                    valid_offset,
+                                    bad_offset,
+                                }) => {
+                                    if valid_offset < blob_size && bad_offset < blob_size {
+                                        warn!(
+                                            blob = state.section,
+                                            bad_offset,
+                                            new_size = valid_offset,
+                                            "trailing bytes detected: truncating"
+                                        );
+                                        // Tail repair is exceptional; make it durable immediately
+                                        // so callers do not need to track replay-time repaired
+                                        // sections separately.
+                                        if let Err(err) = state.blob.resize(valid_offset).await {
+                                            batch.push(Err(err.into()));
+                                            state.done = true;
+                                            return Some((batch, state));
+                                        }
+                                        if let Err(err) = state.blob.sync().await {
+                                            batch.push(Err(err.into()));
+                                            state.done = true;
+                                            return Some((batch, state));
+                                        }
                                     }
                                     state.done = true;
                                     return if batch.is_empty() {
@@ -458,42 +314,6 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
                                     } else {
                                         Some((batch, state))
                                     };
-                                }
-                                Err(err) => {
-                                    batch.push(Err(err.into()));
-                                    state.done = true;
-                                    return Some((batch, state));
-                                }
-                            }
-
-                            // Decode item - use take() to limit bytes read
-                            let item_offset = state.offset;
-                            let next_offset = match state
-                                .offset
-                                .checked_add(varint_len as u64)
-                                .and_then(|o| o.checked_add(item_size as u64))
-                            {
-                                Some(o) => o,
-                                None => {
-                                    batch.push(Err(Error::OffsetOverflow));
-                                    state.done = true;
-                                    return Some((batch, state));
-                                }
-                            };
-                            match decode_item::<V>(
-                                (&mut state.replay).take(item_size),
-                                &state.codec_config,
-                                state.compressed,
-                            ) {
-                                Ok(decoded) => {
-                                    batch.push(Ok((
-                                        state.section,
-                                        item_offset,
-                                        item_size as u32,
-                                        decoded,
-                                    )));
-                                    state.valid_offset = next_offset;
-                                    state.offset = next_offset;
                                 }
                                 Err(err) => {
                                     batch.push(Err(err));
@@ -519,60 +339,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// Returns `(buf, item_len)` where `item_len` is the length of the encoded (and
     /// possibly compressed) payload, excluding the size prefix.
     pub(crate) fn encode_item(compression: Option<u8>, item: &V) -> Result<(Vec<u8>, u32), Error> {
-        let mut buf = Vec::new();
-        let item_len = Self::encode_item_into(compression, item, &mut buf)?;
-        Ok((buf, item_len))
-    }
-
-    /// Encode an item with its length prefix, appending the encoded bytes to `buf`.
-    ///
-    /// Existing contents of `buf` are preserved; this allows callers to accumulate
-    /// multiple encoded items into a single buffer.
-    ///
-    /// Returns the payload length, excluding the size prefix.
-    pub(crate) fn encode_item_into(
-        compression: Option<u8>,
-        item: &V,
-        buf: &mut Vec<u8>,
-    ) -> Result<u32, Error> {
-        if let Some(compression) = compression {
-            // Compressed: encode first, then compress
-            let encoded = item.encode();
-            let compressed =
-                compress(&encoded, compression as i32).map_err(|_| Error::CompressionFailed)?;
-            let item_len = compressed.len();
-            let item_len_u32: u32 = match item_len.try_into() {
-                Ok(len) => len,
-                Err(_) => return Err(Error::ItemTooLarge(item_len)),
-            };
-            let size_len = UInt(item_len_u32).encode_size();
-            let entry_len = size_len
-                .checked_add(item_len)
-                .ok_or(Error::OffsetOverflow)?;
-
-            buf.reserve(entry_len);
-            UInt(item_len_u32).write(buf);
-            buf.extend_from_slice(&compressed);
-
-            Ok(item_len_u32)
-        } else {
-            // Uncompressed: pre-allocate exact size to avoid copying
-            let item_len = item.encode_size();
-            let item_len_u32: u32 = match item_len.try_into() {
-                Ok(len) => len,
-                Err(_) => return Err(Error::ItemTooLarge(item_len)),
-            };
-            let size_len = UInt(item_len_u32).encode_size();
-            let entry_len = size_len
-                .checked_add(item_len)
-                .ok_or(Error::OffsetOverflow)?;
-
-            buf.reserve(entry_len);
-            UInt(item_len_u32).write(buf);
-            item.write(buf);
-
-            Ok(item_len_u32)
-        }
+        encode_item(compression, item)
     }
 
     /// Appends an item to `Journal` in a given `section`, returning the offset
@@ -641,86 +408,6 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         Ok(items)
     }
 
-    /// Read consecutive items from the same section. `offsets` must be sorted in strictly
-    /// ascending order and identify items that are adjacent in the section.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::OffsetDataMismatch`] if the on-disk varint at any offset reports a size
-    /// inconsistent with the gap to the next offset. This indicates either on-disk corruption or a
-    /// caller violation of the byte-adjacency precondition.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `offsets` is not strictly increasing.
-    pub(crate) async fn get_many_consecutive(
-        &self,
-        section: u64,
-        offsets: &[u64],
-    ) -> Result<Vec<V>, Error> {
-        if offsets.len() <= 1 {
-            return self.get_many(section, offsets).await;
-        }
-        let blob = self
-            .manager
-            .get(section)?
-            .ok_or(Error::SectionOutOfRange(section))?;
-
-        let start = offsets[0];
-        let end = offsets[offsets.len() - 1];
-        if end <= start {
-            return self.get_many(section, offsets).await;
-        }
-        let range_len = usize::try_from(end - start).map_err(|_| Error::OffsetOverflow)?;
-        let bytes = blob.read_at(start, range_len).await?.coalesce();
-        let bytes = bytes.as_ref();
-
-        let compressed = self.compression.is_some();
-        let cfg = &self.codec_config;
-        let mut items = Vec::with_capacity(offsets.len());
-        let mut local_offset = 0usize;
-
-        for window in offsets.windows(2) {
-            let offset = window[0];
-            let next_offset = window[1];
-            assert!(offset < next_offset, "offsets must be strictly increasing");
-
-            let item_len =
-                usize::try_from(next_offset - offset).map_err(|_| Error::OffsetOverflow)?;
-
-            let mut cursor = Cursor::new(&bytes[local_offset..]);
-            let (size, varint_len) = decode_length_prefix(&mut cursor)?;
-            let actual_len = size + varint_len;
-            if actual_len != item_len {
-                return Err(Error::OffsetDataMismatch {
-                    section,
-                    offset,
-                    expected_len: item_len,
-                    actual_len,
-                });
-            }
-
-            let data_start = local_offset
-                .checked_add(varint_len)
-                .ok_or(Error::OffsetOverflow)?;
-            let data_end = local_offset
-                .checked_add(item_len)
-                .ok_or(Error::OffsetOverflow)?;
-
-            items.push(decode_item::<V>(
-                &bytes[data_start..data_end],
-                cfg,
-                compressed,
-            )?);
-
-            local_offset = data_end;
-        }
-
-        let (_, _, item) = Self::read(compressed, cfg, blob, end).await?;
-        items.push(item);
-        Ok(items)
-    }
-
     /// Get an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
     pub fn try_get_sync(&self, section: u64, offset: u64) -> Option<V> {
         let mut buf = Vec::new();
@@ -730,57 +417,13 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// Get an item synchronously using caller-provided buffer.
     pub fn try_get_sync_into(&self, section: u64, offset: u64, buf: &mut Vec<u8>) -> Option<V> {
         let blob = self.manager.get(section).ok()??;
-        let remaining = blob.try_size()?.checked_sub(offset)?;
-        let header_len = usize::try_from(remaining.min(MAX_U32_VARINT_SIZE as u64)).ok()?;
-        if header_len == 0 {
-            return None;
-        }
-
-        // Read the varint header to determine item size.
-        let mut header = [0u8; MAX_U32_VARINT_SIZE];
-        if !blob.try_read_sync(offset, &mut header[..header_len]) {
-            return None;
-        }
-        let mut cursor = Cursor::new(&header[..header_len]);
-        let (_, item_info) = find_item(&mut cursor, offset).ok()?;
-
-        let (varint_len, data_len) = match item_info {
-            ItemInfo::Complete {
-                varint_len,
-                data_len,
-            } => (varint_len, data_len),
-            ItemInfo::Incomplete {
-                varint_len,
-                total_len,
-                ..
-            } => (varint_len, total_len),
-        };
-        let item_len = varint_len.checked_add(data_len)?;
-        if item_len > usize::try_from(remaining).ok()? {
-            return None;
-        }
-
-        // If the full item fits in the header read, decode directly.
-        if item_len <= header_len {
-            return decode_item::<V>(
-                &header[varint_len..varint_len + data_len],
-                &self.codec_config,
-                self.compression.is_some(),
-            )
-            .ok();
-        }
-
-        // Otherwise try reading the full item from cache.
-        buf.resize(item_len, 0);
-        if !blob.try_read_sync(offset, buf) {
-            return None;
-        }
-        decode_item::<V>(
-            &buf[varint_len..varint_len + data_len],
+        try_read_item_sync(
+            blob,
+            offset,
             &self.codec_config,
             self.compression.is_some(),
+            buf,
         )
-        .ok()
     }
 
     /// Gets the size of the journal for a specific section.
@@ -788,17 +431,6 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// Returns 0 if the section does not exist.
     pub async fn size(&self, section: u64) -> Result<u64, Error> {
         self.manager.size(section).await
-    }
-
-    /// Rewinds the journal to the given `section` and `offset`, removing any data beyond it.
-    ///
-    /// # Warnings
-    ///
-    /// * This operation is not guaranteed to survive restarts until sync is called.
-    /// * This operation is not atomic, but it will always leave the journal in a consistent state
-    ///   in the event of failure since blobs are always removed in reverse order of section.
-    pub async fn rewind_to_offset(&mut self, section: u64, offset: u64) -> Result<(), Error> {
-        self.manager.rewind(section, offset).await
     }
 
     /// Rewinds the journal to the given `section` and `size`.
@@ -878,6 +510,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use commonware_codec::{varint::UInt, EncodeSize, Write as CodecWrite};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Blob, BufMut, Runner, Storage, Supervisor as _};
     use commonware_utils::{NZUsize, NZU16};

--- a/storage/src/journal/variable_format.rs
+++ b/storage/src/journal/variable_format.rs
@@ -1,0 +1,783 @@
+//! Shared format helpers for variable-length items in the journal layer.
+//!
+//! The on-disk format for a variable-length item is a u32 varint length prefix followed by the
+//! item bytes (optionally `zstd`-compressed by the caller before encoding):
+//!
+//! ```text
+//! +---+---+---+---+---+---+---+---+
+//! |       0 ~ 4       |    ...    |
+//! +---+---+---+---+---+---+---+---+
+//! | Size (varint u32) |   Data    |
+//! +---+---+---+---+---+---+---+---+
+//! ```
+//!
+//! These helpers are format-level only. They do not encode recovery policy (whether to truncate
+//! the blob on a bad varint, when to fall back to an anchor, etc.). Recovery policy lives in the
+//! specific journal implementations.
+//!
+//! Consumers: [`crate::journal::segmented::variable`] and the contiguous variable data adapter.
+
+use crate::journal::Error;
+use commonware_codec::{
+    varint::{UInt, MAX_U32_VARINT_SIZE},
+    Codec, CodecShared, EncodeSize, ReadExt, Write as CodecWrite,
+};
+use commonware_runtime::{
+    buffer::paged::{Append, Replay},
+    Blob, Buf, IoBuf, IoBufMut,
+};
+use std::{future::Future, io::Cursor};
+use zstd::{bulk::compress, decode_all};
+
+/// Result of finding an item in a buffer (offsets/lengths, not slices).
+pub(crate) enum ItemInfo {
+    /// All item data is available in the buffer.
+    Complete {
+        /// Length of the varint prefix.
+        varint_len: usize,
+        /// Length of the item data.
+        data_len: usize,
+    },
+    /// Only some item data is available.
+    Incomplete {
+        /// Length of the varint prefix.
+        varint_len: usize,
+        /// Bytes of item data available in buffer.
+        prefix_len: usize,
+        /// Full size of the item.
+        total_len: usize,
+    },
+}
+
+/// Decode a varint length prefix from `buf`, advancing past it.
+///
+/// Returns `(item_size, varint_len)`.
+pub(crate) fn decode_length_prefix(buf: &mut impl Buf) -> Result<(usize, usize), Error> {
+    let initial = buf.remaining();
+    let size = UInt::<u32>::read(buf)?.0 as usize;
+    let varint_len = initial - buf.remaining();
+    Ok((size, varint_len))
+}
+
+/// Inspect the item header in `buf`, advancing past the varint.
+///
+/// Returns `(next_item_offset, item_info)` where `next_item_offset` is the absolute offset just
+/// past this item (varint + data) and `item_info` reports whether the full item is buffered.
+pub(crate) fn find_item(buf: &mut impl Buf, offset: u64) -> Result<(u64, ItemInfo), Error> {
+    let available = buf.remaining();
+    let (size, varint_len) = decode_length_prefix(buf)?;
+    let next_offset = offset
+        .checked_add(varint_len as u64)
+        .ok_or(Error::OffsetOverflow)?
+        .checked_add(size as u64)
+        .ok_or(Error::OffsetOverflow)?;
+    let buffered = available.saturating_sub(varint_len);
+
+    let item = if buffered >= size {
+        ItemInfo::Complete {
+            varint_len,
+            data_len: size,
+        }
+    } else {
+        ItemInfo::Incomplete {
+            varint_len,
+            prefix_len: buffered,
+            total_len: size,
+        }
+    };
+
+    Ok((next_offset, item))
+}
+
+/// Decode item data, decompressing first if `compressed`.
+pub(crate) fn decode_item<V: Codec>(
+    item_data: impl Buf,
+    cfg: &V::Cfg,
+    compressed: bool,
+) -> Result<V, Error> {
+    if compressed {
+        let decompressed =
+            decode_all(item_data.reader()).map_err(|_| Error::DecompressionFailed)?;
+        V::decode_cfg(decompressed.as_ref(), cfg).map_err(Error::Codec)
+    } else {
+        V::decode_cfg(item_data, cfg).map_err(Error::Codec)
+    }
+}
+
+/// Minimal read surface needed by variable-item helpers.
+///
+/// Implementations are intentionally read-only. Callers keep ownership of storage lifecycle and
+/// repair policy (resize, rewind, prune, sync) outside this trait.
+pub(crate) trait SectionReader: Send + Sync {
+    /// Return the logical section size.
+    fn size(&self) -> impl Future<Output = Result<u64, Error>> + Send;
+
+    /// Read up to `len` bytes starting at `offset`.
+    fn read_prefix(
+        &self,
+        offset: u64,
+        len: usize,
+    ) -> impl Future<Output = Result<IoBuf, Error>> + Send;
+
+    /// Read exactly `len` bytes starting at `offset`.
+    fn read_exact(
+        &self,
+        offset: u64,
+        len: usize,
+    ) -> impl Future<Output = Result<IoBuf, Error>> + Send;
+
+    /// Return the section size if it can be observed without waiting.
+    fn try_size(&self) -> Option<u64>;
+
+    /// Try to read from cache / memory without waiting for I/O.
+    fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool;
+}
+
+impl<B: Blob> SectionReader for Append<B> {
+    async fn size(&self) -> Result<u64, Error> {
+        Ok(Self::size(self).await)
+    }
+
+    async fn read_prefix(&self, offset: u64, len: usize) -> Result<IoBuf, Error> {
+        let (buf, _available) = self
+            .read_up_to(offset, len, IoBufMut::with_capacity(len))
+            .await
+            .map_err(Error::Runtime)?;
+        Ok(buf.freeze())
+    }
+
+    async fn read_exact(&self, offset: u64, len: usize) -> Result<IoBuf, Error> {
+        Ok(self
+            .read_at(offset, len)
+            .await
+            .map_err(Error::Runtime)?
+            .coalesce())
+    }
+
+    fn try_size(&self) -> Option<u64> {
+        Self::try_size(self)
+    }
+
+    fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
+        Self::try_read_sync(self, offset, buf)
+    }
+}
+
+/// One decoded item from replay.
+pub(crate) struct ReplayItem<V> {
+    /// Byte offset where the item's varint prefix begins.
+    pub offset: u64,
+    /// Payload size, excluding the varint prefix.
+    pub size: u32,
+    /// Decoded item.
+    pub item: V,
+}
+
+/// Result of scanning replay for one item.
+pub(crate) enum ReplayScan<V> {
+    /// A complete, decoded item was found.
+    Item(ReplayItem<V>),
+    /// Replay reached trailing bytes or clean end-of-section.
+    End {
+        /// Offset just past the last fully decoded item.
+        valid_offset: u64,
+        /// Offset where scanning stopped.
+        bad_offset: u64,
+    },
+}
+
+/// Encode an item.
+///
+/// Returns `(buf, item_len)` where `item_len` is the encoded payload length, excluding the size
+/// prefix.
+pub(crate) fn encode_item<V: CodecShared>(
+    compression: Option<u8>,
+    item: &V,
+) -> Result<(Vec<u8>, u32), Error> {
+    let mut buf = Vec::new();
+    let item_len = encode_item_into(compression, item, &mut buf)?;
+    Ok((buf, item_len))
+}
+
+/// Encode an item with its length prefix, appending the encoded bytes to `buf`.
+///
+/// Existing contents of `buf` are preserved so callers can accumulate multiple encoded items into
+/// one write buffer.
+pub(crate) fn encode_item_into<V: CodecShared>(
+    compression: Option<u8>,
+    item: &V,
+    buf: &mut Vec<u8>,
+) -> Result<u32, Error> {
+    if let Some(compression) = compression {
+        let encoded = item.encode();
+        let compressed =
+            compress(&encoded, compression as i32).map_err(|_| Error::CompressionFailed)?;
+        let item_len = compressed.len();
+        let item_len_u32: u32 = item_len
+            .try_into()
+            .map_err(|_| Error::ItemTooLarge(item_len))?;
+        let size_len = UInt(item_len_u32).encode_size();
+        let entry_len = size_len
+            .checked_add(item_len)
+            .ok_or(Error::OffsetOverflow)?;
+
+        buf.reserve(entry_len);
+        UInt(item_len_u32).write(buf);
+        buf.extend_from_slice(&compressed);
+
+        Ok(item_len_u32)
+    } else {
+        let item_len = item.encode_size();
+        let item_len_u32: u32 = item_len
+            .try_into()
+            .map_err(|_| Error::ItemTooLarge(item_len))?;
+        let size_len = UInt(item_len_u32).encode_size();
+        let entry_len = size_len
+            .checked_add(item_len)
+            .ok_or(Error::OffsetOverflow)?;
+
+        buf.reserve(entry_len);
+        UInt(item_len_u32).write(buf);
+        item.write(buf);
+
+        Ok(item_len_u32)
+    }
+}
+
+/// Read and decode one variable-length item from a section.
+pub(crate) async fn read_item<V: Codec, R: SectionReader>(
+    section: &R,
+    offset: u64,
+    cfg: &V::Cfg,
+    compressed: bool,
+) -> Result<(u64, u32, V), Error> {
+    let header = section.read_prefix(offset, MAX_U32_VARINT_SIZE).await?;
+    let mut cursor = Cursor::new(header.slice(..));
+    let (next_offset, item_info) = find_item(&mut cursor, offset)?;
+    let section_size = section.size().await?;
+    if next_offset > section_size {
+        return Err(Error::Corruption(format!(
+            "item at offset {offset} extends past section size {section_size}: end={next_offset}"
+        )));
+    }
+
+    let (item_size, decoded) = match item_info {
+        ItemInfo::Complete {
+            varint_len,
+            data_len,
+        } => {
+            let data = header.slice(varint_len..varint_len + data_len);
+            let decoded = decode_item::<V>(data, cfg, compressed)?;
+            (data_len as u32, decoded)
+        }
+        ItemInfo::Incomplete {
+            varint_len,
+            prefix_len,
+            total_len,
+        } => {
+            let prefix = header.slice(varint_len..varint_len + prefix_len);
+            let read_offset = offset
+                .checked_add(varint_len as u64)
+                .and_then(|offset| offset.checked_add(prefix_len as u64))
+                .ok_or(Error::OffsetOverflow)?;
+            let remainder_len = total_len - prefix_len;
+            let remainder = section.read_exact(read_offset, remainder_len).await?;
+            let chained = prefix.chain(remainder);
+            let decoded = decode_item::<V>(chained, cfg, compressed)?;
+            (total_len as u32, decoded)
+        }
+    };
+
+    Ok((next_offset, item_size, decoded))
+}
+
+/// Try to read and decode one item synchronously from cache / memory.
+pub(crate) fn try_read_item_sync<V: Codec, R: SectionReader>(
+    section: &R,
+    offset: u64,
+    cfg: &V::Cfg,
+    compressed: bool,
+    buf: &mut Vec<u8>,
+) -> Option<V> {
+    let remaining = section.try_size()?.checked_sub(offset)?;
+    let header_len = usize::try_from(remaining.min(MAX_U32_VARINT_SIZE as u64)).ok()?;
+    if header_len == 0 {
+        return None;
+    }
+
+    let mut header = [0u8; MAX_U32_VARINT_SIZE];
+    if !section.try_read_sync(offset, &mut header[..header_len]) {
+        return None;
+    }
+    let mut cursor = Cursor::new(&header[..header_len]);
+    let (_, item_info) = find_item(&mut cursor, offset).ok()?;
+    let (varint_len, data_len) = match item_info {
+        ItemInfo::Complete {
+            varint_len,
+            data_len,
+        } => (varint_len, data_len),
+        ItemInfo::Incomplete {
+            varint_len,
+            total_len,
+            ..
+        } => (varint_len, total_len),
+    };
+    let item_len = varint_len.checked_add(data_len)?;
+    if item_len > usize::try_from(remaining).ok()? {
+        return None;
+    }
+
+    if item_len <= header_len {
+        return decode_item::<V>(&header[varint_len..varint_len + data_len], cfg, compressed).ok();
+    }
+
+    buf.resize(item_len, 0);
+    if !section.try_read_sync(offset, buf) {
+        return None;
+    }
+    decode_item::<V>(&buf[varint_len..varint_len + data_len], cfg, compressed).ok()
+}
+
+/// Read byte-adjacent items from one section.
+///
+/// `offsets` must be strictly increasing and identify adjacent items. The final item is read via
+/// [`read_item`] because callers do not provide the byte offset just past it.
+pub(crate) async fn read_many_consecutive<V: Codec, R: SectionReader>(
+    section_num: u64,
+    section: &R,
+    offsets: &[u64],
+    cfg: &V::Cfg,
+    compressed: bool,
+) -> Result<Vec<V>, Error> {
+    if offsets.len() <= 1 {
+        let mut items = Vec::with_capacity(offsets.len());
+        for &offset in offsets {
+            let (_, _, item) = read_item(section, offset, cfg, compressed).await?;
+            items.push(item);
+        }
+        return Ok(items);
+    }
+
+    for window in offsets.windows(2) {
+        if window[0] >= window[1] {
+            return Err(Error::Corruption(format!(
+                "offsets in section {section_num} must be strictly increasing: {} >= {}",
+                window[0], window[1]
+            )));
+        }
+    }
+
+    let start = offsets[0];
+    let end = offsets[offsets.len() - 1];
+    let section_size = section.size().await?;
+    if end > section_size {
+        return Err(Error::Corruption(format!(
+            "offset range {start}..{end} extends past section size {section_size}"
+        )));
+    }
+
+    for window in offsets.windows(2) {
+        let offset = window[0];
+        let next_offset = window[1];
+        let expected_len =
+            usize::try_from(next_offset - offset).map_err(|_| Error::OffsetOverflow)?;
+
+        let header = section.read_prefix(offset, MAX_U32_VARINT_SIZE).await?;
+        let mut cursor = Cursor::new(header.slice(..));
+        let (size, varint_len) = decode_length_prefix(&mut cursor)?;
+        let actual_len = size.checked_add(varint_len).ok_or(Error::OffsetOverflow)?;
+        if actual_len != expected_len {
+            return Err(Error::OffsetDataMismatch {
+                section: section_num,
+                offset,
+                expected_len,
+                actual_len,
+            });
+        }
+
+        let actual_end = offset
+            .checked_add(actual_len as u64)
+            .ok_or(Error::OffsetOverflow)?;
+        if actual_end > section_size {
+            return Err(Error::Corruption(format!(
+                "item at offset {offset} extends past section size {section_size}: end={actual_end}"
+            )));
+        }
+    }
+
+    let range_len = usize::try_from(end - start).map_err(|_| Error::OffsetOverflow)?;
+    let bytes = section.read_exact(start, range_len).await?;
+    let bytes = bytes.as_ref();
+
+    let mut items = Vec::with_capacity(offsets.len());
+    let mut local_offset = 0usize;
+    for window in offsets.windows(2) {
+        let offset = window[0];
+        let next_offset = window[1];
+        let item_len = usize::try_from(next_offset - offset).map_err(|_| Error::OffsetOverflow)?;
+        let mut cursor = Cursor::new(&bytes[local_offset..]);
+        let (size, varint_len) = decode_length_prefix(&mut cursor)?;
+        let actual_len = size.checked_add(varint_len).ok_or(Error::OffsetOverflow)?;
+        if actual_len != item_len {
+            return Err(Error::OffsetDataMismatch {
+                section: section_num,
+                offset,
+                expected_len: item_len,
+                actual_len,
+            });
+        }
+
+        let data_start = local_offset
+            .checked_add(varint_len)
+            .ok_or(Error::OffsetOverflow)?;
+        let data_end = local_offset
+            .checked_add(item_len)
+            .ok_or(Error::OffsetOverflow)?;
+        items.push(decode_item::<V>(
+            &bytes[data_start..data_end],
+            cfg,
+            compressed,
+        )?);
+        local_offset = data_end;
+    }
+
+    let (_, _, item) = read_item(section, end, cfg, compressed).await?;
+    items.push(item);
+    Ok(items)
+}
+
+/// Scan a replay stream for one item.
+///
+/// This function only reports trailing bytes via [`ReplayScan::End`]. It does not resize or sync
+/// storage; the caller owns repair policy.
+pub(crate) async fn scan_replay_item<B: Blob, V: Codec>(
+    replay: &mut Replay<B>,
+    offset: &mut u64,
+    valid_offset: &mut u64,
+    cfg: &V::Cfg,
+    compressed: bool,
+) -> Result<ReplayScan<V>, Error> {
+    match replay.ensure(MAX_U32_VARINT_SIZE).await {
+        Ok(true) => {}
+        Ok(false) => {
+            if replay.remaining() == 0 {
+                return Ok(ReplayScan::End {
+                    valid_offset: *valid_offset,
+                    bad_offset: *offset,
+                });
+            }
+        }
+        Err(err) => return Err(Error::Runtime(err)),
+    }
+
+    let (item_size, varint_len) = match decode_length_prefix(replay) {
+        Ok(result) => result,
+        Err(err) => {
+            if replay.is_exhausted() {
+                return Ok(ReplayScan::End {
+                    valid_offset: *valid_offset,
+                    bad_offset: *offset,
+                });
+            }
+            return Err(err);
+        }
+    };
+
+    match replay.ensure(item_size).await {
+        Ok(true) => {}
+        Ok(false) => {
+            return Ok(ReplayScan::End {
+                valid_offset: *valid_offset,
+                bad_offset: *offset,
+            });
+        }
+        Err(err) => return Err(Error::Runtime(err)),
+    }
+
+    let item_offset = *offset;
+    let next_offset = (*offset)
+        .checked_add(varint_len as u64)
+        .and_then(|o| o.checked_add(item_size as u64))
+        .ok_or(Error::OffsetOverflow)?;
+    let item = decode_item::<V>((&mut *replay).take(item_size), cfg, compressed)?;
+    *valid_offset = next_offset;
+    *offset = next_offset;
+
+    Ok(ReplayScan::Item(ReplayItem {
+        offset: item_offset,
+        size: item_size as u32,
+        item,
+    }))
+}
+
+/// Advance `replay` by `skip_bytes`, returning `false` if the stream ends first.
+pub(crate) async fn skip_replay<B: Blob>(
+    replay: &mut Replay<B>,
+    skip_bytes: &mut u64,
+    offset: &mut u64,
+    valid_offset: &mut u64,
+) -> Result<bool, Error> {
+    while *skip_bytes > 0 {
+        match replay.ensure(MAX_U32_VARINT_SIZE).await {
+            Ok(true) => {}
+            Ok(false) => {
+                if replay.remaining() == 0 {
+                    return Ok(false);
+                }
+            }
+            Err(err) => return Err(Error::Runtime(err)),
+        }
+
+        let to_skip = (*skip_bytes).min(replay.remaining() as u64) as usize;
+        replay.advance(to_skip);
+        *skip_bytes -= to_skip as u64;
+        *offset += to_skip as u64;
+    }
+
+    *valid_offset = *offset;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use rstest::rstest;
+    use std::io::Cursor;
+
+    struct MemorySection {
+        bytes: Vec<u8>,
+        logical_size: Option<u64>,
+    }
+
+    impl MemorySection {
+        fn new(bytes: Vec<u8>) -> Self {
+            Self {
+                bytes,
+                logical_size: None,
+            }
+        }
+
+        fn with_logical_size(bytes: Vec<u8>, logical_size: u64) -> Self {
+            Self {
+                bytes,
+                logical_size: Some(logical_size),
+            }
+        }
+    }
+
+    impl SectionReader for MemorySection {
+        async fn size(&self) -> Result<u64, Error> {
+            self.logical_size.map_or_else(
+                || {
+                    self.bytes
+                        .len()
+                        .try_into()
+                        .map_err(|_| Error::OffsetOverflow)
+                },
+                Ok,
+            )
+        }
+
+        async fn read_prefix(&self, offset: u64, len: usize) -> Result<IoBuf, Error> {
+            let start = usize::try_from(offset).map_err(|_| Error::OffsetOverflow)?;
+            if start >= self.bytes.len() {
+                return Err(Error::Corruption(format!(
+                    "offset {offset} beyond in-memory section"
+                )));
+            }
+            let end = start.saturating_add(len).min(self.bytes.len());
+            Ok(IoBuf::copy_from_slice(&self.bytes[start..end]))
+        }
+
+        async fn read_exact(&self, offset: u64, len: usize) -> Result<IoBuf, Error> {
+            let start = usize::try_from(offset).map_err(|_| Error::OffsetOverflow)?;
+            let end = start.checked_add(len).ok_or(Error::OffsetOverflow)?;
+            if end > self.bytes.len() {
+                return Err(Error::Corruption(format!(
+                    "range {offset}..{end} beyond in-memory section"
+                )));
+            }
+            Ok(IoBuf::copy_from_slice(&self.bytes[start..end]))
+        }
+
+        fn try_size(&self) -> Option<u64> {
+            self.bytes.len().try_into().ok()
+        }
+
+        fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
+            let Ok(start) = usize::try_from(offset) else {
+                return false;
+            };
+            let Some(end) = start.checked_add(buf.len()) else {
+                return false;
+            };
+            let Some(bytes) = self.bytes.get(start..end) else {
+                return false;
+            };
+            buf.copy_from_slice(bytes);
+            true
+        }
+    }
+
+    fn encode_u64_items(values: &[u64]) -> (Vec<u8>, Vec<u64>) {
+        let mut bytes = Vec::new();
+        let mut offsets = Vec::with_capacity(values.len());
+        for value in values {
+            offsets.push(bytes.len() as u64);
+            encode_item_into(None, value, &mut bytes).unwrap();
+        }
+        (bytes, offsets)
+    }
+
+    #[rstest]
+    #[case::single_item(vec![7], vec![7])]
+    #[case::multiple_adjacent_items(vec![11, 22, 33], vec![11, 22, 33])]
+    fn test_read_many_consecutive_decodes_adjacent_items(
+        #[case] values: Vec<u64>,
+        #[case] expected: Vec<u64>,
+    ) {
+        block_on(async {
+            let (bytes, offsets) = encode_u64_items(&values);
+            let section = MemorySection::new(bytes);
+
+            // Adjacent offsets let the helper bulk-read all but the final item and then decode the
+            // final item via `read_item`, matching the offsets/data journal fast path.
+            let actual = read_many_consecutive::<u64, _>(7, &section, &offsets, &(), false)
+                .await
+                .unwrap();
+            assert_eq!(actual, expected);
+        });
+    }
+
+    #[rstest]
+    #[case::gap_too_short(8, 8, 9)]
+    #[case::gap_too_long(10, 10, 9)]
+    fn test_read_many_consecutive_rejects_offset_data_mismatch(
+        #[case] second_offset: u64,
+        #[case] expected_len: usize,
+        #[case] actual_len: usize,
+    ) {
+        block_on(async {
+            let (bytes, _) = encode_u64_items(&[11, 22]);
+            let section = MemorySection::new(bytes);
+
+            // The offsets journal claims the next item starts at `second_offset`, but the data
+            // varint says the first item occupies a different number of bytes.
+            let err = read_many_consecutive::<u64, _>(7, &section, &[0, second_offset], &(), false)
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err,
+                Error::OffsetDataMismatch {
+                    section: 7,
+                    offset: 0,
+                    expected_len: e,
+                    actual_len: a,
+                } if e == expected_len && a == actual_len
+            ));
+        });
+    }
+
+    #[rstest]
+    #[case::duplicate_offset(vec![0, 0])]
+    #[case::decreasing_offset(vec![9, 0])]
+    fn test_read_many_consecutive_rejects_non_increasing_offsets(#[case] offsets: Vec<u64>) {
+        block_on(async {
+            let (bytes, _) = encode_u64_items(&[11, 22]);
+            let section = MemorySection::new(bytes);
+
+            // Non-increasing offsets can come from a corrupt offsets journal. They should surface
+            // as recovery-visible corruption, not as a panic inside the shared format helper.
+            let err = read_many_consecutive::<u64, _>(7, &section, &offsets, &(), false)
+                .await
+                .unwrap_err();
+            assert!(matches!(err, Error::Corruption(_)));
+        });
+    }
+
+    #[test]
+    fn test_read_item_rejects_length_past_section_size() {
+        block_on(async {
+            let mut bytes = Vec::new();
+            UInt(u32::MAX).write(&mut bytes);
+            let section = MemorySection::new(bytes);
+
+            let err = read_item::<u64, _>(&section, 0, &(), false)
+                .await
+                .unwrap_err();
+            assert!(matches!(err, Error::Corruption(_)));
+        });
+    }
+
+    #[test]
+    fn test_read_many_consecutive_rejects_offset_gap_past_section_size() {
+        block_on(async {
+            let (bytes, _) = encode_u64_items(&[11]);
+            let section = MemorySection::new(bytes);
+
+            let err = read_many_consecutive::<u64, _>(7, &section, &[0, u64::MAX], &(), false)
+                .await
+                .unwrap_err();
+            assert!(matches!(err, Error::Corruption(_)));
+        });
+    }
+
+    #[test]
+    fn test_read_many_consecutive_rejects_huge_gap_before_bulk_read() {
+        block_on(async {
+            let (bytes, _) = encode_u64_items(&[11]);
+            let section = MemorySection::with_logical_size(bytes, 1_000_001);
+
+            let err = read_many_consecutive::<u64, _>(7, &section, &[0, 1_000_000], &(), false)
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err,
+                Error::OffsetDataMismatch {
+                    section: 7,
+                    offset: 0,
+                    expected_len: 1_000_000,
+                    actual_len: 9,
+                }
+            ));
+        });
+    }
+
+    #[rstest]
+    #[case::complete_item(9, true, 8)]
+    #[case::partial_item(4, false, 3)]
+    fn test_find_item_reports_buffered_item_extent(
+        #[case] buffered_len: usize,
+        #[case] complete: bool,
+        #[case] available_data_len: usize,
+    ) {
+        let (bytes, _) = encode_u64_items(&[42]);
+        let mut cursor = Cursor::new(&bytes[..buffered_len]);
+
+        // `find_item` reports the full item boundary from the varint even when the caller has only
+        // buffered a prefix of the payload.
+        let (next_offset, item) = find_item(&mut cursor, 11).unwrap();
+        assert_eq!(next_offset, 20);
+        match item {
+            ItemInfo::Complete {
+                varint_len,
+                data_len,
+            } => {
+                assert!(complete);
+                assert_eq!(varint_len, 1);
+                assert_eq!(data_len, available_data_len);
+            }
+            ItemInfo::Incomplete {
+                varint_len,
+                prefix_len,
+                total_len,
+            } => {
+                assert!(!complete);
+                assert_eq!(varint_len, 1);
+                assert_eq!(prefix_len, available_data_len);
+                assert_eq!(total_len, 8);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Moves the contiguous variable journal's data backend onto the same sealed section store used by the fixed journal, and factors variable-item parsing into shared format helpers.

The data journal remains the source of truth. The offsets journal is still the index used for position lookups, but init can now align or rebuild it from the recovered data sections.

## Changes

- Adds `VariableData`, an item-aware adapter over `Sections` for variable-length data sections.
- Refactors the contiguous variable journal to store data in sealed historical sections plus one writable tail.
- Appends data first, records the corresponding offsets afterward, and tracks dirty data sections separately from the offsets journal.
- Makes commit/sync flush dirty data sections before committing/syncing offsets, so a committed offset never points at data that was intentionally skipped.
- Reworks init-time alignment so offsets can be pruned, rewound, or rebuilt from data when a crash leaves the two substrates out of sync.
- Adds `variable_format`, a shared implementation for variable item encoding, decoding, synchronous reads, consecutive batch reads, and replay scanning.
- Updates the segmented variable journal to use the shared format helpers instead of maintaining a separate parser.