### PR TITLE
[storage/journal] Use checked arithmetic

### DIFF
--- a/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
@@ -144,7 +144,6 @@ fn fuzz(input: FuzzInput) {
                     let digest = Sha256::hash(&value.to_be_bytes());
                     match journal.append(&digest).await {
                         Ok(_pos) => journal_size += 1,
-                        // At the representable limit the append is rejected instead of panicking.
                         Err(Error::SizeOverflow) => {}
                         Err(e) => panic!("unexpected append error: {e:?}"),
                     }

--- a/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
@@ -35,6 +35,19 @@ fn bounded_positions(u: &mut Unstructured<'_>) -> Result<Vec<u64>> {
     (0..len).map(|_| u64::arbitrary(u)).collect()
 }
 
+/// Generate a size for `init_at_size`, biased toward the `u64` boundary so the fuzzer reliably
+/// exercises the successor-arithmetic overflow paths (e.g. `init_at_size(u64::MAX)` rejection and
+/// appends that push the size to its representable limit).
+fn boundary_size(u: &mut Unstructured<'_>) -> Result<u64> {
+    Ok(match u.int_in_range(0..=4u8)? {
+        0 => u64::MAX,
+        1 => u64::MAX - 1,
+        2 => u64::MAX - u.int_in_range(0..=64u64)?,
+        3 => u.int_in_range(0..=256u64)?,
+        _ => u64::arbitrary(u)?,
+    })
+}
+
 #[derive(Arbitrary, Debug, Clone)]
 enum JournalOperation {
     Append {
@@ -82,6 +95,7 @@ enum JournalOperation {
     },
     PruningBoundary,
     InitAtSize {
+        #[arbitrary(with = boundary_size)]
         size: u64,
     },
 }
@@ -128,8 +142,12 @@ fn fuzz(input: FuzzInput) {
             match op {
                 JournalOperation::Append { value } => {
                     let digest = Sha256::hash(&value.to_be_bytes());
-                    let _pos = journal.append(&digest).await.unwrap();
-                    journal_size += 1;
+                    match journal.append(&digest).await {
+                        Ok(_pos) => journal_size += 1,
+                        // At the representable limit the append is rejected instead of panicking.
+                        Err(Error::SizeOverflow) => {}
+                        Err(e) => panic!("unexpected append error: {e:?}"),
+                    }
                 }
 
                 JournalOperation::Read { pos } => {
@@ -253,8 +271,11 @@ fn fuzz(input: FuzzInput) {
                                 d
                             })
                             .collect();
-                        journal.append_many(Many::Flat(&items)).await.unwrap();
-                        journal_size += *count as u64;
+                        match journal.append_many(Many::Flat(&items)).await {
+                            Ok(_) => journal_size += *count as u64,
+                            Err(Error::SizeOverflow) => {}
+                            Err(e) => panic!("unexpected append_many error: {e:?}"),
+                        }
                     }
                 }
 
@@ -284,8 +305,11 @@ fn fuzz(input: FuzzInput) {
                             })
                             .collect();
                         let slices: &[&[_]] = &[&items_a, &items_b];
-                        journal.append_many(Many::Nested(slices)).await.unwrap();
-                        journal_size += *count_a as u64 + *count_b as u64;
+                        match journal.append_many(Many::Nested(slices)).await {
+                            Ok(_) => journal_size += *count_a as u64 + *count_b as u64,
+                            Err(Error::SizeOverflow) => {}
+                            Err(e) => panic!("unexpected append_many error: {e:?}"),
+                        }
                     }
                 }
 
