### PR TITLE
[storage/journal/contiguous] strengthen the crash-recovery fuzz target

### DIFF
--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -307,6 +307,21 @@ trait FuzzJournal: Sized {
     fn destroy(self) -> impl Future<Output = Result<(), Error>> + Send;
 }
 
+/// Drain a reader's replay stream into a `(position, item)` vector.
+async fn collect_replay<R: Reader<Item = Item>>(
+    reader: R,
+    buffer: NonZeroUsize,
+    start_pos: u64,
+) -> Result<Vec<(u64, Item)>, Error> {
+    let stream = reader.replay(buffer, start_pos).await?;
+    futures::pin_mut!(stream);
+    let mut out = Vec::new();
+    while let Some(result) = stream.next().await {
+        out.push(result?);
+    }
+    Ok(out)
+}
+
 impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
     type Config = FixedConfig;
 
@@ -451,37 +466,6 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
     async fn destroy(self) -> Result<(), Error> {
         VariableJournal::destroy(self).await
     }
-}
-
-/// Drain a reader's replay stream into a `(position, item)` vector.
-async fn collect_replay<R: Reader<Item = Item>>(
-    reader: R,
-    buffer: NonZeroUsize,
-    start_pos: u64,
-) -> Result<Vec<(u64, Item)>, Error> {
-    let stream = reader.replay(buffer, start_pos).await?;
-    futures::pin_mut!(stream);
-    let mut out = Vec::new();
-    while let Some(result) = stream.next().await {
-        out.push(result?);
-    }
-    Ok(out)
-}
-
-/// Split the operation stream into one `ops` list per cycle, cutting at each `Crash` marker. Always
-/// returns at least one list (possibly empty), so a bare recovery is still exercised.
-fn split_into_cycles(ops: &[JournalOperation]) -> Vec<Vec<JournalOperation>> {
-    let mut cycles = Vec::new();
-    let mut current = Vec::new();
-    for op in ops {
-        if matches!(op, JournalOperation::Crash) {
-            cycles.push(std::mem::take(&mut current));
-        } else {
-            current.push(op.clone());
-        }
-    }
-    cycles.push(current);
-    cycles
 }
 
 /// Verify the recovered journal matches the `Expected` carried from the previous (crashed) cycle.
@@ -802,6 +786,22 @@ where
         run_ops(&mut journal, &mut expected, &ops, params).await;
         expected
     })
