### PR TITLE
[consensus/marshal] Validate coded payload config before decode

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -66,6 +66,10 @@ stability_scope!(BETA {
     /// This trait is required for blocks used with deferred verification in [CertifiableAutomaton].
     /// It allows the verification context to be derived directly from the block when a validator
     /// needs to participate in certification but never verified the block locally (necessary for liveness).
+    ///
+    /// The [`Digestible`] implementation for a [`CertifiableBlock`] must commit to the block's
+    /// embedded consensus context. In other words, changing [`CertifiableBlock::context`] for a
+    /// block must also change [`Digestible::digest`].
     pub trait CertifiableBlock: Block {
         /// The consensus context type stored in this block.
         type Context: Clone + Encode;

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -483,6 +483,82 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_coding_notarized_delivery_rejects_dishonest_payload_config() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let provider = ConstantProvider::new(schemes[0].clone());
+            let honest_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+            let dishonest_config = coding_config_for_participants((NUM_VALIDATORS + 3) as u16);
+            assert_ne!(honest_config, dishonest_config);
+
+            let buffer = RecordingCodingBuffer::default();
+            let (marshal, resolver, _actor_handle) = start_coding_actor_with_recording(
+                context.child("actor_stack"),
+                "coding-dishonest-payload-config",
+                provider,
+                buffer,
+            )
+            .await;
+            let resolver_tx = resolver
+                .sender
+                .clone()
+                .expect("recording resolver should keep its sender");
+
+            let genesis = genesis_block();
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let height = Height::new(1);
+            let candidate_ctx = CodingCtx {
+                round,
+                leader: participants[0].clone(),
+                parent: (
+                    View::zero(),
+                    genesis_coding_commitment::<Sha256, _>(&genesis),
+                ),
+            };
+            let candidate = make_coding_block(candidate_ctx, genesis.digest(), height, 100);
+            let dishonest_block: TestCodedBlock =
+                CodedBlock::new(candidate.clone(), dishonest_config, &Sequential);
+            let proposal = Proposal {
+                round,
+                parent: View::zero(),
+                payload: dishonest_block.commitment(),
+            };
+            let notarization = CodingHarness::make_notarization(proposal, &schemes, QUORUM);
+
+            let (response, response_rx) = oneshot::channel();
+            assert!(resolver_tx
+                .enqueue(handler::Message::Deliver {
+                    delivery: Delivery {
+                        key: handler::Key::Notarized { round },
+                        subscribers: NonEmptyVec::new(handler::Annotation::Notarization { round }),
+                    },
+                    value: (notarization, dishonest_block).encode(),
+                    response,
+                })
+                .accepted());
+            assert!(
+                !response_rx.await.unwrap(),
+                "notarized delivery should reject a dishonest coding config"
+            );
+
+            context.sleep(Duration::from_millis(100)).await;
+            assert!(
+                marshal.get_block(height).await.is_none(),
+                "dishonest deliveries must not store a finalized block"
+            );
+            assert!(
+                marshal.get_finalization(height).await.is_none(),
+                "dishonest deliveries must not archive a finalization"
+            );
+        });
+    }
+
+    #[test_traced("WARN")]
     fn test_coding_block_provider_parent_fetches_by_commitment() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -3,11 +3,11 @@ use crate::{
         ancestry::BlockProvider,
         coding::{
             shards,
-            types::{CodedBlock, CodedBlockCfg, StoredCodedBlock},
+            types::{coding_config_for_participants, CodedBlock, CodedBlockCfg, StoredCodedBlock},
         },
         core::{Buffer, CommitmentFallback, Mailbox, Variant},
     },
-    simplex::types::Context,
+    simplex::{scheme::Scheme as SimplexScheme, types::Context},
     types::{coding::Commitment, Round},
     CertifiableBlock,
 };
@@ -57,6 +57,15 @@ where
         block.context().parent.1
     }
 