@@ -317,19 +341,24 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 JournalOperation::InitAtSize { size } => {
-                    // Cap to avoid excessive memory use
-                    let target_size = *size % 256;
                     drop(journal);
-                    journal = Journal::init_at_size(
-                        context
-                            .child("journal")
-                            .with_attribute("instance", restarts),
-                        cfg.clone(),
-                        target_size,
-                    )
-                    .await
-                    .unwrap();
+                    let attempt = context
+                        .child("journal")
+                        .with_attribute("instance", restarts);
                     restarts += 1;
+                    journal = match Journal::init_at_size(attempt, cfg.clone(), *size).await {
+                        Ok(j) => j,
+                        // `u64::MAX` is rejected (no append could ever succeed) before any reset
+                        // is staged, so the prior on-disk state is intact. Reopen it to continue.
+                        Err(Error::SizeOverflow) => {
+                            let reopen = context
+                                .child("journal")
+                                .with_attribute("instance", restarts);
+                            restarts += 1;
+                            Journal::init(reopen, cfg.clone()).await.unwrap()
+                        }
+                        Err(e) => panic!("unexpected init_at_size error: {e:?}"),
+                    };
                     journal_size = journal.size().await;
                     oldest_retained_pos = journal.reader().await.bounds().start;
                 }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1042,6 +1042,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<(), Error>>,
     {
+        // A journal sized at `u64::MAX` can never accept an append (the successor size
+        // overflows), so reject it before staging any reset intent.
+        if size == u64::MAX {
+            return Err(Error::SizeOverflow);
+        }
+
         // Stage the reset intent durably. Lower the recovery watermark first so external
         // consumers never see a persisted checkpoint beyond `size`. `init_with_metadata` will
         // detect CLEAR_TARGET_KEY and complete the clear via complete_clear_to_size before
@@ -1221,6 +1227,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;
+
+        // Reject the append before writing anything if it would push the size past `u64::MAX`.
+        // This keeps the in-loop `inner.size += batch_count` and `section + 1` arithmetic safe.
+        inner
+            .size
+            .checked_add(items_count as u64)
+            .ok_or(Error::SizeOverflow)?;
+
         let first_dirty_section = inner.size / self.items_per_blob;
         Self::mark_dirty_from(&mut inner, first_dirty_section);
         let mut written = 0;
@@ -2310,6 +2324,54 @@ mod tests {
             assert_eq!(size, 5);
             assert!(repair.is_none());
             inner.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_init_at_max_size_rejected() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+
+            // A journal at `u64::MAX` can never accept an append, so it is rejected at init.
+            assert!(matches!(
+                Journal::<_, Digest>::init_at_size(context.child("max"), cfg.clone(), u64::MAX)
+                    .await,
+                Err(Error::SizeOverflow)
+            ));
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_append_size_overflow() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+
+            // Initialize one item shy of the maximum size.
+            let journal = Journal::<_, Digest>::init_at_size(
+                context.child("near_max"),
+                cfg.clone(),
+                u64::MAX - 1,
+            )
+            .await
+            .expect("failed to initialize journal at size");
+
+            // The first append fills the last representable position.
+            assert_eq!(
+                journal.append(&test_digest(0)).await.expect("first append"),
+                u64::MAX - 1
+            );
+            assert_eq!(journal.size().await, u64::MAX);
+
+            // The next append would overflow the size; it must return a recoverable error
+            // rather than panicking.
+            assert!(matches!(
+                journal.append(&test_digest(1)).await,
+                Err(Error::SizeOverflow)
+            ));
+
+            journal.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -757,6 +757,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // Mutating operations are serialized by taking the write guard.
         let mut inner = self.inner.write().await;
 
+        // Reject the append before writing anything (to either the data or offsets journal) if
+        // it would push the size past `u64::MAX`.
+        inner
+            .size
+            .checked_add(items_count as u64)
+            .ok_or(Error::SizeOverflow)?;
+
         let mut written = 0;
         while written < items_count {
             let section = position_to_section(inner.size, self.items_per_section);
@@ -1469,6 +1476,58 @@ mod tests {
             for (pos, item) in items.iter().enumerate() {
                 assert_eq!(journal.read(pos as u64).await.unwrap(), *item);
             }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_init_at_max_size_rejected() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "init-at-max".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            // The internal offsets journal rejects a maximal size, so init_at_size propagates it.
+            assert!(matches!(
+                Journal::<_, u64>::init_at_size(context.child("max"), cfg, u64::MAX).await,
+                Err(Error::SizeOverflow)
+            ));
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_append_size_overflow() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "append-size-overflow".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            // Initialize one item shy of the maximum size.
+            let journal =
+                Journal::<_, u64>::init_at_size(context.child("near_max"), cfg, u64::MAX - 1)
+                    .await
+                    .unwrap();
+
+            // The first append fills the last representable position.
+            assert_eq!(journal.append(&7).await.unwrap(), u64::MAX - 1);
+            assert_eq!(journal.size().await, u64::MAX);
+
+            // The next append would overflow the size; it must return a recoverable error
+            // rather than panicking.
+            assert!(matches!(journal.append(&8).await, Err(Error::SizeOverflow)));
 
             journal.destroy().await.unwrap();
         });

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -41,6 +41,8 @@ pub enum Error {
     UsizeTooSmall,
     #[error("offset overflow")]
     OffsetOverflow,
+    #[error("size overflow")]
+    SizeOverflow,
     #[error("unexpected size: expected={0} actual={1}")]
     UnexpectedSize(u32, u32),
     #[error("missing blob: {0}")]

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -782,6 +782,40 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_segmented_fixed_rewind_max_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context);
+            let mut journal = Journal::init(context.child("storage"), cfg.clone())
+                .await
+                .expect("failed to init");
+
+            // Append to the maximal section. `section + 1` has no representable successor.
+            journal
+                .append(u64::MAX, &test_digest(0))
+                .await
+                .expect("failed to append");
+            journal.sync_all().await.expect("failed to sync");
+
+            // Rewinding the maximal section removes no sections above it and must not panic.
+            let size = journal.size(u64::MAX).await.expect("failed to get size");
+            journal
+                .rewind(u64::MAX, size)
+                .await
+                .expect("failed to rewind");
+
+            // The section is intact and readable.
+            assert_eq!(
+                journal.size(u64::MAX).await.expect("failed to get size"),
+                size
+            );
+            assert_eq!(journal.get(u64::MAX, 0).await.unwrap(), test_digest(0));
+
+            journal.destroy().await.expect("failed to destroy");
+        });
+    }
+
+    #[test_traced]
     fn test_segmented_fixed_rewind_many_sections() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -356,13 +356,12 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
         self.prune_guard(section)?;
 
         // Remove sections in descending order (newest first) to maintain a contiguous record
