### PR TITLE
[cryptography] Make bls12381 an optional feature

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -21,7 +21,7 @@ commonware-actor.workspace = true
 commonware-broadcast.workspace = true
 commonware-codec.workspace = true
 commonware-coding.workspace = true
-commonware-cryptography.workspace = true
+commonware-cryptography = { workspace = true, features = ["bls12381"] }
 commonware-formatting.workspace = true
 commonware-macros.workspace = true
 commonware-math.workspace = true

--- a/consensus/fuzz/Cargo.toml
+++ b/consensus/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 arbitrary = { workspace = true, features = ["derive"] }
 commonware-codec.workspace = true
 commonware-consensus = { workspace = true, features = ["mocks", "arbitrary"] }
-commonware-cryptography.workspace = true
+commonware-cryptography = { workspace = true, features = ["bls12381"] }
 commonware-macros.workspace = true
 commonware-math.workspace = true
 commonware-p2p = { workspace = true, features = ["mocks"] }

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -16,14 +16,14 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true, optional = true }
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
-ark-ec.workspace = true
-ark-ed-on-bls12-381-bandersnatch = { workspace = true, features = ["r1cs"] }
-ark-ff.workspace = true
-ark-r1cs-std.workspace = true
-ark-relations.workspace = true
-ark-serialize.workspace = true
+ark-ec = { workspace = true, optional = true }
+ark-ed-on-bls12-381-bandersnatch = { workspace = true, features = ["r1cs"], optional = true }
+ark-ff = { workspace = true, optional = true }
+ark-r1cs-std = { workspace = true, optional = true }
+ark-relations = { workspace = true, optional = true }
+ark-serialize = { workspace = true, optional = true }
 blake3 = { workspace = true, features = ["zeroize"] }
-blst = { workspace = true, features = ["no-threads"] }
+blst = { workspace = true, features = ["no-threads"], optional = true }
 bytes.workspace = true
 cfg-if.workspace = true
 commonware-codec.workspace = true
@@ -76,7 +76,16 @@ rstest.workspace = true
 bench = false
 
 [features]
-default = [ "std" ]
+default = [ "bls12381", "std" ]
+bls12381 = [
+	"dep:ark-ec",
+	"dep:ark-ed-on-bls12-381-bandersnatch",
+	"dep:ark-ff",
+	"dep:ark-r1cs-std",
+	"dep:ark-relations",
+	"dep:ark-serialize",
+	"dep:blst",
+]
 blake3-parallel = [ "blake3/rayon", "std" ]
 sha2-asm = [ "sha2/asm" ]
 mocks = [ "std" ]
@@ -88,15 +97,15 @@ arbitrary = [
 	"dep:arbitrary",
 	"std",
 ]
-fuzz = [ "arbitrary", "std" ]
+fuzz = [ "arbitrary", "bls12381", "std" ]
 std = [
 	"anyhow?/std",
-	"ark-ec/std",
-	"ark-ed-on-bls12-381-bandersnatch/std",
-	"ark-ff/std",
-	"ark-r1cs-std/std",
-	"ark-relations/std",
-	"ark-serialize/std",
+	"ark-ec?/std",
+	"ark-ed-on-bls12-381-bandersnatch?/std",
+	"ark-ff?/std",
+	"ark-r1cs-std?/std",
+	"ark-relations?/std",
+	"ark-serialize?/std",
 	"blake3/std",
 	"bytes/std",
 	"chacha20poly1305/getrandom",
@@ -128,6 +137,7 @@ std = [
 name = "bls12381"
 harness = false
 path = "src/bls12381/benches/bench.rs"
+required-features = ["bls12381"]
 
 [[bench]]
 name = "ed25519"

--- a/cryptography/src/certificate.rs
+++ b/cryptography/src/certificate.rs
@@ -57,12 +57,13 @@
 //! (like [bls12381_threshold]). Refer to [ed25519] for an example of a scheme that uses the
 //! same key for both purposes.
 
+#[cfg(feature = "bls12381")]
+pub use crate::bls12381::certificate::{
+    multisig as bls12381_multisig, threshold as bls12381_threshold,
+};
+pub use crate::ed25519::certificate as ed25519;
 #[commonware_macros::stability(ALPHA)]
 pub use crate::secp256r1::certificate as secp256r1;
-pub use crate::{
-    bls12381::certificate::{multisig as bls12381_multisig, threshold as bls12381_threshold},
-    ed25519::certificate as ed25519,
-};
 use crate::{Digest, PublicKey};
 #[cfg(not(feature = "std"))]
 use alloc::{collections::BTreeSet, sync::Arc, vec, vec::Vec};

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -15,12 +15,15 @@ extern crate alloc;
 
 // Modules containing #[macro_export] macros must use verbose cfg.
 // See rust-lang/rust#52234: macro-expanded macro_export macros cannot be referenced by absolute paths.
-#[cfg(not(any(
-    commonware_stability_GAMMA,
-    commonware_stability_DELTA,
-    commonware_stability_EPSILON,
-    commonware_stability_RESERVED
-)))] // BETA
+#[cfg(all(
+    feature = "bls12381",
+    not(any(
+        commonware_stability_GAMMA,
+        commonware_stability_DELTA,
+        commonware_stability_EPSILON,
+        commonware_stability_RESERVED
+    ))
+))] // BETA
 pub mod bls12381;
 #[cfg(not(any(
     commonware_stability_GAMMA,
