### PR TITLE
[qmdb/merkle] Optimize Batch

### DIFF
--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -245,13 +245,13 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         // Each leaf also appends its parent placeholders, so reserve for the full node count.
         let digests = digests.into_iter();
         let n = digests.size_hint().0 as u64;
+        let mut leaves = self.leaves();
+        let mut size = self.size();
         let additional =
-            Position::try_from(self.leaves() + n).map_or(0, |end| (*end - *self.size()) as usize);
+            Position::try_from(leaves + n).map_or(0, |end| (*end - *size) as usize);
         self.appended.reserve(additional);
 
         // Track positions locally so bulk appends do not recompute them from the growing batch.
-        let mut leaves = self.leaves();
-        let mut size = self.size();
         for digest in digests {
             (leaves, size) = self.append_leaf_digest(digest, leaves, size);
         }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -219,14 +219,14 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 
     /// Append a leaf digest and any parent placeholders.
     ///
-    /// `leaves` and `size` are the starting leaf and node counts.
-    /// Returns the new leaf count and size.
+    /// `leaves` is the leaf index this digest occupies and `size` is the starting node count.
+    /// Returns the new size.
     fn append_leaf_digest(
         &mut self,
         digest: D,
         leaves: Location<F>,
         mut size: Position<F>,
-    ) -> (Location<F>, Position<F>) {
+    ) -> Position<F> {
         self.appended.push(digest);
         size += 1;
 
@@ -236,7 +236,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             size += 1;
         }
 
-        (leaves + 1, size)
+        size
     }
 
     /// Add a run of pre-computed leaf digests, in order.
@@ -245,14 +245,15 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         // Each leaf also appends its parent placeholders, so reserve for the full node count.
         let digests = digests.into_iter();
         let n = digests.size_hint().0 as u64;
-        let mut leaves = self.leaves();
+        let leaves = self.leaves();
         let mut size = self.size();
-        let additional = Position::try_from(leaves + n).map_or(0, |end| (*end - *size) as usize);
+        let end = leaves.checked_add(n).expect("leaf count overflow");
+        let additional = (*Position::try_from(end).expect("size overflow") - *size) as usize;
         self.appended.reserve(additional);
 
         // Track positions locally so bulk appends do not recompute them from the growing batch.
-        for digest in digests {
-            (leaves, size) = self.append_leaf_digest(digest, leaves, size);
+        for (i, digest) in (0u64..).zip(digests) {
+            size = self.append_leaf_digest(digest, leaves + i, size);
         }
         self
     }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -251,7 +251,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         let additional = (*Position::try_from(end).expect("size overflow") - *size) as usize;
         self.appended.reserve(additional);
 
-        // Track positions locally so bulk appends do not recompute them from the growing batch.
+        // Maintain leaf position and location incrementally to avoid recomputation on every iteration.
         for (i, digest) in (0u64..).zip(digests) {
             size = self.append_leaf_digest(digest, leaves + i, size);
         }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -247,8 +247,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         let n = digests.size_hint().0 as u64;
         let mut leaves = self.leaves();
         let mut size = self.size();
-        let additional =
-            Position::try_from(leaves + n).map_or(0, |end| (*end - *size) as usize);
+        let additional = Position::try_from(leaves + n).map_or(0, |end| (*end - *size) as usize);
         self.appended.reserve(additional);
 
         // Track positions locally so bulk appends do not recompute them from the growing batch.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -234,8 +234,21 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         let additional =
             Position::try_from(self.leaves() + n).map_or(0, |end| (*end - *self.size()) as usize);
         self.appended.reserve(additional);
+
+        // Track positions locally so bulk appends do not recompute them from the growing batch.
+        let mut leaves = self.leaves();
+        let mut size = self.size();
         for digest in digests {
-            self = self.add_leaf_digest(digest);
+            self.appended.push(digest);
+            size += 1;
+
+            for height in F::parent_heights(leaves) {
+                self.appended.push(D::EMPTY);
+                push_dirty(&mut self.dirty_nodes, height, size);
+                size += 1;
+            }
+
+            leaves += 1;
         }
         self
     }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -228,8 +228,8 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     /// Add a run of pre-computed leaf digests, in order.
     #[cfg(feature = "std")]
     pub(crate) fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
-        let digests = digests.into_iter();
         // Each leaf also appends its parent placeholders, so reserve for the full node count.
+        let digests = digests.into_iter();
         let n = digests.size_hint().0 as u64;
         let additional =
             Position::try_from(self.leaves() + n).map_or(0, |end| (*end - *self.size()) as usize);
@@ -247,7 +247,6 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
                 push_dirty(&mut self.dirty_nodes, height, size);
                 size += 1;
             }
-
             leaves += 1;
         }
         self

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -219,8 +219,8 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 
     /// Append a leaf digest and any parent placeholders.
     ///
-    /// `leaves` and `size` are the starting leaf and node counts, and the returned cursors point
-    /// just past the appended nodes.
+    /// `leaves` and `size` are the starting leaf and node counts.
+    /// Returns the new leaf count and size.
     fn append_leaf_digest(
         &mut self,
         digest: D,

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -213,16 +213,30 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 
     /// Add a pre-computed leaf digest.
     pub fn add_leaf_digest(mut self, digest: D) -> Self {
-        let heights = F::parent_heights(self.leaves());
-        self.appended.push(digest);
+        self.append_leaf_digest(digest, self.leaves(), self.size());
+        self
+    }
 
-        for height in heights {
-            let pos = self.size();
+    /// Append a leaf digest and any parent placeholders.
+    ///
+    /// `leaves` and `size` are the starting leaf and node counts, and the returned cursors point
+    /// just past the appended nodes.
+    fn append_leaf_digest(
+        &mut self,
+        digest: D,
+        leaves: Location<F>,
+        mut size: Position<F>,
+    ) -> (Location<F>, Position<F>) {
+        self.appended.push(digest);
+        size += 1;
+
+        for height in F::parent_heights(leaves) {
             self.appended.push(D::EMPTY);
-            push_dirty(&mut self.dirty_nodes, height, pos);
+            push_dirty(&mut self.dirty_nodes, height, size);
+            size += 1;
         }
 
-        self
+        (leaves + 1, size)
     }
 
     /// Add a run of pre-computed leaf digests, in order.
@@ -239,15 +253,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         let mut leaves = self.leaves();
         let mut size = self.size();
         for digest in digests {
-            self.appended.push(digest);
-            size += 1;
-
-            for height in F::parent_heights(leaves) {
-                self.appended.push(D::EMPTY);
-                push_dirty(&mut self.dirty_nodes, height, size);
-                size += 1;
-            }
-            leaves += 1;
+            (leaves, size) = self.append_leaf_digest(digest, leaves, size);
         }
         self
     }


### PR DESCRIPTION
100k prehashed leaves:

```
   Benchmark        Previous add_leaf_digests    Refactored add_leaf_digests             Improvement
  ━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━
   MMR tree-root                      7.00 ms                        3.33 ms      2.1x faster, -3.67
                                                                                                  ms
  ───────────────  ───────────────────────────  ─────────────────────────────  ──────────────────────
   MMB tree-root                      4.44 ms                        2.85 ms      1.6x faster, -1.58
                                                                                                  ms
                                                                                                  
```