### PR TITLE
[storage/qmdb] generate test per variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,6 +1903,7 @@ dependencies = [
  "criterion",
  "futures",
  "futures-util",
+ "paste",
  "rand 0.8.5",
  "rstest",
  "thiserror 2.0.17",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -38,6 +38,7 @@ commonware-math.workspace = true
 commonware-runtime = { workspace = true, features = ["test-utils"] }
 commonware-storage = { path = ".", features = ["std"] }
 criterion.workspace = true
+paste.workspace = true
 rand.workspace = true
 rstest.workspace = true
 tracing-subscriber.workspace = true

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -1314,167 +1314,125 @@ pub(crate) mod test {
     // Defines MMR-only variants (for tests that require mmr::Family, e.g. proof verification).
     macro_rules! with_mmr_variants {
         ($cb:ident!($($args:tt)*)) => {
-            $cb!($($args)*, "uf", UnorderedFixed, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "uv", UnorderedVariable, mmr::Family, variable_db_config);
-            $cb!($($args)*, "of", OrderedFixed, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "ov", OrderedVariable, mmr::Family, variable_db_config);
-            $cb!($($args)*, "ufp1", UnorderedFixedP1, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "uvp1", UnorderedVariableP1, mmr::Family, variable_db_config);
-            $cb!($($args)*, "ofp1", OrderedFixedP1, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "ovp1", OrderedVariableP1, mmr::Family, variable_db_config);
-            $cb!($($args)*, "ufp2", UnorderedFixedP2, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "uvp2", UnorderedVariableP2, mmr::Family, variable_db_config);
-            $cb!($($args)*, "ofp2", OrderedFixedP2, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "ovp2", OrderedVariableP2, mmr::Family, variable_db_config);
+            $cb!($($args)*, uf, UnorderedFixed, mmr::Family, fixed_db_config);
+            $cb!($($args)*, uv, UnorderedVariable, mmr::Family, variable_db_config);
+            $cb!($($args)*, of, OrderedFixed, mmr::Family, fixed_db_config);
+            $cb!($($args)*, ov, OrderedVariable, mmr::Family, variable_db_config);
+            $cb!($($args)*, ufp1, UnorderedFixedP1, mmr::Family, fixed_db_config);
+            $cb!($($args)*, uvp1, UnorderedVariableP1, mmr::Family, variable_db_config);
+            $cb!($($args)*, ofp1, OrderedFixedP1, mmr::Family, fixed_db_config);
+            $cb!($($args)*, ovp1, OrderedVariableP1, mmr::Family, variable_db_config);
+            $cb!($($args)*, ufp2, UnorderedFixedP2, mmr::Family, fixed_db_config);
+            $cb!($($args)*, uvp2, UnorderedVariableP2, mmr::Family, variable_db_config);
+            $cb!($($args)*, ofp2, OrderedFixedP2, mmr::Family, fixed_db_config);
+            $cb!($($args)*, ovp2, OrderedVariableP2, mmr::Family, variable_db_config);
         };
     }
 
     // Defines all variants (MMR + MMB). Calls $cb!($($args)*, $label, $type, $family, $config) for each.
     macro_rules! with_all_variants {
         ($cb:ident!($($args:tt)*)) => {
-            $cb!($($args)*, "uf", UnorderedFixed, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "uv", UnorderedVariable, mmr::Family, variable_db_config);
-            $cb!($($args)*, "of", OrderedFixed, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "ov", OrderedVariable, mmr::Family, variable_db_config);
-            $cb!($($args)*, "ufp1", UnorderedFixedP1, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "uvp1", UnorderedVariableP1, mmr::Family, variable_db_config);
-            $cb!($($args)*, "ofp1", OrderedFixedP1, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "ovp1", OrderedVariableP1, mmr::Family, variable_db_config);
-            $cb!($($args)*, "ufp2", UnorderedFixedP2, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "uvp2", UnorderedVariableP2, mmr::Family, variable_db_config);
-            $cb!($($args)*, "ofp2", OrderedFixedP2, mmr::Family, fixed_db_config);
-            $cb!($($args)*, "ovp2", OrderedVariableP2, mmr::Family, variable_db_config);
-            $cb!($($args)*, "uf_mmb", MmbUnorderedFixed, mmb::Family, fixed_db_config);
-            $cb!($($args)*, "uv_mmb", MmbUnorderedVariable, mmb::Family, variable_db_config);
-            $cb!($($args)*, "of_mmb", MmbOrderedFixed, mmb::Family, fixed_db_config);
-            $cb!($($args)*, "ov_mmb", MmbOrderedVariable, mmb::Family, variable_db_config);
+            $cb!($($args)*, uf, UnorderedFixed, mmr::Family, fixed_db_config);
+            $cb!($($args)*, uv, UnorderedVariable, mmr::Family, variable_db_config);
+            $cb!($($args)*, of, OrderedFixed, mmr::Family, fixed_db_config);
+            $cb!($($args)*, ov, OrderedVariable, mmr::Family, variable_db_config);
+            $cb!($($args)*, ufp1, UnorderedFixedP1, mmr::Family, fixed_db_config);
+            $cb!($($args)*, uvp1, UnorderedVariableP1, mmr::Family, variable_db_config);
+            $cb!($($args)*, ofp1, OrderedFixedP1, mmr::Family, fixed_db_config);
+            $cb!($($args)*, ovp1, OrderedVariableP1, mmr::Family, variable_db_config);
+            $cb!($($args)*, ufp2, UnorderedFixedP2, mmr::Family, fixed_db_config);
+            $cb!($($args)*, uvp2, UnorderedVariableP2, mmr::Family, variable_db_config);
+            $cb!($($args)*, ofp2, OrderedFixedP2, mmr::Family, fixed_db_config);
+            $cb!($($args)*, ovp2, OrderedVariableP2, mmr::Family, variable_db_config);
+            $cb!($($args)*, uf_mmb, MmbUnorderedFixed, mmb::Family, fixed_db_config);
+            $cb!($($args)*, uv_mmb, MmbUnorderedVariable, mmb::Family, variable_db_config);
+            $cb!($($args)*, of_mmb, MmbOrderedFixed, mmb::Family, fixed_db_config);
+            $cb!($($args)*, ov_mmb, MmbOrderedVariable, mmb::Family, variable_db_config);
         };
     }
 
-    // Runner macros - each receives common args followed by (label, type, family, config)
-    // from with_all_variants. Each variant constructs a fresh `deterministic::Runner` so
-    // the outer state machine of one variant never has to fit alongside the outer state
-    // machines of the others on the test thread stack.
-    macro_rules! test_with_reopen {
-        ($sfx:expr, $f:expr, $l:literal, $db:ty, $family:ty, $cfg:ident) => {{
-            let p = concat!($l, "_", $sfx);
-            let executor = deterministic::Runner::default();
-            executor.start(|context| async move {
-                let ctx = context.child($l);
-                let db = <$db>::init(ctx.child("storage"), $cfg::<OneCap>(p, &ctx))
-                    .await
-                    .unwrap();
-                $f(
-                    ctx,
-                    db,
-                    |ctx| {
-                        Box::pin(async move {
-                            <$db>::init(ctx.child("storage"), $cfg::<OneCap>(p, &ctx))
-                                .await
-                                .unwrap()
-                        })
-                    },
-                    to_digest,
-                )
-                .await;
-            });
-        }};
+    // Emit one `#[test_group("slow")] #[test_traced]` test per variant, named
+    // `<f>_<variant_label>`. `with_reopen` hands the test a db plus a reopen
+    // closure, `with_make_value` hands it just the db.
+    macro_rules! test_for_variant {
+        (with_reopen: $f:ident, $traced:literal, $l:ident, $db:ty, $family:ty, $cfg:ident) => {
+            paste::paste! {
+                #[test_group("slow")]
+                #[test_traced($traced)]
+                fn [<$f _ $l>]() {
+                    let executor = deterministic::Runner::default();
+                    executor.start(|context| async move {
+                        let ctx = context.child(stringify!($l));
+                        let db = <$db>::init(ctx.child("storage"), $cfg::<OneCap>("db", &ctx))
+                            .await
+                            .unwrap();
+                        $f(
+                            ctx,
+                            db,
+                            |ctx| {
+                                Box::pin(async move {
+                                    <$db>::init(ctx.child("storage"), $cfg::<OneCap>("db", &ctx))
+                                        .await
+                                        .unwrap()
+                                })
+                            },
+                            to_digest,
+                        )
+                        .await;
+                    });
+                }
+            }
+        };
+        (with_make_value: $f:ident, $traced:literal, $l:ident, $db:ty, $family:ty, $cfg:ident) => {
+            paste::paste! {
+                #[test_group("slow")]
+                #[test_traced($traced)]
+                fn [<$f _ $l>]() {
+                    let executor = deterministic::Runner::default();
+                    executor.start(|context| async move {
+                        let ctx = context.child(stringify!($l));
+                        let db = <$db>::init(ctx.child("storage"), $cfg::<OneCap>("db", &ctx))
+                            .await
+                            .unwrap();
+                        $f(ctx, db, to_digest).await;
+                    });
+                }
+            }
+        };
     }
 
-    macro_rules! test_with_make_value {
-        ($sfx:expr, $f:expr, $l:literal, $db:ty, $family:ty, $cfg:ident) => {{
-            let p = concat!($l, "_", $sfx);
-            let executor = deterministic::Runner::default();
-            executor.start(|context| async move {
-                let ctx = context.child($l);
-                let db = <$db>::init(ctx.child("storage"), $cfg::<OneCap>(p, &ctx))
-                    .await
-                    .unwrap();
-                $f(ctx, db, to_digest).await;
-            });
-        }};
+    // Generate one slow test per variant across all variants (MMR + MMB).
+    macro_rules! test_for_all_variants {
+        (with_reopen: $f:ident, $traced:literal) => {
+            with_all_variants!(test_for_variant!(with_reopen: $f, $traced));
+        };
+        (with_make_value: $f:ident, $traced:literal) => {
+            with_all_variants!(test_for_variant!(with_make_value: $f, $traced));
+        };
     }
 
-    // Macro to run a test on all DB variants (MMR + MMB).
-    macro_rules! for_all_variants {
-        ($sfx:expr, with_reopen: $f:expr) => {{
-            with_all_variants!(test_with_reopen!($sfx, $f));
-        }};
-        ($sfx:expr, with_make_value: $f:expr) => {{
-            with_all_variants!(test_with_make_value!($sfx, $f));
-        }};
+    // Generate one slow test per variant across the MMR-only variants (for
+    // tests that use mmr::Family-specific features like Location::new or
+    // verify_proof).
+    macro_rules! test_for_mmr_variants {
+        (with_reopen: $f:ident, $traced:literal) => {
+            with_mmr_variants!(test_for_variant!(with_reopen: $f, $traced));
+        };
+        (with_make_value: $f:ident, $traced:literal) => {
+            with_mmr_variants!(test_for_variant!(with_make_value: $f, $traced));
+        };
     }
 
-    // Macro to run a test on MMR-only DB variants (for tests that use mmr::Family-specific
-    // features like Location::new or verify_proof).
-    macro_rules! for_mmr_variants {
-        ($sfx:expr, with_reopen: $f:expr) => {{
-            with_mmr_variants!(test_with_reopen!($sfx, $f));
-        }};
-        ($sfx:expr, with_make_value: $f:expr) => {{
-            with_mmr_variants!(test_with_make_value!($sfx, $f));
-        }};
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_log_replay() {
-        for_all_variants!("lr", with_reopen: test_any_db_log_replay);
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_build_and_authenticate() {
-        for_mmr_variants!("baa", with_reopen: test_any_db_build_and_authenticate);
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_historical_proof_basic() {
-        for_mmr_variants!("hpb", with_make_value: test_any_db_historical_proof_basic);
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_historical_proof_invalid() {
-        for_mmr_variants!("hpi", with_make_value: test_any_db_historical_proof_invalid);
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_historical_proof_edge_cases() {
-        for_mmr_variants!("hpec", with_make_value: test_any_db_historical_proof_edge_cases);
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_multiple_commits_delete_replayed() {
-        for_all_variants!("mcdr", with_reopen: test_any_db_multiple_commits_delete_replayed);
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_non_empty_recovery() {
-        for_all_variants!("ner", with_reopen: test_any_db_non_empty_recovery);
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_empty_recovery() {
-        for_all_variants!("er", with_reopen: test_any_db_empty_recovery);
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_commit_after_sync_recovery() {
-        for_all_variants!("casr", with_reopen: test_any_db_commit_after_sync_recovery);
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_rewind_recovery() {
-        for_mmr_variants!("rr", with_reopen: test_any_db_rewind_recovery);
-    }
+    test_for_all_variants!(with_reopen: test_any_db_log_replay, "WARN");
+    test_for_mmr_variants!(with_reopen: test_any_db_build_and_authenticate, "WARN");
+    test_for_mmr_variants!(with_make_value: test_any_db_historical_proof_basic, "WARN");
+    test_for_mmr_variants!(with_make_value: test_any_db_historical_proof_invalid, "WARN");
+    test_for_mmr_variants!(with_make_value: test_any_db_historical_proof_edge_cases, "WARN");
+    test_for_all_variants!(with_reopen: test_any_db_multiple_commits_delete_replayed, "WARN");
+    test_for_all_variants!(with_reopen: test_any_db_non_empty_recovery, "WARN");
+    test_for_all_variants!(with_reopen: test_any_db_empty_recovery, "WARN");
+    test_for_all_variants!(with_reopen: test_any_db_commit_after_sync_recovery, "WARN");
+    test_for_mmr_variants!(with_reopen: test_any_db_rewind_recovery, "WARN");
 
     fn key(i: u64) -> Digest {
         Sha256::hash(&i.to_be_bytes())

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1452,29 +1452,6 @@ pub mod tests {
         };
     }
 
-    // Runner macros - receive common args followed by (label, type, config).
-    macro_rules! test_simple {
-        ($f:expr, $l:ident, $db:ty, $cfg:ident) => {
-            Box::pin(async {
-                $f(open_db_fn!($db, $cfg));
-            })
-            .await
-        };
-    }
-
-    // Macro to run a test on DB variants.
-    macro_rules! for_all_variants {
-        (simple: $f:expr) => {{
-            with_all_variants!(test_simple!($f));
-        }};
-        (ordered: $f:expr) => {{
-            with_ordered_variants!(test_simple!($f));
-        }};
-        (unordered: $f:expr) => {{
-            with_unordered_variants!(test_simple!($f));
-        }};
-    }
-
     // Emit one `#[test_group("slow")] #[test_traced]` test per variant.
     // The fn name is `<f>_<variant_label>`, the body opens the variant's DB and
     // runs the test function `f`.
@@ -1546,27 +1523,13 @@ pub mod tests {
     test_for_all_variants!(test_simulate_write_failures, "WARN");
     test_for_all_variants!(test_different_pruning_delays_same_root, "WARN");
     test_for_all_variants!(test_sync_persists_bitmap_pruning_boundary, "WARN");
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_commit_after_sync_recovery() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(simple: test_commit_after_sync_recovery);
-        });
-    }
-
-    #[test_traced("WARN")]
-    fn test_all_variants_stale_batch_side_effect_free() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(simple: test_stale_batch_side_effect_free);
-        });
-    }
+    test_for_all_variants!(test_commit_after_sync_recovery, "WARN");
+    test_for_all_variants!(test_stale_batch_side_effect_free, "WARN");
 
     test_for_ordered_variants!(test_ordered_build_big, "WARN");
-    test_for_unordered_variants!(test_unordered_build_big, "WARN");
     test_for_ordered_variants!(test_ordered_build_small_close_reopen, "DEBUG");
+
+    test_for_unordered_variants!(test_unordered_build_big, "WARN");
     test_for_unordered_variants!(test_unordered_build_small_close_reopen, "DEBUG");
 
     // ---- Current-level batch API tests ----

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -525,12 +525,14 @@ pub mod tests {
     };
     use commonware_utils::{bitmap::Readable, NZUsize, NZU16, NZU64};
     use core::future::Future;
+    use ordered::tests::test_build_small_close_reopen as test_ordered_build_small_close_reopen;
     use rand::{rngs::StdRng, RngCore, SeedableRng};
     use std::{
         num::{NonZeroU16, NonZeroUsize},
         sync::Arc,
     };
     use tracing::warn;
+    use unordered::tests::test_build_small_close_reopen as test_unordered_build_small_close_reopen;
 
     type Error<F> = crate::qmdb::Error<F>;
     type Location<F> = merkle::Location<F>;
@@ -1474,14 +1476,14 @@ pub mod tests {
     }
 
     // Emit one `#[test_group("slow")] #[test_traced]` test per variant.
-    // The fn name is `<prefix>_<variant_label>`, the body opens the variant's DB
-    // and runs the user-supplied test function.
+    // The fn name is `<f>_<variant_label>`, the body opens the variant's DB and
+    // runs the test function `f`.
     macro_rules! test_for_variant {
-        ($prefix:ident, $f:path, $traced:literal, $label:ident, $db:ty, $cfg:ident) => {
+        ($f:ident, $traced:literal, $label:ident, $db:ty, $cfg:ident) => {
             paste::paste! {
                 #[test_group("slow")]
                 #[test_traced($traced)]
-                fn [<$prefix _ $label>]() {
+                fn [<$f _ $label>]() {
                     let executor = deterministic::Runner::default();
                     executor.start(|_context| async move {
                         Box::pin(async {
@@ -1496,22 +1498,22 @@ pub mod tests {
 
     // Generate one slow test per variant across all 24 variants.
     macro_rules! test_for_all_variants {
-        ($prefix:ident, $f:path, $traced:literal) => {
-            with_all_variants!(test_for_variant!($prefix, $f, $traced));
+        ($f:ident, $traced:literal) => {
+            with_all_variants!(test_for_variant!($f, $traced));
         };
     }
 
     // Generate one slow test per variant across the 12 ordered variants.
     macro_rules! test_for_ordered_variants {
-        ($prefix:ident, $f:path, $traced:literal) => {
-            with_ordered_variants!(test_for_variant!($prefix, $f, $traced));
+        ($f:ident, $traced:literal) => {
+            with_ordered_variants!(test_for_variant!($f, $traced));
         };
     }
 
     // Generate one slow test per variant across the 12 unordered variants.
     macro_rules! test_for_unordered_variants {
-        ($prefix:ident, $f:path, $traced:literal) => {
-            with_unordered_variants!(test_for_variant!($prefix, $f, $traced));
+        ($f:ident, $traced:literal) => {
+            with_unordered_variants!(test_for_variant!($f, $traced));
         };
     }
 
@@ -1540,26 +1542,10 @@ pub mod tests {
         test_current_db_build_big::<M, C, F, Fut>(open_db);
     }
 
-    test_for_all_variants!(
-        test_all_variants_build_random_close_reopen,
-        test_build_random_close_reopen,
-        "WARN"
-    );
-    test_for_all_variants!(
-        test_all_variants_simulate_write_failures,
-        test_simulate_write_failures,
-        "WARN"
-    );
-    test_for_all_variants!(
-        test_all_variants_different_pruning_delays_same_root,
-        test_different_pruning_delays_same_root,
-        "WARN"
-    );
-    test_for_all_variants!(
-        test_all_variants_sync_persists_bitmap_pruning_boundary,
-        test_sync_persists_bitmap_pruning_boundary,
-        "WARN"
-    );
+    test_for_all_variants!(test_build_random_close_reopen, "WARN");
+    test_for_all_variants!(test_simulate_write_failures, "WARN");
+    test_for_all_variants!(test_different_pruning_delays_same_root, "WARN");
+    test_for_all_variants!(test_sync_persists_bitmap_pruning_boundary, "WARN");
 
     #[test_group("slow")]
     #[test_traced("WARN")]
@@ -1578,26 +1564,10 @@ pub mod tests {
         });
     }
 
-    test_for_ordered_variants!(
-        test_ordered_variants_build_big,
-        test_ordered_build_big,
-        "WARN"
-    );
-    test_for_unordered_variants!(
-        test_unordered_variants_build_big,
-        test_unordered_build_big,
-        "WARN"
-    );
-    test_for_ordered_variants!(
-        test_ordered_variants_build_small_close_reopen,
-        ordered::tests::test_build_small_close_reopen,
-        "DEBUG"
-    );
-    test_for_unordered_variants!(
-        test_unordered_variants_build_small_close_reopen,
-        unordered::tests::test_build_small_close_reopen,
-        "DEBUG"
-    );
+    test_for_ordered_variants!(test_ordered_build_big, "WARN");
+    test_for_unordered_variants!(test_unordered_build_big, "WARN");
+    test_for_ordered_variants!(test_ordered_build_small_close_reopen, "DEBUG");
+    test_for_unordered_variants!(test_unordered_build_small_close_reopen, "DEBUG");
 
     // ---- Current-level batch API tests ----
     //
@@ -2774,11 +2744,7 @@ pub mod tests {
         });
     }
 
-    test_for_all_variants!(
-        test_all_variants_speculative_root_matches_committed,
-        test_speculative_root_matches_committed,
-        "INFO"
-    );
+    test_for_all_variants!(test_speculative_root_matches_committed, "INFO");
 
     /// MerkleizedBatch::get() at the current level reads overlay then base DB.
     #[test_traced("INFO")]

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1387,72 +1387,72 @@ pub mod tests {
     // Defines all variants across both supported Merkle families.
     macro_rules! with_all_variants {
         ($cb:ident!($($args:tt)*)) => {
-            $cb!($($args)*, "of", OrderedFixedDb, fixed_config);
-            $cb!($($args)*, "ov", OrderedVariableDb, variable_config);
-            $cb!($($args)*, "uf", UnorderedFixedDb, fixed_config);
-            $cb!($($args)*, "uv", UnorderedVariableDb, variable_config);
-            $cb!($($args)*, "ofp1", OrderedFixedP1Db, fixed_config);
-            $cb!($($args)*, "ovp1", OrderedVariableP1Db, variable_config);
-            $cb!($($args)*, "ufp1", UnorderedFixedP1Db, fixed_config);
-            $cb!($($args)*, "uvp1", UnorderedVariableP1Db, variable_config);
-            $cb!($($args)*, "ofp2", OrderedFixedP2Db, fixed_config);
-            $cb!($($args)*, "ovp2", OrderedVariableP2Db, variable_config);
-            $cb!($($args)*, "ufp2", UnorderedFixedP2Db, fixed_config);
-            $cb!($($args)*, "uvp2", UnorderedVariableP2Db, variable_config);
-            $cb!($($args)*, "of-mmb", OrderedFixedMmbDb, fixed_config);
-            $cb!($($args)*, "ov-mmb", OrderedVariableMmbDb, variable_config);
-            $cb!($($args)*, "uf-mmb", UnorderedFixedMmbDb, fixed_config);
-            $cb!($($args)*, "uv-mmb", UnorderedVariableMmbDb, variable_config);
-            $cb!($($args)*, "ofp1-mmb", OrderedFixedMmbP1Db, fixed_config);
-            $cb!($($args)*, "ovp1-mmb", OrderedVariableMmbP1Db, variable_config);
-            $cb!($($args)*, "ufp1-mmb", UnorderedFixedMmbP1Db, fixed_config);
-            $cb!($($args)*, "uvp1-mmb", UnorderedVariableMmbP1Db, variable_config);
-            $cb!($($args)*, "ofp2-mmb", OrderedFixedMmbP2Db, fixed_config);
-            $cb!($($args)*, "ovp2-mmb", OrderedVariableMmbP2Db, variable_config);
-            $cb!($($args)*, "ufp2-mmb", UnorderedFixedMmbP2Db, fixed_config);
-            $cb!($($args)*, "uvp2-mmb", UnorderedVariableMmbP2Db, variable_config);
+            $cb!($($args)*, of, OrderedFixedDb, fixed_config);
+            $cb!($($args)*, ov, OrderedVariableDb, variable_config);
+            $cb!($($args)*, uf, UnorderedFixedDb, fixed_config);
+            $cb!($($args)*, uv, UnorderedVariableDb, variable_config);
+            $cb!($($args)*, ofp1, OrderedFixedP1Db, fixed_config);
+            $cb!($($args)*, ovp1, OrderedVariableP1Db, variable_config);
+            $cb!($($args)*, ufp1, UnorderedFixedP1Db, fixed_config);
+            $cb!($($args)*, uvp1, UnorderedVariableP1Db, variable_config);
+            $cb!($($args)*, ofp2, OrderedFixedP2Db, fixed_config);
+            $cb!($($args)*, ovp2, OrderedVariableP2Db, variable_config);
+            $cb!($($args)*, ufp2, UnorderedFixedP2Db, fixed_config);
+            $cb!($($args)*, uvp2, UnorderedVariableP2Db, variable_config);
+            $cb!($($args)*, of_mmb, OrderedFixedMmbDb, fixed_config);
+            $cb!($($args)*, ov_mmb, OrderedVariableMmbDb, variable_config);
+            $cb!($($args)*, uf_mmb, UnorderedFixedMmbDb, fixed_config);
+            $cb!($($args)*, uv_mmb, UnorderedVariableMmbDb, variable_config);
+            $cb!($($args)*, ofp1_mmb, OrderedFixedMmbP1Db, fixed_config);
+            $cb!($($args)*, ovp1_mmb, OrderedVariableMmbP1Db, variable_config);
+            $cb!($($args)*, ufp1_mmb, UnorderedFixedMmbP1Db, fixed_config);
+            $cb!($($args)*, uvp1_mmb, UnorderedVariableMmbP1Db, variable_config);
+            $cb!($($args)*, ofp2_mmb, OrderedFixedMmbP2Db, fixed_config);
+            $cb!($($args)*, ovp2_mmb, OrderedVariableMmbP2Db, variable_config);
+            $cb!($($args)*, ufp2_mmb, UnorderedFixedMmbP2Db, fixed_config);
+            $cb!($($args)*, uvp2_mmb, UnorderedVariableMmbP2Db, variable_config);
         };
     }
 
     // Defines 6 ordered variants.
     macro_rules! with_ordered_variants {
         ($cb:ident!($($args:tt)*)) => {
-            $cb!($($args)*, "of", OrderedFixedDb, fixed_config);
-            $cb!($($args)*, "ov", OrderedVariableDb, variable_config);
-            $cb!($($args)*, "ofp1", OrderedFixedP1Db, fixed_config);
-            $cb!($($args)*, "ovp1", OrderedVariableP1Db, variable_config);
-            $cb!($($args)*, "ofp2", OrderedFixedP2Db, fixed_config);
-            $cb!($($args)*, "ovp2", OrderedVariableP2Db, variable_config);
-            $cb!($($args)*, "of-mmb", OrderedFixedMmbDb, fixed_config);
-            $cb!($($args)*, "ov-mmb", OrderedVariableMmbDb, variable_config);
-            $cb!($($args)*, "ofp1-mmb", OrderedFixedMmbP1Db, fixed_config);
-            $cb!($($args)*, "ovp1-mmb", OrderedVariableMmbP1Db, variable_config);
-            $cb!($($args)*, "ofp2-mmb", OrderedFixedMmbP2Db, fixed_config);
-            $cb!($($args)*, "ovp2-mmb", OrderedVariableMmbP2Db, variable_config);
+            $cb!($($args)*, of, OrderedFixedDb, fixed_config);
+            $cb!($($args)*, ov, OrderedVariableDb, variable_config);
+            $cb!($($args)*, ofp1, OrderedFixedP1Db, fixed_config);
+            $cb!($($args)*, ovp1, OrderedVariableP1Db, variable_config);
+            $cb!($($args)*, ofp2, OrderedFixedP2Db, fixed_config);
+            $cb!($($args)*, ovp2, OrderedVariableP2Db, variable_config);
+            $cb!($($args)*, of_mmb, OrderedFixedMmbDb, fixed_config);
+            $cb!($($args)*, ov_mmb, OrderedVariableMmbDb, variable_config);
+            $cb!($($args)*, ofp1_mmb, OrderedFixedMmbP1Db, fixed_config);
+            $cb!($($args)*, ovp1_mmb, OrderedVariableMmbP1Db, variable_config);
+            $cb!($($args)*, ofp2_mmb, OrderedFixedMmbP2Db, fixed_config);
+            $cb!($($args)*, ovp2_mmb, OrderedVariableMmbP2Db, variable_config);
         };
     }
 
     // Defines 6 unordered variants.
     macro_rules! with_unordered_variants {
         ($cb:ident!($($args:tt)*)) => {
-            $cb!($($args)*, "uf", UnorderedFixedDb, fixed_config);
-            $cb!($($args)*, "uv", UnorderedVariableDb, variable_config);
-            $cb!($($args)*, "ufp1", UnorderedFixedP1Db, fixed_config);
-            $cb!($($args)*, "uvp1", UnorderedVariableP1Db, variable_config);
-            $cb!($($args)*, "ufp2", UnorderedFixedP2Db, fixed_config);
-            $cb!($($args)*, "uvp2", UnorderedVariableP2Db, variable_config);
-            $cb!($($args)*, "uf-mmb", UnorderedFixedMmbDb, fixed_config);
-            $cb!($($args)*, "uv-mmb", UnorderedVariableMmbDb, variable_config);
-            $cb!($($args)*, "ufp1-mmb", UnorderedFixedMmbP1Db, fixed_config);
-            $cb!($($args)*, "uvp1-mmb", UnorderedVariableMmbP1Db, variable_config);
-            $cb!($($args)*, "ufp2-mmb", UnorderedFixedMmbP2Db, fixed_config);
-            $cb!($($args)*, "uvp2-mmb", UnorderedVariableMmbP2Db, variable_config);
+            $cb!($($args)*, uf, UnorderedFixedDb, fixed_config);
+            $cb!($($args)*, uv, UnorderedVariableDb, variable_config);
+            $cb!($($args)*, ufp1, UnorderedFixedP1Db, fixed_config);
+            $cb!($($args)*, uvp1, UnorderedVariableP1Db, variable_config);
+            $cb!($($args)*, ufp2, UnorderedFixedP2Db, fixed_config);
+            $cb!($($args)*, uvp2, UnorderedVariableP2Db, variable_config);
+            $cb!($($args)*, uf_mmb, UnorderedFixedMmbDb, fixed_config);
+            $cb!($($args)*, uv_mmb, UnorderedVariableMmbDb, variable_config);
+            $cb!($($args)*, ufp1_mmb, UnorderedFixedMmbP1Db, fixed_config);
+            $cb!($($args)*, uvp1_mmb, UnorderedVariableMmbP1Db, variable_config);
+            $cb!($($args)*, ufp2_mmb, UnorderedFixedMmbP2Db, fixed_config);
+            $cb!($($args)*, uvp2_mmb, UnorderedVariableMmbP2Db, variable_config);
         };
     }
 
     // Runner macros - receive common args followed by (label, type, config).
     macro_rules! test_simple {
-        ($f:expr, $l:literal, $db:ty, $cfg:ident) => {
+        ($f:expr, $l:ident, $db:ty, $cfg:ident) => {
             Box::pin(async {
                 $f(open_db_fn!($db, $cfg));
             })
@@ -1471,6 +1471,48 @@ pub mod tests {
         (unordered: $f:expr) => {{
             with_unordered_variants!(test_simple!($f));
         }};
+    }
+
+    // Emit one `#[test_group("slow")] #[test_traced]` test per variant.
+    // The fn name is `<prefix>_<variant_label>`, the body opens the variant's DB
+    // and runs the user-supplied test function.
+    macro_rules! per_variant_slow_test_emit {
+        ($prefix:ident, $f:path, $traced:literal, $label:ident, $db:ty, $cfg:ident) => {
+            paste::paste! {
+                #[test_group("slow")]
+                #[test_traced($traced)]
+                fn [<$prefix _ $label>]() {
+                    let executor = deterministic::Runner::default();
+                    executor.start(|_context| async move {
+                        Box::pin(async {
+                            $f(open_db_fn!($db, $cfg));
+                        })
+                        .await
+                    });
+                }
+            }
+        };
+    }
+
+    // Bulk-generate per-variant slow tests across all 24 variants.
+    macro_rules! per_all_variants_slow_tests {
+        ($prefix:ident, $f:path, $traced:literal) => {
+            with_all_variants!(per_variant_slow_test_emit!($prefix, $f, $traced));
+        };
+    }
+
+    // Bulk-generate per-variant slow tests across the 12 ordered variants.
+    macro_rules! per_ordered_variants_slow_tests {
+        ($prefix:ident, $f:path, $traced:literal) => {
+            with_ordered_variants!(per_variant_slow_test_emit!($prefix, $f, $traced));
+        };
+    }
+
+    // Bulk-generate per-variant slow tests across the 12 unordered variants.
+    macro_rules! per_unordered_variants_slow_tests {
+        ($prefix:ident, $f:path, $traced:literal) => {
+            with_unordered_variants!(per_variant_slow_test_emit!($prefix, $f, $traced));
+        };
     }
 
     // Wrapper functions for build_big tests with ordered/unordered expected values.
@@ -1498,41 +1540,26 @@ pub mod tests {
         test_current_db_build_big::<M, C, F, Fut>(open_db);
     }
 
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_build_random_close_reopen() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(simple: test_build_random_close_reopen);
-        });
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_simulate_write_failures() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(simple: test_simulate_write_failures);
-        });
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_different_pruning_delays_same_root() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(simple: test_different_pruning_delays_same_root);
-        });
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_all_variants_sync_persists_bitmap_pruning_boundary() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(simple: test_sync_persists_bitmap_pruning_boundary);
-        });
-    }
+    per_all_variants_slow_tests!(
+        test_all_variants_build_random_close_reopen,
+        test_build_random_close_reopen,
+        "WARN"
+    );
+    per_all_variants_slow_tests!(
+        test_all_variants_simulate_write_failures,
+        test_simulate_write_failures,
+        "WARN"
+    );
+    per_all_variants_slow_tests!(
+        test_all_variants_different_pruning_delays_same_root,
+        test_different_pruning_delays_same_root,
+        "WARN"
+    );
+    per_all_variants_slow_tests!(
+        test_all_variants_sync_persists_bitmap_pruning_boundary,
+        test_sync_persists_bitmap_pruning_boundary,
+        "WARN"
+    );
 
     #[test_group("slow")]
     #[test_traced("WARN")]
@@ -1551,41 +1578,26 @@ pub mod tests {
         });
     }
 
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_ordered_variants_build_big() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(ordered: test_ordered_build_big);
-        });
-    }
-
-    #[test_group("slow")]
-    #[test_traced("WARN")]
-    fn test_unordered_variants_build_big() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(unordered: test_unordered_build_big);
-        });
-    }
-
-    #[test_group("slow")]
-    #[test_traced("DEBUG")]
-    fn test_ordered_variants_build_small_close_reopen() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(ordered: ordered::tests::test_build_small_close_reopen);
-        });
-    }
-
-    #[test_group("slow")]
-    #[test_traced("DEBUG")]
-    fn test_unordered_variants_build_small_close_reopen() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(unordered: unordered::tests::test_build_small_close_reopen);
-        });
-    }
+    per_ordered_variants_slow_tests!(
+        test_ordered_variants_build_big,
+        test_ordered_build_big,
+        "WARN"
+    );
+    per_unordered_variants_slow_tests!(
+        test_unordered_variants_build_big,
+        test_unordered_build_big,
+        "WARN"
+    );
+    per_ordered_variants_slow_tests!(
+        test_ordered_variants_build_small_close_reopen,
+        ordered::tests::test_build_small_close_reopen,
+        "DEBUG"
+    );
+    per_unordered_variants_slow_tests!(
+        test_unordered_variants_build_small_close_reopen,
+        unordered::tests::test_build_small_close_reopen,
+        "DEBUG"
+    );
 
     // ---- Current-level batch API tests ----
     //
@@ -2762,14 +2774,11 @@ pub mod tests {
         });
     }
 