@@ -395,46 +398,55 @@ mod tests {
         assert_eq!(ed25519::Signature::SIZE, 64);
     }
 
+    #[cfg(feature = "bls12381")]
     #[test]
     fn test_bls12381_validate() {
         test_validate::<bls12381::PrivateKey>();
     }
 
+    #[cfg(feature = "bls12381")]
     #[test]
     fn test_bls12381_validate_invalid_public_key() {
         test_validate_invalid_public_key::<bls12381::PrivateKey>();
     }
 
+    #[cfg(feature = "bls12381")]
     #[test]
     fn test_bls12381_sign_and_verify() {
         test_sign_and_verify::<bls12381::PrivateKey>();
     }
 
+    #[cfg(feature = "bls12381")]
     #[test]
     fn test_bls12381_sign_and_verify_wrong_message() {
         test_sign_and_verify_wrong_message::<bls12381::PrivateKey>();
     }
 
+    #[cfg(feature = "bls12381")]
     #[test]
     fn test_bls12381_sign_and_verify_wrong_namespace() {
         test_sign_and_verify_wrong_namespace::<bls12381::PrivateKey>();
     }
 
+    #[cfg(feature = "bls12381")]
     #[test]
     fn test_bls12381_empty_namespace() {
         test_empty_namespace::<bls12381::PrivateKey>();
     }
 
+    #[cfg(feature = "bls12381")]
     #[test]
     fn test_bls12381_signature_determinism() {
         test_signature_determinism::<bls12381::PrivateKey>();
     }
 
+    #[cfg(feature = "bls12381")]
     #[test]
     fn test_bls12381_invalid_signature_publickey_pair() {
         test_invalid_signature_publickey_pair::<bls12381::PrivateKey>();
     }
 
+    #[cfg(feature = "bls12381")]
     #[test]
     fn test_bls12381_len() {
         assert_eq!(bls12381::PublicKey::SIZE, 48);

--- a/cryptography/src/zk/pedersen_to_plain.rs
+++ b/cryptography/src/zk/pedersen_to_plain.rs
@@ -390,7 +390,7 @@ mod conformance {
 }
 
 #[commonware_macros::stability(ALPHA)]
-#[cfg(any(test, feature = "fuzz"))]
+#[cfg(all(feature = "bls12381", any(test, feature = "fuzz")))]
 pub mod fuzz {
     use super::*;
     use crate::bls12381::primitives::group::{Scalar as F, G1 as G};

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -18,7 +18,7 @@ clap.workspace = true
 commonware-actor.workspace = true
 commonware-codec.workspace = true
 commonware-consensus.workspace = true
-commonware-cryptography.workspace = true
+commonware-cryptography = { workspace = true, features = ["bls12381"] }
 commonware-formatting.workspace = true
 commonware-macros.workspace = true
 commonware-p2p.workspace = true

--- a/examples/reshare/Cargo.toml
+++ b/examples/reshare/Cargo.toml
@@ -20,7 +20,7 @@ commonware-actor.workspace = true
 commonware-broadcast.workspace = true
 commonware-codec.workspace = true
 commonware-consensus.workspace = true
-commonware-cryptography.workspace = true
+commonware-cryptography = { workspace = true, features = ["bls12381"] }
 commonware-formatting.workspace = true
 commonware-macros.workspace = true
 commonware-math.workspace = true


### PR DESCRIPTION
Hi @clabby , I tried to give a shot at addressing https://github.com/commonwarexyz/monorepo/issues/561. 

## Overview

Gates the `bls12381` module and its dependencies (`blst`, `ark-*`) behind a new `bls12381` feature, enabled by default. `blst`'s build script cannot compile for riscv32 targets, which made `commonware-cryptography` unusable in zkVM guests (SP1, OpenVM) even when only ed25519/secp256r1/hashing were needed.

- Existing consumers are unaffected, the feature is in default.
- Workspace consumers that need BLS (`consensus`, `examples/bridge`, `examples/reshare`, `fuzz targets`) enable it explicitly. 
- zkVM guests can depend on the crate with `default-features = false` and build for riscv32im-succinct-zkvm-elf.

closes #561

Hope this is useful, we've been carrying a patch downstream to work around the compilation issue and thought it was worth upstreaming.