### PR TITLE
[glue] relax current db committed target equivalence

### DIFF
--- a/glue/src/stateful/actor/syncer/mod.rs
+++ b/glue/src/stateful/actor/syncer/mod.rs
@@ -416,11 +416,12 @@ where
     // we attempt to repair by rewinding the databases back to the marshal floor. If
     // the rewind fails to produce a consistent state, we must crash. This can occur
     // if the databases were corrupted or pruned to aggressively.
-    if databases.committed_targets().await != processed_targets {
+    let committed_targets = databases.committed_targets().await;
+    if !A::Databases::committed_targets_equivalent(&committed_targets, &processed_targets) {
         databases.rewind_to_targets(processed_targets.clone()).await;
         let rewound_targets = databases.committed_targets().await;
         assert!(
-            rewound_targets == processed_targets,
+            A::Databases::committed_targets_equivalent(&rewound_targets, &processed_targets),
             "databases must be consistent with marshal floor after rewind"
         );
     }

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -11,7 +11,7 @@ use crate::stateful::db::{
     Unmerkleized as UnmerkleizedTrait,
 };
 use commonware_codec::{Codec, Read as CodecRead};
-use commonware_cryptography::Hasher;
+use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_storage::{
@@ -46,6 +46,17 @@ use std::{ops::Deref, sync::Arc};
 
 type CurrentDbHandle<F, E, C, I, H, U, const N: usize, S> =
     Arc<AsyncRwLock<Db<F, E, C, I, H, U, N, S>>>;
+
+fn current_committed_target_equivalent<F, D>(
+    actual: &CurrentSyncTarget<F, D>,
+    expected: &CurrentSyncTarget<F, D>,
+) -> bool
+where
+    F: Graftable,
+    D: Digest,
+{
+    actual.root == expected.root && actual.range.end() == expected.range.end()
+}
 
 /// Wraps a QMDB [`UnmerkleizedBatch`] with a reference to the parent
 /// database, implementing the [`Unmerkleized`](super::Unmerkleized) trait.
@@ -381,6 +392,10 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
+    fn committed_target_equivalent(actual: &Self::SyncTarget, expected: &Self::SyncTarget) -> bool {
+        current_committed_target_equivalent(actual, expected)
+    }
+
     async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
         self.apply_batch(batch.inner).await?;
         self.sync().await?;
@@ -400,8 +415,8 @@ where
         self.sync().await?;
 
         let rewound_target = self.sync_target().await;
-        assert_eq!(
-            rewound_target, target,
+        assert!(
+            Self::committed_target_equivalent(&rewound_target, &target),
             "rewound database target mismatch after rewind",
         );
         Ok(())
@@ -472,6 +487,10 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
+    fn committed_target_equivalent(actual: &Self::SyncTarget, expected: &Self::SyncTarget) -> bool {
+        current_committed_target_equivalent(actual, expected)
+    }
+
     async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
         self.apply_batch(batch.inner).await?;
         self.sync().await?;
@@ -491,8 +510,8 @@ where
         self.sync().await?;
 
         let rewound_target = self.sync_target().await;
-        assert_eq!(
-            rewound_target, target,
+        assert!(
+            Self::committed_target_equivalent(&rewound_target, &target),
             "rewound database target mismatch after rewind",
         );
         Ok(())
@@ -640,6 +659,10 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
+    fn committed_target_equivalent(actual: &Self::SyncTarget, expected: &Self::SyncTarget) -> bool {
+        current_committed_target_equivalent(actual, expected)
+    }
+
     async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
         self.apply_batch(batch.inner).await?;
         self.sync().await?;
@@ -659,8 +682,8 @@ where
         self.sync().await?;
 
         let rewound_target = self.sync_target().await;
-        assert_eq!(
-            rewound_target, target,
+        assert!(
+            Self::committed_target_equivalent(&rewound_target, &target),
             "rewound database target mismatch after rewind",
         );
         Ok(())
@@ -736,6 +759,10 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
+    fn committed_target_equivalent(actual: &Self::SyncTarget, expected: &Self::SyncTarget) -> bool {
+        current_committed_target_equivalent(actual, expected)
+    }
+
     async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
         self.apply_batch(batch.inner).await?;
         self.sync().await?;
@@ -755,8 +782,8 @@ where
         self.sync().await?;
 
         let rewound_target = self.sync_target().await;
-        assert_eq!(
-            rewound_target, target,
+        assert!(
+            Self::committed_target_equivalent(&rewound_target, &target),
             "rewound database target mismatch after rewind",
         );
         Ok(())
@@ -1000,7 +1027,7 @@ mod tests {
         merkle::{full::Config as MerkleConfig, mmr},
         qmdb::current::{
             ordered::{fixed as ordered_fixed, variable as ordered_variable},
-            unordered::fixed,
+            unordered::{fixed, variable as unordered_variable},
         },
         translator::TwoCap,
     };
@@ -1329,12 +1356,14 @@ mod tests {
             let db = Arc::new(AsyncRwLock::new(db));
 
             let key = Sha256::hash(b"key");
+            let key2 = Sha256::hash(b"key2");
             let value = Sha256::hash(b"value");
             let metadata = Sha256::hash(b"metadata");
 
             let batch = <FixedDb as ManagedDb<_>>::new_batch(&db)
                 .await
                 .write(key, Some(value))
+                .write(key2, Some(value))
                 .with_metadata(metadata);
             let merkleized = crate::stateful::db::Unmerkleized::merkleize(batch)
                 .await
@@ -1355,11 +1384,29 @@ mod tests {
                 &valid_target,
             ));
 
+            let mut wrong_start = valid_target.clone();
+            wrong_start.range = non_empty_range!(
+                mmr::Location::new(*valid_target.range.start() + 1),
+                mmr::Location::new(*valid_target.range.end())
+            );
+            assert!(!<FixedDb as ManagedDb<_>>::matches_sync_target(
+                &merkleized,
+                &wrong_start,
+            ));
+            assert!(<FixedDb as ManagedDb<_>>::committed_target_equivalent(
+                &wrong_start,
+                &valid_target,
+            ));
+
             let mut wrong_root = valid_target.clone();
             wrong_root.root = Sha256::hash(b"wrong ops root");
             assert!(!<FixedDb as ManagedDb<_>>::matches_sync_target(
                 &merkleized,
                 &wrong_root,
+            ));
+            assert!(!<FixedDb as ManagedDb<_>>::committed_target_equivalent(
+                &wrong_root,
+                &valid_target,
             ));
 
             let mut wrong_range = valid_target.clone();
@@ -1371,6 +1418,223 @@ mod tests {
                 &merkleized,
                 &wrong_range,
             ));
+            assert!(!<FixedDb as ManagedDb<_>>::committed_target_equivalent(
+                &wrong_range,
+                &valid_target,
+            ));
         });
+    }
+
+    // Smallest valid chunk size for a 32-byte digest (N=32 → 256 bits/chunk) so pruning
+    // advances the sync boundary after a few hundred commits in these tests.
+    type PruneFixedDb = fixed::Db<
+        mmr::Family,
+        deterministic::Context,
+        Digest,
+        Digest,
+        Sha256,
+        TwoCap,
+        32,
+        Sequential,
+    >;
+    type PruneVariableDb = unordered_variable::Db<
+        mmr::Family,
+        deterministic::Context,
+        Digest,
+        Digest,
+        Sha256,
+        TwoCap,
+        32,
+        Sequential,
+    >;
+    type PruneOrderedFixedDb = ordered_fixed::Db<
+        mmr::Family,
+        deterministic::Context,
+        Digest,
+        Digest,
+        Sha256,
+        TwoCap,
+        32,
+        Sequential,
+    >;
+    type PruneOrderedVariableDb = ordered_variable::Db<
+        mmr::Family,
+        deterministic::Context,
+        Digest,
+        Digest,
+        Sha256,
+        TwoCap,
+        32,
+        Sequential,
+    >;
+
+    // For `current` QMDB, a committed target's `range.start` is the local `sync_boundary()`
+    // (a retention/pruning lower bound) while `root` + `range.end` identify committed state.
+    // After pruning advances the local floor, reconciling the database back to a target with
+    // an earlier retained `range.start` (e.g. the start a block stamped from
+    // `MerkleizedBatch::sync_boundary` before pruning) is valid and must not panic, even
+    // though the live recomputed `range.start` is now higher. On upstream `main` this panics
+    // with "rewound database target mismatch after rewind"; with the relaxed equivalence it
+    // succeeds.
+    macro_rules! current_prune_rewind_drift_test {
+        ($name:ident, $db:ty, $config:ident, $suffix:literal) => {
+            #[test]
+            fn $name() {
+                deterministic::Runner::default().start(|context| async move {
+                    let config = $config($suffix, &context);
+                    let db = <$db as ManagedDb<_>>::init(context.child("db"), config)
+                        .await
+                        .unwrap();
+                    let db = Arc::new(AsyncRwLock::new(db));
+
+                    // Commit and prune until the live sync boundary advances past 0,
+                    // simulating a node that has pruned past its earliest retained start.
+                    let mut round: u64 = 0;
+                    loop {
+                        let key = Sha256::hash(format!("key-{round}").as_bytes());
+                        let value = Sha256::hash(format!("value-{round}").as_bytes());
+                        let metadata = Sha256::hash(format!("metadata-{round}").as_bytes());
+                        let batch = <$db as ManagedDb<_>>::new_batch(&db)
+                            .await
+                            .write(key, Some(value))
+                            .with_metadata(metadata);
+                        let merkleized = crate::stateful::db::Unmerkleized::merkleize(batch)
+                            .await
+                            .unwrap();
+                        let advanced = {
+                            let mut guard = db.write().await;
+                            <$db as ManagedDb<_>>::finalize(&mut *guard, merkleized)
+                                .await
+                                .unwrap();
+                            let boundary = guard.sync_boundary();
+                            guard.prune(boundary).await.unwrap();
+                            *guard.sync_boundary() > 0
+                        };
+                        if advanced {
+                            break;
+                        }
+                        round += 1;
+                        assert!(round < 4096, "sync_boundary never advanced past 0");
+                    }
+
+                    // Live committed target: root + [advanced_start, end).
+                    let live_target = {
+                        let guard = db.read().await;
+                        <$db as ManagedDb<_>>::sync_target(&*guard).await
+                    };
+                    assert!(
+                        *live_target.range.start() > 0,
+                        "test precondition: pruning advanced the sync boundary",
+                    );
+
+                    // The marshal-floor/block target: same root + end, but an earlier retained
+                    // start (0), as stamped before the local floor advanced.
+                    let floor_target = CurrentSyncTarget::new(
+                        live_target.root,
+                        non_empty_range!(
+                            mmr::Location::new(0),
+                            mmr::Location::new(*live_target.range.end())
+                        ),
+                    );
+                    assert_ne!(*floor_target.range.start(), *live_target.range.start());
+
+                    // Reconcile to the floor target. Panics on upstream main; succeeds here.
+                    {
+                        let mut guard = db.write().await;
+                        <$db as ManagedDb<_>>::rewind_to_target(&mut *guard, floor_target.clone())
+                            .await
+                            .unwrap();
+                    }
+
+                    let rewound = {
+                        let guard = db.read().await;
+                        <$db as ManagedDb<_>>::sync_target(&*guard).await
+                    };
+                    assert_eq!(rewound.root, floor_target.root, "root identifies committed state");
+                    assert_eq!(
+                        *rewound.range.end(),
+                        *floor_target.range.end(),
+                        "range.end identifies committed state",
+                    );
+                    assert!(
+                        *rewound.range.start() >= *live_target.range.start(),
+                        "range.start reflects the local advanced pruning floor, not the floor target's earlier start",
+                    );
+                });
+            }
+        };
+    }
+
+    current_prune_rewind_drift_test!(
+        unordered_fixed_current_db_rewind_accepts_advanced_start,
+        PruneFixedDb,
+        fixed_config,
+        "prune-rewind-unordered-fixed"
+    );
+    current_prune_rewind_drift_test!(
+        unordered_variable_current_db_rewind_accepts_advanced_start,
+        PruneVariableDb,
+        variable_config,
+        "prune-rewind-unordered-variable"
+    );
+    current_prune_rewind_drift_test!(
+        ordered_fixed_current_db_rewind_accepts_advanced_start,
+        PruneOrderedFixedDb,
+        fixed_config,
+        "prune-rewind-ordered-fixed"
+    );
+    current_prune_rewind_drift_test!(
+        ordered_variable_current_db_rewind_accepts_advanced_start,
+        PruneOrderedVariableDb,
+        variable_config,
+        "prune-rewind-ordered-variable"
+    );
+
+    // `DatabaseSet::committed_targets_equivalent` is the predicate the tuple state-sync
+    // convergence check uses. Like the single-DB `committed_target_equivalent`, it must
+    // ignore the per-`current`-DB `range.start` (a local retention boundary) while still
+    // distinguishing committed state via `root` + `range.end`.
+    #[test]
+    fn current_db_set_committed_targets_equivalent_ignores_range_start() {
+        type Set = (Arc<AsyncRwLock<FixedDb>>, Arc<AsyncRwLock<OrderedFixedDb>>);
+        let root = Sha256::hash(b"ops-root");
+        let target = |start: u64, end: u64| {
+            CurrentSyncTarget::new(
+                root,
+                non_empty_range!(mmr::Location::new(start), mmr::Location::new(end)),
+            )
+        };
+
+        let actual = (target(256, 514), target(256, 514));
+
+        // Earlier retained `range.start` on both members: still the same committed state.
+        let earlier_start = (target(0, 514), target(0, 514));
+        assert!(<Set as crate::stateful::db::DatabaseSet<
+            deterministic::Context,
+        >>::committed_targets_equivalent(
+            &actual, &earlier_start,
+        ));
+
+        // Different `range.end` on one member: different committed state.
+        let wrong_end = (target(256, 515), target(256, 514));
+        assert!(!<Set as crate::stateful::db::DatabaseSet<
+            deterministic::Context,
+        >>::committed_targets_equivalent(
+            &actual, &wrong_end,
+        ));
+
+        // Different `root` on one member: different committed state.
+        let wrong_root = (
+            CurrentSyncTarget::new(
+                Sha256::hash(b"other-root"),
+                non_empty_range!(mmr::Location::new(256), mmr::Location::new(514)),
+            ),
+            target(256, 514),
+        );
+        assert!(!<Set as crate::stateful::db::DatabaseSet<
+            deterministic::Context,
+        >>::committed_targets_equivalent(
+            &actual, &wrong_root,
+        ));
     }
 }

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -191,6 +191,14 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
     /// Return true if a merkleized batch matches a committed sync target.
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool;
 
+    /// Return true if two committed sync targets represent the same committed state.
+    ///
+    /// This defaults to exact target equality. Database implementations may relax fields
+    /// that describe local retention boundaries rather than committed state identity.
+    fn committed_target_equivalent(actual: &Self::SyncTarget, expected: &Self::SyncTarget) -> bool {
+        actual == expected
+    }
+
     /// Apply a merkleized batch's changeset to the underlying database.
     ///
     /// In QMDB, this encapsulates calling `merkleized.finalize()` to produce
@@ -262,6 +270,12 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
 
     /// Return true if merkleized batches match the committed sync targets.
     fn matches_sync_targets(batches: &Self::Merkleized, targets: &Self::SyncTargets) -> bool;
+
+    /// Return true if two committed sync target sets represent the same committed state.
+    fn committed_targets_equivalent(
+        actual: &Self::SyncTargets,
+        expected: &Self::SyncTargets,
+    ) -> bool;
 
     /// Apply each merkleized batch's changeset to its underlying database.
     ///
@@ -456,6 +470,13 @@ impl<E: Send + Sync, T: ManagedDb<E> + 'static> DatabaseSet<E> for Arc<AsyncRwLo
         T::matches_sync_target(batches, targets)
     }
 
