### PR TITLE
[Storage] Guarantee post-init durability

### DIFF
--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -522,6 +522,59 @@ mod tests {
         });
     }
 
+    // Recovery durability invariant: records replayed on reopen are readable but not yet known
+    // crash-durable, so they stay pending until synced instead of being treated as durable. To
+    // check that, we inject sync faults after a clean write+sync+reopen: `sync()` has to error
+    // because those sections still need syncing. If recovery dropped them, it would no-op and pass.
+    #[test_traced]
+    fn test_archive_reopen_syncs_recovered_records() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                translator: FourCap,
+                key_partition: "test-index".into(),
+                key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                value_partition: "test-value".into(),
+                codec_config: (),
+                compression: None,
+                key_write_buffer: NZUsize!(1),
+                value_write_buffer: NZUsize!(1),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+                items_per_section: NZU64!(DEFAULT_ITEMS_PER_SECTION),
+            };
+
+            {
+                let mut archive = Archive::init(context.child("first"), cfg.clone())
+                    .await
+                    .expect("Failed to initialize archive");
+                archive
+                    .put(7, test_key("key-7"), 7)
+                    .await
+                    .expect("Failed to put data");
+                archive.sync().await.expect("Failed to sync archive");
+            }
+
+            let mut archive =
+                Archive::<_, _, FixedBytes<64>, i32>::init(context.child("second"), cfg)
+                    .await
+                    .expect("Failed to reopen archive");
+            let value = archive
+                .get(Identifier::Index(7))
+                .await
+                .expect("Failed to get data");
+            assert_eq!(value, Some(7));
+
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                sync_rate: Some(1.0),
+                ..Default::default()
+            };
+            assert!(
+                archive.sync().await.is_err(),
+                "replayed archive sections must remain pending until synced"
+            );
+        });
+    }
+
     fn test_archive_keys_and_restart(num_keys: usize) -> String {
         // Initialize the deterministic context
         let executor = deterministic::Runner::default();

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -175,12 +175,13 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
         let mut extra_indices: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
         let mut keys = Index::new(context.child("index"), cfg.translator.clone());
         let mut intervals = RMap::new();
+        let mut pending = BTreeSet::new();
         {
             debug!("initializing archive from index journal");
             let stream = oversized.replay(0, 0, cfg.replay_buffer).await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
-                let (_section, position, entry) = result?;
+                let (section, position, entry) = result?;
 
                 // Store index location (position in index journal)
                 match indices.entry(entry.index) {
@@ -197,6 +198,10 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
 
                 // Store index in intervals
                 intervals.insert(entry.index);
+
+                // Replayed bytes may be readable from the page cache without being durable, so the
+                // section must be synced on the next `sync` before anything relies on it.
+                pending.insert(section);
             }
             debug!("archive initialized");
         }
@@ -217,7 +222,7 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
         Ok(Self {
             items_per_section: cfg.items_per_section.get(),
             oversized,
-            pending: BTreeSet::new(),
+            pending,
             oldest_allowed: None,
             indices,
             extra_indices,

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -248,6 +248,49 @@ mod tests {
         });
     }
 
+    // Recovery durability invariant: records replayed on reopen are readable but not yet known
+    // crash-durable, so they stay pending until synced instead of being treated as durable. To
+    // check that, we inject sync faults after a clean write+sync+reopen: `sync()` has to error
+    // because those sections still need syncing. If recovery dropped them, it would no-op and pass.
+    #[test_traced]
+    fn test_cache_reopen_syncs_recovered_records() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-partition".into(),
+                codec_config: (),
+                compression: None,
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+                items_per_blob: NZU64!(DEFAULT_ITEMS_PER_BLOB),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            };
+
+            {
+                let mut cache = Cache::init(context.child("first"), cfg.clone())
+                    .await
+                    .expect("Failed to initialize cache");
+                cache.put(7, 7i32).await.expect("Failed to put data");
+                cache.sync().await.expect("Failed to sync cache");
+            }
+
+            let mut cache = Cache::<_, i32>::init(context.child("second"), cfg)
+                .await
+                .expect("Failed to reopen cache");
+            assert_eq!(cache.first(), Some(7));
+            assert_eq!(cache.get(7).await.expect("Failed to get data"), Some(7));
+
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                sync_rate: Some(1.0),
+                ..Default::default()
+            };
+            assert!(
+                cache.sync().await.is_err(),
+                "replayed cache sections must remain pending until synced"
+            );
+        });
+    }
+
     fn test_cache_restart(num_items: usize) -> String {
         // Initialize the deterministic context
         let executor = deterministic::Runner::default();

--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -102,19 +102,24 @@ impl<E: Storage + Metrics, V: CodecShared> Cache<E, V> {
         // Initialize keys and run corruption check
         let mut indices = BTreeMap::new();
         let mut intervals = RMap::new();
+        let mut pending = BTreeSet::new();
         {
             debug!("initializing cache");
             let stream = journal.replay(0, 0, cfg.replay_buffer).await?;
             pin_mut!(stream);
             while let Some(result) = stream.next().await {
                 // Extract key from record
-                let (_, offset, _, data) = result?;
+                let (section, offset, _, data) = result?;
 
                 // Store index
                 indices.insert(data.index, offset);
 
                 // Store index in intervals
                 intervals.insert(data.index);
+
+                // Replayed bytes may be readable from the page cache without being durable, so the
+                // section must be synced on the next `sync` before anything relies on it.
+                pending.insert(section);
             }
             debug!(items = indices.len(), "cache initialized");
         }
@@ -130,7 +135,7 @@ impl<E: Storage + Metrics, V: CodecShared> Cache<E, V> {
         Ok(Self {
             items_per_blob: cfg.items_per_blob.get(),
             journal,
-            pending: BTreeSet::new(),
+            pending,
             oldest_allowed: None,
             indices,
             intervals,

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -415,7 +415,7 @@ pub struct Freezer<E: BufferPooler + Context, K: Array, V: CodecShared> {
     current_section: u64,
     next_epoch: u64,
 
-    // Sections with pending table updates to be synced
+    // Oversized sections that must be synced before the next checkpoint is published
     modified_sections: BTreeSet<u64>,
     resizable: u32,
     resize_progress: Option<u32>,
@@ -658,11 +658,15 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
             .await?;
 
         // Determine checkpoint based on initialization scenario
-        let (checkpoint, resizable) = match (table_len, checkpoint) {
+        let (checkpoint, resizable, modified_sections) = match (table_len, checkpoint) {
             // New table with no data
             (0, None) => {
                 Self::init_table(&table, config.table_initial_size).await?;
-                (Checkpoint::init(config.table_initial_size), 0)
+                (
+                    Checkpoint::init(config.table_initial_size),
+                    0,
+                    BTreeSet::new(),
+                )
             }
 
             // New table with explicit checkpoint (must be empty)
@@ -673,7 +677,11 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
                 assert_eq!(checkpoint.table_size, 0);
 
                 Self::init_table(&table, config.table_initial_size).await?;
-                (Checkpoint::init(config.table_initial_size), 0)
+                (
+                    Checkpoint::init(config.table_initial_size),
+                    0,
+                    BTreeSet::new(),
+                )
             }
 
             // Existing table with checkpoint
@@ -719,14 +727,14 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
                     table.sync().await?;
                 }
 
-                (checkpoint, resizable)
+                (checkpoint, resizable, BTreeSet::new())
             }
 
             // Existing table without checkpoint
             (_, None) => {
                 // Find max epoch/section and clean invalid entries in a single pass
                 let table_size = (table_len / Entry::FULL_SIZE as u64) as u32;
-                let (modified, max_epoch, max_section, resizable) = Self::recover_table(
+                let (_, max_epoch, max_section, resizable) = Self::recover_table(
                     &context,
                     &table,
                     table_size,
@@ -736,10 +744,13 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
                 )
                 .await?;
 
-                // Sync table if needed
-                if modified {
-                    table.sync().await?;
-                }
+                // Don't sync the table here: it indexes the oversized journal, and the
+                // just-recovered oversized sections aren't durable yet, so persisting the table now
+                // could leave a durable entry pointing at bytes a crash drops. Deferring is safe --
+                // recover_table's cleanup is redone on every reopen, and the first `sync` syncs the
+                // oversized sections
+                // (tracked below) before the table. (The `(_, Some(checkpoint))` arm can sync the
+                // table during init: the checkpoint already guarantees its data was durable.)
 
                 // Get sizes from oversized (crash recovery already ran during init)
                 let oversized_size = oversized.size(max_section).await?;
@@ -752,6 +763,7 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
                         table_size,
                     },
                     resizable,
+                    oversized.sections().collect(),
                 )
             }
         };
@@ -781,7 +793,7 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
             blob_target_size: config.value_target_size,
             current_section: checkpoint.section,
             next_epoch: checkpoint.epoch.checked_add(1).expect("epoch overflow"),
-            modified_sections: BTreeSet::new(),
+            modified_sections,
             resizable,
             resize_progress: None,
             puts,
@@ -1064,7 +1076,8 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
     //
     // TODO:(<https://github.com/commonwarexyz/monorepo/issues/2910>): Make this non &mut.
     pub async fn sync(&mut self) -> Result<Checkpoint, Error> {
-        // Sync all modified sections for oversized journal
+        // Sync the recovered oversized sections before computing and returning the checkpoint
+        // below, so the caller never persists a checkpoint that references un-synced data.
         let syncs: Vec<_> = self
             .modified_sections
             .iter()
@@ -1303,6 +1316,191 @@ mod tests {
             .await
             .unwrap();
             drop(freezer);
+        });
+    }
+
+    // On a checkpoint-less reopen the oversized journal's sections are marked pending -- they're
+    // readable but not yet known crash-durable. The first sync makes them durable and clears the
+    // set.
+    #[test_traced]
+    fn test_init_without_checkpoint_marks_recovered_sections_modified() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = super::super::Config {
+                key_partition: "test-key-index".into(),
+                key_write_buffer: NZUsize!(1),
+                key_page_cache: CacheRef::from_pooler(&context, NZU16!(1024), NZUsize!(10)),
+                value_partition: "test-value-journal".into(),
+                value_compression: None,
+                value_write_buffer: NZUsize!(1),
+                value_target_size: 10 * 1024 * 1024,
+                table_partition: "test-table".into(),
+                table_initial_size: 256,
+                table_resize_frequency: u8::MAX,
+                table_resize_chunk_size: 16,
+                table_replay_buffer: NZUsize!(64 * 1024),
+                codec_config: (),
+            };
+
+            {
+                let mut freezer =
+                    Freezer::<_, FixedBytes<64>, i32>::init(context.child("first"), cfg.clone())
+                        .await
+                        .unwrap();
+                for index in 0..64 {
+                    freezer
+                        .put(test_key(&format!("key-{index}")), index)
+                        .await
+                        .unwrap();
+                }
+                freezer.sync().await.unwrap();
+            }
+
+            let mut freezer = Freezer::<_, FixedBytes<64>, i32>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert!(
+                !freezer.modified_sections.is_empty(),
+                "recovered oversized sections must be synced before publishing a checkpoint"
+            );
+
+            freezer.sync().await.unwrap();
+            assert!(freezer.modified_sections.is_empty());
+        });
+    }
+
+    // Same checkpoint-less reopen, then fail every sync. sync() must error rather than return a
+    // checkpoint: publishing one while the recovered sections are still un-synced would point it
+    // at data a crash could drop.
+    #[test_traced]
+    fn test_init_without_checkpoint_blocks_checkpoint_until_recovered_sections_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = super::super::Config {
+                key_partition: "test-key-index".into(),
+                key_write_buffer: NZUsize!(1),
+                key_page_cache: CacheRef::from_pooler(&context, NZU16!(1024), NZUsize!(10)),
+                value_partition: "test-value-journal".into(),
+                value_compression: None,
+                value_write_buffer: NZUsize!(1),
+                value_target_size: 10 * 1024 * 1024,
+                table_partition: "test-table".into(),
+                table_initial_size: 256,
+                table_resize_frequency: u8::MAX,
+                table_resize_chunk_size: 16,
+                table_replay_buffer: NZUsize!(64 * 1024),
+                codec_config: (),
+            };
+
+            {
+                let mut freezer =
+                    Freezer::<_, FixedBytes<64>, i32>::init(context.child("first"), cfg.clone())
+                        .await
+                        .unwrap();
+                for index in 0..64 {
+                    freezer
+                        .put(test_key(&format!("key-{index}")), index)
+                        .await
+                        .unwrap();
+                }
+                freezer.sync().await.unwrap();
+            }
+
+            let mut freezer = Freezer::<_, FixedBytes<64>, i32>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+
+            // sync() syncs the recovered oversized sections before producing a Checkpoint. With
+            // syncs forced to fail, that must surface as an error: the caller must never receive
+            // (and persist) a checkpoint that references un-synced recovered data.
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                sync_rate: Some(1.0),
+                ..Default::default()
+            };
+            assert!(
+                freezer.sync().await.is_err(),
+                "checkpoint must not be produced until recovered sections are durable"
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_init_without_checkpoint_does_not_sync_table_during_init() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = super::super::Config {
+                key_partition: "test-key-index".into(),
+                key_write_buffer: NZUsize!(1),
+                key_page_cache: CacheRef::from_pooler(&context, NZU16!(1024), NZUsize!(10)),
+                value_partition: "test-value-journal".into(),
+                value_compression: None,
+                value_write_buffer: NZUsize!(1),
+                value_target_size: 10 * 1024 * 1024,
+                table_partition: "test-table".into(),
+                table_initial_size: 256,
+                table_resize_frequency: u8::MAX,
+                table_resize_chunk_size: 16,
+                table_replay_buffer: NZUsize!(64 * 1024),
+                codec_config: (),
+            };
+
+            // Write a durable baseline: values land in the oversized journal and entries in the
+            // table. `close` syncs everything, so the oversized journal reopens clean (its
+            // recovery performs no sync of its own).
+            {
+                let mut freezer =
+                    Freezer::<_, FixedBytes<64>, i32>::init(context.child("first"), cfg.clone())
+                        .await
+                        .unwrap();
+                for index in 0..64 {
+                    freezer
+                        .put(test_key(&format!("key-{index}")), index)
+                        .await
+                        .unwrap();
+                }
+                freezer.close().await.unwrap();
+            }
+
+            // Corrupt a table entry so recovery has to rewrite it on reopen. That's the case where
+            // a stray table sync during init would happen, which is what we want to rule out under
+            // the sync faults below. Flipping a byte un-empties the slot and breaks its checksum,
+            // so recovery cleans it whichever keys hashed there.
+            {
+                let (blob, size) = context.open(&cfg.table_partition, b"table").await.unwrap();
+                // Needs an existing (non-empty) table so reopen takes the `(_, None)` arm.
+                assert!(
+                    size > 0,
+                    "table must exist so reopen takes the existing-table path"
+                );
+                let mut entries = blob.read_at(0, Entry::FULL_SIZE).await.unwrap().coalesce();
+                entries.as_mut()[Entry::SIZE - 4] ^= 0xFF;
+                // Sanity-check the corruption landed: the slot must be non-empty and invalid, or
+                // recovery won't rewrite it and the reopen below wouldn't exercise anything.
+                let (slot0, _) =
+                    Freezer::<Context, FixedBytes<64>, i32>::parse_entries(entries.as_ref())
+                        .unwrap();
+                assert!(!slot0.is_empty() && !slot0.is_valid());
+                blob.write_at_sync(0, entries).await.unwrap();
+            }
+
+            // Fail every sync, then reopen without a checkpoint. The table indexes the oversized
+            // journal, whose recovered sections aren't durable yet, so init must not sync the table
+            // here -- and in fact does no syncing at all, so it succeeds despite the faults.
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                sync_rate: Some(1.0),
+                ..Default::default()
+            };
+            let mut freezer = Freezer::<_, FixedBytes<64>, i32>::init(context.child("second"), cfg)
+                .await
+                .expect(
+                    "init must not sync the table while recovered oversized sections are unsynced",
+                );
+
+            // The recovered section is still tracked (just the one, holding the 64 values), and the
+            // first sync enforces it: with syncs failing, sync() must error rather than publish a
+            // checkpoint over un-synced data.
+            assert_eq!(freezer.modified_sections.len(), 1);
+            assert!(freezer.sync().await.is_err());
         });
     }
 }

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -338,6 +338,11 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
             .await
     }
 