+    fn check_payload<S>(scheme: &S, payload: Self::Commitment) -> bool
+    where
+        S: SimplexScheme<Self::Commitment>,
+    {
+        let n_participants = u16::try_from(scheme.participants().len())
+            .expect("scheme must have at most 2^16-1 participants");
+        payload.config() == coding_config_for_participants(n_participants)
+    }
+
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
         expected: Self::Commitment,
@@ -69,6 +78,13 @@ where
 
     fn into_inner(block: Self::Block) -> Self::ApplicationBlock {
         block.into_inner()
+    }
+
+    fn from_application_block(
+        block: Self::ApplicationBlock,
+        payload: Self::Commitment,
+    ) -> Self::Block {
+        CodedBlock::new_trusted(block, payload)
     }
 }
 

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1282,6 +1282,14 @@ where
                     return false;
                 };
 
+                // In contrast to the `Block` and `Notarization` deliveries, the finalization delivery
+                // is guaranteed to be certified (assuming the certificate verifies). Because of this,
+                // we can skip broader payload checks and just check that the application block matches
+                // the commitment in the finalization proposal.
+                //
+                // TODO(https://github.com/commonwarexyz/monorepo/issues/3938): Apply this pattern
+                // conditionally to `Request::Block` and `Request::Notarized`, if the requester knows
+                // the requested block is certified.
                 let commitment = finalization.proposal.payload;
                 if block.height() != height
                     || block.digest() != V::commitment_to_inner(commitment)

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1325,6 +1325,15 @@ where
                     return false;
                 };
 
+                // Wrong-round data must be rejected before the scoped-provider lookup below.
+                // That lookup may miss for pruned epochs even when `all()` was sufficient to
+                // decode the certificate, and missing scoped state is treated as stale rather
+                // than peer-faulting.
+                if notarization.round() != round {
+                    response.send_lossy(false);
+                    return false;
+                }
+
                 // `V::check_payload` requires a scoped provider, and `get_scheme_certificate_verifier`
                 // may use an all-epoch provider.
                 let Some(scheme) = self.provider.scoped(notarization.epoch()) else {
@@ -1347,9 +1356,7 @@ where
                     return false;
                 };
 
-                if notarization.round() != round
-                    || V::commitment(&block) != notarization.proposal.payload
-                {
+                if V::commitment(&block) != notarization.proposal.payload {
                     response.send_lossy(false);
                     return false;
                 }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1276,7 +1276,8 @@ where
                     return false;
                 };
 
-                let Ok(block) = V::ApplicationBlock::read_cfg(&mut value, &self.block_codec_config)
+                let Ok(block) =
+                    V::ApplicationBlock::decode_cfg(&mut value, &self.block_codec_config)
                 else {
                     response.send_lossy(false);
                     return false;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -880,7 +880,7 @@ where
                     debug!(%height, "finalized block missing on request");
                     return;
                 };
