### PR TITLE
[Storage] Durably adopt recovered contiguous data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,6 +1915,7 @@ dependencies = [
  "criterion",
  "futures",
  "futures-util",
+ "governor",
  "paste",
  "rand 0.8.5",
  "rstest",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -38,6 +38,7 @@ commonware-math.workspace = true
 commonware-runtime = { workspace = true, features = ["test-utils"] }
 commonware-storage = { path = ".", features = ["std"] }
 criterion.workspace = true
+governor.workspace = true
 paste.workspace = true
 rand.workspace = true
 rstest.workspace = true

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -726,13 +726,17 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             meta_recovery_watermark,
         )
         .await?;
+        // Bytes beyond the persisted recovery watermark may be readable after reopen without
+        // being crash-durable, so the next commit/sync must force a data sync before advancing it.
+        let dirty_from_section =
+            (recovery_watermark < size).then_some(recovery_watermark / items_per_blob);
 
         let mut inner = Inner {
             journal,
             size,
             metadata,
             pruning_boundary,
-            dirty_from_section: None,
+            dirty_from_section,
         };
         // Persist any lowered checkpoint before applying blob repairs that move recovered state
         // backward.
@@ -1548,6 +1552,44 @@ mod tests {
 
     fn blob_partition(cfg: &Config) -> String {
         format!("{}-blobs", cfg.partition)
+    }
+
+    #[test_traced]
+    fn test_fixed_init_marks_suffix_past_recovery_watermark_dirty() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(10));
+            cfg.partition = "init-adopted-fixed".into();
+
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            journal.append(&1).await.unwrap();
+            journal.append(&2).await.unwrap();
+            journal.sync().await.unwrap();
+            // Simulate the state left by a crash after item 2 became visible to recovery, but
+            // before the persisted recovery watermark advanced past item 1.
+            journal.test_set_recovery_watermark(1).await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.size().await, 2);
+
+            // Regression: init used to recover size 2 while marking no data sections dirty.
+            // commit() would then skip section syncs and succeed even though the recovered suffix
+            // had not been durably adopted. With the fix, item 2's section is dirty, so the forced
+            // sync failure below must surface.
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                sync_rate: Some(1.0),
+                ..Default::default()
+            };
+            assert!(
+                journal.commit().await.is_err(),
+                "commit() must sync recovered data beyond the persisted recovery watermark"
+            );
+        });
     }
 
     async fn scan_partition(context: &Context, partition: &str) -> Vec<Vec<u8>> {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -726,11 +726,11 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             meta_recovery_watermark,
         )
         .await?;
+
         // Bytes beyond the persisted recovery watermark may be readable after reopen without
         // being crash-durable, so the next commit/sync must force a data sync before advancing it.
         let dirty_from_section =
             (recovery_watermark < size).then_some(recovery_watermark / items_per_blob);
-
         let mut inner = Inner {
             journal,
             size,
@@ -738,6 +738,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             pruning_boundary,
             dirty_from_section,
         };
