### PR TITLE
[glue/stateful] Restore sync completion metric

### DIFF
--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -7,7 +7,8 @@
 use crate::stateful::{
     actor::{
         core::{mailbox::Message, processing::Processing, syncing::Syncing},
-        processor::{Processor, ProcessorMetrics},
+        metrics::Metrics as StatefulMetrics,
+        processor::Processor,
         syncer::{self, SyncPlan, SyncResult},
     },
     db::{
@@ -25,7 +26,9 @@ use commonware_consensus::{
     simplex::types::Finalization,
 };
 use commonware_cryptography::{certificate::Scheme, Digestible};
-use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Metrics, Spawner, Storage};
+use commonware_runtime::{
+    spawn_cell, telemetry::metrics::GaugeExt, Clock, ContextCell, Handle, Metrics, Spawner, Storage,
+};
 use commonware_utils::{channel::oneshot, sync::AsyncMutex};
 use futures::join;
 use rand::Rng;
@@ -222,6 +225,7 @@ where
     /// Starts the application in [`Syncing`] mode, kicking off a state sync process
     /// towards the finalized floor specified in the [`SyncPlan`].
     async fn start_state_sync(self, floor: Finalization<S, V::Commitment>) {
+        let metrics = StatefulMetrics::new(self.context.as_present());
         let sync_metadata = Arc::new(AsyncMutex::new(self.plan.into_sync_metadata()));
         let (sync_complete, sync_completed) = oneshot::channel();
         let (syncer, syncer_mailbox) = syncer::Syncer::new(syncer::Config {
@@ -249,6 +253,7 @@ where
             sync_completed,
             max_pending_acks: self.max_pending_acks,
             prune_config: self.prune_config,
+            metrics,
         };
         let _ = join!(syncer.start(), syncing.start());
     }
@@ -270,12 +275,13 @@ where
         // so that this instance can serve peers database operations and proofs.
         self.resolvers.attach_databases(databases.clone()).await;
 
-        let processor_metrics = ProcessorMetrics::new(self.context.child("processor"));
+        let metrics = StatefulMetrics::new(self.context.as_present());
+        let _ = metrics.sync_done.try_set(1);
         let processor = Processor::new(
             self.application,
             databases,
             anchor,
-            processor_metrics,
+            metrics,
             self.max_pending_acks,
             self.prune_config,
         );

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -4,7 +4,8 @@ use crate::stateful::{
             mailbox::{ErasedAncestorStream, Message},
             processing::Processing,
         },
-        processor::{FinalizeStatus, Processor, ProcessorMetrics},
+        metrics::Metrics as StatefulMetrics,
+        processor::{FinalizeStatus, Processor},
         syncer::{self, StateSyncMetadata, SyncResult},
     },
     db::{Anchor, AttachableResolverSet},
@@ -20,7 +21,9 @@ use commonware_consensus::{
 };
 use commonware_cryptography::{certificate::Scheme, Digestible};
 use commonware_macros::select_loop;
-use commonware_runtime::{Clock, ContextCell, Metrics, Spawner, Storage};
+use commonware_runtime::{
+    telemetry::metrics::GaugeExt, Clock, ContextCell, Metrics, Spawner, Storage,
+};
 use commonware_utils::{
     acknowledgement::Exact,
     channel::{fallible::OneshotExt, oneshot},
@@ -96,6 +99,9 @@ where
 
     /// Periodic prune configuration.
     pub(super) prune_config: Option<PruneConfig>,
+
+    /// Metrics shared across syncing and processing.
+    pub(super) metrics: StatefulMetrics,
 }
 
 impl<E, A, S, V, R> Syncing<E, A, S, V, R>
@@ -226,12 +232,12 @@ where
         let artifact = self.artifact.take().expect("transition must have artifact");
         let synced_height = artifact.anchor.height;
 
-        let metrics = ProcessorMetrics::new(self.context.child("processor_metrics"));
+        let _ = self.metrics.sync_done.try_set(1);
         let mut processor = Processor::new(
             self.application,
             artifact.databases,
             artifact.anchor,
-            metrics,
+            self.metrics,
             self.max_pending_acks,
             self.prune_config,
         );
@@ -309,7 +315,10 @@ where
 mod tests {
     use super::{FinalizedHandoff, Syncing};
     use crate::stateful::{
-        actor::syncer::{self, StateSyncMetadata, SyncResult},
+        actor::{
+            metrics::Metrics as StatefulMetrics,
+            syncer::{self, StateSyncMetadata, SyncResult},
+        },
         db::{Anchor, AttachableResolver},
         tests::mocks::{anchor, test_databases, TestApp, TestBlock, TestScheme, TestVariant},
     };
@@ -375,6 +384,7 @@ mod tests {
                     sync_completed,
                     max_pending_acks: NZUsize!(1),
                     prune_config: None,
+                    metrics: StatefulMetrics::new(&context),
                 },
             }
         }

--- a/glue/src/stateful/actor/metrics.rs
+++ b/glue/src/stateful/actor/metrics.rs
@@ -1,7 +1,7 @@
-//! Metrics for the [`Processor`](super::Processor).
+//! Metrics for the stateful actor.
 
 use commonware_runtime::{
-    telemetry::metrics::{histogram::Timed, Registered},
+    telemetry::metrics::{histogram::Timed, GaugeExt, Registered},
     Metrics as MetricsTrait,
 };
 use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Histogram};