-    #[test_group("slow")]
-    #[test_traced("INFO")]
-    fn test_all_variants_speculative_root_matches_committed() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_context| async move {
-            for_all_variants!(simple: test_speculative_root_matches_committed);
-        });
-    }
+    per_all_variants_slow_tests!(
+        test_all_variants_speculative_root_matches_committed,
+        test_speculative_root_matches_committed,
+        "INFO"
+    );
 
     /// MerkleizedBatch::get() at the current level reads overlay then base DB.
     #[test_traced("INFO")]

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1476,7 +1476,7 @@ pub mod tests {
     // Emit one `#[test_group("slow")] #[test_traced]` test per variant.
     // The fn name is `<prefix>_<variant_label>`, the body opens the variant's DB
     // and runs the user-supplied test function.
-    macro_rules! per_variant_slow_test_emit {
+    macro_rules! test_for_variant {
         ($prefix:ident, $f:path, $traced:literal, $label:ident, $db:ty, $cfg:ident) => {
             paste::paste! {
                 #[test_group("slow")]
@@ -1494,24 +1494,24 @@ pub mod tests {
         };
     }
 
-    // Bulk-generate per-variant slow tests across all 24 variants.
-    macro_rules! per_all_variants_slow_tests {
+    // Generate one slow test per variant across all 24 variants.
+    macro_rules! test_for_all_variants {
         ($prefix:ident, $f:path, $traced:literal) => {
-            with_all_variants!(per_variant_slow_test_emit!($prefix, $f, $traced));
+            with_all_variants!(test_for_variant!($prefix, $f, $traced));
         };
     }
 
-    // Bulk-generate per-variant slow tests across the 12 ordered variants.
-    macro_rules! per_ordered_variants_slow_tests {
+    // Generate one slow test per variant across the 12 ordered variants.
+    macro_rules! test_for_ordered_variants {
         ($prefix:ident, $f:path, $traced:literal) => {
-            with_ordered_variants!(per_variant_slow_test_emit!($prefix, $f, $traced));
+            with_ordered_variants!(test_for_variant!($prefix, $f, $traced));
         };
     }
 
-    // Bulk-generate per-variant slow tests across the 12 unordered variants.
-    macro_rules! per_unordered_variants_slow_tests {
+    // Generate one slow test per variant across the 12 unordered variants.
+    macro_rules! test_for_unordered_variants {
         ($prefix:ident, $f:path, $traced:literal) => {
-            with_unordered_variants!(per_variant_slow_test_emit!($prefix, $f, $traced));
+            with_unordered_variants!(test_for_variant!($prefix, $f, $traced));
         };
     }
 
@@ -1540,22 +1540,22 @@ pub mod tests {
         test_current_db_build_big::<M, C, F, Fut>(open_db);
     }
 
-    per_all_variants_slow_tests!(
+    test_for_all_variants!(
         test_all_variants_build_random_close_reopen,
         test_build_random_close_reopen,
         "WARN"
     );
-    per_all_variants_slow_tests!(
+    test_for_all_variants!(
         test_all_variants_simulate_write_failures,
         test_simulate_write_failures,
         "WARN"
     );
-    per_all_variants_slow_tests!(
+    test_for_all_variants!(
         test_all_variants_different_pruning_delays_same_root,
         test_different_pruning_delays_same_root,
         "WARN"
     );
-    per_all_variants_slow_tests!(
+    test_for_all_variants!(
         test_all_variants_sync_persists_bitmap_pruning_boundary,
         test_sync_persists_bitmap_pruning_boundary,
         "WARN"
@@ -1578,22 +1578,22 @@ pub mod tests {
         });
     }
 
-    per_ordered_variants_slow_tests!(
+    test_for_ordered_variants!(
         test_ordered_variants_build_big,
         test_ordered_build_big,
         "WARN"
     );
-    per_unordered_variants_slow_tests!(
+    test_for_unordered_variants!(
         test_unordered_variants_build_big,
         test_unordered_build_big,
         "WARN"
     );
-    per_ordered_variants_slow_tests!(
+    test_for_ordered_variants!(
         test_ordered_variants_build_small_close_reopen,
         ordered::tests::test_build_small_close_reopen,
         "DEBUG"
     );
-    per_unordered_variants_slow_tests!(
+    test_for_unordered_variants!(
         test_unordered_variants_build_small_close_reopen,
         unordered::tests::test_build_small_close_reopen,
         "DEBUG"
@@ -2774,7 +2774,7 @@ pub mod tests {
         });
     }
 
-    per_all_variants_slow_tests!(
+    test_for_all_variants!(
         test_all_variants_speculative_root_matches_committed,
         test_speculative_root_matches_committed,
         "INFO"

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -688,7 +688,7 @@ pub mod tests {
     ///
     /// The factory should return a database when given a context and partition name.
     /// The factory will be called multiple times to test reopening.
-    pub fn test_build_random_close_reopen<M, C, F, Fut>(mut open_db: F)
+    pub async fn test_build_random_close_reopen<M, C, F, Fut>(mut context: Context, mut open_db: F)
     where
         M: merkle::Graftable + 'static,
         C: DbAny<M> + 'static,
@@ -699,9 +699,9 @@ pub mod tests {
     {
         const ELEMENTS: u64 = 1000;
 
-        let executor = deterministic::Runner::default();
+        // Run on the provided runner.
         let mut open_db_clone = open_db.clone();
-        let state1 = executor.start(|mut context| async move {
+        let state1 = {
             let partition = "build-random".to_string();
             let rng_seed = context.next_u64();
             let mut db: C = open_db_clone(context.child("first"), partition.clone()).await;
@@ -722,9 +722,9 @@ pub mod tests {
 
             db.destroy().await.unwrap();
             context.auditor().state()
-        });
+        };
 
-        // Run again to verify determinism
+        // Run again on a fresh runner to verify determinism.
         let executor = deterministic::Runner::default();
         let state2 = executor.start(|mut context| async move {
             let partition = "build-random".to_string();
@@ -750,7 +750,7 @@ pub mod tests {
     }
 
     /// Run `test_commit_after_sync_recovery` against a database factory.
-    pub fn test_commit_after_sync_recovery<M, C, F, Fut>(mut open_db: F)
+    pub async fn test_commit_after_sync_recovery<M, C, F, Fut>(context: Context, mut open_db: F)
     where
         M: merkle::Graftable + 'static,
         C: DbAny<M> + 'static,
@@ -759,45 +759,42 @@ pub mod tests {
         F: FnMut(Context, String) -> Fut + Clone,
         Fut: Future<Output = C>,
     {
-        let executor = deterministic::Runner::default();
         let mut open_db_clone = open_db.clone();
-        executor.start(|context| async move {
-            let partition = "commit-after-sync".to_string();
-            let mut db: C = open_db_clone(context.child("first"), partition.clone()).await;
-            let key0 = <<C as DbAny<M>>::Key as TestKey>::from_seed(0);
-            let key1 = <<C as DbAny<M>>::Key as TestKey>::from_seed(1);
-            let value0 = <C as DbAny<M>>::Value::from_seed(100);
-            let value1 = <C as DbAny<M>>::Value::from_seed(200);
+        let partition = "commit-after-sync".to_string();
+        let mut db: C = open_db_clone(context.child("first"), partition.clone()).await;
+        let key0 = <<C as DbAny<M>>::Key as TestKey>::from_seed(0);
+        let key1 = <<C as DbAny<M>>::Key as TestKey>::from_seed(1);
+        let value0 = <C as DbAny<M>>::Value::from_seed(100);
+        let value1 = <C as DbAny<M>>::Value::from_seed(200);
 
-            // Establish a synced baseline so metadata and journal recovery start from it.
-            commit_writes::<M, C>(&mut db, [(key0, Some(value0.clone()))])
-                .await
-                .unwrap();
-            db.sync().await.unwrap();
+        // Establish a synced baseline so metadata and journal recovery start from it.
+        commit_writes::<M, C>(&mut db, [(key0, Some(value0.clone()))])
+            .await
+            .unwrap();
+        db.sync().await.unwrap();
 
-            // Commit a later batch without syncing metadata; reopen must rebuild it from the log.
-            commit_writes::<M, C>(&mut db, [(key1, Some(value1.clone()))])
-                .await
-                .unwrap();
-            let committed_root = db.root();
-            let committed_size = db.size().await;
-            drop(db);
+        // Commit a later batch without syncing metadata; reopen must rebuild it from the log.
+        commit_writes::<M, C>(&mut db, [(key1, Some(value1.clone()))])
+            .await
+            .unwrap();
+        let committed_root = db.root();
+        let committed_size = db.size().await;
+        drop(db);
 
-            let db: C = open_db(context.child("second"), partition).await;
-            assert_eq!(db.root(), committed_root);
-            assert_eq!(db.size().await, committed_size);
-            assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
-            assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
+        let db: C = open_db(context.child("second"), partition).await;
+        assert_eq!(db.root(), committed_root);
+        assert_eq!(db.size().await, committed_size);
+        assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
+        assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
 
-            db.destroy().await.unwrap();
-        });
+        db.destroy().await.unwrap();
     }
 
     /// Run `test_simulate_write_failures` against a database factory.
     ///
     /// This test builds a random database and simulates recovery from different types of
     /// failure scenarios.
-    pub fn test_simulate_write_failures<M, C, F, Fut>(mut open_db: F)
+    pub async fn test_simulate_write_failures<M, C, F, Fut>(mut context: Context, mut open_db: F)
     where
         M: merkle::Graftable + 'static,
         C: DbAny<M> + 'static,
@@ -808,84 +805,80 @@ pub mod tests {
     {
         const ELEMENTS: u64 = 1000;
 
-        let executor = deterministic::Runner::default();
-        // Box the future to prevent stack overflow when monomorphized across DB variants.
-        executor.start(|mut context| {
-            Box::pin(async move {
-                let partition = "build-random-fail-commit".to_string();
-                let rng_seed = context.next_u64();
-                let mut db: C = open_db(context.child("first"), partition.clone()).await;
-                db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
-                    .await
-                    .unwrap();
-                commit_writes(&mut db, []).await.unwrap();
-                let committed_root = db.root();
-                let committed_op_count = db.bounds().await.end;
-                db.prune(db.sync_boundary().await).await.unwrap();
+        let partition = "build-random-fail-commit".to_string();
+        let rng_seed = context.next_u64();
+        let mut db: C = open_db(context.child("first"), partition.clone()).await;
+        db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
+            .await
+            .unwrap();
+        commit_writes(&mut db, []).await.unwrap();
+        let committed_root = db.root();
+        let committed_op_count = db.bounds().await.end;
+        db.prune(db.sync_boundary().await).await.unwrap();
 
-                // Perform more random operations without committing any of them.
-                let db = apply_random_ops::<M, C>(ELEMENTS, false, rng_seed + 1, db)
-                    .await
-                    .unwrap();
+        // Perform more random operations without committing any of them.
+        let db = apply_random_ops::<M, C>(ELEMENTS, false, rng_seed + 1, db)
+            .await
+            .unwrap();
 
-                // SCENARIO #1: Simulate a crash that happens before any writes. Upon reopening, the
-                // state of the DB should be as of the last commit.
-                drop(db);
-                let db: C = open_db(
-                    context.child("scenario").with_attribute("index", 1),
-                    partition.clone(),
-                )
-                .await;
-                assert_eq!(db.root(), committed_root);
-                assert_eq!(db.bounds().await.end, committed_op_count);
+        // SCENARIO #1: Simulate a crash that happens before any writes. Upon reopening, the
+        // state of the DB should be as of the last commit.
+        drop(db);
+        let db: C = open_db(
+            context.child("scenario").with_attribute("index", 1),
+            partition.clone(),
+        )
+        .await;
+        assert_eq!(db.root(), committed_root);
+        assert_eq!(db.bounds().await.end, committed_op_count);
 
-                // Re-apply the exact same operations, this time committed.
-                let db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed + 1, db)
-                    .await
-                    .unwrap();
+        // Re-apply the exact same operations, this time committed.
+        let db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed + 1, db)
+            .await
+            .unwrap();
 
-                // SCENARIO #2: Simulate a crash that happens after the any db has been committed, but
-                // before sync/prune is called. We do this by dropping the db without calling
-                // sync or prune.
-                let committed_op_count = db.bounds().await.end;
-                drop(db);
+        // SCENARIO #2: Simulate a crash that happens after the any db has been committed, but
+        // before sync/prune is called. We do this by dropping the db without calling
+        // sync or prune.
+        let committed_op_count = db.bounds().await.end;
+        drop(db);
 
-                // We should be able to recover, so the root should differ from the previous commit, and
-                // the op count should be greater than before.
-                let db: C = open_db(
-                    context.child("scenario").with_attribute("index", 2),
-                    partition.clone(),
-                )
-                .await;
-                let scenario_2_root = db.root();
+        // We should be able to recover, so the root should differ from the previous commit, and
+        // the op count should be greater than before.
+        let db: C = open_db(
+            context.child("scenario").with_attribute("index", 2),
+            partition.clone(),
+        )
+        .await;
+        let scenario_2_root = db.root();
 
-                // To confirm the second committed hash is correct we'll re-build the DB in a new
-                // partition, but without any failures. They should have the exact same state.
-                let fresh_partition = "build-random-fail-commit-fresh".to_string();
-                let mut db: C = open_db(context.child("fresh"), fresh_partition.clone()).await;
-                db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
-                    .await
-                    .unwrap();
-                commit_writes(&mut db, []).await.unwrap();
-                db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed + 1, db)
-                    .await
-                    .unwrap();
-                db.prune(db.sync_boundary().await).await.unwrap();
-                // State from scenario #2 should match that of a successful commit.
-                assert_eq!(db.bounds().await.end, committed_op_count);
-                assert_eq!(db.root(), scenario_2_root);
+        // To confirm the second committed hash is correct we'll re-build the DB in a new
+        // partition, but without any failures. They should have the exact same state.
+        let fresh_partition = "build-random-fail-commit-fresh".to_string();
+        let mut db: C = open_db(context.child("fresh"), fresh_partition.clone()).await;
+        db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
+            .await
+            .unwrap();
+        commit_writes(&mut db, []).await.unwrap();
+        db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed + 1, db)
+            .await
+            .unwrap();
+        db.prune(db.sync_boundary().await).await.unwrap();
+        // State from scenario #2 should match that of a successful commit.
+        assert_eq!(db.bounds().await.end, committed_op_count);
+        assert_eq!(db.root(), scenario_2_root);
 
-                db.destroy().await.unwrap();
-            })
-        });
+        db.destroy().await.unwrap();
     }
 
     /// Run `test_different_pruning_delays_same_root` against a database factory.
     ///
     /// This test verifies that pruning operations do not affect the root hash - two databases
     /// with identical operations but different pruning schedules should have the same root.
-    pub fn test_different_pruning_delays_same_root<M, C, F, Fut>(mut open_db: F)
-    where
+    pub async fn test_different_pruning_delays_same_root<M, C, F, Fut>(
+        context: Context,
+        mut open_db: F,
+    ) where
         M: merkle::Graftable,
         C: DbAny<M>,
         C::Key: TestKey,
@@ -895,62 +888,59 @@ pub mod tests {
     {
         const NUM_OPERATIONS: u64 = 1000;
 
-        let executor = deterministic::Runner::default();
         let mut open_db_clone = open_db.clone();
-        executor.start(|context| async move {
-            // Create two databases that are identical other than how they are pruned.
-            let mut db_no_pruning: C =
-                open_db_clone(context.child("no_pruning"), "no-pruning-test".into()).await;
-            let mut db_pruning: C = open_db(context.child("pruning"), "pruning-test".into()).await;
+        // Create two databases that are identical other than how they are pruned.
+        let mut db_no_pruning: C =
+            open_db_clone(context.child("no_pruning"), "no-pruning-test".into()).await;
+        let mut db_pruning: C = open_db(context.child("pruning"), "pruning-test".into()).await;
 
-            // Apply identical operations to both databases, but only prune one.
-            // Accumulate writes between commits.
-            let mut pending_no_pruning: WriteVec<M, C> = Vec::new();
-            let mut pending_pruning: WriteVec<M, C> = Vec::new();
-            for i in 0..NUM_OPERATIONS {
-                let key: C::Key = TestKey::from_seed(i);
-                let value: <C as DbAny<M>>::Value = TestValue::from_seed(i * 1000);
+        // Apply identical operations to both databases, but only prune one.
+        // Accumulate writes between commits.
+        let mut pending_no_pruning: WriteVec<M, C> = Vec::new();
+        let mut pending_pruning: WriteVec<M, C> = Vec::new();
+        for i in 0..NUM_OPERATIONS {
+            let key: C::Key = TestKey::from_seed(i);
+            let value: <C as DbAny<M>>::Value = TestValue::from_seed(i * 1000);
 
-                pending_no_pruning.push((key, Some(value.clone())));
-                pending_pruning.push((key, Some(value)));
+            pending_no_pruning.push((key, Some(value.clone())));
+            pending_pruning.push((key, Some(value)));
 
-                // Commit periodically
-                if i % 50 == 49 {
-                    commit_writes(&mut db_no_pruning, pending_no_pruning.drain(..))
-                        .await
-                        .unwrap();
-                    commit_writes(&mut db_pruning, pending_pruning.drain(..))
-                        .await
-                        .unwrap();
-                    db_pruning
-                        .prune(db_no_pruning.sync_boundary().await)
-                        .await
-                        .unwrap();
-                }
+            // Commit periodically
+            if i % 50 == 49 {
+                commit_writes(&mut db_no_pruning, pending_no_pruning.drain(..))
+                    .await
+                    .unwrap();
+                commit_writes(&mut db_pruning, pending_pruning.drain(..))
+                    .await
+                    .unwrap();
+                db_pruning
+                    .prune(db_no_pruning.sync_boundary().await)
+                    .await
+                    .unwrap();
             }
+        }
 
-            // Final commit for remaining writes.
-            commit_writes(&mut db_no_pruning, pending_no_pruning)
-                .await
-                .unwrap();
-            commit_writes(&mut db_pruning, pending_pruning)
-                .await
-                .unwrap();
+        // Final commit for remaining writes.
+        commit_writes(&mut db_no_pruning, pending_no_pruning)
+            .await
+            .unwrap();
+        commit_writes(&mut db_pruning, pending_pruning)
+            .await
+            .unwrap();
 
-            // Get roots from both databases - they should match
-            let root_no_pruning = db_no_pruning.root();
-            let root_pruning = db_pruning.root();
-            assert_eq!(root_no_pruning, root_pruning);
+        // Get roots from both databases - they should match
+        let root_no_pruning = db_no_pruning.root();
+        let root_pruning = db_pruning.root();
+        assert_eq!(root_no_pruning, root_pruning);
 
-            // Also verify inactivity floors match
-            assert_eq!(
-                db_no_pruning.inactivity_floor_loc().await,
-                db_pruning.inactivity_floor_loc().await
-            );
+        // Also verify inactivity floors match
+        assert_eq!(
+            db_no_pruning.inactivity_floor_loc().await,
+            db_pruning.inactivity_floor_loc().await
+        );
 
-            db_no_pruning.destroy().await.unwrap();
-            db_pruning.destroy().await.unwrap();
-        });
+        db_no_pruning.destroy().await.unwrap();
+        db_pruning.destroy().await.unwrap();
     }
 
     /// Run `test_sync_persists_bitmap_pruning_boundary` against a database factory.
@@ -958,8 +948,10 @@ pub mod tests {
     /// This test verifies that calling `sync()` persists the bitmap pruning boundary that was
     /// set during `commit()`. If `sync()` didn't call `write_pruned`, the
     /// `pruned_bits()` count would be 0 after reopen instead of the expected value.
-    pub fn test_sync_persists_bitmap_pruning_boundary<M, C, F, Fut>(mut open_db: F)
-    where
+    pub async fn test_sync_persists_bitmap_pruning_boundary<M, C, F, Fut>(
+        mut context: Context,
+        mut open_db: F,
+    ) where
         M: merkle::Graftable + 'static,
         C: DbAny<M> + BitmapPrunedBits + 'static,
         C::Key: TestKey,
@@ -969,60 +961,59 @@ pub mod tests {
     {
         const ELEMENTS: u64 = 500;
 
-        let executor = deterministic::Runner::default();
         let mut open_db_clone = open_db.clone();
-        executor.start(|mut context| async move {
-            let partition = "sync-bitmap-pruning".to_string();
-            let rng_seed = context.next_u64();
-            let mut db: C = open_db_clone(context.child("first"), partition.clone()).await;
+        let partition = "sync-bitmap-pruning".to_string();
+        let rng_seed = context.next_u64();
+        let mut db: C = open_db_clone(context.child("first"), partition.clone()).await;
 
-            // Apply random operations with commits to advance the inactivity floor.
-            db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db).await.unwrap();
-            let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+        // Apply random operations with commits to advance the inactivity floor.
+        db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
+            .await
+            .unwrap();
+        let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
 
-            // Prune to flatten bitmap layers and advance pruned_chunks.
-            db.prune(db.sync_boundary().await).await.unwrap();
+        // Prune to flatten bitmap layers and advance pruned_chunks.
+        db.prune(db.sync_boundary().await).await.unwrap();
 
-            let pruned_bits_before = db.pruned_bits();
-            warn!(
-                "pruned_bits_before={}, inactivity_floor={}, op_count={}",
-                pruned_bits_before,
-                *db.inactivity_floor_loc().await,
-                *db.bounds().await.end
-            );
+        let pruned_bits_before = db.pruned_bits();
+        warn!(
+            "pruned_bits_before={}, inactivity_floor={}, op_count={}",
+            pruned_bits_before,
+            *db.inactivity_floor_loc().await,
+            *db.bounds().await.end
+        );
 
-            // Verify we actually have some pruning (otherwise the test is meaningless).
-            assert!(
-                pruned_bits_before > 0,
-                "Expected bitmap to have pruned bits after prune()"
-            );
+        // Verify we actually have some pruning (otherwise the test is meaningless).
+        assert!(
+            pruned_bits_before > 0,
+            "Expected bitmap to have pruned bits after prune()"
+        );
 
-            // Call sync() to persist the bitmap pruning boundary.
-            db.sync().await.unwrap();
+        // Call sync() to persist the bitmap pruning boundary.
+        db.sync().await.unwrap();
 
-            // Record the root before dropping.
-            let root_before = db.root();
-            drop(db);
+        // Record the root before dropping.
+        let root_before = db.root();
+        drop(db);
 
-            // Reopen the database.
-            let db: C = open_db(context.child("second"), partition).await;
+        // Reopen the database.
+        let db: C = open_db(context.child("second"), partition).await;
 
-            // The pruned bits count should match. If sync() didn't persist the bitmap pruned
-            // state, this would be 0.
-            let pruned_bits_after = db.pruned_bits();
-            warn!("pruned_bits_after={}", pruned_bits_after);
+        // The pruned bits count should match. If sync() didn't persist the bitmap pruned
+        // state, this would be 0.
+        let pruned_bits_after = db.pruned_bits();
+        warn!("pruned_bits_after={}", pruned_bits_after);
 
-            assert_eq!(
-                pruned_bits_after, pruned_bits_before,
-                "Bitmap pruned bits mismatch after reopen - sync() may not have called write_pruned()"
-            );
+        assert_eq!(
+            pruned_bits_after, pruned_bits_before,
+            "Bitmap pruned bits mismatch after reopen - sync() may not have called write_pruned()"
+        );
 
-            // Also verify the root matches.
-            assert_eq!(db.root(), root_before);
+        // Also verify the root matches.
+        assert_eq!(db.root(), root_before);
 
-            db.destroy().await.unwrap();
-        });
+        db.destroy().await.unwrap();
     }
 
     /// Run `test_current_db_build_big` against a database factory.
@@ -1030,7 +1021,7 @@ pub mod tests {
     /// This test builds a database with 1000 keys, updates some, deletes some, and verifies that
     /// the final state matches an independently computed HashMap. It also verifies that the state
     /// persists correctly after close and reopen.
-    pub fn test_current_db_build_big<M, C, F, Fut>(mut open_db: F)
+    pub async fn test_current_db_build_big<M, C, F, Fut>(context: Context, mut open_db: F)
     where
         M: merkle::Graftable,
         C: DbAny<M>,
@@ -1041,80 +1032,77 @@ pub mod tests {
     {
         const ELEMENTS: u64 = 1000;
 
-        let executor = deterministic::Runner::default();
         let mut open_db_clone = open_db.clone();
-        executor.start(|context| async move {
-            let mut db: C = open_db_clone(context.child("first"), "build-big".into()).await;
+        let mut db: C = open_db_clone(context.child("first"), "build-big".into()).await;
 
-            let mut map = std::collections::HashMap::<C::Key, <C as DbAny<M>>::Value>::default();
+        let mut map = std::collections::HashMap::<C::Key, <C as DbAny<M>>::Value>::default();
 
-            // All creates, updates, and deletes in one batch.
-            let mut batch = db.new_batch();
+        // All creates, updates, and deletes in one batch.
+        let mut batch = db.new_batch();
 
-            // Initial creates
-            for i in 0u64..ELEMENTS {
-                let k: C::Key = TestKey::from_seed(i);
-                let v: <C as DbAny<M>>::Value = TestValue::from_seed(i * 1000);
-                batch = batch.write(k, Some(v.clone()));
-                map.insert(k, v);
+        // Initial creates
+        for i in 0u64..ELEMENTS {
+            let k: C::Key = TestKey::from_seed(i);
+            let v: <C as DbAny<M>>::Value = TestValue::from_seed(i * 1000);
+            batch = batch.write(k, Some(v.clone()));
+            map.insert(k, v);
+        }
+
+        // Update every 3rd key
+        for i in 0u64..ELEMENTS {
+            if i % 3 != 0 {
+                continue;
             }
+            let k: C::Key = TestKey::from_seed(i);
+            let v: <C as DbAny<M>>::Value = TestValue::from_seed((i + 1) * 10000);
+            batch = batch.write(k, Some(v.clone()));
+            map.insert(k, v);
+        }
 
-            // Update every 3rd key
-            for i in 0u64..ELEMENTS {
-                if i % 3 != 0 {
-                    continue;
-                }
-                let k: C::Key = TestKey::from_seed(i);
-                let v: <C as DbAny<M>>::Value = TestValue::from_seed((i + 1) * 10000);
-                batch = batch.write(k, Some(v.clone()));
-                map.insert(k, v);
+        // Delete every 7th key
+        for i in 0u64..ELEMENTS {
+            if i % 7 != 1 {
+                continue;
             }
+            let k: C::Key = TestKey::from_seed(i);
+            batch = batch.write(k, None);
+            map.remove(&k);
+        }
 
-            // Delete every 7th key
-            for i in 0u64..ELEMENTS {
-                if i % 7 != 1 {
-                    continue;
-                }
-                let k: C::Key = TestKey::from_seed(i);
-                batch = batch.write(k, None);
-                map.remove(&k);
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+
+        // Sync and prune.
+        db.sync().await.unwrap();
+        db.prune(db.sync_boundary().await).await.unwrap();
+
+        // Record root before dropping.
+        let root = db.root();
+        db.sync().await.unwrap();
+        drop(db);
+
+        // Reopen the db and verify it has exactly the same state.
+        let db: C = open_db(context.child("second"), "build-big".into()).await;
+        assert_eq!(root, db.root());
+
+        // Confirm the db's state matches that of the separate map we computed independently.
+        for i in 0u64..ELEMENTS {
+            let k: C::Key = TestKey::from_seed(i);
+            if let Some(map_value) = map.get(&k) {
+                let Some(db_value) = db.get(&k).await.unwrap() else {
+                    panic!("key not found in db: {k}");
+                };
+                assert_eq!(*map_value, db_value);
+            } else {
+                assert!(db.get(&k).await.unwrap().is_none());
             }
-
-            let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-
-            // Sync and prune.
-            db.sync().await.unwrap();
-            db.prune(db.sync_boundary().await).await.unwrap();
-
-            // Record root before dropping.
-            let root = db.root();
-            db.sync().await.unwrap();
-            drop(db);
-
-            // Reopen the db and verify it has exactly the same state.
-            let db: C = open_db(context.child("second"), "build-big".into()).await;
-            assert_eq!(root, db.root());
-
-            // Confirm the db's state matches that of the separate map we computed independently.
-            for i in 0u64..ELEMENTS {
-                let k: C::Key = TestKey::from_seed(i);
-                if let Some(map_value) = map.get(&k) {
-                    let Some(db_value) = db.get(&k).await.unwrap() else {
-                        panic!("key not found in db: {k}");
-                    };
-                    assert_eq!(*map_value, db_value);
-                } else {
-                    assert!(db.get(&k).await.unwrap().is_none());
-                }
-            }
-        });
+        }
     }
 
     /// Run `test_stale_batch_side_effect_free` against a database factory.
     ///
     /// The stale batch must be rejected without mutating the committed state.
-    pub fn test_stale_batch_side_effect_free<M, C, F, Fut>(mut open_db: F)
+    pub async fn test_stale_batch_side_effect_free<M, C, F, Fut>(context: Context, mut open_db: F)
     where
         M: merkle::Graftable,
         C: DbAny<M>,
@@ -1123,42 +1111,39 @@ pub mod tests {
         F: FnMut(Context, String) -> Fut,
         Fut: Future<Output = C>,
     {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            let mut db: C = open_db(context.child("db"), "stale-side-effect-free".into()).await;
+        let mut db: C = open_db(context.child("db"), "stale-side-effect-free".into()).await;
 
-            let key1 = <C::Key as TestKey>::from_seed(1);
-            let key2 = <C::Key as TestKey>::from_seed(2);
-            let value1 = <<C as DbAny<M>>::Value as TestValue>::from_seed(10);
-            let value2 = <<C as DbAny<M>>::Value as TestValue>::from_seed(20);
+        let key1 = <C::Key as TestKey>::from_seed(1);
+        let key2 = <C::Key as TestKey>::from_seed(2);
+        let value1 = <<C as DbAny<M>>::Value as TestValue>::from_seed(10);
+        let value2 = <<C as DbAny<M>>::Value as TestValue>::from_seed(20);
 
-            let mut batch = db.new_batch();
-            batch = batch.write(key1, Some(value1.clone()));
-            let batch_a = batch.merkleize(&db, None).await.unwrap();
-            let mut batch = db.new_batch();
-            batch = batch.write(key2, Some(value2));
-            let batch_b = batch.merkleize(&db, None).await.unwrap();
+        let mut batch = db.new_batch();
+        batch = batch.write(key1, Some(value1.clone()));
+        let batch_a = batch.merkleize(&db, None).await.unwrap();
+        let mut batch = db.new_batch();
+        batch = batch.write(key2, Some(value2));
+        let batch_b = batch.merkleize(&db, None).await.unwrap();
 
-            db.apply_batch(batch_a).await.unwrap();
-            let expected_root = db.root();
-            let expected_bounds = db.bounds().await;
-            let expected_metadata = db.get_metadata().await.unwrap();
-            assert_eq!(db.get(&key1).await.unwrap(), Some(value1.clone()));
-            assert_eq!(db.get(&key2).await.unwrap(), None);
+        db.apply_batch(batch_a).await.unwrap();
+        let expected_root = db.root();
+        let expected_bounds = db.bounds().await;
+        let expected_metadata = db.get_metadata().await.unwrap();
+        assert_eq!(db.get(&key1).await.unwrap(), Some(value1.clone()));
+        assert_eq!(db.get(&key2).await.unwrap(), None);
 
-            let result = db.apply_batch(batch_b).await;
-            assert!(
-                matches!(result, Err(Error::StaleBatch { .. })),
-                "expected StaleBatch error, got {result:?}"
-            );
-            assert_eq!(db.root(), expected_root);
-            assert_eq!(db.bounds().await, expected_bounds);
-            assert_eq!(db.get_metadata().await.unwrap(), expected_metadata);
-            assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
-            assert_eq!(db.get(&key2).await.unwrap(), None);
+        let result = db.apply_batch(batch_b).await;
+        assert!(
+            matches!(result, Err(Error::StaleBatch { .. })),
+            "expected StaleBatch error, got {result:?}"
+        );
+        assert_eq!(db.root(), expected_root);
+        assert_eq!(db.bounds().await, expected_bounds);
+        assert_eq!(db.get_metadata().await.unwrap(), expected_metadata);
+        assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
+        assert_eq!(db.get(&key2).await.unwrap(), None);
 
-            db.destroy().await.unwrap();
-        });
+        db.destroy().await.unwrap();
     }
 
     use crate::translator::OneCap;
@@ -1453,8 +1438,9 @@ pub mod tests {
     }
 
     // Emit one `#[test_group("slow")] #[test_traced]` test per variant.
-    // The fn name is `<f>_<variant_label>`, the body opens the variant's DB and
-    // runs the test function `f`.
+    // The fn name is `<f>_<variant_label>`, the body runs the async test
+    // function `f` on a fresh runner, passing it the `Context` and a DB opener
+    // for the variant.
     macro_rules! test_for_variant {
         ($f:ident, $traced:literal, $label:ident, $db:ty, $cfg:ident) => {
             paste::paste! {
@@ -1462,11 +1448,10 @@ pub mod tests {
                 #[test_traced($traced)]
                 fn [<$f _ $label>]() {
                     let executor = deterministic::Runner::default();
-                    executor.start(|_context| async move {
-                        Box::pin(async {
-                            $f(open_db_fn!($db, $cfg));
-                        })
-                        .await
+                    executor.start(|context| async move {
+                        // Box the future to prevent stack overflow when
+                        // monomorphized across DB variants.
+                        Box::pin($f(context, open_db_fn!($db, $cfg))).await
                     });
                 }
             }
@@ -1495,7 +1480,7 @@ pub mod tests {
     }
 
     // Wrapper functions for build_big tests with ordered/unordered expected values.
-    fn test_ordered_build_big<M, C, F, Fut>(open_db: F)
+    async fn test_ordered_build_big<M, C, F, Fut>(context: Context, open_db: F)
     where
         M: merkle::Graftable,
         C: DbAny<M>,
@@ -1504,10 +1489,10 @@ pub mod tests {
         F: FnMut(Context, String) -> Fut + Clone,
         Fut: Future<Output = C>,
     {
-        test_current_db_build_big::<M, C, F, Fut>(open_db);
+        test_current_db_build_big::<M, C, F, Fut>(context, open_db).await;
     }
 
-    fn test_unordered_build_big<M, C, F, Fut>(open_db: F)
+    async fn test_unordered_build_big<M, C, F, Fut>(context: Context, open_db: F)
     where
         M: merkle::Graftable,
         C: DbAny<M>,
@@ -1516,7 +1501,7 @@ pub mod tests {
         F: FnMut(Context, String) -> Fut + Clone,
         Fut: Future<Output = C>,
     {
-        test_current_db_build_big::<M, C, F, Fut>(open_db);
+        test_current_db_build_big::<M, C, F, Fut>(context, open_db).await;
     }
 
     test_for_all_variants!(test_build_random_close_reopen, "WARN");
@@ -2669,8 +2654,10 @@ pub mod tests {
     ///
     /// Uses enough operations to cross a chunk boundary (CHUNK_SIZE_BITS = N*8), which exercises
     /// the grafted root computation for newly completed chunks.
-    pub fn test_speculative_root_matches_committed<M, C, F, Fut>(mut open_db: F)
-    where
+    pub async fn test_speculative_root_matches_committed<M, C, F, Fut>(
+        context: Context,
+        mut open_db: F,
+    ) where
         M: merkle::Graftable + 'static,
         C: DbAny<M> + 'static,
         C::Key: TestKey,
@@ -2678,33 +2665,30 @@ pub mod tests {
         F: FnMut(Context, String) -> Fut + Clone,
         Fut: Future<Output = C>,
     {
-        let executor = deterministic::Runner::default();
         let mut open_db_clone = open_db.clone();
-        executor.start(|context| async move {
-            let partition = "speculative-root".to_string();
+        let partition = "speculative-root".to_string();
 
-            // Write enough operations to cross a chunk boundary. With N=32 (CHUNK_SIZE_BITS=256),
-            // 260 writes + 1 CommitFloor = 261 operations, completing one chunk with 5 ops in the
-            // next partial chunk. This ensures the grafted root computation must handle the
-            // newly completed chunk.
-            let mut db: C = open_db_clone(context.child("init"), partition.clone()).await;
-            let mut batch = db.new_batch();
-            for i in 0..260 {
-                batch = batch.write(TestKey::from_seed(i), Some(TestValue::from_seed(i + 1000)));
-            }
-            let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            let speculative_root = db.root();
+        // Write enough operations to cross a chunk boundary. With N=32 (CHUNK_SIZE_BITS=256),
+        // 260 writes + 1 CommitFloor = 261 operations, completing one chunk with 5 ops in the
+        // next partial chunk. This ensures the grafted root computation must handle the
+        // newly completed chunk.
+        let mut db: C = open_db_clone(context.child("init"), partition.clone()).await;
+        let mut batch = db.new_batch();
+        for i in 0..260 {
+            batch = batch.write(TestKey::from_seed(i), Some(TestValue::from_seed(i + 1000)));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        let speculative_root = db.root();
 
-            // Sync, close, and reopen to get the root recomputed from committed state.
-            db.sync().await.unwrap();
-            drop(db);
+        // Sync, close, and reopen to get the root recomputed from committed state.
+        db.sync().await.unwrap();
+        drop(db);
 
-            let db: C = open_db(context.child("reopen"), partition).await;
-            assert_eq!(db.root(), speculative_root);
+        let db: C = open_db(context.child("reopen"), partition).await;
+        assert_eq!(db.root(), speculative_root);
 
-            db.destroy().await.unwrap();
-        });
+        db.destroy().await.unwrap();
     }
 
     test_for_all_variants!(test_speculative_root_matches_committed, "INFO");

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -203,7 +203,7 @@ pub mod tests {
     ///
     /// This test builds a small database, performs basic operations (create, delete, commit),
     /// and verifies state is preserved across close/reopen cycles.
-    pub fn test_build_small_close_reopen<F, C, Fn, Fut>(mut open_db: Fn)
+    pub async fn test_build_small_close_reopen<F, C, Fn, Fut>(context: Context, mut open_db: Fn)
     where
         F: Graftable,
         C: DbAny<F> + BitmapPrunedBits,
@@ -212,88 +212,85 @@ pub mod tests {
         Fn: FnMut(Context, String) -> Fut,
         Fut: Future<Output = C>,
     {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            let partition = "build-small".to_string();
-            let db: C = open_db(context.child("first"), partition.clone()).await;
-            assert_eq!(db.inactivity_floor_loc().await, Location::<F>::new(0));
-            assert_eq!(db.oldest_retained().await, 0);
-            let root0 = db.root();
-            drop(db);
-            let mut db: C = open_db(context.child("second"), partition.clone()).await;
-            assert!(db.get_metadata().await.unwrap().is_none());
-            assert_eq!(db.root(), root0);
+        let partition = "build-small".to_string();
+        let db: C = open_db(context.child("first"), partition.clone()).await;
+        assert_eq!(db.inactivity_floor_loc().await, Location::<F>::new(0));
+        assert_eq!(db.oldest_retained().await, 0);
+        let root0 = db.root();
+        drop(db);
+        let mut db: C = open_db(context.child("second"), partition.clone()).await;
+        assert!(db.get_metadata().await.unwrap().is_none());
+        assert_eq!(db.root(), root0);
 
-            // Add one key.
-            let k1: C::Key = TestKey::from_seed(0);
-            let v1: <C as DbAny<F>>::Value = TestValue::from_seed(10);
-            assert!(db.get(&k1).await.unwrap().is_none());
-            let merkleized = db
-                .new_batch()
-                .write(k1, Some(v1.clone()))
-                .merkleize(&db, None)
-                .await
-                .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
-            assert!(db.get_metadata().await.unwrap().is_none());
-            let root1 = db.root();
-            assert_ne!(root1, root0);
+        // Add one key.
+        let k1: C::Key = TestKey::from_seed(0);
+        let v1: <C as DbAny<F>>::Value = TestValue::from_seed(10);
+        assert!(db.get(&k1).await.unwrap().is_none());
+        let merkleized = db
+            .new_batch()
+            .write(k1, Some(v1.clone()))
+            .merkleize(&db, None)
+            .await
+            .unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
+        assert!(db.get_metadata().await.unwrap().is_none());
+        let root1 = db.root();
+        assert_ne!(root1, root0);
 
-            drop(db);
-            let mut db: C = open_db(context.child("third"), partition.clone()).await;
-            assert_eq!(db.root(), root1);
+        drop(db);
+        let mut db: C = open_db(context.child("third"), partition.clone()).await;
+        assert_eq!(db.root(), root1);
 
-            // Create of same key should fail (key already exists).
-            assert!(db.get(&k1).await.unwrap().is_some());
+        // Create of same key should fail (key already exists).
+        assert!(db.get(&k1).await.unwrap().is_some());
 
-            // Delete that one key.
-            assert!(db.get(&k1).await.unwrap().is_some());
-            let metadata: <C as DbAny<F>>::Value = TestValue::from_seed(1);
-            let merkleized = db
-                .new_batch()
-                .write(k1, None)
-                .merkleize(&db, Some(metadata.clone()))
-                .await
-                .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            assert_eq!(db.get_metadata().await.unwrap().unwrap(), metadata);
-            let root2 = db.root();
+        // Delete that one key.
+        assert!(db.get(&k1).await.unwrap().is_some());
+        let metadata: <C as DbAny<F>>::Value = TestValue::from_seed(1);
+        let merkleized = db
+            .new_batch()
+            .write(k1, None)
+            .merkleize(&db, Some(metadata.clone()))
+            .await
+            .unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        assert_eq!(db.get_metadata().await.unwrap().unwrap(), metadata);
+        let root2 = db.root();
 
-            drop(db);
-            let mut db: C = open_db(context.child("fourth"), partition.clone()).await;
-            assert_eq!(db.get_metadata().await.unwrap().unwrap(), metadata);
-            assert_eq!(db.root(), root2);
+        drop(db);
+        let mut db: C = open_db(context.child("fourth"), partition.clone()).await;
+        assert_eq!(db.get_metadata().await.unwrap().unwrap(), metadata);
+        assert_eq!(db.root(), root2);
 
-            // Repeated delete of same key should fail (key already deleted).
-            assert!(db.get(&k1).await.unwrap().is_none());
-            let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            let root3 = db.root();
-            assert_ne!(root3, root2);
+        // Repeated delete of same key should fail (key already deleted).
+        assert!(db.get(&k1).await.unwrap().is_none());
+        let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        let root3 = db.root();
+        assert_ne!(root3, root2);
 
-            // Confirm all activity bits except the last are false.
-            let bounds = db.bounds().await;
-            for i in 0..*bounds.end - 1 {
-                assert!(!db.get_bit(i));
-            }
-            assert!(db.get_bit(*bounds.end - 1));
+        // Confirm all activity bits except the last are false.
+        let bounds = db.bounds().await;
+        for i in 0..*bounds.end - 1 {
+            assert!(!db.get_bit(i));
+        }
+        assert!(db.get_bit(*bounds.end - 1));
 
-            // Test that we can get a non-durable root.
-            let merkleized = db
-                .new_batch()
-                .write(k1, Some(v1))
-                .merkleize(&db, None)
-                .await
-                .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            assert_ne!(db.root(), root3);
+        // Test that we can get a non-durable root.
+        let merkleized = db
+            .new_batch()
+            .write(k1, Some(v1))
+            .merkleize(&db, None)
+            .await
+            .unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        assert_ne!(db.root(), root3);
 
-            db.destroy().await.unwrap();
-        });
+        db.destroy().await.unwrap();
     }
 
     /// Build a tiny database and verify that proofs over uncommitted bitmap chunks are correct.

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -67,7 +67,7 @@ pub mod tests {
     ///
     /// This test builds a small database, performs basic operations (create, delete, commit),
     /// and verifies state is preserved across close/reopen cycles.
-    pub fn test_build_small_close_reopen<F, C, Fn, Fut>(mut open_db: Fn)
+    pub async fn test_build_small_close_reopen<F, C, Fn, Fut>(context: Context, mut open_db: Fn)
     where
         F: Graftable,
         C: DbAny<F> + BitmapPrunedBits,
@@ -76,90 +76,87 @@ pub mod tests {
         Fn: FnMut(Context, String) -> Fut,
         Fut: Future<Output = C>,
     {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            let partition = "build-small".to_string();
-            let db: C = open_db(context.child("first"), partition.clone()).await;
-            assert_eq!(db.inactivity_floor_loc().await, Location::<F>::new(0));
-            assert_eq!(db.oldest_retained().await, 0);
-            let root0 = db.root();
-            drop(db);
-            let mut db: C = open_db(context.child("second"), partition.clone()).await;
-            assert!(db.get_metadata().await.unwrap().is_none());
-            assert_eq!(db.root(), root0);
+        let partition = "build-small".to_string();
+        let db: C = open_db(context.child("first"), partition.clone()).await;
+        assert_eq!(db.inactivity_floor_loc().await, Location::<F>::new(0));
+        assert_eq!(db.oldest_retained().await, 0);
+        let root0 = db.root();
+        drop(db);
+        let mut db: C = open_db(context.child("second"), partition.clone()).await;
+        assert!(db.get_metadata().await.unwrap().is_none());
+        assert_eq!(db.root(), root0);
 
-            // Add one key.
-            let k1: C::Key = TestKey::from_seed(0);
-            let v1: <C as DbAny<F>>::Value = TestValue::from_seed(10);
-            assert!(db.get(&k1).await.unwrap().is_none());
-            let merkleized = db
-                .new_batch()
-                .write(k1, Some(v1.clone()))
-                .merkleize(&db, None)
-                .await
-                .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
-            assert!(db.get_metadata().await.unwrap().is_none());
-            let root1 = db.root();
-            assert_ne!(root1, root0);
-            drop(db);
-            let mut db: C = open_db(context.child("third"), partition.clone()).await;
-            assert!(db.get_metadata().await.unwrap().is_none());
-            assert_eq!(db.root(), root1);
+        // Add one key.
+        let k1: C::Key = TestKey::from_seed(0);
+        let v1: <C as DbAny<F>>::Value = TestValue::from_seed(10);
+        assert!(db.get(&k1).await.unwrap().is_none());
+        let merkleized = db
+            .new_batch()
+            .write(k1, Some(v1.clone()))
+            .merkleize(&db, None)
+            .await
+            .unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
+        assert!(db.get_metadata().await.unwrap().is_none());
+        let root1 = db.root();
+        assert_ne!(root1, root0);
+        drop(db);
+        let mut db: C = open_db(context.child("third"), partition.clone()).await;
+        assert!(db.get_metadata().await.unwrap().is_none());
+        assert_eq!(db.root(), root1);
 
-            // Create of same key should fail (key already exists).
-            assert!(db.get(&k1).await.unwrap().is_some());
+        // Create of same key should fail (key already exists).
+        assert!(db.get(&k1).await.unwrap().is_some());
 
-            // Delete that one key.
-            assert!(db.get(&k1).await.unwrap().is_some());
-            let metadata: <C as DbAny<F>>::Value = TestValue::from_seed(1);
-            let merkleized = db
-                .new_batch()
-                .write(k1, None)
-                .merkleize(&db, Some(metadata.clone()))
-                .await
-                .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            assert_eq!(db.get_metadata().await.unwrap().unwrap(), metadata);
-            let root2 = db.root();
+        // Delete that one key.
+        assert!(db.get(&k1).await.unwrap().is_some());
+        let metadata: <C as DbAny<F>>::Value = TestValue::from_seed(1);
+        let merkleized = db
+            .new_batch()
+            .write(k1, None)
+            .merkleize(&db, Some(metadata.clone()))
+            .await
+            .unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        assert_eq!(db.get_metadata().await.unwrap().unwrap(), metadata);
+        let root2 = db.root();
 
-            // Repeated delete of same key should fail (key already deleted).
-            assert!(db.get(&k1).await.unwrap().is_none());
-            let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.sync().await.unwrap();
-            let root3 = db.root();
-            assert_ne!(root3, root2);
+        // Repeated delete of same key should fail (key already deleted).
+        assert!(db.get(&k1).await.unwrap().is_none());
+        let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.sync().await.unwrap();
+        let root3 = db.root();
+        assert_ne!(root3, root2);
 
-            // Confirm re-open preserves state.
-            drop(db);
-            let mut db: C = open_db(context.child("fourth"), partition.clone()).await;
-            // Last commit had no metadata (passed None to merkleize).
-            assert!(db.get_metadata().await.unwrap().is_none());
-            assert_eq!(db.root(), root3);
+        // Confirm re-open preserves state.
+        drop(db);
+        let mut db: C = open_db(context.child("fourth"), partition.clone()).await;
+        // Last commit had no metadata (passed None to merkleize).
+        assert!(db.get_metadata().await.unwrap().is_none());
+        assert_eq!(db.root(), root3);
 
-            // Confirm all activity bits are false except for the last commit.
-            let bounds = db.bounds().await;
-            for i in 0..*bounds.end - 1 {
-                assert!(!db.get_bit(i));
-            }
-            assert!(db.get_bit(*bounds.end - 1));
+        // Confirm all activity bits are false except for the last commit.
+        let bounds = db.bounds().await;
+        for i in 0..*bounds.end - 1 {
+            assert!(!db.get_bit(i));
+        }
+        assert!(db.get_bit(*bounds.end - 1));
 
-            // Test that we can get a non-durable root.
-            let merkleized = db
-                .new_batch()
-                .write(k1, Some(v1))
-                .merkleize(&db, None)
-                .await
-                .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            assert_ne!(db.root(), root3);
+        // Test that we can get a non-durable root.
+        let merkleized = db
+            .new_batch()
+            .write(k1, Some(v1))
+            .merkleize(&db, None)
+            .await
+            .unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        assert_ne!(db.root(), root3);
 
-            db.destroy().await.unwrap();
-        });
+        db.destroy().await.unwrap();
     }
 
     /// Build a tiny database and verify that proofs over uncommitted bitmap chunks are correct.


### PR DESCRIPTION
Generate one test per variant rather than having a single test with all the variants being tested. This gives us more test parallelism which plays better with CI partitioning.

Extracted from #3878.