+    /// Returns an iterator over all index sections.
+    pub(crate) fn sections(&self) -> impl Iterator<Item = u64> + '_ {
+        self.index.sections()
+    }
+
     /// Sync both journals for given section.
     pub async fn sync(&self, section: u64) -> Result<(), Error> {
         try_join(self.index.sync(section), self.values.sync(section))

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -48,6 +48,14 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
     }
 
     /// A storage structure with capabilities to persist and recover state across restarts.
+    ///
+    /// # Recovery durability invariant
+    ///
+    /// On reopen, a structure may rebuild in-memory state from bytes that are visible through the
+    /// page cache yet not crash-durable (a write is durable only once a later sync returns). It MUST
+    /// sync every recovered section before returning success from [Self::sync]/[Self::commit] or
+    /// persisting any durable artifact derived from those bytes. It must not rewind or discard the
+    /// recovered data: [Self::commit] may have made data durable beyond the recovery watermark.
     pub trait Persistable {
         /// The error type returned when there is a failure from the underlying storage system.
         type Error;

--- a/storage/src/ordinal/mod.rs
+++ b/storage/src/ordinal/mod.rs
@@ -242,6 +242,109 @@ mod tests {
         });
     }
 
+    // Recovery durability invariant: records replayed on reopen are readable but not yet known
+    // crash-durable, so they stay pending until synced instead of being treated as durable. To
+    // check that, we inject sync faults after a clean write+sync+reopen: `sync()` has to error
+    // because those sections still need syncing. If recovery dropped them, it would no-op and pass.
+    #[test_traced]
+    fn test_reopen_syncs_recovered_records() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-ordinal".into(),
+                items_per_blob: NZU64!(DEFAULT_ITEMS_PER_BLOB),
+                write_buffer: NZUsize!(1),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+            };
+            let value = FixedBytes::new([42u8; 32]);
+
+            {
+                let mut store =
+                    Ordinal::<_, FixedBytes<32>>::init(context.child("first"), cfg.clone())
+                        .await
+                        .expect("Failed to initialize store");
+                store
+                    .put(0, value.clone())
+                    .await
+                    .expect("Failed to put data");
+                store.sync().await.expect("Failed to sync data");
+            }
+
+            let store = Ordinal::<_, FixedBytes<32>>::init(context.child("second"), cfg)
+                .await
+                .expect("Failed to reopen store");
+            assert_eq!(store.get(0).await.expect("Failed to get data"), Some(value));
+
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                sync_rate: Some(1.0),
+                ..Default::default()
+            };
+            assert!(
+                store.sync().await.is_err(),
+                "reopened visible records must remain pending until synced"
+            );
+        });
+    }
+
+    // A slot whose record is invalid is excluded from the recovered index, but that decision still
+    // rests on the bytes recovery read. If those bytes are visible-but-unsynced, the section must
+    // be synced too -- not only sections that recovered a valid record. Here the section's only
+    // record is corrupted, so nothing else marks it; after reopen, a forced-failing sync() must
+    // still error because that section is owed a sync.
+    #[test_traced]
+    fn test_reopen_syncs_invalid_only_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-ordinal".into(),
+                items_per_blob: NZU64!(5),
+                write_buffer: NZUsize!(1),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+            };
+
+            {
+                let mut store =
+                    Ordinal::<_, FixedBytes<32>>::init(context.child("first"), cfg.clone())
+                        .await
+                        .expect("Failed to initialize store");
+                store
+                    .put(0, FixedBytes::new([7u8; 32]))
+                    .await
+                    .expect("Failed to put data");
+                store.sync().await.expect("Failed to sync data");
+            }
+
+            // Corrupt index 0's CRC so it reads as invalid and drops out of the index on reopen.
+            // It is the only record in section 0, so no valid record will mark the section.
+            {
+                let (blob, _) = context
+                    .open(&cfg.partition, &0u64.to_be_bytes())
+                    .await
+                    .expect("Failed to open blob");
+                blob.write_at_sync(32, vec![0xFF])
+                    .await
+                    .expect("Failed to corrupt CRC");
+            }
+
+            let store = Ordinal::<_, FixedBytes<32>>::init(context.child("second"), cfg)
+                .await
+                .expect("Failed to reopen store");
+            assert!(
+                !store.has(0),
+                "corrupted record must not be present after recovery"
+            );
+
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                sync_rate: Some(1.0),
+                ..Default::default()
+            };
+            assert!(
+                store.sync().await.is_err(),
+                "a section read during recovery must be synced even when its only record is invalid"
+            );
+        });
+    }
+
     #[test_traced]
     fn test_multiple_indices() {
         // Initialize the deterministic context

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -157,6 +157,7 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         let start = context.current();
         let mut items = 0;
         let mut intervals = RMap::new();
+        let mut pending = BTreeSet::new();
         for (section, (blob, size)) in &blobs {
             // Skip if bits are provided and the section is not in the bits
             if let Some(bits) = &bits {
@@ -198,6 +199,11 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
                 replay_blob.seek_to(offset)?;
                 let mut record_buf = replay_blob.read(Record::<V>::SIZE).await?;
                 offset += Record::<V>::SIZE as u64;
+
+                // We read this slot's bytes to decide whether it holds a valid record, so the
+                // section needs to be synced even when the record is invalid: a slot excluded from
+                // the index based on page-cache bytes must be made durable too, not just one kept.
+                pending.insert(*section);
 
                 // If record is valid, add to intervals
                 if let Ok(record) = Record::<V>::read(&mut record_buf) {
@@ -244,7 +250,7 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
             config,
             blobs,
             intervals,
-            pending: AsyncMutex::new(BTreeSet::new()),
+            pending: AsyncMutex::new(pending),
             puts,
             gets,
             has,


### PR DESCRIPTION
**A crash-recovery reopen could report success for data it never made durable.** On reopen, `cache`, `archive`, `ordinal`, and `freezer` rebuild their in-memory index by replaying stored bytes, but they never marked those replayed sections as needing a sync — so the first `sync` after a restart returned success without flushing them. This PR makes recovery mark them. (The two contiguous journals were already fixed in #3928/#3929; this finishes the remaining four structures.)

## The bug

A `write` is not durable until a later `sync` returns. But an un-synced write still lands in the OS page cache, which survives a process restart — so recovery reads it back as if it had always been there. Each of these stores keeps a "dirty set" of sections that `sync` flushes and clears. That set was seeded only by writes (`put`), never by recovery, so a reopen left it empty:

1. A process writes to a section, then exits before `sync`. The bytes are in the page cache, not on disk.
2. It restarts. Recovery replays the section and rebuilds the index from those bytes — but does not mark the section dirty.
3. The first `sync` flushes the (empty) dirty set and returns success. The caller now believes the data is durable.
4. Power loss. The page cache is gone, so the un-synced bytes vanish.
5. Next reopen: the data the previous run acknowledged is gone. For `freezer`/`ordinal` it is worse than loss (see below).

## The fix

Recovery now seeds the dirty set with every section it replays, so the existing `sync` flushes them. No new machinery: `put` already feeds the same set, and `sync` already drains and clears it.

- **cache, archive, ordinal** — the recovery replay loop inserts each replayed section into `pending`.
- **freezer** — the checkpoint-less `init` path seeds `modified_sections` with the recovered oversized sections, which `sync` flushes before producing the `Checkpoint`.

Two of the four needed more than the missing seed:

- **freezer** also stops syncing its table during checkpoint-less `init`. The table indexes the `oversized` journal; the recovered oversized sections aren't durable yet, so persisting the table there could leave a durable entry pointing at bytes a crash drops. `recover_table`'s repair is redone on every reopen, so it defers safely to the first `sync`, which flushes oversized first.
- **ordinal** marks a section as soon as its slot bytes are read — *before* the valid/invalid CRC check. A slot whose record fails its CRC is excluded from the index, but that "absent" verdict still rests on bytes recovery read; if they aren't synced, the next reopen can read them differently and rebuild a divergent index. Previously only sections holding a valid record were marked.

## A note on cost

These stores keep no recovery watermark, so they mark *every* replayed section: the first `sync` after a restart fsyncs the whole store (every section, concurrently), not just freshly written ones. Later syncs are normal. It is a one-time startup cost that scales with store size, so a large store sees an I/O burst on its first post-restart commit.

## Testing

Each fix ships a regression test that fails if the fix is reverted. They use the deterministic runtime's fault injection: force every sync to fail (`sync_rate = 1.0`), then assert that `sync` errors after a reopen — proving recovery marked the sections. (The deterministic backend discards un-synced writes on recovery, so the tests assert the sync *happens* rather than reproducing the corruption directly.) Covered: `cache`, `archive`, `ordinal`, `freezer`.

## Scope

No storage or wire format change — this only changes *when* syncs happen. The recovery durability invariant is documented on the existing `Persistable` trait. A separate, pre-existing freezer bug (`max_section` selection on checkpoint-less reopen) is left for a follow-up.
