### PR TITLE
[storage/journal/contiguous] fix buggy recovery assert

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -3557,6 +3557,8 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(20));
 
+            // Build two durable sections. Section 1 is only reachable if section 0 remains a full
+            // non-tail section after recovery.
             let journal = Journal::<_, u32>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
@@ -3571,6 +3573,8 @@ mod tests {
             assert_eq!(PAGE_SIZE.get() as u64 % u32::SIZE as u64, 0);
             assert!(items_in_page < cfg.items_per_blob.get());
 
+            // Truncate at a valid physical page boundary. This leaves no invalid trailing page; the
+            // oldest section is simply short while section 1 still exists.
             let (section0, size0) = context
                 .open(&blob_partition(&cfg), &0u64.to_be_bytes())
                 .await
@@ -3579,6 +3583,7 @@ mod tests {
             section0.resize(physical_page_size).await.unwrap();
             section0.sync().await.unwrap();
 
+            // Recovery must stop at the short non-tail section rather than skipping to section 1.
             let journal = Journal::<_, u32>::init(context.child("second"), cfg.clone())
                 .await
                 .unwrap();
@@ -3595,6 +3600,7 @@ mod tests {
                 "orphaned newer section should be truncated away"
             );
 
+            // Appends resume directly after the recovered prefix.
             assert_eq!(journal.append(&42).await.unwrap(), items_in_page);
             assert_eq!(journal.read(items_in_page).await.unwrap(), 42);
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -3432,6 +3432,63 @@ mod tests {
         });
     }
 
+    /// Test recovery when the oldest section is empty but a newer section still holds durable items.
+    ///
+    /// This is the fixed-journal analog of the variable-journal empty-oldest-section gap bug. A
+    /// contiguous journal can only populate a later section after filling the earlier one, so an
+    /// empty oldest section with a populated newer section is an orphaned gap. Length-based recovery
+    /// walks from the oldest section, finds it short (empty), and truncates everything from there,
+    /// aligning the journal to empty without panicking.
+    #[test_traced]
+    fn test_fixed_recovery_empty_oldest_section_orphaned_newer_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(10));
+
+            // Durably persist sections 0 and 1 (positions 0..20).
+            let journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Empty the oldest data section in place, leaving section 1's items orphaned past the
+            // gap.
+            let (section0, size0) = context
+                .open(&blob_partition(&cfg), &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert!(size0 > 0, "section 0 should start durable");
+            section0.resize(0).await.unwrap();
+            section0.sync().await.unwrap();
+
+            // Recovery aligns to an empty journal instead of panicking.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..0);
+            assert!(matches!(
+                journal.read(0).await,
+                Err(Error::ItemOutOfRange(0))
+            ));
+            let names = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert_eq!(
+                names.len(),
+                1,
+                "orphaned newer section should be truncated away"
+            );
+
+            // The orphaned newer section is truncated away and appends resume from position 0.
+            assert_eq!(journal.append(&test_digest(42)).await.unwrap(), 0);
+            assert_eq!(journal.read(0).await.unwrap(), test_digest(42));
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test the contiguous fixed journal with items_per_blob: 1.
     ///
     /// This is an edge case where each item creates its own blob, and the

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -3489,6 +3489,119 @@ mod tests {
         });
     }
 
