### PR TITLE
[storage] remove Persistable trait

### DIFF
--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -36,7 +36,6 @@ use commonware_storage::{
         Error,
     },
     translator::Translator,
-    Persistable,
 };
 use commonware_utils::{channel::mpsc, non_empty_range, sync::AsyncRwLock, Array};
 use std::{ops::Deref, sync::Arc};
@@ -72,8 +71,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding + 'static,
-    C: Mutable<Item = Operation<F, unordered::Update<K, V>>>
-        + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,
@@ -167,8 +165,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding + 'static,
-    C: Mutable<Item = Operation<F, ordered::Update<K, V>>>
-        + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
     I: OrderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,
@@ -237,8 +234,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding + 'static,
-    C: Mutable<Item = Operation<F, unordered::Update<K, V>>>
-        + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,
@@ -265,8 +261,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding + 'static,
-    C: Mutable<Item = Operation<F, ordered::Update<K, V>>>
-        + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
     I: OrderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,
@@ -291,7 +286,7 @@ where
     F: Family,
     E: Storage + Clock + Metrics,
     U: Update,
-    C: Mutable<Item = Operation<F, U>> + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -39,7 +39,6 @@ use commonware_storage::{
         Error,
     },
     translator::Translator,
-    Persistable,
 };
 use commonware_utils::{channel::mpsc, non_empty_range, sync::AsyncRwLock, Array};
 use std::{ops::Deref, sync::Arc};
@@ -73,8 +72,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding + 'static,
-    C: Mutable<Item = Operation<F, unordered::Update<K, V>>>
-        + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,
@@ -169,8 +167,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding + 'static,
-    C: Mutable<Item = Operation<F, ordered::Update<K, V>>>
-        + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
     I: OrderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,
@@ -239,8 +236,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding + 'static,
-    C: Mutable<Item = Operation<F, unordered::Update<K, V>>>
-        + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,
@@ -267,8 +263,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding + 'static,
-    C: Mutable<Item = Operation<F, ordered::Update<K, V>>>
-        + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
     I: OrderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,
@@ -294,7 +289,7 @@ where
     F: Graftable,
     E: Storage + Clock + Metrics,
     U: Update,