-                response.send_lossy((finalization, block).encode());
+                response.send_lossy((finalization, V::into_inner(block)).encode());
             }
             Key::Notarized { round } => {
                 let Some(notarization) = self.cache.get_notarization(round).await else {
@@ -1276,15 +1276,15 @@ where
                     return false;
                 };
 
-                let commitment = finalization.proposal.payload;
-                let block_cfg = V::block_cfg(&self.block_codec_config, commitment);
-                let Ok(block) = V::Block::decode_cfg(value, &block_cfg) else {
+                let Ok(block) = V::ApplicationBlock::read_cfg(&mut value, &self.block_codec_config)
+                else {
                     response.send_lossy(false);
                     return false;
                 };
 
+                let commitment = finalization.proposal.payload;
                 if block.height() != height
-                    || V::commitment(&block) != commitment
+                    || block.digest() != V::commitment_to_inner(commitment)
                     || finalization.epoch() != bounds.epoch()
                 {
                     response.send_lossy(false);
@@ -1316,7 +1316,22 @@ where
                     return false;
                 };
 
+                // `V::check_payload` requires a scoped provider, and `get_scheme_certificate_verifier`
+                // may use an all-epoch provider.
+                let Some(scheme) = self.provider.scoped(notarization.epoch()) else {
+                    debug!(
+                        ?round,
+                        floor = %self.floor.processed_height(),
+                        "ignoring stale delivery"
+                    );
+                    response.send_lossy(true);
+                    return false;
+                };
                 let commitment = notarization.proposal.payload;
+                if !V::check_payload(scheme.as_ref(), commitment) {
+                    response.send_lossy(false);
+                    return false;
+                }
                 let block_cfg = V::block_cfg(&self.block_codec_config, commitment);
                 let Ok(block) = V::Block::decode_cfg(value, &block_cfg) else {
                     response.send_lossy(false);
@@ -1433,6 +1448,7 @@ where
                 } => {
                     // Valid finalization received.
                     response.send_lossy(true);
+                    let block = V::from_application_block(block, finalization.proposal.payload);
                     let round = finalization.round();
                     let height = block.height();
                     let digest = block.digest();

--- a/consensus/src/marshal/core/delivery.rs
+++ b/consensus/src/marshal/core/delivery.rs
@@ -18,7 +18,7 @@ where
     },
     Finalized {
         finalization: Finalization<S, V::Commitment>,
-        block: V::Block,
+        block: V::ApplicationBlock,
         response: oneshot::Sender<bool>,
     },
 }

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -12,7 +12,7 @@
 //! mechanisms, though it is required that the digest can be extracted from the commitment
 //! for lookup purposes.
 
-use crate::{types::Round, Block};
+use crate::{simplex::scheme::Scheme, types::Round, Block};
 use commonware_codec::{Codec, Read};
 use commonware_cryptography::{Digest, Digestible, PublicKey};
 use commonware_p2p::Recipients;
@@ -60,6 +60,11 @@ pub trait Variant: Clone + Send + Sync + 'static {
     /// Returns the parent commitment referenced by `block`.
     fn parent_commitment(block: &Self::Block) -> Self::Commitment;
 
+    /// Validates a certificate payload against the active consensus scheme.
+    fn check_payload<S>(scheme: &S, payload: Self::Commitment) -> bool
+    where
+        S: Scheme<Self::Commitment>;
+
     /// Returns the codec configuration used to decode [`Self::Block`] received over the wire.
     ///
     /// The returned configuration may bind `expected_commitment` so that decoding rejects
@@ -74,6 +79,12 @@ pub trait Variant: Clone + Send + Sync + 'static {
     /// This conversion cannot use `Into` due to orphan rules when `Block` wraps
     /// `ApplicationBlock` (e.g., `CodedBlock<B, C, H> -> B`).
     fn into_inner(block: Self::Block) -> Self::ApplicationBlock;
+
+    /// Reconstructs a working block from an application block and trusted payload.
+    fn from_application_block(
+        block: Self::ApplicationBlock,
+        payload: Self::Commitment,
+    ) -> Self::Block;
 }
 
 /// A buffer for block storage and retrieval, abstracting over different

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -113,6 +113,32 @@ mod tests {
         assert_provider::<Mailbox<S, Standard<B>>>();
     }
 
+    #[derive(Clone)]
+    struct AllOnlyProvider {
+        scheme: Arc<S>,
+    }
+
+    impl AllOnlyProvider {
+        fn new(scheme: S) -> Self {
+            Self {
+                scheme: Arc::new(scheme),
+            }
+        }
+    }
+
+    impl Provider for AllOnlyProvider {
+        type Scope = Epoch;
+        type Scheme = S;
+
+        fn scoped(&self, _: Epoch) -> Option<Arc<S>> {
+            None
+        }
+
+        fn all(&self) -> Option<Arc<S>> {
+            Some(self.scheme.clone())
+        }
+    }
+
     #[test_traced("WARN")]
     fn test_standard_block_provider_parent_fetches_by_commitment() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