+}
+
+/// Split the operation stream into one `ops` list per cycle, cutting at each `Crash` marker. Always
+/// returns at least one list (possibly empty), so a bare recovery is still exercised.
+fn split_into_cycles(ops: &[JournalOperation]) -> Vec<Vec<JournalOperation>> {
+    let mut cycles = Vec::new();
+    let mut current = Vec::new();
+    for op in ops {
+        if matches!(op, JournalOperation::Crash) {
+            cycles.push(std::mem::take(&mut current));
+        } else {
+            current.push(op.clone());
+        }
+    }
+    cycles.push(current);
+    cycles
 }
 
 fn run<J: FuzzJournal + Send + 'static>(input: &FuzzInput, tag: &str)

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -128,7 +128,7 @@ enum JournalOperation {
     Read { pos: u64 },
     /// Sync the journal to storage.
     Sync,
-    /// Flush pending data without advancing the recovery watermark, so recovery walks blob lengths.
+    /// Flush pending data without advancing the recovery watermark.
     Commit,
     /// Rewind the journal to a smaller size.
     Rewind { size: u64 },
@@ -269,7 +269,7 @@ impl Expected {
         self.max_prune = boundary;
     }
 
-    /// Failed prune may have deleted sections (oldest-first) up to `ceiling`, but not for certain.
+    /// Failed prune may have deleted sections (oldest-first) up to `ceiling`, but not certain.
     fn prune_failed(&mut self, ceiling: u64) {
         self.max_prune = self.max_prune.max(ceiling);
     }

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -1,15 +1,31 @@
 #![no_main]
 
 //! Fuzz test for journal crash recovery (both fixed and variable journals).
+//!
+//! Drives a journal through repeated unclean shutdowns. Each cycle:
+//!   1. recovers the journal from the previous (unclean) shutdown,
+//!   2. verifies the recovered state matches a model of what is durably guaranteed (exact item
+//!      content for the durable prefix, pruned positions error, size/boundary within bounds),
+//!   3. continues appending and querying, then
+//!   4. crashes again (faults + unclean drop, losing the in-memory write buffer).
+//!
+//! Each cycle re-runs `init()` on a journal produced by a prior crash recovery, so any bug in the
+//! recovery watermark, pruning metadata, or section layout compounds across restarts. The
+//! operation phase runs under write/sync/resize fault injection, including the torn-write modes
+//! (`partial_write_rate`, `partial_resize_rate`) that model a real crash mid-write.
 
-use arbitrary::{Arbitrary, Result, Unstructured};
+use arbitrary::{Arbitrary, Unstructured};
 use commonware_runtime::{deterministic, BufferPooler, Runner, Supervisor as _};
-use commonware_storage::journal::contiguous::{
-    fixed::{Config as FixedConfig, Journal as FixedJournal},
-    variable::{Config as VariableConfig, Journal as VariableJournal},
-    Reader,
+use commonware_storage::journal::{
+    contiguous::{
+        fixed::{Config as FixedConfig, Journal as FixedJournal},
+        variable::{Config as VariableConfig, Journal as VariableJournal},
+        Reader,
+    },
+    Error,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU64};
+use futures::StreamExt;
 use libfuzzer_sys::fuzz_target;
 use std::{
     future::Future,
@@ -20,7 +36,7 @@ use std::{
 /// Item size for journal entries (32 bytes like a hash digest).
 const ITEM_SIZE: usize = 32;
 
-/// Type alias for the journal item type.
+/// The journal item type.
 type Item = FixedBytes<ITEM_SIZE>;
 
 /// Maximum replay buffer size.
@@ -29,29 +45,47 @@ const MAX_REPLAY_BUF: usize = 2048;
 /// Maximum write buffer size.
 const MAX_WRITE_BUF: usize = 2048;
 
-fn bounded_non_zero(u: &mut Unstructured<'_>) -> Result<usize> {
+/// Buffer size used for internal verification replays.
+const VERIFY_REPLAY_BUF: usize = 1024;
+
+/// Maximum number of operations per fuzz input. Bounds the number of crash cycles and the
+/// per-cycle verification/replay work so executions stay fast and `rebaseline`'s allocation stays
+/// small (total cost is ~O(cycles * size), both capped by this).
+const MAX_OPERATIONS: usize = 128;
+
+fn bounded_non_zero(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
     u.int_in_range(1..=MAX_REPLAY_BUF)
 }
 
-fn bounded_page_size(u: &mut Unstructured<'_>) -> Result<u16> {
+fn bounded_page_size(u: &mut Unstructured<'_>) -> arbitrary::Result<u16> {
     u.int_in_range(1..=256)
 }
 
-fn bounded_page_cache_size(u: &mut Unstructured<'_>) -> Result<usize> {
+fn bounded_page_cache_size(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
     u.int_in_range(1..=16)
 }
 
-fn bounded_items_per_section(u: &mut Unstructured<'_>) -> Result<u64> {
+fn bounded_items_per_section(u: &mut Unstructured<'_>) -> arbitrary::Result<u64> {
     u.int_in_range(1..=64)
 }
 
-fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
+fn bounded_write_buffer(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
     u.int_in_range(1..=MAX_WRITE_BUF)
 }
 
-fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<f64> {
-    let percent: u8 = u.int_in_range(1..=100)?;
+/// A fault rate in [0.0, 1.0]. Allows 0 so the fuzzer can disable individual fault types.
+fn bounded_rate(u: &mut Unstructured<'_>) -> arbitrary::Result<f64> {
+    let percent: u8 = u.int_in_range(0..=100)?;
     Ok(f64::from(percent) / 100.0)
+}
+
+/// A bounded-length operation sequence, so input size (hence cycle count and verification cost)
+/// stays capped regardless of how much data the fuzzer provides.
+fn bounded_operations(u: &mut Unstructured<'_>) -> arbitrary::Result<Vec<JournalOperation>> {
+    let num_ops = u.int_in_range(0..=MAX_OPERATIONS)?;
+    (0..num_ops)
+        .map(|_| JournalOperation::arbitrary(u))
+        .collect()
 }
 
 /// Journal type selector.
@@ -61,15 +95,17 @@ enum JournalType {
     Variable,
 }
 
-/// Operations that can be performed on the journal.
+/// Operations that can be performed on the journal within a segment.
 #[derive(Arbitrary, Debug, Clone)]
 enum JournalOperation {
     /// Append a single item to the journal.
     Append { value: [u8; ITEM_SIZE] },
     /// Read an item at a specific position.
     Read { pos: u64 },
-    /// Sync the journal to storage.
+    /// Sync the journal to storage (durability checkpoint).
     Sync,
+    /// Flush pending data without advancing the recovery watermark, so recovery walks blob lengths.
+    Commit,
     /// Rewind the journal to a smaller size.
     Rewind { size: u64 },
     /// Prune items before a position.
@@ -80,8 +116,9 @@ enum JournalOperation {
         buffer: usize,
         start_pos: u64,
     },
-    /// Commit pending changes (variable journal only, no-op for fixed).
-    Commit,
+    /// Mark an unclean shutdown: end the current segment, drop the journal without a clean sync,
+    /// and recover in the next segment.
+    Crash,
 }
 
 /// Fuzz input containing fault injection parameters and operations.
@@ -103,143 +140,170 @@ struct FuzzInput {
     /// Write buffer size.
     #[arbitrary(with = bounded_write_buffer)]
     write_buffer: usize,
-    /// Failure rate for sync operations (0, 1].
-    #[arbitrary(with = bounded_nonzero_rate)]
-    sync_failure_rate: f64,
-    /// Failure rate for write operations (0, 1].
-    #[arbitrary(with = bounded_nonzero_rate)]
+    /// Failure rate for write operations.
+    #[arbitrary(with = bounded_rate)]
     write_failure_rate: f64,
-    /// Sequence of operations to execute.
+    /// Probability that a write failure is a partial (torn) write.
+    #[arbitrary(with = bounded_rate)]
+    partial_write_rate: f64,
+    /// Failure rate for sync operations.
+    #[arbitrary(with = bounded_rate)]
+    sync_failure_rate: f64,
+    /// Failure rate for resize operations (truncation during rewind/prune).
+    #[arbitrary(with = bounded_rate)]
+    resize_failure_rate: f64,
+    /// Probability that a resize failure is partial.
+    #[arbitrary(with = bounded_rate)]
+    partial_resize_rate: f64,
+    /// Sequence of operations to execute (split into segments at `Crash` markers).
+    #[arbitrary(with = bounded_operations)]
     operations: Vec<JournalOperation>,
 }
 
-fn fixed_config(
-    partition: &str,
-    pooler: &impl BufferPooler,
+/// Configuration knobs shared by every cycle: journal config plus fault-injection rates.
+#[derive(Clone, Copy)]
+struct Params {
     page_size: NonZeroU16,
     page_cache_size: NonZeroUsize,
     items_per_section: u64,
     write_buffer: NonZeroUsize,
-) -> FixedConfig {
-    FixedConfig {
-        partition: partition.into(),
-        items_per_blob: NZU64!(items_per_section),
-        page_cache: commonware_runtime::buffer::paged::CacheRef::from_pooler(
-            pooler,
-            page_size,
-            page_cache_size,
-        ),
-        write_buffer,
+    write_rate: f64,
+    partial_write_rate: f64,
+    sync_rate: f64,
+    resize_rate: f64,
+    partial_resize_rate: f64,
+}
+
+impl Params {
+    /// The fault config applied during the operation phase of each cycle.
+    fn fault_config(&self) -> deterministic::FaultConfig {
+        deterministic::FaultConfig {
+            write_rate: Some(self.write_rate),
+            partial_write_rate: Some(self.partial_write_rate),
+            sync_rate: Some(self.sync_rate),
+            resize_rate: Some(self.resize_rate),
+            partial_resize_rate: Some(self.partial_resize_rate),
+            ..Default::default()
+        }
     }
 }
 
-fn variable_config(
-    partition: &str,
-    pooler: &impl BufferPooler,
-    page_size: NonZeroU16,
-    page_cache_size: NonZeroUsize,
-    items_per_section: u64,
-    write_buffer: NonZeroUsize,
-) -> VariableConfig<()> {
-    VariableConfig {
-        partition: partition.into(),
-        items_per_section: NZU64!(items_per_section),
-        compression: None,
-        codec_config: (),
-        page_cache: commonware_runtime::buffer::paged::CacheRef::from_pooler(
-            pooler,
-            page_size,
-            page_cache_size,
-        ),
-        write_buffer,
+/// Model of the journal's state after an unclean shutdown: a guaranteed-durable floor and
+/// conservative upper bounds.
+///
+/// The bounds are deliberately conservative, so every assertion in `verify_recovery` is sound under
+/// any fault/crash interleaving:
+/// - positions `[0, durable_prune)` are pruned (reads return `ItemPruned`),
+/// - positions `[max_prune, durable_len)` are present with the exact content `values[pos]`,
+/// - the recovered size is in `[durable_len, max_size]`,
+/// - the recovered pruning boundary is in `[durable_prune, max_prune]`,
+/// - `values.len()` tracks the in-memory size, so `values[pos]` is the latest value at `pos`.
+///
+/// The methods below are the per-operation update rules that maintain these invariants.
+#[derive(Clone, Default)]
+struct Model {
+    /// Guaranteed-durable prefix length; also the minimum recovered size.
+    durable_len: u64,
+    /// Upper bound on the recovered size.
+    max_size: u64,
+    /// Guaranteed pruning floor; positions below are guaranteed pruned.
+    durable_prune: u64,
+    /// Upper bound on the recovered pruning boundary.
+    max_prune: u64,
+    /// Latest value appended at each position (index == position).
+    values: Vec<Item>,
+}
+
+impl Model {
+    /// A successful tail append. The item is not durable until the next sync/commit, so it only
+    /// raises the size ceiling.
+    fn appended(&mut self, item: Item) {
+        self.values.push(item);
+        self.max_size = self.max_size.max(self.values.len() as u64);
+    }
+
+    /// A failed append: the item may have partially persisted, so widen the size ceiling only.
+    fn append_failed(&mut self, size_before: u64) {
+        self.max_size = self.max_size.max(size_before + 1);
+    }
+
+    /// Sync makes the whole in-memory state durable: size, content, and pruning boundary are all
+    /// pinned exactly.
+    fn synced(&mut self, bounds: Range<u64>) {
+        self.durable_len = bounds.end;
+        self.max_size = bounds.end;
+        self.durable_prune = bounds.start;
+        self.max_prune = bounds.start;
+    }
+
+    /// Commit makes appended data durable but not the pruning boundary, so pin only the size.
+    fn committed(&mut self, size: u64) {
+        self.durable_len = size;
+        self.max_size = size;
+    }
+
+    /// Rewind to `target`: data below `target` is untouched on disk, while the truncated tail may
+    /// or may not persist, so the recovered size ranges over `[target, prev_size]`.
+    fn rewound(&mut self, target: u64, prev_size: u64) {
+        self.durable_len = self.durable_len.min(target);
+        self.max_size = self.max_size.max(prev_size);
+    }
+
+    /// Prune may advance the recovered pruning boundary up to `boundary` (durable only after sync).
+    fn pruned(&mut self, boundary: u64) {
+        self.max_prune = self.max_prune.max(boundary);
     }
 }
 
-/// Trait abstracting over fixed and variable journals for the fuzz test.
+/// Abstracts over fixed and variable journals. `read` and `replay` return their items so content
+/// can be verified after recovery.
 trait FuzzJournal: Sized {
     type Config;
 
-    fn config(
-        partition: &str,
-        pooler: &impl BufferPooler,
-        page_size: NonZeroU16,
-        page_cache_size: NonZeroUsize,
-        items_per_section: u64,
-        write_buffer: NonZeroUsize,
-    ) -> Self::Config;
+    fn config(partition: &str, pooler: &impl BufferPooler, params: &Params) -> Self::Config;
 
     fn init(
         ctx: deterministic::Context,
         cfg: Self::Config,
-    ) -> impl Future<Output = Result<Self, commonware_storage::journal::Error>> + Send;
+    ) -> impl Future<Output = Result<Self, Error>> + Send;
 
     fn size(&self) -> impl Future<Output = u64> + Send;
     fn bounds(&self) -> impl Future<Output = Range<u64>> + Send;
 
-    fn append(
-        &mut self,
-        item: Item,
-    ) -> impl Future<Output = Result<u64, commonware_storage::journal::Error>> + Send;
+    fn append(&mut self, item: Item) -> impl Future<Output = Result<u64, Error>> + Send;
+    fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send;
+    fn sync(&mut self) -> impl Future<Output = Result<(), Error>> + Send;
+    fn commit(&mut self) -> impl Future<Output = Result<(), Error>> + Send;
+    fn rewind(&mut self, size: u64) -> impl Future<Output = Result<(), Error>> + Send;
+    fn prune(&mut self, min_pos: u64) -> impl Future<Output = Result<bool, Error>> + Send;
 
-    fn read(
-        &self,
-        pos: u64,
-    ) -> impl Future<Output = Result<Item, commonware_storage::journal::Error>> + Send;
-
-    fn sync(
-        &mut self,
-    ) -> impl Future<Output = Result<(), commonware_storage::journal::Error>> + Send;
-
-    fn rewind(
-        &mut self,
-        size: u64,
-    ) -> impl Future<Output = Result<(), commonware_storage::journal::Error>> + Send;
-
-    fn prune(
-        &mut self,
-        min_pos: u64,
-    ) -> impl Future<Output = Result<bool, commonware_storage::journal::Error>> + Send;
-
-    // Return value is ignored in the fuzz test.
+    /// Replay from `start_pos`, returning all `(position, item)` pairs.
     fn replay(
-        &mut self,
+        &self,
         buffer: NonZeroUsize,
         start_pos: u64,
-    ) -> impl Future<Output = Result<(), commonware_storage::journal::Error>> + Send;
+    ) -> impl Future<Output = Result<Vec<(u64, Item)>, Error>> + Send;
 
-    fn commit(
-        &mut self,
-    ) -> impl Future<Output = Result<(), commonware_storage::journal::Error>> + Send;
-
-    fn destroy(self)
-        -> impl Future<Output = Result<(), commonware_storage::journal::Error>> + Send;
+    fn destroy(self) -> impl Future<Output = Result<(), Error>> + Send;
 }
 
 impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
     type Config = FixedConfig;
 
-    fn config(
-        partition: &str,
-        pooler: &impl BufferPooler,
-        page_size: NonZeroU16,
-        page_cache_size: NonZeroUsize,
-        items_per_section: u64,
-        write_buffer: NonZeroUsize,
-    ) -> Self::Config {
-        fixed_config(
-            partition,
-            pooler,
-            page_size,
-            page_cache_size,
-            items_per_section,
-            write_buffer,
-        )
+    fn config(partition: &str, pooler: &impl BufferPooler, params: &Params) -> Self::Config {
+        FixedConfig {
+            partition: partition.into(),
+            items_per_blob: NZU64!(params.items_per_section),
+            page_cache: commonware_runtime::buffer::paged::CacheRef::from_pooler(
+                pooler,
+                params.page_size,
+                params.page_cache_size,
+            ),
+            write_buffer: params.write_buffer,
+        }
     }
 
-    async fn init(
-        ctx: deterministic::Context,
-        cfg: Self::Config,
-    ) -> Result<Self, commonware_storage::journal::Error> {
+    async fn init(ctx: deterministic::Context, cfg: Self::Config) -> Result<Self, Error> {
         FixedJournal::init(ctx, cfg).await
     }
 
@@ -247,52 +311,51 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::size(self).await
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
+    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
     #[allow(clippy::manual_async_fn)]
     fn bounds(&self) -> impl Future<Output = Range<u64>> + Send {
         async { self.reader().await.bounds() }
     }
 
-    async fn append(&mut self, item: Item) -> Result<u64, commonware_storage::journal::Error> {
+    async fn append(&mut self, item: Item) -> Result<u64, Error> {
         FixedJournal::append(self, &item).await
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
+    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
     #[allow(clippy::manual_async_fn)]
-    fn read(
-        &self,
-        pos: u64,
-    ) -> impl Future<Output = Result<Item, commonware_storage::journal::Error>> + Send {
+    fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send {
         async move { self.reader().await.read(pos).await }
     }
 
-    async fn sync(&mut self) -> Result<(), commonware_storage::journal::Error> {
+    async fn sync(&mut self) -> Result<(), Error> {
         FixedJournal::sync(self).await
     }
 
-    async fn rewind(&mut self, size: u64) -> Result<(), commonware_storage::journal::Error> {
+    async fn commit(&mut self) -> Result<(), Error> {
+        // Unlike `sync`, `commit` flushes without advancing the watermark, so recovery must walk
+        // blob lengths; exercise that path here.
+        FixedJournal::commit(self).await
+    }
+
+    async fn rewind(&mut self, size: u64) -> Result<(), Error> {
         FixedJournal::rewind(self, size).await
     }
 
-    async fn prune(&mut self, min_pos: u64) -> Result<bool, commonware_storage::journal::Error> {
+    async fn prune(&mut self, min_pos: u64) -> Result<bool, Error> {
         FixedJournal::prune(self, min_pos).await
     }
 
-    async fn replay(
-        &mut self,
+    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
+    #[allow(clippy::manual_async_fn)]
+    fn replay(
+        &self,
         buffer: NonZeroUsize,
         start_pos: u64,
-    ) -> Result<(), commonware_storage::journal::Error> {
-        let _ = self.reader().await.replay(buffer, start_pos).await?;
-        Ok(())
+    ) -> impl Future<Output = Result<Vec<(u64, Item)>, Error>> + Send {
+        async move { collect_replay(self.reader().await, buffer, start_pos).await }
     }
 
-    async fn commit(&mut self) -> Result<(), commonware_storage::journal::Error> {
-        // Fixed journal doesn't have commit; call sync instead
-        self.sync().await
-    }
-
-    async fn destroy(self) -> Result<(), commonware_storage::journal::Error> {
+    async fn destroy(self) -> Result<(), Error> {
         FixedJournal::destroy(self).await
     }
 }
@@ -300,28 +363,22 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
 impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
     type Config = VariableConfig<()>;
 
-    fn config(
-        partition: &str,
-        pooler: &impl BufferPooler,
-        page_size: NonZeroU16,
-        page_cache_size: NonZeroUsize,
-        items_per_section: u64,
-        write_buffer: NonZeroUsize,
-    ) -> Self::Config {
-        variable_config(
-            partition,
-            pooler,
-            page_size,
-            page_cache_size,
-            items_per_section,
-            write_buffer,
-        )
+    fn config(partition: &str, pooler: &impl BufferPooler, params: &Params) -> Self::Config {
+        VariableConfig {
+            partition: partition.into(),
+            items_per_section: NZU64!(params.items_per_section),
+            compression: None,
+            codec_config: (),
+            page_cache: commonware_runtime::buffer::paged::CacheRef::from_pooler(
+                pooler,
+                params.page_size,
+                params.page_cache_size,
+            ),
+            write_buffer: params.write_buffer,
+        }
     }
 
-    async fn init(
-        ctx: deterministic::Context,
-        cfg: Self::Config,
-    ) -> Result<Self, commonware_storage::journal::Error> {
+    async fn init(ctx: deterministic::Context, cfg: Self::Config) -> Result<Self, Error> {
         VariableJournal::init(ctx, cfg).await
     }
 
@@ -329,295 +386,477 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::size(self).await
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
+    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
     #[allow(clippy::manual_async_fn)]
     fn bounds(&self) -> impl Future<Output = Range<u64>> + Send {
         async { self.reader().await.bounds() }
     }
 
-    async fn append(&mut self, item: Item) -> Result<u64, commonware_storage::journal::Error> {
+    async fn append(&mut self, item: Item) -> Result<u64, Error> {
         VariableJournal::append(self, &item).await
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
+    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
     #[allow(clippy::manual_async_fn)]
-    fn read(
-        &self,
-        pos: u64,
-    ) -> impl Future<Output = Result<Item, commonware_storage::journal::Error>> + Send {
+    fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send {
         async move { self.reader().await.read(pos).await }
     }
 
-    async fn sync(&mut self) -> Result<(), commonware_storage::journal::Error> {
+    async fn sync(&mut self) -> Result<(), Error> {
         VariableJournal::sync(self).await
     }
 
-    async fn rewind(&mut self, size: u64) -> Result<(), commonware_storage::journal::Error> {
-        VariableJournal::rewind(self, size).await
-    }
-
-    async fn prune(&mut self, min_pos: u64) -> Result<bool, commonware_storage::journal::Error> {
-        VariableJournal::prune(self, min_pos).await
-    }
-
-    async fn replay(
-        &mut self,
-        buffer: NonZeroUsize,
-        start_pos: u64,
-    ) -> Result<(), commonware_storage::journal::Error> {
-        let _ = self.reader().await.replay(buffer, start_pos).await?;
-        Ok(())
-    }
-
-    async fn commit(&mut self) -> Result<(), commonware_storage::journal::Error> {
+    async fn commit(&mut self) -> Result<(), Error> {
         VariableJournal::commit(self).await
     }
 
-    async fn destroy(self) -> Result<(), commonware_storage::journal::Error> {
+    async fn rewind(&mut self, size: u64) -> Result<(), Error> {
+        VariableJournal::rewind(self, size).await
+    }
+
+    async fn prune(&mut self, min_pos: u64) -> Result<bool, Error> {
+        VariableJournal::prune(self, min_pos).await
+    }
+
+    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
+    #[allow(clippy::manual_async_fn)]
+    fn replay(
+        &self,
+        buffer: NonZeroUsize,
+        start_pos: u64,
+    ) -> impl Future<Output = Result<Vec<(u64, Item)>, Error>> + Send {
+        async move { collect_replay(self.reader().await, buffer, start_pos).await }
+    }
+
+    async fn destroy(self) -> Result<(), Error> {
         VariableJournal::destroy(self).await
     }
 }
 
-async fn run_operations<J: FuzzJournal>(
-    journal: &mut J,
-    operations: &[JournalOperation],
-) -> (u64, u64, u64, u64) {
-    let mut min_expected_size = 0u64;
-    let mut max_expected_size = journal.size().await;
-    let mut min_expected_oldest = 0u64;
-    let mut max_expected_oldest = journal.bounds().await.start;
+/// Drain a reader's replay stream into a `(position, item)` vector.
+async fn collect_replay<R: Reader<Item = Item>>(
+    reader: R,
+    buffer: NonZeroUsize,
+    start_pos: u64,
+) -> Result<Vec<(u64, Item)>, Error> {
+    let stream = reader.replay(buffer, start_pos).await?;
+    futures::pin_mut!(stream);
+    let mut out = Vec::new();
+    while let Some(result) = stream.next().await {
+        out.push(result?);
+    }
+    Ok(out)
+}
 
-    for op in operations.iter() {
-        let step_result: Result<(), ()> = match op {
+/// Split the operation stream into one segment per crash cycle, cutting at each `Crash` marker.
+/// Always returns at least one segment (possibly empty), so a bare recovery is still exercised.
+fn split_segments(ops: &[JournalOperation]) -> Vec<Vec<JournalOperation>> {
+    let mut segments = Vec::new();
+    let mut current = Vec::new();
+    for op in ops {
+        if matches!(op, JournalOperation::Crash) {
+            segments.push(std::mem::take(&mut current));
+        } else {
+            current.push(op.clone());
+        }
+    }
+    segments.push(current);
+    segments
+}
+
+/// Verify the recovered journal matches the model carried from the previous (crashed) segment.
+async fn verify_recovery<J: FuzzJournal>(journal: &J, model: &Model) {
+    let Range {
+        start: boundary,
+        end: size,
+    } = journal.bounds().await;
+    assert!(size >= boundary, "size {size} < boundary {boundary}");
+
+    // Size and boundary fall within the modeled bounds.
+    assert!(
+        size >= model.durable_len,
+        "recovered size {size} < durable_len {}",
+        model.durable_len
+    );
+    assert!(
+        size <= model.max_size,
+        "recovered size {size} > max_size {}",
+        model.max_size
+    );
+    assert!(
+        boundary >= model.durable_prune,
+        "recovered boundary {boundary} < durable_prune {}",
+        model.durable_prune
+    );
+    assert!(
+        boundary <= model.max_prune,
+        "recovered boundary {boundary} > max_prune {}",
+        model.max_prune
+    );
+
+    // Below the recovered boundary every position is pruned, so reads must return `ItemPruned`.
+    // Using the actual boundary (not the model's `durable_prune` floor) makes the pruned vs.
+    // in-bounds split exact, so the loop below can require everything in bounds to be readable.
+    for pos in 0..boundary {
+        match journal.read(pos).await {
+            Err(Error::ItemPruned(_)) => {}
+            other => panic!("expected ItemPruned below boundary at {pos}, got {other:?}"),
+        }
+    }
+
+    // Within bounds [boundary, size) every position must be readable (never pruned). Content is
+    // pinned to the model for the durable prefix; the volatile tail is readable but its content is
+    // unconstrained (torn writes / unsynced rewind). Reads are collected for the replay cross-check.
+    let mut read_items = Vec::with_capacity((size - boundary) as usize);
+    for pos in boundary..size {
+        let item = journal
+            .read(pos)
+            .await
+            .unwrap_or_else(|e| panic!("in-bounds pos {pos} unreadable: {e:?}"));
+        if pos < model.durable_len {
+            assert_eq!(
+                item, model.values[pos as usize],
+                "content mismatch at durable pos {pos}"
+            );
+        }
+        read_items.push(item);
+    }
+
+    // Replay must yield exactly [boundary, size) contiguously and agree with `read()` at every
+    // position. The cross-check covers the whole range, including the volatile tail where neither
+    // path is checked against the model, so a read/replay divergence cannot slip through.
+    let items = journal
+        .replay(NZUsize!(VERIFY_REPLAY_BUF), boundary)
+        .await
+        .expect("replay during recovery verification");
+    assert_eq!(
+        items.len() as u64,
+        size - boundary,
+        "replay returned {} items but bounds are [{boundary}, {size})",
+        items.len()
+    );
+    for (i, (pos, item)) in items.iter().enumerate() {
+        let expected = boundary + i as u64;
+        assert_eq!(
+            *pos, expected,
+            "replay non-contiguous: got {pos}, expected {expected}"
+        );
+        assert_eq!(*item, read_items[i], "replay/read divergence at {pos}");
+    }
+}
+
+/// Re-baseline the model to the now-on-disk recovered state. The recovered data came from disk and
+/// is durable against the next unclean drop (except where a later rewind/prune/torn-append touches
+/// it, which the per-op update rules handle).
+async fn rebaseline<J: FuzzJournal>(journal: &J) -> Model {
+    let bounds = journal.bounds().await;
+    let items = journal
+        .replay(NZUsize!(VERIFY_REPLAY_BUF), bounds.start)
+        .await
+        .expect("rebaseline replay");
+    let mut values = vec![Item::from([0u8; ITEM_SIZE]); bounds.end as usize];
+    for (pos, item) in items {
+        values[pos as usize] = item;
+    }
+    Model {
+        durable_len: bounds.end,
+        max_size: bounds.end,
+        durable_prune: bounds.start,
+        max_prune: bounds.start,
+        values,
+    }
+}
+
+/// Confirm the journal is usable after opening by appending a sentinel and reading it back. Runs
+/// fault-free, so it must succeed; the sentinel is unsynced, so it only widens the size ceiling.
+async fn prove_usable<J: FuzzJournal>(journal: &mut J, model: &mut Model) {
+    let size = journal.size().await;
+    let sentinel = Item::from([0xCDu8; ITEM_SIZE]);
+    let pos = journal
+        .append(sentinel.clone())
+        .await
+        .expect("append after open");
+    assert_eq!(pos, size, "post-open append at wrong position");
+    assert_eq!(
+        journal.read(pos).await.expect("read sentinel"),
+        sentinel,
+        "sentinel readback mismatch"
+    );
+    model.appended(sentinel);
+}
+
+/// Check a read/replay of an in-range position, returning whether the segment stays alive. `Ok` is
+/// fine; an I/O fault (e.g. a failed internal flush) may have left the journal inconsistent, so the
+/// segment ends. `ItemPruned`/`ItemOutOfRange` can't happen in range, so it means a broken `Reader`
+/// contract and panics.
+fn in_range_probe<T>(result: Result<T, Error>, pos: u64, bounds: &Range<u64>) -> bool {
+    match result {
+        Ok(_) => true,
+        Err(e @ (Error::ItemPruned(_) | Error::ItemOutOfRange(_))) => panic!(
+            "in-bounds access at {pos} ([{}, {})) returned {e:?}",
+            bounds.start, bounds.end
+        ),
+        Err(_) => false,
+    }
+}
+
+/// Check a read/replay of an arbitrary position. Success, or a validation error that did no I/O
+/// (`ItemPruned`/`ItemOutOfRange`), keeps the segment alive; any other error is an I/O fault that
+/// may have left the journal inconsistent, so the segment ends.
+fn raw_probe<T>(result: Result<T, Error>) -> bool {
+    matches!(
+        result,
+        Ok(_) | Err(Error::ItemPruned(_)) | Err(Error::ItemOutOfRange(_))
+    )
+}
+
+/// Run the segment's ops under faults, updating `model`. Stops early if an op may have left the
+/// journal inconsistent (any mutable error, or an in-range read/replay that hit an I/O fault); the
+/// caller then drops the journal to simulate the crash.
+async fn run_segment<J: FuzzJournal>(
+    journal: &mut J,
+    model: &mut Model,
+    ops: &[JournalOperation],
+    params: Params,
+) {
+    for op in ops {
+        // `alive` becomes false once an op may have left the journal inconsistent; the segment ends.
+        let alive = match op {
             JournalOperation::Append { value } => {
+                let item = Item::from(*value);
                 let size_before = journal.size().await;
-                if journal.append(Item::from(*value)).await.is_err() {
-                    max_expected_size = max_expected_size.max(size_before + 1);
-                    Err(())
-                } else {
-                    max_expected_size = max_expected_size.max(journal.size().await);
-                    Ok(())
+                match journal.append(item.clone()).await {
+                    Ok(pos) => {
+                        assert_eq!(pos, size_before, "append returned non-contiguous position");
+                        model.appended(item);
+                        true
+                    }
+                    Err(_) => {
+                        model.append_failed(size_before);
+                        false
+                    }
                 }
             }
 
             JournalOperation::Read { pos } => {
-                let _ = journal.read(*pos).await;
-                Ok(())
+                // An in-range read must succeed; the raw read also exercises the out-of-range and
+                // pruned paths.
+                let bounds = journal.bounds().await;
+                let mut alive = true;
+                if !bounds.is_empty() {
+                    let target = bounds.start + (*pos % (bounds.end - bounds.start));
+                    alive = in_range_probe(journal.read(target).await, target, &bounds);
+                }
+                if alive {
+                    alive = raw_probe(journal.read(*pos).await);
+                }
+                alive
             }
 
-            JournalOperation::Sync => {
-                if journal.sync().await.is_err() {
-                    Err(())
-                } else {
-                    let size = journal.size().await;
-                    min_expected_size = size;
-                    max_expected_size = max_expected_size.max(size);
-                    let oldest = journal.bounds().await.start;
-                    min_expected_oldest = oldest;
-                    max_expected_oldest = max_expected_oldest.max(oldest);
-                    Ok(())
+            JournalOperation::Sync => match journal.sync().await {
+                Ok(()) => {
+                    model.synced(journal.bounds().await);
+                    true
                 }
-            }
-
-            JournalOperation::Rewind { size } => {
-                let prev_size = journal.size().await;
-                if *size >= prev_size {
-                    Ok(())
-                } else if journal.rewind(*size).await.is_err() {
-                    min_expected_size = min_expected_size.min(*size);
-                    Err(())
-                } else {
-                    min_expected_size = min_expected_size.min(*size);
-                    Ok(())
-                }
-            }
-
-            JournalOperation::Prune { min_pos } => match journal.prune(*min_pos).await {
-                Err(_) => {
-                    max_expected_oldest =
-                        max_expected_oldest.max((*min_pos).min(journal.size().await));
-                    Err(())
-                }
-                Ok(false) => Ok(()),
-                Ok(true) => {
-                    let new_oldest = journal.bounds().await.start;
-                    min_expected_oldest = new_oldest;
-                    max_expected_oldest = new_oldest;
-                    Ok(())
-                }
+                Err(_) => false,
             },
 
-            JournalOperation::Replay { buffer, start_pos } => {
-                // Replay may internally do a write so failure should be treated as fatal
-                if journal.replay(NZUsize!(*buffer), *start_pos).await.is_err() {
-                    Err(())
+            JournalOperation::Commit => match journal.commit().await {
+                Ok(()) => {
+                    model.committed(journal.size().await);
+                    true
+                }
+                Err(_) => false,
+            },
+
+            JournalOperation::Rewind { size } => {
+                let bounds = journal.bounds().await;
+                if bounds.is_empty() {
+                    true
                 } else {
-                    Ok(())
+                    // Usually clamp to a retained position in [start, end]; occasionally pass the raw
+                    // value to exercise the validation paths (target past the end, or below the
+                    // pruning boundary).
+                    let target = if *size % 8 == 0 {
+                        *size
+                    } else {
+                        bounds.start + (*size % (bounds.end - bounds.start + 1))
+                    };
+                    match journal.rewind(target).await {
+                        Ok(()) => {
+                            // Rewound to `target`; the truncated tail may or may not persist.
+                            model.rewound(target, bounds.end);
+                            model.values.truncate(target as usize);
+                            true
+                        }
+                        // Validation error (target out of range): rejected before any mutation, so
+                        // the journal is unchanged and the model must stay put (lowering durable_len
+                        // would mask later loss of still-durable data).
+                        Err(Error::InvalidRewind(_)) | Err(Error::ItemPruned(_)) => true,
+                        // I/O fault mid-truncation: data above `target` may be lost, so lower
+                        // durable_len conservatively and end the segment.
+                        Err(_) => {
+                            model.rewound(target.min(bounds.end), bounds.end);
+                            false
+                        }
+                    }
                 }
             }
 
-            JournalOperation::Commit => {
-                if journal.commit().await.is_err() {
-                    Err(())
-                } else {
-                    let size = journal.size().await;
-                    min_expected_size = size;
-                    max_expected_size = size;
-                    let oldest = journal.bounds().await.start;
-                    min_expected_oldest = oldest;
-                    max_expected_oldest = oldest;
-                    Ok(())
+            JournalOperation::Prune { min_pos } => {
+                // Pass the raw position: `prune` caps it to the size internally, so this also covers
+                // the prune-past-size path. The capped target bounds how far the boundary can move.
+                let size = journal.size().await;
+                match journal.prune(*min_pos).await {
+                    Ok(_) => {
+                        model.pruned(journal.bounds().await.start);
+                        true
+                    }
+                    Err(_) => {
+                        // Pruning removes whole sections, so a failed prune can advance the boundary
+                        // at most to the section-aligned floor of the capped target.
+                        let capped = (*min_pos).min(size);
+                        let section_floor =
+                            capped / params.items_per_section * params.items_per_section;
+                        model.pruned(section_floor);
+                        false
+                    }
                 }
             }
+
+            JournalOperation::Replay { buffer, start_pos } => {
+                // Same contract as `Read`: the clamped (in-range) replay must succeed; the raw replay
+                // probes the validation paths.
+                let bounds = journal.bounds().await;
+                let clamped = bounds.start + (*start_pos % (bounds.end - bounds.start + 1));
+                let mut alive = in_range_probe(
+                    journal.replay(NZUsize!(*buffer), clamped).await,
+                    clamped,
+                    &bounds,
+                );
+                if alive {
+                    alive = raw_probe(journal.replay(NZUsize!(*buffer), *start_pos).await);
+                }
+                alive
+            }
+
+            // `split_segments` strips `Crash`; treat a stray one defensively as ending the segment.
+            JournalOperation::Crash => false,
         };
 
-        if step_result.is_err() {
+        if !alive {
             break;
         }
     }
-
-    (
-        min_expected_size,
-        max_expected_size,
-        min_expected_oldest,
-        max_expected_oldest,
-    )
 }
 
-async fn verify_recovery<J: FuzzJournal>(
-    journal: &mut J,
-    min_expected_size: u64,
-    max_expected_size: u64,
-    min_expected_oldest: u64,
-    max_expected_oldest: u64,
-) {
-    let size = journal.size().await;
-    let oldest = journal.bounds().await.start;
-    assert!(size >= oldest);
-
-    assert!(
-        size <= max_expected_size,
-        "size {} > max {}",
-        size,
-        max_expected_size
-    );
-    assert!(
-        size >= min_expected_size,
-        "size {} < min {}",
-        size,
-        min_expected_size
-    );
-
-    assert!(oldest >= min_expected_oldest);
-    assert!(oldest <= max_expected_oldest);
-
-    // Verify we can append new data after recovery
-    let test_value = [0xABu8; ITEM_SIZE];
-    let new_pos = journal
-        .append(Item::from(test_value))
-        .await
-        .expect("Should be able to append after recovery");
-    assert_eq!(new_pos, size);
-}
-
-fn fuzz_journal<J: FuzzJournal + Send + 'static>(input: &FuzzInput, partition_prefix: &str)
+/// Run one crash cycle: recover via `init`, verify the recovered state matches the model
+/// carried from the prior crash, re-baseline, prove the journal still works, then run the segment
+/// under faults and crash (drop). Returns the updated model and a checkpoint for the next cycle.
+fn run_cycle<J: FuzzJournal + Send + 'static>(
+    runner: deterministic::Runner,
+    incoming: Model,
+    ops: Vec<JournalOperation>,
+    partition: String,
+    params: Params,
+) -> (Model, deterministic::Checkpoint)
 where
     J::Config: Send,
 {
-    let page_size = NonZeroU16::new(input.page_size).unwrap();
-    let page_cache_size = NonZeroUsize::new(input.page_cache_size).unwrap();
-    let items_per_section = input.items_per_section;
-    let write_buffer = NonZeroUsize::new(input.write_buffer).unwrap();
-    let cfg = deterministic::Config::default().with_seed(input.seed);
-    let partition_name = format!("{}-{}", partition_prefix, input.seed);
-    let runner = deterministic::Runner::new(cfg);
-    let operations = input.operations.clone();
-    let sync_failure_rate = input.sync_failure_rate;
-    let write_failure_rate = input.write_failure_rate;
-
-    let (
-        (min_expected_size, max_expected_size, min_expected_oldest, max_expected_oldest),
-        checkpoint,
-    ) = runner.start_and_recover(|ctx| {
-        let partition_name = partition_name.clone();
-        let operations = operations.clone();
-        async move {
-            let mut journal = J::init(
-                ctx.child("journal"),
-                J::config(
-                    &partition_name,
-                    &ctx,
-                    page_size,
-                    page_cache_size,
-                    items_per_section,
-                    write_buffer,
-                ),
-            )
-            .await
-            .unwrap();
-
-            let storage_fault_cfg = ctx.storage_fault_config();
-            *storage_fault_cfg.write() = deterministic::FaultConfig {
-                sync_rate: Some(sync_failure_rate),
-                write_rate: Some(write_failure_rate),
-                ..Default::default()
-            };
-
-            run_operations(&mut journal, &operations).await
-        }
-    });
-
-    let runner = deterministic::Runner::from(checkpoint);
-    runner.start(|ctx| async move {
+    runner.start_and_recover(move |ctx| async move {
+        // Recover with faults disabled to obtain clean ground truth.
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
+        let cfg = J::config(&partition, &ctx, &params);
+        let mut journal = J::init(ctx.child("journal"), cfg)
+            .await
+            .expect("recovery should succeed without panic");
+        // The recovered state must match what the previous cycle left durable.
+        verify_recovery(&journal, &incoming).await;
 
+        let mut model = rebaseline(&journal).await;
+        prove_usable(&mut journal, &mut model).await;
+
+        // Enable faults for the operation phase, then drop the journal at the end (the crash).
+        *ctx.storage_fault_config().write() = params.fault_config();
+        run_segment(&mut journal, &mut model, &ops, params).await;
+        model
+    })
+}
+
+fn run<J: FuzzJournal + Send + 'static>(input: &FuzzInput, tag: &str)
+where
+    J::Config: Send,
+{
+    let params = Params {
+        page_size: NonZeroU16::new(input.page_size).unwrap(),
+        page_cache_size: NonZeroUsize::new(input.page_cache_size).unwrap(),
+        items_per_section: input.items_per_section,
+        write_buffer: NonZeroUsize::new(input.write_buffer).unwrap(),
+        write_rate: input.write_failure_rate,
+        partial_write_rate: input.partial_write_rate,
+        sync_rate: input.sync_failure_rate,
+        resize_rate: input.resize_failure_rate,
+        partial_resize_rate: input.partial_resize_rate,
+    };
+    let partition = format!("crash-recovery-{tag}-{}", input.seed);
+    let segments = split_segments(&input.operations);
+
+    // First cycle starts from a fresh runtime, recovers an empty journal, and the model is empty.
+    let runner = deterministic::Runner::new(deterministic::Config::default().with_seed(input.seed));
+    let (mut model, mut checkpoint) = run_cycle::<J>(
+        runner,
+        Model::default(),
+        segments[0].clone(),
+        partition.clone(),
+        params,
+    );
+
+    // Each later cycle recovers from the previous crash and runs its ops, then crashes again.
+    for ops in segments.iter().skip(1) {
+        let runner = deterministic::Runner::from(checkpoint);
+        (model, checkpoint) = run_cycle::<J>(
+            runner,
+            model.clone(),
+            ops.clone(),
+            partition.clone(),
+            params,
+        );
+    }
+
+    // Final fault-free recovery: full verification, a clean durable round-trip, then cleanup.
+    deterministic::Runner::from(checkpoint).start(move |ctx| async move {
+        *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
         let mut journal = J::init(
-            ctx.child("recovered"),
-            J::config(
-                &partition_name,
-                &ctx,
-                page_size,
-                page_cache_size,
-                items_per_section,
-                write_buffer,
-            ),
+            ctx.child("journal_final"),
+            J::config(&partition, &ctx, &params),
         )
         .await
-        .expect("Journal recovery should succeed without panic");
+        .expect("final recovery should succeed");
 
-        verify_recovery(
-            &mut journal,
-            min_expected_size,
-            max_expected_size,
-            min_expected_oldest,
-            max_expected_oldest,
-        )
-        .await;
+        verify_recovery(&journal, &model).await;
 
-        journal
-            .destroy()
+        let size = journal.size().await;
+        let sentinel = Item::from([0xEFu8; ITEM_SIZE]);
+        let pos = journal
+            .append(sentinel.clone())
             .await
-            .expect("Should be able to destroy journal");
+            .expect("final append");
+        assert_eq!(pos, size);
+        journal.sync().await.expect("final sync");
+        assert_eq!(
+            journal.read(pos).await.expect("final read"),
+            sentinel,
+            "final sentinel readback mismatch"
+        );
+        journal.destroy().await.expect("destroy");
     });
 }
 
 fn fuzz(input: FuzzInput) {
-    if input.operations.is_empty() {
-        return;
-    }
-
     match input.journal_type {
-        JournalType::Fixed => {
-            fuzz_journal::<FixedJournal<deterministic::Context, Item>>(
-                &input,
-                "fixed-crash-recovery",
-            );
-        }
+        JournalType::Fixed => run::<FixedJournal<deterministic::Context, Item>>(&input, "fixed"),
         JournalType::Variable => {
-            fuzz_journal::<VariableJournal<deterministic::Context, Item>>(
-                &input,
-                "variable-crash-recovery",
-            );
+            run::<VariableJournal<deterministic::Context, Item>>(&input, "variable")
         }
     }
 }

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -1,38 +1,37 @@
 #![no_main]
 
-//! Fuzz target for crash recovery of the contiguous journals (fixed and variable).
+//! Fuzz target contiguous journal crash recovery.
 //!
 //! A journal is an append-only log of items. Appends are buffered; `sync` and `commit` push data
 //! to storage, and an unclean shutdown loses anything not yet durable. On the next `init()` the
-//! journal must rebuild a consistent state from whatever survived. This target stresses that
-//! rebuild under storage faults.
+//! journal must rebuild a consistent state from whatever survived. This target tests recovering
+//! after storage faults.
 //!
 //! # Cycles
 //!
-//! One fuzz input drives a single journal through a series of *cycles*. A cycle is one
-//! crash-and-recover round:
-//!   1. `init()` recovers the journal left behind by the previous cycle's crash.
-//!   2. Check the recovered journal against the `Expected` carried over from that crash.
+//! One fuzz input drives a single journal through a series of *cycles*, each one crash-and-recover
+//! round:
+//!   1. `init()` recovers the journal left by the previous cycle's crash.
+//!   2. Check it against the `Expected` carried from that crash.
 //!   3. Append and query under fault injection (the cycle's `ops`).
-//!   4. Drop the journal without a clean shutdown. That is the crash: unsynced data is lost.
+//!   4. Drop the journal without a clean shutdown: the crash. Unsynced data is lost.
 //!
-//! The fuzzer's operation list is split at `Crash` markers, giving one `ops` list per cycle.
-//! Repeating this on the same journal is the point: bugs in the recovery watermark, pruning
-//! metadata, or section layout tend to surface only after a journal has been recovered, mutated,
-//! and crashed several times over, not on the first crash.
+//! The op list is split at `Crash` markers, one `ops` list per cycle. Repeating on the same journal
+//! is the point: watermark, pruning-metadata, and section-layout bugs tend to surface only after
+//! several recover-mutate-crash rounds, not on the first crash.
 //!
 //! # Expected
 //!
-//! A crash can land anywhere in a range of outcomes, so `Expected` tracks conservative bounds (a
-//! guaranteed-durable prefix plus size/pruning ceilings) rather than an exact state.
-//! `assert_matches_expected` checks recovery lands within them; `observe` then reads the now-known
-//! state back as the next cycle's starting point.
+//! A crash can land anywhere in a range, so `Expected` tracks conservative bounds (a
+//! guaranteed-durable prefix plus size/pruning ceilings), not an exact state.
+//! `assert_matches_expected` checks recovery falls within them; `observe` then snapshots it as the
+//! next cycle's start.
 //!
 //! # Faults
 //!
 //! The operation phase runs under write/sync/resize fault injection. The torn-write modes
-//! (`partial_write_rate`, `partial_resize_rate`) cut a write or truncation off partway, leaving the
-//! half-finished bytes a real crash would leave behind for recovery to sort out.
+//! (`partial_write_rate`, `partial_resize_rate`) cut a write or truncation short, leaving the
+//! half-finished bytes a real crash would.
 
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_runtime::{deterministic, BufferPooler, Runner, Supervisor as _};
@@ -113,14 +112,14 @@ enum JournalType {
     Variable,
 }
 
-/// Operations applied to the journal within a cycle.
+/// Operations that can be performed on the journal.
 #[derive(Arbitrary, Debug, Clone)]
 enum JournalOperation {
     /// Append a single item to the journal.
     Append { value: [u8; ITEM_SIZE] },
     /// Read an item at a specific position.
     Read { pos: u64 },
-    /// Sync the journal to storage (durability checkpoint).
+    /// Sync the journal to storage.
     Sync,
     /// Flush pending data without advancing the recovery watermark, so recovery walks blob lengths.
     Commit,
@@ -269,8 +268,7 @@ impl Expected {
     }
 }
 
-/// Abstracts over fixed and variable journals. `read` and `replay` return their items so content
-/// can be verified after recovery.
+/// Trait abstracting over fixed and variable journals for the fuzz test.
 trait FuzzJournal: Sized {
     type Config;
 
@@ -291,7 +289,6 @@ trait FuzzJournal: Sized {
     fn rewind(&mut self, size: u64) -> impl Future<Output = Result<(), Error>> + Send;
     fn prune(&mut self, min_pos: u64) -> impl Future<Output = Result<bool, Error>> + Send;
 
-    /// Replay from `start_pos`, returning all `(position, item)` pairs.
     fn replay(
         &self,
         buffer: NonZeroUsize,
@@ -340,7 +337,7 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::size(self).await
     }
 
-    // `async fn` can't add the `+ Send` bound here (RPITIT).
+    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
     #[allow(clippy::manual_async_fn)]
     fn bounds(&self) -> impl Future<Output = Range<u64>> + Send {
         async { self.reader().await.bounds() }
@@ -350,7 +347,7 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::append(self, &item).await
     }
 
-    // `async fn` can't add the `+ Send` bound here (RPITIT).
+    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
     #[allow(clippy::manual_async_fn)]
     fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send {
         async move { self.reader().await.read(pos).await }
@@ -372,7 +369,7 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::prune(self, min_pos).await
     }
 
-    // `async fn` can't add the `+ Send` bound here (RPITIT).
+    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
     #[allow(clippy::manual_async_fn)]
     fn replay(
         &self,
@@ -413,7 +410,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::size(self).await
     }
 
-    // `async fn` can't add the `+ Send` bound here (RPITIT).
+    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
     #[allow(clippy::manual_async_fn)]
     fn bounds(&self) -> impl Future<Output = Range<u64>> + Send {
         async { self.reader().await.bounds() }
@@ -423,7 +420,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::append(self, &item).await
     }
 
-    // `async fn` can't add the `+ Send` bound here (RPITIT).
+    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
     #[allow(clippy::manual_async_fn)]
     fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send {
         async move { self.reader().await.read(pos).await }
@@ -431,10 +428,6 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
 
     async fn sync(&mut self) -> Result<(), Error> {
         VariableJournal::sync(self).await
-    }
-
-    async fn commit(&mut self) -> Result<(), Error> {
-        VariableJournal::commit(self).await
     }
 
     async fn rewind(&mut self, size: u64) -> Result<(), Error> {
@@ -445,7 +438,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::prune(self, min_pos).await
     }
 
-    // `async fn` can't add the `+ Send` bound here (RPITIT).
+    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
     #[allow(clippy::manual_async_fn)]
     fn replay(
         &self,
@@ -453,6 +446,10 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         start_pos: u64,
     ) -> impl Future<Output = Result<Vec<(u64, Item)>, Error>> + Send {
         async move { collect_replay(self.reader().await, buffer, start_pos).await }
+    }
+
+    async fn commit(&mut self) -> Result<(), Error> {
+        VariableJournal::commit(self).await
     }
 
     async fn destroy(self) -> Result<(), Error> {
@@ -796,11 +793,11 @@ async fn run_ops<J: FuzzJournal>(
     }
 }
 
-/// Run one crash cycle: recover, check against `incoming`, run the ops under faults, then crash
+/// Run one crash cycle: recover, check against `expected`, run the ops under faults, then crash
 /// (drop). Returns the `Expected` and checkpoint for the next cycle.
 fn run_cycle<J: FuzzJournal + Send + 'static>(
     runner: deterministic::Runner,
-    incoming: Expected,
+    expected: Expected,
     ops: Vec<JournalOperation>,
     partition: String,
     params: Params,
@@ -816,7 +813,7 @@ where
             .await
             .expect("recovery should succeed without panic");
         // The recovered state must match what the previous cycle left durable.
-        assert_matches_expected(&journal, &incoming).await;
+        assert_matches_expected(&journal, &expected).await;
 
         let mut expected = observe(&journal).await;
         assert_round_trip(&mut journal, &mut expected).await;

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -23,11 +23,10 @@
 //!
 //! # Expected
 //!
-//! A crash can land anywhere in a range of outcomes, so we cannot predict the exact recovered
-//! state. `Expected` instead tracks conservative bounds: a guaranteed-durable prefix plus ceilings
-//! on the size and pruning boundary. `assert_matches_expected` asserts the real recovery lands within them.
-//! Once it passes, the state is known exactly, so `observe` reads it back as the precise starting
-//! point for the next cycle.
+//! A crash can land anywhere in a range of outcomes, so `Expected` tracks conservative bounds (a
+//! guaranteed-durable prefix plus size/pruning ceilings) rather than an exact state.
+//! `assert_matches_expected` checks recovery lands within them; `observe` then reads the now-known
+//! state back as the next cycle's starting point.
 //!
 //! # Faults
 //!
@@ -208,18 +207,11 @@ impl Params {
     }
 }
 
-/// What a recovery is expected to produce after an unclean shutdown: a guaranteed-durable floor and
-/// conservative upper bounds.
-///
-/// The bounds are deliberately conservative, so every assertion in `assert_matches_expected` is sound under
-/// any fault/crash interleaving:
+/// Conservative bounds on what a recovery may produce after an unclean shutdown:
 /// - positions `[0, durable_prune)` are pruned (reads return `ItemPruned`),
-/// - positions `[max_prune, durable_len)` are present with the exact content `values[pos]`,
+/// - positions `[max_prune, durable_len)` hold the exact content `values[pos]`,
 /// - the recovered size is in `[durable_len, max_size]`,
-/// - the recovered pruning boundary is in `[durable_prune, max_prune]`,
-/// - `values.len()` tracks the in-memory size, so `values[pos]` is the latest value at `pos`.
-///
-/// The methods below are the per-operation update rules that maintain these invariants.
+/// - the recovered pruning boundary is in `[durable_prune, max_prune]`.
 #[derive(Clone, Default)]
 struct Expected {
     /// Guaranteed-durable prefix length; also the minimum recovered size.
@@ -235,20 +227,18 @@ struct Expected {
 }
 
 impl Expected {
-    /// A successful tail append. The item is not durable until the next sync/commit, so it only
-    /// raises the size ceiling.
+    /// Successful append: not durable until the next sync/commit, so only raise the ceiling.
     fn appended(&mut self, item: Item) {
         self.values.push(item);
         self.max_size = self.max_size.max(self.values.len() as u64);
     }
 
-    /// A failed append: the item may have partially persisted, so widen the size ceiling only.
+    /// Failed append: the item may have partially persisted, so only raise the ceiling.
     fn append_failed(&mut self, size_before: u64) {
         self.max_size = self.max_size.max(size_before + 1);
     }
 
-    /// Sync makes the whole in-memory state durable: size, content, and pruning boundary are all
-    /// pinned exactly.
+    /// Sync pins size, content, and pruning boundary exactly.
     fn synced(&mut self, bounds: Range<u64>) {
         self.durable_len = bounds.end;
         self.max_size = bounds.end;
@@ -256,32 +246,26 @@ impl Expected {
         self.max_prune = bounds.start;
     }
 
-    /// Commit makes appended data durable but not the pruning boundary, so pin only the size.
+    /// Commit pins the size but not the pruning boundary.
     fn committed(&mut self, size: u64) {
         self.durable_len = size;
         self.max_size = size;
     }
 
-    /// Rewind to `target`: data below `target` is untouched on disk, while the truncated tail may
-    /// or may not persist, so the recovered size ranges over `[target, prev_size]`.
+    /// Rewind: the truncated tail may or may not persist, so recovered size is in `[target, prev]`.
     fn rewound(&mut self, target: u64, prev_size: u64) {
         self.durable_len = self.durable_len.min(target);
         self.max_size = self.max_size.max(prev_size);
     }
 
-    /// A successful prune durably advances the pruning boundary to `boundary`. Pruning deletes whole
-    /// section blobs from storage (`context.remove`, not buffered behind a sync), and recovery
-    /// rebuilds the boundary forward from the surviving blobs, so a reopen can never resurrect data
-    /// below `boundary`. Pin the boundary exactly. (The boundary only moves forward, so this never
-    /// lowers `durable_prune`.)
+    /// Successful prune durably deletes whole sections, so recovery can never reopen below
+    /// `boundary`; pin it exactly. (The boundary only moves forward.)
     fn pruned(&mut self, boundary: u64) {
         self.durable_prune = boundary;
         self.max_prune = boundary;
     }
 
-    /// A failed prune may have deleted some sections before erroring (sections go oldest-first), so
-    /// the boundary may have advanced as far as `ceiling` but is not guaranteed to have moved. Raise
-    /// only the ceiling.
+    /// Failed prune may have deleted sections (oldest-first) up to `ceiling`, but not for certain.
     fn prune_failed(&mut self, ceiling: u64) {
         self.max_prune = self.max_prune.max(ceiling);
     }
@@ -379,8 +363,6 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
     }
 
     async fn commit(&mut self) -> Result<(), Error> {
-        // Unlike `sync`, `commit` flushes without advancing the watermark, so recovery must walk
-        // blob lengths; exercise that path here.
         FixedJournal::commit(self).await
     }
 
@@ -510,9 +492,7 @@ async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expecte
         expected.max_prune
     );
 
-    // Below the recovered boundary every position is pruned, so reads must return `ItemPruned`.
-    // Using the actual boundary (not the `durable_prune` floor) makes the pruned vs. in-bounds
-    // split exact, so the loop below can require everything in bounds to be readable.
+    // Below the boundary every position is pruned.
     for pos in 0..boundary {
         match journal.read(pos).await {
             Err(Error::ItemPruned(_)) => {}
@@ -520,9 +500,8 @@ async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expecte
         }
     }
 
-    // Within bounds [boundary, size) every position must be readable (never pruned). Content is
-    // pinned for the durable prefix; the volatile tail is readable but its content is unconstrained
-    // (torn writes / unsynced rewind). Reads are collected for the replay cross-check.
+    // Within [boundary, size) every position is readable; content is pinned only for the durable
+    // prefix. Reads are kept for the replay cross-check.
     let mut read_items = Vec::with_capacity((size - boundary) as usize);
     for pos in boundary..size {
         let item = journal
@@ -538,9 +517,7 @@ async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expecte
         read_items.push(item);
     }
 
-    // Replay must yield exactly [boundary, size) contiguously and agree with `read()` at every
-    // position. The cross-check covers the whole range, including the volatile tail where neither
-    // path is checked against `expected`, so a read/replay divergence cannot slip through.
+    // Replay must yield exactly [boundary, size) contiguously and agree with `read()` everywhere.
     let items = journal
         .replay(NZUsize!(VERIFY_REPLAY_BUF), boundary)
         .await
@@ -561,9 +538,7 @@ async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expecte
     }
 }
 
-/// Read the recovered journal back into an `Expected` describing exactly that state. The data is on
-/// disk and durable against the next unclean drop, except where a later rewind/prune/torn-append
-/// touches it (handled by the per-op update rules).
+/// Read the recovered journal back into an `Expected` pinned to exactly that state.
 async fn observe<J: FuzzJournal>(journal: &J) -> Expected {
     let bounds = journal.bounds().await;
     let items = journal
@@ -583,8 +558,8 @@ async fn observe<J: FuzzJournal>(journal: &J) -> Expected {
     }
 }
 
-/// Confirm the journal is usable after opening by appending a sentinel and reading it back. Runs
-/// fault-free, so it must succeed; the sentinel is unsynced, so it only widens the size ceiling.
+/// Confirm the journal accepts and reads back a sentinel after opening. Recorded as a ceiling-only
+/// append, not pinned: an unsynced append may flush durably, so recovery may or may not surface it.
 async fn assert_round_trip<J: FuzzJournal>(journal: &mut J, expected: &mut Expected) {
     let size = journal.size().await;
     let sentinel = Item::from([0xCDu8; ITEM_SIZE]);
@@ -601,15 +576,12 @@ async fn assert_round_trip<J: FuzzJournal>(journal: &mut J, expected: &mut Expec
     expected.appended(sentinel);
 }
 
-/// Check that `read(pos)` returned the right result for where `pos` sits, and panic if it did not.
-///
-/// Relative to the live range `bounds` (= `[start, end)`):
+/// Check `read(pos)` against `bounds` (= `[start, end)`), panicking on a wrong result:
 ///   - live (`start <= pos < end`) -> `Ok(item)`,
 ///   - pruned (`pos < start`)      -> `Err(ItemPruned)`,
 ///   - past the end (`pos >= end`) -> `Err(ItemOutOfRange)`.
 ///
-/// Anything else is a real bug: no read faults are injected and `read` is a pure lookup, so it
-/// cannot legitimately fail here (unlike `replay`, which repairs the tail). A bad read panics.
+/// No read faults are injected and `read` is a pure lookup, so any other result is a real bug.
 fn assert_read(result: Result<Item, Error>, pos: u64, bounds: &Range<u64>) {
     let ok = match &result {
         Ok(_) => bounds.contains(&pos),
@@ -624,15 +596,10 @@ fn assert_read(result: Result<Item, Error>, pos: u64, bounds: &Range<u64>) {
     );
 }
 
-/// Whether the cycle should continue after a raw `replay(start_pos)` at an arbitrary start.
-///
-/// `replay` validates the start before doing any I/O, so an out-of-range start is deterministic:
-///   - `start_pos < start` -> `Err(ItemPruned)`,
-///   - `start_pos > end`   -> `Err(ItemOutOfRange)` (`start_pos == end` is in range: an empty replay).
-///
-/// An in-range start either succeeds or hits a legitimate tail-repair I/O fault (`replay` resizes
-/// and syncs under faults); the fault ends the cycle. Success out of range, the wrong validation
-/// error, or a validation error for an in-range start is a bug, so panic.
+/// Whether the cycle continues after a raw `replay(start_pos)`. Validation precedes any I/O, so an
+/// out-of-range start is deterministic: `< start` -> `ItemPruned`, `> end` -> `ItemOutOfRange`
+/// (`== end` is in range). An in-range start succeeds or hits a tail-repair I/O fault (ends the
+/// cycle); any other result is a bug.
 fn should_continue_raw_replay(
     result: Result<Vec<(u64, Item)>, Error>,
     start_pos: u64,
@@ -655,8 +622,6 @@ fn should_continue_raw_replay(
 }
 
 /// Assert an in-bounds `replay(start)` returned the full contiguous suffix `[start, bounds.end)`.
-/// The `Append` write buffer serves replay from its logical view, so buffered (unsynced) tail items
-/// are included; the recovered length equals `bounds.end - start` exactly.
 fn assert_replay_suffix(items: &[(u64, Item)], start: u64, bounds: &Range<u64>) {
     assert_eq!(
         items.len() as u64,
@@ -703,10 +668,7 @@ async fn run_ops<J: FuzzJournal>(
             }
 
             JournalOperation::Read { pos } => {
-                // Exercise a guaranteed in-bounds read each cycle (the raw `pos` may be out of
-                // bounds), then the raw read to cover the pruned / out-of-range paths. Reads inject
-                // no faults and are pure lookups, so every outcome is determined by `bounds` and is
-                // asserted exactly; a read never ends the cycle.
+                // A guaranteed in-bounds read, then the raw read for the pruned/out-of-range paths.
                 let bounds = journal.bounds().await;
                 if !bounds.is_empty() {
                     let target = bounds.start + (*pos % (bounds.end - bounds.start));
@@ -737,9 +699,8 @@ async fn run_ops<J: FuzzJournal>(
                 if bounds.is_empty() {
                     true
                 } else {
-                    // Usually clamp to a retained position in [start, end], which is always a valid
-                    // rewind target; occasionally pass the raw value to exercise the validation
-                    // paths (target past the end, or below the pruning boundary).
+                    // Usually clamp to a valid retained target; occasionally pass the raw value to
+                    // exercise the validation paths.
                     let use_raw_target = *size % 8 == 0;
                     let target = if use_raw_target {
                         *size
@@ -753,11 +714,8 @@ async fn run_ops<J: FuzzJournal>(
                             expected.values.truncate(target as usize);
                             true
                         }
-                        // Validation error (target out of range): rejected before any mutation, so
-                        // the journal is unchanged and the expectation must stay put (lowering
-                        // durable_len would mask later loss of still-durable data). Only the raw
-                        // target can be invalid; a clamped target is always a retained position, so
-                        // a validation error there is a bug.
+                        // Validation error: rejected before any mutation, so leave the expectation
+                        // put. Only a raw target can be invalid; on a clamped target this is a bug.
                         Err(e @ (Error::InvalidRewind(_) | Error::ItemPruned(_))) => {
                             assert!(
                                 use_raw_target,
@@ -778,8 +736,7 @@ async fn run_ops<J: FuzzJournal>(
             }
 
             JournalOperation::Prune { min_pos } => {
-                // Pass the raw position: `prune` caps it to the size internally, so this also covers
-                // the prune-past-size path. The capped target bounds how far the boundary can move.
+                // Raw position: `prune` caps it to size internally, covering prune-past-size.
                 let size = journal.size().await;
                 match journal.prune(*min_pos).await {
                     Ok(_) => {
@@ -788,8 +745,7 @@ async fn run_ops<J: FuzzJournal>(
                         true
                     }
                     Err(_) => {
-                        // Pruning removes whole sections, so a failed prune can advance the boundary
-                        // at most to the section-aligned floor of the capped target.
+                        // A failed prune advances the boundary at most to the section floor.
                         let capped = (*min_pos).min(size);
                         let section_floor =
                             capped / params.items_per_section * params.items_per_section;
@@ -800,17 +756,14 @@ async fn run_ops<J: FuzzJournal>(
             }
 
             JournalOperation::Replay { buffer, start_pos } => {
-                // The clamped (in-bounds) replay must return the full contiguous suffix matching
-                // `read()`, or hit a legitimate tail-repair I/O fault; the raw replay probes the
-                // validation paths.
+                // The clamped (in-bounds) replay must return the full suffix matching `read()`, or
+                // hit a tail-repair I/O fault; the raw replay probes the validation paths.
                 let bounds = journal.bounds().await;
                 let clamped = bounds.start + (*start_pos % (bounds.end - bounds.start + 1));
                 let clamped_ok = match journal.replay(NZUsize!(*buffer), clamped).await {
                     Ok(items) => {
                         assert_replay_suffix(&items, clamped, &bounds);
-                        // Cross-check replay content against `read()` (reads are fault-free here),
-                        // so a start-dependent replay regression cannot pass as long as it returns
-                        // `Ok`.
+                        // Cross-check replay content against `read()`.
                         for (pos, item) in &items {
                             let via_read = journal.read(*pos).await.unwrap_or_else(|e| {
                                 panic!("read({pos}) cross-check during replay: {e:?}")
@@ -835,7 +788,7 @@ async fn run_ops<J: FuzzJournal>(
                     )
             }
 
-            // `split_into_cycles` strips `Crash`; treat a stray one defensively as ending the cycle.
+            // `split_into_cycles` strips `Crash`; a stray one defensively ends the cycle.
             JournalOperation::Crash => false,
         };
 
@@ -845,10 +798,8 @@ async fn run_ops<J: FuzzJournal>(
     }
 }
 
-/// Run one crash cycle: recover via `init`, verify the recovered state matches the `Expected`
-/// carried from the prior crash, `observe` the journal, prove it still works, then run the cycle's
-/// ops under faults and crash (drop). Returns the updated `Expected` and a checkpoint for the next
-/// cycle.
+/// Run one crash cycle: recover, check against `incoming`, run the ops under faults, then crash
+/// (drop). Returns the `Expected` and checkpoint for the next cycle.
 fn run_cycle<J: FuzzJournal + Send + 'static>(
     runner: deterministic::Runner,
     incoming: Expected,
@@ -936,7 +887,8 @@ where
         );
     }
 
-    // Final fault-free recovery: full verification, a clean durable round-trip, then cleanup.
+    // Final fault-free phase: verify the carried state recovers, then prove a synced round-trip is
+    // durable across an actual reopen (not just readable from the live handle), and clean up.
     deterministic::Runner::from(checkpoint).start(move |ctx| async move {
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
         let mut journal = J::init(
@@ -945,9 +897,10 @@ where
         )
         .await
         .expect("final recovery should succeed");
-
         assert_matches_expected(&journal, &expected).await;
 
+        // Append a sentinel and sync it, pinning the exact durable state.
+        let mut expected = observe(&journal).await;
         let size = journal.size().await;
         let sentinel = Item::from([0xEFu8; ITEM_SIZE]);
         let pos = journal
@@ -955,7 +908,19 @@ where
             .await
             .expect("final append");
         assert_eq!(pos, size);
+        expected.appended(sentinel.clone());
         journal.sync().await.expect("final sync");
+        expected.synced(journal.bounds().await);
+        drop(journal);
+
+        // Reopen and confirm the synced sentinel survived the restart.
+        let journal = J::init(
+            ctx.child("journal_final_verify"),
+            J::config(&partition, &ctx, &params),
+        )
+        .await
+        .expect("final reopen should succeed");
+        assert_matches_expected(&journal, &expected).await;
         assert_eq!(
             journal.read(pos).await.expect("final read"),
             sentinel,

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -1,18 +1,39 @@
 #![no_main]
 
-//! Fuzz test for journal crash recovery (both fixed and variable journals).
+//! Fuzz target for crash recovery of the contiguous journals (fixed and variable).
 //!
-//! Drives a journal through repeated unclean shutdowns. Each cycle:
-//!   1. recovers the journal from the previous (unclean) shutdown,
-//!   2. verifies the recovered state matches a model of what is durably guaranteed (exact item
-//!      content for the durable prefix, pruned positions error, size/boundary within bounds),
-//!   3. continues appending and querying, then
-//!   4. crashes again (faults + unclean drop, losing the in-memory write buffer).
+//! A journal is an append-only log of items. Appends are buffered; `sync` and `commit` push data
+//! to storage, and an unclean shutdown loses anything not yet durable. On the next `init()` the
+//! journal must rebuild a consistent state from whatever survived. This target stresses that
+//! rebuild under storage faults.
 //!
-//! Each cycle re-runs `init()` on a journal produced by a prior crash recovery, so any bug in the
-//! recovery watermark, pruning metadata, or section layout compounds across restarts. The
-//! operation phase runs under write/sync/resize fault injection, including the torn-write modes
-//! (`partial_write_rate`, `partial_resize_rate`) that model a real crash mid-write.
+//! # Cycles
+//!
+//! One fuzz input drives a single journal through a series of *cycles*. A cycle is one
+//! crash-and-recover round:
+//!   1. `init()` recovers the journal left behind by the previous cycle's crash.
+//!   2. Check the recovered journal against the `Expected` carried over from that crash.
+//!   3. Append and query under fault injection (the cycle's `ops`).
+//!   4. Drop the journal without a clean shutdown. That is the crash: unsynced data is lost.
+//!
+//! The fuzzer's operation list is split at `Crash` markers, giving one `ops` list per cycle.
+//! Repeating this on the same journal is the point: bugs in the recovery watermark, pruning
+//! metadata, or section layout tend to surface only after a journal has been recovered, mutated,
+//! and crashed several times over, not on the first crash.
+//!
+//! # Expected
+//!
+//! A crash can land anywhere in a range of outcomes, so we cannot predict the exact recovered
+//! state. `Expected` instead tracks conservative bounds: a guaranteed-durable prefix plus ceilings
+//! on the size and pruning boundary. `verify_recovery` asserts the real recovery lands within them.
+//! Once it passes, the state is known exactly, so `observe` reads it back as the precise starting
+//! point for the next cycle.
+//!
+//! # Faults
+//!
+//! The operation phase runs under write/sync/resize fault injection. The torn-write modes
+//! (`partial_write_rate`, `partial_resize_rate`) cut a write or truncation off partway, leaving the
+//! half-finished bytes a real crash would leave behind for recovery to sort out.
 
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_runtime::{deterministic, BufferPooler, Runner, Supervisor as _};
@@ -48,9 +69,9 @@ const MAX_WRITE_BUF: usize = 2048;
 /// Buffer size used for internal verification replays.
 const VERIFY_REPLAY_BUF: usize = 1024;
 
-/// Maximum number of operations per fuzz input. Bounds the number of crash cycles and the
-/// per-cycle verification/replay work so executions stay fast and `rebaseline`'s allocation stays
-/// small (total cost is ~O(cycles * size), both capped by this).
+/// Maximum number of operations per fuzz input. Bounds the number of crash cycles and the per-cycle
+/// verification/replay work so executions stay fast (total cost is ~O(cycles * size), both capped
+/// here).
 const MAX_OPERATIONS: usize = 128;
 
 fn bounded_non_zero(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
@@ -95,7 +116,7 @@ enum JournalType {
     Variable,
 }
 
-/// Operations that can be performed on the journal within a segment.
+/// Operations applied to the journal within a cycle.
 #[derive(Arbitrary, Debug, Clone)]
 enum JournalOperation {
     /// Append a single item to the journal.
@@ -116,8 +137,7 @@ enum JournalOperation {
         buffer: usize,
         start_pos: u64,
     },
-    /// Mark an unclean shutdown: end the current segment, drop the journal without a clean sync,
-    /// and recover in the next segment.
+    /// End the current cycle: drop the journal without a clean sync and recover in the next cycle.
     Crash,
 }
 
@@ -155,7 +175,7 @@ struct FuzzInput {
     /// Probability that a resize failure is partial.
     #[arbitrary(with = bounded_rate)]
     partial_resize_rate: f64,
-    /// Sequence of operations to execute (split into segments at `Crash` markers).
+    /// Operations to execute, split into one `ops` list per cycle at each `Crash` marker.
     #[arbitrary(with = bounded_operations)]
     operations: Vec<JournalOperation>,
 }
@@ -188,7 +208,7 @@ impl Params {
     }
 }
 
-/// Model of the journal's state after an unclean shutdown: a guaranteed-durable floor and
+/// What a recovery is expected to produce after an unclean shutdown: a guaranteed-durable floor and
 /// conservative upper bounds.
 ///
 /// The bounds are deliberately conservative, so every assertion in `verify_recovery` is sound under
@@ -201,7 +221,7 @@ impl Params {
 ///
 /// The methods below are the per-operation update rules that maintain these invariants.
 #[derive(Clone, Default)]
-struct Model {
+struct Expected {
     /// Guaranteed-durable prefix length; also the minimum recovered size.
     durable_len: u64,
     /// Upper bound on the recovered size.
@@ -214,7 +234,7 @@ struct Model {
     values: Vec<Item>,
 }
 
-impl Model {
+impl Expected {
     /// A successful tail append. The item is not durable until the next sync/commit, so it only
     /// raises the size ceiling.
     fn appended(&mut self, item: Item) {
@@ -311,7 +331,7 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::size(self).await
     }
 
-    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
+    // `async fn` can't add the `+ Send` bound here (RPITIT).
     #[allow(clippy::manual_async_fn)]
     fn bounds(&self) -> impl Future<Output = Range<u64>> + Send {
         async { self.reader().await.bounds() }
@@ -321,7 +341,7 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::append(self, &item).await
     }
 
-    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
+    // `async fn` can't add the `+ Send` bound here (RPITIT).
     #[allow(clippy::manual_async_fn)]
     fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send {
         async move { self.reader().await.read(pos).await }
@@ -345,7 +365,7 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::prune(self, min_pos).await
     }
 
-    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
+    // `async fn` can't add the `+ Send` bound here (RPITIT).
     #[allow(clippy::manual_async_fn)]
     fn replay(
         &self,
@@ -386,7 +406,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::size(self).await
     }
 
-    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
+    // `async fn` can't add the `+ Send` bound here (RPITIT).
     #[allow(clippy::manual_async_fn)]
     fn bounds(&self) -> impl Future<Output = Range<u64>> + Send {
         async { self.reader().await.bounds() }
@@ -396,7 +416,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::append(self, &item).await
     }
 
-    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
+    // `async fn` can't add the `+ Send` bound here (RPITIT).
     #[allow(clippy::manual_async_fn)]
     fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send {
         async move { self.reader().await.read(pos).await }
@@ -418,7 +438,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::prune(self, min_pos).await
     }
 
-    // Spelled-out future, not `async fn`: the latter can't carry the `+ Send` bound (RPITIT).
+    // `async fn` can't add the `+ Send` bound here (RPITIT).
     #[allow(clippy::manual_async_fn)]
     fn replay(
         &self,
@@ -448,55 +468,55 @@ async fn collect_replay<R: Reader<Item = Item>>(
     Ok(out)
 }
 
-/// Split the operation stream into one segment per crash cycle, cutting at each `Crash` marker.
-/// Always returns at least one segment (possibly empty), so a bare recovery is still exercised.
-fn split_segments(ops: &[JournalOperation]) -> Vec<Vec<JournalOperation>> {
-    let mut segments = Vec::new();
+/// Split the operation stream into one `ops` list per cycle, cutting at each `Crash` marker. Always
+/// returns at least one list (possibly empty), so a bare recovery is still exercised.
+fn split_into_cycles(ops: &[JournalOperation]) -> Vec<Vec<JournalOperation>> {
+    let mut cycles = Vec::new();
     let mut current = Vec::new();
     for op in ops {
         if matches!(op, JournalOperation::Crash) {
-            segments.push(std::mem::take(&mut current));
+            cycles.push(std::mem::take(&mut current));
         } else {
             current.push(op.clone());
         }
     }
-    segments.push(current);
-    segments
+    cycles.push(current);
+    cycles
 }
 
-/// Verify the recovered journal matches the model carried from the previous (crashed) segment.
-async fn verify_recovery<J: FuzzJournal>(journal: &J, model: &Model) {
+/// Verify the recovered journal matches the `Expected` carried from the previous (crashed) cycle.
+async fn verify_recovery<J: FuzzJournal>(journal: &J, expected: &Expected) {
     let Range {
         start: boundary,
         end: size,
     } = journal.bounds().await;
     assert!(size >= boundary, "size {size} < boundary {boundary}");
 
-    // Size and boundary fall within the modeled bounds.
+    // Size and boundary fall within the expected bounds.
     assert!(
-        size >= model.durable_len,
+        size >= expected.durable_len,
         "recovered size {size} < durable_len {}",
-        model.durable_len
+        expected.durable_len
     );
     assert!(
-        size <= model.max_size,
+        size <= expected.max_size,
         "recovered size {size} > max_size {}",
-        model.max_size
+        expected.max_size
     );
     assert!(
-        boundary >= model.durable_prune,
+        boundary >= expected.durable_prune,
         "recovered boundary {boundary} < durable_prune {}",
-        model.durable_prune
+        expected.durable_prune
     );
     assert!(
-        boundary <= model.max_prune,
+        boundary <= expected.max_prune,
         "recovered boundary {boundary} > max_prune {}",
-        model.max_prune
+        expected.max_prune
     );
 
     // Below the recovered boundary every position is pruned, so reads must return `ItemPruned`.
-    // Using the actual boundary (not the model's `durable_prune` floor) makes the pruned vs.
-    // in-bounds split exact, so the loop below can require everything in bounds to be readable.
+    // Using the actual boundary (not the `durable_prune` floor) makes the pruned vs. in-bounds
+    // split exact, so the loop below can require everything in bounds to be readable.
     for pos in 0..boundary {
         match journal.read(pos).await {
             Err(Error::ItemPruned(_)) => {}
@@ -505,17 +525,17 @@ async fn verify_recovery<J: FuzzJournal>(journal: &J, model: &Model) {
     }
 
     // Within bounds [boundary, size) every position must be readable (never pruned). Content is
-    // pinned to the model for the durable prefix; the volatile tail is readable but its content is
-    // unconstrained (torn writes / unsynced rewind). Reads are collected for the replay cross-check.
+    // pinned for the durable prefix; the volatile tail is readable but its content is unconstrained
+    // (torn writes / unsynced rewind). Reads are collected for the replay cross-check.
     let mut read_items = Vec::with_capacity((size - boundary) as usize);
     for pos in boundary..size {
         let item = journal
             .read(pos)
             .await
             .unwrap_or_else(|e| panic!("in-bounds pos {pos} unreadable: {e:?}"));
-        if pos < model.durable_len {
+        if pos < expected.durable_len {
             assert_eq!(
-                item, model.values[pos as usize],
+                item, expected.values[pos as usize],
                 "content mismatch at durable pos {pos}"
             );
         }
@@ -524,7 +544,7 @@ async fn verify_recovery<J: FuzzJournal>(journal: &J, model: &Model) {
 
     // Replay must yield exactly [boundary, size) contiguously and agree with `read()` at every
     // position. The cross-check covers the whole range, including the volatile tail where neither
-    // path is checked against the model, so a read/replay divergence cannot slip through.
+    // path is checked against `expected`, so a read/replay divergence cannot slip through.
     let items = journal
         .replay(NZUsize!(VERIFY_REPLAY_BUF), boundary)
         .await
@@ -536,29 +556,29 @@ async fn verify_recovery<J: FuzzJournal>(journal: &J, model: &Model) {
         items.len()
     );
     for (i, (pos, item)) in items.iter().enumerate() {
-        let expected = boundary + i as u64;
+        let expected_pos = boundary + i as u64;
         assert_eq!(
-            *pos, expected,
-            "replay non-contiguous: got {pos}, expected {expected}"
+            *pos, expected_pos,
+            "replay non-contiguous: got {pos}, expected {expected_pos}"
         );
         assert_eq!(*item, read_items[i], "replay/read divergence at {pos}");
     }
 }
 
-/// Re-baseline the model to the now-on-disk recovered state. The recovered data came from disk and
-/// is durable against the next unclean drop (except where a later rewind/prune/torn-append touches
-/// it, which the per-op update rules handle).
-async fn rebaseline<J: FuzzJournal>(journal: &J) -> Model {
+/// Read the recovered journal back into an `Expected` describing exactly that state. The data is on
+/// disk and durable against the next unclean drop, except where a later rewind/prune/torn-append
+/// touches it (handled by the per-op update rules).
+async fn observe<J: FuzzJournal>(journal: &J) -> Expected {
     let bounds = journal.bounds().await;
     let items = journal
         .replay(NZUsize!(VERIFY_REPLAY_BUF), bounds.start)
         .await
-        .expect("rebaseline replay");
+        .expect("observe replay");
     let mut values = vec![Item::from([0u8; ITEM_SIZE]); bounds.end as usize];
     for (pos, item) in items {
         values[pos as usize] = item;
     }
-    Model {
+    Expected {
         durable_len: bounds.end,
         max_size: bounds.end,
         durable_prune: bounds.start,
@@ -569,7 +589,7 @@ async fn rebaseline<J: FuzzJournal>(journal: &J) -> Model {
 
 /// Confirm the journal is usable after opening by appending a sentinel and reading it back. Runs
 /// fault-free, so it must succeed; the sentinel is unsynced, so it only widens the size ceiling.
-async fn prove_usable<J: FuzzJournal>(journal: &mut J, model: &mut Model) {
+async fn prove_usable<J: FuzzJournal>(journal: &mut J, expected: &mut Expected) {
     let size = journal.size().await;
     let sentinel = Item::from([0xCDu8; ITEM_SIZE]);
     let pos = journal
@@ -582,14 +602,14 @@ async fn prove_usable<J: FuzzJournal>(journal: &mut J, model: &mut Model) {
         sentinel,
         "sentinel readback mismatch"
     );
-    model.appended(sentinel);
+    expected.appended(sentinel);
 }
 
-/// Check a read/replay of an in-range position, returning whether the segment stays alive. `Ok` is
-/// fine; an I/O fault (e.g. a failed internal flush) may have left the journal inconsistent, so the
-/// segment ends. `ItemPruned`/`ItemOutOfRange` can't happen in range, so it means a broken `Reader`
-/// contract and panics.
-fn in_range_probe<T>(result: Result<T, Error>, pos: u64, bounds: &Range<u64>) -> bool {
+/// Interpret a read/replay of an in-bounds position, returning whether the cycle stays alive. `Ok`
+/// is fine; an I/O fault (e.g. a failed internal flush) may have left the journal inconsistent, so
+/// the cycle ends. `ItemPruned`/`ItemOutOfRange` can't happen in bounds, so they signal a broken
+/// `Reader` contract and panic.
+fn in_bounds_probe<T>(result: Result<T, Error>, pos: u64, bounds: &Range<u64>) -> bool {
     match result {
         Ok(_) => true,
         Err(e @ (Error::ItemPruned(_) | Error::ItemOutOfRange(_))) => panic!(
@@ -600,27 +620,27 @@ fn in_range_probe<T>(result: Result<T, Error>, pos: u64, bounds: &Range<u64>) ->
     }
 }
 
-/// Check a read/replay of an arbitrary position. Success, or a validation error that did no I/O
-/// (`ItemPruned`/`ItemOutOfRange`), keeps the segment alive; any other error is an I/O fault that
-/// may have left the journal inconsistent, so the segment ends.
-fn raw_probe<T>(result: Result<T, Error>) -> bool {
+/// Interpret a read/replay of an arbitrary position. Success, or a validation error that did no I/O
+/// (`ItemPruned`/`ItemOutOfRange`), keeps the cycle alive; any other error is an I/O fault that may
+/// have left the journal inconsistent, so the cycle ends.
+fn arbitrary_probe<T>(result: Result<T, Error>) -> bool {
     matches!(
         result,
         Ok(_) | Err(Error::ItemPruned(_)) | Err(Error::ItemOutOfRange(_))
     )
 }
 
-/// Run the segment's ops under faults, updating `model`. Stops early if an op may have left the
-/// journal inconsistent (any mutable error, or an in-range read/replay that hit an I/O fault); the
+/// Run a cycle's ops under faults, updating `expected`. Stops early if an op may have left the
+/// journal inconsistent (any mutable error, or an in-bounds read/replay that hit an I/O fault); the
 /// caller then drops the journal to simulate the crash.
-async fn run_segment<J: FuzzJournal>(
+async fn run_ops<J: FuzzJournal>(
     journal: &mut J,
-    model: &mut Model,
+    expected: &mut Expected,
     ops: &[JournalOperation],
     params: Params,
 ) {
     for op in ops {
-        // `alive` becomes false once an op may have left the journal inconsistent; the segment ends.
+        // `alive` becomes false once an op may have left the journal inconsistent; the cycle ends.
         let alive = match op {
             JournalOperation::Append { value } => {
                 let item = Item::from(*value);
@@ -628,34 +648,34 @@ async fn run_segment<J: FuzzJournal>(
                 match journal.append(item.clone()).await {
                     Ok(pos) => {
                         assert_eq!(pos, size_before, "append returned non-contiguous position");
-                        model.appended(item);
+                        expected.appended(item);
                         true
                     }
                     Err(_) => {
-                        model.append_failed(size_before);
+                        expected.append_failed(size_before);
                         false
                     }
                 }
             }
 
             JournalOperation::Read { pos } => {
-                // An in-range read must succeed; the raw read also exercises the out-of-range and
+                // An in-bounds read must succeed; the raw read also exercises the out-of-range and
                 // pruned paths.
                 let bounds = journal.bounds().await;
                 let mut alive = true;
                 if !bounds.is_empty() {
                     let target = bounds.start + (*pos % (bounds.end - bounds.start));
-                    alive = in_range_probe(journal.read(target).await, target, &bounds);
+                    alive = in_bounds_probe(journal.read(target).await, target, &bounds);
                 }
                 if alive {
-                    alive = raw_probe(journal.read(*pos).await);
+                    alive = arbitrary_probe(journal.read(*pos).await);
                 }
                 alive
             }
 
             JournalOperation::Sync => match journal.sync().await {
                 Ok(()) => {
-                    model.synced(journal.bounds().await);
+                    expected.synced(journal.bounds().await);
                     true
                 }
                 Err(_) => false,
@@ -663,7 +683,7 @@ async fn run_segment<J: FuzzJournal>(
 
             JournalOperation::Commit => match journal.commit().await {
                 Ok(()) => {
-                    model.committed(journal.size().await);
+                    expected.committed(journal.size().await);
                     true
                 }
                 Err(_) => false,
@@ -685,18 +705,18 @@ async fn run_segment<J: FuzzJournal>(
                     match journal.rewind(target).await {
                         Ok(()) => {
                             // Rewound to `target`; the truncated tail may or may not persist.
-                            model.rewound(target, bounds.end);
-                            model.values.truncate(target as usize);
+                            expected.rewound(target, bounds.end);
+                            expected.values.truncate(target as usize);
                             true
                         }
                         // Validation error (target out of range): rejected before any mutation, so
-                        // the journal is unchanged and the model must stay put (lowering durable_len
-                        // would mask later loss of still-durable data).
+                        // the journal is unchanged and the expectation must stay put (lowering
+                        // durable_len would mask later loss of still-durable data).
                         Err(Error::InvalidRewind(_)) | Err(Error::ItemPruned(_)) => true,
                         // I/O fault mid-truncation: data above `target` may be lost, so lower
-                        // durable_len conservatively and end the segment.
+                        // durable_len conservatively and end the cycle.
                         Err(_) => {
-                            model.rewound(target.min(bounds.end), bounds.end);
+                            expected.rewound(target.min(bounds.end), bounds.end);
                             false
                         }
                     }
@@ -709,7 +729,7 @@ async fn run_segment<J: FuzzJournal>(
                 let size = journal.size().await;
                 match journal.prune(*min_pos).await {
                     Ok(_) => {
-                        model.pruned(journal.bounds().await.start);
+                        expected.pruned(journal.bounds().await.start);
                         true
                     }
                     Err(_) => {
@@ -718,29 +738,29 @@ async fn run_segment<J: FuzzJournal>(
                         let capped = (*min_pos).min(size);
                         let section_floor =
                             capped / params.items_per_section * params.items_per_section;
-                        model.pruned(section_floor);
+                        expected.pruned(section_floor);
                         false
                     }
                 }
             }
 
             JournalOperation::Replay { buffer, start_pos } => {
-                // Same contract as `Read`: the clamped (in-range) replay must succeed; the raw replay
-                // probes the validation paths.
+                // Same contract as `Read`: the clamped (in-bounds) replay must succeed; the raw
+                // replay probes the validation paths.
                 let bounds = journal.bounds().await;
                 let clamped = bounds.start + (*start_pos % (bounds.end - bounds.start + 1));
-                let mut alive = in_range_probe(
+                let mut alive = in_bounds_probe(
                     journal.replay(NZUsize!(*buffer), clamped).await,
                     clamped,
                     &bounds,
                 );
                 if alive {
-                    alive = raw_probe(journal.replay(NZUsize!(*buffer), *start_pos).await);
+                    alive = arbitrary_probe(journal.replay(NZUsize!(*buffer), *start_pos).await);
                 }
                 alive
             }
 
-            // `split_segments` strips `Crash`; treat a stray one defensively as ending the segment.
+            // `split_into_cycles` strips `Crash`; treat a stray one defensively as ending the cycle.
             JournalOperation::Crash => false,
         };
 
@@ -750,16 +770,17 @@ async fn run_segment<J: FuzzJournal>(
     }
 }
 
-/// Run one crash cycle: recover via `init`, verify the recovered state matches the model
-/// carried from the prior crash, re-baseline, prove the journal still works, then run the segment
-/// under faults and crash (drop). Returns the updated model and a checkpoint for the next cycle.
+/// Run one crash cycle: recover via `init`, verify the recovered state matches the `Expected`
+/// carried from the prior crash, `observe` the journal, prove it still works, then run the cycle's
+/// ops under faults and crash (drop). Returns the updated `Expected` and a checkpoint for the next
+/// cycle.
 fn run_cycle<J: FuzzJournal + Send + 'static>(
     runner: deterministic::Runner,
-    incoming: Model,
+    incoming: Expected,
     ops: Vec<JournalOperation>,
     partition: String,
     params: Params,
-) -> (Model, deterministic::Checkpoint)
+) -> (Expected, deterministic::Checkpoint)
 where
     J::Config: Send,
 {
@@ -773,13 +794,13 @@ where
         // The recovered state must match what the previous cycle left durable.
         verify_recovery(&journal, &incoming).await;
 
-        let mut model = rebaseline(&journal).await;
-        prove_usable(&mut journal, &mut model).await;
+        let mut expected = observe(&journal).await;
+        prove_usable(&mut journal, &mut expected).await;
 
         // Enable faults for the operation phase, then drop the journal at the end (the crash).
         *ctx.storage_fault_config().write() = params.fault_config();
-        run_segment(&mut journal, &mut model, &ops, params).await;
-        model
+        run_ops(&mut journal, &mut expected, &ops, params).await;
+        expected
     })
 }
 
@@ -799,24 +820,25 @@ where
         partial_resize_rate: input.partial_resize_rate,
     };
     let partition = format!("crash-recovery-{tag}-{}", input.seed);
-    let segments = split_segments(&input.operations);
+    let cycles = split_into_cycles(&input.operations);
 
-    // First cycle starts from a fresh runtime, recovers an empty journal, and the model is empty.
+    // First cycle starts from a fresh runtime and recovers an empty journal, so the expectation is
+    // empty too.
     let runner = deterministic::Runner::new(deterministic::Config::default().with_seed(input.seed));
-    let (mut model, mut checkpoint) = run_cycle::<J>(
+    let (mut expected, mut checkpoint) = run_cycle::<J>(
         runner,
-        Model::default(),
-        segments[0].clone(),
+        Expected::default(),
+        cycles[0].clone(),
         partition.clone(),
         params,
     );
 
-    // Each later cycle recovers from the previous crash and runs its ops, then crashes again.
-    for ops in segments.iter().skip(1) {
+    // Each later cycle recovers from the previous crash, runs its ops, then crashes again.
+    for ops in cycles.iter().skip(1) {
         let runner = deterministic::Runner::from(checkpoint);
-        (model, checkpoint) = run_cycle::<J>(
+        (expected, checkpoint) = run_cycle::<J>(
             runner,
-            model.clone(),
+            expected.clone(),
             ops.clone(),
             partition.clone(),
             params,
@@ -833,7 +855,7 @@ where
         .await
         .expect("final recovery should succeed");
 
-        verify_recovery(&journal, &model).await;
+        verify_recovery(&journal, &expected).await;
 
         let size = journal.size().await;
         let sentinel = Item::from([0xEFu8; ITEM_SIZE]);

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -16,9 +16,9 @@
 //!   3. Append and query under fault injection (the cycle's `ops`).
 //!   4. Drop the journal without a clean shutdown: the crash. Unsynced data is lost.
 //!
-//! The op list is split at `Crash` markers, one `ops` list per cycle. Repeating on the same journal
-//! is the point: watermark, pruning-metadata, and section-layout bugs tend to surface only after
-//! several recover-mutate-crash rounds, not on the first crash.
+//! `Crash` markers split the op list into one `ops` list per cycle. Driving recovery repeatedly on
+//! the same journal is the point: watermark, pruning-metadata, and section-layout bugs often need a
+//! recover-then-mutate-then-recover sequence to appear, not just a single crash.
 //!
 //! # Expected
 //!
@@ -128,7 +128,7 @@ enum JournalOperation {
     Read { pos: u64 },
     /// Sync the journal to storage.
     Sync,
-    /// Flush pending data without advancing the recovery watermark.
+    /// Commit the journal.
     Commit,
     /// Rewind the journal to a smaller size.
     Rewind { size: u64 },
@@ -860,8 +860,8 @@ where
         );
     }
 
-    // Final fault-free phase: verify recovery, then prove a synced round-trip survives an actual
-    // reopen (not just a read from the live handle), and clean up.
+    // Final fault-free phase: verify the last recovery, then append, sync, drop, and reopen a
+    // sentinel to prove the synced state survives restart.
     deterministic::Runner::from(checkpoint).start(move |ctx| async move {
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
         let mut journal = J::init(

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -68,9 +68,8 @@ const MAX_WRITE_BUF: usize = 2048;
 /// Buffer size used for internal verification replays.
 const VERIFY_REPLAY_BUF: usize = 1024;
 
-/// Maximum number of operations per fuzz input. Bounds the number of crash cycles and the per-cycle
-/// verification/replay work so executions stay fast (total cost is ~O(cycles * size), both capped
-/// here).
+/// Maximum number of operations per fuzz input. Caps the crash-cycle count and per-cycle
+/// verification work so executions stay fast.
 const MAX_OPERATIONS: usize = 128;
 
 fn bounded_non_zero(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
@@ -99,8 +98,7 @@ fn bounded_rate(u: &mut Unstructured<'_>) -> arbitrary::Result<f64> {
     Ok(f64::from(percent) / 100.0)
 }
 
-/// A bounded-length operation sequence, so input size (hence cycle count and verification cost)
-/// stays capped regardless of how much data the fuzzer provides.
+/// Op sequence capped at `MAX_OPERATIONS`; a derived `Vec` would instead grow with input length.
 fn bounded_operations(u: &mut Unstructured<'_>) -> arbitrary::Result<Vec<JournalOperation>> {
     let num_ops = u.int_in_range(0..=MAX_OPERATIONS)?;
     (0..num_ops)

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -24,7 +24,7 @@
 //!
 //! A crash can land anywhere in a range, so `Expected` tracks conservative bounds (a
 //! guaranteed-durable prefix plus size/pruning ceilings), not an exact state.
-//! `assert_matches_expected` checks recovery falls within them; `observe` then snapshots it as the
+//! `assert_matches_expected` checks recovery falls within them; `to_expected` then snapshots it as the
 //! next cycle's start.
 //!
 //! # Faults
@@ -32,6 +32,14 @@
 //! The operation phase runs under write/sync/resize fault injection. The torn-write modes
 //! (`partial_write_rate`, `partial_resize_rate`) cut a write or truncation short, leaving the
 //! half-finished bytes a real crash would.
+//!
+//! # Positions
+//!
+//! Position arguments (`Read`, `Rewind`, `Replay`) come straight from the fuzzer, so a random `u64`
+//! is almost always out of range. Each such op runs twice: once with the value clamped into the
+//! live range, which must take the success path, and once with the raw value, which exercises the
+//! validation path (`ItemPruned` below the start, `ItemOutOfRange` past the end). Clamping
+//! guarantees the success path is covered on every input; the raw value still tests rejection.
 
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_runtime::{deterministic, BufferPooler, Runner, Supervisor as _};
@@ -67,8 +75,7 @@ const MAX_WRITE_BUF: usize = 2048;
 /// Buffer size used for internal verification replays.
 const VERIFY_REPLAY_BUF: usize = 1024;
 
-/// Maximum number of operations per fuzz input. Caps the crash-cycle count and per-cycle
-/// verification work so executions stay fast.
+/// Maximum number of operations per fuzz input.
 const MAX_OPERATIONS: usize = 128;
 
 fn bounded_non_zero(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
@@ -176,7 +183,7 @@ struct FuzzInput {
     operations: Vec<JournalOperation>,
 }
 
-/// Configuration knobs shared by every cycle: journal config plus fault-injection rates.
+/// Journal config plus fault-injection rates, shared by every cycle.
 #[derive(Clone, Copy)]
 struct Params {
     page_size: NonZeroU16,
@@ -496,7 +503,7 @@ async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expecte
     }
 
     // Within [boundary, size) every position is readable; content is pinned only for the durable
-    // prefix. Reads are kept for the replay cross-check.
+    // prefix. Items are saved for the replay cross-check below.
     let mut read_items = Vec::with_capacity((size - boundary) as usize);
     for pos in boundary..size {
         let item = journal
@@ -534,12 +541,12 @@ async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expecte
 }
 
 /// Read the recovered journal back into an `Expected` pinned to exactly that state.
-async fn observe<J: FuzzJournal>(journal: &J) -> Expected {
+async fn to_expected<J: FuzzJournal>(journal: &J) -> Expected {
     let bounds = journal.bounds().await;
     let items = journal
         .replay(NZUsize!(VERIFY_REPLAY_BUF), bounds.start)
         .await
-        .expect("observe replay");
+        .expect("to_expected replay");
     let mut values = vec![Item::from([0u8; ITEM_SIZE]); bounds.end as usize];
     for (pos, item) in items {
         values[pos as usize] = item;
@@ -553,8 +560,9 @@ async fn observe<J: FuzzJournal>(journal: &J) -> Expected {
     }
 }
 
-/// Confirm the journal accepts and reads back a sentinel after opening. Recorded as a ceiling-only
-/// append, not pinned: an unsynced append may flush durably, so recovery may or may not surface it.
+/// Append a sentinel and read it back, confirming the reopened journal is writable. The append is
+/// not synced, so it only raises the expected size ceiling, not the durable floor: a later crash
+/// may or may not have persisted it.
 async fn assert_round_trip<J: FuzzJournal>(journal: &mut J, expected: &mut Expected) {
     let size = journal.size().await;
     let sentinel = Item::from([0xCDu8; ITEM_SIZE]);
@@ -571,12 +579,8 @@ async fn assert_round_trip<J: FuzzJournal>(journal: &mut J, expected: &mut Expec
     expected.appended(sentinel);
 }
 
-/// Check `read(pos)` against `bounds` (= `[start, end)`), panicking on a wrong result:
-///   - live (`start <= pos < end`) -> `Ok(item)`,
-///   - pruned (`pos < start`)      -> `Err(ItemPruned)`,
-///   - past the end (`pos >= end`) -> `Err(ItemOutOfRange)`.
-///
-/// No read faults are injected and `read` is a pure lookup, so any other result is a real bug.
+/// Check `read(pos)` against `bounds`. No read faults are injected and `read` is a pure lookup, so
+/// anything but `Ok` in range / `ItemPruned` below / `ItemOutOfRange` past the end is a real bug.
 fn assert_read(result: Result<Item, Error>, pos: u64, bounds: &Range<u64>) {
     let ok = match &result {
         Ok(_) => bounds.contains(&pos),
@@ -591,10 +595,10 @@ fn assert_read(result: Result<Item, Error>, pos: u64, bounds: &Range<u64>) {
     );
 }
 
-/// Whether the cycle continues after a raw `replay(start_pos)`. Validation precedes any I/O, so an
-/// out-of-range start is deterministic: `< start` -> `ItemPruned`, `> end` -> `ItemOutOfRange`
-/// (`== end` is in range). An in-range start succeeds or hits a tail-repair I/O fault (ends the
-/// cycle); any other result is a bug.
+/// Whether the cycle continues after the raw replay. Validation
+/// precedes any I/O, so an out-of-range start is deterministic: `< start` -> `ItemPruned`,
+/// `> end` -> `ItemOutOfRange` (`== end` is in range). An in-range start succeeds or hits a
+/// tail-repair I/O fault (ends the cycle); any other result is a bug.
 fn should_continue_raw_replay(
     result: Result<Vec<(u64, Item)>, Error>,
     start_pos: u64,
@@ -616,7 +620,8 @@ fn should_continue_raw_replay(
     }
 }
 
-/// Assert an in-bounds `replay(start)` returned the full contiguous suffix `[start, bounds.end)`.
+/// Assert the items from replaying an in-bounds `start` are exactly positions `[start, bounds.end)`,
+/// contiguous and in order.
 fn assert_replay_suffix(items: &[(u64, Item)], start: u64, bounds: &Range<u64>) {
     assert_eq!(
         items.len() as u64,
@@ -634,10 +639,9 @@ fn assert_replay_suffix(items: &[(u64, Item)], start: u64, bounds: &Range<u64>) 
     }
 }
 
-/// Run a cycle's ops under faults, updating `expected`. Stops early if an op may have left the
-/// journal inconsistent (any mutable error, or a replay that hit a tail-repair I/O fault); the
-/// caller then drops the journal to simulate the crash. Reads never fault here, so a bad read
-/// panics rather than ending the cycle.
+/// Run a cycle's ops under faults, updating `expected`. Stops early on any error that may have left
+/// the journal inconsistent (a mutable-method error or a tail-repair I/O fault); the caller then
+/// drops the journal to crash. Reads never fault, so a bad read panics instead of ending the cycle.
 async fn run_ops<J: FuzzJournal>(
     journal: &mut J,
     expected: &mut Expected,
@@ -663,7 +667,6 @@ async fn run_ops<J: FuzzJournal>(
             }
 
             JournalOperation::Read { pos } => {
-                // A guaranteed in-bounds read, then the raw read for the pruned/out-of-range paths.
                 let bounds = journal.bounds().await;
                 if !bounds.is_empty() {
                     let target = bounds.start + (*pos % (bounds.end - bounds.start));
@@ -704,7 +707,6 @@ async fn run_ops<J: FuzzJournal>(
                     };
                     match journal.rewind(target).await {
                         Ok(()) => {
-                            // Rewound to `target`; the truncated tail may or may not persist.
                             expected.rewound(target, bounds.end);
                             expected.values.truncate(target as usize);
                             true
@@ -735,7 +737,6 @@ async fn run_ops<J: FuzzJournal>(
                 let size = journal.size().await;
                 match journal.prune(*min_pos).await {
                     Ok(_) => {
-                        // The deleted sections are durably gone; pin the boundary exactly.
                         expected.pruned(journal.bounds().await.start);
                         true
                     }
@@ -751,14 +752,13 @@ async fn run_ops<J: FuzzJournal>(
             }
 
             JournalOperation::Replay { buffer, start_pos } => {
-                // The clamped (in-bounds) replay must return the full suffix matching `read()`, or
-                // hit a tail-repair I/O fault; the raw replay probes the validation paths.
+                // The clamped replay must return the full suffix matching `read()`, or hit a
+                // tail-repair I/O fault.
                 let bounds = journal.bounds().await;
                 let clamped = bounds.start + (*start_pos % (bounds.end - bounds.start + 1));
                 let clamped_ok = match journal.replay(NZUsize!(*buffer), clamped).await {
                     Ok(items) => {
                         assert_replay_suffix(&items, clamped, &bounds);
-                        // Cross-check replay content against `read()`.
                         for (pos, item) in &items {
                             let via_read = journal.read(*pos).await.unwrap_or_else(|e| {
                                 panic!("read({pos}) cross-check during replay: {e:?}")
@@ -812,13 +812,12 @@ where
         let mut journal = J::init(ctx.child("journal"), cfg)
             .await
             .expect("recovery should succeed without panic");
-        // The recovered state must match what the previous cycle left durable.
         assert_matches_expected(&journal, &expected).await;
 
-        let mut expected = observe(&journal).await;
+        let mut expected = to_expected(&journal).await;
         assert_round_trip(&mut journal, &mut expected).await;
 
-        // Enable faults for the operation phase, then drop the journal at the end (the crash).
+        // Faults on for the operation phase; returning drops the journal (the crash).
         *ctx.storage_fault_config().write() = params.fault_config();
         run_ops(&mut journal, &mut expected, &ops, params).await;
         expected
@@ -870,7 +869,6 @@ where
         params,
     );
 
-    // Each later cycle recovers from the previous crash, runs its ops, then crashes again.
     for ops in cycles.iter().skip(1) {
         let runner = deterministic::Runner::from(checkpoint);
         (expected, checkpoint) = run_cycle::<J>(
@@ -882,8 +880,8 @@ where
         );
     }
 
-    // Final fault-free phase: verify the carried state recovers, then prove a synced round-trip is
-    // durable across an actual reopen (not just readable from the live handle), and clean up.
+    // Final fault-free phase: verify recovery, then prove a synced round-trip survives an actual
+    // reopen (not just a read from the live handle), and clean up.
     deterministic::Runner::from(checkpoint).start(move |ctx| async move {
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
         let mut journal = J::init(
@@ -895,7 +893,7 @@ where
         assert_matches_expected(&journal, &expected).await;
 
         // Append a sentinel and sync it, pinning the exact durable state.
-        let mut expected = observe(&journal).await;
+        let mut expected = to_expected(&journal).await;
         let size = journal.size().await;
         let sentinel = Item::from([0xEFu8; ITEM_SIZE]);
         let pos = journal

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -560,25 +560,6 @@ async fn to_expected<J: FuzzJournal>(journal: &J) -> Expected {
     }
 }
 
-/// Append a sentinel and read it back, confirming the reopened journal is writable. The append is
-/// not synced, so it only raises the expected size ceiling, not the durable floor: a later crash
-/// may or may not have persisted it.
-async fn assert_round_trip<J: FuzzJournal>(journal: &mut J, expected: &mut Expected) {
-    let size = journal.size().await;
-    let sentinel = Item::from([0xCDu8; ITEM_SIZE]);
-    let pos = journal
-        .append(sentinel.clone())
-        .await
-        .expect("append after open");
-    assert_eq!(pos, size, "post-open append at wrong position");
-    assert_eq!(
-        journal.read(pos).await.expect("read sentinel"),
-        sentinel,
-        "sentinel readback mismatch"
-    );
-    expected.appended(sentinel);
-}
-
 /// Check `read(pos)` against `bounds`. No read faults are injected and `read` is a pure lookup, so
 /// anything but `Ok` in range / `ItemPruned` below / `ItemOutOfRange` past the end is a real bug.
 fn assert_read(result: Result<Item, Error>, pos: u64, bounds: &Range<u64>) {
@@ -815,7 +796,6 @@ where
         assert_matches_expected(&journal, &expected).await;
 
         let mut expected = to_expected(&journal).await;
-        assert_round_trip(&mut journal, &mut expected).await;
 
         // Faults on for the operation phase; returning drops the journal (the crash).
         *ctx.storage_fault_config().write() = params.fault_config();

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -25,7 +25,7 @@
 //!
 //! A crash can land anywhere in a range of outcomes, so we cannot predict the exact recovered
 //! state. `Expected` instead tracks conservative bounds: a guaranteed-durable prefix plus ceilings
-//! on the size and pruning boundary. `verify_recovery` asserts the real recovery lands within them.
+//! on the size and pruning boundary. `assert_matches_expected` asserts the real recovery lands within them.
 //! Once it passes, the state is known exactly, so `observe` reads it back as the precise starting
 //! point for the next cycle.
 //!
@@ -211,7 +211,7 @@ impl Params {
 /// What a recovery is expected to produce after an unclean shutdown: a guaranteed-durable floor and
 /// conservative upper bounds.
 ///
-/// The bounds are deliberately conservative, so every assertion in `verify_recovery` is sound under
+/// The bounds are deliberately conservative, so every assertion in `assert_matches_expected` is sound under
 /// any fault/crash interleaving:
 /// - positions `[0, durable_prune)` are pruned (reads return `ItemPruned`),
 /// - positions `[max_prune, durable_len)` are present with the exact content `values[pos]`,
@@ -269,9 +269,21 @@ impl Expected {
         self.max_size = self.max_size.max(prev_size);
     }
 
-    /// Prune may advance the recovered pruning boundary up to `boundary` (durable only after sync).
+    /// A successful prune durably advances the pruning boundary to `boundary`. Pruning deletes whole
+    /// section blobs from storage (`context.remove`, not buffered behind a sync), and recovery
+    /// rebuilds the boundary forward from the surviving blobs, so a reopen can never resurrect data
+    /// below `boundary`. Pin the boundary exactly. (The boundary only moves forward, so this never
+    /// lowers `durable_prune`.)
     fn pruned(&mut self, boundary: u64) {
-        self.max_prune = self.max_prune.max(boundary);
+        self.durable_prune = boundary;
+        self.max_prune = boundary;
+    }
+
+    /// A failed prune may have deleted some sections before erroring (sections go oldest-first), so
+    /// the boundary may have advanced as far as `ceiling` but is not guaranteed to have moved. Raise
+    /// only the ceiling.
+    fn prune_failed(&mut self, ceiling: u64) {
+        self.max_prune = self.max_prune.max(ceiling);
     }
 }
 
@@ -469,7 +481,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
 }
 
 /// Verify the recovered journal matches the `Expected` carried from the previous (crashed) cycle.
-async fn verify_recovery<J: FuzzJournal>(journal: &J, expected: &Expected) {
+async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expected) {
     let Range {
         start: boundary,
         end: size,
@@ -573,7 +585,7 @@ async fn observe<J: FuzzJournal>(journal: &J) -> Expected {
 
 /// Confirm the journal is usable after opening by appending a sentinel and reading it back. Runs
 /// fault-free, so it must succeed; the sentinel is unsynced, so it only widens the size ceiling.
-async fn prove_usable<J: FuzzJournal>(journal: &mut J, expected: &mut Expected) {
+async fn assert_round_trip<J: FuzzJournal>(journal: &mut J, expected: &mut Expected) {
     let size = journal.size().await;
     let sentinel = Item::from([0xCDu8; ITEM_SIZE]);
     let pos = journal
@@ -589,34 +601,83 @@ async fn prove_usable<J: FuzzJournal>(journal: &mut J, expected: &mut Expected) 
     expected.appended(sentinel);
 }
 
-/// Interpret a read/replay of an in-bounds position, returning whether the cycle stays alive. `Ok`
-/// is fine; an I/O fault (e.g. a failed internal flush) may have left the journal inconsistent, so
-/// the cycle ends. `ItemPruned`/`ItemOutOfRange` can't happen in bounds, so they signal a broken
-/// `Reader` contract and panic.
-fn in_bounds_probe<T>(result: Result<T, Error>, pos: u64, bounds: &Range<u64>) -> bool {
-    match result {
-        Ok(_) => true,
-        Err(e @ (Error::ItemPruned(_) | Error::ItemOutOfRange(_))) => panic!(
-            "in-bounds access at {pos} ([{}, {})) returned {e:?}",
+/// Check that `read(pos)` returned the right result for where `pos` sits, and panic if it did not.
+///
+/// Relative to the live range `bounds` (= `[start, end)`):
+///   - live (`start <= pos < end`) -> `Ok(item)`,
+///   - pruned (`pos < start`)      -> `Err(ItemPruned)`,
+///   - past the end (`pos >= end`) -> `Err(ItemOutOfRange)`.
+///
+/// Anything else is a real bug: no read faults are injected and `read` is a pure lookup, so it
+/// cannot legitimately fail here (unlike `replay`, which repairs the tail). A bad read panics.
+fn assert_read(result: Result<Item, Error>, pos: u64, bounds: &Range<u64>) {
+    let ok = match &result {
+        Ok(_) => bounds.contains(&pos),
+        Err(Error::ItemPruned(_)) => pos < bounds.start,
+        Err(Error::ItemOutOfRange(_)) => pos >= bounds.end,
+        Err(_) => false,
+    };
+    assert!(
+        ok,
+        "read at {pos} (bounds [{}, {})) returned {result:?}",
+        bounds.start, bounds.end
+    );
+}
+
+/// Whether the cycle should continue after a raw `replay(start_pos)` at an arbitrary start.
+///
+/// `replay` validates the start before doing any I/O, so an out-of-range start is deterministic:
+///   - `start_pos < start` -> `Err(ItemPruned)`,
+///   - `start_pos > end`   -> `Err(ItemOutOfRange)` (`start_pos == end` is in range: an empty replay).
+///
+/// An in-range start either succeeds or hits a legitimate tail-repair I/O fault (`replay` resizes
+/// and syncs under faults); the fault ends the cycle. Success out of range, the wrong validation
+/// error, or a validation error for an in-range start is a bug, so panic.
+fn should_continue_raw_replay(
+    result: Result<Vec<(u64, Item)>, Error>,
+    start_pos: u64,
+    bounds: &Range<u64>,
+) -> bool {
+    let in_range = start_pos >= bounds.start && start_pos <= bounds.end;
+    match &result {
+        Ok(_) if in_range => true,
+        Err(Error::ItemPruned(_)) if start_pos < bounds.start => true,
+        Err(Error::ItemOutOfRange(_)) if start_pos > bounds.end => true,
+        // An in-range start that failed with a non-validation error is a tail-repair I/O fault.
+        Err(e) if in_range && !matches!(e, Error::ItemPruned(_) | Error::ItemOutOfRange(_)) => {
+            false
+        }
+        _ => panic!(
+            "raw replay at {start_pos} (bounds [{}, {})) returned {result:?}",
             bounds.start, bounds.end
         ),
-        Err(_) => false,
     }
 }
 
-/// Interpret a read/replay of an arbitrary position. Success, or a validation error that did no I/O
-/// (`ItemPruned`/`ItemOutOfRange`), keeps the cycle alive; any other error is an I/O fault that may
-/// have left the journal inconsistent, so the cycle ends.
-fn arbitrary_probe<T>(result: Result<T, Error>) -> bool {
-    matches!(
-        result,
-        Ok(_) | Err(Error::ItemPruned(_)) | Err(Error::ItemOutOfRange(_))
-    )
+/// Assert an in-bounds `replay(start)` returned the full contiguous suffix `[start, bounds.end)`.
+/// The `Append` write buffer serves replay from its logical view, so buffered (unsynced) tail items
+/// are included; the recovered length equals `bounds.end - start` exactly.
+fn assert_replay_suffix(items: &[(u64, Item)], start: u64, bounds: &Range<u64>) {
+    assert_eq!(
+        items.len() as u64,
+        bounds.end - start,
+        "replay from {start} returned {} items, expected suffix [{start}, {})",
+        items.len(),
+        bounds.end
+    );
+    for (i, (pos, _)) in items.iter().enumerate() {
+        let want = start + i as u64;
+        assert_eq!(
+            *pos, want,
+            "replay from {start} non-contiguous: got {pos}, expected {want}"
+        );
+    }
 }
 
 /// Run a cycle's ops under faults, updating `expected`. Stops early if an op may have left the
-/// journal inconsistent (any mutable error, or an in-bounds read/replay that hit an I/O fault); the
-/// caller then drops the journal to simulate the crash.
+/// journal inconsistent (any mutable error, or a replay that hit a tail-repair I/O fault); the
+/// caller then drops the journal to simulate the crash. Reads never fault here, so a bad read
+/// panics rather than ending the cycle.
 async fn run_ops<J: FuzzJournal>(
     journal: &mut J,
     expected: &mut Expected,
@@ -624,8 +685,7 @@ async fn run_ops<J: FuzzJournal>(
     params: Params,
 ) {
     for op in ops {
-        // `alive` becomes false once an op may have left the journal inconsistent; the cycle ends.
-        let alive = match op {
+        let should_continue = match op {
             JournalOperation::Append { value } => {
                 let item = Item::from(*value);
                 let size_before = journal.size().await;
@@ -643,18 +703,17 @@ async fn run_ops<J: FuzzJournal>(
             }
 
             JournalOperation::Read { pos } => {
-                // An in-bounds read must succeed; the raw read also exercises the out-of-range and
-                // pruned paths.
+                // Exercise a guaranteed in-bounds read each cycle (the raw `pos` may be out of
+                // bounds), then the raw read to cover the pruned / out-of-range paths. Reads inject
+                // no faults and are pure lookups, so every outcome is determined by `bounds` and is
+                // asserted exactly; a read never ends the cycle.
                 let bounds = journal.bounds().await;
-                let mut alive = true;
                 if !bounds.is_empty() {
                     let target = bounds.start + (*pos % (bounds.end - bounds.start));
-                    alive = in_bounds_probe(journal.read(target).await, target, &bounds);
+                    assert_read(journal.read(target).await, target, &bounds);
                 }
-                if alive {
-                    alive = arbitrary_probe(journal.read(*pos).await);
-                }
-                alive
+                assert_read(journal.read(*pos).await, *pos, &bounds);
+                true
             }
 
             JournalOperation::Sync => match journal.sync().await {
@@ -678,10 +737,11 @@ async fn run_ops<J: FuzzJournal>(
                 if bounds.is_empty() {
                     true
                 } else {
-                    // Usually clamp to a retained position in [start, end]; occasionally pass the raw
-                    // value to exercise the validation paths (target past the end, or below the
-                    // pruning boundary).
-                    let target = if *size % 8 == 0 {
+                    // Usually clamp to a retained position in [start, end], which is always a valid
+                    // rewind target; occasionally pass the raw value to exercise the validation
+                    // paths (target past the end, or below the pruning boundary).
+                    let use_raw_target = *size % 8 == 0;
+                    let target = if use_raw_target {
                         *size
                     } else {
                         bounds.start + (*size % (bounds.end - bounds.start + 1))
@@ -695,8 +755,18 @@ async fn run_ops<J: FuzzJournal>(
                         }
                         // Validation error (target out of range): rejected before any mutation, so
                         // the journal is unchanged and the expectation must stay put (lowering
-                        // durable_len would mask later loss of still-durable data).
-                        Err(Error::InvalidRewind(_)) | Err(Error::ItemPruned(_)) => true,
+                        // durable_len would mask later loss of still-durable data). Only the raw
+                        // target can be invalid; a clamped target is always a retained position, so
+                        // a validation error there is a bug.
+                        Err(e @ (Error::InvalidRewind(_) | Error::ItemPruned(_))) => {
+                            assert!(
+                                use_raw_target,
+                                "rewind to clamped retained target {target} (bounds [{}, {})) \
+                                 returned {e:?}",
+                                bounds.start, bounds.end
+                            );
+                            true
+                        }
                         // I/O fault mid-truncation: data above `target` may be lost, so lower
                         // durable_len conservatively and end the cycle.
                         Err(_) => {
@@ -713,6 +783,7 @@ async fn run_ops<J: FuzzJournal>(
                 let size = journal.size().await;
                 match journal.prune(*min_pos).await {
                     Ok(_) => {
+                        // The deleted sections are durably gone; pin the boundary exactly.
                         expected.pruned(journal.bounds().await.start);
                         true
                     }
@@ -722,33 +793,53 @@ async fn run_ops<J: FuzzJournal>(
                         let capped = (*min_pos).min(size);
                         let section_floor =
                             capped / params.items_per_section * params.items_per_section;
-                        expected.pruned(section_floor);
+                        expected.prune_failed(section_floor);
                         false
                     }
                 }
             }
 
             JournalOperation::Replay { buffer, start_pos } => {
-                // Same contract as `Read`: the clamped (in-bounds) replay must succeed; the raw
-                // replay probes the validation paths.
+                // The clamped (in-bounds) replay must return the full contiguous suffix matching
+                // `read()`, or hit a legitimate tail-repair I/O fault; the raw replay probes the
+                // validation paths.
                 let bounds = journal.bounds().await;
                 let clamped = bounds.start + (*start_pos % (bounds.end - bounds.start + 1));
-                let mut alive = in_bounds_probe(
-                    journal.replay(NZUsize!(*buffer), clamped).await,
-                    clamped,
-                    &bounds,
-                );
-                if alive {
-                    alive = arbitrary_probe(journal.replay(NZUsize!(*buffer), *start_pos).await);
-                }
-                alive
+                let clamped_ok = match journal.replay(NZUsize!(*buffer), clamped).await {
+                    Ok(items) => {
+                        assert_replay_suffix(&items, clamped, &bounds);
+                        // Cross-check replay content against `read()` (reads are fault-free here),
+                        // so a start-dependent replay regression cannot pass as long as it returns
+                        // `Ok`.
+                        for (pos, item) in &items {
+                            let via_read = journal.read(*pos).await.unwrap_or_else(|e| {
+                                panic!("read({pos}) cross-check during replay: {e:?}")
+                            });
+                            assert_eq!(*item, via_read, "replay/read divergence at {pos}");
+                        }
+                        true
+                    }
+                    // A clamped start is always in bounds, so a validation error is a bug.
+                    Err(e @ (Error::ItemPruned(_) | Error::ItemOutOfRange(_))) => panic!(
+                        "in-bounds replay at {clamped} (bounds [{}, {})) returned {e:?}",
+                        bounds.start, bounds.end
+                    ),
+                    // Tail-repair I/O fault: end the cycle.
+                    Err(_) => false,
+                };
+                clamped_ok
+                    && should_continue_raw_replay(
+                        journal.replay(NZUsize!(*buffer), *start_pos).await,
+                        *start_pos,
+                        &bounds,
+                    )
             }
 
             // `split_into_cycles` strips `Crash`; treat a stray one defensively as ending the cycle.
             JournalOperation::Crash => false,
         };
 
-        if !alive {
+        if !should_continue {
             break;
         }
     }
@@ -776,10 +867,10 @@ where
             .await
             .expect("recovery should succeed without panic");
         // The recovered state must match what the previous cycle left durable.
-        verify_recovery(&journal, &incoming).await;
+        assert_matches_expected(&journal, &incoming).await;
 
         let mut expected = observe(&journal).await;
-        prove_usable(&mut journal, &mut expected).await;
+        assert_round_trip(&mut journal, &mut expected).await;
 
         // Enable faults for the operation phase, then drop the journal at the end (the crash).
         *ctx.storage_fault_config().write() = params.fault_config();
@@ -855,7 +946,7 @@ where
         .await
         .expect("final recovery should succeed");
 
-        verify_recovery(&journal, &expected).await;
+        assert_matches_expected(&journal, &expected).await;
 
         let size = journal.size().await;
         let sentinel = Item::from([0xEFu8; ITEM_SIZE]);


### PR DESCRIPTION
## Summary

Rewrites the `journal_crash_recovery` target to drive the fixed and variable contiguous journals through **repeated** unclean shutdowns and verify recovered **content**, not just size bounds. The old target crashed once and only checked that size/oldest fell in a loose `[min, max]` range — so it couldn't catch silent corruption or compounding recovery bugs. Single file changed; same name and CI registration.

## Changes

Each input drives one journal through a sequence of crash cycles. Per cycle: **recover** (`init`, or `init_at_size` for a reset), **verify** the recovered state against a model of what is durably guaranteed, **continue** appending/querying, then **crash** again (run ops under fault injection, drop without a clean sync). The op stream is split into cycles at `Crash`/`Reset` markers; a mutable-method error also ends a cycle (a DB is unusable after one).

## Key changes vs. the existing fuzz test

- **Repeated recovery.** Each cycle re-runs `init()` on a journal produced by a prior crash recovery, so watermark / pruning-metadata / section-layout bugs compound across restarts.
- **Exact-content oracle.** A conservative `Model` asserts, after each recovery: durable-prefix bytes match exactly, pruned positions return `ItemPruned`, the volatile tail is readable-or-pruned, and replay is contiguous.
- **Torn-write faults.** Adds `resize`, `partial_write`, and `partial_resize` (previously only `write`/`sync`).
- **Reset path.** `Reset` reopens via `init_at_size` (discards all data, resets the logical size); a later cycle's `init()` must not resurrect stale pre-reset data.