-    C: Mutable<Item = Operation<F, U>> + Persistable<Error = commonware_storage::journal::Error>,
+    C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     S: Strategy,

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -14,11 +14,8 @@ use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_storage::{
-    journal::{
-        contiguous::{
-            fixed::Journal as FixedJournal, variable::Journal as VariableJournal, Mutable,
-        },
-        Error as JournalError,
+    journal::contiguous::{
+        fixed::Journal as FixedJournal, variable::Journal as VariableJournal, Mutable,
     },
     merkle::{Family, Location},
     qmdb::{
@@ -32,7 +29,6 @@ use commonware_storage::{
         Error,
     },
     translator::Translator,
-    Persistable,
 };
 use commonware_utils::{channel::mpsc, non_empty_range, sync::AsyncRwLock, Array};
 use std::{ops::Deref, sync::Arc};
@@ -48,7 +44,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     H: Hasher,
     T: Translator,
     S: Strategy,
@@ -66,7 +62,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     H: Hasher,
     T: Translator,
     S: Strategy,
@@ -85,7 +81,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     H: Hasher,
     T: Translator,
     S: Strategy,
@@ -135,7 +131,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     H: Hasher,
     T: Translator,
     S: Strategy,
@@ -151,7 +147,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     H: Hasher,
     T: Translator,
     S: Strategy,
@@ -170,7 +166,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     H: Hasher,
     T: Translator,
     S: Strategy,
@@ -197,7 +193,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     H: Hasher,
     T: Translator,
     S: Strategy,
@@ -226,7 +222,7 @@ where
     E: Storage + Clock + Metrics,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     H: Hasher,
     T: Translator,
     S: Strategy,

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -15,11 +15,8 @@ use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_storage::{
-    journal::{
-        contiguous::{
-            fixed::Journal as FixedJournal, variable::Journal as VariableJournal, Mutable,
-        },
-        Error as JournalError,
+    journal::contiguous::{
+        fixed::Journal as FixedJournal, variable::Journal as VariableJournal, Mutable,
     },
     merkle::{Family, Location},
     qmdb::{
@@ -31,7 +28,6 @@ use commonware_storage::{
         sync::{self, resolver::Resolver, Target as AnySyncTarget},
         Error,
     },
-    Persistable,
 };
 use commonware_utils::{channel::mpsc, non_empty_range, sync::AsyncRwLock};
 use std::{ops::Deref, sync::Arc};
@@ -45,7 +41,7 @@ where
     F: Family,
     E: Storage + Clock + Metrics,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
     S: Strategy,
     Operation<F, V>: EncodeShared,
@@ -61,7 +57,7 @@ where
     F: Family,
     E: Storage + Clock + Metrics,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
     S: Strategy,
     Operation<F, V>: EncodeShared,
@@ -78,7 +74,7 @@ where
     F: Family,
     E: Storage + Clock + Metrics,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
     S: Strategy,
     Operation<F, V>: EncodeShared,
@@ -130,7 +126,7 @@ where
     F: Family,
     E: Storage + Clock + Metrics,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
     S: Strategy,
     Operation<F, V>: EncodeShared,
@@ -144,7 +140,7 @@ where
     F: Family,
     E: Storage + Clock + Metrics,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
     S: Strategy,
     Operation<F, V>: EncodeShared,
@@ -161,7 +157,7 @@ where
     F: Family,
     E: Storage + Clock + Metrics,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
     S: Strategy,
     Operation<F, V>: EncodeShared,
@@ -190,7 +186,7 @@ where
     F: Family,
     E: Storage + Clock + Metrics,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
     S: Strategy,
     Operation<F, V>: EncodeShared,
@@ -217,7 +213,7 @@ where
     F: Family,
     E: Storage + Clock + Metrics,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
     S: Strategy,
     Operation<F, V>: EncodeShared,

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -10,10 +10,7 @@
 
 use arbitrary::{Arbitrary, Result, Unstructured};
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervisor as _};
-use commonware_storage::{
-    queue::{Config, Queue},
-    Persistable,
-};
+use commonware_storage::queue::{Config, Queue};
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::BTreeMap,

--- a/storage/fuzz/fuzz_targets/queue_operations.rs
+++ b/storage/fuzz/fuzz_targets/queue_operations.rs
@@ -2,10 +2,7 @@
 
 use arbitrary::{Arbitrary, Result, Unstructured};
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervisor as _};
-use commonware_storage::{
-    queue::{Config, Queue},
-    Persistable,
-};
+use commonware_storage::queue::{Config, Queue};
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::BTreeSet,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -17,7 +17,7 @@ use crate::{
         mem::Mem,
         Bagging, Family, Location, Position, Proof, Readable,
     },
-    Context, Persistable,
+    Context,
 };
 use alloc::{
     sync::{Arc, Weak},
@@ -352,7 +352,7 @@ impl<F, E, C, H, S> Journal<F, E, C, H, S>
 where
     F: Family,
     E: Context,
-    C: Contiguous<Item: EncodeShared> + Persistable<Error = JournalError>,
+    C: Mutable<Item: EncodeShared>,
     H: Hasher,
     S: Strategy,
 {
@@ -657,7 +657,7 @@ impl<F, E, C, H, S> Journal<F, E, C, H, S>
 where
     F: Family,
     E: Context,
-    C: Contiguous<Item: EncodeShared> + Persistable<Error = JournalError>,
+    C: Mutable<Item: EncodeShared>,
     H: Hasher,
     S: Strategy,
 {
@@ -782,10 +782,22 @@ where
     async fn rewind(&mut self, size: u64) -> Result<(), JournalError> {
         self.rewind(size).await.map_err(Self::map_error)
     }
+
+    async fn commit(&self) -> Result<(), JournalError> {
+        Self::commit(self).await.map_err(Self::map_error)
+    }
+
+    async fn sync(&self) -> Result<(), JournalError> {
+        Self::sync(self).await.map_err(Self::map_error)
+    }
+
+    async fn destroy(self) -> Result<(), JournalError> {
+        Self::destroy(self).await.map_err(Self::map_error)
+    }
 }
 
 /// A [Mutable] journal that can serve as the inner journal of an authenticated [Journal].
-pub trait Inner<E: Context>: Mutable + Persistable<Error = JournalError> {
+pub trait Inner<E: Context>: Mutable {
     /// The configuration needed to initialize this journal.
     type Config: Clone + Send;
 
@@ -800,29 +812,6 @@ pub trait Inner<E: Context>: Mutable + Persistable<Error = JournalError> {
     where
         Self: Sized,
         Self::Item: EncodeShared;
-}
-
-impl<F, E, C, H, S> Persistable for Journal<F, E, C, H, S>
-where
-    F: Family,
-    E: Context,
-    C: Contiguous<Item: EncodeShared> + Persistable<Error = JournalError>,
-    H: Hasher,
-    S: Strategy,
-{
-    type Error = JournalError;
-
-    async fn commit(&self) -> Result<(), JournalError> {
-        self.commit().await.map_err(Self::map_error)
-    }
-
-    async fn sync(&self) -> Result<(), JournalError> {
-        self.sync().await.map_err(Self::map_error)
-    }
-
-    async fn destroy(self) -> Result<(), JournalError> {
-        self.destroy().await.map_err(Self::map_error)
-    }
 }
 
 #[cfg(test)]

--- a/storage/src/journal/benches/bench.rs
+++ b/storage/src/journal/benches/bench.rs
@@ -1,14 +1,8 @@
 use commonware_runtime::{buffer::paged::CacheRef, tokio::Context};
-use commonware_storage::{
-    journal::{
-        contiguous::{
-            fixed::{Config as FixedConfig, Journal as FixedJournal},
-            variable::{Config as VariableConfig, Journal as VariableJournal},
-            Mutable,
-        },
-        Error as JournalError,
-    },
-    Persistable,
+use commonware_storage::journal::contiguous::{
+    fixed::{Config as FixedConfig, Journal as FixedJournal},
+    variable::{Config as VariableConfig, Journal as VariableJournal},
+    Mutable,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
 use criterion::criterion_main;
@@ -66,7 +60,7 @@ async fn get_fixed_journal<const ITEM_SIZE: usize>(
 /// Append `items_to_write` random items to the given fixed journal, syncing the changes before returning.
 async fn append_fixed_random_data<C, const ITEM_SIZE: usize>(journal: &mut C, items_to_write: u64)
 where
-    C: Mutable<Item = FixedBytes<ITEM_SIZE>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = FixedBytes<ITEM_SIZE>>,
 {
     // Append `items_to_write` random items to the journal.
     let mut rng = StdRng::seed_from_u64(0);

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -94,7 +94,7 @@ use crate::{
         Error,
     },
     metadata::{Config as MetadataConfig, Metadata},
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::CodecFixedShared;
 use commonware_runtime::buffer::paged::CacheRef;
@@ -1420,21 +1420,17 @@ impl<E: Context, A: CodecFixedShared> Mutable for Journal<E, A> {
     async fn rewind(&mut self, size: u64) -> Result<(), Error> {
         Self::rewind(self, size).await
     }
-}
-
-impl<E: Context, A: CodecFixedShared> Persistable for Journal<E, A> {
-    type Error = Error;
 
     async fn commit(&self) -> Result<(), Error> {
-        self.commit().await
+        Self::commit(self).await
     }
 
     async fn sync(&self) -> Result<(), Error> {
-        self.sync().await
+        Self::sync(self).await
     }
 
     async fn destroy(self) -> Result<(), Error> {
-        self.destroy().await
+        Self::destroy(self).await
     }
 }
 

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -224,6 +224,33 @@ pub trait Mutable: Contiguous + Send + Sync {
     /// Returns an error if the underlying storage operation fails.
     fn rewind(&mut self, size: u64) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 
+    /// Durably persist the journal, guaranteeing the current state will survive a crash.
+    ///
+    /// For a stronger guarantee that eliminates potential recovery, use [Self::sync] instead.
+    fn commit(&self) -> impl std::future::Future<Output = Result<(), Error>> + Send {
+        self.sync()
+    }
+
+    /// Durably persist the journal, guaranteeing the current state will survive a crash, and that
+    /// no recovery will be needed on startup.
+    ///
+    /// This provides a stronger guarantee than [Self::commit] but may be slower.
+    fn sync(&self) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+
+    /// Destroy the journal, removing all associated storage.
+    ///
+    /// This method consumes the journal and deletes all persisted data, leaving behind no storage
+    /// artifacts. This can be used to clean up disk resources in tests.
+    ///
+    /// # Crash Safety
+    ///
+    /// This operation is intended for final teardown and is not crash-safe. If interrupted,
+    /// reopening the same storage may observe partially removed state. Use a reset operation
+    /// provided by the concrete type when the journal must remain recoverable.
+    fn destroy(self) -> impl std::future::Future<Output = Result<(), Error>> + Send
+    where
+        Self: Sized;
+
     /// Rewinds the journal to the last item matching `predicate`. If no item matches, the journal
     /// is rewound to the pruning boundary, discarding all unpruned items.
     ///

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -1,10 +1,7 @@
 //! Generic test suite for [Contiguous] trait implementations.
 
 use super::{Contiguous, Many, Reader as _};
-use crate::{
-    journal::{contiguous::Mutable, Error},
-    Persistable,
-};
+use crate::journal::{contiguous::Mutable, Error};
 use commonware_utils::NZUsize;
 use futures::{future::BoxFuture, StreamExt};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -180,12 +177,9 @@ pub(super) mod partition_sync_fault {
     }
 }
 
-pub(super) trait PersistableContiguous:
-    Mutable<Item = u64> + Persistable<Error = Error>
-{
-}
+pub(super) trait MutableContiguous: Mutable<Item = u64> {}
 
-impl<T> PersistableContiguous for T where T: Mutable<Item = u64> + Persistable<Error = Error> {}
+impl<T> MutableContiguous for T where T: Mutable<Item = u64> {}
 
 async fn get_bounds<J: Contiguous>(journal: &J) -> std::ops::Range<u64> {
     let reader = journal.reader().await;
@@ -211,7 +205,7 @@ async fn read_item<J: Contiguous>(journal: &J, position: u64) -> Result<J::Item,
 pub(super) async fn run_contiguous_tests<F, J>(factory: F)
 where
     F: Fn(String, usize) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let counter = AtomicUsize::new(0);
     let indexed_factory = |name: String| {
@@ -263,7 +257,7 @@ where
 async fn test_empty_journal_bounds<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let journal = factory("empty".into()).await.unwrap();
     let bounds = get_bounds(&journal).await;
@@ -277,7 +271,7 @@ where
 async fn test_bounds_with_items<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("bounds-with-items".into()).await.unwrap();
 
@@ -299,7 +293,7 @@ where
 async fn test_bounds_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("bounds-after-prune".into()).await.unwrap();
 
@@ -349,7 +343,7 @@ where
 async fn test_append_and_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("append-and-size".into()).await.unwrap();
 
@@ -374,7 +368,7 @@ where
 async fn test_sequential_appends<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("sequential-appends".into()).await.unwrap();
 
@@ -396,7 +390,7 @@ where
 async fn test_replay_from_start<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("replay-from-start".into()).await.unwrap();
 
@@ -428,7 +422,7 @@ where
 async fn test_replay_from_middle<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("replay-from-middle".into()).await.unwrap();
 
@@ -460,7 +454,7 @@ where
 async fn test_prune_retains_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("prune-retains-size".into()).await.unwrap();
 
@@ -493,7 +487,7 @@ where
 async fn test_through_trait<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("through-trait".into()).await.unwrap();
 
@@ -513,7 +507,7 @@ where
 async fn test_replay_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("replay-after-prune".into()).await.unwrap();
 
@@ -552,7 +546,7 @@ where
 async fn test_prune_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("prune-then-append".into()).await.unwrap();
 
@@ -578,7 +572,7 @@ where
 async fn test_position_stability<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("position-stability".into()).await.unwrap();
 
@@ -628,7 +622,7 @@ where
 async fn test_sync_behavior<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("sync-behavior".into()).await.unwrap();
 
@@ -653,7 +647,7 @@ where
 async fn test_replay_on_empty<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let journal = factory("replay-on-empty".into()).await.unwrap();
 
@@ -677,7 +671,7 @@ where
 async fn test_replay_at_exact_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("replay-at-exact-size".into()).await.unwrap();
 
@@ -707,7 +701,7 @@ where
 async fn test_multiple_prunes<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("multiple-prunes".into()).await.unwrap();
 
@@ -732,7 +726,7 @@ where
 async fn test_prune_beyond_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("prune-beyond-size".into()).await.unwrap();
 
@@ -757,7 +751,7 @@ where
 async fn test_persistence_basic<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let test_name = "persistence-basic".to_string();
 
@@ -812,7 +806,7 @@ where
 async fn test_persistence_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let test_name = "persistence-after-prune".to_string();
 
@@ -887,7 +881,7 @@ where
 pub(super) async fn test_read_by_position<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("read-by-position".into()).await.unwrap();
 
@@ -908,7 +902,7 @@ where
 pub(super) async fn test_read_many<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("read-many".into()).await.unwrap();
 
@@ -928,7 +922,7 @@ where
 pub(super) async fn test_read_out_of_range<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("read-out-of-range".into()).await.unwrap();
 
@@ -945,7 +939,7 @@ where
 pub(super) async fn test_read_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("read-after-prune".into()).await.unwrap();
 
@@ -966,7 +960,7 @@ where
 async fn test_rewind_to_middle<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("rewind-to-middle".into()).await.unwrap();
 
@@ -1005,7 +999,7 @@ where
 async fn test_rewind_to_zero<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("rewind-to-zero".into()).await.unwrap();
 
@@ -1030,7 +1024,7 @@ where
 async fn test_rewind_current_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("rewind-current-size".into()).await.unwrap();
 
@@ -1049,7 +1043,7 @@ where
 async fn test_rewind_invalid_forward<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("rewind-invalid-forward".into()).await.unwrap();
 
@@ -1068,7 +1062,7 @@ where
 async fn test_rewind_invalid_pruned<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("rewind-invalid-pruned".into()).await.unwrap();
 
@@ -1091,7 +1085,7 @@ where
 async fn test_rewind_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("rewind-then-append".into()).await.unwrap();
 
@@ -1119,7 +1113,7 @@ where
 async fn test_rewind_zero_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("rewind-zero-then-append".into()).await.unwrap();
 
@@ -1150,7 +1144,7 @@ where
 async fn test_rewind_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("rewind-after-prune".into()).await.unwrap();
 
@@ -1198,7 +1192,7 @@ where
 async fn test_section_boundary_behavior<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("section-boundary".into()).await.unwrap();
 
@@ -1256,7 +1250,7 @@ where
 async fn test_destroy_and_reinit<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let test_name = "destroy-and-reinit".to_string();
 
@@ -1306,7 +1300,7 @@ where
 async fn test_append_many_empty<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("append-many-empty".into()).await.unwrap();
 
@@ -1328,7 +1322,7 @@ where
 async fn test_append_many_basic<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("append-many-basic".into()).await.unwrap();
 
@@ -1350,7 +1344,7 @@ where
 async fn test_append_many_across_sections<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("append-many-sections".into()).await.unwrap();
 
@@ -1371,7 +1365,7 @@ where
 async fn test_append_many_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("append-many-then-single".into()).await.unwrap();
 
@@ -1394,7 +1388,7 @@ where
 async fn test_append_many_single_item<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: PersistableContiguous,
+    J: MutableContiguous,
 {
     let mut journal = factory("append-many-single".into()).await.unwrap();
 

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -177,10 +177,6 @@ pub(super) mod partition_sync_fault {
     }
 }
 
-pub(super) trait MutableContiguous: Mutable<Item = u64> {}
-
-impl<T> MutableContiguous for T where T: Mutable<Item = u64> {}
-
 async fn get_bounds<J: Contiguous>(journal: &J) -> std::ops::Range<u64> {
     let reader = journal.reader().await;
     reader.bounds()
@@ -205,7 +201,7 @@ async fn read_item<J: Contiguous>(journal: &J, position: u64) -> Result<J::Item,
 pub(super) async fn run_contiguous_tests<F, J>(factory: F)
 where
     F: Fn(String, usize) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let counter = AtomicUsize::new(0);
     let indexed_factory = |name: String| {
@@ -257,7 +253,7 @@ where
 async fn test_empty_journal_bounds<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let journal = factory("empty".into()).await.unwrap();
     let bounds = get_bounds(&journal).await;
@@ -271,7 +267,7 @@ where
 async fn test_bounds_with_items<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("bounds-with-items".into()).await.unwrap();
 
@@ -293,7 +289,7 @@ where
 async fn test_bounds_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("bounds-after-prune".into()).await.unwrap();
 
@@ -343,7 +339,7 @@ where
 async fn test_append_and_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("append-and-size".into()).await.unwrap();
 
@@ -368,7 +364,7 @@ where
 async fn test_sequential_appends<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("sequential-appends".into()).await.unwrap();
 
@@ -390,7 +386,7 @@ where
 async fn test_replay_from_start<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("replay-from-start".into()).await.unwrap();
 
@@ -422,7 +418,7 @@ where
 async fn test_replay_from_middle<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("replay-from-middle".into()).await.unwrap();
 
@@ -454,7 +450,7 @@ where
 async fn test_prune_retains_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("prune-retains-size".into()).await.unwrap();
 
@@ -487,7 +483,7 @@ where
 async fn test_through_trait<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("through-trait".into()).await.unwrap();
 
@@ -507,7 +503,7 @@ where
 async fn test_replay_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("replay-after-prune".into()).await.unwrap();
 
@@ -546,7 +542,7 @@ where
 async fn test_prune_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("prune-then-append".into()).await.unwrap();
 
@@ -572,7 +568,7 @@ where
 async fn test_position_stability<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("position-stability".into()).await.unwrap();
 
@@ -622,7 +618,7 @@ where
 async fn test_sync_behavior<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("sync-behavior".into()).await.unwrap();
 
@@ -647,7 +643,7 @@ where
 async fn test_replay_on_empty<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let journal = factory("replay-on-empty".into()).await.unwrap();
 
@@ -671,7 +667,7 @@ where
 async fn test_replay_at_exact_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("replay-at-exact-size".into()).await.unwrap();
 
@@ -701,7 +697,7 @@ where
 async fn test_multiple_prunes<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("multiple-prunes".into()).await.unwrap();
 
@@ -726,7 +722,7 @@ where
 async fn test_prune_beyond_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("prune-beyond-size".into()).await.unwrap();
 
@@ -751,7 +747,7 @@ where
 async fn test_persistence_basic<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let test_name = "persistence-basic".to_string();
 
@@ -806,7 +802,7 @@ where
 async fn test_persistence_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let test_name = "persistence-after-prune".to_string();
 
@@ -881,7 +877,7 @@ where
 pub(super) async fn test_read_by_position<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("read-by-position".into()).await.unwrap();
 
@@ -902,7 +898,7 @@ where
 pub(super) async fn test_read_many<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("read-many".into()).await.unwrap();
 
@@ -922,7 +918,7 @@ where
 pub(super) async fn test_read_out_of_range<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("read-out-of-range".into()).await.unwrap();
 
@@ -939,7 +935,7 @@ where
 pub(super) async fn test_read_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("read-after-prune".into()).await.unwrap();
 
@@ -960,7 +956,7 @@ where
 async fn test_rewind_to_middle<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("rewind-to-middle".into()).await.unwrap();
 
@@ -999,7 +995,7 @@ where
 async fn test_rewind_to_zero<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("rewind-to-zero".into()).await.unwrap();
 
@@ -1024,7 +1020,7 @@ where
 async fn test_rewind_current_size<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("rewind-current-size".into()).await.unwrap();
 
@@ -1043,7 +1039,7 @@ where
 async fn test_rewind_invalid_forward<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("rewind-invalid-forward".into()).await.unwrap();
 
@@ -1062,7 +1058,7 @@ where
 async fn test_rewind_invalid_pruned<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("rewind-invalid-pruned".into()).await.unwrap();
 
@@ -1085,7 +1081,7 @@ where
 async fn test_rewind_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("rewind-then-append".into()).await.unwrap();
 
@@ -1113,7 +1109,7 @@ where
 async fn test_rewind_zero_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("rewind-zero-then-append".into()).await.unwrap();
 
@@ -1144,7 +1140,7 @@ where
 async fn test_rewind_after_prune<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("rewind-after-prune".into()).await.unwrap();
 
@@ -1192,7 +1188,7 @@ where
 async fn test_section_boundary_behavior<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("section-boundary".into()).await.unwrap();
 
@@ -1250,7 +1246,7 @@ where
 async fn test_destroy_and_reinit<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let test_name = "destroy-and-reinit".to_string();
 
@@ -1300,7 +1296,7 @@ where
 async fn test_append_many_empty<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("append-many-empty".into()).await.unwrap();
 
@@ -1322,7 +1318,7 @@ where
 async fn test_append_many_basic<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("append-many-basic".into()).await.unwrap();
 
@@ -1344,7 +1340,7 @@ where
 async fn test_append_many_across_sections<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("append-many-sections".into()).await.unwrap();
 
@@ -1365,7 +1361,7 @@ where
 async fn test_append_many_then_append<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("append-many-then-single".into()).await.unwrap();
 
@@ -1388,7 +1384,7 @@ where
 async fn test_append_many_single_item<F, J>(factory: &F)
 where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
-    J: MutableContiguous,
+    J: Mutable<Item = u64>,
 {
     let mut journal = factory("append-many-single".into()).await.unwrap();
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -10,7 +10,7 @@ use crate::{
         segmented::variable,
         Error,
     },
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::{Codec, CodecShared};
 use commonware_runtime::buffer::paged::CacheRef;
@@ -1340,21 +1340,17 @@ impl<E: Context, V: CodecShared> Mutable for Journal<E, V> {
     async fn rewind(&mut self, size: u64) -> Result<(), Error> {
         Self::rewind(self, size).await
     }
-}
-
-impl<E: Context, V: CodecShared> Persistable for Journal<E, V> {
-    type Error = Error;
 
     async fn commit(&self) -> Result<(), Error> {
-        self.commit().await
+        Self::commit(self).await
     }
 
     async fn sync(&self) -> Result<(), Error> {
-        self.sync().await
+        Self::sync(self).await
     }
 
     async fn destroy(self) -> Result<(), Error> {
-        self.destroy().await
+        Self::destroy(self).await
     }
 }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -47,36 +47,6 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
     {
     }
 
-    /// A storage structure with capabilities to persist and recover state across restarts.
-    pub trait Persistable {
-        /// The error type returned when there is a failure from the underlying storage system.
-        type Error;
-
-        /// Durably persist the structure, guaranteeing the current state will survive a crash.
-        ///
-        /// For a stronger guarantee that eliminates potential recovery, use [Self::sync] instead.
-        fn commit(&self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
-            self.sync()
-        }
-
-        /// Durably persist the structure, guaranteeing the current state will survive a crash, and that
-        /// no recovery will be needed on startup.
-        ///
-        /// This provides a stronger guarantee than [Self::commit] but may be slower.
-        fn sync(&self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
-
-        /// Destroy the structure, removing all associated storage.
-        ///
-        /// This method consumes the structure and deletes all persisted data, leaving behind no storage
-        /// artifacts. This can be used to clean up disk resources in tests.
-        ///
-        /// # Crash Safety
-        ///
-        /// This operation is intended for final teardown and is not crash-safe. If interrupted,
-        /// reopening the same storage may observe partially removed state. Use a reset operation
-        /// provided by the concrete type when the structure must remain recoverable.
-        fn destroy(self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
-    }
 });
 commonware_macros::stability_scope!(BETA {
     pub mod translator;

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -1,8 +1,6 @@
 use super::{Config, Error};
-use crate::{rmap::RMap, Context, Persistable};
-use commonware_codec::{
-    CodecFixed, CodecFixedShared, Encode, FixedSize, Read, ReadExt, Write as CodecWrite,
-};
+use crate::{rmap::RMap, Context};
+use commonware_codec::{CodecFixed, Encode, FixedSize, Read, ReadExt, Write as CodecWrite};
 use commonware_cryptography::{crc32, Crc32};
 use commonware_formatting::hex;
 use commonware_runtime::{
@@ -419,6 +417,13 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         Ok(())
     }
 
+    /// Durably persist the ordinal, guaranteeing the current state will survive a crash.
+    ///
+    /// This is an alias for [Self::sync].
+    pub async fn commit(&self) -> Result<(), Error> {
+        self.sync().await
+    }
+
     /// Destroy [Ordinal] and remove all data.
     pub async fn destroy(self) -> Result<(), Error> {
         for (i, blob) in self.blobs.into_iter() {
@@ -436,22 +441,6 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
             Err(err) => return Err(Error::Runtime(err)),
         }
         Ok(())
-    }
-}
-
-impl<E: BufferPooler + Context, V: CodecFixedShared> Persistable for Ordinal<E, V> {
-    type Error = Error;
-
-    async fn commit(&self) -> Result<(), Self::Error> {
-        self.sync().await
-    }
-
-    async fn sync(&self) -> Result<(), Self::Error> {
-        self.sync().await
-    }
-
-    async fn destroy(self) -> Result<(), Self::Error> {
-        self.destroy().await
     }
 }
 

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -417,13 +417,6 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         Ok(())
     }
 
-    /// Durably persist the ordinal, guaranteeing the current state will survive a crash.
-    ///
-    /// This is an alias for [Self::sync].
-    pub async fn commit(&self) -> Result<(), Error> {
-        self.sync().await
-    }
-
     /// Destroy [Ordinal] and remove all data.
     pub async fn destroy(self) -> Result<(), Error> {
         for (i, blob) in self.blobs.into_iter() {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1717,7 +1717,7 @@ where
     F: Family,
     E: Context,
     U: update::Update + Send + Sync + 'static,
-    C: Mutable<Item = Operation<F, U>> + crate::Persistable<Error = crate::journal::Error>,
+    C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
     S: Strategy,
@@ -1969,8 +1969,7 @@ mod trait_impls {
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>
-            + crate::Persistable<Error = crate::journal::Error>,
+        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
         H: Hasher,
         S: Strategy,
@@ -2001,8 +2000,7 @@ mod trait_impls {
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>
-            + crate::Persistable<Error = crate::journal::Error>,
+        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
         H: Hasher,
         S: Strategy,

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -18,7 +18,7 @@ use crate::{
         operation::Operation as OperationTrait,
         update_known_loc, Error,
     },
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::{Codec, CodecShared};
 use commonware_cryptography::Hasher;
@@ -612,13 +612,13 @@ where
     }
 }
 
-// Functionality requiring Mutable + Persistable journal.
+// Functionality requiring a mutable journal.
 impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: Family,
     E: Context,
     U: Update,
-    C: Mutable<Item = Operation<F, U>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
     S: Strategy,
@@ -775,31 +775,5 @@ where
     /// Destroy the db, removing all data from disk.
     pub async fn destroy(self) -> Result<(), crate::qmdb::Error<F>> {
         self.log.destroy().await.map_err(Into::into)
-    }
-}
-
-impl<F, E, U, C, I, H, const N: usize, S> Persistable for Db<F, E, C, I, H, U, N, S>
-where
-    F: Family,
-    E: Context,
-    U: Update,
-    C: Mutable<Item = Operation<F, U>> + Persistable<Error = JournalError>,
-    I: UnorderedIndex<Value = Location<F>>,
-    H: Hasher,
-    S: Strategy,
-    Operation<F, U>: Codec,
-{
-    type Error = crate::qmdb::Error<F>;
-
-    async fn commit(&self) -> Result<(), crate::qmdb::Error<F>> {
-        Self::commit(self).await
-    }
-
-    async fn sync(&self) -> Result<(), crate::qmdb::Error<F>> {
-        Self::sync(self).await
-    }
-
-    async fn destroy(self) -> Result<(), crate::qmdb::Error<F>> {
-        self.destroy().await
     }
 }

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(any(test, feature = "test-traits"))]
-use crate::qmdb::any::traits::PersistableMutableLog;
 use crate::{
     index::Ordered as Index,
     journal::contiguous::{Contiguous, Reader},
@@ -261,7 +259,7 @@ crate::qmdb::any::traits::impl_db_any! {
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<F, K, V>>,
+        C: crate::journal::contiguous::Mutable<Item = Operation<F, K, V>>,
         I: Index<Value = crate::merkle::Location<F>> + 'static,
         H: Hasher,
         S: Strategy,
@@ -279,7 +277,7 @@ crate::qmdb::any::traits::impl_provable! {
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<F, K, V>>,
+        C: crate::journal::contiguous::Mutable<Item = Operation<F, K, V>>,
         I: Index<Value = crate::merkle::Location<F>> + 'static,
         H: Hasher,
         S: Strategy,

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -40,7 +40,7 @@ use crate::{
         operation::{Committable, Key},
     },
     translator::Translator,
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
@@ -68,7 +68,7 @@ where
     I: IndexFactory<T, Value = Location<F>>,
     H: Hasher,
     T: Translator,
-    C: Mutable<Item = Operation<F, U>> + Persistable<Error = crate::journal::Error>,
+    C: Mutable<Item = Operation<F, U>>,
     S: Strategy,
     Operation<F, U>: Codec + Committable + CodecShared,
 {

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -18,7 +18,6 @@ use crate::{
             Engine, Target,
         },
     },
-    Persistable,
 };
 use commonware_codec::Encode;
 use commonware_cryptography::sha256::Digest;

--- a/storage/src/qmdb/any/traits.rs
+++ b/storage/src/qmdb/any/traits.rs
@@ -1,26 +1,13 @@
 //! Trait providing a unified test/benchmark interface across all Any database variants.
 
 use crate::{
-    journal::contiguous::Mutable,
     merkle::{Family, Location, Proof},
     qmdb::{operation::Key, Error},
-    Persistable,
 };
 use commonware_codec::CodecShared;
 use commonware_cryptography::Digest;
 use core::num::NonZeroU64;
 use std::{future::Future, ops::Range};
-
-/// A mutable operation log that can be durably persisted.
-pub(crate) trait PersistableMutableLog<O>:
-    Mutable<Item = O> + Persistable<Error = crate::journal::Error>
-{
-}
-
-impl<T, O> PersistableMutableLog<O> for T where
-    T: Mutable<Item = O> + Persistable<Error = crate::journal::Error>
-{
-}
 
 /// Unmerkleized batch of operations.
 pub trait UnmerkleizedBatch<Db: ?Sized>: Sized {
@@ -79,10 +66,7 @@ pub trait BatchableDb {
 /// This trait provides access to authentication (root), pruning, persistence,
 /// reads, and batch mutations.
 pub trait DbAny<F: Family>:
-    BatchableDb<Family = F, K = <Self as DbAny<F>>::Key, V = <Self as DbAny<F>>::Value>
-    + Persistable<Error = Error<F>>
-    + Send
-    + Sync
+    BatchableDb<Family = F, K = <Self as DbAny<F>>::Key, V = <Self as DbAny<F>>::Value> + Send + Sync
 {
     /// The key type used to look up values.
     type Key: Key;
@@ -118,6 +102,22 @@ pub trait DbAny<F: Family>:
 
     /// Prune historical operations prior to `loc`.
     fn prune(&mut self, loc: Location<F>) -> impl Future<Output = Result<(), Error<F>>> + Send;
+
+    /// Durably persist the database, guaranteeing the current state will survive a crash.
+    ///
+    /// For a stronger guarantee that eliminates potential recovery, use [Self::sync] instead.
+    fn commit(&self) -> impl Future<Output = Result<(), Error<F>>> + Send;
+
+    /// Durably persist the database, guaranteeing the current state will survive a crash, and that
+    /// no recovery will be needed on startup.
+    ///
+    /// This provides a stronger guarantee than [Self::commit] but may be slower.
+    fn sync(&self) -> impl Future<Output = Result<(), Error<F>>> + Send;
+
+    /// Destroy the database, removing all data from disk.
+    fn destroy(self) -> impl Future<Output = Result<(), Error<F>>> + Send
+    where
+        Self: Sized;
 
     /// The location before which all operations can be pruned.
     fn inactivity_floor_loc(&self) -> impl Future<Output = Location<F>> + Send;
@@ -207,6 +207,18 @@ macro_rules! impl_db_any {
                 loc: $crate::merkle::Location<$fam>,
             ) -> ::core::result::Result<(), $crate::qmdb::Error<$fam>> {
                 <$ty>::prune(self, loc).await
+            }
+
+            async fn commit(&self) -> ::core::result::Result<(), $crate::qmdb::Error<$fam>> {
+                <$ty>::commit(self).await
+            }
+
+            async fn sync(&self) -> ::core::result::Result<(), $crate::qmdb::Error<$fam>> {
+                <$ty>::sync(self).await
+            }
+
+            async fn destroy(self) -> ::core::result::Result<(), $crate::qmdb::Error<$fam>> {
+                <$ty>::destroy(self).await
             }
 
             async fn inactivity_floor_loc(&self) -> $crate::merkle::Location<$fam> {

--- a/storage/src/qmdb/any/unordered/mod.rs
+++ b/storage/src/qmdb/any/unordered/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(any(test, feature = "test-traits"))]
-use crate::qmdb::any::traits::PersistableMutableLog;
 use crate::{
     index::Unordered as Index,
     journal::contiguous::{Contiguous, Reader},
@@ -66,7 +64,7 @@ crate::qmdb::any::traits::impl_db_any! {
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<F, K, V>>,
+        C: crate::journal::contiguous::Mutable<Item = Operation<F, K, V>>,
         I: Index<Value = crate::merkle::Location<F>> + Send + Sync + 'static,
         H: Hasher,
         S: Strategy,
@@ -84,7 +82,7 @@ crate::qmdb::any::traits::impl_provable! {
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: PersistableMutableLog<Operation<F, K, V>>,
+        C: crate::journal::contiguous::Mutable<Item = Operation<F, K, V>>,
         I: Index<Value = crate::merkle::Location<F>> + Send + Sync + 'static,
         H: Hasher,
         S: Strategy,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -931,7 +931,6 @@ mod trait_impls {
             BatchableDb, MerkleizedBatch as MerkleizedBatchTrait,
             UnmerkleizedBatch as UnmerkleizedBatchTrait,
         },
-        Persistable,
     };
     use std::future::Future;
 
@@ -947,8 +946,7 @@ mod trait_impls {
         V: ValueEncoding + 'static,
         H: Hasher,
         E: Context,
-        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>
-            + Persistable<Error = crate::journal::Error>,
+        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
         S: Strategy,
         Operation<F, update::Unordered<K, V>>: Codec,
@@ -981,8 +979,7 @@ mod trait_impls {
         V: ValueEncoding + 'static,
         H: Hasher,
         E: Context,
-        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>
-            + Persistable<Error = crate::journal::Error>,
+        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: crate::index::Ordered<Value = Location<F>> + 'static,
         S: Strategy,
         Operation<F, update::Ordered<K, V>>: Codec,
@@ -1030,8 +1027,7 @@ mod trait_impls {
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>
-            + Persistable<Error = crate::journal::Error>,
+        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
         H: Hasher,
         S: Strategy,
@@ -1063,8 +1059,7 @@ mod trait_impls {
         E: Context,
         K: Key,
         V: ValueEncoding + 'static,
-        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>
-            + Persistable<Error = crate::journal::Error>,
+        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: crate::index::Ordered<Value = Location<F>> + 'static,
         H: Hasher,
         S: Strategy,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -30,7 +30,7 @@ use crate::{
         operation::Operation as _,
         Error,
     },
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::{Codec, CodecShared, DecodeExt};
 use commonware_cryptography::{Digest, DigestOf, Hasher};
@@ -748,7 +748,7 @@ where
     F: merkle::Graftable,
     E: Context,
     U: Update,
-    C: Mutable<Item = Operation<F, U>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
     S: Strategy,
@@ -785,7 +785,7 @@ where
     F: merkle::Graftable,
     E: Context,
     U: Update + 'static,
-    C: Mutable<Item = Operation<F, U>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
     S: Strategy,
@@ -811,32 +811,6 @@ where
         self.root = batch.canonical_root;
         self.update_metrics();
         Ok(range)
-    }
-}
-
-impl<F, E, U, C, I, H, const N: usize, S> Persistable for Db<F, E, C, I, H, U, N, S>
-where
-    F: merkle::Graftable,
-    E: Context,
-    U: Update,
-    C: Mutable<Item = Operation<F, U>> + Persistable<Error = JournalError>,
-    I: UnorderedIndex<Value = Location<F>>,
-    H: Hasher,
-    S: Strategy,
-    Operation<F, U>: Codec,
-{
-    type Error = Error<F>;
-
-    async fn commit(&self) -> Result<(), Error<F>> {
-        Self::commit(self).await
-    }
-
-    async fn sync(&self) -> Result<(), Error<F>> {
-        Self::sync(self).await
-    }
-
-    async fn destroy(self) -> Result<(), Error<F>> {
-        self.destroy().await
     }
 }
 

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -151,7 +151,7 @@ pub mod tests {
     use super::{db, ExclusionProof};
     use crate::{
         index::ordered::Index,
-        journal::{contiguous::Mutable, Error as JournalError},
+        journal::contiguous::Mutable,
         merkle::{Graftable, Location, Proof},
         mmb,
         qmdb::{
@@ -170,7 +170,6 @@ pub mod tests {
             Error,
         },
         translator::OneCap,
-        Persistable,
     };
     use commonware_codec::{Codec, Decode as _, Encode as _, EncodeSize as _};
     use commonware_cryptography::{sha256::Digest, Digest as _, Hasher as _, Sha256};
@@ -301,7 +300,7 @@ pub mod tests {
         mut open_db: Fn,
     ) where
         F: Graftable,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
+        C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,
@@ -464,7 +463,7 @@ pub mod tests {
     pub(super) fn test_range_proofs<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
         F: Graftable,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
+        C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,
@@ -541,7 +540,7 @@ pub mod tests {
     pub(super) fn test_key_value_proof<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
         F: Graftable,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
+        C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,
@@ -624,7 +623,7 @@ pub mod tests {
     pub(super) fn test_proving_repeated_updates<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
         F: Graftable,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
+        C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,
@@ -678,7 +677,7 @@ pub mod tests {
     pub(super) fn test_exclusion_proofs<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
         F: Graftable + PartialEq,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
+        C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + PartialEq + core::fmt::Debug + 'static,
         Operation<F, Digest, V>: Codec,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -65,7 +65,7 @@ use crate::{
         sync::{resolver::fetch_operations, Database, DatabaseConfig as Config},
     },
     translator::Translator,
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::{DigestOf, Hasher};
@@ -112,7 +112,7 @@ where
     I: IndexFactory<T, Value = Location<F>>,
     H: Hasher,
     T: Translator,
-    J: Mutable<Item = Operation<F, U>> + Persistable<Error = crate::journal::Error>,
+    J: Mutable<Item = Operation<F, U>>,
     S: Strategy,
     Operation<F, U>: Codec + Committable + CodecShared,
 {

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -20,7 +20,7 @@ pub mod tests {
     use super::db;
     use crate::{
         index::unordered::Index,
-        journal::{contiguous::Mutable, Error as JournalError},
+        journal::contiguous::Mutable,
         merkle::{Graftable, Location, Proof},
         qmdb::{
             any::{
@@ -34,7 +34,6 @@ pub mod tests {
             Error,
         },
         translator::TwoCap,
-        Persistable,
     };
     use commonware_codec::Codec;
     use commonware_cryptography::{sha256::Digest, Digest as _, Hasher as _, Sha256};
@@ -167,7 +166,7 @@ pub mod tests {
         mut open_db: Fn,
     ) where
         F: Graftable,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
+        C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,
@@ -314,7 +313,7 @@ pub mod tests {
     pub(super) fn test_range_proofs<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
         F: Graftable,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
+        C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,
@@ -392,7 +391,7 @@ pub mod tests {
     pub(super) fn test_key_value_proof<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
         F: Graftable,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
+        C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,
@@ -470,7 +469,7 @@ pub mod tests {
     pub(super) fn test_proving_repeated_updates<F, C, V, Fn, Fut>(mut open_db: Fn)
     where
         F: Graftable,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError> + 'static,
+        C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + 'static,
         Operation<F, Digest, V>: Codec,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -2,7 +2,7 @@
 
 use super::Immutable;
 use crate::{
-    journal::{authenticated, contiguous::Mutable, Error as JournalError},
+    journal::{authenticated, contiguous::Mutable},
     merkle::{Family, Location},
     qmdb::{
         any::{batch::lookup_sorted, ValueEncoding},
@@ -12,7 +12,7 @@ use crate::{
         Error,
     },
     translator::Translator,
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::EncodeShared;
 use commonware_cryptography::{Digest, Hasher as CHasher};
@@ -105,7 +105,7 @@ where
     ) -> Self
     where
         E: Context,
-        C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, K, V>>,
         C::Item: EncodeShared,
         T: Translator,
     {
@@ -135,7 +135,7 @@ where
     ) -> Result<Option<V::Value>, Error<F>>
     where
         E: Context,
-        C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, K, V>>,
         C::Item: EncodeShared,
         T: Translator,
     {
@@ -169,7 +169,7 @@ where
     ) -> Result<Vec<Option<V::Value>>, Error<F>>
     where
         E: Context,
-        C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, K, V>>,
         C::Item: EncodeShared,
         T: Translator,
     {
@@ -238,7 +238,7 @@ where
     ) -> Arc<MerkleizedBatch<F, H::Digest, K, V, S>>
     where
         E: Context,
-        C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, K, V>>,
         C::Item: EncodeShared,
         T: Translator,
     {
@@ -331,7 +331,7 @@ where
     ) -> Result<Option<V::Value>, Error<F>>
     where
         E: Context,
-        C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, K, V>>,
         C::Item: EncodeShared,
         H: CHasher<Digest = D>,
         T: Translator,
@@ -357,7 +357,7 @@ where
     ) -> Result<Vec<Option<V::Value>>, Error<F>>
     where
         E: Context,
-        C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, K, V>>,
         C::Item: EncodeShared,
         H: CHasher<Digest = D>,
         T: Translator,
@@ -432,7 +432,7 @@ where
     E: Context,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     C::Item: EncodeShared,
     H: CHasher,
     T: Translator,

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -82,7 +82,6 @@ use crate::{
     journal::{
         authenticated,
         contiguous::{Contiguous, Mutable, Reader},
-        Error as JournalError,
     },
     merkle::{full::Config as MerkleConfig, Family, Location, Proof},
     qmdb::{
@@ -93,7 +92,7 @@ use crate::{
         Error,
     },
     translator::Translator,
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher as CHasher;
@@ -163,7 +162,7 @@ pub struct Immutable<
     E: Context,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     H: CHasher,
     T: Translator,
     S: Strategy,
@@ -201,7 +200,7 @@ where
     E: Context,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, K, V>>,
     C::Item: EncodeShared,
     H: CHasher,
     T: Translator,
@@ -768,7 +767,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let db = open_db(context.child("first")).await;
@@ -813,7 +812,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("first")).await;
@@ -848,7 +847,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         // Build a db with 2 keys.
@@ -923,7 +922,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("first")).await;
@@ -954,7 +953,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("first")).await;
@@ -996,7 +995,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("first")).await;
@@ -1047,7 +1046,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         // Build a db with `ELEMENTS` key/value pairs and prove ranges over them.
@@ -1096,7 +1095,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         // Insert 1000 keys then sync.
@@ -1151,7 +1150,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("first")).await;
@@ -1189,7 +1188,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         // Build a db with `ELEMENTS` key/value pairs then prune some of them.
@@ -1297,7 +1296,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("test")).await;
@@ -1360,7 +1359,7 @@ pub(super) mod test {
     ) -> Range<Location<F>>
     where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         commit_sets_with_floor(db, sets, metadata, Location::new(0)).await
@@ -1374,7 +1373,7 @@ pub(super) mod test {
     ) -> Range<Location<F>>
     where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut batch = db.new_batch();
@@ -1396,7 +1395,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1463,7 +1462,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1506,7 +1505,7 @@ pub(super) mod test {
             -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_small_sections_db(context.child("db")).await;
@@ -1573,7 +1572,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1614,7 +1613,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let db = open_db(context.child("db")).await;
@@ -1650,7 +1649,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1700,7 +1699,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1737,7 +1736,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1782,7 +1781,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1823,7 +1822,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1872,7 +1871,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1911,7 +1910,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -1966,7 +1965,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2009,7 +2008,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2057,7 +2056,7 @@ pub(super) mod test {
             -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db_small_sections(context.child("db")).await;
@@ -2107,7 +2106,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2140,7 +2139,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2190,7 +2189,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2235,7 +2234,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2282,7 +2281,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2323,7 +2322,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2363,7 +2362,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2405,7 +2404,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2450,7 +2449,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -2500,7 +2499,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("test")).await;
@@ -2551,7 +2550,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("test")).await;
@@ -2604,7 +2603,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("test")).await;
@@ -2652,7 +2651,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("test")).await;
@@ -2693,7 +2692,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("test")).await;
@@ -2751,7 +2750,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("test")).await;
@@ -2805,7 +2804,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("test")).await;
@@ -2854,7 +2853,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("first")).await;
@@ -2914,7 +2913,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("first")).await;
@@ -2975,7 +2974,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("first")).await;
@@ -3021,7 +3020,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("first")).await;
@@ -3076,7 +3075,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("test")).await;
@@ -3187,7 +3186,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
@@ -3249,7 +3248,7 @@ pub(super) mod test {
         ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
     ) where
         V: ValueEncoding<Value = Digest>,
-        C: Mutable<Item = Operation<F, Digest, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -3,7 +3,6 @@ use crate::{
     journal::{
         authenticated,
         contiguous::{Mutable, Reader as _},
-        Error as JournalError,
     },
     merkle::{
         full::{self, Merkle},
@@ -19,7 +18,7 @@ use crate::{
         Error,
     },
     translator::Translator,
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::{Encode, EncodeShared, Read};
 use commonware_cryptography::Hasher;
@@ -32,9 +31,7 @@ where
     E: Context,
     K: Key,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, K, V>>
-        + Persistable<Error = JournalError>
-        + sync::Journal<F, Context = E, Op = Operation<F, K, V>>,
+    C: Mutable<Item = Operation<F, K, V>> + sync::Journal<F, Context = E, Op = Operation<F, K, V>>,
     C::Item: EncodeShared,
     C::Config: Clone + Send,
     H: Hasher,

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -2,14 +2,14 @@
 
 use super::{operation::Operation, Keyless};
 use crate::{
-    journal::{authenticated, contiguous::Mutable, Error as JournalError},
+    journal::{authenticated, contiguous::Mutable},
     merkle::{Family, Location},
     qmdb::{
         any::value::ValueEncoding,
         batch_chain::{self, Bounds},
         Error,
     },
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::EncodeShared;
 use commonware_cryptography::{Digest, Hasher};
@@ -118,7 +118,7 @@ where
     pub(super) fn new<E, C>(keyless: &Keyless<F, E, V, C, H, S>, journal_size: u64) -> Self
     where
         E: Context,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
     {
         Self {
             journal_batch: keyless.journal.new_batch(),
@@ -150,7 +150,7 @@ where
     ) -> Result<Option<V::Value>, Error<F>>
     where
         E: Context,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
     {
         let loc_val = *loc;
 
@@ -189,7 +189,7 @@ where
     ) -> Result<Vec<Option<V::Value>>, Error<F>>
     where
         E: Context,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
     {
         if locs.is_empty() {
             return Ok(Vec::new());
@@ -256,7 +256,7 @@ where
     ) -> Arc<MerkleizedBatch<F, H::Digest, V, S>>
     where
         E: Context,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
     {
         let base = self.base_size;
 
@@ -330,7 +330,7 @@ where
     where
         E: Context,
         H: Hasher<Digest = D>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
     {
         let loc_val = *loc;
 
@@ -358,7 +358,7 @@ where
     where
         E: Context,
         H: Hasher<Digest = D>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
     {
         if locs.is_empty() {
             return Ok(Vec::new());

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -47,7 +47,6 @@ use crate::{
     journal::{
         authenticated,
         contiguous::{Contiguous, Mutable, Reader},
-        Error as JournalError,
     },
     merkle::{full::Config as MerkleConfig, Family, Location, Proof},
     qmdb::{
@@ -56,7 +55,7 @@ use crate::{
         metrics::{LocationReadMetrics, OperationMetrics, StateMetrics},
         Error,
     },
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher;
@@ -141,7 +140,7 @@ where
     F: Family,
     E: Context,
     V: ValueEncoding,
-    C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+    C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
     S: Strategy,
     Operation<F, V>: EncodeShared,
@@ -555,9 +554,8 @@ where
 pub(crate) mod tests {
     use super::*;
     use crate::{
-        journal::{contiguous::Mutable, Error as JournalError},
+        journal::contiguous::Mutable,
         qmdb::{self, verify_proof},
-        Persistable,
     };
     use commonware_cryptography::Sha256;
     use commonware_parallel::Strategy;
@@ -593,7 +591,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -653,7 +651,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -697,7 +695,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -747,7 +745,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -819,7 +817,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
         let hasher = qmdb::hasher::<Sha256>();
@@ -857,7 +855,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -883,7 +881,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -937,7 +935,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1019,7 +1017,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1116,7 +1114,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         let v1 = V::Value::make(1);
@@ -1165,7 +1163,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         let v1 = V::Value::make(10);
@@ -1200,7 +1198,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1227,7 +1225,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1264,7 +1262,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         let batch = db.new_batch();
@@ -1296,7 +1294,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1385,7 +1383,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
         let hasher = qmdb::hasher::<Sha256>();
@@ -1461,7 +1459,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, Sha256, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
         let hasher = qmdb::hasher::<Sha256>();
@@ -1541,7 +1539,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1572,7 +1570,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1614,7 +1612,7 @@ pub(crate) mod tests {
         db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         let v1 = V::Value::make(1);
@@ -1640,7 +1638,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1669,7 +1667,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         let base_val = V::Value::make(10);
@@ -1708,7 +1706,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1741,7 +1739,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
         let hasher = qmdb::hasher::<Sha256>();
@@ -1780,7 +1778,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -1810,7 +1808,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         let base_val = V::Value::make(10);
@@ -1851,7 +1849,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
         let hasher = qmdb::hasher::<Sha256>();
@@ -1885,7 +1883,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         let parent = db.new_batch().append(V::Value::make(1)).merkleize(
@@ -1920,7 +1918,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         let parent = db.new_batch().append(V::Value::make(1)).merkleize(
@@ -1943,7 +1941,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         let parent = db.new_batch().append(V::Value::make(1)).merkleize(
@@ -1974,7 +1972,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
         // Build the child while the parent is still pending.
@@ -2011,7 +2009,7 @@ pub(crate) mod tests {
     ) -> core::ops::Range<Location<F>>
     where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2039,7 +2037,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2143,7 +2141,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2195,7 +2193,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2242,7 +2240,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2286,7 +2284,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2323,7 +2321,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2371,7 +2369,7 @@ pub(crate) mod tests {
         mut db_b: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2412,7 +2410,7 @@ pub(crate) mod tests {
         mut db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2445,7 +2443,7 @@ pub(crate) mod tests {
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2508,7 +2506,7 @@ pub(crate) mod tests {
     ) where
         F: Family,
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2555,7 +2553,7 @@ pub(crate) mod tests {
     ) where
         F: Family,
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2593,7 +2591,7 @@ pub(crate) mod tests {
     ) where
         F: Family,
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
@@ -2691,7 +2689,7 @@ pub(crate) mod tests {
     ) where
         F: Family,
         V: ValueEncoding<Value: TestValue>,
-        C: Mutable<Item = Operation<F, V>> + Persistable<Error = JournalError>,
+        C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -2,7 +2,6 @@ use crate::{
     journal::{
         authenticated,
         contiguous::{Contiguous as _, Mutable, Reader as _},
-        Error as JournalError,
     },
     merkle::{
         full::{self, Merkle},
@@ -14,7 +13,7 @@ use crate::{
         keyless::{operation::Codec, CompactDb, Keyless, Metrics, Operation},
         sync,
     },
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::{Encode, EncodeShared, Read};
 use commonware_cryptography::Hasher;
@@ -26,9 +25,7 @@ where
     F: Family,
     E: Context,
     V: ValueEncoding + Codec,
-    C: Mutable<Item = Operation<F, V>>
-        + Persistable<Error = JournalError>
-        + sync::Journal<F, Context = E, Op = Operation<F, V>>,
+    C: Mutable<Item = Operation<F, V>> + sync::Journal<F, Context = E, Op = Operation<F, V>>,
     C::Config: Clone + Send,
     H: Hasher,
     S: Strategy,

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -31,8 +31,7 @@
 //!
 //! # Traits
 //!
-//! Keyed mutable variants ([any] and [current]) implement `any::traits::DbAny` and
-//! persistence methods exposed by each database type.
+//! Keyed mutable variants ([any] and [current]) implement `any::traits::DbAny`.
 //!
 //! # Acknowledgments
 //!

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -32,7 +32,7 @@
 //! # Traits
 //!
 //! Keyed mutable variants ([any] and [current]) implement `any::traits::DbAny` and
-//! [crate::Persistable].
+//! persistence methods exposed by each database type.
 //!
 //! # Acknowledgments
 //!

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -93,7 +93,7 @@ use crate::{
         update_key, FloorHelper,
     },
     translator::Translator,
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::{CodecShared, Read};
 use commonware_utils::Array;
@@ -491,28 +491,6 @@ where
     /// Durably commit the journal state published by prior [`Db::apply_batch`] calls.
     pub async fn commit(&self) -> Result<(), Error> {
         self.log.commit().await.map_err(Into::into)
-    }
-}
-
-impl<E, K, V, T> Persistable for Db<E, K, V, T>
-where
-    E: Context,
-    K: Array,
-    V: VariableValue,
-    T: Translator,
-{
-    type Error = Error;
-
-    async fn commit(&self) -> Result<(), Error> {
-        Self::commit(self).await
-    }
-
-    async fn sync(&self) -> Result<(), Error> {
-        self.sync().await
-    }
-
-    async fn destroy(self) -> Result<(), Error> {
-        self.destroy().await
     }
 }
 

--- a/storage/src/queue/conformance.rs
+++ b/storage/src/queue/conformance.rs
@@ -1,9 +1,6 @@
 //! Queue conformance tests
 
-use crate::{
-    queue::{Config, Queue},
-    Persistable,
-};
+use crate::queue::{Config, Queue};
 use commonware_codec::RangeCfg;
 use commonware_conformance::{conformance_tests, Conformance};
 use commonware_runtime::{

--- a/storage/src/queue/shared.rs
+++ b/storage/src/queue/shared.rs
@@ -7,7 +7,7 @@
 //! Writers can be cloned to allow multiple tasks to enqueue items concurrently.
 
 use super::{Config, Error, Queue};
-use crate::{Context, Persistable};
+use crate::Context;
 use commonware_codec::CodecShared;
 use commonware_utils::{channel::mpsc, sync::AsyncMutex};
 use std::{ops::Range, sync::Arc};

--- a/storage/src/queue/storage.rs
+++ b/storage/src/queue/storage.rs
@@ -4,7 +4,7 @@ use super::{metrics, Error};
 use crate::{
     journal::contiguous::{variable, Reader as _},
     rmap::RMap,
-    Context, Persistable,
+    Context,
 };
 use commonware_codec::CodecShared;
 use commonware_runtime::{buffer::paged::CacheRef, telemetry::metrics::GaugeExt};
@@ -331,31 +331,27 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
         self.journal.size().await.saturating_sub(self.read_pos)
     }
 
-    /// Returns the count of acknowledged items above the ack floor (test-only).
-    #[cfg(test)]
-    pub(crate) fn acked_above_count(&self) -> usize {
-        self.acked_above
-            .iter()
-            .map(|(&s, &e)| (e - s + 1) as usize)
-            .sum()
-    }
-}
-
-impl<E: Context + Send, V: CodecShared + Send> Persistable for Queue<E, V> {
-    type Error = Error;
-
-    async fn commit(&self) -> Result<(), Error> {
+    /// Durably persist the queue, guaranteeing the current state will survive a crash.
+    ///
+    /// This does not persist acknowledgements. For a stronger guarantee that eliminates potential
+    /// recovery and prunes acknowledged items, use [Self::sync] instead.
+    pub async fn commit(&self) -> Result<(), Error> {
         self.journal.commit().await?;
         Ok(())
     }
 
-    async fn sync(&self) -> Result<(), Error> {
+    /// Durably persist the queue, guaranteeing the current state will survive a crash, and that
+    /// no recovery will be needed on startup.
+    ///
+    /// This also prunes acknowledged items.
+    pub async fn sync(&self) -> Result<(), Error> {
         self.journal.sync().await?;
         self.journal.prune(self.ack_floor).await?;
         Ok(())
     }
 
-    async fn destroy(self) -> Result<(), Error> {
+    /// Destroy the queue, removing all data from disk.
+    pub async fn destroy(self) -> Result<(), Error> {
         self.journal.destroy().await?;
         Ok(())
     }
@@ -384,6 +380,14 @@ mod tests {
             page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
             write_buffer: NZUsize!(4096),
         }
+    }
+
+    fn acked_above_count<E: Context, V: CodecShared>(queue: &Queue<E, V>) -> usize {
+        queue
+            .acked_above
+            .iter()
+            .map(|(&s, &e)| (e - s + 1) as usize)
+            .sum()
     }
 
     #[test_traced]
@@ -660,17 +664,17 @@ mod tests {
             // Ack some items out of order first
             queue.ack(7).await.unwrap();
             queue.ack(8).await.unwrap();
-            assert_eq!(queue.acked_above_count(), 2);
+            assert_eq!(acked_above_count(&queue), 2);
 
             // Batch ack up to 5
             queue.ack_up_to(5).await.unwrap();
             assert_eq!(queue.ack_floor(), 5);
-            assert_eq!(queue.acked_above_count(), 2);
+            assert_eq!(acked_above_count(&queue), 2);
 
             // Now batch ack up to 9 - should consume the acked_above entries
             queue.ack_up_to(9).await.unwrap();
             assert_eq!(queue.ack_floor(), 9);
-            assert_eq!(queue.acked_above_count(), 0);
+            assert_eq!(acked_above_count(&queue), 0);
         });
     }
 
@@ -1142,12 +1146,12 @@ mod tests {
 
             // Acked_above should have items 1-8
             assert_eq!(queue.ack_floor(), 0);
-            assert!(queue.acked_above_count() > 0);
+            assert!(acked_above_count(&queue) > 0);
 
             // Now ack 0 - floor should advance to 9, consuming all acked_above
             queue.ack(0).await.unwrap();
             assert_eq!(queue.ack_floor(), 9);
-            assert_eq!(queue.acked_above_count(), 0);
+            assert_eq!(acked_above_count(&queue), 0);
         });
     }
 


### PR DESCRIPTION
`Persistable` isn't really adding value, and this gives us more flexibility for individual storage classes to implement appropriate sync/commit/etc functionality with fewer constraints.

## Summary

- Removed crate-level `storage::Persistable`.
- Moved journal persistence methods (`commit`, `sync`, `destroy`) onto `journal::contiguous::Mutable`.
- Simplified journal/QMDB/glue bounds from `Mutable + Persistable<journal::Error>` to `Mutable`.
- Preserved non-journal persistence APIs as inherent methods and added explicit `DbAny` persistence methods for generic tests/benches.