@@ -4697,6 +4723,48 @@ mod tests {
             assert!(
                 !response_rx.await.expect("delivery response missing"),
                 "wrong-round notarized delivery must not satisfy the request"
+            );
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_notarized_delivery_acknowledges_stale_without_scoped_provider() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(Sha256::hash(b""), Height::new(1), 100);
+            let proposal = Proposal::new(round, View::zero(), StandardHarness::commitment(&block));
+            let notarization = StandardHarness::make_notarization(proposal, &schemes, QUORUM);
+
+            let (_mailbox, _buffer, resolver, _actor_handle) = start_standard_actor(
+                context.child("validator"),
+                "notarized-delivery-stale-all-only",
+                AllOnlyProvider::new(schemes[0].clone()),
+                Application::<B>::manual_ack(),
+                Some(RecordingBuffer::default()),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+            )
+            .await;
+
+            let (response, response_rx) = oneshot::channel();
+            assert!(resolver
+                .enqueue(handler::Message::Deliver {
+                    delivery: Delivery {
+                        key: handler::Key::Notarized { round },
+                        subscribers: NonEmptyVec::new(handler::Annotation::Notarization {
+                            round,
+                        }),
+                    },
+                    value: (notarization, block).encode(),
+                    response,
+                })
+                .accepted());
+            assert!(
+                response_rx.await.expect("delivery response missing"),
+                "stale notarized delivery should acknowledge without blaming the peer"
             );
         });
     }

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -4754,9 +4754,7 @@ mod tests {
                 .enqueue(handler::Message::Deliver {
                     delivery: Delivery {
                         key: handler::Key::Notarized { round },
-                        subscribers: NonEmptyVec::new(handler::Annotation::Notarization {
-                            round,
-                        }),
+                        subscribers: NonEmptyVec::new(handler::Annotation::Notarization { round }),
                     },
                     value: (notarization, block).encode(),
                     response,

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -72,7 +72,7 @@ mod tests {
     use commonware_broadcast::buffered;
     use commonware_codec::Encode;
     use commonware_cryptography::{
-        certificate::{mocks::Fixture, ConstantProvider, Scheme as _},
+        certificate::{mocks::Fixture, ConstantProvider, Provider, Scheme as _},
         ed25519::PublicKey,
         sha256::Sha256,
         Digestible, Hasher as _,
@@ -111,6 +111,32 @@ mod tests {
     fn mailbox_provides_application_blocks() {
         fn assert_provider<P: BlockProvider<Block = B>>() {}
         assert_provider::<Mailbox<S, Standard<B>>>();
+    }
+
+    #[derive(Clone)]
+    struct AllOnlyProvider {
+        scheme: Arc<S>,
+    }
+
+    impl AllOnlyProvider {
+        fn new(scheme: S) -> Self {
+            Self {
+                scheme: Arc::new(scheme),
+            }
+        }
+    }
+
+    impl Provider for AllOnlyProvider {
+        type Scope = Epoch;
+        type Scheme = S;
+
+        fn scoped(&self, _: Epoch) -> Option<Arc<S>> {
+            None
+        }
+
+        fn all(&self) -> Option<Arc<S>> {
+            Some(self.scheme.clone())
+        }
     }
 
     #[test_traced("WARN")]
@@ -2854,10 +2880,10 @@ mod tests {
         }
     }
 
-    async fn start_standard_actor<R, Buf>(
+    async fn start_standard_actor<R, Buf, P>(
         context: deterministic::Context,
         partition_prefix: &str,
-        provider: ConstantProvider<S, Epoch>,
+        provider: P,
         application: R,
         buffer: Option<Buf>,
         start: Start<S, D, B>,
@@ -2869,6 +2895,7 @@ mod tests {
     )
     where
         R: Reporter<Activity = Update<B>>,
+        P: Provider<Scope = Epoch, Scheme = S>,
         Buf: crate::marshal::core::Buffer<Standard<B>, PublicKey = PublicKey> + Clone,
     {
         let config = Config {
@@ -4648,6 +4675,55 @@ mod tests {
                     panic!("notarized delivery did not wake block subscriber");
                 },
             }
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_notarized_delivery_rejects_wrong_round_without_scoped_provider() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+
+            let requested_round = Round::new(Epoch::new(1), View::new(1));
+            let delivered_round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(Sha256::hash(b""), Height::new(1), 100);
+            let proposal = Proposal::new(
+                delivered_round,
+                View::zero(),
+                StandardHarness::commitment(&block),
+            );
+            let notarization = StandardHarness::make_notarization(proposal, &schemes, QUORUM);
+
+            let (_mailbox, _buffer, resolver, _actor_handle) = start_standard_actor(
+                context.child("validator"),
+                "notarized-delivery-wrong-round-all-only",
+                AllOnlyProvider::new(schemes[0].clone()),
+                Application::<B>::manual_ack(),
+                Some(RecordingBuffer::default()),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+            )
+            .await;
+
+            let (response, response_rx) = oneshot::channel();
+            assert!(resolver
+                .enqueue(handler::Message::Deliver {
+                    delivery: Delivery {
+                        key: handler::Key::Notarized {
+                            round: requested_round,
+                        },
+                        subscribers: NonEmptyVec::new(handler::Annotation::Notarization {
+                            round: requested_round,
+                        }),
+                    },
+                    value: (notarization, block).encode(),
+                    response,
+                })
+                .accepted());
+            assert!(
+                !response_rx.await.expect("delivery response missing"),
+                "wrong-round notarized delivery must not satisfy the request"
+            );
         });
     }
 

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -113,32 +113,6 @@ mod tests {
         assert_provider::<Mailbox<S, Standard<B>>>();
     }
 
-    #[derive(Clone)]
-    struct AllOnlyProvider {
-        scheme: Arc<S>,
-    }
-
-    impl AllOnlyProvider {
-        fn new(scheme: S) -> Self {
-            Self {
-                scheme: Arc::new(scheme),
-            }
-        }
-    }
-
-    impl Provider for AllOnlyProvider {
-        type Scope = Epoch;
-        type Scheme = S;
-
-        fn scoped(&self, _: Epoch) -> Option<Arc<S>> {
-            None
-        }
-
-        fn all(&self) -> Option<Arc<S>> {
-            Some(self.scheme.clone())
-        }
-    }
-
     #[test_traced("WARN")]
     fn test_standard_block_provider_parent_fetches_by_commitment() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
@@ -4679,7 +4653,7 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_standard_notarized_delivery_rejects_wrong_round_without_scoped_provider() {
+    fn test_standard_notarized_delivery_rejects_wrong_round() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
@@ -4697,8 +4671,8 @@ mod tests {
 
             let (_mailbox, _buffer, resolver, _actor_handle) = start_standard_actor(
                 context.child("validator"),
-                "notarized-delivery-wrong-round-all-only",
-                AllOnlyProvider::new(schemes[0].clone()),
+                "notarized-delivery-wrong-round",
+                ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
                 Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -8,6 +8,7 @@ use crate::{
         ancestry::BlockProvider,
         core::{Buffer, CommitmentFallback, Mailbox, Variant},
     },
+    simplex::scheme::Scheme as SimplexScheme,
     types::Round,
     Block,
 };
@@ -48,6 +49,13 @@ where
         block.parent()
     }
 
+    fn check_payload<S>(_scheme: &S, _payload: Self::Commitment) -> bool
+    where
+        S: SimplexScheme<Self::Commitment>,
+    {
+        true
+    }
+
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
         _expected: Self::Commitment,
@@ -56,6 +64,13 @@ where
     }
 
     fn into_inner(block: Self::Block) -> Self::ApplicationBlock {
+        block
+    }
+
+    fn from_application_block(
+        block: Self::ApplicationBlock,
+        _payload: Self::Commitment,
+    ) -> Self::Block {
         block
     }
 }


### PR DESCRIPTION
## Overview

Validates that the `CodingConfig` in received `Notarization` certificates is sensible, relative to the declared `Epoch`'s scheme, before decoding.

Also adjusts the `Finalized` delivery path to not require re-encoding, since the `payload` within `Finalization` certificates is trusted.

closes https://github.com/commonwarexyz/monorepo/issues/3937
future work #3938