+
         // Persist any lowered checkpoint before applying blob repairs that move recovered state
         // backward.
         Self::persist_metadata_entries(

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -9,6 +9,177 @@ use commonware_utils::NZUsize;
 use futures::{future::BoxFuture, StreamExt};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+pub(super) mod partition_sync_fault {
+    use commonware_runtime::{
+        deterministic, telemetry::metrics, Blob, Clock, Error, IoBufs, IoBufsMut, Metrics, Name,
+        Storage, Supervisor, Tracing,
+    };
+    use governor::clock::{Clock as GovernorClock, ReasonablyRealtime};
+    use std::{
+        future::Future,
+        io::Error as IoError,
+        ops::RangeInclusive,
+        time::{Duration, SystemTime},
+    };
+
+    pub(in crate::journal::contiguous) struct Context {
+        inner: deterministic::Context,
+        fail_partition: String,
+    }
+
+    impl Context {
+        pub(in crate::journal::contiguous) fn new(
+            inner: deterministic::Context,
+            fail_partition: String,
+        ) -> Self {
+            Self {
+                inner,
+                fail_partition,
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    pub(in crate::journal::contiguous) struct BlobWithSyncFault<B: Blob> {
+        inner: B,
+        partition: String,
+        fail_partition: String,
+    }
+
+    impl Supervisor for Context {
+        fn name(&self) -> Name {
+            self.inner.name()
+        }
+
+        fn child(&self, label: &'static str) -> Self {
+            Self {
+                inner: self.inner.child(label),
+                fail_partition: self.fail_partition.clone(),
+            }
+        }
+
+        fn with_attribute(mut self, key: &'static str, value: impl std::fmt::Display) -> Self {
+            self.inner = self.inner.with_attribute(key, value);
+            self
+        }
+    }
+
+    impl Tracing for Context {
+        fn with_span(mut self) -> Self {
+            self.inner = self.inner.with_span();
+            self
+        }
+    }
+
+    impl Metrics for Context {
+        fn register<N: Into<String>, H: Into<String>, M: metrics::Metric>(
+            &self,
+            name: N,
+            help: H,
+            metric: M,
+        ) -> metrics::Registered<M> {
+            self.inner.register(name, help, metric)
+        }
+
+        fn encode(&self) -> String {
+            self.inner.encode()
+        }
+    }
+
+    impl Clock for Context {
+        fn current(&self) -> SystemTime {
+            self.inner.current()
+        }
+
+        fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + Send + 'static {
+            self.inner.sleep(duration)
+        }
+
+        fn sleep_until(&self, deadline: SystemTime) -> impl Future<Output = ()> + Send + 'static {
+            self.inner.sleep_until(deadline)
+        }
+    }
+
+    impl GovernorClock for Context {
+        type Instant = SystemTime;
+
+        fn now(&self) -> Self::Instant {
+            self.current()
+        }
+    }
+
+    impl ReasonablyRealtime for Context {}
+
+    impl Storage for Context {
+        type Blob = BlobWithSyncFault<<deterministic::Context as Storage>::Blob>;
+
+        async fn open_versioned(
+            &self,
+            partition: &str,
+            name: &[u8],
+            versions: RangeInclusive<u16>,
+        ) -> Result<(Self::Blob, u64, u16), Error> {
+            let (inner, len, version) =
+                self.inner.open_versioned(partition, name, versions).await?;
+            Ok((
+                BlobWithSyncFault {
+                    inner,
+                    partition: partition.to_string(),
+                    fail_partition: self.fail_partition.clone(),
+                },
+                len,
+                version,
+            ))
+        }
+
+        async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
+            self.inner.remove(partition, name).await
+        }
+
+        async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
+            self.inner.scan(partition).await
+        }
+    }
+
+    impl<B: Blob> Blob for BlobWithSyncFault<B> {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            bufs: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, bufs).await
+        }
+
+        async fn write_at(&self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
+            self.inner.write_at(offset, bufs).await
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            self.inner.write_at_sync(offset, bufs).await
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            if self.partition == self.fail_partition {
+                return Err(Error::Io(IoError::other("injected partition sync fault")));
+            }
+            self.inner.sync().await
+        }
+    }
+}
+
 pub(super) trait PersistableContiguous:
     Mutable<Item = u64> + Persistable<Error = Error>
 {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -430,6 +430,26 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         );
     }
 
+    /// Sync data sections backing rebuilt offsets before the offsets are made durable.
+    async fn sync_data_range(
+        data: &variable::Journal<E, V>,
+        start_position: u64,
+        end_position: u64,
+        items_per_section: u64,
+    ) -> Result<(), Error> {
+        if start_position >= end_position {
+            return Ok(());
+        }
+
+        let start_section = position_to_section(start_position, items_per_section);
+        let end_section = position_to_section(end_position - 1, items_per_section);
+        let start_section = data
+            .oldest_section()
+            .map_or(start_section, |oldest| start_section.max(oldest));
+        try_join_all((start_section..=end_section).map(|section| data.sync(section))).await?;
+        Ok(())
+    }
+
     /// Initialize a contiguous variable journal.
     ///
     /// # Crash Recovery
@@ -1119,7 +1139,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             recovery_watermark
         };
 