+    /// Test recovery when the oldest section keeps a complete item but ends with a partial item.
+    ///
+    /// The segmented fixed journal first trims trailing partial-item bytes to the last complete
+    /// item. Contiguous recovery then treats the oldest section as a short non-tail section and
+    /// truncates the newer orphaned section.
+    #[test_traced]
+    fn test_fixed_recovery_partial_oldest_section_orphaned_newer_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(10));
+
+            // Durably persist sections 0 and 1 (positions 0..20).
+            let journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Leave one complete physical page plus one trailing partial byte in the oldest
+            // section. The append layer recovers the complete page, then the fixed journal trims
+            // the remaining logical bytes down to one complete item.
+            let (section0, size0) = context
+                .open(&blob_partition(&cfg), &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            let physical_page_size = PAGE_SIZE.get() as u64 + 12;
+            assert!(size0 > physical_page_size);
+            section0.resize(physical_page_size + 1).await.unwrap();
+            section0.sync().await.unwrap();
+
+            // Recovery trims the partial item, keeps the complete prefix, and drops section 1.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..1);
+            assert_eq!(journal.read(0).await.unwrap(), test_digest(0));
+            assert!(matches!(
+                journal.read(1).await,
+                Err(Error::ItemOutOfRange(1))
+            ));
+            let names = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert_eq!(
+                names.len(),
+                1,
+                "orphaned newer section should be truncated away"
+            );
+
+            assert_eq!(journal.append(&test_digest(42)).await.unwrap(), 1);
+            assert_eq!(journal.read(1).await.unwrap(), test_digest(42));
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Test recovery when the oldest section ends at a clean page boundary but is still short.
+    ///
+    /// No trailing bytes are repaired in this case: the first section simply contains fewer
+    /// complete items than its capacity. Since a later section exists, recovery must treat the
+    /// short non-tail section as the end of the contiguous prefix and drop the later section.
+    #[test_traced]
+    fn test_fixed_recovery_clean_short_oldest_section_orphaned_newer_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(20));
+
+            let journal = Journal::<_, u32>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u32 {
+                journal.append(&i).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let physical_page_size = PAGE_SIZE.get() as u64 + 12;
+            let items_in_page = PAGE_SIZE.get() as u64 / u32::SIZE as u64;
+            assert_eq!(PAGE_SIZE.get() as u64 % u32::SIZE as u64, 0);
+            assert!(items_in_page < cfg.items_per_blob.get());
+
+            let (section0, size0) = context
+                .open(&blob_partition(&cfg), &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert!(size0 > physical_page_size);
+            section0.resize(physical_page_size).await.unwrap();
+            section0.sync().await.unwrap();
+
+            let journal = Journal::<_, u32>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..items_in_page);
+            assert_eq!(journal.read(items_in_page - 1).await.unwrap(), 10);
+            assert!(matches!(
+                journal.read(items_in_page).await,
+                Err(Error::ItemOutOfRange(pos)) if pos == items_in_page
+            ));
+            let names = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert_eq!(
+                names.len(),
+                1,
+                "orphaned newer section should be truncated away"
+            );
+
+            assert_eq!(journal.append(&42).await.unwrap(), items_in_page);
+            assert_eq!(journal.read(items_in_page).await.unwrap(), 42);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test the contiguous fixed journal with items_per_blob: 1.
     ///
     /// This is an edge case where each item creates its own blob, and the

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1159,17 +1159,19 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             let offsets_bounds = offsets_reader.bounds();
             assert_eq!(offsets_bounds.end, data_size);
 
-            // After alignment, offsets and data must be in the same section.
-            // We return bounds.start from offsets as the true boundary.
-            assert!(
-                !offsets_bounds.is_empty(),
-                "offsets should have data after alignment"
-            );
-            assert_eq!(
-                offsets_bounds.start / items_per_section,
-                data_first_section,
-                "offsets and data should be in same oldest section"
-            );
+            // Recovery can truncate the data journal back to empty (e.g. an empty oldest
+            // section preceded the only populated section, so no contiguous data-backed
+            // prefix exists). In that case there is no oldest section to anchor against.
+            if !offsets_bounds.is_empty() {
+                // After alignment, offsets and data must be in the same section.
+                assert_eq!(
+                    offsets_bounds.start / items_per_section,
+                    data_first_section,
+                    "offsets and data should be in same oldest section"
+                );
+            }
+
+            // Return bounds.start from offsets as the true boundary.
             offsets_bounds.start
         };
 
@@ -1426,7 +1428,7 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_runtime::{
         buffer::paged::{Append, CacheRef},
-        deterministic, Metrics as _, Runner, Storage, Supervisor as _,
+        deterministic, Blob as _, Metrics as _, Runner, Storage, Supervisor as _,
     };
     use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
     use futures::FutureExt as _;
