### PR TITLE
[storage/qmdb] always batch-hash leaves in parallel

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -115,38 +115,49 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         })
     }
 
-    /// Like [`merkleize`](Self::merkleize), but the caller supplies the items instead of
-    /// accumulating them with [`add`](Self::add). The two approaches must not be mixed: do
-    /// not call [`add`](Self::add) before this method.
-    ///
-    /// The items are encoded and hashed into the Merkle structure, and the `Arc` is stored
-    /// directly in the resulting [`MerkleizedBatch`] without copying.
+    /// Compute leaf digests for caller-supplied items without consuming the batch.
     ///
     /// # Panics
     ///
     /// Panics if items were previously added via [`add`](Self::add).
-    pub(crate) fn merkleize_with(
-        self,
-        base: &Mem<F, H::Digest>,
-        items: Arc<Vec<Item>>,
-    ) -> MerkleizedBatchArc<F, H, Item, S> {
+    pub(crate) fn leaf_digests_with(&self, items: &[Item]) -> Vec<H::Digest> {
         assert!(
             self.items.is_empty(),
-            "merkleize_with expects no items added via add"
+            "leaf_digests_with expects no items added via add"
         );
 
         let hasher = &self.hasher;
-        let merkle = self.inner.merkleize_leaves(
-            base,
-            hasher,
-            items.as_slice(),
-            Vec::new,
-            |buf, item, pos| {
-                buf.clear();
-                item.write(buf);
-                hasher.leaf_digest(pos, buf.as_slice())
-            },
+        self.inner.leaf_digests(items, Vec::new, |buf, item, pos| {
+            buf.clear();
+            item.write(buf);
+            hasher.leaf_digest(pos, buf.as_slice())
+        })
+    }
+
+    /// Like [`merkleize`](Self::merkleize), but uses pre-computed leaf digests for `items`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if items were previously added via [`add`](Self::add).
+    pub(crate) fn merkleize_with_leaf_digests(
+        self,
+        base: &Mem<F, H::Digest>,
+        items: Arc<Vec<Item>>,
+        digests: Vec<H::Digest>,
+    ) -> MerkleizedBatchArc<F, H, Item, S> {
+        assert!(
+            self.items.is_empty(),
+            "merkleize_with_leaf_digests expects no items added via add"
         );
+        assert_eq!(
+            digests.len(),
+            items.len(),
+            "pre-computed leaf digest count must match item count"
+        );
+
+        let merkle = self
+            .inner
+            .merkleize_leaf_digests(base, &self.hasher, digests);
         let ancestor_items = Self::collect_ancestor_items(&self.parent);
         Arc::new(MerkleizedBatch {
             inner: merkle,
@@ -900,6 +911,15 @@ mod tests {
             .merkle
             .with_mem(|mem| batch.root(mem, &journal.hasher, 0))
             .unwrap()
+    }
+
+    fn merkleize_with<F: Family + PartialEq>(
+        batch: UnmerkleizedBatch<F, Sha256, TestOp<F>, Sequential>,
+        base: &Mem<F, Digest>,
+        items: Arc<Vec<TestOp<F>>>,
+    ) -> MerkleizedBatchArc<F, Sha256, TestOp<F>, Sequential> {
+        let digests = batch.leaf_digests_with(items.as_slice());
+        batch.merkleize_with_leaf_digests(base, items, digests)
     }
 
     /// Create Merkle configuration for tests.
@@ -2722,7 +2742,7 @@ mod tests {
         let batch = journal.new_batch();
         let actual = journal
             .merkle
-            .with_mem(|mem| batch.merkleize_with(mem, Arc::new(ops)));
+            .with_mem(|mem| merkleize_with(batch, mem, Arc::new(ops)));
 
         assert_eq!(
             batch_root(&journal, &actual),
@@ -2750,7 +2770,7 @@ mod tests {
         let batch = journal.new_batch();
         let merkleized = journal
             .merkle
-            .with_mem(|mem| batch.merkleize_with(mem, Arc::new(ops.clone())));
+            .with_mem(|mem| merkleize_with(batch, mem, Arc::new(ops.clone())));
 
         let expected_root = batch_root(&journal, &merkleized);
         journal.apply_batch(&merkleized).await.unwrap();
@@ -2784,7 +2804,7 @@ mod tests {
         let batch = journal.new_batch();
         let merkleized = journal
             .merkle
-            .with_mem(|mem| batch.merkleize_with(mem, ops_clone));
+            .with_mem(|mem| merkleize_with(batch, mem, ops_clone));
 
         // The batch should hold the same Arc allocation, not a copy.
         assert!(Arc::ptr_eq(&merkleized.items, &ops));

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -144,7 +144,8 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
     ///
     /// # Panics
     ///
-    /// Panics if items were previously added via [`add`](Self::add).
+    /// - If items were previously added via [`add`](Self::add).
+    /// - If `digests` and `items` have different lengths.
     pub(crate) fn merkleize_with_leaf_digests(
         self,
         base: &Mem<F, H::Digest>,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -140,27 +140,16 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         )
     }
 
-    /// Like [`merkleize`](Self::merkleize), but uses pre-computed leaf digests for `items`.
+    /// Add caller-supplied items using pre-computed leaf digests.
     ///
     /// # Panics
     ///
     /// - If items were previously added via [`add`](Self::add).
     /// - If `digests` and `items` have different lengths.
-    pub(crate) fn merkleize_with_leaf_digests(
-        self,
-        base: &Mem<F, H::Digest>,
-        items: Arc<Vec<Item>>,
-        digests: Vec<H::Digest>,
-    ) -> MerkleizedBatchArc<F, H, Item, S> {
-        let Self {
-            inner,
-            hasher,
-            items: batch_items,
-            parent,
-        } = self;
+    pub(crate) fn add_leaf_digests(mut self, items: Vec<Item>, digests: Vec<H::Digest>) -> Self {
         assert!(
-            batch_items.is_empty(),
-            "merkleize_with_leaf_digests expects no items added via add"
+            self.items.is_empty(),
+            "add_leaf_digests expects no items added via add"
         );
         assert_eq!(
             digests.len(),
@@ -168,16 +157,9 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
             "pre-computed leaf digest count must match item count"
         );
 
-        let inner = inner.add_leaf_digests(digests);
-        let merkle = inner.merkleize(base, &hasher);
-        let ancestor_items = Self::collect_ancestor_items(&parent);
-        Arc::new(MerkleizedBatch {
-            inner: merkle,
-            bagging: hasher.root_bagging(),
-            items,
-            parent: parent.as_ref().map(Arc::downgrade),
-            ancestor_items,
-        })
+        self.inner = self.inner.add_leaf_digests(digests);
+        self.items = items;
+        self
     }
 }
 
@@ -928,10 +910,10 @@ mod tests {
     fn merkleize_with<F: Family + PartialEq>(
         batch: UnmerkleizedBatch<F, Sha256, TestOp<F>, Sequential>,
         base: &Mem<F, Digest>,
-        items: Arc<Vec<TestOp<F>>>,
+        items: Vec<TestOp<F>>,
     ) -> MerkleizedBatchArc<F, Sha256, TestOp<F>, Sequential> {
         let digests = batch.leaf_digests_with(items.as_slice());
-        batch.merkleize_with_leaf_digests(base, items, digests)
+        batch.add_leaf_digests(items, digests).merkleize(base)
     }
 
     /// Create Merkle configuration for tests.
@@ -2754,7 +2736,7 @@ mod tests {
         let batch = journal.new_batch();
         let actual = journal
             .merkle
-            .with_mem(|mem| merkleize_with(batch, mem, Arc::new(ops)));
+            .with_mem(|mem| merkleize_with(batch, mem, ops));
 
         assert_eq!(
             batch_root(&journal, &actual),
@@ -2782,7 +2764,7 @@ mod tests {
         let batch = journal.new_batch();
         let merkleized = journal
             .merkle
-            .with_mem(|mem| merkleize_with(batch, mem, Arc::new(ops.clone())));
+            .with_mem(|mem| merkleize_with(batch, mem, ops.clone()));
 
         let expected_root = batch_root(&journal, &merkleized);
         journal.apply_batch(&merkleized).await.unwrap();
@@ -2805,33 +2787,6 @@ mod tests {
     fn test_merkleize_with_apply_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(test_merkleize_with_apply_inner::<mmb::Family>);
-    }
-
-    /// merkleize_with stores the caller's Arc directly (no deep copy).
-    async fn test_merkleize_with_shares_arc_inner<F: Family + PartialEq>(context: Context) {
-        let journal = create_journal_with_ops::<F>(context, "mw-arc", 3).await;
-
-        let ops = Arc::new(vec![create_operation::<F>(20), create_operation::<F>(21)]);
-        let ops_clone = Arc::clone(&ops);
-        let batch = journal.new_batch();
-        let merkleized = journal
-            .merkle
-            .with_mem(|mem| merkleize_with(batch, mem, ops_clone));
-
-        // The batch should hold the same Arc allocation, not a copy.
-        assert!(Arc::ptr_eq(&merkleized.items, &ops));
-    }
-
-    #[test_traced("INFO")]
-    fn test_merkleize_with_shares_arc_mmr() {
-        let executor = deterministic::Runner::default();
-        executor.start(test_merkleize_with_shares_arc_inner::<mmr::Family>);
-    }
-
-    #[test_traced("INFO")]
-    fn test_merkleize_with_shares_arc_mmb() {
-        let executor = deterministic::Runner::default();
-        executor.start(test_merkleize_with_shares_arc_inner::<mmb::Family>);
     }
 
     /// Apply C (grandchild of A) after only A is committed. B's journal items

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -152,8 +152,14 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         items: Arc<Vec<Item>>,
         digests: Vec<H::Digest>,
     ) -> MerkleizedBatchArc<F, H, Item, S> {
+        let Self {
+            inner,
+            hasher,
+            items: batch_items,
+            parent,
+        } = self;
         assert!(
-            self.items.is_empty(),
+            batch_items.is_empty(),
             "merkleize_with_leaf_digests expects no items added via add"
         );
         assert_eq!(
@@ -162,15 +168,14 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
             "pre-computed leaf digest count must match item count"
         );
 
-        let merkle = self
-            .inner
-            .merkleize_leaf_digests(base, &self.hasher, digests);
-        let ancestor_items = Self::collect_ancestor_items(&self.parent);
+        let inner = inner.add_leaf_digests(digests);
+        let merkle = inner.merkleize(base, &hasher);
+        let ancestor_items = Self::collect_ancestor_items(&parent);
         Arc::new(MerkleizedBatch {
             inner: merkle,
-            bagging: self.hasher.root_bagging(),
+            bagging: hasher.root_bagging(),
             items,
-            parent: self.parent.as_ref().map(Arc::downgrade),
+            parent: parent.as_ref().map(Arc::downgrade),
             ancestor_items,
         })
     }

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -136,15 +136,16 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         );
 
         let starting_leaves = self.inner.leaves();
+        let hasher = &self.hasher;
         let digests: Vec<H::Digest> = self.inner.strategy().map_init_collect_vec(
             items.iter().enumerate(),
-            || (self.hasher.clone(), Vec::new()),
-            |(h, buf), (i, item)| {
+            Vec::new,
+            |buf, (i, item)| {
                 let loc = Location::<F>::new(*starting_leaves + i as u64);
                 let pos = Position::try_from(loc).expect("valid leaf location");
                 buf.clear();
                 item.write(buf);
-                h.leaf_digest(pos, buf.as_slice())
+                hasher.leaf_digest(pos, buf.as_slice())
             },
         );
         self.inner = self.inner.add_leaf_digests(digests);

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -145,9 +145,7 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
                 h.leaf_digest(pos, &item.encode())
             },
         );
-        for digest in digests {
-            self.inner = self.inner.add_leaf_digest(digest);
-        }
+        self.inner = self.inner.add_leaf_digests(digests);
 
         let merkle = self.inner.merkleize(base, &self.hasher);
         let ancestor_items = Self::collect_ancestor_items(&self.parent);

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -126,7 +126,7 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
     ///
     /// Panics if items were previously added via [`add`](Self::add).
     pub(crate) fn merkleize_with(
-        mut self,
+        self,
         base: &Mem<F, H::Digest>,
         items: Arc<Vec<Item>>,
     ) -> MerkleizedBatchArc<F, H, Item, S> {
@@ -135,22 +135,18 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
             "merkleize_with expects no items added via add"
         );
 
-        let starting_leaves = self.inner.leaves();
         let hasher = &self.hasher;
-        let digests: Vec<H::Digest> = self.inner.strategy().map_init_collect_vec(
-            items.iter().enumerate(),
+        let merkle = self.inner.merkleize_leaves(
+            base,
+            hasher,
+            items.as_slice(),
             Vec::new,
-            |buf, (i, item)| {
-                let loc = Location::<F>::new(*starting_leaves + i as u64);
-                let pos = Position::try_from(loc).expect("valid leaf location");
+            |buf, item, pos| {
                 buf.clear();
                 item.write(buf);
                 hasher.leaf_digest(pos, buf.as_slice())
             },
         );
-        self.inner = self.inner.add_leaf_digests(digests);
-
-        let merkle = self.inner.merkleize(base, &self.hasher);
         let ancestor_items = Self::collect_ancestor_items(&self.parent);
         Arc::new(MerkleizedBatch {
             inner: merkle,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -115,20 +115,20 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         })
     }
 
-    /// Compute leaf digests for caller-supplied items without consuming the batch.
+    /// Add caller-supplied items to the batch.
     ///
     /// # Panics
     ///
     /// Panics if items were previously added via [`add`](Self::add).
-    pub(crate) fn leaf_digests_with(&self, items: &[Item]) -> Vec<H::Digest> {
+    pub(crate) fn add_many(mut self, items: Vec<Item>) -> Self {
         assert!(
             self.items.is_empty(),
-            "leaf_digests_with expects no items added via add"
+            "add_many expects no items added via add"
         );
 
         let first = self.inner.leaves();
         let hasher = &self.hasher;
-        self.inner.strategy().map_init_collect_vec(
+        let digests = self.inner.strategy().map_init_collect_vec(
             items.iter().enumerate(),
             Vec::new,
             |buf, (i, item)| {
@@ -137,24 +137,6 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
                 item.write(buf);
                 hasher.leaf_digest(pos, buf.as_slice())
             },
-        )
-    }
-
-    /// Add caller-supplied items using pre-computed leaf digests.
-    ///
-    /// # Panics
-    ///
-    /// - If items were previously added via [`add`](Self::add).
-    /// - If `digests` and `items` have different lengths.
-    pub(crate) fn add_leaf_digests(mut self, items: Vec<Item>, digests: Vec<H::Digest>) -> Self {
-        assert!(
-            self.items.is_empty(),
-            "add_leaf_digests expects no items added via add"
-        );
-        assert_eq!(
-            digests.len(),
-            items.len(),
-            "pre-computed leaf digest count must match item count"
         );
 
         self.inner = self.inner.add_leaf_digests(digests);
@@ -912,8 +894,7 @@ mod tests {
         base: &Mem<F, Digest>,
         items: Vec<TestOp<F>>,
     ) -> MerkleizedBatchArc<F, Sha256, TestOp<F>, Sequential> {
-        let digests = batch.leaf_digests_with(items.as_slice());
-        batch.add_leaf_digests(items, digests).merkleize(base)
+        batch.add_many(items).merkleize(base)
     }
 
     /// Create Merkle configuration for tests.

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -138,11 +138,13 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         let starting_leaves = self.inner.leaves();
         let digests: Vec<H::Digest> = self.inner.strategy().map_init_collect_vec(
             items.iter().enumerate(),
-            || self.hasher.clone(),
-            |h, (i, item)| {
+            || (self.hasher.clone(), Vec::new()),
+            |(h, buf), (i, item)| {
                 let loc = Location::<F>::new(*starting_leaves + i as u64);
                 let pos = Position::try_from(loc).expect("valid leaf location");
-                h.leaf_digest(pos, &item.encode())
+                buf.clear();
+                item.write(buf);
+                h.leaf_digest(pos, buf.as_slice())
             },
         );
         self.inner = self.inner.add_leaf_digests(digests);

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -126,12 +126,18 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
             "leaf_digests_with expects no items added via add"
         );
 
+        let first = self.inner.leaves();
         let hasher = &self.hasher;
-        self.inner.leaf_digests(items, Vec::new, |buf, item, pos| {
-            buf.clear();
-            item.write(buf);
-            hasher.leaf_digest(pos, buf.as_slice())
-        })
+        self.inner.strategy().map_init_collect_vec(
+            items.iter().enumerate(),
+            Vec::new,
+            |buf, (i, item)| {
+                let pos = Position::try_from(first + i as u64).expect("valid leaf location");
+                buf.clear();
+                item.write(buf);
+                hasher.leaf_digest(pos, buf.as_slice())
+            },
+        )
     }
 
     /// Like [`merkleize`](Self::merkleize), but uses pre-computed leaf digests for `items`.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -242,6 +242,16 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         self
     }
 
+    /// Append a run of pre-computed leaf digests and merkleize.
+    pub(crate) fn merkleize_leaf_digests(
+        self,
+        base: &Mem<F, D>,
+        hasher: &impl Hasher<F, Digest = D>,
+        digests: impl IntoIterator<Item = D>,
+    ) -> Arc<MerkleizedBatch<F, D, S>> {
+        self.add_leaf_digests(digests).merkleize(base, hasher)
+    }
+
     /// Hash `leaves` in parallel, append them, and merkleize.
     pub fn merkleize_leaves<L, T>(
         self,
@@ -249,7 +259,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         hasher: &impl Hasher<F, Digest = D>,
         leaves: &[L],
         init: impl Fn() -> T + Send + Sync,
-        leaf: impl Fn(&mut T, &L, Position<F>) -> D + Send + Sync,
+        leaf_digest: impl Fn(&mut T, &L, Position<F>) -> D + Send + Sync,
     ) -> Arc<MerkleizedBatch<F, D, S>>
     where
         L: Sync,
@@ -261,10 +271,10 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             init,
             |state, (i, value)| {
                 let pos = Position::try_from(first + i as u64).expect("valid leaf location");
-                leaf(state, value, pos)
+                leaf_digest(state, value, pos)
             },
         );
-        self.add_leaf_digests(digests).merkleize(base, hasher)
+        self.merkleize_leaf_digests(base, hasher, digests)
     }
 
     /// Hash `element` and add it as a leaf.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -227,12 +227,16 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 
     /// Add a run of pre-computed leaf digests, in order.
     ///
-    /// Equivalent to calling [`Self::add_leaf_digest`] for each digest, but reserves capacity for
-    /// the incoming leaves up front to avoid repeated reallocation. Pairs with computing the
-    /// digests in parallel (e.g. via [`commonware_parallel::Strategy::map_init_collect_vec`]).
+    /// Equivalent to calling [`Self::add_leaf_digest`] for each digest, but reserves capacity up
+    /// front to avoid repeated reallocation.
     pub fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
         let digests = digests.into_iter();
-        self.appended.reserve(digests.size_hint().0);
+        // Each leaf also appends its parent placeholders, so reserve for the full node count
+        // `position(leaves + n) - position(leaves)`, not just the `n` leaves.
+        let n = digests.size_hint().0 as u64;
+        let additional =
+            Position::try_from(self.leaves() + n).map_or(0, |end| (*end - *self.size()) as usize);
+        self.appended.reserve(additional);
         for digest in digests {
             self = self.add_leaf_digest(digest);
         }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -225,6 +225,20 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         self
     }
 
+    /// Add a run of pre-computed leaf digests, in order.
+    ///
+    /// Equivalent to calling [`Self::add_leaf_digest`] for each digest, but reserves capacity for
+    /// the incoming leaves up front to avoid repeated reallocation. Pairs with computing the
+    /// digests in parallel (e.g. via [`commonware_parallel::Strategy::map_init_collect_vec`]).
+    pub fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
+        let digests = digests.into_iter();
+        self.appended.reserve(digests.size_hint().0);
+        for digest in digests {
+            self = self.add_leaf_digest(digest);
+        }
+        self
+    }
+
     /// Hash `element` and add it as a leaf.
     pub fn add(self, hasher: &impl Hasher<F, Digest = D>, element: &[u8]) -> Self {
         let digest = hasher.leaf_digest(self.size(), element);
@@ -645,6 +659,36 @@ mod tests {
                 assert_eq!(
                     mem_root(&result, &hasher),
                     mem_root(&reference, &hasher),
+                    "root mismatch for n={n}"
+                );
+            }
+        });
+    }
+
+    fn add_leaf_digests_matches_individual<F: Family>() {
+        let executor = deterministic::Runner::default();
+        executor.start(|_| async move {
+            let hasher: H = Standard::new(ForwardFold);
+            for &n in &[0u64, 1, 2, 10, 199] {
+                let base = build_reference::<F>(&hasher, 7);
+                let digests: Vec<D> = (0..n).map(|i| hasher.digest(&i.to_be_bytes())).collect();
+
+                // Append the leaves one at a time.
+                let mut individual = base.new_batch();
+                for &digest in &digests {
+                    individual = individual.add_leaf_digest(digest);
+                }
+                let individual = individual.merkleize(&base, &hasher);
+
+                // Append the same leaves via the bulk helper.
+                let bulk = base
+                    .new_batch()
+                    .add_leaf_digests(digests.iter().copied())
+                    .merkleize(&base, &hasher);
+
+                assert_eq!(
+                    batch_root(&base, &individual, &hasher),
+                    batch_root(&base, &bulk, &hasher),
                     "root mismatch for n={n}"
                 );
             }
@@ -1098,6 +1142,10 @@ mod tests {
         consistency_with_reference::<crate::mmr::Family>();
     }
     #[test]
+    fn mmr_add_leaf_digests_matches_individual() {
+        add_leaf_digests_matches_individual::<crate::mmr::Family>();
+    }
+    #[test]
     fn mmr_lifecycle() {
         lifecycle::<crate::mmr::Family>();
     }
@@ -1171,6 +1219,10 @@ mod tests {
     #[test]
     fn mmb_consistency() {
         consistency_with_reference::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_add_leaf_digests_matches_individual() {
+        add_leaf_digests_matches_individual::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_lifecycle() {

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -229,7 +229,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     ///
     /// Equivalent to calling [`Self::add_leaf_digest`] for each digest, but reserves capacity up
     /// front to avoid repeated reallocation.
-    pub fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
+    fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
         let digests = digests.into_iter();
         // Each leaf also appends its parent placeholders, so reserve for the full node count.
         let n = digests.size_hint().0 as u64;
@@ -240,6 +240,31 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             self = self.add_leaf_digest(digest);
         }
         self
+    }
+
+    /// Hash `leaves` in parallel, append them, and merkleize.
+    pub fn merkleize_leaves<L, T>(
+        self,
+        base: &Mem<F, D>,
+        hasher: &impl Hasher<F, Digest = D>,
+        leaves: &[L],
+        init: impl Fn() -> T + Send + Sync,
+        leaf: impl Fn(&mut T, &L, Position<F>) -> D + Send + Sync,
+    ) -> Arc<MerkleizedBatch<F, D, S>>
+    where
+        L: Sync,
+        T: Send,
+    {
+        let first = self.leaves();
+        let digests: Vec<D> = self.strategy().map_init_collect_vec(
+            leaves.iter().enumerate(),
+            init,
+            |state, (i, value)| {
+                let pos = Position::try_from(first + i as u64).expect("valid leaf location");
+                leaf(state, value, pos)
+            },
+        );
+        self.add_leaf_digests(digests).merkleize(base, hasher)
     }
 
     /// Hash `element` and add it as a leaf.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -687,9 +687,11 @@ mod tests {
                 let individual = individual.merkleize(&base, &hasher);
 
                 // Append the same leaves via the bulk helper.
-                let bulk = base
-                    .new_batch()
-                    .merkleize_leaf_digests(&base, &hasher, digests.iter().copied());
+                let bulk = base.new_batch().merkleize_leaf_digests(
+                    &base,
+                    &hasher,
+                    digests.iter().copied(),
+                );
 
                 assert_eq!(
                     batch_root(&base, &individual, &hasher),

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -225,11 +225,13 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         self
     }
 
-    /// Add a run of pre-computed leaf digests, in order.
-    ///
-    /// Equivalent to calling [`Self::add_leaf_digest`] for each digest, but reserves capacity up
-    /// front to avoid repeated reallocation.
-    fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
+    /// Append a run of pre-computed leaf digests and merkleize.
+    pub(crate) fn merkleize_leaf_digests(
+        mut self,
+        base: &Mem<F, D>,
+        hasher: &impl Hasher<F, Digest = D>,
+        digests: impl IntoIterator<Item = D>,
+    ) -> Arc<MerkleizedBatch<F, D, S>> {
         let digests = digests.into_iter();
         // Each leaf also appends its parent placeholders, so reserve for the full node count.
         let n = digests.size_hint().0 as u64;
@@ -239,39 +241,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         for digest in digests {
             self = self.add_leaf_digest(digest);
         }
-        self
-    }
-
-    /// Append a run of pre-computed leaf digests and merkleize.
-    pub(crate) fn merkleize_leaf_digests(
-        self,
-        base: &Mem<F, D>,
-        hasher: &impl Hasher<F, Digest = D>,
-        digests: impl IntoIterator<Item = D>,
-    ) -> Arc<MerkleizedBatch<F, D, S>> {
-        self.add_leaf_digests(digests).merkleize(base, hasher)
-    }
-
-    /// Hash `leaves` in parallel.
-    pub(crate) fn leaf_digests<L, T>(
-        &self,
-        leaves: &[L],
-        init: impl Fn() -> T + Send + Sync,
-        leaf_digest: impl Fn(&mut T, &L, Position<F>) -> D + Send + Sync,
-    ) -> Vec<D>
-    where
-        L: Sync,
-        T: Send,
-    {
-        let first = self.leaves();
-        self.strategy().map_init_collect_vec(
-            leaves.iter().enumerate(),
-            init,
-            |state, (i, value)| {
-                let pos = Position::try_from(first + i as u64).expect("valid leaf location");
-                leaf_digest(state, value, pos)
-            },
-        )
+        self.merkleize(base, hasher)
     }
 
     /// Hash `element` and add it as a leaf.
@@ -700,7 +670,7 @@ mod tests {
         });
     }
 
-    fn add_leaf_digests_matches_individual<F: Family>() {
+    fn merkleize_leaf_digests_matches_individual<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
             let hasher: H = Standard::new(ForwardFold);
@@ -718,8 +688,7 @@ mod tests {
                 // Append the same leaves via the bulk helper.
                 let bulk = base
                     .new_batch()
-                    .add_leaf_digests(digests.iter().copied())
-                    .merkleize(&base, &hasher);
+                    .merkleize_leaf_digests(&base, &hasher, digests.iter().copied());
 
                 assert_eq!(
                     batch_root(&base, &individual, &hasher),
@@ -1177,8 +1146,8 @@ mod tests {
         consistency_with_reference::<crate::mmr::Family>();
     }
     #[test]
-    fn mmr_add_leaf_digests_matches_individual() {
-        add_leaf_digests_matches_individual::<crate::mmr::Family>();
+    fn mmr_merkleize_leaf_digests_matches_individual() {
+        merkleize_leaf_digests_matches_individual::<crate::mmr::Family>();
     }
     #[test]
     fn mmr_lifecycle() {
@@ -1256,8 +1225,8 @@ mod tests {
         consistency_with_reference::<crate::mmb::Family>();
     }
     #[test]
-    fn mmb_add_leaf_digests_matches_individual() {
-        add_leaf_digests_matches_individual::<crate::mmb::Family>();
+    fn mmb_merkleize_leaf_digests_matches_individual() {
+        merkleize_leaf_digests_matches_individual::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_lifecycle() {

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -226,7 +226,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     }
 
     /// Add a run of pre-computed leaf digests, in order.
-    #[cfg(any(feature = "std", test))]
+    #[cfg(feature = "std")]
     pub(crate) fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
         let digests = digests.into_iter();
         // Each leaf also appends its parent placeholders, so reserve for the full node count.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -225,14 +225,9 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         self
     }
 
-    /// Append a run of pre-computed leaf digests and merkleize.
+    /// Add a run of pre-computed leaf digests, in order.
     #[cfg(any(feature = "std", test))]
-    pub(crate) fn merkleize_leaf_digests(
-        mut self,
-        base: &Mem<F, D>,
-        hasher: &impl Hasher<F, Digest = D>,
-        digests: impl IntoIterator<Item = D>,
-    ) -> Arc<MerkleizedBatch<F, D, S>> {
+    pub(crate) fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
         let digests = digests.into_iter();
         // Each leaf also appends its parent placeholders, so reserve for the full node count.
         let n = digests.size_hint().0 as u64;
@@ -242,7 +237,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         for digest in digests {
             self = self.add_leaf_digest(digest);
         }
-        self.merkleize(base, hasher)
+        self
     }
 
     /// Hash `element` and add it as a leaf.
@@ -665,37 +660,6 @@ mod tests {
                 assert_eq!(
                     mem_root(&result, &hasher),
                     mem_root(&reference, &hasher),
-                    "root mismatch for n={n}"
-                );
-            }
-        });
-    }
-
-    fn merkleize_leaf_digests_matches_individual<F: Family>() {
-        let executor = deterministic::Runner::default();
-        executor.start(|_| async move {
-            let hasher: H = Standard::new(ForwardFold);
-            for &n in &[0u64, 1, 2, 10, 199] {
-                let base = build_reference::<F>(&hasher, 7);
-                let digests: Vec<D> = (0..n).map(|i| hasher.digest(&i.to_be_bytes())).collect();
-
-                // Append the leaves one at a time.
-                let mut individual = base.new_batch();
-                for &digest in &digests {
-                    individual = individual.add_leaf_digest(digest);
-                }
-                let individual = individual.merkleize(&base, &hasher);
-
-                // Append the same leaves via the bulk helper.
-                let bulk = base.new_batch().merkleize_leaf_digests(
-                    &base,
-                    &hasher,
-                    digests.iter().copied(),
-                );
-
-                assert_eq!(
-                    batch_root(&base, &individual, &hasher),
-                    batch_root(&base, &bulk, &hasher),
                     "root mismatch for n={n}"
                 );
             }
@@ -1149,10 +1113,6 @@ mod tests {
         consistency_with_reference::<crate::mmr::Family>();
     }
     #[test]
-    fn mmr_merkleize_leaf_digests_matches_individual() {
-        merkleize_leaf_digests_matches_individual::<crate::mmr::Family>();
-    }
-    #[test]
     fn mmr_lifecycle() {
         lifecycle::<crate::mmr::Family>();
     }
@@ -1226,10 +1186,6 @@ mod tests {
     #[test]
     fn mmb_consistency() {
         consistency_with_reference::<crate::mmb::Family>();
-    }
-    #[test]
-    fn mmb_merkleize_leaf_digests_matches_individual() {
-        merkleize_leaf_digests_matches_individual::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_lifecycle() {

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -226,6 +226,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     }
 
     /// Append a run of pre-computed leaf digests and merkleize.
+    #[cfg(any(feature = "std", test))]
     pub(crate) fn merkleize_leaf_digests(
         mut self,
         base: &Mem<F, D>,

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -252,29 +252,26 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         self.add_leaf_digests(digests).merkleize(base, hasher)
     }
 
-    /// Hash `leaves` in parallel, append them, and merkleize.
-    pub fn merkleize_leaves<L, T>(
-        self,
-        base: &Mem<F, D>,
-        hasher: &impl Hasher<F, Digest = D>,
+    /// Hash `leaves` in parallel.
+    pub(crate) fn leaf_digests<L, T>(
+        &self,
         leaves: &[L],
         init: impl Fn() -> T + Send + Sync,
         leaf_digest: impl Fn(&mut T, &L, Position<F>) -> D + Send + Sync,
-    ) -> Arc<MerkleizedBatch<F, D, S>>
+    ) -> Vec<D>
     where
         L: Sync,
         T: Send,
     {
         let first = self.leaves();
-        let digests: Vec<D> = self.strategy().map_init_collect_vec(
+        self.strategy().map_init_collect_vec(
             leaves.iter().enumerate(),
             init,
             |state, (i, value)| {
                 let pos = Position::try_from(first + i as u64).expect("valid leaf location");
                 leaf_digest(state, value, pos)
             },
-        );
-        self.merkleize_leaf_digests(base, hasher, digests)
+        )
     }
 
     /// Hash `element` and add it as a leaf.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -231,8 +231,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     /// front to avoid repeated reallocation.
     pub fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
         let digests = digests.into_iter();
-        // Each leaf also appends its parent placeholders, so reserve for the full node count
-        // `position(leaves + n) - position(leaves)`, not just the `n` leaves.
+        // Each leaf also appends its parent placeholders, so reserve for the full node count.
         let n = digests.size_hint().0 as u64;
         let additional =
             Position::try_from(self.leaves() + n).map_or(0, |end| (*end - *self.size()) as usize);

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -63,6 +63,13 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         }
     }
 
+    /// Add a run of pre-computed leaf digests, in order.
+    pub fn add_leaf_digests(self, digests: impl IntoIterator<Item = D>) -> Self {
+        Self {
+            inner: self.inner.add_leaf_digests(digests),
+        }
+    }
+
     /// The number of leaves visible through this batch.
     pub fn leaves(&self) -> Location<F> {
         self.inner.leaves()

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -63,14 +63,11 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         }
     }
 
-    /// Append a run of pre-computed leaf digests and merkleize.
-    pub(crate) fn merkleize_leaf_digests(
-        self,
-        base: &Mem<F, D>,
-        hasher: &impl Hasher<F, Digest = D>,
-        digests: impl IntoIterator<Item = D>,
-    ) -> Arc<batch::MerkleizedBatch<F, D, S>> {
-        self.inner.merkleize_leaf_digests(base, hasher, digests)
+    /// Add a run of pre-computed leaf digests, in order.
+    pub(crate) fn add_leaf_digests(self, digests: impl IntoIterator<Item = D>) -> Self {
+        Self {
+            inner: self.inner.add_leaf_digests(digests),
+        }
     }
 
     /// The number of leaves visible through this batch.

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -63,11 +63,21 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         }
     }
 
-    /// Add a run of pre-computed leaf digests, in order.
-    pub fn add_leaf_digests(self, digests: impl IntoIterator<Item = D>) -> Self {
-        Self {
-            inner: self.inner.add_leaf_digests(digests),
-        }
+    /// Hash `leaves` in parallel, append them, and merkleize.
+    pub fn merkleize_leaves<L, T>(
+        self,
+        base: &Mem<F, D>,
+        hasher: &impl Hasher<F, Digest = D>,
+        leaves: &[L],
+        init: impl Fn() -> T + Send + Sync,
+        leaf: impl Fn(&mut T, &L, Position<F>) -> D + Send + Sync,
+    ) -> Arc<batch::MerkleizedBatch<F, D, S>>
+    where
+        L: Sync,
+        T: Send,
+    {
+        self.inner
+            .merkleize_leaves(base, hasher, leaves, init, leaf)
     }
 
     /// The number of leaves visible through this batch.

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -63,21 +63,14 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         }
     }
 
-    /// Hash `leaves` in parallel, append them, and merkleize.
-    pub fn merkleize_leaves<L, T>(
+    /// Append a run of pre-computed leaf digests and merkleize.
+    pub(crate) fn merkleize_leaf_digests(
         self,
         base: &Mem<F, D>,
         hasher: &impl Hasher<F, Digest = D>,
-        leaves: &[L],
-        init: impl Fn() -> T + Send + Sync,
-        leaf: impl Fn(&mut T, &L, Position<F>) -> D + Send + Sync,
-    ) -> Arc<batch::MerkleizedBatch<F, D, S>>
-    where
-        L: Sync,
-        T: Send,
-    {
-        self.inner
-            .merkleize_leaves(base, hasher, leaves, init, leaf)
+        digests: impl IntoIterator<Item = D>,
+    ) -> Arc<batch::MerkleizedBatch<F, D, S>> {
+        self.inner.merkleize_leaf_digests(base, hasher, digests)
     }
 
     /// The number of leaves visible through this batch.

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -821,9 +821,13 @@ where
         let ops = Arc::new(ops);
         let leaves = Location::new(self.base_size + ops.len() as u64);
         let inactive_peaks = db.inactive_peaks(leaves, floor);
-        let journal = db
-            .log
-            .with_mem(|base| self.journal_batch.merkleize_with(base, ops));
+        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
+
+        // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
+        let journal = db.log.with_mem(|base| {
+            self.journal_batch
+                .merkleize_with_leaf_digests(base, ops, leaf_digests)
+        });
         let root = db
             .log
             .with_mem(|base| journal.root(base, &db.log.hasher, inactive_peaks))?;

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -818,16 +818,13 @@ where
         // parent already contains all prior batches' Merkle state, so we only
         // add THIS batch's operations. Parent operations are never re-cloned,
         // re-encoded, or re-hashed.
-        let ops = Arc::new(ops);
         let leaves = Location::new(self.base_size + ops.len() as u64);
         let inactive_peaks = db.inactive_peaks(leaves, floor);
-        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
 
         // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
-        let journal = db.log.with_mem(|base| {
-            self.journal_batch
-                .merkleize_with_leaf_digests(base, ops, leaf_digests)
-        });
+        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
+        let journal_batch = self.journal_batch.add_leaf_digests(ops, leaf_digests);
+        let journal = db.log.with_mem(|base| journal_batch.merkleize(base));
         let root = db
             .log
             .with_mem(|base| journal.root(base, &db.log.hasher, inactive_peaks))?;

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -821,9 +821,8 @@ where
         let leaves = Location::new(self.base_size + ops.len() as u64);
         let inactive_peaks = db.inactive_peaks(leaves, floor);
 
-        // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
-        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
-        let journal_batch = self.journal_batch.add_leaf_digests(ops, leaf_digests);
+        // Hash before `with_mem` borrows committed Merkle state under its read lock.
+        let journal_batch = self.journal_batch.add_many(ops);
         let journal = db.log.with_mem(|base| journal_batch.merkleize(base));
         let root = db
             .log

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -22,13 +22,20 @@ where
     S: Strategy,
     Op: EncodeShared,
 {
-    // Hash each operation's leaf digest in parallel, then merkleize.
     let hasher = qmdb::hasher::<H>();
-    merkle.with_mem(|mem| {
-        batch.merkleize_leaves(mem, &hasher, ops, Vec::new, |buf, op, pos| {
-            buf.clear();
-            op.write(buf);
-            hasher.leaf_digest(pos, buf.as_slice())
-        })
-    })
+    let first_leaf = batch.leaves();
+
+    // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
+    let leaf_digests =
+        merkle
+            .strategy()
+            .map_init_collect_vec(ops.iter().enumerate(), Vec::new, |buf, (i, op)| {
+                let offset = u64::try_from(i).expect("operation offset exceeds u64");
+                let pos = F::location_to_position(first_leaf + offset);
+                buf.clear();
+                op.write(buf);
+                hasher.leaf_digest(pos, buf.as_slice())
+            });
+
+    merkle.with_mem(|mem| batch.merkleize_leaf_digests(mem, &hasher, leaf_digests))
 }

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -25,7 +25,7 @@ where
     let hasher = qmdb::hasher::<H>();
     let first_leaf = batch.leaves();
 
-    // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
+    // Hash before `with_mem` borrows committed Merkle state under its read lock.
     let leaf_digests =
         merkle
             .strategy()

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -37,5 +37,6 @@ where
                 hasher.leaf_digest(pos, buf.as_slice())
             });
 
-    merkle.with_mem(|mem| batch.merkleize_leaf_digests(mem, &hasher, leaf_digests))
+    let batch = batch.add_leaf_digests(leaf_digests);
+    merkle.with_mem(|mem| batch.merkleize(mem, &hasher))
 }

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -23,11 +23,12 @@ where
     Op: EncodeShared,
 {
     // Compute the leaf digests in parallel.
+    let hasher = qmdb::hasher::<H>();
     let first_leaf = batch.leaves();
     let leaf_digests = merkle.strategy().map_init_collect_vec(
         ops.iter().enumerate(),
-        || (qmdb::hasher::<H>(), Vec::new()),
-        |(hasher, buf), (i, op)| {
+        Vec::new,
+        |buf, (i, op)| {
             let offset = u64::try_from(i).expect("operation offset exceeds u64");
             let pos = F::location_to_position(first_leaf + offset);
             buf.clear();
@@ -40,5 +41,5 @@ where
     batch = batch.add_leaf_digests(leaf_digests);
 
     // Merkleize the batch.
-    merkle.with_mem(|mem| batch.merkleize(mem, &qmdb::hasher::<H>()))
+    merkle.with_mem(|mem| batch.merkleize(mem, &hasher))
 }

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -1,7 +1,7 @@
 //! Shared helpers for compact QMDB batches.
 
 use crate::{
-    merkle::{batch, compact, Family},
+    merkle::{batch, compact, hasher::Hasher as _, Family},
     qmdb, Context,
 };
 use commonware_codec::EncodeShared;
@@ -22,9 +22,21 @@ where
     S: Strategy,
     Op: EncodeShared,
 {
-    let hasher = qmdb::hasher::<H>();
-    for op in ops {
-        batch = batch.add(&hasher, &op.encode());
-    }
-    merkle.with_mem(|mem| batch.merkleize(mem, &hasher))
+    // Compute the leaf digests in parallel.
+    let first_leaf = batch.leaves();
+    let leaf_digests = merkle.strategy().map_init_collect_vec(
+        ops.iter().enumerate(),
+        qmdb::hasher::<H>,
+        |hasher, (i, op)| {
+            let offset = u64::try_from(i).expect("operation offset exceeds u64");
+            let pos = F::location_to_position(first_leaf + offset);
+            hasher.leaf_digest(pos, &op.encode())
+        },
+    );
+
+    // Add the leaf digests to the batch.
+    batch = batch.add_leaf_digests(leaf_digests);
+
+    // Merkleize the batch.
+    merkle.with_mem(|mem| batch.merkleize(mem, &qmdb::hasher::<H>()))
 }

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 /// Encode operations, append them to a compact Merkle batch, and compute its root.
 pub(crate) fn merkleize_ops<F, E, H, S, Op>(
     merkle: &compact::Merkle<F, E, H::Digest, S>,
-    mut batch: compact::UnmerkleizedBatch<F, H::Digest, S>,
+    batch: compact::UnmerkleizedBatch<F, H::Digest, S>,
     ops: &[Op],
 ) -> Arc<batch::MerkleizedBatch<F, H::Digest, S>>
 where
@@ -22,23 +22,13 @@ where
     S: Strategy,
     Op: EncodeShared,
 {
-    // Compute the leaf digests in parallel.
+    // Hash each operation's leaf digest in parallel, then merkleize.
     let hasher = qmdb::hasher::<H>();
-    let first_leaf = batch.leaves();
-    let leaf_digests =
-        merkle
-            .strategy()
-            .map_init_collect_vec(ops.iter().enumerate(), Vec::new, |buf, (i, op)| {
-                let offset = u64::try_from(i).expect("operation offset exceeds u64");
-                let pos = F::location_to_position(first_leaf + offset);
-                buf.clear();
-                op.write(buf);
-                hasher.leaf_digest(pos, buf.as_slice())
-            });
-
-    // Add the leaf digests to the batch.
-    batch = batch.add_leaf_digests(leaf_digests);
-
-    // Merkleize the batch.
-    merkle.with_mem(|mem| batch.merkleize(mem, &hasher))
+    merkle.with_mem(|mem| {
+        batch.merkleize_leaves(mem, &hasher, ops, Vec::new, |buf, op, pos| {
+            buf.clear();
+            op.write(buf);
+            hasher.leaf_digest(pos, buf.as_slice())
+        })
+    })
 }

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -25,17 +25,16 @@ where
     // Compute the leaf digests in parallel.
     let hasher = qmdb::hasher::<H>();
     let first_leaf = batch.leaves();
-    let leaf_digests = merkle.strategy().map_init_collect_vec(
-        ops.iter().enumerate(),
-        Vec::new,
-        |buf, (i, op)| {
-            let offset = u64::try_from(i).expect("operation offset exceeds u64");
-            let pos = F::location_to_position(first_leaf + offset);
-            buf.clear();
-            op.write(buf);
-            hasher.leaf_digest(pos, buf.as_slice())
-        },
-    );
+    let leaf_digests =
+        merkle
+            .strategy()
+            .map_init_collect_vec(ops.iter().enumerate(), Vec::new, |buf, (i, op)| {
+                let offset = u64::try_from(i).expect("operation offset exceeds u64");
+                let pos = F::location_to_position(first_leaf + offset);
+                buf.clear();
+                op.write(buf);
+                hasher.leaf_digest(pos, buf.as_slice())
+            });
 
     // Add the leaf digests to the batch.
     batch = batch.add_leaf_digests(leaf_digests);

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -26,11 +26,13 @@ where
     let first_leaf = batch.leaves();
     let leaf_digests = merkle.strategy().map_init_collect_vec(
         ops.iter().enumerate(),
-        qmdb::hasher::<H>,
-        |hasher, (i, op)| {
+        || (qmdb::hasher::<H>(), Vec::new()),
+        |(hasher, buf), (i, op)| {
             let offset = u64::try_from(i).expect("operation offset exceeds u64");
             let pos = F::location_to_position(first_leaf + offset);
-            hasher.leaf_digest(pos, &op.encode())
+            buf.clear();
+            op.write(buf);
+            hasher.leaf_digest(pos, buf.as_slice())
         },
     );
 

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1153,15 +1153,12 @@ pub(super) async fn build_grafted_tree<
         Mem::new()
     };
 
-    // Append the pre-computed grafted leaf digests and merkleize.
+    // Add each grafted leaf digest.
     if !leaves.is_empty() {
         let batch = {
             let batch = grafted_tree.new_batch_with_strategy(strategy.clone());
-            batch.merkleize_leaf_digests(
-                &grafted_tree,
-                &grafted_hasher,
-                leaves.iter().map(|&(_, digest)| digest),
-            )
+            let batch = batch.add_leaf_digests(leaves.iter().map(|&(_, digest)| digest));
+            batch.merkleize(&grafted_tree, &grafted_hasher)
         };
         grafted_tree.apply_batch(&batch)?;
     }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1156,10 +1156,8 @@ pub(super) async fn build_grafted_tree<
     // Add each grafted leaf digest.
     if !leaves.is_empty() {
         let batch = {
-            let mut batch = grafted_tree.new_batch_with_strategy(strategy.clone());
-            for &(_ops_pos, digest) in &leaves {
-                batch = batch.add_leaf_digest(digest);
-            }
+            let batch = grafted_tree.new_batch_with_strategy(strategy.clone());
+            let batch = batch.add_leaf_digests(leaves.iter().map(|&(_, digest)| digest));
             batch.merkleize(&grafted_tree, &grafted_hasher)
         };
         grafted_tree.apply_batch(&batch)?;

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1153,12 +1153,18 @@ pub(super) async fn build_grafted_tree<
         Mem::new()
     };
 
-    // Add each grafted leaf digest.
+    // Append the pre-computed grafted leaf digests and merkleize. The digests are already
+    // computed, so the per-leaf closure is an identity passthrough.
     if !leaves.is_empty() {
         let batch = {
             let batch = grafted_tree.new_batch_with_strategy(strategy.clone());
-            let batch = batch.add_leaf_digests(leaves.iter().map(|&(_, digest)| digest));
-            batch.merkleize(&grafted_tree, &grafted_hasher)
+            batch.merkleize_leaves(
+                &grafted_tree,
+                &grafted_hasher,
+                &leaves,
+                || (),
+                |_, &(_, digest), _pos| digest,
+            )
         };
         grafted_tree.apply_batch(&batch)?;
     }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1153,17 +1153,14 @@ pub(super) async fn build_grafted_tree<
         Mem::new()
     };
 
-    // Append the pre-computed grafted leaf digests and merkleize. The digests are already
-    // computed, so the per-leaf closure is an identity passthrough.
+    // Append the pre-computed grafted leaf digests and merkleize.
     if !leaves.is_empty() {
         let batch = {
             let batch = grafted_tree.new_batch_with_strategy(strategy.clone());
-            batch.merkleize_leaves(
+            batch.merkleize_leaf_digests(
                 &grafted_tree,
                 &grafted_hasher,
-                &leaves,
-                || (),
-                |_, &(_, digest), _pos| digest,
+                leaves.iter().map(|&(_, digest)| digest),
             )
         };
         grafted_tree.apply_batch(&batch)?;

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -260,16 +260,15 @@ where
 
         let total_size = base + ops.len() as u64;
 
-        // Add operations to the journal batch and merkleize.
-        let mut journal_batch = self.journal_batch;
-        for op in &ops {
-            journal_batch = journal_batch.add(op.clone());
-        }
+        // Hash the operations' leaf digests in parallel, then merkleize the journal batch.
+        let ops = Arc::new(ops);
         let inactive_peaks = F::inactive_peaks(
             F::location_to_position(Location::new(total_size)),
             inactivity_floor,
         );
-        let journal_merkleized = db.journal.with_mem(|mem| journal_batch.merkleize(mem));
+        let journal_merkleized = db
+            .journal
+            .with_mem(|mem| self.journal_batch.merkleize_with(mem, ops));
         let root = db
             .journal
             .with_mem(|mem| journal_merkleized.root(mem, &db.journal.hasher, inactive_peaks))

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -260,16 +260,12 @@ where
 
         let total_size = base + ops.len() as u64;
 
-        let ops = Arc::new(ops);
-
         // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
         let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
 
         // Merkleize the journal batch.
-        let journal = db.journal.with_mem(|mem| {
-            self.journal_batch
-                .merkleize_with_leaf_digests(mem, ops, leaf_digests)
-        });
+        let journal_batch = self.journal_batch.add_leaf_digests(ops, leaf_digests);
+        let journal = db.journal.with_mem(|mem| journal_batch.merkleize(mem));
 
         // Compute the root.
         let inactive_peaks = F::inactive_peaks(

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -266,9 +266,13 @@ where
             F::location_to_position(Location::new(total_size)),
             inactivity_floor,
         );
-        let journal_merkleized = db
-            .journal
-            .with_mem(|mem| self.journal_batch.merkleize_with(mem, ops));
+        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
+
+        // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
+        let journal_merkleized = db.journal.with_mem(|mem| {
+            self.journal_batch
+                .merkleize_with_leaf_digests(mem, ops, leaf_digests)
+        });
         let root = db
             .journal
             .with_mem(|mem| journal_merkleized.root(mem, &db.journal.hasher, inactive_peaks))

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -260,24 +260,27 @@ where
 
         let total_size = base + ops.len() as u64;
 
-        // Hash the operations' leaf digests in parallel, then merkleize the journal batch.
+        // Merkleize the journal batch.
         let ops = Arc::new(ops);
+        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
+
+        // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
+        let journal = db.journal.with_mem(|mem| {
+            self.journal_batch
+                .merkleize_with_leaf_digests(mem, ops, leaf_digests)
+        });
+
+        // Compute the root.
         let inactive_peaks = F::inactive_peaks(
             F::location_to_position(Location::new(total_size)),
             inactivity_floor,
         );
-        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
-
-        // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
-        let journal_merkleized = db.journal.with_mem(|mem| {
-            self.journal_batch
-                .merkleize_with_leaf_digests(mem, ops, leaf_digests)
-        });
         let root = db
             .journal
-            .with_mem(|mem| journal_merkleized.root(mem, &db.journal.hasher, inactive_peaks))
+            .with_mem(|mem| journal.root(mem, &db.journal.hasher, inactive_peaks))
             .expect("inactive_peaks computed from batch size");
 
+        // Compute the batch chain bounds.
         let mut ancestor_diffs = Vec::new();
         let mut ancestors = Vec::new();
         for batch in
@@ -291,7 +294,7 @@ where
         }
 
         Arc::new(MerkleizedBatch {
-            journal_batch: journal_merkleized,
+            journal_batch: journal,
             root,
             diff: Arc::new(diff),
             parent: self.parent.as_ref().map(Arc::downgrade),

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -260,11 +260,8 @@ where
 
         let total_size = base + ops.len() as u64;
 
-        // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
-        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
-
-        // Merkleize the journal batch.
-        let journal_batch = self.journal_batch.add_leaf_digests(ops, leaf_digests);
+        // Hash before `with_mem` borrows committed Merkle state under its read lock.
+        let journal_batch = self.journal_batch.add_many(ops);
         let journal = db.journal.with_mem(|mem| journal_batch.merkleize(mem));
 
         // Compute the root.

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -260,11 +260,12 @@ where
 
         let total_size = base + ops.len() as u64;
 
-        // Merkleize the journal batch.
         let ops = Arc::new(ops);
-        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
 
         // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
+        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
+
+        // Merkleize the journal batch.
         let journal = db.journal.with_mem(|mem| {
             self.journal_batch
                 .merkleize_with_leaf_digests(mem, ops, leaf_digests)

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -269,16 +269,15 @@ where
 
         let total_size = base + ops.len() as u64;
 
-        // Add operations to the journal batch and merkleize.
-        let mut journal_batch = self.journal_batch;
-        for op in &ops {
-            journal_batch = journal_batch.add(op.clone());
-        }
+        // Hash the operations' leaf digests in parallel, then merkleize the journal batch.
+        let ops = Arc::new(ops);
         let inactive_peaks = F::inactive_peaks(
             F::location_to_position(Location::new(total_size)),
             inactivity_floor,
         );
-        let journal = db.journal.with_mem(|mem| journal_batch.merkleize(mem));
+        let journal = db
+            .journal
+            .with_mem(|mem| self.journal_batch.merkleize_with(mem, ops));
         let root = db
             .journal
             .with_mem(|mem| journal.root(mem, &db.journal.hasher, inactive_peaks))

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -258,8 +258,6 @@ where
         E: Context,
         C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
     {
-        let base = self.base_size;
-
         // Build operations: one Append per value, then Commit.
         let mut ops: Vec<Operation<F, V>> = Vec::with_capacity(self.appends.len() + 1);
         for value in self.appends {
@@ -267,22 +265,25 @@ where
         }
         ops.push(Operation::Commit(metadata, inactivity_floor));
 
-        let total_size = base + ops.len() as u64;
+        let total_size = self.base_size + ops.len() as u64;
 
-        // Hash the operations' leaf digests in parallel, then merkleize the journal batch.
+        // Merkleize the journal batch.
         let ops = Arc::new(ops);
+        let journal = db
+            .journal
+            .with_mem(|mem| self.journal_batch.merkleize_with(mem, ops));
+
+        // Compute the root.
         let inactive_peaks = F::inactive_peaks(
             F::location_to_position(Location::new(total_size)),
             inactivity_floor,
         );
-        let journal = db
-            .journal
-            .with_mem(|mem| self.journal_batch.merkleize_with(mem, ops));
         let root = db
             .journal
             .with_mem(|mem| journal.root(mem, &db.journal.hasher, inactive_peaks))
             .expect("inactive_peaks computed from batch size");
 
+        // Compute the batch chain bounds.
         let ancestors =
             batch_chain::parent_and_ancestors(self.parent.as_ref(), |parent| parent.ancestors());
         let ancestors = batch_chain::collect_ancestor_bounds(

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -267,9 +267,8 @@ where
 
         let total_size = self.base_size + ops.len() as u64;
 
-        // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
-        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
-        let journal_batch = self.journal_batch.add_leaf_digests(ops, leaf_digests);
+        // Hash before `with_mem` borrows committed Merkle state under its read lock.
+        let journal_batch = self.journal_batch.add_many(ops);
         let journal = db.journal.with_mem(|mem| journal_batch.merkleize(mem));
 
         // Compute the root.

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -269,9 +269,13 @@ where
 
         // Merkleize the journal batch.
         let ops = Arc::new(ops);
-        let journal = db
-            .journal
-            .with_mem(|mem| self.journal_batch.merkleize_with(mem, ops));
+        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
+
+        // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
+        let journal = db.journal.with_mem(|mem| {
+            self.journal_batch
+                .merkleize_with_leaf_digests(mem, ops, leaf_digests)
+        });
 
         // Compute the root.
         let inactive_peaks = F::inactive_peaks(

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -267,15 +267,10 @@ where
 
         let total_size = self.base_size + ops.len() as u64;
 
-        // Merkleize the journal batch.
-        let ops = Arc::new(ops);
-        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
-
         // Hash before borrowing committed Merkle state so the read lock only covers merkleization.
-        let journal = db.journal.with_mem(|mem| {
-            self.journal_batch
-                .merkleize_with_leaf_digests(mem, ops, leaf_digests)
-        });
+        let leaf_digests = self.journal_batch.leaf_digests_with(ops.as_slice());
+        let journal_batch = self.journal_batch.add_leaf_digests(ops, leaf_digests);
+        let journal = db.journal.with_mem(|mem| journal_batch.merkleize(mem));
 
         // Compute the root.
         let inactive_peaks = F::inactive_peaks(


### PR DESCRIPTION
 ## [storage/qmdb] Hash operation leaf digests in parallel across all db types
  
  Move per-operation leaf hashing off the sequential `batch.add()` loop and onto the configured parallel `Strategy`, so leaf digests are computed
  concurrently before being appended. Previously only parent-node hashing (inside `merkleize`) was parallel; leaf hashing was the remaining sequential
  gap.

  ### Changes

  - **`compact` dbs** (`qmdb/compact/batch.rs::merkleize_ops`): compute leaf digests via `Strategy::map_init_collect_vec`, then append precomputed
  digests.
  - **`immutable` / `keyless` dbs**: route their `merkleize` through the authenticated journal's parallel `merkleize_with` instead of the `add`-loop,
  matching what `any`/`current` already did. Also drops a per-operation `Operation::clone()`.
  - **New `merkle::batch::UnmerkleizedBatch::add_leaf_digests`**: appends a run of precomputed leaf digests in one call, reserving capacity up front.
  Replaces the repeated `for d in digests { batch.add_leaf_digest(d) }` pattern in `merkleize_ops`, `merkleize_with`, and
  `current::build_grafted_tree`. Mirrored on the `persisted::compact` wrapper.
