### PR TITLE
[storage/jouirnals] add synchronous page-cache fast path to single read()

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -307,14 +307,18 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
     async fn read(&self, pos: u64) -> Result<A, Error> {
         let _timer = self.metrics.read_timer();
         self.metrics.read_calls.inc();
-        let result = match self.guard.read(pos, self.items_per_blob).await {
-            Ok(item) => {
-                self.metrics.items_read.inc();
-                Ok(item)
-            }
-            Err(error) => Err(error),
-        };
-        result
+
+        // Serve from the page cache synchronously when possible, avoiding the async storage path.
+        if let Some(item) = self.guard.try_read_sync(pos, self.items_per_blob) {
+            self.metrics.record_cache_hits(1);
+            self.metrics.items_read.inc();
+            return Ok(item);
+        }
+        self.metrics.record_cache_misses(1);
+
+        let item = self.guard.read(pos, self.items_per_blob).await?;
+        self.metrics.items_read.inc();
+        Ok(item)
     }
 
     async fn read_many(&self, positions: &[u64]) -> Result<Vec<A>, Error> {

--- a/storage/src/journal/contiguous/metrics.rs
+++ b/storage/src/journal/contiguous/metrics.rs
@@ -46,7 +46,7 @@ pub(super) struct CommonMetrics<E: Clock> {
     pub append_many_calls: Counter,
     /// Duration of append-many calls.
     append_many_duration: Timed,
-    /// Single-item async read calls.
+    /// Single-item read calls.
     pub read_calls: Counter,
     /// Duration of single-item read calls.
     read_duration: Timed,

--- a/storage/src/journal/contiguous/metrics.rs
+++ b/storage/src/journal/contiguous/metrics.rs
@@ -13,8 +13,8 @@ use std::{ops::Deref, sync::Arc};
 pub(super) struct CacheMetrics {
     /// Fixed items read without async storage fallback.
     hits: Counter,
-    /// Fixed items not satisfied synchronously: misses inside `read_many` plus
-    /// all `try_read_sync` calls that returned `None`, including invalid or pruned probes.
+    /// Fixed items not satisfied synchronously: misses from `read` and `read_many`
+    /// plus all `try_read_sync` calls that returned `None`, including invalid or pruned probes.
     misses: Counter,
 }
 
@@ -201,8 +201,8 @@ impl<E: RuntimeMetrics + Clock> FixedMetrics<E> {
             .counter("cache_hits", "Number of fixed items read synchronously");
         let misses = context.as_ref().counter(
             "cache_misses",
-            "Number of fixed items not satisfied synchronously, including pruned or out-of-range \
-             try_read_sync probes that returned None",
+            "Number of fixed items not satisfied synchronously by read or read_many, including \
+             pruned or out-of-range try_read_sync probes that returned None",
         );
         let calls = context
             .as_ref()

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -267,18 +267,23 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<'_, E, V> {
     async fn read(&self, position: u64) -> Result<V, Error> {
         let _timer = self.metrics.read_timer();
         self.metrics.read_calls.inc();
-        let result = match self
+
+        // Serve from the page cache synchronously when possible, collapsing the offsets and data
+        // lookups into buffer copies and avoiding the async storage path on a hit.
+        if let Some(item) =
+            self.guard
+                .try_read_sync(position, self.items_per_section, &self.offsets)
+        {
+            self.metrics.items_read.inc();
+            return Ok(item);
+        }
+
+        let item = self
             .guard
             .read(position, self.items_per_section, &self.offsets)
-            .await
-        {
-            Ok(item) => {
-                self.metrics.items_read.inc();
-                Ok(item)
-            }
-            Err(error) => Err(error),
-        };
-        result
+            .await?;
+        self.metrics.items_read.inc();
+        Ok(item)
     }
 
     async fn read_many(&self, positions: &[u64]) -> Result<Vec<V>, Error> {


### PR DESCRIPTION
Both fixed and variable contiguous journals already drained page-cache hits synchronously in read_many via try_read_sync, but single read() went straight to the async storage path. Attempt try_read_sync first and only fall back to the async path on a miss.

For the variable journal this collapses the two dependent async hops (offsets lookup then data fetch) into synchronous buffer copies on a hit. The fixed journal records cache hits/misses for single reads to match the read_many accounting; the variable journal has no cache counters.

## Journal `read()` page-cache fast path — benchmark results

  Times are Criterion medians (post-PR); change is vs. baseline. `read_many` omitted (path unchanged). Item size = 32 B throughout.

  ### Fixed journal — random reads
  
  | Mode | items | Time | Change |
  |---|---:|---:|---:|
  | serial | 100 | 9.61 µs | **−45.5%** |
  | serial | 1,000 | 113.0 µs | **−40.8%** |
  | serial | 10,000 | 1.44 ms | **−39.1%** |
  | serial | 100,000 | 507.7 ms | +0.4% (n.s.) |
  | concurrent | 100 | 20.65 µs | **−33.0%** |
  | concurrent | 1,000 | 216.5 µs | **−33.9%** |
  | concurrent | 10,000 | 2.46 ms | **−33.0%** |
  | concurrent | 100,000 | 181.2 ms | −1.6% (n.s.) |

  ### Fixed journal — sequential reads

  | items | Time | Change |
  |---:|---:|---:|
  | 1,000 | 77.65 µs | **−54.3%** |
  | 10,000 | 786.3 µs | **−55.0%** |
  | 100,000 | 7.91 ms | **−54.6%** |
  | 500,000 | 39.42 ms | **−55.0%** |

  ### Variable journal — random reads
  
  | Mode | items | Time | Change |
  |---|---:|---:|---:|
  | serial | 100 | 17.09 µs | **−59.5%** |
  | serial | 1,000 | 201.0 µs | **−56.7%** |
  | serial | 10,000 | 106.6 ms | +0.1% (n.s.) |
  | serial | 100,000 | 923.3 ms | −0.5% (n.s.) |
  | concurrent | 100 | 29.66 µs | **−49.7%** |
  | concurrent | 1,000 | 314.3 µs | **−49.1%** |
  | concurrent | 10,000 | 21.53 ms | −6.1% (n.s.) |
  | concurrent | 100,000 | 369.3 ms | **−4.2%** |

  **n.s.** = within noise (p > 0.05); these are the cache-miss-dominated working sets where the fast path has little to bite on.