@@ -2351,6 +2353,81 @@ mod tests {
             // Appends resume cleanly from the recovered boundary.
             assert_eq!(journal.append(&1234).await.unwrap(), 10);
             assert_eq!(journal.read(10).await.unwrap(), 1234);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Test recovery when the oldest data section is empty but a newer section still holds
+    /// durable items and the offsets journal is gone.
+    ///
+    /// A contiguous journal can only populate a later section after filling the earlier one, so an
+    /// empty oldest section with a populated newer section is an orphaned gap. Replaying from the
+    /// empty oldest section immediately yields the newer section's items, which are "ahead" of the
+    /// expected section, so recovery truncates everything past the gap and aligns the journal to
+    /// empty. This regresses a bad invariant that asserted offsets must be non-empty after
+    /// alignment.
+    #[test_traced]
+    fn test_variable_recovery_empty_oldest_section_orphaned_newer_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "recovery-empty-oldest-section".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            // Durably persist sections 0 and 1 (positions 0..20).
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Empty the oldest data section in place, leaving section 1's items orphaned past the
+            // gap, then drop the offsets journal so recovery rebuilds from the data alone.
+            let data_partition = cfg.data_partition();
+            let mut names = context.scan(&data_partition).await.unwrap();
+            names.sort();
+            assert_eq!(names.len(), 2);
+            let (section0, size0) = context.open(&data_partition, &names[0]).await.unwrap();
+            assert!(size0 > 0, "section 0 should start durable");
+            section0.resize(0).await.unwrap();
+            section0.sync().await.unwrap();
+            context
+                .remove(&format!("{}-blobs", cfg.offsets_partition()), None)
+                .await
+                .unwrap();
+            context
+                .remove(&format!("{}-metadata", cfg.offsets_partition()), None)
+                .await
+                .unwrap();
+
+            // Recovery aligns to an empty journal instead of panicking.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..0);
+            assert!(matches!(
+                journal.read(0).await,
+                Err(Error::ItemOutOfRange(0))
+            ));
+
+            // The orphaned newer section is truncated away and appends resume from position 0.
+            assert_eq!(journal.append(&42).await.unwrap(), 0);
+            assert_eq!(journal.read(0).await.unwrap(), 42);
+            let data_blobs = context.scan(&cfg.data_partition()).await.unwrap();
+            assert_eq!(
+                data_blobs.len(),
+                1,
+                "orphaned newer section should be truncated away"
+            );
 
             journal.destroy().await.unwrap();
         });

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2451,6 +2451,8 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
+            // Build two durable data sections. Section 1 is only reachable if replay incorrectly
+            // skips the missing tail of section 0.
             let journal = Journal::<_, FixedBytes<31>>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
