### PR TITLE
[glue/stateful] Simplify resolver keep-alive

### DIFF
--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -275,8 +275,7 @@ where
         // so that this instance can serve peers database operations and proofs.
         self.resolvers.attach_databases(databases.clone()).await;
 
-        // Leak the resolver mailboxes to keep the resolvers alive to serve other peers.
-        std::mem::forget(self.resolvers);
+        keep_resolvers_alive(self.context.as_present(), self.resolvers);
 
         let metrics = StatefulMetrics::new(self.context.as_present());
         let _ = metrics.sync_done.try_set(1);
@@ -299,6 +298,19 @@ where
         .start()
         .await
     }
+}
+
+fn keep_resolvers_alive<E, R>(context: &E, resolvers: R)
+where
+    E: Spawner,
+    R: Send + 'static,
+{
+    context
+        .child("resolver_keepalive")
+        .spawn(|context| async move {
+            let _ = context.stopped().await;
+            drop(resolvers);
+        });
 }
 
 #[cfg(test)]

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -275,6 +275,9 @@ where
         // so that this instance can serve peers database operations and proofs.
         self.resolvers.attach_databases(databases.clone()).await;
 
+        // Leak the resolver mailboxes to keep the resolvers alive to serve other peers.
+        std::mem::forget(self.resolvers);
+
         let metrics = StatefulMetrics::new(self.context.as_present());
         let _ = metrics.sync_done.try_set(1);
         let processor = Processor::new(
@@ -290,7 +293,6 @@ where
             mailbox: self.mailbox,
             input_provider: self.input_provider,
             marshal: self.marshal,
-            resolvers: self.resolvers,
             processor,
             skip_finalized_until,
         }

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -33,7 +33,7 @@ enum Step<M, P> {
     Prune(P),
 }
 
-pub(super) struct Processing<E, A, S, V, R>
+pub(super) struct Processing<E, A, S, V>
 where
     E: Rng + Spawner + Metrics + Clock,
     A: Application<E>,
@@ -52,13 +52,6 @@ where
     /// Marshal mailbox used for lazy block lookup.
     pub(super) marshal: MarshalMailbox<S, V>,
 
-    /// State sync resolvers stay alive here so peers can keep syncing from us.
-    #[expect(
-        dead_code,
-        reason = "processing keeps resolver handles alive for peer state sync"
-    )]
-    pub(super) resolvers: R,
-
     /// The processing state of the actor.
     pub(super) processor: Processor<E, A>,
 
@@ -67,7 +60,7 @@ where
     pub(super) skip_finalized_until: Option<Height>,
 }
 
-impl<E, A, S, V, R> Processing<E, A, S, V, R>
+impl<E, A, S, V> Processing<E, A, S, V>
 where
     E: Rng + Spawner + Metrics + Clock,
     A: Application<E>,

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -1,6 +1,7 @@
 use crate::stateful::{
     actor::{
         core::{
+            keep_resolvers_alive,
             mailbox::{ErasedAncestorStream, Message},
             processing::Processing,
         },
@@ -297,8 +298,7 @@ where
                 .await;
         }
 
-        // Leak the resolver mailboxes to keep the resolvers alive to serve other peers.
-        std::mem::forget(self.resolvers);
+        keep_resolvers_alive(self.context.as_present(), self.resolvers);
 
         Processing {
             context: self.context,

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -297,12 +297,14 @@ where
                 .await;
         }
 
+        // Leak the resolver mailboxes to keep the resolvers alive to serve other peers.
+        std::mem::forget(self.resolvers);
+
         Processing {
             context: self.context,
             mailbox: self.mailbox,
             input_provider: self.input_provider,
             marshal: self.marshal,
-            resolvers: self.resolvers,
             processor,
             skip_finalized_until: Some(synced_height),
         }


### PR DESCRIPTION
## Overview

> [!NOTE]
> PR Stack (merge in reverse order):
> - #3998
> - #3984 👈
> - #3981
> - #3965
> - `main`

Simplifies the resolver keep-alive in the `Processing` mode by leaking the resolver mailboxes rather than having them be held by the `Processor`.