### PR TITLE
[CI] Set min stack size to prevent stack overflow in CI tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
-# Storage/qmdb tests build very large async state machines (many awaited generic sub-futures,
-# monomorphized across DB variants) and the deterministic runtime polls them inline on libtest's
-# per-test thread. Give test threads ample stack so they don't overflow on platforms with small
-# defaults (e.g. Windows). See the qmdb tests under storage/src/qmdb/.
+# Some qmdb tests build very large async state machines that the deterministic runtime polls inline
+# on libtest's per-test thread. Raise the per-test stack so they don't overflow where the default is
+# small (e.g. Windows).
 [env]
 RUST_MIN_STACK = "16777216"  # 16 MiB

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# Storage/qmdb tests build very large async state machines (many awaited generic sub-futures,
+# monomorphized across DB variants) and the deterministic runtime polls them inline on libtest's
+# per-test thread. Give test threads ample stack so they don't overflow on platforms with small
+# defaults (e.g. Windows). See the qmdb tests under storage/src/qmdb/.
+[env]
+RUST_MIN_STACK = "16777216"  # 16 MiB

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -377,20 +377,15 @@ where
     executor.start(|mut context| async move {
         let original_ops_data = H::create_ops(original_ops);
 
-        // Heap-pin large sub-futures so their state machines don't inflate this test's outer
-        // state machine and overflow the test thread stack.
-        let mut target_db = Box::pin(H::init_db(context.child("target"))).await;
+        let mut target_db = H::init_db(context.child("target")).await;
         let sync_db_config = H::config(&context.next_u64().to_string(), &context);
         let client_context = context.child("client");
-        let mut sync_db: H::Db = Box::pin(H::init_db_with_config(
-            client_context.child("client"),
-            sync_db_config.clone(),
-        ))
-        .await;
+        let mut sync_db: H::Db =
+            H::init_db_with_config(client_context.child("client"), sync_db_config.clone()).await;
 
         // Apply the same operations to both databases
-        target_db = Box::pin(H::apply_ops(target_db, original_ops_data.clone())).await;
-        sync_db = Box::pin(H::apply_ops(sync_db, original_ops_data.clone())).await;
+        target_db = H::apply_ops(target_db, original_ops_data.clone()).await;
+        sync_db = H::apply_ops(sync_db, original_ops_data.clone()).await;
         // commit already done in apply_ops
         // commit already done in apply_ops
 
@@ -399,7 +394,7 @@ where
         // Add more operations and commit the target database
         // (use different seed to avoid key collisions)
         let more_ops = H::create_ops_seeded(1, 1);
-        target_db = Box::pin(H::apply_ops(target_db, more_ops.clone())).await;
+        target_db = H::apply_ops(target_db, more_ops.clone()).await;
         // commit already done in apply_ops
 
         let sync_root = H::sync_target_root(&target_db);

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -613,9 +613,7 @@ pub mod tests {
 
     /// Apply random operations to the given db, committing them (randomly and at the end) only if
     /// `commit_changes` is true. Returns the db; callers should commit if needed.
-    ///
-    /// Returns a boxed future to prevent stack overflow when monomorphized across many DB variants.
-    async fn apply_random_ops_inner<F, C>(
+    pub async fn apply_random_ops<F, C>(
         num_elements: u64,
         commit_changes: bool,
         rng_seed: u64,
@@ -662,26 +660,6 @@ pub mod tests {
             commit_writes(&mut db, pending).await?;
         }
         Ok(db)
-    }
-
-    pub fn apply_random_ops<F, C>(
-        num_elements: u64,
-        commit_changes: bool,
-        rng_seed: u64,
-        db: C,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<C, Error<F>>>>>
-    where
-        F: merkle::Graftable + 'static,
-        C: DbAny<F> + 'static,
-        C::Key: TestKey,
-        <C as DbAny<F>>::Value: TestValue,
-    {
-        Box::pin(apply_random_ops_inner::<F, C>(
-            num_elements,
-            commit_changes,
-            rng_seed,
-            db,
-        ))
     }
 
     /// Run `test_build_random_close_reopen` against a database factory.
@@ -1449,9 +1427,7 @@ pub mod tests {
                 fn [<$f _ $label>]() {
                     let executor = deterministic::Runner::default();
                     executor.start(|context| async move {
-                        // Box the future to prevent stack overflow when
-                        // monomorphized across DB variants.
-                        Box::pin($f(context, open_db_fn!($db, $cfg))).await
+                        $f(context, open_db_fn!($db, $cfg)).await
                     });
                 }
             }


### PR DESCRIPTION
And remove now-unneeded `Box::pin` from tests