@@ -13,12 +13,15 @@ use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Hist
 /// [`Buckets::LOCAL`]: commonware_runtime::telemetry::metrics::histogram::Buckets::LOCAL
 const BUCKETS: [f64; 10] = [0.001, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0];
 
-/// Metrics for the stateful processor.
+/// Metrics for the stateful actor.
 ///
 /// All duration histograms use [`Timed`] wrappers for automatic recording via
 /// [`Timer`](commonware_runtime::telemetry::metrics::histogram::Timer).
 #[derive(Clone)]
 pub(crate) struct Metrics {
+    /// Whether startup state sync is complete.
+    pub sync_done: Registered<Gauge>,
+
     /// Current number of entries in the in-memory pending map.
     pub pending_blocks: Registered<Gauge>,
 
@@ -42,11 +45,17 @@ pub(crate) struct Metrics {
 }
 
 impl Metrics {
-    /// Create and register all processor metrics.
+    /// Create and register all stateful metrics.
     ///
-    /// The provided `context` is cloned internally to avoid further nesting the
-    /// label hierarchy.
-    pub fn new<E: MetricsTrait>(context: E) -> Self {
+    /// The provided `context` determines the metric label hierarchy.
+    pub fn new<E: MetricsTrait>(context: &E) -> Self {
+        let sync_done = context.register(
+            "sync_done",
+            "Whether startup state sync is complete",
+            Gauge::default(),
+        );
+        let _ = sync_done.try_set(0);
+
         let pending_blocks = context.register(
             "pending_blocks",
             "Current entries in the in-memory pending map",
@@ -90,6 +99,7 @@ impl Metrics {
         );
 
         Self {
+            sync_done,
             pending_blocks,
             pruned_forks,
             propose_duration: Timed::new(propose_hist),

--- a/glue/src/stateful/actor/mod.rs
+++ b/glue/src/stateful/actor/mod.rs
@@ -1,6 +1,8 @@
 mod core;
 pub use core::{Config, Mailbox, PruneConfig, Stateful};
 
+mod metrics;
+
 mod syncer;
 pub use syncer::SyncPlan;
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -23,6 +23,7 @@
 //! [`await_or_cancel`].
 
 use crate::stateful::{
+    actor::metrics::Metrics as StatefulMetrics,
     db::{Anchor, DatabaseSet},
     Application, Proposed, PruneConfig,
 };
@@ -47,9 +48,6 @@ use std::{
     num::NonZeroUsize,
 };
 use tracing::{debug, warn};
-
-mod metrics;
-pub(crate) use metrics::Metrics as ProcessorMetrics;
 
 type PendingDigest<A, E> = <<A as Application<E>>::Block as Digestible>::Digest;
 type PendingBatches<A, E> = <<A as Application<E>>::Databases as DatabaseSet<E>>::Merkleized;
@@ -198,7 +196,7 @@ where
     databases: A::Databases,
     pending: PendingMap<A, E>,
     last_processed: Anchor<PendingDigest<A, E>>,
-    metrics: ProcessorMetrics,
+    metrics: StatefulMetrics,
     pruning: Option<Pruning<PendingSyncTargets<A, E>>>,
 }
 
@@ -213,7 +211,7 @@ where
         app: A,
         databases: A::Databases,
         last_processed: Anchor<PendingDigest<A, E>>,
-        metrics: ProcessorMetrics,
+        metrics: StatefulMetrics,
         max_pending_acks: NonZeroUsize,
         prune_config: Option<PruneConfig>,
     ) -> Self {
@@ -896,7 +894,7 @@ mod tests {
         Pruning,
     };
     use crate::stateful::{
-        actor::processor::ProcessorMetrics,
+        actor::metrics::Metrics as StatefulMetrics,
         db::{Anchor, DatabaseSet, Merkleized as _, Unmerkleized as _},
         Application, Proposed, PruneConfig,
     };
@@ -1325,7 +1323,7 @@ mod tests {
                 deterministic::Context,
             >>::init(context.child("db_set"), config.clone())
             .await;
-            let metrics = ProcessorMetrics::new(context.child("processor_metrics"));
+            let metrics = StatefulMetrics::new(&context);
             Self {
                 context_cell: ContextCell::new(context),
                 processor: Processor::new(
@@ -1695,7 +1693,7 @@ mod tests {
                     round: Block::genesis().context().round,
                     digest: Block::genesis().digest(),
                 },
-                ProcessorMetrics::new(harness.context_cell.child("staged_processor_metrics")),
+                StatefulMetrics::new(harness.context_cell.as_present()),
                 NZUsize!(1),
                 Some(PruneConfig {
                     maintenance_interval: NZUsize!(1),


### PR DESCRIPTION
## Overview

> [!NOTE]
> PR Stack (merge in reverse order):
> - #3998
> - #3984 
> - #3981 👈
> - #3965
> - `main`

Somewhere along the line, the sync completion metric was removed from `glue::stateful`. Adds it back.
