### PR TITLE
[deployer] add attach command

### DIFF
--- a/deployer/src/aws/attach.rs
+++ b/deployer/src/aws/attach.rs
@@ -1,16 +1,16 @@
 //! `attach` subcommand for `ec2`
 
 use crate::aws::{
-    deployer_directory,
-    ec2::{self, Region},
-    utils::ssh_attach,
-    Error, Metadata, CREATED_FILE_NAME, DESTROYED_FILE_NAME, METADATA_FILE_NAME,
+    deployer_directory, utils::ssh_attach, Error, Hosts, Metadata, CREATED_FILE_NAME,
+    DESTROYED_FILE_NAME, METADATA_FILE_NAME,
 };
 use std::{
     fs::{self, File},
     net::IpAddr,
 };
-use tracing::info;
+use tracing::{info, warn};
+
+const HOSTS_FILE_NAME: &str = "hosts.yaml";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct InstanceMatch {
@@ -23,12 +23,16 @@ struct InstanceMatch {
 pub async fn attach(ip: &str) -> Result<(), Error> {
     let ip = normalize_ip(ip)?;
 
-    let mut matches = Vec::new();
     for metadata in load_active_deployments()? {
-        matches.extend(find_matches(&metadata, &ip).await?);
+        if let Some(instance) = find_match(&metadata, &ip) {
+            return attach_to_instance(&instance).await;
+        }
     }
 
-    let instance = select_match(&ip, matches)?;
+    Err(Error::InstanceNotFound(ip))
+}
+
+async fn attach_to_instance(instance: &InstanceMatch) -> Result<(), Error> {
     let key_path = deployer_directory(Some(&instance.tag)).join(format!("id_rsa_{}", instance.tag));
     if !key_path.exists() {
         return Err(Error::PrivateKeyNotFound);
@@ -79,63 +83,52 @@ fn load_active_deployments() -> Result<Vec<Metadata>, Error> {
     Ok(deployments)
 }
 
-async fn find_matches(metadata: &Metadata, ip: &str) -> Result<Vec<InstanceMatch>, Error> {
-    let mut matches = Vec::new();
-    for region in &metadata.regions {
-        let ec2_client = ec2::create_client(Region::new(region.clone())).await;
-        let resp = ec2_client
-            .describe_instances()
-            .filters(
-                aws_sdk_ec2::types::Filter::builder()
-                    .name("tag:deployer")
-                    .values(&metadata.tag)
-                    .build(),
-            )
-            .filters(
-                aws_sdk_ec2::types::Filter::builder()
-                    .name("instance-state-name")
-                    .values("running")
-                    .build(),
-            )
-            .send()
-            .await
-            .map_err(|err| err.into_service_error())?;
-
-        for instance in resp
-            .reservations
-            .unwrap_or_default()
-            .into_iter()
-            .flat_map(|reservation| reservation.instances.unwrap_or_default())
-        {
-            if instance.public_ip_address.as_deref() != Some(ip) {
-                continue;
-            }
-            matches.push(InstanceMatch {
-                tag: metadata.tag.clone(),
-                region: region.clone(),
-                ip: ip.to_string(),
-            });
+fn find_match(metadata: &Metadata, ip: &str) -> Option<InstanceMatch> {
+    let hosts_path = deployer_directory(Some(&metadata.tag)).join(HOSTS_FILE_NAME);
+    let file = match File::open(&hosts_path) {
+        Ok(file) => file,
+        Err(error) => {
+            warn!(
+                tag = metadata.tag.as_str(),
+                path = ?hosts_path,
+                ?error,
+                "failed to open hosts file while looking for attach target"
+            );
+            return None;
         }
-    }
-    Ok(matches)
+    };
+    let hosts = match serde_yaml::from_reader::<_, Hosts>(file) {
+        Ok(hosts) => hosts,
+        Err(error) => {
+            warn!(
+                tag = metadata.tag.as_str(),
+                path = ?hosts_path,
+                ?error,
+                "failed to parse hosts file while looking for attach target"
+            );
+            return None;
+        }
+    };
+    find_host_match(&metadata.tag, hosts, ip)
 }
 
-fn select_match(ip: &str, mut matches: Vec<InstanceMatch>) -> Result<InstanceMatch, Error> {
-    matches.sort_by(|a, b| {
-        a.tag
-            .cmp(&b.tag)
-            .then_with(|| a.region.cmp(&b.region))
-            .then_with(|| a.ip.cmp(&b.ip))
-    });
-    matches
+fn find_host_match(tag: &str, hosts: Hosts, ip: &str) -> Option<InstanceMatch> {
+    hosts
+        .hosts
         .into_iter()
-        .next()
-        .ok_or_else(|| Error::InstanceNotFound(ip.to_string()))
+        .find(|host| host.ip.to_string() == ip)
+        .map(|host| InstanceMatch {
+            tag: tag.to_string(),
+            region: host.region,
+            ip: ip.to_string(),
+        })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_ip, select_match, InstanceMatch};
+    use super::{find_host_match, normalize_ip, InstanceMatch};
+    use crate::aws::{Host, Hosts};
+    use std::net::IpAddr;
 
     fn instance(tag: &str, region: &str, ip: &str) -> InstanceMatch {
         InstanceMatch {
@@ -143,13 +136,6 @@ mod tests {
             region: region.to_string(),
             ip: ip.to_string(),
         }
-    }
-
-    #[test]
-    fn test_select_match() {
-        let selected = select_match("1.1.1.1", vec![instance("a", "us-east-1", "1.1.1.1")])
-            .expect("match missing");
-        assert_eq!(selected.tag, "a");
     }
 
     #[test]
@@ -161,8 +147,23 @@ mod tests {
     }
 
     #[test]
-    fn test_select_match_missing() {
-        let err = select_match("1.1.1.1", Vec::new()).expect_err("missing match selected");
-        assert_eq!(err.to_string(), "instance not found: 1.1.1.1");
+    fn test_instance_match() {
+        let selected = instance("a", "us-east-1", "1.1.1.1");
+        assert_eq!(selected.tag, "a");
+    }
+
+    #[test]
+    fn test_find_host_match() {
+        let hosts = Hosts {
+            monitoring: "10.0.0.1".parse::<IpAddr>().unwrap(),
+            hosts: vec![Host {
+                name: "node".to_string(),
+                region: "us-east-1".to_string(),
+                ip: "1.1.1.1".parse::<IpAddr>().unwrap(),
+            }],
+        };
+        let selected = find_host_match("tag", hosts, "1.1.1.1").expect("match missing");
+        assert_eq!(selected.tag, "tag");
+        assert_eq!(selected.region, "us-east-1");
     }
 }

--- a/deployer/src/aws/attach.rs
+++ b/deployer/src/aws/attach.rs
@@ -2,7 +2,7 @@
 
 use crate::aws::{
     deployer_directory, utils::ssh_attach, Error, Hosts, Metadata, CREATED_FILE_NAME,
-    DESTROYED_FILE_NAME, METADATA_FILE_NAME,
+    DESTROYED_FILE_NAME, METADATA_FILE_NAME, MONITORING_REGION,
 };
 use std::{
     fs::{self, File},
@@ -113,6 +113,14 @@ fn find_match(metadata: &Metadata, ip: &str) -> Option<InstanceMatch> {
 }
 
 fn find_host_match(tag: &str, hosts: Hosts, ip: &str) -> Option<InstanceMatch> {
+    if hosts.monitoring.public.to_string() == ip {
+        return Some(InstanceMatch {
+            tag: tag.to_string(),
+            region: MONITORING_REGION.to_string(),
+            ip: ip.to_string(),
+        });
+    }
+
     hosts
         .hosts
         .into_iter()
@@ -127,7 +135,7 @@ fn find_host_match(tag: &str, hosts: Hosts, ip: &str) -> Option<InstanceMatch> {
 #[cfg(test)]
 mod tests {
     use super::{find_host_match, normalize_ip, InstanceMatch};
-    use crate::aws::{Host, Hosts};
+    use crate::aws::{Host, Hosts, MonitoringIps, MONITORING_REGION};
     use std::net::IpAddr;
 
     fn instance(tag: &str, region: &str, ip: &str) -> InstanceMatch {
@@ -155,7 +163,10 @@ mod tests {
     #[test]
     fn test_find_host_match() {
         let hosts = Hosts {
-            monitoring: "10.0.0.1".parse::<IpAddr>().unwrap(),
+            monitoring: MonitoringIps {
+                public: "2.2.2.2".parse::<IpAddr>().unwrap(),
+                private: "10.0.0.1".parse::<IpAddr>().unwrap(),
+            },
             hosts: vec![Host {
                 name: "node".to_string(),
                 region: "us-east-1".to_string(),
@@ -165,5 +176,19 @@ mod tests {
         let selected = find_host_match("tag", hosts, "1.1.1.1").expect("match missing");
         assert_eq!(selected.tag, "tag");
         assert_eq!(selected.region, "us-east-1");
+    }
+
+    #[test]
+    fn test_find_monitoring_match() {
+        let hosts = Hosts {
+            monitoring: MonitoringIps {
+                public: "2.2.2.2".parse::<IpAddr>().unwrap(),
+                private: "10.0.0.1".parse::<IpAddr>().unwrap(),
+            },
+            hosts: Vec::new(),
+        };
+        let selected = find_host_match("tag", hosts, "2.2.2.2").expect("match missing");
+        assert_eq!(selected.tag, "tag");
+        assert_eq!(selected.region, MONITORING_REGION);
     }
 }

--- a/deployer/src/aws/attach.rs
+++ b/deployer/src/aws/attach.rs
@@ -135,7 +135,7 @@ fn find_host_match(tag: &str, hosts: Hosts, ip: &str) -> Option<InstanceMatch> {
 #[cfg(test)]
 mod tests {
     use super::{find_host_match, normalize_ip, InstanceMatch};
-    use crate::aws::{Host, Hosts, MonitoringIps, MONITORING_REGION};
+    use crate::aws::{Host, Hosts, Ips, MONITORING_REGION};
     use std::net::IpAddr;
 
     fn instance(tag: &str, region: &str, ip: &str) -> InstanceMatch {
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn test_find_host_match() {
         let hosts = Hosts {
-            monitoring: MonitoringIps {
+            monitoring: Ips {
                 public: "2.2.2.2".parse::<IpAddr>().unwrap(),
                 private: "10.0.0.1".parse::<IpAddr>().unwrap(),
             },
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn test_find_monitoring_match() {
         let hosts = Hosts {
-            monitoring: MonitoringIps {
+            monitoring: Ips {
                 public: "2.2.2.2".parse::<IpAddr>().unwrap(),
                 private: "10.0.0.1".parse::<IpAddr>().unwrap(),
             },

--- a/deployer/src/aws/attach.rs
+++ b/deployer/src/aws/attach.rs
@@ -1,0 +1,168 @@
+//! `attach` subcommand for `ec2`
+
+use crate::aws::{
+    deployer_directory,
+    ec2::{self, Region},
+    utils::ssh_attach,
+    Error, Metadata, CREATED_FILE_NAME, DESTROYED_FILE_NAME, METADATA_FILE_NAME,
+};
+use std::{
+    fs::{self, File},
+    net::IpAddr,
+};
+use tracing::info;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct InstanceMatch {
+    tag: String,
+    region: String,
+    ip: String,
+}
+
+/// Opens an interactive SSH session to a deployed instance.
+pub async fn attach(ip: &str) -> Result<(), Error> {
+    let ip = normalize_ip(ip)?;
+
+    let mut matches = Vec::new();
+    for metadata in load_active_deployments()? {
+        matches.extend(find_matches(&metadata, &ip).await?);
+    }
+
+    let instance = select_match(&ip, matches)?;
+    let key_path = deployer_directory(Some(&instance.tag)).join(format!("id_rsa_{}", instance.tag));
+    if !key_path.exists() {
+        return Err(Error::PrivateKeyNotFound);
+    }
+
+    info!(
+        tag = instance.tag.as_str(),
+        region = instance.region.as_str(),
+        ip = instance.ip.as_str(),
+        "attaching to instance"
+    );
+    ssh_attach(key_path.to_str().unwrap(), &instance.ip).await
+}
+
+fn normalize_ip(ip: &str) -> Result<String, Error> {
+    Ok(ip.parse::<IpAddr>()?.to_string())
+}
+
+fn load_active_deployments() -> Result<Vec<Metadata>, Error> {
+    let deployer_dir = deployer_directory(None);
+    if !deployer_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut deployments: Vec<Metadata> = Vec::new();
+    for entry in fs::read_dir(&deployer_dir)? {
+        let path = entry?.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if path.join(DESTROYED_FILE_NAME).exists() {
+            continue;
+        }
+        if !path.join(CREATED_FILE_NAME).exists() {
+            continue;
+        }
+
+        let metadata_path = path.join(METADATA_FILE_NAME);
+        let Ok(file) = File::open(&metadata_path) else {
+            continue;
+        };
+        let Ok(metadata) = serde_yaml::from_reader(file) else {
+            continue;
+        };
+        deployments.push(metadata);
+    }
+    deployments.sort_by(|a, b| a.tag.cmp(&b.tag));
+    Ok(deployments)
+}
+
+async fn find_matches(metadata: &Metadata, ip: &str) -> Result<Vec<InstanceMatch>, Error> {
+    let mut matches = Vec::new();
+    for region in &metadata.regions {
+        let ec2_client = ec2::create_client(Region::new(region.clone())).await;
+        let resp = ec2_client
+            .describe_instances()
+            .filters(
+                aws_sdk_ec2::types::Filter::builder()
+                    .name("tag:deployer")
+                    .values(&metadata.tag)
+                    .build(),
+            )
+            .filters(
+                aws_sdk_ec2::types::Filter::builder()
+                    .name("instance-state-name")
+                    .values("running")
+                    .build(),
+            )
+            .send()
+            .await
+            .map_err(|err| err.into_service_error())?;
+
+        for instance in resp
+            .reservations
+            .unwrap_or_default()
+            .into_iter()
+            .flat_map(|reservation| reservation.instances.unwrap_or_default())
+        {
+            if instance.public_ip_address.as_deref() != Some(ip) {
+                continue;
+            }
+            matches.push(InstanceMatch {
+                tag: metadata.tag.clone(),
+                region: region.clone(),
+                ip: ip.to_string(),
+            });
+        }
+    }
+    Ok(matches)
+}
+
+fn select_match(ip: &str, mut matches: Vec<InstanceMatch>) -> Result<InstanceMatch, Error> {
+    matches.sort_by(|a, b| {
+        a.tag
+            .cmp(&b.tag)
+            .then_with(|| a.region.cmp(&b.region))
+            .then_with(|| a.ip.cmp(&b.ip))
+    });
+    matches
+        .into_iter()
+        .next()
+        .ok_or_else(|| Error::InstanceNotFound(ip.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_ip, select_match, InstanceMatch};
+
+    fn instance(tag: &str, region: &str, ip: &str) -> InstanceMatch {
+        InstanceMatch {
+            tag: tag.to_string(),
+            region: region.to_string(),
+            ip: ip.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_select_match() {
+        let selected = select_match("1.1.1.1", vec![instance("a", "us-east-1", "1.1.1.1")])
+            .expect("match missing");
+        assert_eq!(selected.tag, "a");
+    }
+
+    #[test]
+    fn test_normalize_ip() {
+        assert_eq!(
+            normalize_ip("2001:db8:0:0::1").expect("failed to parse ip"),
+            "2001:db8::1"
+        );
+    }
+
+    #[test]
+    fn test_select_match_missing() {
+        let err = select_match("1.1.1.1", Vec::new()).expect_err("missing match selected");
+        assert_eq!(err.to_string(), "instance not found: 1.1.1.1");
+    }
+}

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -6,8 +6,9 @@ use crate::aws::{
     s3::{self, *},
     services::*,
     utils::*,
-    Architecture, Config, Error, Host, Hosts, InstanceConfig, Metadata, CREATED_FILE_NAME,
-    LOGS_PORT, METADATA_FILE_NAME, MONITORING_NAME, MONITORING_REGION, PROFILES_PORT, TRACES_PORT,
+    Architecture, Config, Error, Host, Hosts, InstanceConfig, Metadata, MonitoringIps,
+    CREATED_FILE_NAME, LOGS_PORT, METADATA_FILE_NAME, MONITORING_NAME, MONITORING_REGION,
+    PROFILES_PORT, TRACES_PORT,
 };
 use commonware_cryptography::{Hasher as _, Sha256};
 use futures::{
@@ -905,7 +906,10 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
 
     // Generate hosts.yaml and upload once (shared by all instances)
     let hosts = Hosts {
-        monitoring: monitoring_private_ip.clone().parse::<IpAddr>().unwrap(),
+        monitoring: MonitoringIps {
+            public: monitoring_ip.clone().parse::<IpAddr>().unwrap(),
+            private: monitoring_private_ip.clone().parse::<IpAddr>().unwrap(),
+        },
         hosts: deployments
             .iter()
             .map(|d| Host {

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -6,9 +6,8 @@ use crate::aws::{
     s3::{self, *},
     services::*,
     utils::*,
-    Architecture, Config, Error, Host, Hosts, InstanceConfig, Metadata, MonitoringIps,
-    CREATED_FILE_NAME, LOGS_PORT, METADATA_FILE_NAME, MONITORING_NAME, MONITORING_REGION,
-    PROFILES_PORT, TRACES_PORT,
+    Architecture, Config, Error, Host, Hosts, InstanceConfig, Ips, Metadata, CREATED_FILE_NAME,
+    LOGS_PORT, METADATA_FILE_NAME, MONITORING_NAME, MONITORING_REGION, PROFILES_PORT, TRACES_PORT,
 };
 use commonware_cryptography::{Hasher as _, Sha256};
 use futures::{
@@ -906,7 +905,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
 
     // Generate hosts.yaml and upload once (shared by all instances)
     let hosts = Hosts {
-        monitoring: MonitoringIps {
+        monitoring: Ips {
             public: monitoring_ip.clone().parse::<IpAddr>().unwrap(),
             private: monitoring_private_ip.clone().parse::<IpAddr>().unwrap(),
         },

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -598,13 +598,13 @@ pub struct Host {
     pub ip: IpAddr,
 }
 
-/// Monitoring instance IP addresses.
+/// Instance IP addresses.
 #[derive(Serialize, Deserialize, Clone)]
-pub struct MonitoringIps {
-    /// Public IP address of the monitoring instance.
+pub struct Ips {
+    /// Public IP address of the instance.
     pub public: IpAddr,
 
-    /// Private IP address of the monitoring instance.
+    /// Private IP address of the instance.
     pub private: IpAddr,
 }
 
@@ -612,7 +612,7 @@ pub struct MonitoringIps {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Hosts {
     /// Public and private IP addresses of the monitoring instance.
-    pub monitoring: MonitoringIps,
+    pub monitoring: Ips,
 
     /// Hosts deployed across all regions
     pub hosts: Vec<Host>,

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -345,6 +345,8 @@ cfg_if::cfg_if! {
         pub use clean::clean;
         mod profile;
         pub use profile::profile;
+        mod attach;
+        pub use attach::attach;
         mod list;
         pub use list::list;
         pub mod s3;
@@ -400,6 +402,9 @@ cfg_if::cfg_if! {
 
         /// Profile subcommand name
         pub const PROFILE_CMD: &str = "profile";
+
+        /// Attach subcommand name
+        pub const ATTACH_CMD: &str = "attach";
 
         /// List subcommand name
         pub const LIST_CMD: &str = "list";

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -598,11 +598,21 @@ pub struct Host {
     pub ip: IpAddr,
 }
 
+/// Monitoring instance IP addresses.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct MonitoringIps {
+    /// Public IP address of the monitoring instance.
+    pub public: IpAddr,
+
+    /// Private IP address of the monitoring instance.
+    pub private: IpAddr,
+}
+
 /// List of hosts
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Hosts {
-    /// Private IP address of the monitoring instance
-    pub monitoring: IpAddr,
+    /// Public and private IP addresses of the monitoring instance.
+    pub monitoring: MonitoringIps,
 
     /// Hosts deployed across all regions
     pub hosts: Vec<Host>,

--- a/deployer/src/aws/utils.rs
+++ b/deployer/src/aws/utils.rs
@@ -43,6 +43,10 @@ fn scp_target(ip: &str, remote_path: &str) -> String {
     format!("{}:{remote_path}", ssh_target(ip))
 }
 
+fn ssh_attach_code_ok(code: Option<i32>) -> bool {
+    matches!(code, Some(0 | 130))
+}
+
 /// Fetch the current machine's public IPv4 address
 pub async fn get_public_ip() -> Result<String, Error> {
     // icanhazip.com is maintained by Cloudflare as of 6/6/2021 (https://major.io/p/a-new-future-for-icanhazip/)
@@ -97,7 +101,7 @@ pub async fn ssh_attach(key_file: &str, ip: &str) -> Result<(), Error> {
         .stderr(Stdio::inherit())
         .status()
         .await?;
-    if status.success() {
+    if ssh_attach_code_ok(status.code()) {
         return Ok(());
     }
     Err(Error::SshFailed)
@@ -253,7 +257,7 @@ async fn download_file_once(url: &str, dest: &Path) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::{scp_target, ssh_target};
+    use super::{scp_target, ssh_attach_code_ok, ssh_target};
 
     #[test]
     fn test_ssh_target_ipv4() {
@@ -271,5 +275,14 @@ mod tests {
             scp_target("2001:db8::1", "/tmp/profile.json"),
             "ubuntu@[2001:db8::1]:/tmp/profile.json"
         );
+    }
+
+    #[test]
+    fn test_ssh_attach_code_ok() {
+        assert!(ssh_attach_code_ok(Some(0)));
+        assert!(ssh_attach_code_ok(Some(130)));
+        assert!(!ssh_attach_code_ok(Some(1)));
+        assert!(!ssh_attach_code_ok(Some(255)));
+        assert!(!ssh_attach_code_ok(None));
     }
 }

--- a/deployer/src/aws/utils.rs
+++ b/deployer/src/aws/utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions for interacting with EC2 instances
 
 use crate::aws::Error;
-use std::{path::Path, process::Stdio};
+use std::{net::IpAddr, path::Path, process::Stdio};
 use tokio::{
     fs::File,
     io::AsyncWriteExt,
@@ -28,6 +28,21 @@ pub const DEPLOYER_MIN_PORT: i32 = 0;
 /// Maximum port for deployer ingress
 pub const DEPLOYER_MAX_PORT: i32 = 65535;
 
+fn ssh_host(ip: &str) -> String {
+    match ip.parse::<IpAddr>() {
+        Ok(IpAddr::V6(ip)) => format!("[{ip}]"),
+        _ => ip.to_string(),
+    }
+}
+
+fn ssh_target(ip: &str) -> String {
+    format!("ubuntu@{}", ssh_host(ip))
+}
+
+fn scp_target(ip: &str, remote_path: &str) -> String {
+    format!("{}:{remote_path}", ssh_target(ip))
+}
+
 /// Fetch the current machine's public IPv4 address
 pub async fn get_public_ip() -> Result<String, Error> {
     // icanhazip.com is maintained by Cloudflare as of 6/6/2021 (https://major.io/p/a-new-future-for-icanhazip/)
@@ -52,7 +67,7 @@ pub async fn ssh_execute(key_file: &str, ip: &str, command: &str) -> Result<(), 
             .arg("ServerAliveInterval=600")
             .arg("-o")
             .arg("StrictHostKeyChecking=no")
-            .arg(format!("ubuntu@{ip}"))
+            .arg(ssh_target(ip))
             .arg(command)
             .output()
             .await?;
@@ -76,7 +91,7 @@ pub async fn ssh_attach(key_file: &str, ip: &str) -> Result<(), Error> {
         .arg("ServerAliveInterval=600")
         .arg("-o")
         .arg("StrictHostKeyChecking=no")
-        .arg(format!("ubuntu@{ip}"))
+        .arg(ssh_target(ip))
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
@@ -100,7 +115,7 @@ pub async fn poll_service_active(key_file: &str, ip: &str, service: &str) -> Res
             .arg("ServerAliveInterval=600")
             .arg("-o")
             .arg("StrictHostKeyChecking=no")
-            .arg(format!("ubuntu@{ip}"))
+            .arg(ssh_target(ip))
             .arg(format!("systemctl is-active {service}"))
             .output()
             .await?;
@@ -131,7 +146,7 @@ pub async fn poll_service_inactive(key_file: &str, ip: &str, service: &str) -> R
             .arg("ServerAliveInterval=600")
             .arg("-o")
             .arg("StrictHostKeyChecking=no")
-            .arg(format!("ubuntu@{ip}"))
+            .arg(ssh_target(ip))
             .arg(format!("systemctl is-active {service}"))
             .output()
             .await?;
@@ -167,7 +182,7 @@ pub async fn scp_download(
             .arg("ServerAliveInterval=600")
             .arg("-o")
             .arg("StrictHostKeyChecking=no")
-            .arg(format!("ubuntu@{ip}:{remote_path}"))
+            .arg(scp_target(ip, remote_path))
             .arg(local_path)
             .output()
             .await?;
@@ -234,4 +249,27 @@ async fn download_file_once(url: &str, dest: &Path) -> Result<(), Error> {
     file.flush().await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{scp_target, ssh_target};
+
+    #[test]
+    fn test_ssh_target_ipv4() {
+        assert_eq!(ssh_target("1.2.3.4"), "ubuntu@1.2.3.4");
+    }
+
+    #[test]
+    fn test_ssh_target_ipv6() {
+        assert_eq!(ssh_target("2001:db8::1"), "ubuntu@[2001:db8::1]");
+    }
+
+    #[test]
+    fn test_scp_target_ipv6() {
+        assert_eq!(
+            scp_target("2001:db8::1", "/tmp/profile.json"),
+            "ubuntu@[2001:db8::1]:/tmp/profile.json"
+        );
+    }
 }

--- a/deployer/src/aws/utils.rs
+++ b/deployer/src/aws/utils.rs
@@ -28,7 +28,7 @@ pub const DEPLOYER_MIN_PORT: i32 = 0;
 /// Maximum port for deployer ingress
 pub const DEPLOYER_MAX_PORT: i32 = 65535;
 
-fn ssh_host(ip: &str) -> String {
+fn scp_host(ip: &str) -> String {
     match ip.parse::<IpAddr>() {
         Ok(IpAddr::V6(ip)) => format!("[{ip}]"),
         _ => ip.to_string(),
@@ -36,11 +36,11 @@ fn ssh_host(ip: &str) -> String {
 }
 
 fn ssh_target(ip: &str) -> String {
-    format!("ubuntu@{}", ssh_host(ip))
+    format!("ubuntu@{ip}")
 }
 
 fn scp_target(ip: &str, remote_path: &str) -> String {
-    format!("{}:{remote_path}", ssh_target(ip))
+    format!("ubuntu@{}:{remote_path}", scp_host(ip))
 }
 
 fn ssh_attach_code_ok(code: Option<i32>) -> bool {
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_ssh_target_ipv6() {
-        assert_eq!(ssh_target("2001:db8::1"), "ubuntu@[2001:db8::1]");
+        assert_eq!(ssh_target("2001:db8::1"), "ubuntu@2001:db8::1");
     }
 
     #[test]

--- a/deployer/src/aws/utils.rs
+++ b/deployer/src/aws/utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions for interacting with EC2 instances
 
 use crate::aws::Error;
-use std::path::Path;
+use std::{path::Path, process::Stdio};
 use tokio::{
     fs::File,
     io::AsyncWriteExt,
@@ -61,6 +61,29 @@ pub async fn ssh_execute(key_file: &str, ip: &str, command: &str) -> Result<(), 
         }
         warn!(ip, stderr = ?String::from_utf8_lossy(&output.stderr), stdout = ?String::from_utf8_lossy(&output.stdout), "SSH command failed");
         sleep(RETRY_INTERVAL).await;
+    }
+    Err(Error::SshFailed)
+}
+
+/// Opens an interactive SSH session to a remote instance
+pub async fn ssh_attach(key_file: &str, ip: &str) -> Result<(), Error> {
+    let status = Command::new("ssh")
+        .arg("-i")
+        .arg(key_file)
+        .arg("-o")
+        .arg("IdentitiesOnly=yes")
+        .arg("-o")
+        .arg("ServerAliveInterval=600")
+        .arg("-o")
+        .arg("StrictHostKeyChecking=no")
+        .arg(format!("ubuntu@{ip}"))
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .await?;
+    if status.success() {
+        return Ok(());
     }
     Err(Error::SshFailed)
 }

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -143,7 +143,17 @@ async fn main() -> std::process::ExitCode {
                                 .help("Path to local binary with debug symbols for symbolication")
                                 .value_parser(clap::value_parser!(PathBuf)),
                         ),
-                ),
+                )
+                .subcommand(
+                    Command::new(aws::ATTACH_CMD)
+                        .about("Open an SSH session to a deployed instance.")
+                        .arg(
+                            Arg::new("ip")
+                                .required(true)
+                                .help("Public IP address of instance to attach to")
+                                .value_parser(clap::value_parser!(String)),
+                        ),
+                )
         )
         .get_matches();
 
@@ -215,6 +225,14 @@ async fn main() -> std::process::ExitCode {
                 let binary = matches.get_one::<PathBuf>("binary").unwrap();
                 if let Err(e) = aws::profile(config_path, instance, duration, binary).await {
                     error!(error=?e, "failed to profile instance");
+                } else {
+                    return std::process::ExitCode::SUCCESS;
+                }
+            }
+            Some((aws::ATTACH_CMD, matches)) => {
+                let ip = matches.get_one::<String>("ip").unwrap();
+                if let Err(e) = aws::attach(ip).await {
+                    error!(error=?e, "failed to attach to instance");
                 } else {
                     return std::process::ExitCode::SUCCESS;
                 }

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -77,7 +77,7 @@ fn main() {
         // Configure telemetry
         let tracing = if config.instrument {
             Some(tokio::tracing::Config {
-                endpoint: format!("http://{}:4318/v1/traces", hosts.monitoring),
+                endpoint: format!("http://{}:4318/v1/traces", hosts.monitoring.private),
                 name: public_key.to_string(),
                 rate: 1.0,
             })


### PR DESCRIPTION
## Overview

Adds a convenience `attach` subcommand that locates the tag belonging to a given IP address of an EC2 instance and ssh's into the box with the identity.