-        // if a crash occurs during rewind.
-        let sections_to_remove: Vec<u64> = self
-            .blobs
-            .range((section + 1)..)
-            .rev()
-            .map(|(&s, _)| s)
-            .collect();
+        // if a crash occurs during rewind. Section `u64::MAX` has no successor, so there are
+        // no sections above it to remove.
+        let sections_to_remove: Vec<u64> = match section.checked_add(1) {
+            Some(next) => self.blobs.range(next..).rev().map(|(&s, _)| s).collect(),
+            None => Vec::new(),
+        };
 
         for s in sections_to_remove {
             // Remove the underlying blob from storage

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -1890,6 +1890,33 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_journal_rewind_max_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-partition".into(),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::init(context, cfg).await.unwrap();
+
+            // Append to the maximal section. `section + 1` has no representable successor.
+            let (offset, _) = journal.append(u64::MAX, &42i32).await.unwrap();
+            let size = journal.size(u64::MAX).await.unwrap();
+            assert!(size > 0);
+
+            // Rewinding the maximal section removes no sections above it and must not panic.
+            journal.rewind(u64::MAX, size).await.unwrap();
+
+            // The section is intact and readable.
+            assert_eq!(journal.size(u64::MAX).await.unwrap(), size);
+            assert_eq!(journal.get(u64::MAX, offset).await.unwrap(), 42i32);
+        });
+    }
+
+    #[test_traced]
     fn test_journal_rewind_section() {
         // Initialize the deterministic context
         let executor = deterministic::Runner::default();


### PR DESCRIPTION
## Context

The storage journal APIs accept caller-selected `u64` logical sizes (contiguous journals) and section IDs (segmented journals). At the extreme boundary, later code performed unchecked successor arithmetic (`+ 1`, `+=`). Because the repo enables `overflow-checks` in all profiles, these overflow and **panic** (process crash) instead of returning a recoverable error. An authorized storage caller can trigger this through the public journal APIs (local availability/correctness issue).

Two reachable panic paths:
1. **Contiguous (fixed + variable)**: `init_at_size(u64::MAX)` then `append` one item → `inner.size += batch_count` overflows.
2. **Segmented (fixed + variable)**: append to section `u64::MAX`, then rewind that section → `manager.rewind()` computes `section + 1` which overflows.

## Changes

- Add `Error::SizeOverflow` to the shared `journal::Error` enum.
- **Contiguous fixed** (`init_at_size_cleared`): reject `size == u64::MAX` up front (a journal at that size can never accept an append). `append_many_inner`: guard with `inner.size.checked_add(items_count)` before writing anything, making the in-loop `+= batch_count` and `section + 1` provably safe.
- **Contiguous variable**: inherits the init rejection via its internal offsets journal; `append_many_inner` adds the same up-front `checked_add` guard before writing to either the data or offsets journal.
- **Segmented `manager.rewind`**: compute the successor with `section.checked_add(1)`; section `u64::MAX` has no successor, so no sections above it are removed (graceful no-op, no panic). This covers segmented fixed/variable and the contiguous internal rewind calls. Appending to `u64::MAX` stays valid.

## Tests

Added boundary tests across all four journal flavors:
- contiguous fixed/variable: `init_at_size(u64::MAX)` returns `Err(SizeOverflow)`; init at `u64::MAX - 1`, append once (size reaches `u64::MAX`), then a further append returns `Err(SizeOverflow)` instead of panicking.
- segmented fixed/variable: append to section `u64::MAX`, then `rewind(u64::MAX, size)` returns `Ok` and the section stays intact/readable.

All 335 `commonware-storage journal` tests pass; `just lint` is clean.

Fixes #3907

🤖 Generated with [Claude Code](https://claude.com/claude-code)