@@ -2468,10 +2470,16 @@ mod tests {
             let mut names = context.scan(&data_partition).await.unwrap();
             names.sort();
             assert_eq!(names.len(), 2);
+
+            // Truncate at a valid physical page boundary. This leaves a clean short data section,
+            // not trailing corruption.
             let (section0, size0) = context.open(&data_partition, &names[0]).await.unwrap();
             assert!(size0 > physical_page_size);
             section0.resize(physical_page_size).await.unwrap();
             section0.sync().await.unwrap();
+
+            // Remove offsets so recovery must rebuild by replaying data and checking section
+            // continuity.
             context
                 .remove(&format!("{}-blobs", cfg.offsets_partition()), None)
                 .await
@@ -2481,6 +2489,8 @@ mod tests {
                 .await
                 .unwrap();
 
+            // Recovery must stop at the short non-tail section rather than accepting section 1's
+            // items as later logical positions.
             let journal = Journal::<_, FixedBytes<31>>::init(context.child("second"), cfg.clone())
                 .await
                 .unwrap();
@@ -2501,6 +2511,7 @@ mod tests {
                 "orphaned newer section should be truncated away"
             );
 
+            // Appends resume directly after the recovered prefix.
             assert_eq!(
                 journal.append(&FixedBytes::new([42; 31])).await.unwrap(),
                 items_in_page

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2433,6 +2433,87 @@ mod tests {
         });
     }
 
+    /// Test recovery when the oldest data section ends at a clean page boundary but is still short.
+    ///
+    /// No trailing bytes are repaired in this case: the data section simply contains fewer complete
+    /// items than its capacity. Replaying from the start must still detect the jump to the newer
+    /// section and truncate it instead of skipping missing logical positions.
+    #[test_traced]
+    fn test_variable_recovery_clean_short_oldest_section_orphaned_newer_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "recovery-clean-short-oldest-section".into(),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, FixedBytes<31>>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..128u8 {
+                journal.append(&FixedBytes::new([i; 31])).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let physical_page_size = LARGE_PAGE_SIZE.get() as u64 + 12;
+            let items_in_page = LARGE_PAGE_SIZE.get() as u64 / 32;
+            assert!(items_in_page < cfg.items_per_section.get());
+
+            let data_partition = cfg.data_partition();
+            let mut names = context.scan(&data_partition).await.unwrap();
+            names.sort();
+            assert_eq!(names.len(), 2);
+            let (section0, size0) = context.open(&data_partition, &names[0]).await.unwrap();
+            assert!(size0 > physical_page_size);
+            section0.resize(physical_page_size).await.unwrap();
+            section0.sync().await.unwrap();
+            context
+                .remove(&format!("{}-blobs", cfg.offsets_partition()), None)
+                .await
+                .unwrap();
+            context
+                .remove(&format!("{}-metadata", cfg.offsets_partition()), None)
+                .await
+                .unwrap();
+
+            let journal = Journal::<_, FixedBytes<31>>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..items_in_page);
+            assert_eq!(
+                journal.read(items_in_page - 1).await.unwrap(),
+                FixedBytes::new([(items_in_page - 1) as u8; 31])
+            );
+            assert!(matches!(
+                journal.read(items_in_page).await,
+                Err(Error::ItemOutOfRange(pos)) if pos == items_in_page
+            ));
+
+            let data_blobs = context.scan(&cfg.data_partition()).await.unwrap();
+            assert_eq!(
+                data_blobs.len(),
+                1,
+                "orphaned newer section should be truncated away"
+            );
+
+            assert_eq!(
+                journal.append(&FixedBytes::new([42; 31])).await.unwrap(),
+                items_in_page
+            );
+            assert_eq!(
+                journal.read(items_in_page).await.unwrap(),
+                FixedBytes::new([42; 31])
+            );
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test that a crash partway through a multi-section sync leaves a contiguous durable prefix
     /// that recovery preserves.
     ///


### PR DESCRIPTION
Resolves: https://github.com/commonwarexyz/monorepo/issues/3916

## Summary

  Fixes a crash-recovery panic in the contiguous variable journal (`align_journals`) when the data journal contains an **empty oldest section**  followed by a **populated newer section** (an orphaned gap), discovered by the `journal_crash_recovery` fuzz target.

  In this state, the `items_in_last_section` check only inspects the *newest* section (non-empty), so the empty-data early return is skipped. Recovery then replays from the empty oldest section, immediately hits items from the newer section that are "ahead" of the expected section, and correctly truncates everything past the gap via `data.rewind(0, 0)` — leaving a legitimately **empty** journal (`size=0`, `offsets_bounds=0..0`).
  
  The final invariant `assert!(!offsets_bounds.is_empty(), "offsets should have data after alignment")` wrongly treated this valid outcome as impossible and panicked.

  ## Fix

  - Remove the over-strict `assert!(!offsets_bounds.is_empty())`.
  - Guard the "offsets and data in same oldest section" `assert_eq!` behind `if !offsets_bounds.is_empty()`, since an empty journal has no oldest section to anchor against. The `assert_eq!(offsets_bounds.end, data_size)` invariant still runs unconditionally.

  Truncate-to-empty is the correct semantics here: a contiguous journal cannot populate a later section without filling the earlier one, so an empty oldest section means the newer data sits past a gap and is discarded — consistent with the existing gap-handling repair path.

  ## Testing

  - Added regression test `test_variable_recovery_empty_oldest_section_orphaned_newer_section` that reconstructs the exact crash state (empty section  0 blob, durable section 1, dropped offsets) and asserts recovery aligns to `0..0`, truncates the orphaned section, and resumes appends from position 0.
  - Verified the test fails with the original assert (`offsets should have data after alignment`) and passes with the fix.