### PR TITLE
 [consensus/simplex/twins] improve case generation algorithm

### DIFF
--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -14,13 +14,17 @@
 //! Advancing one round refines those cells by splitting each group according to
 //! the role its members take in the new round.
 //!
-//! The full enumeration approach guarantees that every case within a campaign
-//! is structurally distinct -- no duplicate (scenario, compromised-assignment)
-//! pairs are ever emitted. For each canonical scenario, `cases()` computes the
-//! residual symmetry cells and generates only the unique compromised-node
-//! assignments: two assignments that differ only in which members of a cell
-//! are chosen are equivalent and collapsed to a single representative. When the
-//! case space exceeds `max_cases`, scenarios are sampled without replacement.
+//! Scenario generation guarantees that every case within a campaign is
+//! structurally distinct -- no duplicate (scenario, compromised-assignment)
+//! pairs are ever emitted. The scenario space is counted with an exact
+//! compressed transition DAG: each edge stores a residual symmetry-cell
+//! transition and the exact number of concrete round scenarios represented by
+//! that transition. When the scenario space exceeds the configured budget,
+//! sampled campaigns choose canonical scenarios uniformly without replacement.
+//! For each selected scenario, `cases()` computes the residual symmetry cells
+//! and generates only the unique compromised-node assignments: two assignments
+//! that differ only in which members of a cell are chosen are equivalent and
+//! collapsed to a single representative.
 //!
 //! These recipient sets are not required to be disjoint. A participant may
 //! appear in both masks for a round, meaning both twin halves can exchange