+    fn committed_targets_equivalent(
+        actual: &Self::SyncTargets,
+        expected: &Self::SyncTargets,
+    ) -> bool {
+        T::committed_target_equivalent(actual, expected)
+    }
+
     async fn finalize(&self, batches: Self::Merkleized) {
         let mut database = self.write().await;
         finalize_or_panic(&mut *database, batches, None).await;
@@ -468,7 +489,8 @@ impl<E: Send + Sync, T: ManagedDb<E> + 'static> DatabaseSet<E> for Arc<AsyncRwLo
 
     async fn rewind_to_targets(&self, target: Self::SyncTargets) {
         let mut database = self.write().await;
-        if T::sync_target(&*database).await == target {
+        let current = T::sync_target(&*database).await;
+        if T::committed_target_equivalent(&current, &target) {
             return;
         }
         rewind_or_panic(&mut *database, target, None).await;
@@ -577,8 +599,9 @@ where
 
         let (db_result, (converged_anchor, converged_target)) = join!(sync, coordinator);
         let database = db_result?;
+        let synced_target = T::sync_target(&database).await;
         assert!(
-            T::sync_target(&database).await == converged_target,
+            T::committed_target_equivalent(&synced_target, &converged_target),
             "state sync database target does not match the coordinator target",
         );
         Ok((Self::new(AsyncRwLock::new(database)), converged_anchor))
@@ -681,6 +704,13 @@ macro_rules! impl_database_set {
                 $($T::matches_sync_target(&batches.$idx, &targets.$idx))&&+
             }
 
+            fn committed_targets_equivalent(
+                actual: &Self::SyncTargets,
+                expected: &Self::SyncTargets,
+            ) -> bool {
+                $($T::committed_target_equivalent(&actual.$idx, &expected.$idx))&&+
+            }
+
             async fn finalize(&self, batches: Self::Merkleized) {
                 join!($(
                     async {
@@ -703,7 +733,8 @@ macro_rules! impl_database_set {
                 join!($(
                     async {
                         let mut database = self.$idx.write().await;
-                        if $T::sync_target(&*database).await == targets.$idx {
+                        let current = $T::sync_target(&*database).await;
+                        if $T::committed_target_equivalent(&current, &targets.$idx) {
                             return;
                         }
                         rewind_or_panic(&mut *database, targets.$idx, Some($idx)).await;
@@ -1062,7 +1093,11 @@ macro_rules! impl_state_sync_set {
                 let Some((converged_anchor, converged_targets)) = converged_anchor else {
                     return Err("state sync coordinator did not report a converged anchor".into());
                 };
-                if <Self as DatabaseSet<E>>::committed_targets(&synced).await != converged_targets {
+                let synced_targets = <Self as DatabaseSet<E>>::committed_targets(&synced).await;
+                if !<Self as DatabaseSet<E>>::committed_targets_equivalent(
+                    &synced_targets,
+                    &converged_targets,
+                ) {
                     return Err(
                         "state sync database targets do not match the coordinator target set"
                             .into(),


### PR DESCRIPTION
Fixes #3948.

## Problem

`glue::stateful` reconciliation compares committed sync `Target`s with full-range equality (`Target`'s `PartialEq`, which includes `range.start`). For `current` QMDB, `range.start` is the locally chosen safe sync/prune boundary (`Db::sync_boundary()` — the most recent location the database can safely be synced from, and the upper bound on `prune`), not committed-state identity. It advances as the floor advances and is not restorable by a rewind (pruned chunk-pairs are graft-absorbed; `pruned_chunks` is persisted in `current` QMDB grafted metadata and `Prunable::truncate` refuses to shrink the pruned region).

So reconciling a database back to a target whose `range.start` was stamped (from `MerkleizedBatch::sync_boundary`) before pruning panics, even though `root` and `range.end` match:

```text
assertion `left == right` failed: rewound database target mismatch after rewind
left:  Target { root: <h>, range: Location(256)..Location(514) }
right: Target { root: <h>, range: Location(0)..Location(514) }
```

Full mechanism and context in #3948.

## Change

- Add `ManagedDb::committed_target_equivalent` (default: exact equality) and `DatabaseSet::committed_targets_equivalent`.
- `current` QMDB overrides the predicate to compare `root` + `range.end` only.
- Use it for all reconciliation-time comparisons: `rewind_to_target` (all four `current` impls), `rewind_to_targets`, startup `init_databases_from_marshal`, and the single- and tuple-DB post-state-sync convergence checks.
- Sync-target validation, fetch planning, and `matches_sync_target` (propose/verify) stay strict.

## Tests

Per-variant regression tests (unordered/ordered × fixed/variable) that prune to advance the sync boundary, then reconcile to an earlier-start target. They **fail on the prior behavior** with the exact `rewound database target mismatch after rewind` panic (same `root` + `range.end`, `range.start` 256 vs 0) and **pass with this change**. Plus a unit test for the tuple-level `committed_targets_equivalent` predicate.

The existing crash/restart tests (`single_db_app`, `multi_db_app`) exercise only `any` QMDB, where the inactivity floor is restored by a rewind — which is why this was not previously caught.

## Verification

- New tests fail on `main` (the panic above) and pass with this change, across all four `current` variants.
- `commonware-glue` lib suite: 158 passing.
- `cargo clippy -p commonware-glue --all-targets -- -D warnings`: clean.
- `rustfmt` (project config): clean.

## Notes for reviewers

This is a follow-up edge case for the rewind/crash-recovery work in #3444 (which modeled `[inactivity_floor, commit_floor)` ranges generally and assumed the lower bound is restorable); same class as #3403 (recoverable state rejected by a strict check).

I extended the relaxation to the post-state-sync convergence checks for consistency (same predicate); production did not exhibit post-sync drift. Happy to revert those two sites to strict, or to adopt a different shape (e.g. normalizing the application-derived target's `range.start`) if you'd prefer.
