### PR TITLE
[storage/merkle/persisted] flush merkleized nodes from RAM on authenticated journal commit

### DIFF
--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -267,7 +267,7 @@ impl<T: Translator, V: Send + Sync> Drop for Index<T, V> {
     /// To avoid stack overflow on keys with many collisions, we implement an iterative drop (in
     /// lieu of Rust's default recursive drop).
     fn drop(&mut self) {
-        for (_, record) in self.map.iter_mut() {
+        for record in self.map.values_mut() {
             let mut next = record.next.take();
             while let Some(mut record) = next {
                 next = record.next.take();

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -340,10 +340,18 @@ where
     H: Hasher,
     S: Strategy,
 {
-    /// Durably persist the journal. This is faster than `sync()` but does not persist the Merkle
-    /// structure, meaning recovery will be required on startup if we crash before `sync()`.
+    /// Durably persist the journal. This is faster than `sync()` but does not guarantee that the
+    /// Merkle structure is durably persisted, meaning recovery may be required on startup in the
+    /// event of a crash.
     pub async fn commit(&self) -> Result<(), Error<F>> {
-        self.journal.commit().await.map_err(Error::Journal)
+        // Though not necessary for recovery, we flush the merkle structure (without syncing it) to
+        // limit memory bloat.
+        try_join!(
+            self.journal.commit().map_err(Error::Journal),
+            self.merkle.flush().map_err(Error::Merkle)
+        )?;
+
+        Ok(())
     }
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1135,9 +1135,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         if items.is_empty() {
             return Err(Error::EmptyAppend);
         }
-        let items_count = items.len();
         let items_buf = Self::encode_items(items);
-        self.write_encoded(items_buf, items_count).await
+        self.write_encoded(items_buf).await
     }
 
     /// Encode `items` into an owned fixed-width byte buffer.
@@ -1163,24 +1162,20 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         items_buf
     }
 
-    /// Append `items_count` records pre-encoded by [`Self::encode_items`] into `items_buf`.
+    /// Append records pre-encoded by [`Self::encode_items`] into `items_buf`.
     ///
     /// Records no metrics: the public [`append`](Self::append) / [`append_many`](Self::append_many)
     /// wrappers record their own, and callers that encode separately record whatever fits their
     /// operation.
-    pub(crate) async fn write_encoded(
-        &self,
-        items_buf: Vec<u8>,
-        items_count: usize,
-    ) -> Result<u64, Error> {
+    pub(crate) async fn write_encoded(&self, items_buf: Vec<u8>) -> Result<u64, Error> {
+        assert!(
+            items_buf.len().is_multiple_of(A::SIZE),
+            "encoded buffer length must be a multiple of the item size"
+        );
+        let items_count = items_buf.len() / A::SIZE;
         if items_count == 0 {
             return Err(Error::EmptyAppend);
         }
-        assert_eq!(
-            items_buf.len(),
-            items_count * A::SIZE,
-            "encoded buffer length must match item count"
-        );
 
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1141,7 +1141,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     }
 
     /// Encode `items` into a single contiguous buffer using the fixed-width record layout, ready to
-    /// be appended via [`Self::append_encoded`]. This is synchronous and holds no locks, so a caller
+    /// be appended via [`Self::write_encoded`]. This is synchronous and holds no locks, so a caller
     /// can encode borrowed data (e.g. under a read lock) and release the borrow before the append.
     ///
     /// Uses `Write::write` directly to avoid the per-item allocations of `Encode::encode`.
@@ -1164,26 +1164,16 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         items_buf
     }
 
-    /// Append `items_count` records pre-encoded by [`Self::encode_items`] into `items_buf`,
-    /// recording batch-append metrics (the counterpart to [`Self::append_many`] for callers that
-    /// encode separately).
+    /// Append `items_count` records pre-encoded by [`Self::encode_items`] into `items_buf`.
     ///
-    /// The only caller is the ALPHA-stability `merkle` module, which is excluded under the BETA
-    /// stability check (`commonware_stability_BETA`) while this BETA-stability journal remains;
-    /// allow dead code there so the annotation check does not flag this internal helper.
-    #[cfg_attr(commonware_stability_BETA, allow(dead_code))]
-    pub(crate) async fn append_encoded(
+    /// Records no metrics: the public [`append`](Self::append) / [`append_many`](Self::append_many)
+    /// wrappers record their own, and callers that encode separately record whatever fits their
+    /// operation.
+    pub(crate) async fn write_encoded(
         &self,
         items_buf: Vec<u8>,
         items_count: usize,
     ) -> Result<u64, Error> {
-        let _timer = self.metrics.append_many_timer();
-        self.metrics.append_many_calls.inc();
-        self.write_encoded(items_buf, items_count).await
-    }
-
-    /// Append `items_count` pre-encoded records into `items_buf`, without recording metrics.
-    async fn write_encoded(&self, items_buf: Vec<u8>, items_count: usize) -> Result<u64, Error> {
         if items_count == 0 {
             return Err(Error::EmptyAppend);
         }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1135,28 +1135,63 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         if items.is_empty() {
             return Err(Error::EmptyAppend);
         }
+        let items_count = items.len();
+        let items_buf = Self::encode_items(items);
+        self.write_encoded(items_buf, items_count).await
+    }
 
-        // Encode all items into a single contiguous buffer before taking the write guard.
-        // Uses Write::write directly to avoid per-item Bytes allocations from Encode::encode.
-        let items_count = match &items {
-            Many::Flat(items) => items.len(),
-            Many::Nested(nested_items) => nested_items.iter().map(|s| s.len()).sum(),
-        };
-        let mut items_buf = Vec::with_capacity(items_count * A::SIZE);
-        match &items {
+    /// Encode `items` into a single contiguous buffer using the fixed-width record layout, ready to
+    /// be appended via [`Self::append_encoded`]. This is synchronous and holds no locks, so a caller
+    /// can encode borrowed data (e.g. under a read lock) and release the borrow before the append.
+    ///
+    /// Uses `Write::write` directly to avoid the per-item allocations of `Encode::encode`.
+    pub(crate) fn encode_items(items: Many<'_, A>) -> Vec<u8> {
+        let mut items_buf = Vec::with_capacity(items.len() * A::SIZE);
+        match items {
             Many::Flat(items) => {
-                for item in *items {
+                for item in items {
                     item.write(&mut items_buf);
                 }
             }
             Many::Nested(nested_items) => {
-                for items in *nested_items {
+                for items in nested_items {
                     for item in *items {
                         item.write(&mut items_buf);
                     }
                 }
             }
         }
+        items_buf
+    }
+
+    /// Append `items_count` records pre-encoded by [`Self::encode_items`] into `items_buf`,
+    /// recording batch-append metrics (the counterpart to [`Self::append_many`] for callers that
+    /// encode separately).
+    ///
+    /// The only caller is the ALPHA-stability `merkle` module, which is excluded under the BETA
+    /// stability check (`commonware_stability_BETA`) while this BETA-stability journal remains;
+    /// allow dead code there so the annotation check does not flag this internal helper.
+    #[cfg_attr(commonware_stability_BETA, allow(dead_code))]
+    pub(crate) async fn append_encoded(
+        &self,
+        items_buf: Vec<u8>,
+        items_count: usize,
+    ) -> Result<u64, Error> {
+        let _timer = self.metrics.append_many_timer();
+        self.metrics.append_many_calls.inc();
+        self.write_encoded(items_buf, items_count).await
+    }
+
+    /// Append `items_count` pre-encoded records into `items_buf`, without recording metrics.
+    async fn write_encoded(&self, items_buf: Vec<u8>, items_count: usize) -> Result<u64, Error> {
+        if items_count == 0 {
+            return Err(Error::EmptyAppend);
+        }
+        assert_eq!(
+            items_buf.len(),
+            items_count * A::SIZE,
+            "encoded buffer length must match item count"
+        );
 
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -105,9 +105,17 @@ use commonware_utils::{
 use futures::{future::try_join_all, stream::Stream, StreamExt};
 use std::{
     future::Future,
+    marker::PhantomData,
     num::{NonZeroU64, NonZeroUsize},
 };
 use tracing::warn;
+
+/// Items encoded for a deferred append, created by [`Journal::prepare_append`] and consumed by
+/// [`Journal::append_prepared`].
+pub struct PreparedAppend<A> {
+    buf: Vec<u8>,
+    _marker: PhantomData<A>,
+}
 
 /// Metadata key for a mid-section pruning boundary.
 ///
@@ -1132,46 +1140,48 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
     // Shared implementation for `append` and `append_many`; public wrappers record metrics.
     async fn append_many_inner<'a>(&'a self, items: Many<'a, A>) -> Result<u64, Error> {
-        if items.is_empty() {
-            return Err(Error::EmptyAppend);
-        }
-        let items_buf = Self::encode_items(items);
-        self.write_encoded(items_buf).await
+        self.write_encoded(self.prepare_append(items)).await
     }
 
-    /// Encode `items` into an owned fixed-width byte buffer.
+    /// Encode `items` into a buffer that can be appended later with [`Self::append_prepared`].
     ///
-    /// This lets callers serialize borrowed items synchronously, release those borrows, and append
-    /// the bytes later without holding unrelated locks across journal I/O.
-    pub(crate) fn encode_items(items: Many<'_, A>) -> Vec<u8> {
-        let mut items_buf = Vec::with_capacity(items.len() * A::SIZE);
+    /// This lets callers serialize borrowed items synchronously, release those borrows, and
+    /// perform the append without holding unrelated locks across journal I/O.
+    pub fn prepare_append(&self, items: Many<'_, A>) -> PreparedAppend<A> {
+        let mut buf = Vec::with_capacity(items.len() * A::SIZE);
         match items {
             Many::Flat(items) => {
                 for item in items {
-                    item.write(&mut items_buf);
+                    item.write(&mut buf);
                 }
             }
             Many::Nested(nested_items) => {
                 for items in nested_items {
                     for item in *items {
-                        item.write(&mut items_buf);
+                        item.write(&mut buf);
                     }
                 }
             }
         }
-        items_buf
+        PreparedAppend {
+            buf,
+            _marker: PhantomData,
+        }
     }
 
-    /// Append records pre-encoded by [`Self::encode_items`] into `items_buf`.
+    /// Append items encoded by [`Self::prepare_append`], returning the position of the last item
+    /// appended.
     ///
-    /// Records no metrics: the public [`append`](Self::append) / [`append_many`](Self::append_many)
-    /// wrappers record their own, and callers that encode separately record whatever fits their
-    /// operation.
-    pub(crate) async fn write_encoded(&self, items_buf: Vec<u8>) -> Result<u64, Error> {
-        assert!(
-            items_buf.len().is_multiple_of(A::SIZE),
-            "encoded buffer length must be a multiple of the item size"
-        );
+    /// Returns [Error::EmptyAppend] if `prepared` contains no items.
+    pub async fn append_prepared(&self, prepared: PreparedAppend<A>) -> Result<u64, Error> {
+        let _timer = self.metrics.append_prepared_timer();
+        self.metrics.append_prepared_calls.inc();
+        self.write_encoded(prepared).await
+    }
+
+    // Write pre-encoded items; shared by all append paths. Records no call metrics.
+    async fn write_encoded(&self, prepared: PreparedAppend<A>) -> Result<u64, Error> {
+        let items_buf = prepared.buf;
         let items_count = items_buf.len() / A::SIZE;
         if items_count == 0 {
             return Err(Error::EmptyAppend);

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1140,11 +1140,10 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         self.write_encoded(items_buf, items_count).await
     }
 
-    /// Encode `items` into a single contiguous buffer using the fixed-width record layout, ready to
-    /// be appended via [`Self::write_encoded`]. This is synchronous and holds no locks, so a caller
-    /// can encode borrowed data (e.g. under a read lock) and release the borrow before the append.
+    /// Encode `items` into an owned fixed-width byte buffer.
     ///
-    /// Uses `Write::write` directly to avoid the per-item allocations of `Encode::encode`.
+    /// This lets callers serialize borrowed items synchronously, release those borrows, and append
+    /// the bytes later without holding unrelated locks across journal I/O.
     pub(crate) fn encode_items(items: Many<'_, A>) -> Vec<u8> {
         let mut items_buf = Vec::with_capacity(items.len() * A::SIZE);
         match items {

--- a/storage/src/journal/contiguous/metrics.rs
+++ b/storage/src/journal/contiguous/metrics.rs
@@ -46,6 +46,10 @@ pub(super) struct CommonMetrics<E: Clock> {
     pub append_many_calls: Counter,
     /// Duration of append-many calls.
     append_many_duration: Timed,
+    /// Pre-encoded batch append calls.
+    pub append_prepared_calls: Counter,
+    /// Duration of pre-encoded batch append calls.
+    append_prepared_duration: Timed,
     /// Single-item read calls.
     pub read_calls: Counter,
     /// Duration of single-item read calls.
@@ -95,6 +99,15 @@ impl<E: RuntimeMetrics + Clock> CommonMetrics<E> {
             "append_many_duration",
             "Duration of append-many calls",
         );
+        let append_prepared_calls = context.as_ref().counter(
+            "append_prepared_calls",
+            "Number of pre-encoded batch append calls",
+        );
+        let append_prepared_duration = duration_histogram(
+            context.as_ref(),
+            "append_prepared_duration",
+            "Duration of pre-encoded batch append calls",
+        );
         let read_calls = context
             .as_ref()
             .counter("read_calls", "Number of single-item read calls");
@@ -137,6 +150,8 @@ impl<E: RuntimeMetrics + Clock> CommonMetrics<E> {
             append_duration: Timed::new(append_duration),
             append_many_calls,
             append_many_duration: Timed::new(append_many_duration),
+            append_prepared_calls,
+            append_prepared_duration: Timed::new(append_prepared_duration),
             read_calls,
             read_duration: Timed::new(read_duration),
             read_many_calls,
@@ -156,6 +171,10 @@ impl<E: Clock> CommonMetrics<E> {
 
     pub(super) fn append_many_timer(&self) -> ScopedTimer<E> {
         self.append_many_duration.scoped(&self.clock)
+    }
+
+    pub(super) fn append_prepared_timer(&self) -> ScopedTimer<E> {
+        self.append_prepared_duration.scoped(&self.clock)
     }
 
     pub(super) fn read_timer(&self) -> ScopedTimer<E> {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -23,11 +23,20 @@ use core::ops::Range;
 use futures::{future::try_join_all, stream, Stream, StreamExt as _};
 use std::{
     cmp::Ordering,
+    marker::PhantomData,
     num::{NonZeroU64, NonZeroUsize},
 };
 #[commonware_macros::stability(ALPHA)]
 use tracing::debug;
 use tracing::warn;
+
+/// Items encoded for a deferred append, created by [`Journal::prepare_append`] and consumed by
+/// [`Journal::append_prepared`].
+pub struct PreparedAppend<V> {
+    encoded: Vec<u8>,
+    item_starts: Vec<usize>,
+    _marker: PhantomData<V>,
+}
 
 const REPLAY_BUFFER_SIZE: NonZeroUsize = NZUsize!(1024);
 
@@ -754,31 +763,61 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     }
 
     async fn append_many_inner<'a>(&'a self, items: Many<'a, V>) -> Result<u64, Error> {
-        if items.is_empty() {
-            return Err(Error::EmptyAppend);
-        }
-        let items_count = items.len();
+        self.write_encoded(self.prepare_append(items)?).await
+    }
 
-        // Encode every item into a single buffer for bulk-writing before grabbing write guard.
+    /// Encode `items` into a buffer that can be appended later with [`Self::append_prepared`].
+    ///
+    /// This lets callers serialize borrowed items synchronously, release those borrows, and
+    /// perform the append without holding unrelated locks across journal I/O.
+    pub fn prepare_append(&self, items: Many<'_, V>) -> Result<PreparedAppend<V>, Error> {
         let mut encoded = Vec::new();
-        let mut item_starts = Vec::with_capacity(items_count);
+        let mut item_starts = Vec::with_capacity(items.len());
         let mut encode = |item: &V| {
             item_starts.push(encoded.len());
             variable::Journal::<E, V>::encode_item_into(self.compression, item, &mut encoded)
         };
-        match &items {
+        match items {
             Many::Flat(items) => {
-                for item in *items {
+                for item in items {
                     encode(item)?;
                 }
             }
             Many::Nested(nested_items) => {
-                for items in *nested_items {
+                for items in nested_items {
                     for item in *items {
                         encode(item)?;
                     }
                 }
             }
+        }
+        Ok(PreparedAppend {
+            encoded,
+            item_starts,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Append items encoded by [`Self::prepare_append`], returning the position of the last item
+    /// appended.
+    ///
+    /// Returns [Error::EmptyAppend] if `prepared` contains no items.
+    pub async fn append_prepared(&self, prepared: PreparedAppend<V>) -> Result<u64, Error> {
+        let _timer = self.metrics.append_prepared_timer();
+        self.metrics.append_prepared_calls.inc();
+        self.write_encoded(prepared).await
+    }
+
+    // Write pre-encoded items; shared by all append paths. Records no call metrics.
+    async fn write_encoded(&self, prepared: PreparedAppend<V>) -> Result<u64, Error> {
+        let PreparedAppend {
+            encoded,
+            item_starts,
+            ..
+        } = prepared;
+        let items_count = item_starts.len();
+        if items_count == 0 {
+            return Err(Error::EmptyAppend);
         }
 
         let _op_guard = self.op_lock.lock().await;

--- a/storage/src/merkle/benches/bench.rs
+++ b/storage/src/merkle/benches/bench.rs
@@ -2,6 +2,7 @@ use criterion::criterion_main;
 
 mod append;
 mod append_additional;
+mod flush;
 mod position_to_location;
 mod prove_many_elements;
 mod prove_single_element;
@@ -10,6 +11,7 @@ mod update;
 criterion_main!(
     append::benches,
     append_additional::benches,
+    flush::benches,
     position_to_location::benches,
     prove_many_elements::benches,
     prove_single_element::benches,

--- a/storage/src/merkle/benches/flush.rs
+++ b/storage/src/merkle/benches/flush.rs
@@ -1,9 +1,13 @@
 //! Benchmark for flushing the journaled Merkle structure's in-memory nodes to the journal.
 //!
-//! Each iteration applies a batch of `n` leaves to the in-memory structure (untimed setup), then
-//! times [`full::Merkle::flush`], which encodes the un-journaled nodes and appends them to the
-//! journal before pruning them from memory. `flush` does not fsync, so the timed region is the
+//! Each measured flush applies a batch of `n` leaves to the in-memory structure (untimed setup),
+//! then times [`full::Merkle::flush`], which encodes the un-journaled nodes and appends them to
+//! the journal before pruning them from memory. `flush` does not fsync, so the timed region is the
 //! encode/append/prune CPU work (the cost this benchmark is meant to surface), not disk latency.
+//!
+//! Following the `qmdb::chained_growth` model, the structure is rebuilt (and its journal
+//! destroyed) every `cycles` flushes so the backing journal doesn't grow without bound over a run.
+//! `cycles` scales down as `n` grows so the peak on-disk size stays roughly constant.
 
 use commonware_cryptography::{sha256, Sha256};
 use commonware_math::algebra::Random as _;
@@ -19,16 +23,20 @@ use commonware_utils::{NZUsize, NZU16, NZU64};
 use criterion::{criterion_group, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
-    num::{NonZeroU16, NonZeroUsize},
+    num::{NonZeroU16, NonZeroU64, NonZeroUsize},
     time::{Duration, Instant},
 };
 
 type StandardHasher<H> = merkle::hasher::Standard<H>;
 
-const ITEMS_PER_BLOB: std::num::NonZeroU64 = NZU64!(10_000_000);
+const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(10_000_000);
 const PAGE_SIZE: NonZeroU16 = NZU16!(16384);
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(512);
 const WRITE_BUFFER_SIZE: NonZeroUsize = NZUsize!(2 * 1024 * 1024);
+
+/// Rebuild the structure after roughly this many flushed nodes so the journal stays bounded on
+/// disk over a run (~32 bytes/node, so the live journal stays around 64 MiB).
+const REBUILD_NODE_BUDGET: usize = 2_000_000;
 
 #[cfg(not(full_bench))]
 const N_LEAVES: [usize; 2] = [10_000, 100_000];
@@ -46,44 +54,52 @@ fn merkle_cfg(ctx: &impl BufferPooler, family: &str) -> full::Config<Sequential>
     }
 }
 
-fn bench_flush_family<F: Family>(c: &mut Criterion, family: &str) {
+fn bench_flush_family<F: Family>(c: &mut Criterion, family: &'static str) {
     let runner = tokio::Runner::new(Config::default());
     for n in N_LEAVES {
-        c.bench_function(
-            &format!("{}/n={n} family={family}", module_path!()),
-            |b| {
-                b.to_async(&runner).iter_custom(|iters| async move {
-                    let ctx = context::get::<Context>();
-                    let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-                    let mmr = full::Merkle::<F, _, sha256::Digest, _>::init(
-                        ctx.child("mmr"),
+        // Flush moves ~2n nodes; rebuild every `cycles` flushes to cap the journal's on-disk size.
+        let cycles = (REBUILD_NODE_BUDGET / (2 * n)).max(1);
+        c.bench_function(&format!("{}/n={n} family={family}", module_path!()), |b| {
+            b.to_async(&runner).iter_custom(move |iters| async move {
+                let ctx = context::get::<Context>();
+                let hasher = StandardHasher::<Sha256>::new(ForwardFold);
+                let mut rng = StdRng::seed_from_u64(0);
+                let mut total = Duration::ZERO;
+
+                // `iters` is the number of flushes to time. Rebuild a fresh structure every
+                // `cycles` flushes so the journal it appends to never grows without bound.
+                let mut remaining = iters;
+                while remaining > 0 {
+                    let merkle = full::Merkle::<F, _, sha256::Digest, _>::init(
+                        ctx.child(family),
                         &hasher,
                         merkle_cfg(&ctx, family),
                     )
                     .await
                     .unwrap();
 
-                    let mut rng = StdRng::seed_from_u64(0);
-                    let mut total = Duration::ZERO;
-                    for _ in 0..iters {
+                    let flushes = (cycles as u64).min(remaining);
+                    for _ in 0..flushes {
                         // Untimed: apply a batch of `n` leaves to the in-memory structure.
-                        let mut batch = mmr.new_batch();
+                        let mut batch = merkle.new_batch();
                         for _ in 0..n {
                             batch = batch.add(&hasher, &sha256::Digest::random(&mut rng));
                         }
-                        let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-                        mmr.apply_batch(&batch).unwrap();
+                        let batch = merkle.with_mem(|mem| batch.merkleize(mem, &hasher));
+                        merkle.apply_batch(&batch).unwrap();
 
                         // Timed: flush the freshly applied nodes to the journal.
                         let start = Instant::now();
-                        mmr.flush().await.unwrap();
+                        merkle.flush().await.unwrap();
                         total += start.elapsed();
                     }
-                    mmr.destroy().await.unwrap();
-                    total
-                });
-            },
-        );
+
+                    merkle.destroy().await.unwrap();
+                    remaining -= flushes;
+                }
+                total
+            });
+        });
     }
 }
 

--- a/storage/src/merkle/benches/flush.rs
+++ b/storage/src/merkle/benches/flush.rs
@@ -1,0 +1,99 @@
+//! Benchmark for flushing the journaled Merkle structure's in-memory nodes to the journal.
+//!
+//! Each iteration applies a batch of `n` leaves to the in-memory structure (untimed setup), then
+//! times [`full::Merkle::flush`], which encodes the un-journaled nodes and appends them to the
+//! journal before pruning them from memory. `flush` does not fsync, so the timed region is the
+//! encode/append/prune CPU work (the cost this benchmark is meant to surface), not disk latency.
+
+use commonware_cryptography::{sha256, Sha256};
+use commonware_math::algebra::Random as _;
+use commonware_parallel::Sequential;
+use commonware_runtime::{
+    benchmarks::{context, tokio},
+    buffer::paged::CacheRef,
+    tokio::{Config, Context},
+    BufferPooler, Supervisor as _,
+};
+use commonware_storage::merkle::{self, full, Bagging::ForwardFold, Family};
+use commonware_utils::{NZUsize, NZU16, NZU64};
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{
+    num::{NonZeroU16, NonZeroUsize},
+    time::{Duration, Instant},
+};
+
+type StandardHasher<H> = merkle::hasher::Standard<H>;
+
+const ITEMS_PER_BLOB: std::num::NonZeroU64 = NZU64!(10_000_000);
+const PAGE_SIZE: NonZeroU16 = NZU16!(16384);
+const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(512);
+const WRITE_BUFFER_SIZE: NonZeroUsize = NZUsize!(2 * 1024 * 1024);
+
+#[cfg(not(full_bench))]
+const N_LEAVES: [usize; 2] = [10_000, 100_000];
+#[cfg(full_bench)]
+const N_LEAVES: [usize; 3] = [10_000, 100_000, 1_000_000];
+
+fn merkle_cfg(ctx: &impl BufferPooler, family: &str) -> full::Config<Sequential> {
+    full::Config {
+        journal_partition: format!("journal-bench-flush-{family}"),
+        metadata_partition: format!("metadata-bench-flush-{family}"),
+        items_per_blob: ITEMS_PER_BLOB,
+        write_buffer: WRITE_BUFFER_SIZE,
+        strategy: Sequential,
+        page_cache: CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE),
+    }
+}
+
+fn bench_flush_family<F: Family>(c: &mut Criterion, family: &str) {
+    let runner = tokio::Runner::new(Config::default());
+    for n in N_LEAVES {
+        c.bench_function(
+            &format!("{}/n={n} family={family}", module_path!()),
+            |b| {
+                b.to_async(&runner).iter_custom(|iters| async move {
+                    let ctx = context::get::<Context>();
+                    let hasher = StandardHasher::<Sha256>::new(ForwardFold);
+                    let mmr = full::Merkle::<F, _, sha256::Digest, _>::init(
+                        ctx.child("mmr"),
+                        &hasher,
+                        merkle_cfg(&ctx, family),
+                    )
+                    .await
+                    .unwrap();
+
+                    let mut rng = StdRng::seed_from_u64(0);
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        // Untimed: apply a batch of `n` leaves to the in-memory structure.
+                        let mut batch = mmr.new_batch();
+                        for _ in 0..n {
+                            batch = batch.add(&hasher, &sha256::Digest::random(&mut rng));
+                        }
+                        let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
+                        mmr.apply_batch(&batch).unwrap();
+
+                        // Timed: flush the freshly applied nodes to the journal.
+                        let start = Instant::now();
+                        mmr.flush().await.unwrap();
+                        total += start.elapsed();
+                    }
+                    mmr.destroy().await.unwrap();
+                    total
+                });
+            },
+        );
+    }
+}
+
+fn bench_flush(c: &mut Criterion) {
+    bench_flush_family::<commonware_storage::mmr::Family>(c, "mmr");
+    bench_flush_family::<commonware_storage::mmb::Family>(c, "mmb");
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_flush
+}

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -197,6 +197,24 @@ impl<F: Family, D: Digest> Mem<F, D> {
         &self.nodes[self.pos_to_index(pos)]
     }
 
+    /// Return the retained nodes at positions `[from_pos, size())`, in order, as up to two
+    /// contiguous slices (the second is non-empty only when the range wraps the underlying ring
+    /// buffer). Lets callers copy or encode a run of nodes without a per-position lookup.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `from_pos` precedes the oldest retained position.
+    #[cfg(feature = "std")]
+    pub(crate) fn nodes_from(&self, from_pos: Position<F>) -> (&[D], &[D]) {
+        let start = self.pos_to_index(from_pos);
+        let (head, tail) = self.nodes.as_slices();
+        if start >= head.len() {
+            (&tail[start - head.len()..], &[])
+        } else {
+            (&head[start..], tail)
+        }
+    }
+
     /// Return the index of the element in the current nodes vector given its position.
     ///
     /// # Panics

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -639,9 +639,8 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
                 return Ok(());
             }
 
-            // Encode the un-journaled tail of the mem straight into a byte buffer, with no
-            // intermediate `Vec<D>` and no second serialization pass. The buffer is owned, so the
-            // read lock is released before the journal I/O below.
+            // Encode the un-journaled tail to an owned buffer so the read lock is released before
+            // the journal I/O below.
             let (head, tail) = inner.mem.nodes_from(journal_size);
             let count = head.len() + tail.len();
             let encoded = Journal::<E, D>::encode_items(Many::Nested(&[head, tail]));

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -626,7 +626,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
 
         // Encode the nodes missing from the journal directly to bytes and snapshot the pinned
         // node set for the current pruning boundary.
-        let (sync_target_leaves, encoded, count, pinned_nodes) = {
+        let (sync_target_leaves, encoded, pinned_nodes) = {
             let inner = self.inner.read();
             let size = inner.mem.size();
             let sync_target_leaves = inner.mem.leaves();
@@ -642,7 +642,6 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
             // Encode the un-journaled tail to an owned buffer so the read lock is released before
             // the journal I/O below.
             let (head, tail) = inner.mem.nodes_from(journal_size);
-            let count = head.len() + tail.len();
             let encoded = Journal::<E, D>::encode_items(Many::Nested(&[head, tail]));
 
             // Recompute pinned nodes since we'll need to repopulate the cache after it is cleared
@@ -654,11 +653,11 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
                 pinned_nodes.insert(pos, *digest);
             }
 
-            (sync_target_leaves, encoded, count, pinned_nodes)
+            (sync_target_leaves, encoded, pinned_nodes)
         };
 
         // Append missing nodes to the journal without holding the mem read lock.
-        self.journal.write_encoded(encoded, count).await?;
+        self.journal.write_encoded(encoded).await?;
         *journal_dirty = true;
 
         // Now that the missing nodes are readable from the journal, it's safe to prune them from

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -659,7 +659,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
         };
 
         // Append missing nodes to the journal without holding the mem read lock.
-        self.journal.append_encoded(encoded, count).await?;
+        self.journal.write_encoded(encoded, count).await?;
         *journal_dirty = true;
 
         // Now that the missing nodes are readable from the journal, it's safe to prune them from

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -642,7 +642,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
             // Encode the un-journaled tail to an owned buffer so the read lock is released before
             // the journal I/O below.
             let (head, tail) = inner.mem.nodes_from(journal_size);
-            let encoded = Journal::<E, D>::encode_items(Many::Nested(&[head, tail]));
+            let encoded = self.journal.prepare_append(Many::Nested(&[head, tail]));
 
             // Recompute pinned nodes since we'll need to repopulate the cache after it is cleared
             // by pruning the mem.
@@ -657,7 +657,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
         };
 
         // Append missing nodes to the journal without holding the mem read lock.
-        self.journal.write_encoded(encoded).await?;
+        self.journal.append_prepared(encoded).await?;
         *journal_dirty = true;
 
         // Now that the missing nodes are readable from the journal, it's safe to prune them from

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -624,9 +624,9 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
     async fn flush_internal(&self, journal_dirty: &mut bool) -> Result<(), Error<F>> {
         let journal_size = Position::<F>::new(self.journal.size().await);
 
-        // Snapshot nodes in the mem that are missing from the journal, along with the pinned
+        // Encode the nodes missing from the journal directly to bytes and snapshot the pinned
         // node set for the current pruning boundary.
-        let (sync_target_leaves, missing_nodes, pinned_nodes) = {
+        let (sync_target_leaves, encoded, count, pinned_nodes) = {
             let inner = self.inner.read();
             let size = inner.mem.size();
             let sync_target_leaves = inner.mem.leaves();
@@ -639,11 +639,12 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
                 return Ok(());
             }
 
-            let mut missing_nodes = Vec::with_capacity((*size - *journal_size) as usize);
-            for pos in *journal_size..*size {
-                let node = *inner.mem.get_node_unchecked(Position::new(pos));
-                missing_nodes.push(node);
-            }
+            // Encode the un-journaled tail of the mem straight into a byte buffer, with no
+            // intermediate `Vec<D>` and no second serialization pass. The buffer is owned, so the
+            // read lock is released before the journal I/O below.
+            let (head, tail) = inner.mem.nodes_from(journal_size);
+            let count = head.len() + tail.len();
+            let encoded = Journal::<E, D>::encode_items(Many::Nested(&[head, tail]));
 
             // Recompute pinned nodes since we'll need to repopulate the cache after it is cleared
             // by pruning the mem.
@@ -654,11 +655,11 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
                 pinned_nodes.insert(pos, *digest);
             }
 
-            (sync_target_leaves, missing_nodes, pinned_nodes)
+            (sync_target_leaves, encoded, count, pinned_nodes)
         };
 
         // Append missing nodes to the journal without holding the mem read lock.
-        self.journal.append_many(Many::Flat(&missing_nodes)).await?;
+        self.journal.append_encoded(encoded, count).await?;
         *journal_dirty = true;
 
         // Now that the missing nodes are readable from the journal, it's safe to prune them from

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -154,8 +154,9 @@ pub struct Merkle<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strate
     /// contents change only when the pruning boundary moves.
     pub(crate) metadata: Metadata<E, U64, Vec<u8>>,
 
-    /// Serializes concurrent sync calls.
-    pub(crate) sync_lock: AsyncMutex<()>,
+    /// Serializes concurrent flush and sync calls. The guarded flag is true while the journal may
+    /// contain flushed nodes that have not yet been made durable.
+    pub(crate) sync_lock: AsyncMutex<bool>,
 
     /// The strategy to use for parallelization.
     pub(crate) strategy: S,
@@ -277,7 +278,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
                 }),
                 journal,
                 metadata,
-                sync_lock: AsyncMutex::new(()),
+                sync_lock: AsyncMutex::new(false),
                 strategy: cfg.strategy,
             });
         }
@@ -408,7 +409,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
             }),
             journal,
             metadata,
-            sync_lock: AsyncMutex::new(()),
+            sync_lock: AsyncMutex::new(false),
             strategy: cfg.strategy,
         })
     }
@@ -528,7 +529,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
             }),
             journal,
             metadata,
-            sync_lock: AsyncMutex::new(()),
+            sync_lock: AsyncMutex::new(false),
             strategy: cfg.config.strategy,
         })
     }
@@ -593,10 +594,34 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
         futures::future::try_join_all(futs).await
     }
 
-    /// Sync the structure to disk.
-    pub async fn sync(&self) -> Result<(), Error<F>> {
-        let _sync_guard = self.sync_lock.lock().await;
+    /// Flush all nodes cached in the in-memory structure to the journal without forcing them to
+    /// disk. Flushed nodes are pruned from the in-memory structure and remain readable through the
+    /// journal, but they are not guaranteed to survive a crash until [Self::sync] is called.
+    pub async fn flush(&self) -> Result<(), Error<F>> {
+        let mut journal_dirty = self.sync_lock.lock().await;
+        self.flush_internal(&mut journal_dirty).await
+    }
 
+    /// Flush all nodes cached in the in-memory structure to the journal and make them durable.
+    pub async fn sync(&self) -> Result<(), Error<F>> {
+        let mut journal_dirty = self.sync_lock.lock().await;
+        self.flush_internal(&mut journal_dirty).await?;
+
+        // Sync the journal while still holding the sync_lock to ensure durability before
+        // returning. This covers nodes appended by the flush above as well as nodes left
+        // non-durable by earlier [Self::flush] calls.
+        if *journal_dirty {
+            self.journal.sync().await?;
+            *journal_dirty = false;
+        }
+
+        Ok(())
+    }
+
+    /// Append nodes cached in the in-memory structure that are missing from the journal, then
+    /// prune them from the in-memory structure. Sets `journal_dirty` (the value guarded by
+    /// `sync_lock`, which the caller must hold) when nodes are appended.
+    async fn flush_internal(&self, journal_dirty: &mut bool) -> Result<(), Error<F>> {
         let journal_size = Position::<F>::new(self.journal.size().await);
 
         // Snapshot nodes in the mem that are missing from the journal, along with the pinned
@@ -634,12 +659,10 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
 
         // Append missing nodes to the journal without holding the mem read lock.
         self.journal.append_many(Many::Flat(&missing_nodes)).await?;
+        *journal_dirty = true;
 
-        // Sync the journal while still holding the sync_lock to ensure durability before returning.
-        self.journal.sync().await?;
-
-        // Now that the missing nodes are in the journal, it's safe to prune them from the
-        // mem. We prune to the previously captured leaf count to avoid a race with concurrent
+        // Now that the missing nodes are readable from the journal, it's safe to prune them from
+        // the mem. We prune to the previously captured leaf count to avoid a race with concurrent
         // appends between the read lock above and this write lock.
         {
             let mut inner = self.inner.write();
@@ -1320,6 +1343,188 @@ mod tests {
     fn test_full_basic_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(full_basic_inner::<mmb::Family>);
+    }
+
+    /// Flush moves cached nodes into the journal and prunes them from memory, preserving reads,
+    /// proofs, and the root.
+    async fn full_flush_inner<F: Family>(context: deterministic::Context) {
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
+            context.child("first"),
+            &hasher,
+            test_config(&context),
+        )
+        .await
+        .unwrap();
+
+        const LEAF_COUNT: usize = 100;
+        let mut leaves = Vec::with_capacity(LEAF_COUNT);
+        for i in 0..LEAF_COUNT {
+            leaves.push(test_digest(i));
+        }
+        let mut batch = mmr.new_batch();
+        for leaf in &leaves {
+            batch = batch.add(&hasher, leaf);
+        }
+        let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
+        mmr.apply_batch(&batch).unwrap();
+        let expected_size = Position::<F>::try_from(Location::<F>::new(LEAF_COUNT as u64)).unwrap();
+        let root = mmr.root(&hasher, 0).unwrap();
+
+        // Flush writes all cached nodes to the journal and prunes them from the mem.
+        mmr.flush().await.unwrap();
+        assert_eq!(Position::<F>::new(mmr.journal.size().await), expected_size);
+        assert_eq!(mmr.size(), expected_size);
+        assert_eq!(
+            mmr.with_mem(|mem| mem.bounds().start),
+            Location::<F>::new(LEAF_COUNT as u64)
+        );
+
+        // Flushing again is a no-op.
+        mmr.flush().await.unwrap();
+        assert_eq!(Position::<F>::new(mmr.journal.size().await), expected_size);
+
+        // Flushed nodes remain readable and provable, and the root is unchanged.
+        assert_eq!(mmr.root(&hasher, 0).unwrap(), root);
+        const TEST_ELEMENT: usize = 42;
+        let loc: Location<F> = Location::new(TEST_ELEMENT as u64);
+        let proof = mmr.proof(&hasher, loc, 0).await.unwrap();
+        assert!(proof.verify_element_inclusion(&hasher, &leaves[TEST_ELEMENT], loc, &root));
+
+        // Sync after flush succeeds (and must fsync the journal even though there is nothing
+        // left to flush).
+        mmr.sync().await.unwrap();
+
+        mmr.destroy().await.unwrap();
+    }
+
+    #[test_traced]
+    fn test_full_flush_mmr() {
+        let executor = deterministic::Runner::default();
+        executor.start(full_flush_inner::<mmr::Family>);
+    }
+
+    #[test_traced]
+    fn test_full_flush_mmb() {
+        let executor = deterministic::Runner::default();
+        executor.start(full_flush_inner::<mmb::Family>);
+    }
+
+    /// Flushed-but-unsynced nodes are lost on a crash, while synced nodes survive: the durability
+    /// barrier comes from `sync`, not `flush`.
+    fn full_flush_crash_inner<F: Family>() {
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
+
+        // Phase 1: durably sync a first batch of leaves, flush (but don't sync) a second batch,
+        // then simulate an unclean shutdown.
+        let executor = deterministic::Runner::default();
+        let (synced_size, checkpoint) = executor.start_and_recover(|context| async move {
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
+            let mmr = Merkle::<F, _, Digest, Sequential>::init(
+                context.child("first"),
+                &hasher,
+                test_config(&context),
+            )
+            .await
+            .unwrap();
+
+            let mut batch = mmr.new_batch();
+            for i in 0..50usize {
+                batch = batch.add(&hasher, &test_digest(i));
+            }
+            let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
+            mmr.apply_batch(&batch).unwrap();
+            mmr.sync().await.unwrap();
+            let synced_size = mmr.size();
+
+            let mut batch = mmr.new_batch();
+            for i in 50..100usize {
+                batch = batch.add(&hasher, &test_digest(i));
+            }
+            let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
+            mmr.apply_batch(&batch).unwrap();
+            mmr.flush().await.unwrap();
+            assert_eq!(Position::<F>::new(mmr.journal.size().await), mmr.size());
+
+            synced_size
+        });
+
+        // Phase 2: recover. Only the synced prefix survives.
+        let executor = deterministic::Runner::from(checkpoint);
+        executor.start(|context| async move {
+            let mmr = Merkle::<F, _, Digest, Sequential>::init(
+                context.child("second"),
+                &hasher,
+                test_config(&context),
+            )
+            .await
+            .unwrap();
+            assert_eq!(mmr.size(), synced_size);
+        });
+    }
+
+    #[test_traced]
+    fn test_full_flush_crash_recovery_mmr() {
+        full_flush_crash_inner::<mmr::Family>();
+    }
+
+    #[test_traced]
+    fn test_full_flush_crash_recovery_mmb() {
+        full_flush_crash_inner::<mmb::Family>();
+    }
+
+    /// A sync after a flush must make the flushed nodes durable, even though the flush left
+    /// nothing further to write from memory.
+    fn full_flush_then_sync_crash_inner<F: Family>() {
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
+
+        // Phase 1: flush a batch of leaves, then sync with nothing left to flush, then simulate
+        // an unclean shutdown.
+        let executor = deterministic::Runner::default();
+        let (full_size, checkpoint) = executor.start_and_recover(|context| async move {
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
+            let mmr = Merkle::<F, _, Digest, Sequential>::init(
+                context.child("first"),
+                &hasher,
+                test_config(&context),
+            )
+            .await
+            .unwrap();
+
+            let mut batch = mmr.new_batch();
+            for i in 0..100usize {
+                batch = batch.add(&hasher, &test_digest(i));
+            }
+            let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
+            mmr.apply_batch(&batch).unwrap();
+            mmr.flush().await.unwrap();
+            mmr.sync().await.unwrap();
+
+            mmr.size()
+        });
+
+        // Phase 2: recover. Everything survives.
+        let executor = deterministic::Runner::from(checkpoint);
+        executor.start(|context| async move {
+            let mmr = Merkle::<F, _, Digest, Sequential>::init(
+                context.child("second"),
+                &hasher,
+                test_config(&context),
+            )
+            .await
+            .unwrap();
+            assert_eq!(mmr.size(), full_size);
+        });
+    }
+
+    #[test_traced]
+    fn test_full_flush_then_sync_crash_recovery_mmr() {
+        full_flush_then_sync_crash_inner::<mmr::Family>();
+    }
+
+    #[test_traced]
+    fn test_full_flush_then_sync_crash_recovery_mmb() {
+        full_flush_then_sync_crash_inner::<mmb::Family>();
     }
 
     /// Generates a stateful structure, simulates a crash that wrote a leaf but not its parent


### PR DESCRIPTION
The in-memory footprint of the authenticated journal grows indefinitely until `sync` is called.  This change makes the new merkleized nodes get flushed to disk (without fsycing) on each commit to limit this memory growth between syncs.

The flush adds ~no commit latency since it runs concurrently with the item journal's fsync, and it shrinks sync()'s critical path: sync now only writes nodes accumulated since the last commit rather than since the last sync.

Also optimizes the flush path, and adds a new benchmark to evalute the optimizations:

## Benchmark: `merkle::flush` (optimized vs. baseline)
  
  | Family | n (leaves) | Time (median) | Δ vs. baseline | Significance |
  |--------|-----------:|--------------:|---------------:|--------------|
  | mmr | 10,000 | 126.98 µs | **−24.3%** | p < 0.05 |
  | mmr | 100,000 | 1.1885 ms | **−26.5%** | p < 0.05 |
  | mmb | 10,000 | 139.36 µs | **−21.5%** | p < 0.05 (2 high outliers) |
  | mmb | 100,000 | 1.2823 ms | **−21.3%** | p < 0.05 (1 outlier) |
  
  <details>
  <summary>Full confidence intervals</summary>

  | Family | n | Time CI [low, mid, high] | Change CI [low, mid, high] |
  |--------|--:|--------------------------|----------------------------|
  | mmr | 10,000 | [124.71, 126.98, 130.36] µs | [−26.0%, −24.3%, −22.7%] |
  | mmr | 100,000 | [1.1644, 1.1885, 1.2100] ms | [−27.6%, −26.5%, −25.4%] |
  | mmb | 10,000 | [129.24, 139.36, 153.35] µs | [−25.6%, −21.5%, −17.1%] |
  | mmb | 100,000 | [1.2036, 1.2823, 1.4048] ms | [−24.2%, −21.3%, −17.4%] |

  </details>

  A consistent **~21–27% reduction in flush time**, significant (p < 0.05) across both families and batch sizes. Removing the `Vec<D>` intermediate
  and the second serialization pass in `flush_internal` — encoding the in-memory tail directly to the journal's byte buffer in a single pass —
  accounts for the win; the flush path was more copy-bound than hashing/IO-bound. The mmb runs show wider intervals (timer noise at `sample_size =
  10`), but the effect is unambiguous (lower CI bound still ≥ 17%).