-        let data_size = match Self::rebuild_offsets_from_anchor(
+        let (data_size, data_sync_start) = match Self::rebuild_offsets_from_anchor(
             data,
             offsets,
             items_per_section,
@@ -1128,7 +1148,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         )
         .await?
         {
-            Some(size) => size,
+            Some(size) => (size, recovery_start),
             None if recovery_start != offsets_bounds.start => {
                 warn!(
                     recovery_watermark = recovery_start,
@@ -1143,6 +1163,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                     offsets_bounds.start,
                 )
                 .await?
+                .map(|size| (size, offsets_bounds.start))
                 .expect("rebuild from pruning boundary should succeed after pruning alignment")
             }
             None => {
@@ -1175,6 +1196,9 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             offsets_bounds.start
         };
 
+        // Rebuilt offsets are about to become durable. First make the data they point at durable
+        // too; on real filesystems, init may have adopted bytes that were readable but not synced.
+        Self::sync_data_range(data, data_sync_start, data_size, items_per_section).await?;
         offsets.sync().await?;
         Ok((pruning_boundary, data_size))
     }
@@ -1424,7 +1448,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::journal::contiguous::tests::run_contiguous_tests;
+    use crate::journal::contiguous::tests::{partition_sync_fault, run_contiguous_tests};
     use commonware_macros::test_traced;
     use commonware_runtime::{
         buffer::paged::{Append, CacheRef},
@@ -1440,6 +1464,48 @@ mod tests {
     // Larger page sizes for tests that need more buffer space.
     const LARGE_PAGE_SIZE: NonZeroU16 = NZU16!(1024);
     const SMALL_PAGE_SIZE: NonZeroU16 = NZU16!(512);
+
+    #[test_traced]
+    fn test_variable_init_syncs_adopted_data_before_offsets_watermark_advance() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "init-adopted-variable".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let journal = Journal::<_, FixedBytes<32>>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            journal.append(&FixedBytes::new([1; 32])).await.unwrap();
+            journal.append(&FixedBytes::new([2; 32])).await.unwrap();
+            journal.sync().await.unwrap();
+            // Simulate the state left by a crash after item 2's data became visible to recovery,
+            // but before the offsets journal's recovery watermark advanced past item 1.
+            journal
+                .test_set_offsets_recovery_watermark(1)
+                .await
+                .unwrap();
+            drop(journal);
+
+            // Regression: init used to rebuild and sync offsets through item 2 without first
+            // syncing the adopted data range they point at. A sync fault scoped only to the data
+            // partition would therefore be missed. With the fix, init must sync data before the
+            // rebuilt offsets become durable, so this reopen fails.
+            let data_partition = format!("{}{}", cfg.partition, DATA_SUFFIX);
+            let context = partition_sync_fault::Context::new(context, data_partition);
+            assert!(
+                Journal::<_, FixedBytes<32>>::init(context.child("second"), cfg.clone())
+                    .await
+                    .is_err(),
+                "init must sync adopted data before advancing rebuilt offsets"
+            );
+        });
+    }
 
     #[test_traced]
     fn test_variable_append_many_compressed() {


### PR DESCRIPTION
## Summary

This fixes a recovery durability bug in contiguous fixed and variable journals. When init observes journal data beyond the persisted recovery watermark, that recovered suffix must be made durable before the journal records metadata or index state that depends on it.

## Bug

A successful write can leave dirty pages in the OS page cache without persisting them. If the process crashes, a later process can reopen the blob and read those dirty cached bytes. They are visible, but they are not crash-durable until the blob is synced.

The contiguous journal init path recovers bounds from readable blob contents, so it can adopt this page-cache-visible suffix as part of the journal.

The fixed journal recovered the larger size but initialized `dirty_from_section` to `None`. A later `commit()` or `sync()` could therefore skip data-section syncs and still advance metadata to the recovered size. That can make the metadata durable before the adopted data is durable.

The variable journal had the same durability ordering issue with an extra layer: init can rebuild missing offset entries by replaying data after the offsets recovery watermark, then sync the offsets journal. If the data range is not synced first, the durable offsets can point at data bytes that were only page-cache-visible.

## Fix

For fixed journals, init now marks the section containing the recovered suffix dirty whenever the recovered size is ahead of the persisted recovery watermark. The existing commit/sync path then forces those sections through `sync_section` before clearing the dirty marker or advancing recovery metadata.

For variable journals, `align_journals` now tracks the data range used to rebuild offsets and syncs the corresponding data sections before syncing the offsets journal. This preserves the required ordering: adopted data becomes durable before durable metadata or offset entries depend on it.