@@ -87,9 +91,14 @@ impl Scenario {
 
     /// Routes a message from sender to the correct twin half at a given view.
     ///
-    /// Unlike [`partitions`](Self::partitions), this avoids allocating temporary
-    /// Vecs by comparing bitmasks directly for inbound twin traffic. When a
-    /// sender appears in both masks, this returns [`SplitTarget::Both`].
+    /// For scripted rounds, inbound twin traffic is routed by checking the
+    /// sender against the primary and secondary bitmasks. When a sender appears
+    /// in both masks, this returns [`SplitTarget::Both`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `sender` is not present in `participants` for a scripted
+    /// round.
     pub fn route<P: PartialEq>(&self, view: View, sender: &P, participants: &[P]) -> SplitTarget {
         let idx = view.get().saturating_sub(1) as usize;
         if let Some(round) = self.rounds.get(idx) {
@@ -125,6 +134,10 @@ fn route_with_groups<P: PartialEq>(sender: &P, primary: &[P], secondary: &[P]) -
 }
 
 /// Returns the strict disjoint split at index `view % n`.
+///
+/// # Panics
+///
+/// Panics if `participants` is empty.
 pub fn view_partitions<P: Clone>(view: View, participants: &[P]) -> (Vec<P>, Vec<P>) {
     let split = (view.get() as usize) % participants.len();
     let (primary, secondary) = participants.split_at(split);
@@ -132,6 +145,11 @@ pub fn view_partitions<P: Clone>(view: View, participants: &[P]) -> (Vec<P>, Vec
 }
 
 /// Routes a sender according to [`view_partitions`].
+///
+/// # Panics
+///
+/// Panics if `participants` is empty or `sender` is not present in
+/// `participants`.
 pub fn view_route<P: Clone + PartialEq>(view: View, sender: &P, participants: &[P]) -> SplitTarget {
     let (primary, secondary) = view_partitions(view, participants);
     route_with_groups(sender, &primary, &secondary)
@@ -156,6 +174,10 @@ impl<C: Default> Default for Elector<C> {
 
 impl<C> Elector<C> {
     /// Create a twins elector from a scenario and fallback elector.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any scenario leader is outside `0..participants`.
     pub fn new(fallback: C, scenario: &Scenario, participants: usize) -> Self {
         let round_leaders: Vec<_> = scenario
             .rounds()
@@ -208,10 +230,9 @@ where
             return leader;
         }
 
-        // After the scripted attack prefix, intentionally resume the caller's
-        // fallback elector rather than forcing an honest-only suffix. Twins
-        // campaigns should not prevent the protocol from timing out in
-        // later views (if a twin is elected).
+        // After the scripted attack prefix, the caller's fallback elector
+        // controls leader selection. Twins campaigns should not prevent the
+        // protocol from timing out in later views (if a twin is elected).
         self.fallback.elect(round, certificate)
     }
 }
@@ -236,10 +257,12 @@ pub enum Mode {
 /// per equivalence class. This keeps the case budget focused on structurally
 /// distinct attack configurations.
 ///
-/// The total case count is the sum, over generated scenarios, of the number of
-/// symmetry-unique compromised assignments for that scenario's residual cells.
-/// [`Framework::max_cases`] caps the total emitted cases; the full scenario
-/// space must fit within this budget (panics otherwise).
+/// The generator selects canonical scenarios first: all scenarios when the
+/// scenario count fits within [`Framework::max_cases`], or uniformly sampled
+/// scenario ranks when it does not. It then expands the selected scenarios
+/// across their symmetry-unique compromised assignments, shuffles the cases,
+/// and truncates to [`Framework::max_cases`]. Scenario counts must fit in
+/// `u128`; overflowing configurations panic.
 #[derive(Clone, Copy, Debug)]
 pub struct Framework {
     /// Number of participants in the network.
@@ -250,12 +273,8 @@ pub struct Framework {
     pub rounds: usize,
     /// How multi-round scenarios are constructed.
     pub mode: Mode,
-    /// Upper bound on the total number of emitted cases (scenario x
-    /// compromised-assignment pairs). Also used to cap the number of
-    /// scenarios enumerated (since each scenario produces >= 1 case).
-    /// When the scenario space exceeds this, scenarios are sampled
-    /// uniformly without replacement; the resulting cases are then
-    /// shuffled and truncated to this budget.
+    /// Upper bound on emitted cases. This also caps the number of canonical
+    /// scenarios selected before compromised assignments are expanded.
     pub max_cases: usize,
 }
 
@@ -270,11 +289,19 @@ pub struct Case {
 
 /// Generate executable Twins cases from framework parameters.
 ///
-/// The full enumeration approach guarantees no duplicate cases within a
-/// campaign. For each canonical scenario, the generator computes the residual
-/// symmetry cells and emits only the structurally unique compromised-node
-/// assignments. When the total exceeds [`Framework::max_cases`], scenarios
-/// are sampled without replacement so every emitted case is distinct.
+/// The generator computes exact scenario counts from compressed transition
+/// multiplicities. It emits every scenario when the count fits within
+/// [`Framework::max_cases`] and samples scenario ranks uniformly without
+/// replacement when it does not. For each canonical scenario, the generator
+/// computes the residual symmetry cells and emits only the structurally unique
+/// compromised-node assignments.
+///
+/// # Panics
+///
+/// Panics if `framework` has fewer than 2 participants, more participants than
+/// fit in the route masks, zero faults, faults greater than or equal to
+/// participants, zero rounds, or zero max cases. Panics if the canonical
+/// scenario count overflows `u128`.
 pub fn cases(rng: &mut impl Rng, framework: Framework) -> Vec<Case> {
     assert!(framework.participants > 1, "participants must be > 1");
     assert!(
@@ -375,244 +402,495 @@ fn cells_to_ranges(cells: &[usize]) -> Vec<(usize, usize)> {
         .collect()
 }
 
-/// Enumerates all canonical next-round refinements from the current cell state.
+/// Compact representation of a canonical cell partition.
 ///
-/// Each round refines participants into up to 4 non-leader placements relative
-/// to the primary and secondary recipient sets: outside both, shared by both
-/// halves, primary-only, and secondary-only. The chosen leader is then
-/// isolated into its own singleton cell and may be visible to either half or
-/// both halves.
-fn next_round_transitions(cells: &[usize]) -> Vec<(RoundScenario, Vec<usize>)> {
-    // Accumulated state for a round where the secondary recipient set differs:
-    // the masks built so far and leader.
-    #[derive(Clone, Copy)]
-    struct SecondaryState {
-        primary_mask: u64,
-        secondary_mask: u64,
-        leader: Option<usize>,
+/// Bit `i` is set when there is a cell boundary after participant `i`. The
+/// unset gaps between boundaries belong to the same residual symmetry cell.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct CellState(u64);
+
+impl CellState {
+    /// Converts explicit cell sizes into a boundary mask.
+    fn from_cells(cells: &[usize]) -> Self {
+        let mut mask = 0u64;
+        let mut end = 0usize;
+        for size in cells.iter().take(cells.len().saturating_sub(1)) {
+            end += size;
+            mask |= 1u64 << (end - 1);
+        }
+        Self(mask)
     }
 
-    const LEADER_PLACEMENTS: &[(bool, bool)] = &[(true, false), (false, true), (true, true)];
+    /// Returns whether this state has a boundary after `idx`.
+    const fn boundary_after(self, idx: usize) -> bool {
+        (self.0 & (1u64 << idx)) != 0
+    }
 
-    fn push_nonzero_cells(next_cells: &mut Vec<usize>, sizes: [usize; 4]) {
-        for size in sizes {
-            if size > 0 {
-                next_cells.push(size);
+    /// Converts the state back into cell sizes.
+    fn to_cells(self, n: usize) -> Vec<usize> {
+        let mut cells = Vec::new();
+        let mut start = 0usize;
+        for idx in 0..n.saturating_sub(1) {
+            if self.boundary_after(idx) {
+                cells.push(idx + 1 - start);
+                start = idx + 1;
             }
+        }
+        cells.push(n - start);
+        cells
+    }
+
+    /// Converts the state into contiguous `(start, len)` cell ranges.
+    fn ranges(self, n: usize) -> Vec<(usize, usize)> {
+        let mut ranges = Vec::new();
+        let mut start = 0usize;
+        for idx in 0..n.saturating_sub(1) {
+            if self.boundary_after(idx) {
+                ranges.push((start, idx + 1 - start));
+                start = idx + 1;
+            }
+        }
+        ranges.push((start, n - start));
+        ranges
+    }
+}
+
+/// One local cell refinement used while building compressed transition edges.
+///
+/// A non-leader cell can split into at most the four non-empty role buckets
+/// `outside`, `both`, `secondary-only`, and `primary-only`. The leader cell
+/// uses the same buckets for its non-leader prefix and then appends the leader
+/// singleton as the final part.
+#[derive(Clone, Copy, Debug)]
+struct LocalRefinement {
+    parts: [usize; 5],
+    len: usize,
+    multiplicity: u128,
+}
+
+impl LocalRefinement {
+    /// Creates a refinement from `parts`, copying them into fixed storage.
+    fn new(parts: &[usize], multiplicity: u128) -> Self {
+        let mut stored = [0usize; 5];
+        stored[..parts.len()].copy_from_slice(parts);
+        Self {
+            parts: stored,
+            len: parts.len(),
+            multiplicity,
         }
     }
 
-    /// Refines cells for a round where both halves have identical recipient
-    /// sets.
-    fn no_secondary(
+    /// Returns the non-zero contiguous parts that form this refinement.
+    fn parts(&self) -> &[usize] {
+        &self.parts[..self.len]
+    }
+}
+
+/// Compressed group of concrete next-round scenarios.
+///
+/// `multiplicity` is the exact number of `RoundScenario`s that produce `next`
+/// when `leader_cell` supplies the canonical leader. During suffix counting,
+/// this edge contributes `multiplicity * suffix_count(next)`. `None` means the
+/// multiplicity overflowed `u128`, so the scenario count should also report
+/// overflow.
+#[derive(Clone, Copy, Debug)]
+struct TransitionEdge {
+    next: CellState,
+    leader_cell: usize,
+    multiplicity: Option<u128>,
+}
+
+/// Role of a non-leader contiguous part in a round refinement.
+///
+/// The declaration order is the canonical role order used when reconstructing
+/// a concrete transition from its rank.
+#[derive(Clone, Copy, Debug)]
+enum Role {
+    Outside,
+    Both,
+    Secondary,
+    Primary,
+}
+
+/// Exact compressed counter and unranker for canonical scenarios.
+struct ScenarioGenerator {
+    n: usize,
+    count_memo: Vec<HashMap<CellState, Option<u128>>>,
+    transition_memo: HashMap<CellState, Arc<[TransitionEdge]>>,
+    local_memo: HashMap<(usize, bool), Arc<[LocalRefinement]>>,
+}
+
+impl ScenarioGenerator {
+    /// Creates a generator for `n` participants and at most `rounds` suffixes.
+    fn new(n: usize, rounds: usize) -> Self {
+        Self {
+            n,
+            count_memo: vec![HashMap::new(); rounds + 1],
+            transition_memo: HashMap::new(),
+            local_memo: HashMap::new(),
+        }
+    }
+
+    /// Counts exact scenario suffixes reachable from `state`.
+    ///
+    /// This uses the compressed transition DAG. An edge may represent millions
+    /// of concrete rounds when many role assignments leave the same residual
+    /// symmetry cells, but its multiplicity preserves the exact count.
+    fn count(&mut self, state: CellState, rounds: usize) -> Option<u128> {
+        if rounds == 0 {
+            return Some(1);
+        }
+        if let Some(cached) = self.count_memo[rounds].get(&state) {
+            return *cached;
+        }
+
+        let result = (|| {
+            let mut total = 0u128;
+            for edge in self.transitions(state).iter().copied() {
+                let multiplicity = edge.multiplicity?;
+                let suffix = self.count(edge.next, rounds - 1)?;
+                let edge_count = multiplicity.checked_mul(suffix)?;
+                total = total.checked_add(edge_count)?;
+            }
+            Some(total)
+        })();
+        self.count_memo[rounds].insert(state, result);
+        result
+    }
+
+    /// Reconstructs the scenario at `rank` under the compressed ordering.
+    fn scenario_from_rank(
+        &mut self,
+        state: CellState,
+        rounds: usize,
+        rank: u128,
+    ) -> (Scenario, Vec<usize>) {
+        let mut scenario = Vec::with_capacity(rounds);
+        let residual = self.push_scenario_from_rank(state, rounds, rank, &mut scenario);
+        (Scenario { rounds: scenario }, residual.to_cells(self.n))
+    }
+
+    /// Appends the ranked scenario suffix to `scenario` and returns its final
+    /// residual cell state.
+    fn push_scenario_from_rank(
+        &mut self,
+        state: CellState,
+        rounds: usize,
+        mut rank: u128,
+        scenario: &mut Vec<RoundScenario>,
+    ) -> CellState {
+        if rounds == 0 {
+            return state;
+        }
+
+        for edge in self.transitions(state).iter().copied() {
+            let suffix = self
+                .count(edge.next, rounds - 1)
+                .expect("canonical scenario count should fit in u128");
+            let multiplicity = edge
+                .multiplicity
+                .expect("transition multiplicity should fit in u128");
+            let subtree_count = multiplicity
+                .checked_mul(suffix)
+                .expect("canonical scenario count should fit in u128");
+
+            if rank < subtree_count {
+                // Split the rank into the selected concrete transition inside
+                // this compressed edge and the selected suffix below it.
+                let transition_rank = rank / suffix;
+                let suffix_rank = rank % suffix;
+                scenario.push(self.round_from_edge(state, edge, transition_rank));
+                return self.push_scenario_from_rank(edge.next, rounds - 1, suffix_rank, scenario);
+            }
+            rank -= subtree_count;
+        }
+
+        unreachable!("canonical scenario rank out of bounds")
+    }
+
+    /// Returns compressed transition edges for `state`.
+    fn transitions(&mut self, state: CellState) -> Arc<[TransitionEdge]> {
+        if let Some(edges) = self.transition_memo.get(&state) {
+            return edges.clone();
+        }
+
+        let ranges = state.ranges(self.n);
+        let mut edges = Vec::new();
+        for leader_cell in 0..ranges.len() {
+            self.build_transitions(&ranges, leader_cell, 0, 0, Some(1), &mut edges);
+        }
+        let edges: Arc<[TransitionEdge]> = Arc::from(edges);
+        self.transition_memo.insert(state, edges.clone());
+        edges
+    }
+
+    /// Recursively combines local cell refinements into compressed edges.
+    fn build_transitions(
+        &mut self,
         ranges: &[(usize, usize)],
         leader_cell: usize,
         cell_idx: usize,
-        primary_mask: u64,
-        leader: Option<usize>,
-        next_cells: &mut Vec<usize>,
-        out: &mut Vec<(RoundScenario, Vec<usize>)>,
+        next_mask: u64,
+        multiplicity: Option<u128>,
+        edges: &mut Vec<TransitionEdge>,
     ) {
         if cell_idx == ranges.len() {
-            // Primary and secondary coincide in this branch, so the round is
-            // fully described by a single recipient mask.
-            out.push((
-                RoundScenario {
-                    leader: leader.expect("leader cell should assign a leader"),
-                    primary_mask,
-                    secondary_mask: primary_mask,
-                },
-                next_cells.clone(),
-            ));
+            edges.push(TransitionEdge {
+                next: CellState(next_mask),
+                leader_cell,
+                multiplicity,
+            });
             return;
         }
 
         let (start, size) = ranges[cell_idx];
-        // The designated leader must be isolated into its own singleton cell,
-        // so the leader's source cell can contribute at most `size - 1`
-        // non-leader members to the ordinary recipient-set buckets.
-        let max_outside = if cell_idx == leader_cell {
-            size - 1
-        } else {
-            size
-        };
-        for outside in 0..=max_outside {
-            // Within a cell we keep participants contiguous in canonical role
-            // order: excluded from both partitions first, then shared by both
-            // halves, and finally the leader singleton (if this is the leader
-            // cell). `next_cells` records those refined cell sizes.
-            let both = if cell_idx == leader_cell {
-                size - outside - 1
-            } else {
-                size - outside
-            };
-
-            if outside > 0 {
-                next_cells.push(outside);
-            }
-            if both > 0 {
-                next_cells.push(both);
-            }
-
-            let mut next_primary = primary_mask | range_mask(start + outside, both);
-            let mut next_leader = leader;
-            if cell_idx == leader_cell {
-                // Place the leader at the end of its refined block so later
-                // rounds can distinguish it from the rest of the cell.
-                let leader_idx = start + outside + both;
-                next_primary |= 1u64 << leader_idx;
-                next_cells.push(1);
-                next_leader = Some(leader_idx);
-            }
-
-            no_secondary(
+        let is_leader = cell_idx == leader_cell;
+        let refinements = self.local_refinements(size, is_leader);
+        for refinement in refinements.iter().copied() {
+            let next_mask = add_local_boundaries(next_mask, start, self.n, refinement.parts());
+            let multiplicity = multiplicity.and_then(|m| m.checked_mul(refinement.multiplicity));
+            self.build_transitions(
                 ranges,
                 leader_cell,
                 cell_idx + 1,
-                next_primary,
-                next_leader,
-                next_cells,
-                out,
+                next_mask,
+                multiplicity,
+                edges,
             );
-
-            // Backtrack in reverse push order before exploring the next split.
-            if cell_idx == leader_cell {
-                next_cells.pop();
-            }
-            if both > 0 {
-                next_cells.pop();
-            }
-            if outside > 0 {
-                next_cells.pop();
-            }
         }
     }
 
-    /// Refines cells for a round where the halves have distinct recipient
-    /// sets.
-    fn with_secondary(
-        ranges: &[(usize, usize)],
-        leader_cell: usize,
-        cell_idx: usize,
-        state: SecondaryState,
-        next_cells: &mut Vec<usize>,
-        out: &mut Vec<(RoundScenario, Vec<usize>)>,
-    ) {
-        if cell_idx == ranges.len() {
-            if state.primary_mask == state.secondary_mask {
-                // Equal recipient masks are already emitted by
-                // `no_secondary`, so skipping them here avoids duplicates.
-                return;
+    /// Returns all local refinements for a cell of `size`.
+    fn local_refinements(&mut self, size: usize, is_leader: bool) -> Arc<[LocalRefinement]> {
+        self.local_memo
+            .entry((size, is_leader))
+            .or_insert_with(|| Arc::from(build_local_refinements(size, is_leader)))
+            .clone()
+    }
+
+    /// Reconstructs one concrete round represented by `edge`.
+    fn round_from_edge(
+        &self,
+        state: CellState,
+        edge: TransitionEdge,
+        mut rank: u128,
+    ) -> RoundScenario {
+        let mut primary_mask = 0u64;
+        let mut secondary_mask = 0u64;
+        let mut leader = None;
+
+        for (cell_idx, (start, size)) in state.ranges(self.n).into_iter().enumerate() {
+            let parts = parts_in_cell(edge.next, start, size);
+            if cell_idx == edge.leader_cell {
+                let non_leader_len = parts.len() - 1;
+                let role_count = role_subset_count(non_leader_len);
+                let local_space = role_count * 3;
+                let local_rank = rank % local_space;
+                rank /= local_space;
+
+                let roles = roles_from_rank(non_leader_len, local_rank / 3);
+                apply_roles(
+                    start,
+                    &parts[..non_leader_len],
+                    &roles[..non_leader_len],
+                    &mut primary_mask,
+                    &mut secondary_mask,
+                );
+
+                let leader_idx = start + size - 1;
+                let leader_bit = 1u64 << leader_idx;
+                match local_rank % 3 {
+                    0 => primary_mask |= leader_bit,
+                    1 => secondary_mask |= leader_bit,
+                    2 => {
+                        primary_mask |= leader_bit;
+                        secondary_mask |= leader_bit;
+                    }
+                    _ => unreachable!("leader placement rank out of bounds"),
+                }
+                leader = Some(leader_idx);
+            } else {
+                let role_count = role_subset_count(parts.len());
+                let local_rank = rank % role_count;
+                rank /= role_count;
+
+                let roles = roles_from_rank(parts.len(), local_rank);
+                apply_roles(
+                    start,
+                    &parts,
+                    &roles[..parts.len()],
+                    &mut primary_mask,
+                    &mut secondary_mask,
+                );
             }
-            out.push((
-                RoundScenario {
-                    leader: state.leader.expect("leader cell should assign a leader"),
-                    primary_mask: state.primary_mask,
-                    secondary_mask: state.secondary_mask,
-                },
-                next_cells.clone(),
-            ));
-            return;
         }
 
-        let (start, size) = ranges[cell_idx];
-        let has_leader = cell_idx == leader_cell;
-        let available = if has_leader { size - 1 } else { size };
-        let outside_range = 0..=available;
+        assert_eq!(rank, 0, "transition rank should be fully consumed");
+        RoundScenario {
+            leader: leader.expect("leader cell should assign a leader"),
+            primary_mask,
+            secondary_mask,
+        }
+    }
+}
 
-        for outside in outside_range {
-            let remaining_after_outside = available - outside;
-            for both in 0..=remaining_after_outside {
-                let remaining = remaining_after_outside - both;
-                for secondary in 0..=remaining {
-                    // The canonical contiguous layout for a refined cell is:
-                    // outside -> both-halves -> secondary-only -> primary-only
-                    // -> leader.
-                    let primary = remaining - secondary;
-                    let checkpoint = next_cells.len();
-                    push_nonzero_cells(next_cells, [outside, both, secondary, primary]);
+/// Adds boundaries for `parts` starting at `start` to `mask`.
+fn add_local_boundaries(mut mask: u64, start: usize, n: usize, parts: &[usize]) -> u64 {
+    let mut offset = 0usize;
+    for part in parts {
+        offset += part;
+        let end = start + offset;
+        if end < n {
+            mask |= 1u64 << (end - 1);
+        }
+    }
+    mask
+}
 
-                    let shared_mask = range_mask(start + outside, both);
-                    let next_secondary = state.secondary_mask
-                        | shared_mask
-                        | range_mask(start + outside + both, secondary);
-                    let next_primary = state.primary_mask
-                        | shared_mask
-                        | range_mask(start + outside + both + secondary, primary);
-                    if has_leader {
-                        // As in `no_secondary`, keep the leader as a singleton
-                        // at the tail of its source cell's refined block.
-                        // Enumerate all distinct twin-half placements so the
-                        // leader may be isolated with either recipient set or
-                        // bridge both halves when the masks differ.
-                        let leader_idx = start + outside + both + secondary + primary;
-                        next_cells.push(1);
-                        for &(leader_in_primary, leader_in_secondary) in LEADER_PLACEMENTS {
-                            let leader_bit = 1u64 << leader_idx;
-                            with_secondary(
-                                ranges,
-                                leader_cell,
-                                cell_idx + 1,
-                                SecondaryState {
-                                    primary_mask: if leader_in_primary {
-                                        next_primary | leader_bit
-                                    } else {
-                                        next_primary
-                                    },
-                                    secondary_mask: if leader_in_secondary {
-                                        next_secondary | leader_bit
-                                    } else {
-                                        next_secondary
-                                    },
-                                    leader: Some(leader_idx),
-                                },
-                                next_cells,
-                                out,
-                            );
-                        }
-                    } else {
-                        with_secondary(
-                            ranges,
-                            leader_cell,
-                            cell_idx + 1,
-                            SecondaryState {
-                                primary_mask: next_primary,
-                                secondary_mask: next_secondary,
-                                leader: state.leader,
-                            },
-                            next_cells,
-                            out,
-                        );
-                    }
-                    next_cells.truncate(checkpoint);
+/// Returns the positive parts of the cell `[start, start + size)` in `state`.
+fn parts_in_cell(state: CellState, start: usize, size: usize) -> Vec<usize> {
+    let end = start + size;
+    let mut parts = Vec::new();
+    let mut part_start = start;
+    for idx in start..end {
+        if idx + 1 == end || state.boundary_after(idx) {
+            parts.push(idx + 1 - part_start);
+            part_start = idx + 1;
+        }
+    }
+    parts
+}
+
+/// Number of ways to choose `len` non-empty role buckets from four ordered
+/// non-leader roles.
+const fn role_subset_count(len: usize) -> u128 {
+    match len {
+        0 => 1,
+        1 => 4,
+        2 => 6,
+        3 => 4,
+        4 => 1,
+        _ => 0,
+    }
+}
+
+/// Builds all local refinements for a cell.
+fn build_local_refinements(size: usize, is_leader: bool) -> Vec<LocalRefinement> {
+    let mut refinements = Vec::new();
+    let available = if is_leader { size - 1 } else { size };
+    let mut prefix = Vec::new();
+    for_each_composition(available, 4, &mut prefix, &mut |parts| {
+        let role_choices = role_subset_count(parts.len());
+        let mut local = Vec::with_capacity(parts.len() + usize::from(is_leader));
+        local.extend_from_slice(parts);
+        let multiplicity = if is_leader {
+            local.push(1);
+            role_choices * 3
+        } else {
+            role_choices
+        };
+        refinements.push(LocalRefinement::new(&local, multiplicity));
+    });
+    refinements
+}
+
+/// Enumerates positive compositions of `total` into at most `max_parts` parts.
+///
+/// The empty composition is emitted for `total == 0`, which is needed for a
+/// singleton leader cell with no non-leader prefix.
+fn for_each_composition<F: FnMut(&[usize])>(
+    total: usize,
+    max_parts: usize,
+    current: &mut Vec<usize>,
+    f: &mut F,
+) {
+    if total == 0 {
+        f(current);
+        return;
+    }
+    for parts in 1..=total.min(max_parts) {
+        for_each_composition_with_len(total, parts, current, f);
+    }
+}
+
+/// Enumerates positive compositions of `remaining` with exactly `parts_left`
+/// parts.
+fn for_each_composition_with_len<F: FnMut(&[usize])>(
+    remaining: usize,
+    parts_left: usize,
+    current: &mut Vec<usize>,
+    f: &mut F,
+) {
+    if parts_left == 0 {
+        if remaining == 0 {
+            f(current);
+        }
+        return;
+    }
+    if parts_left == 1 {
+        current.push(remaining);
+        f(current);
+        current.pop();
+        return;
+    }
+
+    let max_first = remaining - (parts_left - 1);
+    for first in 1..=max_first {
+        current.push(first);
+        for_each_composition_with_len(remaining - first, parts_left - 1, current, f);
+        current.pop();
+    }
+}
+
+/// Returns the ranked subset of `len` roles from the four ordered non-leader
+/// roles. The selected roles are returned in canonical role order.
+fn roles_from_rank(len: usize, rank: u128) -> [Role; 4] {
+    let mut seen = 0u128;
+    for mask in 0u8..16 {
+        if mask.count_ones() as usize != len {
+            continue;
+        }
+        if seen == rank {
+            let mut roles = [Role::Outside; 4];
+            let mut next = 0usize;
+            for (bit, role) in [Role::Outside, Role::Both, Role::Secondary, Role::Primary]
+                .into_iter()
+                .enumerate()
+            {
+                if (mask & (1u8 << bit)) != 0 {
+                    roles[next] = role;
+                    next += 1;
                 }
             }
+            return roles;
         }
+        seen += 1;
     }
+    unreachable!("role subset rank out of bounds")
+}
 
-    let ranges = cells_to_ranges(cells);
-    let mut out = Vec::new();
-    for leader_cell in 0..cells.len() {
-        // Any current symmetry cell may supply the next leader. Enumerate the
-        // equal-recipient-set and split-recipient-set cases separately to keep
-        // the output canonical and duplicate-free.
-        let mut next_cells = Vec::new();
-        no_secondary(&ranges, leader_cell, 0, 0, None, &mut next_cells, &mut out);
-        let mut next_cells = Vec::new();
-        with_secondary(
-            &ranges,
-            leader_cell,
-            0,
-            SecondaryState {
-                primary_mask: 0,
-                secondary_mask: 0,
-                leader: None,
-            },
-            &mut next_cells,
-            &mut out,
-        );
+/// Applies `roles` to contiguous `parts` starting at `start`.
+fn apply_roles(
+    start: usize,
+    parts: &[usize],
+    roles: &[Role],
+    primary_mask: &mut u64,
+    secondary_mask: &mut u64,
+) {
+    let mut offset = 0usize;
+    for (part, role) in parts.iter().zip(roles) {
+        let mask = range_mask(start + offset, *part);
+        match role {
+            Role::Outside => {}
+            Role::Both => {
+                *primary_mask |= mask;
+                *secondary_mask |= mask;
+            }
+            Role::Secondary => *secondary_mask |= mask,
+            Role::Primary => *primary_mask |= mask,
+        }
+        offset += part;
     }
-    out
 }
 
 /// Generates compromised-node assignments that are unique modulo residual
@@ -664,58 +942,6 @@ fn allocate_faults(
     }
 }
 
-/// Counts canonical scenario suffixes reachable from a cell state.
-fn canonical_scenario_count(
-    cells: &[usize],
-    rounds: usize,
-    memo: &mut HashMap<(Vec<usize>, usize), Option<u128>>,
-) -> Option<u128> {
-    if rounds == 0 {
-        return Some(1);
-    }
-    let key = (cells.to_vec(), rounds);
-    if let Some(cached) = memo.get(&key) {
-        return *cached;
-    }
-
-    let result = (|| {
-        let mut total = 0u128;
-        for (_, next_cells) in next_round_transitions(cells) {
-            let suffix = canonical_scenario_count(&next_cells, rounds - 1, memo)?;
-            total = total.checked_add(suffix)?;
-        }
-        Some(total)
-    })();
-    memo.insert(key, result);
-    result
-}
-
-/// Reconstructs the canonical scenario and residual cells at a given
-/// lexicographic rank.
-fn canonical_scenario_from_rank(
-    cells: &[usize],
-    rounds: usize,
-    mut rank: u128,
-    memo: &mut HashMap<(Vec<usize>, usize), Option<u128>>,
-) -> (Scenario, Vec<usize>) {
-    if rounds == 0 {
-        return (Scenario { rounds: Vec::new() }, cells.to_vec());
-    }
-
-    for (round, next_cells) in next_round_transitions(cells) {
-        let suffix = canonical_scenario_count(&next_cells, rounds - 1, memo)
-            .expect("canonical scenario count should fit in u128");
-        if rank < suffix {
-            let (mut scenario, residual) =
-                canonical_scenario_from_rank(&next_cells, rounds - 1, rank, memo);
-            scenario.rounds.insert(0, round);
-            return (scenario, residual);
-        }
-        rank -= suffix;
-    }
-    unreachable!("canonical scenario rank out of bounds")
-}
-
 /// Samples unique indices without replacement from `[0, total)`.
 fn sample_unique_indices(rng: &mut impl Rng, total: u128, samples: usize) -> Vec<u128> {
     assert!(
@@ -755,18 +981,19 @@ fn generate_scenarios(
     rounds: usize,
     max_scenarios: usize,
 ) -> Vec<(Scenario, Vec<usize>)> {
-    let mut memo = HashMap::new();
-    let initial_cells = vec![n];
-    let total = canonical_scenario_count(&initial_cells, rounds, &mut memo)
+    let mut generator = ScenarioGenerator::new(n, rounds);
+    let initial = CellState::from_cells(&[n]);
+    let total = generator
+        .count(initial, rounds)
         .expect("scenario space overflows u128; reduce rounds or participants");
     if total <= max_scenarios as u128 {
         return (0..total)
-            .map(|idx| canonical_scenario_from_rank(&initial_cells, rounds, idx, &mut memo))
+            .map(|idx| generator.scenario_from_rank(initial, rounds, idx))
             .collect();
     }
     sample_unique_indices(rng, total, max_scenarios)
         .into_iter()
-        .map(|idx| canonical_scenario_from_rank(&initial_cells, rounds, idx, &mut memo))
+        .map(|idx| generator.scenario_from_rank(initial, rounds, idx))
         .collect()
 }
 
@@ -783,6 +1010,251 @@ mod tests {
     use commonware_cryptography::{ed25519::PrivateKey, Sha256, Signer};
     use commonware_utils::{ordered::Set, test_rng, test_rng_seeded};
     use std::collections::HashSet;
+
+    // Independent reference enumerator for small test cases. The production
+    // generator uses compressed transition edges, while this helper expands
+    // next-round refinements directly so tests can compare the optimized
+    // counter and unranker against a simpler implementation.
+    fn reference_next_round_transitions(cells: &[usize]) -> Vec<(RoundScenario, Vec<usize>)> {
+        #[derive(Clone, Copy)]
+        struct SecondaryState {
+            primary_mask: u64,
+            secondary_mask: u64,
+            leader: Option<usize>,
+        }
+
+        const LEADER_PLACEMENTS: &[(bool, bool)] = &[(true, false), (false, true), (true, true)];
+
+        fn push_nonzero_cells(next_cells: &mut Vec<usize>, sizes: [usize; 4]) {
+            for size in sizes {
+                if size > 0 {
+                    next_cells.push(size);
+                }
+            }
+        }
+
+        fn no_secondary(
+            ranges: &[(usize, usize)],
+            leader_cell: usize,
+            cell_idx: usize,
+            primary_mask: u64,
+            leader: Option<usize>,
+            next_cells: &mut Vec<usize>,
+            out: &mut Vec<(RoundScenario, Vec<usize>)>,
+        ) {
+            if cell_idx == ranges.len() {
+                out.push((
+                    RoundScenario {
+                        leader: leader.expect("leader cell should assign a leader"),
+                        primary_mask,
+                        secondary_mask: primary_mask,
+                    },
+                    next_cells.clone(),
+                ));
+                return;
+            }
+
+            let (start, size) = ranges[cell_idx];
+            let max_outside = if cell_idx == leader_cell {
+                size - 1
+            } else {
+                size
+            };
+            for outside in 0..=max_outside {
+                let both = if cell_idx == leader_cell {
+                    size - outside - 1
+                } else {
+                    size - outside
+                };
+
+                if outside > 0 {
+                    next_cells.push(outside);
+                }
+                if both > 0 {
+                    next_cells.push(both);
+                }
+
+                let mut next_primary = primary_mask | range_mask(start + outside, both);
+                let mut next_leader = leader;
+                if cell_idx == leader_cell {
+                    let leader_idx = start + outside + both;
+                    next_primary |= 1u64 << leader_idx;
+                    next_cells.push(1);
+                    next_leader = Some(leader_idx);
+                }
+
+                no_secondary(
+                    ranges,
+                    leader_cell,
+                    cell_idx + 1,
+                    next_primary,
+                    next_leader,
+                    next_cells,
+                    out,
+                );
+
+                if cell_idx == leader_cell {
+                    next_cells.pop();
+                }
+                if both > 0 {
+                    next_cells.pop();
+                }
+                if outside > 0 {
+                    next_cells.pop();
+                }
+            }
+        }
+
+        fn with_secondary(
+            ranges: &[(usize, usize)],
+            leader_cell: usize,
+            cell_idx: usize,
+            state: SecondaryState,
+            next_cells: &mut Vec<usize>,
+            out: &mut Vec<(RoundScenario, Vec<usize>)>,
+        ) {
+            if cell_idx == ranges.len() {
+                if state.primary_mask == state.secondary_mask {
+                    return;
+                }
+                out.push((
+                    RoundScenario {
+                        leader: state.leader.expect("leader cell should assign a leader"),
+                        primary_mask: state.primary_mask,
+                        secondary_mask: state.secondary_mask,
+                    },
+                    next_cells.clone(),
+                ));
+                return;
+            }
+
+            let (start, size) = ranges[cell_idx];
+            let has_leader = cell_idx == leader_cell;
+            let available = if has_leader { size - 1 } else { size };
+
+            for outside in 0..=available {
+                let remaining_after_outside = available - outside;
+                for both in 0..=remaining_after_outside {
+                    let remaining = remaining_after_outside - both;
+                    for secondary in 0..=remaining {
+                        let primary = remaining - secondary;
+                        let checkpoint = next_cells.len();
+                        push_nonzero_cells(next_cells, [outside, both, secondary, primary]);
+
+                        let shared_mask = range_mask(start + outside, both);
+                        let next_secondary = state.secondary_mask
+                            | shared_mask
+                            | range_mask(start + outside + both, secondary);
+                        let next_primary = state.primary_mask
+                            | shared_mask
+                            | range_mask(start + outside + both + secondary, primary);
+                        if has_leader {
+                            let leader_idx = start + outside + both + secondary + primary;
+                            next_cells.push(1);
+                            for &(leader_in_primary, leader_in_secondary) in LEADER_PLACEMENTS {
+                                let leader_bit = 1u64 << leader_idx;
+                                with_secondary(
+                                    ranges,
+                                    leader_cell,
+                                    cell_idx + 1,
+                                    SecondaryState {
+                                        primary_mask: if leader_in_primary {
+                                            next_primary | leader_bit
+                                        } else {
+                                            next_primary
+                                        },
+                                        secondary_mask: if leader_in_secondary {
+                                            next_secondary | leader_bit
+                                        } else {
+                                            next_secondary
+                                        },
+                                        leader: Some(leader_idx),
+                                    },
+                                    next_cells,
+                                    out,
+                                );
+                            }
+                        } else {
+                            with_secondary(
+                                ranges,
+                                leader_cell,
+                                cell_idx + 1,
+                                SecondaryState {
+                                    primary_mask: next_primary,
+                                    secondary_mask: next_secondary,
+                                    leader: state.leader,
+                                },
+                                next_cells,
+                                out,
+                            );
+                        }
+                        next_cells.truncate(checkpoint);
+                    }
+                }
+            }
+        }
+
+        let ranges = cells_to_ranges(cells);
+        let mut out = Vec::new();
+        for leader_cell in 0..cells.len() {
+            let mut next_cells = Vec::new();
+            no_secondary(&ranges, leader_cell, 0, 0, None, &mut next_cells, &mut out);
+            let mut next_cells = Vec::new();
+            with_secondary(
+                &ranges,
+                leader_cell,
+                0,
+                SecondaryState {
+                    primary_mask: 0,
+                    secondary_mask: 0,
+                    leader: None,
+                },
+                &mut next_cells,
+                &mut out,
+            );
+        }
+        out
+    }
+
+    fn reference_scenario_count(
+        cells: &[usize],
+        rounds: usize,
+        memo: &mut HashMap<(Vec<usize>, usize), Option<u128>>,
+    ) -> Option<u128> {
+        if rounds == 0 {
+            return Some(1);
+        }
+        let key = (cells.to_vec(), rounds);
+        if let Some(cached) = memo.get(&key) {
+            return *cached;
+        }
+
+        let result = (|| {
+            let mut total = 0u128;
+            for (_, next_cells) in reference_next_round_transitions(cells) {
+                let suffix = reference_scenario_count(&next_cells, rounds - 1, memo)?;
+                total = total.checked_add(suffix)?;
+            }
+            Some(total)
+        })();
+        memo.insert(key, result);
+        result
+    }
+
+    fn reference_scenarios(cells: &[usize], rounds: usize) -> HashSet<(Scenario, Vec<usize>)> {
+        if rounds == 0 {
+            return HashSet::from([(Scenario { rounds: Vec::new() }, cells.to_vec())]);
+        }
+
+        let mut out = HashSet::new();
+        for (round, next_cells) in reference_next_round_transitions(cells) {
+            for (mut scenario, residual) in reference_scenarios(&next_cells, rounds - 1) {
+                scenario.rounds.insert(0, round);
+                out.insert((scenario, residual));
+            }
+        }
+        out
+    }
 
     fn expected_single_round_transitions(n: usize) -> HashSet<(RoundScenario, Vec<usize>)> {
         let mut out = HashSet::new();
@@ -890,6 +1362,27 @@ mod tests {
     }
 
     #[test]
+    fn sampled_cases_are_unique() {
+        let framework = Framework {
+            participants: 7,
+            faults: 2,
+            rounds: 3,
+            mode: Mode::Sampled,
+            max_cases: 64,
+        };
+        let generated = cases(&mut test_rng(), framework);
+        assert_eq!(generated.len(), framework.max_cases);
+
+        let mut seen = HashSet::new();
+        for case in generated {
+            assert!(
+                seen.insert((case.scenario, case.compromised)),
+                "duplicate generated case"
+            );
+        }
+    }
+
+    #[test]
     fn generated_scenarios_include_leaders_visible_only_to_secondary() {
         let scenarios = generate_scenarios(&mut test_rng(), 3, 1, usize::MAX);
         assert!(scenarios.iter().any(|(scenario, _)| {
@@ -937,6 +1430,57 @@ mod tests {
             .map(|(scenario, cells)| (scenario.rounds[0], cells))
             .collect();
         assert_eq!(generated, expected_single_round_transitions(4));
+    }
+
+    #[test]
+    fn cell_state_roundtrips_cell_partitions() {
+        for cells in [
+            vec![5],
+            vec![1, 4],
+            vec![2, 1, 2],
+            vec![1, 1, 1, 1],
+            vec![3, 2, 1],
+        ] {
+            let n = cells.iter().sum();
+            let state = CellState::from_cells(&cells);
+            let ranges = cells_to_ranges(&cells);
+
+            assert_eq!(state.to_cells(n), cells);
+            assert_eq!(state.ranges(n), ranges);
+        }
+    }
+
+    #[test]
+    fn compressed_counts_match_reference_enumeration() {
+        for n in 2..=4 {
+            for rounds in 1..=3 {
+                let initial_cells = vec![n];
+                let mut reference_memo = HashMap::new();
+                let reference =
+                    reference_scenario_count(&initial_cells, rounds, &mut reference_memo);
+
+                let mut generator = ScenarioGenerator::new(n, rounds);
+                let compressed = generator.count(CellState::from_cells(&initial_cells), rounds);
+                assert_eq!(
+                    compressed, reference,
+                    "count mismatch for n={n} rounds={rounds}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn compressed_unranking_matches_reference_space() {
+        for (n, rounds) in [(2usize, 3usize), (3, 2), (3, 3), (4, 2), (4, 3), (5, 2)] {
+            let generated: HashSet<_> = generate_scenarios(&mut test_rng(), n, rounds, usize::MAX)
+                .into_iter()
+                .collect();
+            assert_eq!(
+                generated,
+                reference_scenarios(&[n], rounds),
+                "mismatch for n={n} rounds={rounds}"
+            );
+        }
     }
 
     #[test]
@@ -1154,13 +1698,72 @@ mod tests {
 
     #[test]
     fn canonical_scenario_count_caches_overflow_results() {
-        let initial_cells = vec![4];
-        let mut memo = HashMap::new();
-        assert_eq!(
-            canonical_scenario_count(&initial_cells, 40, &mut memo),
-            None
-        );
-        assert_eq!(memo.get(&(initial_cells, 40)), Some(&None));
+        let initial = CellState::from_cells(&[4]);
+        let mut generator = ScenarioGenerator::new(4, 40);
+        assert_eq!(generator.count(initial, 40), None);
+        assert_eq!(generator.count_memo[40].get(&initial), Some(&None));
+    }
+
+    #[test]
+    #[ignore = "manual timing probe for case generation"]
+    fn timing_probe_cases() {
+        eprintln!("label,cases,seconds");
+        for (label, framework) in [
+            (
+                "n5_r3_sampled_max20",
+                Framework {
+                    participants: 5,
+                    faults: 1,
+                    rounds: 3,
+                    mode: Mode::Sampled,
+                    max_cases: 20,
+                },
+            ),
+            (
+                "n5_r3_sustained_max20",
+                Framework {
+                    participants: 5,
+                    faults: 1,
+                    rounds: 3,
+                    mode: Mode::Sustained,
+                    max_cases: 20,
+                },
+            ),
+            (
+                "n7_r3_sampled_max20",
+                Framework {
+                    participants: 7,
+                    faults: 2,
+                    rounds: 3,
+                    mode: Mode::Sampled,
+                    max_cases: 20,
+                },
+            ),
+            (
+                "n10_r5_sustained_max20",
+                Framework {
+                    participants: 10,
+                    faults: 3,
+                    rounds: 5,
+                    mode: Mode::Sustained,
+                    max_cases: 20,
+                },
+            ),
+            (
+                "n10_r5_sampled_max20",
+                Framework {
+                    participants: 10,
+                    faults: 3,
+                    rounds: 5,
+                    mode: Mode::Sampled,
+                    max_cases: 20,
+                },
+            ),
+        ] {
+            let start = std::time::Instant::now();
+            let cases = cases(&mut test_rng(), framework);
+            eprintln!("{label},{},{}", cases.len(), start.elapsed().as_secs_f64());
+        }
     }
 
     #[test]

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -1813,68 +1813,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "manual timing probe for case generation"]
-    fn timing_probe_cases() {
-        eprintln!("label,cases,seconds");
-        for (label, framework) in [
-            (
-                "n5_r3_sampled_max20",
-                Framework {
-                    participants: 5,
-                    faults: 1,
-                    rounds: 3,
-                    mode: Mode::Sampled,
-                    max_cases: 20,
-                },
-            ),
-            (
-                "n5_r3_sustained_max20",
-                Framework {
-                    participants: 5,
-                    faults: 1,
-                    rounds: 3,
-                    mode: Mode::Sustained,
-                    max_cases: 20,
-                },
-            ),
-            (
-                "n7_r3_sampled_max20",
-                Framework {
-                    participants: 7,
-                    faults: 2,
-                    rounds: 3,
-                    mode: Mode::Sampled,
-                    max_cases: 20,
-                },
-            ),
-            (
-                "n10_r5_sustained_max20",
-                Framework {
-                    participants: 10,
-                    faults: 3,
-                    rounds: 5,
-                    mode: Mode::Sustained,
-                    max_cases: 20,
-                },
-            ),
-            (
-                "n10_r5_sampled_max20",
-                Framework {
-                    participants: 10,
-                    faults: 3,
-                    rounds: 5,
-                    mode: Mode::Sampled,
-                    max_cases: 20,
-                },
-            ),
-        ] {
-            let start = std::time::Instant::now();
-            let cases = cases(&mut test_rng(), framework);
-            eprintln!("{label},{},{}", cases.len(), start.elapsed().as_secs_f64());
-        }
-    }
-
-    #[test]
     fn unique_index_sampling_handles_near_full_ranges() {
         let total = 100_000u128;
         let samples = 99_999usize;

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -33,7 +33,7 @@
 //! role buckets: outside both halves, visible to both halves, visible only to
 //! the secondary half, or visible only to the primary half. The generated
 //! leader is a singleton at the end of its cell and must be visible to at least
-//! one half; total leader isolation is outside this scenario space.
+//! one half. Total leader isolation is outside this scenario space.
 //!
 //! A residual cell is a group of participants with identical role history in
 //! the scripted prefix. When a participant leads, it becomes a permanent
@@ -41,9 +41,9 @@
 //! its old cell. A transition records only the next residual cell boundaries.
 //! For a fixed set of part sizes, multiple role-bucket choices can produce the
 //! same next boundaries, so the transition stores their count as
-//! `multiplicity`. Scenario counts are computed over this compressed
-//! transition DAG, and `round_from_edge` reconstructs sampled rounds by
-//! decoding the chosen edge's rank as mixed-radix digits in cell order.
+//! `multiplicity`. Scenario counts are computed over this compressed transition
+//! DAG, and `round_from_edge` reconstructs sampled rounds by decoding the
+//! chosen edge's rank as mixed-radix digits in cell order.
 //!
 //! For example, with one cell of three participants and leader `2`, a round can
 //! split the two non-leaders as `[both = 1, primary-only = 1]` and place the
@@ -60,8 +60,8 @@
 //! transition and the exact number of concrete round scenarios represented by
 //! that transition. Counts are computed bottom-up over the reachable residual
 //! states. When the scenario space exceeds the configured budget, sampled
-//! campaigns choose canonical scenarios uniformly without replacement. For
-//! each selected scenario, `cases()` computes the residual symmetry cells and
+//! campaigns choose canonical scenarios uniformly without replacement. For each
+//! selected scenario, `cases()` computes the residual symmetry cells and
 //! generates only the unique compromised-node assignments: two assignments that
 //! differ only in which members of a cell are chosen are equivalent and
 //! collapsed to a single representative.
@@ -78,15 +78,33 @@ use commonware_cryptography::certificate::Scheme;
 use commonware_p2p::simulated::SplitTarget;
 use commonware_utils::ordered::Set;
 use rand::{seq::SliceRandom, Rng};
-use std::{collections::{HashMap, HashSet}, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
+/// Maximum participant count supported by the scenario generator.
 const MAX_PARTICIPANTS: usize = u64::BITS as usize;
+
+/// Sizes of the residual symmetry cells in canonical participant order.
+///
+/// For example, `[2, 1]` represents cells `{0, 1}` and `{2}`.
+type Cells = Vec<usize>;
+
+/// Sizes of contiguous role parts within one residual cell.
+type Parts = Vec<usize>;
+
+/// Participant index in canonical scenario order.
+type ParticipantIndex = usize;
+
+/// Canonical compromised participant indices for one generated case.
+type Compromised = Vec<ParticipantIndex>;
 
 /// Per-round adversarial setting from the Twins framework.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct RoundScenario {
     // Participant index chosen to lead this round.
-    leader: usize,
+    leader: ParticipantIndex,
     // Bitmasks selecting which participant identities each twin half can
     // exchange messages with. The masks may overlap.
     primary_mask: u64,
@@ -97,6 +115,29 @@ impl RoundScenario {
     /// Returns the designated leader index for this round scenario.
     pub const fn leader(&self) -> usize {
         self.leader
+    }
+
+    /// Returns recipient sets for this round's twin halves.
+    fn partitions<P: Clone>(&self, participants: &[P]) -> (Vec<P>, Vec<P>) {
+        let primary = partition_for_mask(self.primary_mask, participants);
+        let secondary = partition_for_mask(self.secondary_mask, participants);
+        (primary, secondary)
+    }
+
+    /// Routes a sender according to this round's recipient masks.
+    fn route<P: PartialEq>(&self, sender: &P, participants: &[P]) -> SplitTarget {
+        let sender_idx = participants
+            .iter()
+            .position(|participant| participant == sender)
+            .expect("sender missing from runtime participant list");
+        let in_primary = mask_contains(self.primary_mask, sender_idx);
+        let in_secondary = mask_contains(self.secondary_mask, sender_idx);
+        match (in_primary, in_secondary) {
+            (true, true) => SplitTarget::Both,
+            (true, false) => SplitTarget::Primary,
+            (false, true) => SplitTarget::Secondary,
+            (false, false) => SplitTarget::None,
+        }
     }
 }
 
@@ -123,7 +164,7 @@ impl Scenario {
     pub fn partitions<P: Clone>(&self, view: View, participants: &[P]) -> (Vec<P>, Vec<P>) {
         let idx = view.get().saturating_sub(1) as usize;
         if let Some(round) = self.rounds.get(idx) {
-            return masks_to_partitions(round.primary_mask, round.secondary_mask, participants);
+            return round.partitions(participants);
         }
         (participants.to_vec(), participants.to_vec())
     }
@@ -141,18 +182,7 @@ impl Scenario {
     pub fn route<P: PartialEq>(&self, view: View, sender: &P, participants: &[P]) -> SplitTarget {
         let idx = view.get().saturating_sub(1) as usize;
         if let Some(round) = self.rounds.get(idx) {
-            let sender_idx = participants
-                .iter()
-                .position(|participant| participant == sender)
-                .expect("sender missing from runtime participant list");
-            let in_primary = mask_contains(round.primary_mask, sender_idx);
-            let in_secondary = mask_contains(round.secondary_mask, sender_idx);
-            return match (in_primary, in_secondary) {
-                (true, true) => SplitTarget::Both,
-                (true, false) => SplitTarget::Primary,
-                (false, true) => SplitTarget::Secondary,
-                (false, false) => SplitTarget::None,
-            };
+            return round.route(sender, participants);
         }
         // After attack rounds, both halves see everyone.
         SplitTarget::Both
@@ -268,9 +298,10 @@ where
             return leader;
         }
 
-        // After the scripted attack prefix, the caller's fallback elector
-        // controls leader selection. Twins campaigns should not prevent the
-        // protocol from timing out in later views (if a twin is elected).
+        // After the scripted attack prefix, intentionally resume the caller's
+        // fallback elector rather than forcing an honest-only suffix. Twins
+        // campaigns should not prevent the protocol from timing out in
+        // later views (if a twin is elected).
         self.fallback.elect(round, certificate)
     }
 }
@@ -296,9 +327,9 @@ pub enum Mode {
 /// that differ only in which members of a symmetry cell are compromised are
 /// equivalent under relabeling for the adversarial prefix, so the framework
 /// generates only one representative per equivalence class. This keeps the case
-/// budget focused on structurally distinct attack configurations.
-/// The synchronous suffix may elect different concrete participant indices
-/// after such a relabeling, but under full synchrony the pass/fail verdict is
+/// budget focused on structurally distinct attack configurations. The
+/// synchronous suffix may elect different concrete participant indices after
+/// such a relabeling, but under full synchrony the pass/fail verdict is
 /// invariant to that relabeling.
 ///
 /// The generator selects canonical scenarios first: all scenarios when the
@@ -306,7 +337,7 @@ pub enum Mode {
 /// scenario ranks when it does not. It then expands the selected scenarios
 /// across their symmetry-unique compromised assignments, shuffles the cases,
 /// and truncates to [`Framework::max_cases`]. Scenario counts must fit in
-/// `u128`; overflowing configurations panic.
+/// `u128`, overflowing configurations panic.
 #[derive(Clone, Copy, Debug)]
 pub struct Framework {
     /// Number of participants in the network. Must be at most 64.
@@ -326,7 +357,7 @@ pub struct Framework {
 #[derive(Clone, Debug)]
 pub struct Case {
     /// Compromised participant indices for this case.
-    pub compromised: Vec<usize>,
+    pub compromised: Compromised,
     /// Multi-round scenario for this case.
     pub scenario: Scenario,
 }
@@ -360,20 +391,15 @@ pub fn cases(rng: &mut impl Rng, framework: Framework) -> Vec<Case> {
     assert!(framework.rounds > 0, "rounds must be > 0");
     assert!(framework.max_cases > 0, "max_cases must be > 0");
 
+    let mut generator = ScenarioGenerator::new(framework.participants);
     let scenarios = match framework.mode {
-        Mode::Sampled => generate_scenarios(
-            rng,
-            framework.participants,
-            framework.rounds,
-            framework.max_cases,
-        ),
+        Mode::Sampled => generator.generate(rng, framework.rounds, framework.max_cases),
         Mode::Sustained => {
             // Generate 1-round scenarios and repeat across all rounds.
             // The 1-round residual cells are valid here because applying
             // the same recipient-set pattern repeatedly never distinguishes
             // participants that were indistinguishable after the first round.
-            let single_round =
-                generate_scenarios(rng, framework.participants, 1, framework.max_cases);
+            let single_round = generator.generate(rng, 1, framework.max_cases);
             single_round
                 .into_iter()
                 .map(|(s, cells)| {
@@ -413,29 +439,18 @@ fn partition_for_mask<P: Clone>(mask: u64, participants: &[P]) -> Vec<P> {
     group
 }
 
-/// Converts twins routing bitmasks into concrete recipient sets.
-fn masks_to_partitions<P: Clone>(
-    primary_mask: u64,
-    secondary_mask: u64,
-    participants: &[P],
-) -> (Vec<P>, Vec<P>) {
-    let primary = partition_for_mask(primary_mask, participants);
-    let secondary = partition_for_mask(secondary_mask, participants);
-    (primary, secondary)
-}
-
 /// Sets bit `idx` in `mask`.
-fn set_mask_bit(mask: &mut u64, idx: usize) {
-    debug_assert!(idx < MAX_PARTICIPANTS);
+#[inline]
+const fn set_mask_bit(mask: &mut u64, idx: usize) {
     *mask |= 1u64 << idx;
 }
 
 /// Sets every bit in the contiguous range `[start, start + len)`.
-fn set_mask_range(mask: &mut u64, start: usize, len: usize) {
+#[inline]
+const fn set_mask_range(mask: &mut u64, start: usize, len: usize) {
     if len == 0 {
         return;
     }
-    debug_assert!(start + len <= MAX_PARTICIPANTS);
     let range = if len == u64::BITS as usize {
         u64::MAX
     } else {
@@ -445,6 +460,7 @@ fn set_mask_range(mask: &mut u64, start: usize, len: usize) {
 }
 
 /// Returns whether bit `idx` is set in `mask`.
+#[inline]
 const fn mask_contains(mask: u64, idx: usize) -> bool {
     idx < MAX_PARTICIPANTS && (mask & (1u64 << idx)) != 0
 }
@@ -475,10 +491,11 @@ struct CellState {
 impl CellState {
     /// Returns the state with a single symmetry cell covering all participants.
     fn initial(n: usize) -> Self {
-        assert!(n <= MAX_PARTICIPANTS, "participants must be <= {MAX_PARTICIPANTS}");
-        Self {
-            boundaries: 0,
-        }
+        assert!(
+            n <= MAX_PARTICIPANTS,
+            "participants must be <= {MAX_PARTICIPANTS}"
+        );
+        Self { boundaries: 0 }
     }
 
     /// Converts explicit cell sizes into a boundary mask.
@@ -500,7 +517,7 @@ impl CellState {
     }
 
     /// Converts the state back into cell sizes.
-    fn to_cells(self, n: usize) -> Vec<usize> {
+    fn to_cells(self, n: usize) -> Cells {
         self.ranges(n).into_iter().map(|(_, len)| len).collect()
     }
 
@@ -516,6 +533,20 @@ impl CellState {
         }
         ranges.push((start, n - start));
         ranges
+    }
+
+    /// Returns the positive parts of the cell `[start, start + size)`.
+    fn parts_in_cell(&self, start: usize, size: usize) -> Parts {
+        let end = start + size;
+        let mut parts = Vec::new();
+        let mut part_start = start;
+        for idx in start..end {
+            if idx + 1 == end || self.boundary_after(idx) {
+                parts.push(idx + 1 - part_start);
+                part_start = idx + 1;
+            }
+        }
+        parts
     }
 
     /// Adds boundaries for `parts` starting at `start`.
@@ -660,6 +691,36 @@ impl ScenarioGenerator {
         }
     }
 
+    /// Enumerates canonical scenarios with their residual symmetry cells.
+    ///
+    /// Returns all scenarios when the space fits within `max_scenarios`;
+    /// otherwise samples `max_scenarios` without replacement.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the scenario space overflows `u128`.
+    fn generate(
+        &mut self,
+        rng: &mut impl Rng,
+        rounds: usize,
+        max_scenarios: usize,
+    ) -> Vec<(Scenario, Cells)> {
+        let initial = CellState::initial(self.n);
+        let counts = self
+            .counts(&initial, rounds)
+            .expect("scenario space overflows u128; reduce rounds or participants");
+        let total = counts[rounds][&initial];
+        if total <= max_scenarios as u128 {
+            return (0..total)
+                .map(|idx| self.scenario_from_rank(&initial, rounds, idx, &counts))
+                .collect();
+        }
+        sample_unique_indices(rng, total, max_scenarios)
+            .into_iter()
+            .map(|idx| self.scenario_from_rank(&initial, rounds, idx, &counts))
+            .collect()
+    }
+
     /// Builds bottom-up scenario counts for paths starting at `initial`.
     ///
     /// `counts[r][state]` is the exact number of canonical scenario suffixes
@@ -725,7 +786,7 @@ impl ScenarioGenerator {
         rounds: usize,
         mut rank: u128,
         counts: &[HashMap<CellState, u128>],
-    ) -> (Scenario, Vec<usize>) {
+    ) -> (Scenario, Cells) {
         let mut scenario = Vec::with_capacity(rounds);
         let mut state = *initial;
 
@@ -824,7 +885,7 @@ impl ScenarioGenerator {
         // role subset, and the leader cell has an extra digit for which half
         // sees the leader.
         for (cell_idx, (start, size)) in state.ranges(self.n).into_iter().enumerate() {
-            let parts = parts_in_cell(&edge.next, start, size);
+            let parts = edge.next.parts_in_cell(start, size);
             if cell_idx == edge.leader_cell {
                 let non_leader_len = parts.len() - 1;
                 let role_count = role_subset_count(non_leader_len);
@@ -877,20 +938,6 @@ impl ScenarioGenerator {
     }
 }
 
-/// Returns the positive parts of the cell `[start, start + size)` in `state`.
-fn parts_in_cell(state: &CellState, start: usize, size: usize) -> Vec<usize> {
-    let end = start + size;
-    let mut parts = Vec::new();
-    let mut part_start = start;
-    for idx in start..end {
-        if idx + 1 == end || state.boundary_after(idx) {
-            parts.push(idx + 1 - part_start);
-            part_start = idx + 1;
-        }
-    }
-    parts
-}
-
 /// Number of ways to choose `len` non-empty role buckets from four ordered
 /// non-leader roles.
 const fn role_subset_count(len: usize) -> u128 {
@@ -931,7 +978,7 @@ fn build_local_refinements(size: usize, is_leader: bool) -> Vec<LocalRefinement>
 fn for_each_composition<F: FnMut(&[usize])>(
     total: usize,
     max_parts: usize,
-    current: &mut Vec<usize>,
+    current: &mut Parts,
     f: &mut F,
 ) {
     if total == 0 {
@@ -948,7 +995,7 @@ fn for_each_composition<F: FnMut(&[usize])>(
 fn for_each_composition_with_len<F: FnMut(&[usize])>(
     remaining: usize,
     parts_left: usize,
-    current: &mut Vec<usize>,
+    current: &mut Parts,
     f: &mut F,
 ) {
     if parts_left == 0 {
@@ -1030,7 +1077,7 @@ fn apply_roles(
 /// permuting participants within the same cell. This function emits exactly
 /// one canonical representative per equivalence class by always picking the
 /// first indices from each cell.
-fn compromised_sets_for_cells(cells: &[usize], faults: usize) -> Vec<Vec<usize>> {
+fn compromised_sets_for_cells(cells: &[usize], faults: usize) -> Vec<Compromised> {
     let ranges = cells_to_ranges(cells);
     let mut result = Vec::new();
     let mut current = Vec::new();
@@ -1045,8 +1092,8 @@ fn allocate_faults(
     ranges: &[(usize, usize)],
     cell_idx: usize,
     remaining: usize,
-    current: &mut Vec<usize>,
-    result: &mut Vec<Vec<usize>>,
+    current: &mut Compromised,
+    result: &mut Vec<Compromised>,
 ) {
     if remaining == 0 {
         result.push(current.clone());
@@ -1100,34 +1147,6 @@ fn sample_unique_indices(rng: &mut impl Rng, total: u128, samples: usize) -> Vec
     sampled
 }
 
-/// Enumerates canonical scenarios with their residual symmetry cells.
-///
-/// Returns all scenarios when the space fits within `max_scenarios`;
-/// otherwise samples `max_scenarios` without replacement. Panics if the
-/// scenario space overflows u128 and cannot be sampled.
-fn generate_scenarios(
-    rng: &mut impl Rng,
-    n: usize,
-    rounds: usize,
-    max_scenarios: usize,
-) -> Vec<(Scenario, Vec<usize>)> {
-    let mut generator = ScenarioGenerator::new(n);
-    let initial = CellState::initial(n);
-    let counts = generator
-        .counts(&initial, rounds)
-        .expect("scenario space overflows u128; reduce rounds or participants");
-    let total = counts[rounds][&initial];
-    if total <= max_scenarios as u128 {
-        return (0..total)
-            .map(|idx| generator.scenario_from_rank(&initial, rounds, idx, &counts))
-            .collect();
-    }
-    sample_unique_indices(rng, total, max_scenarios)
-        .into_iter()
-        .map(|idx| generator.scenario_from_rank(&initial, rounds, idx, &counts))
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1161,7 +1180,7 @@ mod tests {
     // generator uses compressed transition edges, while this helper expands
     // next-round refinements directly so tests can compare the DAG counter and
     // unranker against a simpler implementation.
-    fn reference_next_round_transitions(cells: &[usize]) -> Vec<(RoundScenario, Vec<usize>)> {
+    fn reference_next_round_transitions(cells: &[usize]) -> Vec<(RoundScenario, Cells)> {
         let n = cells.iter().sum();
 
         #[derive(Clone, Copy)]
@@ -1179,7 +1198,7 @@ mod tests {
 
         const LEADER_PLACEMENTS: &[(bool, bool)] = &[(true, false), (false, true), (true, true)];
 
-        fn push_nonzero_cells(next_cells: &mut Vec<usize>, sizes: [usize; 4]) {
+        fn push_nonzero_cells(next_cells: &mut Cells, sizes: [usize; 4]) {
             for size in sizes {
                 if size > 0 {
                     next_cells.push(size);
@@ -1193,8 +1212,8 @@ mod tests {
             leader_cell: usize,
             cell_idx: usize,
             state: PrimaryState,
-            next_cells: &mut Vec<usize>,
-            out: &mut Vec<(RoundScenario, Vec<usize>)>,
+            next_cells: &mut Cells,
+            out: &mut Vec<(RoundScenario, Cells)>,
         ) {
             if cell_idx == ranges.len() {
                 out.push((
@@ -1269,8 +1288,8 @@ mod tests {
             leader_cell: usize,
             cell_idx: usize,
             state: SecondaryState,
-            next_cells: &mut Vec<usize>,
-            out: &mut Vec<(RoundScenario, Vec<usize>)>,
+            next_cells: &mut Cells,
+            out: &mut Vec<(RoundScenario, Cells)>,
         ) {
             if cell_idx == ranges.len() {
                 if state.primary_mask == state.secondary_mask {
@@ -1393,7 +1412,7 @@ mod tests {
     fn reference_scenario_count(
         cells: &[usize],
         rounds: usize,
-        memo: &mut HashMap<(Vec<usize>, usize), Option<u128>>,
+        memo: &mut HashMap<(Cells, usize), Option<u128>>,
     ) -> Option<u128> {
         if rounds == 0 {
             return Some(1);
@@ -1415,7 +1434,7 @@ mod tests {
         result
     }
 
-    fn reference_scenarios(cells: &[usize], rounds: usize) -> HashSet<(Scenario, Vec<usize>)> {
+    fn reference_scenarios(cells: &[usize], rounds: usize) -> HashSet<(Scenario, Cells)> {
         if rounds == 0 {
             return HashSet::from([(Scenario { rounds: Vec::new() }, cells.to_vec())]);
         }
@@ -1430,7 +1449,7 @@ mod tests {
         out
     }
 
-    fn expected_single_round_transitions(n: usize) -> HashSet<(RoundScenario, Vec<usize>)> {
+    fn expected_single_round_transitions(n: usize) -> HashSet<(RoundScenario, Cells)> {
         let mut out = HashSet::new();
 
         for outside in 0..n {
@@ -1545,7 +1564,9 @@ mod tests {
     #[test]
     fn generated_single_round_scenarios_match_expected_canonical_space() {
         for n in 3..=5 {
-            let generated: HashSet<_> = generate_scenarios(&mut test_rng(), n, 1, usize::MAX)
+            let mut generator = ScenarioGenerator::new(n);
+            let generated: HashSet<_> = generator
+                .generate(&mut test_rng(), 1, usize::MAX)
                 .into_iter()
                 .map(|(scenario, cells)| (scenario.rounds[0], cells))
                 .collect();
@@ -1595,7 +1616,9 @@ mod tests {
     #[test]
     fn compressed_unranking_matches_reference_space() {
         for (n, rounds) in [(2usize, 3usize), (3, 2)] {
-            let generated: HashSet<_> = generate_scenarios(&mut test_rng(), n, rounds, usize::MAX)
+            let mut generator = ScenarioGenerator::new(n);
+            let generated: HashSet<_> = generator
+                .generate(&mut test_rng(), rounds, usize::MAX)
                 .into_iter()
                 .collect();
             assert_eq!(
@@ -1718,7 +1741,8 @@ mod tests {
 
     #[test]
     fn generated_split_round_leaders_belong_to_at_least_one_half() {
-        let scenarios = generate_scenarios(&mut test_rng(), 4, 2, usize::MAX);
+        let mut generator = ScenarioGenerator::new(4);
+        let scenarios = generator.generate(&mut test_rng(), 2, usize::MAX);
         for (scenario, _) in scenarios {
             for round in scenario.rounds {
                 if round.primary_mask == round.secondary_mask {
@@ -1900,7 +1924,8 @@ mod tests {
 
     #[test]
     fn pruned_scenarios_vary_across_round_positions() {
-        let scenarios = generate_scenarios(&mut test_rng(), 5, 3, 32);
+        let mut generator = ScenarioGenerator::new(5);
+        let scenarios = generator.generate(&mut test_rng(), 3, 32);
         for round in 0..3 {
             let unique: HashSet<_> = scenarios
                 .iter()
@@ -1948,7 +1973,8 @@ mod tests {
             max_cases: usize::MAX,
         };
         let all_cases = cases(&mut test_rng(), framework);
-        let scenarios = generate_scenarios(&mut test_rng(), 5, 1, usize::MAX);
+        let mut generator = ScenarioGenerator::new(5);
+        let scenarios = generator.generate(&mut test_rng(), 1, usize::MAX);
         // Naive cross-product would be scenarios * C(5,1) = scenarios * 5.
         // Symmetry-aware should produce fewer.
         let naive = scenarios.len() * 5;

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -1,11 +1,24 @@
 //! Twins framework scenario generator and executor helpers.
 //!
-//! This module follows the testing architecture from
+//! This module follows the campaign structure from
 //! [Twins: BFT Systems Made Robust](https://arxiv.org/pdf/2004.10617):
 //! 1. Generate primary/secondary recipient-set scenarios.
 //! 2. Combine those sets with leader choices per round.
 //! 3. Arrange those round choices into full multi-round scenarios.
 //! 4. Execute each scenario across compromised-node assignments.
+//!
+//! The original paper models disjoint network partitions over nodes and their
+//! twins. This harness deliberately uses a stronger Simplex-specific
+//! recipient-set model: the primary and secondary halves are represented as
+//! independent recipient masks, so a participant may be visible to both halves,
+//! one half, or neither half in a scripted round. After the scripted prefix,
+//! traffic returns to all-to-all synchrony and leader election resumes through
+//! the caller's fallback elector.
+//!
+//! Campaigns are intended to cover small representative Twins schedules rather
+//! than production-sized validator sets. Participant sets are capped at 64 so
+//! recipient sets and residual cell boundaries can be stored as plain `u64`
+//! masks.
 //!
 //! Scenarios are generated in a canonical unlabeled form instead of by
 //! enumerating every participant relabeling. The generator tracks participant
@@ -18,14 +31,27 @@
 //!
 //! In each round, every non-leader participant belongs to one of four ordered
 //! role buckets: outside both halves, visible to both halves, visible only to
-//! the secondary half, or visible only to the primary half. The leader is a
-//! singleton at the end of its cell and must be visible to at least one half.
-//! A transition records only the next residual cell boundaries. For a fixed
-//! set of part sizes, multiple role-bucket choices can produce the same next
-//! boundaries, so the transition stores their count as `multiplicity`.
-//! Scenario counts are computed over this compressed transition DAG, and
-//! `round_from_edge` reconstructs sampled rounds by decoding the chosen edge's
-//! rank as mixed-radix digits in cell order.
+//! the secondary half, or visible only to the primary half. The generated
+//! leader is a singleton at the end of its cell and must be visible to at least
+//! one half; total leader isolation is outside this scenario space.
+//!
+//! A residual cell is a group of participants with identical role history in
+//! the scripted prefix. When a participant leads, it becomes a permanent
+//! singleton because future rounds can distinguish it from the other members of
+//! its old cell. A transition records only the next residual cell boundaries.
+//! For a fixed set of part sizes, multiple role-bucket choices can produce the
+//! same next boundaries, so the transition stores their count as
+//! `multiplicity`. Scenario counts are computed over this compressed
+//! transition DAG, and `round_from_edge` reconstructs sampled rounds by
+//! decoding the chosen edge's rank as mixed-radix digits in cell order.
+//!
+//! For example, with one cell of three participants and leader `2`, a round can
+//! split the two non-leaders as `[both = 1, primary-only = 1]` and place the
+//! leader in the secondary half. The canonical representative sets primary to
+//! `{0, 1}` and secondary to `{0, 2}`, producing residual cells `[1, 1, 1]`.
+//! The same part sizes with `both` and `secondary-only` roles instead produce
+//! the same residual cells but different masks, so they share the transition
+//! target and contribute to its multiplicity.
 //!
 //! Scenario generation guarantees that every case within a campaign is
 //! structurally distinct -- no duplicate (scenario, compromised-assignment)
@@ -52,21 +78,19 @@ use commonware_cryptography::certificate::Scheme;
 use commonware_p2p::simulated::SplitTarget;
 use commonware_utils::ordered::Set;
 use rand::{seq::SliceRandom, Rng};
-use std::{
-    collections::{HashMap, HashSet},
-    hash::{Hash, Hasher},
-    sync::Arc,
-};
+use std::{collections::{HashMap, HashSet}, sync::Arc};
+
+const MAX_PARTICIPANTS: usize = u64::BITS as usize;
 
 /// Per-round adversarial setting from the Twins framework.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct RoundScenario {
     // Participant index chosen to lead this round.
     leader: usize,
-    // Dynamic bitmasks selecting which participant identities each twin half can
+    // Bitmasks selecting which participant identities each twin half can
     // exchange messages with. The masks may overlap.
-    primary_mask: BitMask,
-    secondary_mask: BitMask,
+    primary_mask: u64,
+    secondary_mask: u64,
 }
 
 impl RoundScenario {
@@ -99,7 +123,7 @@ impl Scenario {
     pub fn partitions<P: Clone>(&self, view: View, participants: &[P]) -> (Vec<P>, Vec<P>) {
         let idx = view.get().saturating_sub(1) as usize;
         if let Some(round) = self.rounds.get(idx) {
-            return masks_to_partitions(&round.primary_mask, &round.secondary_mask, participants);
+            return masks_to_partitions(round.primary_mask, round.secondary_mask, participants);
         }
         (participants.to_vec(), participants.to_vec())
     }
@@ -121,8 +145,8 @@ impl Scenario {
                 .iter()
                 .position(|participant| participant == sender)
                 .expect("sender missing from runtime participant list");
-            let in_primary = round.primary_mask.contains(sender_idx);
-            let in_secondary = round.secondary_mask.contains(sender_idx);
+            let in_primary = mask_contains(round.primary_mask, sender_idx);
+            let in_secondary = mask_contains(round.secondary_mask, sender_idx);
             return match (in_primary, in_secondary) {
                 (true, true) => SplitTarget::Both,
                 (true, false) => SplitTarget::Primary,
@@ -264,12 +288,18 @@ pub enum Mode {
 
 /// Framework configuration for generating Twins cases.
 ///
+/// The generator uses `u64` masks for recipient sets and residual cell
+/// boundaries, so campaigns support at most 64 participants.
+///
 /// Each canonical scenario tracks residual symmetry cells -- participants that
 /// were treated identically across all rounds. Two compromised-node assignments
 /// that differ only in which members of a symmetry cell are compromised are
 /// equivalent under relabeling for the adversarial prefix, so the framework
 /// generates only one representative per equivalence class. This keeps the case
 /// budget focused on structurally distinct attack configurations.
+/// The synchronous suffix may elect different concrete participant indices
+/// after such a relabeling, but under full synchrony the pass/fail verdict is
+/// invariant to that relabeling.
 ///
 /// The generator selects canonical scenarios first: all scenarios when the
 /// scenario count fits within [`Framework::max_cases`], or uniformly sampled
@@ -279,7 +309,7 @@ pub enum Mode {
 /// `u128`; overflowing configurations panic.
 #[derive(Clone, Copy, Debug)]
 pub struct Framework {
-    /// Number of participants in the network.
+    /// Number of participants in the network. Must be at most 64.
     pub participants: usize,
     /// Number of compromised participants.
     pub faults: usize,
@@ -313,10 +343,15 @@ pub struct Case {
 /// # Panics
 ///
 /// Panics if `framework` has fewer than 2 participants, zero faults, faults
-/// greater than or equal to participants, zero rounds, or zero max cases.
-/// Panics if the canonical scenario count overflows `u128`.
+/// greater than or equal to participants, more than 64 participants, zero
+/// rounds, or zero max cases. Panics if the canonical scenario count overflows
+/// `u128`.
 pub fn cases(rng: &mut impl Rng, framework: Framework) -> Vec<Case> {
     assert!(framework.participants > 1, "participants must be > 1");
+    assert!(
+        framework.participants <= MAX_PARTICIPANTS,
+        "participants must be <= {MAX_PARTICIPANTS}"
+    );
     assert!(framework.faults > 0, "faults must be > 0");
     assert!(
         framework.faults < framework.participants,
@@ -343,7 +378,7 @@ pub fn cases(rng: &mut impl Rng, framework: Framework) -> Vec<Case> {
                 .into_iter()
                 .map(|(s, cells)| {
                     let scenario = Scenario {
-                        rounds: vec![s.rounds[0].clone(); framework.rounds],
+                        rounds: vec![s.rounds[0]; framework.rounds],
                     };
                     (scenario, cells)
                 })
@@ -368,10 +403,10 @@ pub fn cases(rng: &mut impl Rng, framework: Framework) -> Vec<Case> {
 }
 
 /// Materializes the participants selected by a bitmask.
-fn partition_for_mask<P: Clone>(mask: &BitMask, participants: &[P]) -> Vec<P> {
+fn partition_for_mask<P: Clone>(mask: u64, participants: &[P]) -> Vec<P> {
     let mut group = Vec::new();
     for (idx, participant) in participants.iter().enumerate() {
-        if mask.contains(idx) {
+        if mask_contains(mask, idx) {
             group.push(participant.clone());
         }
     }
@@ -380,8 +415,8 @@ fn partition_for_mask<P: Clone>(mask: &BitMask, participants: &[P]) -> Vec<P> {
 
 /// Converts twins routing bitmasks into concrete recipient sets.
 fn masks_to_partitions<P: Clone>(
-    primary_mask: &BitMask,
-    secondary_mask: &BitMask,
+    primary_mask: u64,
+    secondary_mask: u64,
     participants: &[P],
 ) -> (Vec<P>, Vec<P>) {
     let primary = partition_for_mask(primary_mask, participants);
@@ -389,145 +424,29 @@ fn masks_to_partitions<P: Clone>(
     (primary, secondary)
 }
 
-/// Bitmask used for participant sets and cell boundaries.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum BitMask {
-    /// Inline storage for masks that fit in one word.
-    Inline(u64),
-    /// Heap storage for masks that need more than one word.
-    Heap(Box<[u64]>),
+/// Sets bit `idx` in `mask`.
+fn set_mask_bit(mask: &mut u64, idx: usize) {
+    debug_assert!(idx < MAX_PARTICIPANTS);
+    *mask |= 1u64 << idx;
 }
 
-impl Hash for BitMask {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            Self::Inline(word) => state.write_u64(*word),
-            Self::Heap(words) => {
-                state.write_usize(words.len());
-                for word in words.iter() {
-                    state.write_u64(*word);
-                }
-            }
-        }
-    }
-}
-
-impl BitMask {
-    /// Returns an all-zero mask large enough to address `bits` positions.
-    fn zero(bits: usize) -> Self {
-        if bits <= u64::BITS as usize {
-            Self::Inline(0)
-        } else {
-            Self::Heap(vec![0; bits.div_ceil(u64::BITS as usize)].into_boxed_slice())
-        }
-    }
-
-    #[cfg(test)]
-    fn from_u64(bits: usize, mask: u64) -> Self {
-        match Self::zero(bits) {
-            Self::Inline(_) => Self::Inline(mask),
-            Self::Heap(mut words) => {
-                words[0] = mask;
-                Self::Heap(words)
-            }
-        }
-    }
-
-    /// Sets bit `idx`.
-    fn set(&mut self, idx: usize) {
-        match self {
-            Self::Inline(word) => {
-                *word |= 1u64 << idx;
-            }
-            Self::Heap(words) => {
-                let word = idx / u64::BITS as usize;
-                let bit = idx % u64::BITS as usize;
-                words[word] |= 1u64 << bit;
-            }
-        }
-    }
-
-    /// Sets every bit in the contiguous range `[start, start + len)`.
-    fn set_range(&mut self, start: usize, len: usize) {
-        match self {
-            Self::Inline(word) => set_word_range(word, start, len),
-            Self::Heap(words) => {
-                let mut idx = start;
-                let end = start + len;
-                while idx < end {
-                    let word = idx / u64::BITS as usize;
-                    let bit = idx % u64::BITS as usize;
-                    let take = (u64::BITS as usize - bit).min(end - idx);
-                    set_word_range(&mut words[word], bit, take);
-                    idx += take;
-                }
-            }
-        }
-    }
-
-    /// Returns whether bit `idx` is set.
-    fn contains(&self, idx: usize) -> bool {
-        match self {
-            Self::Inline(word) => idx < u64::BITS as usize && (word & (1u64 << idx)) != 0,
-            Self::Heap(words) => {
-                let word = idx / u64::BITS as usize;
-                let bit = idx % u64::BITS as usize;
-                words
-                    .get(word)
-                    .is_some_and(|word| (word & (1u64 << bit)) != 0)
-            }
-        }
-    }
-
-    #[cfg(test)]
-    fn intersects_except(&self, other: &Self, excluded: usize) -> bool {
-        self.any_word_except(other, excluded, |lhs, rhs| lhs & rhs)
-    }
-
-    #[cfg(test)]
-    fn difference_except(&self, other: &Self, excluded: usize) -> bool {
-        self.any_word_except(other, excluded, |lhs, rhs| lhs & !rhs)
-    }
-
-    #[cfg(test)]
-    fn any_word_except(&self, other: &Self, excluded: usize, f: impl Fn(u64, u64) -> u64) -> bool {
-        match (self, other) {
-            (Self::Inline(lhs), Self::Inline(rhs)) => {
-                let mut word = f(*lhs, *rhs);
-                if excluded < u64::BITS as usize {
-                    word &= !(1u64 << excluded);
-                }
-                word != 0
-            }
-            (Self::Heap(lhs), Self::Heap(rhs)) => {
-                assert_eq!(lhs.len(), rhs.len(), "mask widths must match");
-                for (word_idx, (&lhs, &rhs)) in lhs.iter().zip(rhs.iter()).enumerate() {
-                    let mut word = f(lhs, rhs);
-                    if excluded / u64::BITS as usize == word_idx {
-                        word &= !(1u64 << (excluded % u64::BITS as usize));
-                    }
-                    if word != 0 {
-                        return true;
-                    }
-                }
-                false
-            }
-            _ => panic!("mask storage must match"),
-        }
-    }
-}
-
-/// Sets `len` bits in `word` starting at bit offset `start`.
-const fn set_word_range(word: &mut u64, start: usize, len: usize) {
+/// Sets every bit in the contiguous range `[start, start + len)`.
+fn set_mask_range(mask: &mut u64, start: usize, len: usize) {
     if len == 0 {
         return;
     }
-    let mask = if len == u64::BITS as usize {
+    debug_assert!(start + len <= MAX_PARTICIPANTS);
+    let range = if len == u64::BITS as usize {
         u64::MAX
     } else {
         ((1u64 << len) - 1) << start
     };
-    *word |= mask;
+    *mask |= range;
+}
+
+/// Returns whether bit `idx` is set in `mask`.
+const fn mask_contains(mask: u64, idx: usize) -> bool {
+    idx < MAX_PARTICIPANTS && (mask & (1u64 << idx)) != 0
 }
 
 /// Converts cell sizes into contiguous index ranges.
@@ -550,14 +469,15 @@ fn cells_to_ranges(cells: &[usize]) -> Vec<(usize, usize)> {
 /// unset gaps between boundaries belong to the same residual symmetry cell.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct CellState {
-    boundaries: BitMask,
+    boundaries: u64,
 }
 
 impl CellState {
     /// Returns the state with a single symmetry cell covering all participants.
     fn initial(n: usize) -> Self {
+        assert!(n <= MAX_PARTICIPANTS, "participants must be <= {MAX_PARTICIPANTS}");
         Self {
-            boundaries: BitMask::zero(n),
+            boundaries: 0,
         }
     }
 
@@ -569,14 +489,14 @@ impl CellState {
         let mut end = 0usize;
         for size in cells.iter().take(cells.len().saturating_sub(1)) {
             end += size;
-            state.boundaries.set(end - 1);
+            set_mask_bit(&mut state.boundaries, end - 1);
         }
         state
     }
 
     /// Returns whether this state has a boundary after `idx`.
-    fn boundary_after(&self, idx: usize) -> bool {
-        self.boundaries.contains(idx)
+    const fn boundary_after(&self, idx: usize) -> bool {
+        mask_contains(self.boundaries, idx)
     }
 
     /// Converts the state back into cell sizes.
@@ -605,7 +525,7 @@ impl CellState {
             offset += part;
             let end = start + offset;
             if end < n {
-                self.boundaries.set(end - 1);
+                set_mask_bit(&mut self.boundaries, end - 1);
             }
         }
     }
@@ -648,7 +568,9 @@ impl LocalRefinement {
 ///
 /// `multiplicity` is the exact number of `RoundScenario`s that produce `next`
 /// when `leader_cell` supplies the canonical leader. During suffix counting,
-/// this edge contributes `multiplicity * suffix_count(next)`.
+/// this edge contributes `multiplicity * suffix_count(next)`. This value must
+/// match the product of the per-cell local spaces decoded by
+/// `round_from_edge`.
 #[derive(Clone, Debug)]
 struct TransitionEdge {
     next: CellState,
@@ -887,8 +809,8 @@ impl ScenarioGenerator {
         edge: &TransitionEdge,
         mut rank: u128,
     ) -> RoundScenario {
-        let mut primary_mask = BitMask::zero(self.n);
-        let mut secondary_mask = BitMask::zero(self.n);
+        let mut primary_mask = 0u64;
+        let mut secondary_mask = 0u64;
         let mut leader = None;
 
         // The edge fixes only the next residual cell boundaries. Decode the
@@ -915,11 +837,11 @@ impl ScenarioGenerator {
 
                 let leader_idx = start + size - 1;
                 match local_rank % 3 {
-                    0 => primary_mask.set(leader_idx),
-                    1 => secondary_mask.set(leader_idx),
+                    0 => set_mask_bit(&mut primary_mask, leader_idx),
+                    1 => set_mask_bit(&mut secondary_mask, leader_idx),
                     2 => {
-                        primary_mask.set(leader_idx);
-                        secondary_mask.set(leader_idx);
+                        set_mask_bit(&mut primary_mask, leader_idx);
+                        set_mask_bit(&mut secondary_mask, leader_idx);
                     }
                     _ => unreachable!("leader placement rank out of bounds"),
                 }
@@ -1076,8 +998,8 @@ fn apply_roles(
     start: usize,
     parts: &[usize],
     roles: &[Role],
-    primary_mask: &mut BitMask,
-    secondary_mask: &mut BitMask,
+    primary_mask: &mut u64,
+    secondary_mask: &mut u64,
 ) {
     let mut offset = 0usize;
     for (part, role) in parts.iter().zip(roles) {
@@ -1085,11 +1007,11 @@ fn apply_roles(
         match role {
             Role::Outside => {}
             Role::Both => {
-                primary_mask.set_range(range_start, *part);
-                secondary_mask.set_range(range_start, *part);
+                set_mask_range(primary_mask, range_start, *part);
+                set_mask_range(secondary_mask, range_start, *part);
             }
-            Role::Secondary => secondary_mask.set_range(range_start, *part),
-            Role::Primary => primary_mask.set_range(range_start, *part),
+            Role::Secondary => set_mask_range(secondary_mask, range_start, *part),
+            Role::Primary => set_mask_range(primary_mask, range_start, *part),
         }
         offset += part;
     }
@@ -1214,15 +1136,11 @@ mod tests {
     use commonware_utils::{ordered::Set, test_rng, test_rng_seeded};
     use std::collections::HashSet;
 
-    fn mask(bits: usize, mask: u64) -> BitMask {
-        BitMask::from_u64(bits, mask)
-    }
-
-    fn round(n: usize, leader: usize, primary_mask: u64, secondary_mask: u64) -> RoundScenario {
+    fn round(_: usize, leader: usize, primary_mask: u64, secondary_mask: u64) -> RoundScenario {
         RoundScenario {
             leader,
-            primary_mask: mask(n, primary_mask),
-            secondary_mask: mask(n, secondary_mask),
+            primary_mask,
+            secondary_mask,
         }
     }
 
@@ -1499,7 +1417,7 @@ mod tests {
         let mut out = HashSet::new();
         for (round, next_cells) in reference_next_round_transitions(cells) {
             for (mut scenario, residual) in reference_scenarios(&next_cells, rounds - 1) {
-                scenario.rounds.insert(0, round.clone());
+                scenario.rounds.insert(0, round);
                 out.insert((scenario, residual));
             }
         }
@@ -1619,57 +1537,14 @@ mod tests {
     }
 
     #[test]
-    fn generated_scenarios_include_leaders_visible_only_to_secondary() {
-        let scenarios = generate_scenarios(&mut test_rng(), 3, 1, usize::MAX);
-        assert!(scenarios.iter().any(|(scenario, _)| {
-            let round = &scenario.rounds[0];
-            !round.primary_mask.contains(round.leader)
-                && round.secondary_mask.contains(round.leader)
-        }));
-    }
-
-    #[test]
-    fn generated_scenarios_include_shared_non_leaders_in_split_rounds() {
-        let scenarios = generate_scenarios(&mut test_rng(), 5, 1, usize::MAX);
-        assert!(scenarios.iter().any(|(scenario, _)| {
-            let round = &scenario.rounds[0];
-            round
-                .primary_mask
-                .intersects_except(&round.secondary_mask, round.leader)
-                && round
-                    .primary_mask
-                    .difference_except(&round.secondary_mask, round.leader)
-                && round
-                    .secondary_mask
-                    .difference_except(&round.primary_mask, round.leader)
-        }));
-    }
-
-    #[test]
-    fn generated_scenarios_include_shared_non_leaders_when_only_leader_splits_halves() {
-        let scenarios = generate_scenarios(&mut test_rng(), 4, 1, usize::MAX);
-        assert!(scenarios.iter().any(|(scenario, _)| {
-            let round = &scenario.rounds[0];
-            round
-                .primary_mask
-                .intersects_except(&round.secondary_mask, round.leader)
-                && !round
-                    .primary_mask
-                    .difference_except(&round.secondary_mask, round.leader)
-                && !round
-                    .secondary_mask
-                    .difference_except(&round.primary_mask, round.leader)
-                && round.primary_mask != round.secondary_mask
-        }));
-    }
-
-    #[test]
     fn generated_single_round_scenarios_match_expected_canonical_space() {
-        let generated: HashSet<_> = generate_scenarios(&mut test_rng(), 4, 1, usize::MAX)
-            .into_iter()
-            .map(|(scenario, cells)| (scenario.rounds[0].clone(), cells))
-            .collect();
-        assert_eq!(generated, expected_single_round_transitions(4));
+        for n in 3..=5 {
+            let generated: HashSet<_> = generate_scenarios(&mut test_rng(), n, 1, usize::MAX)
+                .into_iter()
+                .map(|(scenario, cells)| (scenario.rounds[0], cells))
+                .collect();
+            assert_eq!(generated, expected_single_round_transitions(n));
+        }
     }
 
     #[test]
@@ -1843,23 +1718,11 @@ mod tests {
                 if round.primary_mask == round.secondary_mask {
                     continue;
                 }
-                let leader_in_primary = round.primary_mask.contains(round.leader);
-                let leader_in_secondary = round.secondary_mask.contains(round.leader);
+                let leader_in_primary = mask_contains(round.primary_mask, round.leader);
+                let leader_in_secondary = mask_contains(round.secondary_mask, round.leader);
                 assert!(leader_in_primary || leader_in_secondary);
             }
         }
-    }
-
-    #[test]
-    fn generated_split_rounds_include_leaders_visible_to_both_halves() {
-        let scenarios = generate_scenarios(&mut test_rng(), 4, 1, usize::MAX);
-        assert!(scenarios.iter().any(|(scenario, _)| {
-            let round = &scenario.rounds[0];
-            if round.primary_mask == round.secondary_mask {
-                return false;
-            }
-            round.primary_mask.contains(round.leader) && round.secondary_mask.contains(round.leader)
-        }));
     }
 
     #[test]
@@ -2035,7 +1898,7 @@ mod tests {
         for round in 0..3 {
             let unique: HashSet<_> = scenarios
                 .iter()
-                .map(|(scenario, _)| scenario.rounds[round].clone())
+                .map(|(scenario, _)| scenario.rounds[round])
                 .collect();
             assert!(
                 unique.len() > 1,
@@ -2091,11 +1954,80 @@ mod tests {
     }
 
     #[test]
-    fn cases_support_frameworks_that_exceed_one_mask_word() {
+    fn cases_reject_more_than_64_participants() {
+        let result = std::panic::catch_unwind(|| {
+            cases(
+                &mut test_rng(),
+                Framework {
+                    participants: MAX_PARTICIPANTS + 1,
+                    faults: 1,
+                    rounds: 1,
+                    mode: Mode::Sampled,
+                    max_cases: 1,
+                },
+            )
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn mask_helpers_set_boundary_ranges() {
+        let mut mask = 0u64;
+        set_mask_bit(&mut mask, 63);
+        assert!(!mask_contains(mask, 62));
+        assert!(mask_contains(mask, 63));
+
+        let mut mask = 0u64;
+        set_mask_range(&mut mask, 60, 4);
+        for idx in 60..=63 {
+            assert!(mask_contains(mask, idx), "bit {idx} should be set");
+        }
+        assert!(!mask_contains(mask, 59));
+    }
+
+    #[test]
+    fn scenario_masks_route_within_one_word() {
+        let mut primary_mask = 0u64;
+        set_mask_range(&mut primary_mask, 60, 4);
+        let mut secondary_mask = 0u64;
+        set_mask_bit(&mut secondary_mask, 61);
+        set_mask_bit(&mut secondary_mask, 63);
+        let scenario = Scenario {
+            rounds: vec![RoundScenario {
+                leader: 63,
+                primary_mask,
+                secondary_mask,
+            }],
+        };
+        let participants: Vec<_> = (0..64).collect();
+
+        let (primary, secondary) = scenario.partitions(View::new(1), &participants);
+        assert_eq!(primary, vec![60, 61, 62, 63]);
+        assert_eq!(secondary, vec![61, 63]);
+        assert_eq!(
+            scenario.route(View::new(1), &60, &participants),
+            SplitTarget::Primary
+        );
+        assert_eq!(
+            scenario.route(View::new(1), &61, &participants),
+            SplitTarget::Both
+        );
+        assert_eq!(
+            scenario.route(View::new(1), &63, &participants),
+            SplitTarget::Both
+        );
+        assert_eq!(
+            scenario.route(View::new(1), &0, &participants),
+            SplitTarget::None
+        );
+    }
+
+    #[test]
+    fn cases_support_64_participants() {
         let generated = cases(
             &mut test_rng(),
             Framework {
-                participants: (u64::BITS as usize) + 1,
+                participants: MAX_PARTICIPANTS,
                 faults: 1,
                 rounds: 1,
                 mode: Mode::Sampled,
@@ -2103,60 +2035,6 @@ mod tests {
             },
         );
         assert_eq!(generated.len(), 1);
-    }
-
-    #[test]
-    fn bitmask_sets_ranges_across_words() {
-        let mut mask = BitMask::zero(130);
-        mask.set(64);
-        assert!(!mask.contains(63));
-        assert!(mask.contains(64));
-        assert!(!mask.contains(65));
-
-        mask.set_range(62, 5);
-        for idx in 62..=66 {
-            assert!(mask.contains(idx), "bit {idx} should be set");
-        }
-        assert!(!mask.contains(61));
-        assert!(!mask.contains(67));
-        assert!(!mask.contains(129));
-    }
-
-    #[test]
-    fn scenario_masks_route_across_words() {
-        let mut primary_mask = BitMask::zero(70);
-        primary_mask.set_range(62, 4);
-        let mut secondary_mask = BitMask::zero(70);
-        secondary_mask.set(64);
-        secondary_mask.set(69);
-        let scenario = Scenario {
-            rounds: vec![RoundScenario {
-                leader: 64,
-                primary_mask,
-                secondary_mask,
-            }],
-        };
-        let participants: Vec<_> = (0..70).collect();
-
-        let (primary, secondary) = scenario.partitions(View::new(1), &participants);
-        assert_eq!(primary, vec![62, 63, 64, 65]);
-        assert_eq!(secondary, vec![64, 69]);
-        assert_eq!(
-            scenario.route(View::new(1), &63, &participants),
-            SplitTarget::Primary
-        );
-        assert_eq!(
-            scenario.route(View::new(1), &64, &participants),
-            SplitTarget::Both
-        );
-        assert_eq!(
-            scenario.route(View::new(1), &69, &participants),
-            SplitTarget::Secondary
-        );
-        assert_eq!(
-            scenario.route(View::new(1), &0, &participants),
-            SplitTarget::None
-        );
     }
 
     #[test]

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -1,6 +1,6 @@
 //! Twins framework scenario generator and executor helpers.
 //!
-//! This module follows the campaign structure from
+//! This module follows the testing architecture from
 //! [Twins: BFT Systems Made Robust](https://arxiv.org/pdf/2004.10617):
 //! 1. Generate primary/secondary recipient-set scenarios.
 //! 2. Combine those sets with leader choices per round.

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -568,7 +568,7 @@ impl CellState {
 /// `outside`, `both`, `secondary-only`, and `primary-only`. The leader cell
 /// uses the same buckets for its non-leader prefix and then appends the leader
 /// singleton as the final part. `parts` stores the resulting non-empty bucket
-/// sizes; `multiplicity` counts how many ordered role-bucket choices produce
+/// sizes, `multiplicity` counts how many ordered role-bucket choices produce
 /// those same sizes.
 #[derive(Clone, Copy, Debug)]
 struct LocalRefinement {
@@ -600,8 +600,7 @@ impl LocalRefinement {
 /// `multiplicity` is the exact number of `RoundScenario`s that produce `next`
 /// when `leader_cell` supplies the canonical leader. During suffix counting,
 /// this edge contributes `multiplicity * suffix_count(next)`. This value must
-/// match the product of the per-cell local spaces decoded by
-/// `round_from_edge`.
+/// match the product of the per-cell local spaces decoded by `round_from_edge`.
 #[derive(Clone, Copy, Debug)]
 struct TransitionEdge {
     next: CellState,
@@ -612,7 +611,7 @@ struct TransitionEdge {
 /// Compressed outgoing transitions for one residual cell state.
 ///
 /// `overflowed` is set when at least one transition multiplicity cannot be
-/// represented as a `u128`; scenario counting treats that as count overflow.
+/// represented as a `u128`, scenario counting treats that as count overflow.
 #[derive(Clone, Debug, Default)]
 struct TransitionSet {
     edges: Vec<TransitionEdge>,
@@ -630,6 +629,10 @@ fn build_transitions(
     transitions: &mut TransitionSet,
 ) {
     if cell_idx == ranges.len() {
+        // Every current cell has chosen one local refinement. The accumulated
+        // boundary mask identifies the residual state reached by this round,
+        // and multiplicity is the product of the local role spaces that map to
+        // that same residual state.
         transitions.edges.push(TransitionEdge {
             next: next_state,
             leader_cell,
@@ -644,6 +647,11 @@ fn build_transitions(
         .map(|(start, len)| start + len)
         .expect("transition ranges must be non-empty");
     for refinement in refinements_by_cell[cell_idx].iter().copied() {
+        // Choose one refinement for this cell and carry its contribution into
+        // the DFS prefix. Different refinements may produce the same
+        // `next_state`, keeping them as separate edges is intentional because
+        // unranking uses each edge's multiplicity to reconstruct a concrete
+        // round.
         let Some(multiplicity) = multiplicity.checked_mul(refinement.multiplicity) else {
             transitions.overflowed = true;
             continue;
@@ -674,10 +682,22 @@ enum Role {
     Primary,
 }
 
-/// Compressed transition DAG and scenario unranker.
+/// Scenario generator for a fixed participant count.
+///
+/// The generator lazily memoizes the compressed transition DAG keyed by
+/// residual symmetry state. Each transition set describes the canonical
+/// one-round refinements reachable from a state, with edge multiplicities
+/// carrying the number of concrete role choices represented by that edge.
+/// Generation first builds exact suffix counts over this DAG, then enumerates
+/// or samples scenario ranks and unpacks each selected rank into concrete
+/// [`RoundScenario`] masks.
 struct ScenarioGenerator {
+    /// Number of participants in the generated scenarios.
     n: usize,
+    /// Memoized outgoing transitions for each residual symmetry state.
     transition_memo: HashMap<CellState, TransitionSet>,
+    /// Memoized cell-local refinements keyed by cell size and whether the cell
+    /// contains the round leader.
     local_memo: HashMap<(usize, bool), Vec<LocalRefinement>>,
 }
 
@@ -693,7 +713,7 @@ impl ScenarioGenerator {
 
     /// Enumerates canonical scenarios with their residual symmetry cells.
     ///
-    /// Returns all scenarios when the space fits within `max_scenarios`;
+    /// Returns all scenarios when the space fits within `max_scenarios`,
     /// otherwise samples `max_scenarios` without replacement.
     ///
     /// # Panics
@@ -706,10 +726,18 @@ impl ScenarioGenerator {
         max_scenarios: usize,
     ) -> Vec<(Scenario, Cells)> {
         let initial = CellState::initial(self.n);
+
+        // Count the complete canonical scenario space before choosing which
+        // ranks to materialize. The same count table is reused by unranking so
+        // each selected rank can skip whole compressed subtrees.
         let counts = self
             .counts(&initial, rounds)
             .expect("scenario space overflows u128; reduce rounds or participants");
         let total = counts[rounds][&initial];
+
+        // If the requested budget covers the whole space, enumerate ranks in
+        // canonical order. Otherwise sample distinct ranks uniformly and
+        // materialize only those scenarios.
         if total <= max_scenarios as u128 {
             return (0..total)
                 .map(|idx| self.scenario_from_rank(&initial, rounds, idx, &counts))
@@ -731,6 +759,9 @@ impl ScenarioGenerator {
         initial: &CellState,
         rounds: usize,
     ) -> Option<Vec<HashMap<CellState, u128>>> {
+        // First discover which residual states can appear at each depth from
+        // the initial state. Later DP layers only need to account for these
+        // reachable states.
         let mut layers = Vec::with_capacity(rounds + 1);
         layers.push(HashSet::from([*initial]));
 
@@ -749,11 +780,17 @@ impl ScenarioGenerator {
             layers.push(next_layer);
         }
 
+        // A zero-round suffix has exactly one continuation: emit no more
+        // rounds. Seed that base case for every state reachable after the full
+        // scripted prefix.
         let mut counts = vec![HashMap::new(); rounds + 1];
         for state in layers[rounds].iter() {
             counts[0].insert(*state, 1);
         }
 
+        // Fold suffix counts back toward the initial state. Each outgoing edge
+        // contributes its round multiplicity times the number of suffixes from
+        // the edge's next residual state.
         for remaining in 1..=rounds {
             let depth = rounds - remaining;
             for state in layers[depth].iter() {
@@ -790,6 +827,10 @@ impl ScenarioGenerator {
         let mut scenario = Vec::with_capacity(rounds);
         let mut state = *initial;
 
+        // Walk the scenario prefix from left to right. At each residual state,
+        // each edge owns a contiguous rank interval equal to its concrete
+        // round multiplicity times the number of suffixes behind its next
+        // state.
         for remaining in (1..=rounds).rev() {
             self.ensure_transitions(&state);
             let transitions = self.transitions(&state);
@@ -810,6 +851,9 @@ impl ScenarioGenerator {
                     .expect("canonical scenario count should fit in u128");
 
                 if rank < subtree_count {
+                    // The high digit selects which concrete round within this
+                    // edge to decode, the remainder is the suffix rank used at
+                    // the next residual state.
                     let transition_rank = rank / suffix;
                     scenario.push(self.round_from_edge(&state, edge, transition_rank));
                     state = edge.next;
@@ -832,6 +876,10 @@ impl ScenarioGenerator {
         }
         let ranges = state.ranges(self.n);
         let mut transitions = TransitionSet::default();
+
+        // Try each residual cell as the canonical source of this round's
+        // leader. The leader cell's local refinements reserve its final
+        // participant as a singleton leader part.
         for leader_cell in 0..ranges.len() {
             let refinements: Vec<_> = ranges
                 .iter()
@@ -841,6 +889,9 @@ impl ScenarioGenerator {
                         .to_vec()
                 })
                 .collect();
+
+            // Combine one local refinement per cell into complete outgoing
+            // edges for this leader choice.
             build_transitions(
                 &ranges,
                 &refinements,
@@ -885,6 +936,8 @@ impl ScenarioGenerator {
         // role subset, and the leader cell has an extra digit for which half
         // sees the leader.
         for (cell_idx, (start, size)) in state.ranges(self.n).into_iter().enumerate() {
+            // Recover this current cell's part sizes by slicing it with the
+            // next state's residual boundaries.
             let parts = edge.next.parts_in_cell(start, size);
             if cell_idx == edge.leader_cell {
                 let non_leader_len = parts.len() - 1;
@@ -893,6 +946,9 @@ impl ScenarioGenerator {
                 let local_rank = rank % local_space;
                 rank /= local_space;
 
+                // The leader cell first consumes a role-subset digit for its
+                // non-leader prefix, then one of three leader placements:
+                // primary-only, secondary-only, or both halves.
                 let roles = roles_from_rank(non_leader_len, local_rank / 3);
                 apply_roles(
                     start,
@@ -918,6 +974,7 @@ impl ScenarioGenerator {
                 let local_rank = rank % role_count;
                 rank /= role_count;
 
+                // Non-leader cells only consume a role-subset digit.
                 let roles = roles_from_rank(parts.len(), local_rank);
                 apply_roles(
                     start,
@@ -952,15 +1009,25 @@ const fn role_subset_count(len: usize) -> u128 {
 }
 
 /// Builds all local refinements for a cell.
+///
+/// A local refinement is the shape this cell can have after one round. The
+/// shape only stores contiguous part sizes; `multiplicity` records how many
+/// assignments of those parts to the ordered non-leader roles produce the same
+/// shape.
 fn build_local_refinements(size: usize, is_leader: bool) -> Vec<LocalRefinement> {
     let mut refinements = Vec::new();
     let available = if is_leader { size - 1 } else { size };
     let mut prefix = Vec::new();
     for_each_composition(available, 4, &mut prefix, &mut |parts| {
+        // `parts` partitions the non-leader portion into the non-empty role
+        // buckets that will remain distinguishable after this round.
         let role_choices = role_subset_count(parts.len());
         let mut local = Vec::with_capacity(parts.len() + usize::from(is_leader));
         local.extend_from_slice(parts);
         let multiplicity = if is_leader {
+            // The leader is always the final participant in its current cell
+            // and becomes a singleton residual cell. It can be visible to the
+            // primary half, the secondary half, or both halves.
             local.push(1);
             role_choices * 3
         } else {
@@ -1021,6 +1088,10 @@ fn for_each_composition_with_len<F: FnMut(&[usize])>(
 
 /// Returns the ranked subset of `len` roles from the four ordered non-leader
 /// roles. The selected roles are returned in canonical role order.
+///
+/// A local refinement with `len` parts does not store which role bucket each
+/// part came from. Its rank selects one of the `C(4, len)` non-empty subsets of
+/// the ordered role list: outside, both, secondary-only, primary-only.
 fn roles_from_rank(len: usize, rank: u128) -> [Role; 4] {
     let mut seen = 0u128;
     for mask in 0u8..16 {
@@ -1030,6 +1101,9 @@ fn roles_from_rank(len: usize, rank: u128) -> [Role; 4] {
         if seen == rank {
             let mut roles = [Role::Outside; 4];
             let mut next = 0usize;
+            // Scan masks in numeric order while assigning selected bits in the
+            // canonical role order. This is the inverse of the
+            // `role_subset_count(len)` space used by local refinements.
             for (bit, role) in [Role::Outside, Role::Both, Role::Secondary, Role::Primary]
                 .into_iter()
                 .enumerate()

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -467,7 +467,7 @@ fn cells_to_ranges(cells: &[usize]) -> Vec<(usize, usize)> {
 ///
 /// Bit `i` is set when there is a cell boundary after participant `i`. The
 /// unset gaps between boundaries belong to the same residual symmetry cell.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct CellState {
     boundaries: u64,
 }
@@ -500,7 +500,7 @@ impl CellState {
     }
 
     /// Converts the state back into cell sizes.
-    fn to_cells(&self, n: usize) -> Vec<usize> {
+    fn to_cells(self, n: usize) -> Vec<usize> {
         self.ranges(n).into_iter().map(|(_, len)| len).collect()
     }
 
@@ -571,7 +571,7 @@ impl LocalRefinement {
 /// this edge contributes `multiplicity * suffix_count(next)`. This value must
 /// match the product of the per-cell local spaces decoded by
 /// `round_from_edge`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 struct TransitionEdge {
     next: CellState,
     leader_cell: usize,
@@ -588,42 +588,46 @@ struct TransitionSet {
     overflowed: bool,
 }
 
-/// Builder for the outgoing transition set of one residual cell state.
-struct TransitionBuilder<'a> {
-    n: usize,
-    ranges: &'a [(usize, usize)],
+/// Recursively combines precomputed local cell refinements into compressed edges.
+fn build_transitions(
+    ranges: &[(usize, usize)],
+    refinements_by_cell: &[Vec<LocalRefinement>],
     leader_cell: usize,
-    refinements_by_cell: &'a [Vec<LocalRefinement>],
-}
+    cell_idx: usize,
+    next_state: CellState,
+    multiplicity: u128,
+    transitions: &mut TransitionSet,
+) {
+    if cell_idx == ranges.len() {
+        transitions.edges.push(TransitionEdge {
+            next: next_state,
+            leader_cell,
+            multiplicity,
+        });
+        return;
+    }
 
-impl TransitionBuilder<'_> {
-    /// Recursively combines precomputed local cell refinements into compressed edges.
-    fn build(
-        &self,
-        cell_idx: usize,
-        next_state: CellState,
-        multiplicity: u128,
-        transitions: &mut TransitionSet,
-    ) {
-        if cell_idx == self.ranges.len() {
-            transitions.edges.push(TransitionEdge {
-                next: next_state,
-                leader_cell: self.leader_cell,
-                multiplicity,
-            });
-            return;
-        }
-
-        let (start, _) = self.ranges[cell_idx];
-        for refinement in self.refinements_by_cell[cell_idx].iter().copied() {
-            let Some(multiplicity) = multiplicity.checked_mul(refinement.multiplicity) else {
-                transitions.overflowed = true;
-                continue;
-            };
-            let mut next_state = next_state.clone();
-            next_state.add_local_boundaries(start, self.n, refinement.parts());
-            self.build(cell_idx + 1, next_state, multiplicity, transitions);
-        }
+    let (start, _) = ranges[cell_idx];
+    let n = ranges
+        .last()
+        .map(|(start, len)| start + len)
+        .expect("transition ranges must be non-empty");
+    for refinement in refinements_by_cell[cell_idx].iter().copied() {
+        let Some(multiplicity) = multiplicity.checked_mul(refinement.multiplicity) else {
+            transitions.overflowed = true;
+            continue;
+        };
+        let mut next_state = next_state;
+        next_state.add_local_boundaries(start, n, refinement.parts());
+        build_transitions(
+            ranges,
+            refinements_by_cell,
+            leader_cell,
+            cell_idx + 1,
+            next_state,
+            multiplicity,
+            transitions,
+        );
     }
 }
 
@@ -667,7 +671,7 @@ impl ScenarioGenerator {
         rounds: usize,
     ) -> Option<Vec<HashMap<CellState, u128>>> {
         let mut layers = Vec::with_capacity(rounds + 1);
-        layers.push(HashSet::from([initial.clone()]));
+        layers.push(HashSet::from([*initial]));
 
         for depth in 0..rounds {
             let mut next_layer = HashSet::new();
@@ -678,7 +682,7 @@ impl ScenarioGenerator {
                     return None;
                 }
                 for edge in &transitions.edges {
-                    next_layer.insert(edge.next.clone());
+                    next_layer.insert(edge.next);
                 }
             }
             layers.push(next_layer);
@@ -686,7 +690,7 @@ impl ScenarioGenerator {
 
         let mut counts = vec![HashMap::new(); rounds + 1];
         for state in layers[rounds].iter() {
-            counts[0].insert(state.clone(), 1);
+            counts[0].insert(*state, 1);
         }
 
         for remaining in 1..=rounds {
@@ -707,7 +711,7 @@ impl ScenarioGenerator {
                     let edge_count = edge.multiplicity.checked_mul(suffix)?;
                     total = total.checked_add(edge_count)?;
                 }
-                counts[remaining].insert(state.clone(), total);
+                counts[remaining].insert(*state, total);
             }
         }
 
@@ -723,7 +727,7 @@ impl ScenarioGenerator {
         counts: &[HashMap<CellState, u128>],
     ) -> (Scenario, Vec<usize>) {
         let mut scenario = Vec::with_capacity(rounds);
-        let mut state = initial.clone();
+        let mut state = *initial;
 
         for remaining in (1..=rounds).rev() {
             self.ensure_transitions(&state);
@@ -747,7 +751,7 @@ impl ScenarioGenerator {
                 if rank < subtree_count {
                     let transition_rank = rank / suffix;
                     scenario.push(self.round_from_edge(&state, edge, transition_rank));
-                    state = edge.next.clone();
+                    state = edge.next;
                     rank %= suffix;
                     selected = true;
                     break;
@@ -776,15 +780,17 @@ impl ScenarioGenerator {
                         .to_vec()
                 })
                 .collect();
-            TransitionBuilder {
-                n: self.n,
-                ranges: &ranges,
+            build_transitions(
+                &ranges,
+                &refinements,
                 leader_cell,
-                refinements_by_cell: &refinements,
-            }
-            .build(0, CellState::initial(self.n), 1, &mut transitions);
+                0,
+                CellState::initial(self.n),
+                1,
+                &mut transitions,
+            );
         }
-        self.transition_memo.insert(state.clone(), transitions);
+        self.transition_memo.insert(*state, transitions);
     }
 
     /// Returns memoized compressed transition edges for `state`.

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -19,11 +19,12 @@
 //! pairs are ever emitted. The scenario space is counted with an exact
 //! compressed transition DAG: each edge stores a residual symmetry-cell
 //! transition and the exact number of concrete round scenarios represented by
-//! that transition. When the scenario space exceeds the configured budget,
-//! sampled campaigns choose canonical scenarios uniformly without replacement.
-//! For each selected scenario, `cases()` computes the residual symmetry cells
-//! and generates only the unique compromised-node assignments: two assignments
-//! that differ only in which members of a cell are chosen are equivalent and
+//! that transition. Counts are computed bottom-up over the reachable residual
+//! states. When the scenario space exceeds the configured budget, sampled
+//! campaigns choose canonical scenarios uniformly without replacement. For
+//! each selected scenario, `cases()` computes the residual symmetry cells and
+//! generates only the unique compromised-node assignments: two assignments that
+//! differ only in which members of a cell are chosen are equivalent and
 //! collapsed to a single representative.
 //!
 //! These recipient sets are not required to be disjoint. A participant may
@@ -40,23 +41,24 @@ use commonware_utils::ordered::Set;
 use rand::{seq::SliceRandom, Rng};
 use std::{
     collections::{HashMap, HashSet},
+    hash::{Hash, Hasher},
     sync::Arc,
 };
 
 /// Per-round adversarial setting from the Twins framework.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct RoundScenario {
     // Participant index chosen to lead this round.
     leader: usize,
-    // Bitmasks selecting which participant identities each twin half can
+    // Dynamic bitmasks selecting which participant identities each twin half can
     // exchange messages with. The masks may overlap.
-    primary_mask: u64,
-    secondary_mask: u64,
+    primary_mask: BitMask,
+    secondary_mask: BitMask,
 }
 
 impl RoundScenario {
     /// Returns the designated leader index for this round scenario.
-    pub const fn leader(self) -> usize {
+    pub const fn leader(&self) -> usize {
         self.leader
     }
 }
@@ -84,7 +86,7 @@ impl Scenario {
     pub fn partitions<P: Clone>(&self, view: View, participants: &[P]) -> (Vec<P>, Vec<P>) {
         let idx = view.get().saturating_sub(1) as usize;
         if let Some(round) = self.rounds.get(idx) {
-            return masks_to_partitions(round.primary_mask, round.secondary_mask, participants);
+            return masks_to_partitions(&round.primary_mask, &round.secondary_mask, participants);
         }
         (participants.to_vec(), participants.to_vec())
     }
@@ -106,9 +108,8 @@ impl Scenario {
                 .iter()
                 .position(|participant| participant == sender)
                 .expect("sender missing from runtime participant list");
-            let bit = 1u64 << sender_idx;
-            let in_primary = (round.primary_mask & bit) != 0;
-            let in_secondary = (round.secondary_mask & bit) != 0;
+            let in_primary = round.primary_mask.contains(sender_idx);
+            let in_secondary = round.secondary_mask.contains(sender_idx);
             return match (in_primary, in_secondary) {
                 (true, true) => SplitTarget::Both,
                 (true, false) => SplitTarget::Primary,
@@ -298,16 +299,11 @@ pub struct Case {
 ///
 /// # Panics
 ///
-/// Panics if `framework` has fewer than 2 participants, more participants than
-/// fit in the route masks, zero faults, faults greater than or equal to
-/// participants, zero rounds, or zero max cases. Panics if the canonical
-/// scenario count overflows `u128`.
+/// Panics if `framework` has fewer than 2 participants, zero faults, faults
+/// greater than or equal to participants, zero rounds, or zero max cases.
+/// Panics if the canonical scenario count overflows `u128`.
 pub fn cases(rng: &mut impl Rng, framework: Framework) -> Vec<Case> {
     assert!(framework.participants > 1, "participants must be > 1");
-    assert!(
-        framework.participants <= u64::BITS as usize,
-        "participants must fit in u64 masks"
-    );
     assert!(framework.faults > 0, "faults must be > 0");
     assert!(
         framework.faults < framework.participants,
@@ -334,7 +330,7 @@ pub fn cases(rng: &mut impl Rng, framework: Framework) -> Vec<Case> {
                 .into_iter()
                 .map(|(s, cells)| {
                     let scenario = Scenario {
-                        rounds: vec![s.rounds[0]; framework.rounds],
+                        rounds: vec![s.rounds[0].clone(); framework.rounds],
                     };
                     (scenario, cells)
                 })
@@ -359,10 +355,10 @@ pub fn cases(rng: &mut impl Rng, framework: Framework) -> Vec<Case> {
 }
 
 /// Materializes the participants selected by a bitmask.
-fn partition_for_mask<P: Clone>(mask: u64, participants: &[P]) -> Vec<P> {
+fn partition_for_mask<P: Clone>(mask: &BitMask, participants: &[P]) -> Vec<P> {
     let mut group = Vec::new();
     for (idx, participant) in participants.iter().enumerate() {
-        if (mask & (1u64 << idx)) != 0 {
+        if mask.contains(idx) {
             group.push(participant.clone());
         }
     }
@@ -371,8 +367,8 @@ fn partition_for_mask<P: Clone>(mask: u64, participants: &[P]) -> Vec<P> {
 
 /// Converts twins routing bitmasks into concrete recipient sets.
 fn masks_to_partitions<P: Clone>(
-    primary_mask: u64,
-    secondary_mask: u64,
+    primary_mask: &BitMask,
+    secondary_mask: &BitMask,
     participants: &[P],
 ) -> (Vec<P>, Vec<P>) {
     let primary = partition_for_mask(primary_mask, participants);
@@ -380,12 +376,150 @@ fn masks_to_partitions<P: Clone>(
     (primary, secondary)
 }
 
-/// Returns a contiguous bitmask range `[start, start + len)`.
-const fn range_mask(start: usize, len: usize) -> u64 {
-    if len == 0 {
-        return 0;
+/// Bitmask used for participant sets and cell boundaries.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum BitMask {
+    /// Inline storage for masks that fit in one word.
+    Inline(u64),
+    /// Heap storage for masks that need more than one word.
+    Heap(Box<[u64]>),
+}
+
+impl Hash for BitMask {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Inline(word) => state.write_u64(*word),
+            Self::Heap(words) => {
+                state.write_usize(words.len());
+                for word in words.iter() {
+                    state.write_u64(*word);
+                }
+            }
+        }
     }
-    (((1u128 << len) - 1) << start) as u64
+}
+
+impl BitMask {
+    /// Returns an all-zero mask large enough to address `bits` positions.
+    fn zero(bits: usize) -> Self {
+        if bits <= u64::BITS as usize {
+            Self::Inline(0)
+        } else {
+            Self::Heap(vec![0; bits.div_ceil(u64::BITS as usize)].into_boxed_slice())
+        }
+    }
+
+    #[cfg(test)]
+    fn from_u64(bits: usize, mask: u64) -> Self {
+        match Self::zero(bits) {
+            Self::Inline(_) => Self::Inline(mask),
+            Self::Heap(mut words) => {
+                words[0] = mask;
+                Self::Heap(words)
+            }
+        }
+    }
+
+    /// Sets bit `idx`.
+    fn set(&mut self, idx: usize) {
+        match self {
+            Self::Inline(word) => {
+                *word |= 1u64 << idx;
+            }
+            Self::Heap(words) => {
+                let word = idx / u64::BITS as usize;
+                let bit = idx % u64::BITS as usize;
+                words[word] |= 1u64 << bit;
+            }
+        }
+    }
+
+    /// Sets every bit in the contiguous range `[start, start + len)`.
+    fn set_range(&mut self, start: usize, len: usize) {
+        match self {
+            Self::Inline(word) => set_word_range(word, start, len),
+            Self::Heap(words) => {
+                let mut idx = start;
+                let end = start + len;
+                while idx < end {
+                    let word = idx / u64::BITS as usize;
+                    let bit = idx % u64::BITS as usize;
+                    let take = (u64::BITS as usize - bit).min(end - idx);
+                    set_word_range(&mut words[word], bit, take);
+                    idx += take;
+                }
+            }
+        }
+    }
+
+    /// Returns whether bit `idx` is set.
+    fn contains(&self, idx: usize) -> bool {
+        match self {
+            Self::Inline(word) => idx < u64::BITS as usize && (word & (1u64 << idx)) != 0,
+            Self::Heap(words) => {
+                let word = idx / u64::BITS as usize;
+                let bit = idx % u64::BITS as usize;
+                words
+                    .get(word)
+                    .is_some_and(|word| (word & (1u64 << bit)) != 0)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn intersects_except(&self, other: &Self, excluded: usize) -> bool {
+        self.any_word_except(other, excluded, |lhs, rhs| lhs & rhs)
+    }
+
+    #[cfg(test)]
+    fn difference_except(&self, other: &Self, excluded: usize) -> bool {
+        self.any_word_except(other, excluded, |lhs, rhs| lhs & !rhs)
+    }
+
+    #[cfg(test)]
+    fn any_word_except(
+        &self,
+        other: &Self,
+        excluded: usize,
+        f: impl Fn(u64, u64) -> u64,
+    ) -> bool {
+        match (self, other) {
+            (Self::Inline(lhs), Self::Inline(rhs)) => {
+                let mut word = f(*lhs, *rhs);
+                if excluded < u64::BITS as usize {
+                    word &= !(1u64 << excluded);
+                }
+                word != 0
+            }
+            (Self::Heap(lhs), Self::Heap(rhs)) => {
+                assert_eq!(lhs.len(), rhs.len(), "mask widths must match");
+                for (word_idx, (&lhs, &rhs)) in lhs.iter().zip(rhs.iter()).enumerate() {
+                    let mut word = f(lhs, rhs);
+                    if excluded / u64::BITS as usize == word_idx {
+                        word &= !(1u64 << (excluded % u64::BITS as usize));
+                    }
+                    if word != 0 {
+                        return true;
+                    }
+                }
+                false
+            }
+            _ => panic!("mask storage must match"),
+        }
+    }
+}
+
+/// Sets `len` bits in `word` starting at bit offset `start`.
+const fn set_word_range(word: &mut u64, start: usize, len: usize) {
+    if len == 0 {
+        return;
+    }
+    let mask = if len == u64::BITS as usize {
+        u64::MAX
+    } else {
+        ((1u64 << len) - 1) << start
+    };
+    *word |= mask;
 }
 
 /// Converts cell sizes into contiguous index ranges.
@@ -406,28 +540,39 @@ fn cells_to_ranges(cells: &[usize]) -> Vec<(usize, usize)> {
 ///
 /// Bit `i` is set when there is a cell boundary after participant `i`. The
 /// unset gaps between boundaries belong to the same residual symmetry cell.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct CellState(u64);
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct CellState {
+    boundaries: BitMask,
+}
 
 impl CellState {
+    /// Returns the state with a single symmetry cell covering all participants.
+    fn initial(n: usize) -> Self {
+        Self {
+            boundaries: BitMask::zero(n),
+        }
+    }
+
     /// Converts explicit cell sizes into a boundary mask.
+    #[cfg(test)]
     fn from_cells(cells: &[usize]) -> Self {
-        let mut mask = 0u64;
+        let n = cells.iter().sum();
+        let mut state = Self::initial(n);
         let mut end = 0usize;
         for size in cells.iter().take(cells.len().saturating_sub(1)) {
             end += size;
-            mask |= 1u64 << (end - 1);
+            state.boundaries.set(end - 1);
         }
-        Self(mask)
+        state
     }
 
     /// Returns whether this state has a boundary after `idx`.
-    const fn boundary_after(self, idx: usize) -> bool {
-        (self.0 & (1u64 << idx)) != 0
+    fn boundary_after(&self, idx: usize) -> bool {
+        self.boundaries.contains(idx)
     }
 
     /// Converts the state back into cell sizes.
-    fn to_cells(self, n: usize) -> Vec<usize> {
+    fn to_cells(&self, n: usize) -> Vec<usize> {
         let mut cells = Vec::new();
         let mut start = 0usize;
         for idx in 0..n.saturating_sub(1) {
@@ -441,7 +586,7 @@ impl CellState {
     }
 
     /// Converts the state into contiguous `(start, len)` cell ranges.
-    fn ranges(self, n: usize) -> Vec<(usize, usize)> {
+    fn ranges(&self, n: usize) -> Vec<(usize, usize)> {
         let mut ranges = Vec::new();
         let mut start = 0usize;
         for idx in 0..n.saturating_sub(1) {
@@ -452,6 +597,18 @@ impl CellState {
         }
         ranges.push((start, n - start));
         ranges
+    }
+
+    /// Adds boundaries for `parts` starting at `start`.
+    fn add_local_boundaries(&mut self, start: usize, n: usize, parts: &[usize]) {
+        let mut offset = 0usize;
+        for part in parts {
+            offset += part;
+            let end = start + offset;
+            if end < n {
+                self.boundaries.set(end - 1);
+            }
+        }
     }
 }
 
@@ -486,18 +643,65 @@ impl LocalRefinement {
     }
 }
 
-/// Compressed group of concrete next-round scenarios.
+/// Compressed transition to a residual cell state.
 ///
 /// `multiplicity` is the exact number of `RoundScenario`s that produce `next`
 /// when `leader_cell` supplies the canonical leader. During suffix counting,
-/// this edge contributes `multiplicity * suffix_count(next)`. `None` means the
-/// multiplicity overflowed `u128`, so the scenario count should also report
-/// overflow.
-#[derive(Clone, Copy, Debug)]
+/// this edge contributes `multiplicity * suffix_count(next)`.
+#[derive(Clone, Debug)]
 struct TransitionEdge {
     next: CellState,
     leader_cell: usize,
-    multiplicity: Option<u128>,
+    multiplicity: u128,
+}
+
+/// Compressed outgoing transitions for one residual cell state.
+///
+/// `overflowed` is set when at least one transition multiplicity cannot be
+/// represented as a `u128`; scenario counting treats that as count overflow.
+#[derive(Clone, Debug, Default)]
+struct TransitionSet {
+    edges: Vec<TransitionEdge>,
+    overflowed: bool,
+}
+
+/// Builder for the outgoing transition set of one residual cell state.
+struct TransitionBuilder<'a> {
+    n: usize,
+    ranges: &'a [(usize, usize)],
+    leader_cell: usize,
+    refinements_by_cell: &'a [Vec<LocalRefinement>],
+}
+
+impl TransitionBuilder<'_> {
+    /// Recursively combines precomputed local cell refinements into compressed edges.
+    fn build(
+        &self,
+        cell_idx: usize,
+        next_state: CellState,
+        multiplicity: u128,
+        transitions: &mut TransitionSet,
+    ) {
+        if cell_idx == self.ranges.len() {
+            transitions.edges.push(TransitionEdge {
+                next: next_state,
+                leader_cell: self.leader_cell,
+                multiplicity,
+            });
+            return;
+        }
+
+        let (start, _) = self.ranges[cell_idx];
+        for refinement in self.refinements_by_cell[cell_idx].iter().copied() {
+            let Some(multiplicity) = multiplicity.checked_mul(refinement.multiplicity) else {
+                transitions.overflowed = true;
+                continue;
+            };
+            let mut next_state = next_state.clone();
+            next_state.add_local_boundaries(start, self.n, refinement.parts());
+            self.build(cell_idx + 1, next_state, multiplicity, transitions);
+        }
+    }
 }
 
 /// Role of a non-leader contiguous part in a round refinement.
@@ -512,175 +716,182 @@ enum Role {
     Primary,
 }
 
-/// Exact compressed counter and unranker for canonical scenarios.
+/// Compressed transition DAG and scenario unranker.
 struct ScenarioGenerator {
     n: usize,
-    count_memo: Vec<HashMap<CellState, Option<u128>>>,
-    transition_memo: HashMap<CellState, Arc<[TransitionEdge]>>,
-    local_memo: HashMap<(usize, bool), Arc<[LocalRefinement]>>,
+    transition_memo: HashMap<CellState, TransitionSet>,
+    local_memo: HashMap<(usize, bool), Vec<LocalRefinement>>,
 }
 
 impl ScenarioGenerator {
-    /// Creates a generator for `n` participants and at most `rounds` suffixes.
-    fn new(n: usize, rounds: usize) -> Self {
+    /// Creates a generator for `n` participants.
+    fn new(n: usize) -> Self {
         Self {
             n,
-            count_memo: vec![HashMap::new(); rounds + 1],
             transition_memo: HashMap::new(),
             local_memo: HashMap::new(),
         }
     }
 
-    /// Counts exact scenario suffixes reachable from `state`.
+    /// Builds bottom-up scenario counts for paths starting at `initial`.
     ///
-    /// This uses the compressed transition DAG. An edge may represent millions
-    /// of concrete rounds when many role assignments leave the same residual
-    /// symmetry cells, but its multiplicity preserves the exact count.
-    fn count(&mut self, state: CellState, rounds: usize) -> Option<u128> {
-        if rounds == 0 {
-            return Some(1);
-        }
-        if let Some(cached) = self.count_memo[rounds].get(&state) {
-            return *cached;
+    /// `counts[r][state]` is the exact number of canonical scenario suffixes
+    /// of length `r` reachable from `state`. `None` indicates arithmetic
+    /// overflow while building transitions or summing suffix counts.
+    fn counts(
+        &mut self,
+        initial: &CellState,
+        rounds: usize,
+    ) -> Option<Vec<HashMap<CellState, u128>>> {
+        let mut layers = Vec::with_capacity(rounds + 1);
+        layers.push(HashSet::from([initial.clone()]));
+
+        for depth in 0..rounds {
+            let mut next_layer = HashSet::new();
+            for state in layers[depth].iter() {
+                self.ensure_transitions(state);
+                let transitions = self.transitions(state);
+                if transitions.overflowed {
+                    return None;
+                }
+                for edge in &transitions.edges {
+                    next_layer.insert(edge.next.clone());
+                }
+            }
+            layers.push(next_layer);
         }
 
-        let result = (|| {
-            let mut total = 0u128;
-            for edge in self.transitions(state).iter().copied() {
-                let multiplicity = edge.multiplicity?;
-                let suffix = self.count(edge.next, rounds - 1)?;
-                let edge_count = multiplicity.checked_mul(suffix)?;
-                total = total.checked_add(edge_count)?;
+        let mut counts = vec![HashMap::new(); rounds + 1];
+        for state in layers[rounds].iter() {
+            counts[0].insert(state.clone(), 1);
+        }
+
+        for remaining in 1..=rounds {
+            let depth = rounds - remaining;
+            for state in layers[depth].iter() {
+                self.ensure_transitions(state);
+                let transitions = self.transitions(state);
+                if transitions.overflowed {
+                    return None;
+                }
+
+                let mut total = 0u128;
+                for edge in &transitions.edges {
+                    let suffix = counts[remaining - 1]
+                        .get(&edge.next)
+                        .copied()
+                        .expect("next state missing from count layer");
+                    let edge_count = edge.multiplicity.checked_mul(suffix)?;
+                    total = total.checked_add(edge_count)?;
+                }
+                counts[remaining].insert(state.clone(), total);
             }
-            Some(total)
-        })();
-        self.count_memo[rounds].insert(state, result);
-        result
+        }
+
+        Some(counts)
     }
 
     /// Reconstructs the scenario at `rank` under the compressed ordering.
     fn scenario_from_rank(
         &mut self,
-        state: CellState,
-        rounds: usize,
-        rank: u128,
-    ) -> (Scenario, Vec<usize>) {
-        let mut scenario = Vec::with_capacity(rounds);
-        let residual = self.push_scenario_from_rank(state, rounds, rank, &mut scenario);
-        (Scenario { rounds: scenario }, residual.to_cells(self.n))
-    }
-
-    /// Appends the ranked scenario suffix to `scenario` and returns its final
-    /// residual cell state.
-    fn push_scenario_from_rank(
-        &mut self,
-        state: CellState,
+        initial: &CellState,
         rounds: usize,
         mut rank: u128,
-        scenario: &mut Vec<RoundScenario>,
-    ) -> CellState {
-        if rounds == 0 {
-            return state;
-        }
+        counts: &[HashMap<CellState, u128>],
+    ) -> (Scenario, Vec<usize>) {
+        let mut scenario = Vec::with_capacity(rounds);
+        let mut state = initial.clone();
 
-        for edge in self.transitions(state).iter().copied() {
-            let suffix = self
-                .count(edge.next, rounds - 1)
-                .expect("canonical scenario count should fit in u128");
-            let multiplicity = edge
-                .multiplicity
-                .expect("transition multiplicity should fit in u128");
-            let subtree_count = multiplicity
-                .checked_mul(suffix)
-                .expect("canonical scenario count should fit in u128");
+        for remaining in (1..=rounds).rev() {
+            self.ensure_transitions(&state);
+            let transitions = self.transitions(&state);
+            assert!(
+                !transitions.overflowed,
+                "transition multiplicity should fit in u128"
+            );
 
-            if rank < subtree_count {
-                // Split the rank into the selected concrete transition inside
-                // this compressed edge and the selected suffix below it.
-                let transition_rank = rank / suffix;
-                let suffix_rank = rank % suffix;
-                scenario.push(self.round_from_edge(state, edge, transition_rank));
-                return self.push_scenario_from_rank(edge.next, rounds - 1, suffix_rank, scenario);
+            let mut selected = false;
+            for edge in &transitions.edges {
+                let suffix = counts[remaining - 1]
+                    .get(&edge.next)
+                    .copied()
+                    .expect("next state missing from count layer");
+                let subtree_count = edge
+                    .multiplicity
+                    .checked_mul(suffix)
+                    .expect("canonical scenario count should fit in u128");
+
+                if rank < subtree_count {
+                    let transition_rank = rank / suffix;
+                    scenario.push(self.round_from_edge(&state, edge, transition_rank));
+                    state = edge.next.clone();
+                    rank %= suffix;
+                    selected = true;
+                    break;
+                }
+                rank -= subtree_count;
             }
-            rank -= subtree_count;
+            assert!(selected, "canonical scenario rank out of bounds");
         }
 
-        unreachable!("canonical scenario rank out of bounds")
+        (Scenario { rounds: scenario }, state.to_cells(self.n))
     }
 
-    /// Returns compressed transition edges for `state`.
-    fn transitions(&mut self, state: CellState) -> Arc<[TransitionEdge]> {
-        if let Some(edges) = self.transition_memo.get(&state) {
-            return edges.clone();
-        }
-
-        let ranges = state.ranges(self.n);
-        let mut edges = Vec::new();
-        for leader_cell in 0..ranges.len() {
-            self.build_transitions(&ranges, leader_cell, 0, 0, Some(1), &mut edges);
-        }
-        let edges: Arc<[TransitionEdge]> = Arc::from(edges);
-        self.transition_memo.insert(state, edges.clone());
-        edges
-    }
-
-    /// Recursively combines local cell refinements into compressed edges.
-    fn build_transitions(
-        &mut self,
-        ranges: &[(usize, usize)],
-        leader_cell: usize,
-        cell_idx: usize,
-        next_mask: u64,
-        multiplicity: Option<u128>,
-        edges: &mut Vec<TransitionEdge>,
-    ) {
-        if cell_idx == ranges.len() {
-            edges.push(TransitionEdge {
-                next: CellState(next_mask),
-                leader_cell,
-                multiplicity,
-            });
+    /// Ensures compressed transition edges for `state` are memoized.
+    fn ensure_transitions(&mut self, state: &CellState) {
+        if self.transition_memo.contains_key(state) {
             return;
         }
-
-        let (start, size) = ranges[cell_idx];
-        let is_leader = cell_idx == leader_cell;
-        let refinements = self.local_refinements(size, is_leader);
-        for refinement in refinements.iter().copied() {
-            let next_mask = add_local_boundaries(next_mask, start, self.n, refinement.parts());
-            let multiplicity = multiplicity.and_then(|m| m.checked_mul(refinement.multiplicity));
-            self.build_transitions(
-                ranges,
+        let ranges = state.ranges(self.n);
+        let mut transitions = TransitionSet::default();
+        for leader_cell in 0..ranges.len() {
+            let refinements: Vec<_> = ranges
+                .iter()
+                .enumerate()
+                .map(|(cell_idx, (_, size))| {
+                    self.local_refinements(*size, cell_idx == leader_cell)
+                        .to_vec()
+                })
+                .collect();
+            TransitionBuilder {
+                n: self.n,
+                ranges: &ranges,
                 leader_cell,
-                cell_idx + 1,
-                next_mask,
-                multiplicity,
-                edges,
-            );
+                refinements_by_cell: &refinements,
+            }
+            .build(0, CellState::initial(self.n), 1, &mut transitions);
         }
+        self.transition_memo.insert(state.clone(), transitions);
+    }
+
+    /// Returns memoized compressed transition edges for `state`.
+    fn transitions(&self, state: &CellState) -> &TransitionSet {
+        self.transition_memo
+            .get(state)
+            .expect("transition set should be memoized")
     }
 
     /// Returns all local refinements for a cell of `size`.
-    fn local_refinements(&mut self, size: usize, is_leader: bool) -> Arc<[LocalRefinement]> {
+    fn local_refinements(&mut self, size: usize, is_leader: bool) -> &[LocalRefinement] {
         self.local_memo
             .entry((size, is_leader))
-            .or_insert_with(|| Arc::from(build_local_refinements(size, is_leader)))
-            .clone()
+            .or_insert_with(|| build_local_refinements(size, is_leader))
+            .as_slice()
     }
 
     /// Reconstructs one concrete round represented by `edge`.
     fn round_from_edge(
         &self,
-        state: CellState,
-        edge: TransitionEdge,
+        state: &CellState,
+        edge: &TransitionEdge,
         mut rank: u128,
     ) -> RoundScenario {
-        let mut primary_mask = 0u64;
-        let mut secondary_mask = 0u64;
+        let mut primary_mask = BitMask::zero(self.n);
+        let mut secondary_mask = BitMask::zero(self.n);
         let mut leader = None;
 
         for (cell_idx, (start, size)) in state.ranges(self.n).into_iter().enumerate() {
-            let parts = parts_in_cell(edge.next, start, size);
+            let parts = parts_in_cell(&edge.next, start, size);
             if cell_idx == edge.leader_cell {
                 let non_leader_len = parts.len() - 1;
                 let role_count = role_subset_count(non_leader_len);
@@ -698,13 +909,12 @@ impl ScenarioGenerator {
                 );
 
                 let leader_idx = start + size - 1;
-                let leader_bit = 1u64 << leader_idx;
                 match local_rank % 3 {
-                    0 => primary_mask |= leader_bit,
-                    1 => secondary_mask |= leader_bit,
+                    0 => primary_mask.set(leader_idx),
+                    1 => secondary_mask.set(leader_idx),
                     2 => {
-                        primary_mask |= leader_bit;
-                        secondary_mask |= leader_bit;
+                        primary_mask.set(leader_idx);
+                        secondary_mask.set(leader_idx);
                     }
                     _ => unreachable!("leader placement rank out of bounds"),
                 }
@@ -734,21 +944,8 @@ impl ScenarioGenerator {
     }
 }
 
-/// Adds boundaries for `parts` starting at `start` to `mask`.
-fn add_local_boundaries(mut mask: u64, start: usize, n: usize, parts: &[usize]) -> u64 {
-    let mut offset = 0usize;
-    for part in parts {
-        offset += part;
-        let end = start + offset;
-        if end < n {
-            mask |= 1u64 << (end - 1);
-        }
-    }
-    mask
-}
-
 /// Returns the positive parts of the cell `[start, start + size)` in `state`.
-fn parts_in_cell(state: CellState, start: usize, size: usize) -> Vec<usize> {
+fn parts_in_cell(state: &CellState, start: usize, size: usize) -> Vec<usize> {
     let end = start + size;
     let mut parts = Vec::new();
     let mut part_start = start;
@@ -874,20 +1071,20 @@ fn apply_roles(
     start: usize,
     parts: &[usize],
     roles: &[Role],
-    primary_mask: &mut u64,
-    secondary_mask: &mut u64,
+    primary_mask: &mut BitMask,
+    secondary_mask: &mut BitMask,
 ) {
     let mut offset = 0usize;
     for (part, role) in parts.iter().zip(roles) {
-        let mask = range_mask(start + offset, *part);
+        let range_start = start + offset;
         match role {
             Role::Outside => {}
             Role::Both => {
-                *primary_mask |= mask;
-                *secondary_mask |= mask;
+                primary_mask.set_range(range_start, *part);
+                secondary_mask.set_range(range_start, *part);
             }
-            Role::Secondary => *secondary_mask |= mask,
-            Role::Primary => *primary_mask |= mask,
+            Role::Secondary => secondary_mask.set_range(range_start, *part),
+            Role::Primary => primary_mask.set_range(range_start, *part),
         }
         offset += part;
     }
@@ -981,19 +1178,20 @@ fn generate_scenarios(
     rounds: usize,
     max_scenarios: usize,
 ) -> Vec<(Scenario, Vec<usize>)> {
-    let mut generator = ScenarioGenerator::new(n, rounds);
-    let initial = CellState::from_cells(&[n]);
-    let total = generator
-        .count(initial, rounds)
+    let mut generator = ScenarioGenerator::new(n);
+    let initial = CellState::initial(n);
+    let counts = generator
+        .counts(&initial, rounds)
         .expect("scenario space overflows u128; reduce rounds or participants");
+    let total = counts[rounds][&initial];
     if total <= max_scenarios as u128 {
         return (0..total)
-            .map(|idx| generator.scenario_from_rank(initial, rounds, idx))
+            .map(|idx| generator.scenario_from_rank(&initial, rounds, idx, &counts))
             .collect();
     }
     sample_unique_indices(rng, total, max_scenarios)
         .into_iter()
-        .map(|idx| generator.scenario_from_rank(initial, rounds, idx))
+        .map(|idx| generator.scenario_from_rank(&initial, rounds, idx, &counts))
         .collect()
 }
 
@@ -1011,11 +1209,38 @@ mod tests {
     use commonware_utils::{ordered::Set, test_rng, test_rng_seeded};
     use std::collections::HashSet;
 
+    fn mask(bits: usize, mask: u64) -> BitMask {
+        BitMask::from_u64(bits, mask)
+    }
+
+    fn round(n: usize, leader: usize, primary_mask: u64, secondary_mask: u64) -> RoundScenario {
+        RoundScenario {
+            leader,
+            primary_mask: mask(n, primary_mask),
+            secondary_mask: mask(n, secondary_mask),
+        }
+    }
+
+    fn range_mask(start: usize, len: usize) -> u64 {
+        if len == 0 {
+            return 0;
+        }
+        (((1u128 << len) - 1) << start) as u64
+    }
+
     // Independent reference enumerator for small test cases. The production
     // generator uses compressed transition edges, while this helper expands
-    // next-round refinements directly so tests can compare the optimized
-    // counter and unranker against a simpler implementation.
+    // next-round refinements directly so tests can compare the DAG counter and
+    // unranker against a simpler implementation.
     fn reference_next_round_transitions(cells: &[usize]) -> Vec<(RoundScenario, Vec<usize>)> {
+        let n = cells.iter().sum();
+
+        #[derive(Clone, Copy)]
+        struct PrimaryState {
+            primary_mask: u64,
+            leader: Option<usize>,
+        }
+
         #[derive(Clone, Copy)]
         struct SecondaryState {
             primary_mask: u64,
@@ -1034,21 +1259,22 @@ mod tests {
         }
 
         fn no_secondary(
+            n: usize,
             ranges: &[(usize, usize)],
             leader_cell: usize,
             cell_idx: usize,
-            primary_mask: u64,
-            leader: Option<usize>,
+            state: PrimaryState,
             next_cells: &mut Vec<usize>,
             out: &mut Vec<(RoundScenario, Vec<usize>)>,
         ) {
             if cell_idx == ranges.len() {
                 out.push((
-                    RoundScenario {
-                        leader: leader.expect("leader cell should assign a leader"),
-                        primary_mask,
-                        secondary_mask: primary_mask,
-                    },
+                    round(
+                        n,
+                        state.leader.expect("leader cell should assign a leader"),
+                        state.primary_mask,
+                        state.primary_mask,
+                    ),
                     next_cells.clone(),
                 ));
                 return;
@@ -1074,8 +1300,8 @@ mod tests {
                     next_cells.push(both);
                 }
 
-                let mut next_primary = primary_mask | range_mask(start + outside, both);
-                let mut next_leader = leader;
+                let mut next_primary = state.primary_mask | range_mask(start + outside, both);
+                let mut next_leader = state.leader;
                 if cell_idx == leader_cell {
                     let leader_idx = start + outside + both;
                     next_primary |= 1u64 << leader_idx;
@@ -1084,11 +1310,14 @@ mod tests {
                 }
 
                 no_secondary(
+                    n,
                     ranges,
                     leader_cell,
                     cell_idx + 1,
-                    next_primary,
-                    next_leader,
+                    PrimaryState {
+                        primary_mask: next_primary,
+                        leader: next_leader,
+                    },
                     next_cells,
                     out,
                 );
@@ -1106,6 +1335,7 @@ mod tests {
         }
 
         fn with_secondary(
+            n: usize,
             ranges: &[(usize, usize)],
             leader_cell: usize,
             cell_idx: usize,
@@ -1118,11 +1348,12 @@ mod tests {
                     return;
                 }
                 out.push((
-                    RoundScenario {
-                        leader: state.leader.expect("leader cell should assign a leader"),
-                        primary_mask: state.primary_mask,
-                        secondary_mask: state.secondary_mask,
-                    },
+                    round(
+                        n,
+                        state.leader.expect("leader cell should assign a leader"),
+                        state.primary_mask,
+                        state.secondary_mask,
+                    ),
                     next_cells.clone(),
                 ));
                 return;
@@ -1154,6 +1385,7 @@ mod tests {
                             for &(leader_in_primary, leader_in_secondary) in LEADER_PLACEMENTS {
                                 let leader_bit = 1u64 << leader_idx;
                                 with_secondary(
+                                    n,
                                     ranges,
                                     leader_cell,
                                     cell_idx + 1,
@@ -1176,6 +1408,7 @@ mod tests {
                             }
                         } else {
                             with_secondary(
+                                n,
                                 ranges,
                                 leader_cell,
                                 cell_idx + 1,
@@ -1198,9 +1431,21 @@ mod tests {
         let mut out = Vec::new();
         for leader_cell in 0..cells.len() {
             let mut next_cells = Vec::new();
-            no_secondary(&ranges, leader_cell, 0, 0, None, &mut next_cells, &mut out);
+            no_secondary(
+                n,
+                &ranges,
+                leader_cell,
+                0,
+                PrimaryState {
+                    primary_mask: 0,
+                    leader: None,
+                },
+                &mut next_cells,
+                &mut out,
+            );
             let mut next_cells = Vec::new();
             with_secondary(
+                n,
                 &ranges,
                 leader_cell,
                 0,
@@ -1249,7 +1494,7 @@ mod tests {
         let mut out = HashSet::new();
         for (round, next_cells) in reference_next_round_transitions(cells) {
             for (mut scenario, residual) in reference_scenarios(&next_cells, rounds - 1) {
-                scenario.rounds.insert(0, round);
+                scenario.rounds.insert(0, round.clone());
                 out.insert((scenario, residual));
             }
         }
@@ -1275,11 +1520,7 @@ mod tests {
             cells.push(1);
 
             out.insert((
-                RoundScenario {
-                    leader,
-                    primary_mask: mask,
-                    secondary_mask: mask,
-                },
+                round(n, leader, mask, mask),
                 cells,
             ));
         }
@@ -1313,27 +1554,20 @@ mod tests {
                     cells.push(1);
 
                     out.insert((
-                        RoundScenario {
-                            leader,
-                            primary_mask: primary_mask | leader_bit,
-                            secondary_mask,
-                        },
+                        round(n, leader, primary_mask | leader_bit, secondary_mask),
                         cells.clone(),
                     ));
                     out.insert((
-                        RoundScenario {
-                            leader,
-                            primary_mask,
-                            secondary_mask: secondary_mask | leader_bit,
-                        },
+                        round(n, leader, primary_mask, secondary_mask | leader_bit),
                         cells.clone(),
                     ));
                     out.insert((
-                        RoundScenario {
+                        round(
+                            n,
                             leader,
-                            primary_mask: primary_mask | leader_bit,
-                            secondary_mask: secondary_mask | leader_bit,
-                        },
+                            primary_mask | leader_bit,
+                            secondary_mask | leader_bit,
+                        ),
                         cells,
                     ));
                 }
@@ -1386,9 +1620,8 @@ mod tests {
     fn generated_scenarios_include_leaders_visible_only_to_secondary() {
         let scenarios = generate_scenarios(&mut test_rng(), 3, 1, usize::MAX);
         assert!(scenarios.iter().any(|(scenario, _)| {
-            let round = scenario.rounds[0];
-            let leader_bit = 1u64 << round.leader;
-            (round.primary_mask & leader_bit) == 0 && (round.secondary_mask & leader_bit) != 0
+            let round = &scenario.rounds[0];
+            !round.primary_mask.contains(round.leader) && round.secondary_mask.contains(round.leader)
         }));
     }
 
@@ -1396,12 +1629,16 @@ mod tests {
     fn generated_scenarios_include_shared_non_leaders_in_split_rounds() {
         let scenarios = generate_scenarios(&mut test_rng(), 5, 1, usize::MAX);
         assert!(scenarios.iter().any(|(scenario, _)| {
-            let round = scenario.rounds[0];
-            let leader_bit = 1u64 << round.leader;
-            let shared_non_leaders = (round.primary_mask & round.secondary_mask) & !leader_bit;
-            let primary_only = round.primary_mask & !round.secondary_mask;
-            let secondary_only = round.secondary_mask & !round.primary_mask;
-            shared_non_leaders != 0 && primary_only != 0 && secondary_only != 0
+            let round = &scenario.rounds[0];
+            round
+                .primary_mask
+                .intersects_except(&round.secondary_mask, round.leader)
+                && round
+                    .primary_mask
+                    .difference_except(&round.secondary_mask, round.leader)
+                && round
+                    .secondary_mask
+                    .difference_except(&round.primary_mask, round.leader)
         }));
     }
 
@@ -1409,16 +1646,16 @@ mod tests {
     fn generated_scenarios_include_shared_non_leaders_when_only_leader_splits_halves() {
         let scenarios = generate_scenarios(&mut test_rng(), 4, 1, usize::MAX);
         assert!(scenarios.iter().any(|(scenario, _)| {
-            let round = scenario.rounds[0];
-            let leader_bit = 1u64 << round.leader;
-            let shared_non_leaders = (round.primary_mask & round.secondary_mask) & !leader_bit;
-            let primary_only_non_leaders =
-                (round.primary_mask & !round.secondary_mask) & !leader_bit;
-            let secondary_only_non_leaders =
-                (round.secondary_mask & !round.primary_mask) & !leader_bit;
-            shared_non_leaders != 0
-                && primary_only_non_leaders == 0
-                && secondary_only_non_leaders == 0
+            let round = &scenario.rounds[0];
+            round
+                .primary_mask
+                .intersects_except(&round.secondary_mask, round.leader)
+                && !round
+                    .primary_mask
+                    .difference_except(&round.secondary_mask, round.leader)
+                && !round
+                    .secondary_mask
+                    .difference_except(&round.primary_mask, round.leader)
                 && round.primary_mask != round.secondary_mask
         }));
     }
@@ -1427,7 +1664,7 @@ mod tests {
     fn generated_single_round_scenarios_match_expected_canonical_space() {
         let generated: HashSet<_> = generate_scenarios(&mut test_rng(), 4, 1, usize::MAX)
             .into_iter()
-            .map(|(scenario, cells)| (scenario.rounds[0], cells))
+            .map(|(scenario, cells)| (scenario.rounds[0].clone(), cells))
             .collect();
         assert_eq!(generated, expected_single_round_transitions(4));
     }
@@ -1459,8 +1696,10 @@ mod tests {
                 let reference =
                     reference_scenario_count(&initial_cells, rounds, &mut reference_memo);
 
-                let mut generator = ScenarioGenerator::new(n, rounds);
-                let compressed = generator.count(CellState::from_cells(&initial_cells), rounds);
+                let initial = CellState::from_cells(&initial_cells);
+                let mut generator = ScenarioGenerator::new(n);
+                let counts = generator.counts(&initial, rounds);
+                let compressed = counts.as_ref().map(|counts| counts[rounds][&initial]);
                 assert_eq!(
                     compressed, reference,
                     "count mismatch for n={n} rounds={rounds}"
@@ -1471,7 +1710,7 @@ mod tests {
 
     #[test]
     fn compressed_unranking_matches_reference_space() {
-        for (n, rounds) in [(2usize, 3usize), (3, 2), (3, 3), (4, 2), (4, 3), (5, 2)] {
+        for (n, rounds) in [(2usize, 3usize), (3, 2)] {
             let generated: HashSet<_> = generate_scenarios(&mut test_rng(), n, rounds, usize::MAX)
                 .into_iter()
                 .collect();
@@ -1486,11 +1725,7 @@ mod tests {
     #[test]
     fn scripted_partitions_preserve_participant_order_and_overlap() {
         let scenario = Scenario {
-            rounds: vec![RoundScenario {
-                leader: 3,
-                primary_mask: 0b1011,
-                secondary_mask: 0b0110,
-            }],
+            rounds: vec![round(4, 3, 0b1011, 0b0110)],
         };
         let participants: Vec<u32> = (0..4).collect();
         let (primary, secondary) = scenario.partitions(View::new(1), &participants);
@@ -1556,11 +1791,7 @@ mod tests {
     #[test]
     fn route_supports_shared_non_leaders_in_split_rounds() {
         let scenario = Scenario {
-            rounds: vec![RoundScenario {
-                leader: 4,
-                primary_mask: 0b11010,
-                secondary_mask: 0b00110,
-            }],
+            rounds: vec![round(5, 4, 0b11010, 0b00110)],
         };
         let participants: Vec<u32> = (0..5).collect();
         assert_eq!(
@@ -1588,11 +1819,7 @@ mod tests {
     #[test]
     fn leader_visible_to_both_halves_preserves_partitions_and_route() {
         let scenario = Scenario {
-            rounds: vec![RoundScenario {
-                leader: 3,
-                primary_mask: 0b1010,
-                secondary_mask: 0b1100,
-            }],
+            rounds: vec![round(4, 3, 0b1010, 0b1100)],
         };
         let participants: Vec<u32> = (0..4).collect();
         let (primary, secondary) = scenario.partitions(View::new(1), &participants);
@@ -1613,9 +1840,8 @@ mod tests {
                 if round.primary_mask == round.secondary_mask {
                     continue;
                 }
-                let leader_bit = 1u64 << round.leader;
-                let leader_in_primary = (round.primary_mask & leader_bit) != 0;
-                let leader_in_secondary = (round.secondary_mask & leader_bit) != 0;
+                let leader_in_primary = round.primary_mask.contains(round.leader);
+                let leader_in_secondary = round.secondary_mask.contains(round.leader);
                 assert!(leader_in_primary || leader_in_secondary);
             }
         }
@@ -1625,23 +1851,18 @@ mod tests {
     fn generated_split_rounds_include_leaders_visible_to_both_halves() {
         let scenarios = generate_scenarios(&mut test_rng(), 4, 1, usize::MAX);
         assert!(scenarios.iter().any(|(scenario, _)| {
-            let round = scenario.rounds[0];
+            let round = &scenario.rounds[0];
             if round.primary_mask == round.secondary_mask {
                 return false;
             }
-            let leader_bit = 1u64 << round.leader;
-            (round.primary_mask & leader_bit) != 0 && (round.secondary_mask & leader_bit) != 0
+            round.primary_mask.contains(round.leader) && round.secondary_mask.contains(round.leader)
         }));
     }
 
     #[test]
     fn route_selects_correct_half() {
         let scenario = Scenario {
-            rounds: vec![RoundScenario {
-                leader: 0,
-                primary_mask: 0b0011,
-                secondary_mask: 0b1100,
-            }],
+            rounds: vec![round(4, 0, 0b0011, 0b1100)],
         };
         let participants: Vec<u32> = (0..4).collect();
         assert_eq!(
@@ -1665,11 +1886,7 @@ mod tests {
     #[test]
     fn route_returns_both_after_scripted_rounds() {
         let scenario = Scenario {
-            rounds: vec![RoundScenario {
-                leader: 0,
-                primary_mask: 0b0011,
-                secondary_mask: 0b1100,
-            }],
+            rounds: vec![round(4, 0, 0b0011, 0b1100)],
         };
         let participants: Vec<u32> = (0..4).collect();
 
@@ -1684,11 +1901,7 @@ mod tests {
     #[test]
     fn scenarios_fall_back_to_synchrony_after_attack_rounds() {
         let scenario = Scenario {
-            rounds: vec![RoundScenario {
-                leader: 0,
-                primary_mask: 0b0011,
-                secondary_mask: 0b1100,
-            }],
+            rounds: vec![round(4, 0, 0b0011, 0b1100)],
         };
         let participants: Vec<u32> = (0..4).collect();
         let (primary, secondary) = scenario.partitions(View::new(2), &participants);
@@ -1697,11 +1910,10 @@ mod tests {
     }
 
     #[test]
-    fn canonical_scenario_count_caches_overflow_results() {
+    fn canonical_scenario_count_reports_overflow() {
         let initial = CellState::from_cells(&[4]);
-        let mut generator = ScenarioGenerator::new(4, 40);
-        assert_eq!(generator.count(initial, 40), None);
-        assert_eq!(generator.count_memo[40].get(&initial), Some(&None));
+        let mut generator = ScenarioGenerator::new(4);
+        assert_eq!(generator.counts(&initial, 40), None);
     }
 
     #[test]
@@ -1820,7 +2032,7 @@ mod tests {
         for round in 0..3 {
             let unique: HashSet<_> = scenarios
                 .iter()
-                .map(|(scenario, _)| scenario.rounds[round])
+                .map(|(scenario, _)| scenario.rounds[round].clone())
                 .collect();
             assert!(
                 unique.len() > 1,
@@ -1876,9 +2088,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "participants must fit in u64 masks")]
-    fn cases_reject_frameworks_that_exceed_mask_width() {
-        let _ = cases(
+    fn cases_support_frameworks_that_exceed_one_mask_word() {
+        let generated = cases(
             &mut test_rng(),
             Framework {
                 participants: (u64::BITS as usize) + 1,
@@ -1888,16 +2099,13 @@ mod tests {
                 max_cases: 1,
             },
         );
+        assert_eq!(generated.len(), 1);
     }
 
     #[test]
     fn route_returns_none_for_participants_outside_selected_partitions() {
         let scenario = Scenario {
-            rounds: vec![RoundScenario {
-                leader: 0,
-                primary_mask: 0b0001,
-                secondary_mask: 0b0010,
-            }],
+            rounds: vec![round(4, 0, 0b0001, 0b0010)],
         };
         let participants: Vec<u32> = (0..4).collect();
         assert_eq!(
@@ -1910,11 +2118,7 @@ mod tests {
     #[should_panic(expected = "sender missing from runtime participant list")]
     fn route_panics_when_sender_is_missing_from_participants() {
         let scenario = Scenario {
-            rounds: vec![RoundScenario {
-                leader: 0,
-                primary_mask: 0b0001,
-                secondary_mask: 0b0010,
-            }],
+            rounds: vec![round(4, 0, 0b0001, 0b0010)],
         };
         let participants: Vec<u32> = (0..4).collect();
         let _ = scenario.route(View::new(1), &99, &participants);

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -477,12 +477,7 @@ impl BitMask {
     }
 
     #[cfg(test)]
-    fn any_word_except(
-        &self,
-        other: &Self,
-        excluded: usize,
-        f: impl Fn(u64, u64) -> u64,
-    ) -> bool {
+    fn any_word_except(&self, other: &Self, excluded: usize, f: impl Fn(u64, u64) -> u64) -> bool {
         match (self, other) {
             (Self::Inline(lhs), Self::Inline(rhs)) => {
                 let mut word = f(*lhs, *rhs);
@@ -1519,10 +1514,7 @@ mod tests {
             }
             cells.push(1);
 
-            out.insert((
-                round(n, leader, mask, mask),
-                cells,
-            ));
+            out.insert((round(n, leader, mask, mask), cells));
         }
 
         for outside in 0..n {
@@ -1621,7 +1613,8 @@ mod tests {
         let scenarios = generate_scenarios(&mut test_rng(), 3, 1, usize::MAX);
         assert!(scenarios.iter().any(|(scenario, _)| {
             let round = &scenario.rounds[0];
-            !round.primary_mask.contains(round.leader) && round.secondary_mask.contains(round.leader)
+            !round.primary_mask.contains(round.leader)
+                && round.secondary_mask.contains(round.leader)
         }));
     }
 

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -14,6 +14,19 @@
 //! Advancing one round refines those cells by splitting each group according to
 //! the role its members take in the new round.
 //!
+//! ## Algorithm
+//!
+//! In each round, every non-leader participant belongs to one of four ordered
+//! role buckets: outside both halves, visible to both halves, visible only to
+//! the secondary half, or visible only to the primary half. The leader is a
+//! singleton at the end of its cell and must be visible to at least one half.
+//! A transition records only the next residual cell boundaries. For a fixed
+//! set of part sizes, multiple role-bucket choices can produce the same next
+//! boundaries, so the transition stores their count as `multiplicity`.
+//! Scenario counts are computed over this compressed transition DAG, and
+//! `round_from_edge` reconstructs sampled rounds by decoding the chosen edge's
+//! rank as mixed-radix digits in cell order.
+//!
 //! Scenario generation guarantees that every case within a campaign is
 //! structurally distinct -- no duplicate (scenario, compromised-assignment)
 //! pairs are ever emitted. The scenario space is counted with an exact
@@ -188,7 +201,7 @@ impl<C> Elector<C> {
                     round.leader() < participants,
                     "scenario leader out of bounds"
                 );
-                Participant::new(round.leader() as u32)
+                Participant::from_usize(round.leader())
             })
             .collect();
         Self {
@@ -253,10 +266,10 @@ pub enum Mode {
 ///
 /// Each canonical scenario tracks residual symmetry cells -- participants that
 /// were treated identically across all rounds. Two compromised-node assignments
-/// that differ only in which members of a symmetry cell are compromised produce
-/// identical test behavior, so the framework generates only one representative
-/// per equivalence class. This keeps the case budget focused on structurally
-/// distinct attack configurations.
+/// that differ only in which members of a symmetry cell are compromised are
+/// equivalent under relabeling for the adversarial prefix, so the framework
+/// generates only one representative per equivalence class. This keeps the case
+/// budget focused on structurally distinct attack configurations.
 ///
 /// The generator selects canonical scenarios first: all scenarios when the
 /// scenario count fits within [`Framework::max_cases`], or uniformly sampled
@@ -568,16 +581,7 @@ impl CellState {
 
     /// Converts the state back into cell sizes.
     fn to_cells(&self, n: usize) -> Vec<usize> {
-        let mut cells = Vec::new();
-        let mut start = 0usize;
-        for idx in 0..n.saturating_sub(1) {
-            if self.boundary_after(idx) {
-                cells.push(idx + 1 - start);
-                start = idx + 1;
-            }
-        }
-        cells.push(n - start);
-        cells
+        self.ranges(n).into_iter().map(|(_, len)| len).collect()
     }
 
     /// Converts the state into contiguous `(start, len)` cell ranges.
@@ -612,7 +616,9 @@ impl CellState {
 /// A non-leader cell can split into at most the four non-empty role buckets
 /// `outside`, `both`, `secondary-only`, and `primary-only`. The leader cell
 /// uses the same buckets for its non-leader prefix and then appends the leader
-/// singleton as the final part.
+/// singleton as the final part. `parts` stores the resulting non-empty bucket
+/// sizes; `multiplicity` counts how many ordered role-bucket choices produce
+/// those same sizes.
 #[derive(Clone, Copy, Debug)]
 struct LocalRefinement {
     parts: [usize; 5],
@@ -885,6 +891,10 @@ impl ScenarioGenerator {
         let mut secondary_mask = BitMask::zero(self.n);
         let mut leader = None;
 
+        // The edge fixes only the next residual cell boundaries. Decode the
+        // edge-local rank in cell order: each low digit selects this cell's
+        // role subset, and the leader cell has an extra digit for which half
+        // sees the leader.
         for (cell_idx, (start, size)) in state.ranges(self.n).into_iter().enumerate() {
             let parts = parts_in_cell(&edge.next, start, size);
             if cell_idx == edge.leader_cell {
@@ -962,7 +972,7 @@ const fn role_subset_count(len: usize) -> u128 {
         2 => 6,
         3 => 4,
         4 => 1,
-        _ => 0,
+        _ => panic!("role bucket count exceeds role space"),
     }
 }
 
@@ -2096,6 +2106,60 @@ mod tests {
     }
 
     #[test]
+    fn bitmask_sets_ranges_across_words() {
+        let mut mask = BitMask::zero(130);
+        mask.set(64);
+        assert!(!mask.contains(63));
+        assert!(mask.contains(64));
+        assert!(!mask.contains(65));
+
+        mask.set_range(62, 5);
+        for idx in 62..=66 {
+            assert!(mask.contains(idx), "bit {idx} should be set");
+        }
+        assert!(!mask.contains(61));
+        assert!(!mask.contains(67));
+        assert!(!mask.contains(129));
+    }
+
+    #[test]
+    fn scenario_masks_route_across_words() {
+        let mut primary_mask = BitMask::zero(70);
+        primary_mask.set_range(62, 4);
+        let mut secondary_mask = BitMask::zero(70);
+        secondary_mask.set(64);
+        secondary_mask.set(69);
+        let scenario = Scenario {
+            rounds: vec![RoundScenario {
+                leader: 64,
+                primary_mask,
+                secondary_mask,
+            }],
+        };
+        let participants: Vec<_> = (0..70).collect();
+
+        let (primary, secondary) = scenario.partitions(View::new(1), &participants);
+        assert_eq!(primary, vec![62, 63, 64, 65]);
+        assert_eq!(secondary, vec![64, 69]);
+        assert_eq!(
+            scenario.route(View::new(1), &63, &participants),
+            SplitTarget::Primary
+        );
+        assert_eq!(
+            scenario.route(View::new(1), &64, &participants),
+            SplitTarget::Both
+        );
+        assert_eq!(
+            scenario.route(View::new(1), &69, &participants),
+            SplitTarget::Secondary
+        );
+        assert_eq!(
+            scenario.route(View::new(1), &0, &participants),
+            SplitTarget::None
+        );
+    }
+
+    #[test]
     fn route_returns_none_for_participants_outside_selected_partitions() {
         let scenario = Scenario {
             rounds: vec![round(4, 0, 0b0001, 0b0010)],
@@ -2151,7 +2215,7 @@ mod tests {
             let round = Round::new(Epoch::new(0), View::new((round_idx as u64) + 1));
             assert_eq!(
                 twins.elect(round, None),
-                Participant::new(round_scenario.leader() as u32),
+                Participant::from_usize(round_scenario.leader()),
                 "unexpected leader in scripted attack round"
             );
         }

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -1011,7 +1011,7 @@ const fn role_subset_count(len: usize) -> u128 {
 /// Builds all local refinements for a cell.
 ///
 /// A local refinement is the shape this cell can have after one round. The
-/// shape only stores contiguous part sizes; `multiplicity` records how many
+/// shape only stores contiguous part sizes, `multiplicity` records how many
 /// assignments of those parts to the ordered non-leader roles produce the same
 /// shape.
 fn build_local_refinements(size: usize, is_leader: bool) -> Vec<LocalRefinement> {


### PR DESCRIPTION
This PR replaces twins `cases()` generation with a compressed canonical scenario generator. Instead of expanding every concrete participant assignment, the generator tracks residual symmetry cells: groups of participants that are indistinguishable under the scripted prefix so far. Each round refines those cells by assigning contiguous groups to twins roles, and each compressed transition stores both the next residual cell state and the exact multiplicity of concrete rounds represented by that transition.

Scenario counting is then done over that compressed transition DAG. When the full space fits the campaign budget, we enumerate ranks directly. When it does not, we sample unique ranks uniformly without replacement and unrank only the selected scenarios. Compromised assignments are generated the same way: one representative per residual-cell equivalence class, preserving the same pass/fail coverage up to participant relabeling.

It keeps the existing simplex-specific semantics: primary and secondary recipient sets are independent masks, so a participant can be visible to both halves, one half, or neither half in a scripted round. This is strictly more expressive than the disjoint-partition model in the twins paper.

I also experimented with arbitrary-width bitmasks to support more than 64 participants. That worked mechanically, but it made the implementation more complex without opening up much practical coverage: the compressed scenario DAG still grows exponentially, so large validator sets quickly become too expensive to explore meaningfully. The twins paper also argues that small validator sets are enough to expose these classes of protocol bugs, so this PR keeps the simpler `u64` representation and caps generated campaigns at 64 participants.

### Results

| Case | Old time | New time | Speedup |
|---|---:|---:|---:|
| `n5 f1 r3 sampled max20` | `24.42 ms` | `0.541 ms` | `45.17x` |
| `n5 f1 r3 sustained max20` | `0.261 ms` | `0.071 ms` | `3.68x` |
| `n7 f2 r3 sampled max20` | `466.15 ms` | `0.793 ms` | `588.04x` |
| `n10 f3 r5 sustained max20` | `1.43 ms` | `0.257 ms` | `5.57x` |
| `n10 f3 r5 sampled max20` | `5m 32.77s` | `22.21 ms` | `14981.79x` |
