### PR TITLE
[consensus] run 1k test with mock certificate scheme

### DIFF
--- a/consensus/src/aggregation/mocks/mod.rs
+++ b/consensus/src/aggregation/mocks/mod.rs
@@ -8,3 +8,4 @@ mod reporter;
 pub use reporter::{Mailbox as ReporterMailbox, Reporter};
 mod provider;
 pub use provider::Provider;
+pub mod scheme;

--- a/consensus/src/aggregation/mocks/scheme.rs
+++ b/consensus/src/aggregation/mocks/scheme.rs
@@ -1,0 +1,6 @@
+//! Mock implementation of the [`Scheme`] trait for `aggregation` tests.
+
+use crate::aggregation::types::{Item, Namespace};
+use commonware_cryptography::impl_certificate_mock;
+
+impl_certificate_mock!(&'a Item<D>, Namespace);

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -1131,4 +1131,56 @@ mod tests {
         insufficient_validators(ed25519::fixture);
         insufficient_validators(secp256r1::fixture);
     }
+
+    fn run_1k<S, F>(fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnOnce(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let cfg = deterministic::Config::new();
+        let runner = deterministic::Runner::new(cfg);
+
+        runner.start(|mut context| async move {
+            let num_validators = 10;
+            let fixture = fixture(&mut context, TEST_NAMESPACE, num_validators);
+            let epoch = Epoch::new(111);
+
+            let delayed_link = Link {
+                latency: Duration::from_millis(80),
+                jitter: Duration::from_millis(10),
+                success_rate: 0.98,
+            };
+
+            let (mut oracle, mut registrations) =
+                initialize_simulation(context.child("simulation"), &fixture, delayed_link).await;
+
+            let reporters = spawn_validator_engines(
+                context.child("validator"),
+                &fixture,
+                &mut registrations,
+                &mut oracle,
+                epoch,
+                Duration::from_secs(5),
+                vec![],
+            );
+
+            await_reporters(
+                context.child("reporter"),
+                &reporters,
+                Height::new(1_000),
+                epoch,
+            )
+            .await;
+        });
+    }
+
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_1k() {
+        // Runs 1000 heights using the mock certificate scheme. The real signing
+        // schemes are exercised by the other end-to-end tests, using mock
+        // crypto here keeps this test cheap while still verifying the engine
+        // over many heights.
+        run_1k(mocks::scheme::fixture);
+    }
 }

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -1093,19 +1093,23 @@ mod tests {
         let runner = deterministic::Runner::new(cfg);
 
         runner.start(|mut context| async move {
+            // Create validators
             let num_validators = 10;
             let fixture = fixture(&mut context, TEST_NAMESPACE, num_validators);
             let epoch = Epoch::new(111);
 
+            // Configure a delayed, lossy link
             let delayed_link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
                 success_rate: 0.98,
             };
 
+            // Initialize the simulated network
             let (mut oracle, mut registrations) =
                 initialize_simulation(context.child("simulation"), &fixture, delayed_link).await;
 
+            // Start all validators
             let reporters = spawn_validator_engines(
                 context.child("validator"),
                 &fixture,
@@ -1116,6 +1120,7 @@ mod tests {
                 vec![],
             );
 
+            // Wait for every validator to recover 1,000 certificates
             await_reporters(
                 context.child("reporter"),
                 &reporters,

--- a/consensus/src/ordered_broadcast/mocks/mod.rs
+++ b/consensus/src/ordered_broadcast/mocks/mod.rs
@@ -10,3 +10,4 @@ mod sequencers;
 pub use sequencers::Sequencers;
 mod provider;
 pub use provider::Provider;
+pub mod scheme;

--- a/consensus/src/ordered_broadcast/mocks/scheme.rs
+++ b/consensus/src/ordered_broadcast/mocks/scheme.rs
@@ -1,0 +1,6 @@
+//! Mock implementation of the [`Scheme`] trait for `ordered_broadcast` tests.
+
+use crate::ordered_broadcast::types::{AckNamespace, AckSubject};
+use commonware_cryptography::impl_certificate_mock;
+
+impl_certificate_mock!(AckSubject<'a, P, D>, AckNamespace);

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -1112,37 +1112,11 @@ mod tests {
 
     #[test_group("slow")]
     #[test_traced]
-    fn test_1k_bls12381_threshold_min_pk() {
-        run_1k(bls12381_threshold::fixture::<MinPk, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_bls12381_threshold_min_sig() {
-        run_1k(bls12381_threshold::fixture::<MinSig, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_bls12381_multisig_min_pk() {
-        run_1k(bls12381_multisig::fixture::<MinPk, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_bls12381_multisig_min_sig() {
-        run_1k(bls12381_multisig::fixture::<MinSig, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_ed25519() {
-        run_1k(ed25519::fixture);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_secp256r1() {
-        run_1k(secp256r1::fixture);
+    fn test_1k() {
+        // Runs 1000 heights using the mock certificate scheme. The real signing
+        // schemes are exercised by the other end-to-end tests, using mock
+        // crypto here keeps this test cheap while still verifying the engine
+        // over many heights.
+        run_1k(mocks::scheme::fixture);
     }
 }

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -416,7 +416,6 @@ mod tests {
         simplex::{
             elector::{Config as Elector, Elector as ElectorTrait, Random, RoundRobin},
             mocks::{
-                scheme as scheme_mocks,
                 twins::{self, Elector as TwinsElector},
                 wrapped,
             },
@@ -3611,7 +3610,7 @@ mod tests {
                 participants,
                 schemes,
                 ..
-            } = scheme_mocks::fixture(&mut context, &namespace, n);
+            } = mocks::scheme::fixture(&mut context, &namespace, n);
             let me = participants[0].clone();
             let mut oracle =
                 start_test_network_with_peers(context.child("network"), participants.clone(), true)
@@ -4852,50 +4851,12 @@ mod tests {
 
     #[test_group("slow")]
     #[test_traced]
-    fn test_1k_bls12381_threshold_vrf_min_pk() {
-        run_1k::<_, _, Random>(bls12381_threshold_vrf::fixture::<MinPk, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_bls12381_threshold_vrf_min_sig() {
-        run_1k::<_, _, Random>(bls12381_threshold_vrf::fixture::<MinSig, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_bls12381_threshold_std_min_pk() {
-        run_1k::<_, _, RoundRobin>(bls12381_threshold_std::fixture::<MinPk, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_bls12381_threshold_std_min_sig() {
-        run_1k::<_, _, RoundRobin>(bls12381_threshold_std::fixture::<MinSig, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_bls12381_multisig_min_pk() {
-        run_1k::<_, _, RoundRobin>(bls12381_multisig::fixture::<MinPk, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_bls12381_multisig_min_sig() {
-        run_1k::<_, _, RoundRobin>(bls12381_multisig::fixture::<MinSig, _>);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_ed25519() {
-        run_1k::<_, _, RoundRobin>(ed25519::fixture);
-    }
-
-    #[test_group("slow")]
-    #[test_traced]
-    fn test_1k_secp256r1() {
-        run_1k::<_, _, RoundRobin>(secp256r1::fixture);
+    fn test_1k() {
+        // Runs 1000 views using the mock certificate scheme. The real signing
+        // schemes are exercised by the other end-to-end tests, using mock
+        // crypto here keeps this test cheap while still verifying the engine
+        // over many views.
+        run_1k::<_, _, RoundRobin>(mocks::scheme::fixture);
     }
 
     fn engine_shutdown<S, F, L>(seed: u64, mut fixture: F, graceful: bool)
@@ -6764,7 +6725,7 @@ mod tests {
                 &mut test_rng(),
                 TWINS_CAMPAIGN,
                 link,
-                scheme_mocks::fixture,
+                mocks::scheme::fixture,
             );
         }
     }
@@ -6788,7 +6749,7 @@ mod tests {
                 &mut test_rng(),
                 campaign,
                 link,
-                scheme_mocks::fixture,
+                mocks::scheme::fixture,
             );
         }
     }
@@ -6805,7 +6766,7 @@ mod tests {
             &mut test_rng(),
             campaign,
             TWINS_LINK,
-            scheme_mocks::fixture,
+            mocks::scheme::fixture,
         );
     }
 
@@ -6822,7 +6783,7 @@ mod tests {
             &mut test_rng(),
             campaign,
             TWINS_LINK,
-            scheme_mocks::fixture,
+            mocks::scheme::fixture,
         );
     }
 


### PR DESCRIPTION
Run all 1k consensus tests with the mock certificate scheme. Also adds a 1k test for aggregation for completeness sake.