### PR TITLE
[qmdb] Optimize Batch Processing

### DIFF
--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -24,7 +24,7 @@ use commonware_storage::{
     merkle::{Family, Location},
     qmdb::{
         any::{
-            batch::{MerkleizedBatch, ResolvedLocations, UnmerkleizedBatch},
+            batch::{MerkleizedBatch, UnmerkleizedBatch},
             db::Db,
             operation::{Operation, Update},
             ordered, unordered,
@@ -38,12 +38,7 @@ use commonware_storage::{
     translator::Translator,
     Persistable,
 };
-use commonware_utils::{
-    channel::mpsc,
-    non_empty_range,
-    sync::{AsyncRwLock, Mutex},
-    Array,
-};
+use commonware_utils::{channel::mpsc, non_empty_range, sync::AsyncRwLock, Array};
 use std::{ops::Deref, sync::Arc};
 
 // Matches commonware_storage::qmdb::any::BITMAP_CHUNK_BYTES, which is crate-private.
@@ -68,9 +63,6 @@ where
     batch: UnmerkleizedBatch<F, H, U, S>,
     db: AnyDbHandle<F, E, C, I, H, U, S>,
     metadata: Option<U::Value>,
-    /// Locations resolved by `get_many` reads, attached to the batch at `merkleize` so it skips
-    /// re-reading those keys. Interior-mutable because reads take `&self`.
-    resolved: Mutex<Option<ResolvedLocations<U::Key, F>>>,
 }
 
 /// Key-value operations for the `any` unordered update kind.
@@ -103,18 +95,9 @@ where
     /// Read multiple values by key, falling back to committed state.
     ///
     /// Returns results in the same order as the input keys.
-    ///
-    /// Locations resolved by the read are retained and attached to the batch when it is
-    /// merkleized, so `merkleize` skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
-        let (values, resolved) = self.batch.get_many_with_locations(keys, &*db).await?;
-        let mut slot = self.resolved.lock();
-        match slot.as_mut() {
-            Some(existing) => existing.merge(resolved),
-            None => *slot = Some(resolved),
-        }
-        Ok(values)
+        self.batch.get_many(keys, &*db).await
     }
 
     /// Record a mutation. `Some(value)` for upsert, `None` for delete.
@@ -266,11 +249,7 @@ where
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
         let db = self.db.read().await;
-        let mut batch = self.batch;
-        if let Some(resolved) = self.resolved.lock().take() {
-            batch = batch.with_resolved(resolved);
-        }
-        let merkleized = batch.merkleize(&*db, self.metadata).await?;
+        let merkleized = self.batch.merkleize(&*db, self.metadata).await?;
         Ok(AnyMerkleized {
             inner: merkleized,
             db: self.db.clone(),
@@ -331,7 +310,6 @@ where
             batch: self.inner.new_batch::<H>(),
             db: self.db.clone(),
             metadata: None,
-            resolved: Mutex::new(None),
         }
     }
 }
@@ -396,7 +374,6 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
-            resolved: Mutex::new(None),
         }
     }
 
@@ -494,7 +471,6 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
-            resolved: Mutex::new(None),
         }
     }
 

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -94,7 +94,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Locations resolved by the read are
+    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -24,7 +24,7 @@ use commonware_storage::{
     merkle::{Family, Location},
     qmdb::{
         any::{
-            batch::{MerkleizedBatch, UnmerkleizedBatch},
+            batch::{MerkleizedBatch, ResolvedLocations, UnmerkleizedBatch},
             db::Db,
             operation::{Operation, Update},
             ordered, unordered,
@@ -38,7 +38,12 @@ use commonware_storage::{
     translator::Translator,
     Persistable,
 };
-use commonware_utils::{channel::mpsc, non_empty_range, sync::AsyncRwLock, Array};
+use commonware_utils::{
+    channel::mpsc,
+    non_empty_range,
+    sync::{AsyncRwLock, Mutex},
+    Array,
+};
 use std::{ops::Deref, sync::Arc};
 
 // Matches commonware_storage::qmdb::any::BITMAP_CHUNK_BYTES, which is crate-private.
@@ -63,6 +68,9 @@ where
     batch: UnmerkleizedBatch<F, H, U, S>,
     db: AnyDbHandle<F, E, C, I, H, U, S>,
     metadata: Option<U::Value>,
+    /// Locations resolved by `get_many` reads, attached to the batch at `merkleize` so it skips
+    /// re-reading those keys. Interior-mutable because reads take `&self`.
+    resolved: Mutex<Option<ResolvedLocations<U::Key, F>>>,
 }
 
 /// Key-value operations for the `any` unordered update kind.
@@ -95,9 +103,18 @@ where
     /// Read multiple values by key, falling back to committed state.
     ///
     /// Returns results in the same order as the input keys.
+    ///
+    /// Locations resolved by the read are retained and attached to the batch when it is
+    /// merkleized, so `merkleize` skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get_many(keys, &*db).await
+        let (values, resolved) = self.batch.get_many_with_locations(keys, &*db).await?;
+        let mut slot = self.resolved.lock();
+        match slot.as_mut() {
+            Some(existing) => existing.merge(resolved),
+            None => *slot = Some(resolved),
+        }
+        Ok(values)
     }
 
     /// Record a mutation. `Some(value)` for upsert, `None` for delete.
@@ -249,7 +266,11 @@ where
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
         let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&*db, self.metadata).await?;
+        let mut batch = self.batch;
+        if let Some(resolved) = self.resolved.lock().take() {
+            batch = batch.with_resolved(resolved);
+        }
+        let merkleized = batch.merkleize(&*db, self.metadata).await?;
         Ok(AnyMerkleized {
             inner: merkleized,
             db: self.db.clone(),
@@ -310,6 +331,7 @@ where
             batch: self.inner.new_batch::<H>(),
             db: self.db.clone(),
             metadata: None,
+            resolved: Mutex::new(None),
         }
     }
 }
@@ -374,6 +396,7 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
+            resolved: Mutex::new(None),
         }
     }
 
@@ -471,6 +494,7 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
+            resolved: Mutex::new(None),
         }
     }
 

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -95,7 +95,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Locations resolved by the read are
+    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -25,7 +25,6 @@ use commonware_storage::{
     merkle::{Graftable, Location},
     qmdb::{
         any::{
-            batch::ResolvedLocations,
             operation::{Operation, Update},
             ordered, unordered,
             value::{self, FixedEncoding, ValueEncoding, VariableEncoding},
@@ -42,12 +41,7 @@ use commonware_storage::{
     translator::Translator,
     Persistable,
 };
-use commonware_utils::{
-    channel::mpsc,
-    non_empty_range,
-    sync::{AsyncRwLock, Mutex},
-    Array,
-};
+use commonware_utils::{channel::mpsc, non_empty_range, sync::AsyncRwLock, Array};
 use std::{ops::Deref, sync::Arc};
 
 type CurrentDbHandle<F, E, C, I, H, U, const N: usize, S> =
@@ -69,9 +63,6 @@ where
     batch: UnmerkleizedBatch<F, H, U, N, S>,
     db: CurrentDbHandle<F, E, C, I, H, U, N, S>,
     metadata: Option<U::Value>,
-    /// Locations resolved by `get_many` reads, attached to the batch at `merkleize` so it skips
-    /// re-reading those keys. Interior-mutable because reads take `&self`.
-    resolved: Mutex<Option<ResolvedLocations<U::Key, F>>>,
 }
 
 /// Key-value operations for the `current` unordered update kind.
@@ -105,18 +96,9 @@ where
     /// Read multiple values by key, falling back to committed state.
     ///
     /// Returns results in the same order as the input keys.
-    ///
-    /// Locations resolved by the read are retained and attached to the batch when it is
-    /// merkleized, so `merkleize` skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
-        let (values, resolved) = self.batch.get_many_with_locations(keys, &*db).await?;
-        let mut slot = self.resolved.lock();
-        match slot.as_mut() {
-            Some(existing) => existing.merge(resolved),
-            None => *slot = Some(resolved),
-        }
-        Ok(values)
+        self.batch.get_many(keys, &*db).await
     }
 
     /// Record a mutation. `Some(value)` for upsert, `None` for delete.
@@ -269,11 +251,7 @@ where
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
         let db = self.db.read().await;
-        let mut batch = self.batch;
-        if let Some(resolved) = self.resolved.lock().take() {
-            batch = batch.with_resolved(resolved);
-        }
-        let merkleized = batch.merkleize(&*db, self.metadata).await?;
+        let merkleized = self.batch.merkleize(&*db, self.metadata).await?;
         Ok(CurrentMerkleized {
             inner: merkleized,
             db: self.db.clone(),
@@ -335,7 +313,6 @@ where
             batch: self.inner.new_batch::<H>(),
             db: self.db.clone(),
             metadata: None,
-            resolved: Mutex::new(None),
         }
     }
 }
@@ -395,7 +372,6 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
-            resolved: Mutex::new(None),
         }
     }
 
@@ -490,7 +466,6 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
-            resolved: Mutex::new(None),
         }
     }
 
@@ -662,7 +637,6 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
-            resolved: Mutex::new(None),
         }
     }
 
@@ -762,7 +736,6 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
-            resolved: Mutex::new(None),
         }
     }
 

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -25,6 +25,7 @@ use commonware_storage::{
     merkle::{Graftable, Location},
     qmdb::{
         any::{
+            batch::ResolvedLocations,
             operation::{Operation, Update},
             ordered, unordered,
             value::{self, FixedEncoding, ValueEncoding, VariableEncoding},
@@ -41,7 +42,12 @@ use commonware_storage::{
     translator::Translator,
     Persistable,
 };
-use commonware_utils::{channel::mpsc, non_empty_range, sync::AsyncRwLock, Array};
+use commonware_utils::{
+    channel::mpsc,
+    non_empty_range,
+    sync::{AsyncRwLock, Mutex},
+    Array,
+};
 use std::{ops::Deref, sync::Arc};
 
 type CurrentDbHandle<F, E, C, I, H, U, const N: usize, S> =
@@ -63,6 +69,9 @@ where
     batch: UnmerkleizedBatch<F, H, U, N, S>,
     db: CurrentDbHandle<F, E, C, I, H, U, N, S>,
     metadata: Option<U::Value>,
+    /// Locations resolved by `get_many` reads, attached to the batch at `merkleize` so it skips
+    /// re-reading those keys. Interior-mutable because reads take `&self`.
+    resolved: Mutex<Option<ResolvedLocations<U::Key, F>>>,
 }
 
 /// Key-value operations for the `current` unordered update kind.
@@ -96,9 +105,18 @@ where
     /// Read multiple values by key, falling back to committed state.
     ///
     /// Returns results in the same order as the input keys.
+    ///
+    /// Locations resolved by the read are retained and attached to the batch when it is
+    /// merkleized, so `merkleize` skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get_many(keys, &*db).await
+        let (values, resolved) = self.batch.get_many_with_locations(keys, &*db).await?;
+        let mut slot = self.resolved.lock();
+        match slot.as_mut() {
+            Some(existing) => existing.merge(resolved),
+            None => *slot = Some(resolved),
+        }
+        Ok(values)
     }
 
     /// Record a mutation. `Some(value)` for upsert, `None` for delete.
@@ -251,7 +269,11 @@ where
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
         let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&*db, self.metadata).await?;
+        let mut batch = self.batch;
+        if let Some(resolved) = self.resolved.lock().take() {
+            batch = batch.with_resolved(resolved);
+        }
+        let merkleized = batch.merkleize(&*db, self.metadata).await?;
         Ok(CurrentMerkleized {
             inner: merkleized,
             db: self.db.clone(),
@@ -313,6 +335,7 @@ where
             batch: self.inner.new_batch::<H>(),
             db: self.db.clone(),
             metadata: None,
+            resolved: Mutex::new(None),
         }
     }
 }
@@ -372,6 +395,7 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
+            resolved: Mutex::new(None),
         }
     }
 
@@ -466,6 +490,7 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
+            resolved: Mutex::new(None),
         }
     }
 
@@ -637,6 +662,7 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
+            resolved: Mutex::new(None),
         }
     }
 
@@ -736,6 +762,7 @@ where
             batch: inner.new_batch(),
             db: db.clone(),
             metadata: None,
+            resolved: Mutex::new(None),
         }
     }
 

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -68,6 +68,7 @@ commonware_macros::stability_scope!(BETA {
         if #[cfg(feature = "std")] {
             use rayon::{
                 iter::{IntoParallelIterator, ParallelIterator},
+                slice::ParallelSliceMut,
                 ThreadPool as RThreadPool, ThreadPoolBuildError, ThreadPoolBuilder,
             };
             use std::{num::NonZeroUsize, sync::Arc};
@@ -378,6 +379,18 @@ commonware_macros::stability_scope!(BETA {
             RA: Send,
             RB: Send;
 
+        /// Sort `slice` in place using `compare`, potentially in parallel.
+        ///
+        /// The sort is unstable: equal elements may be reordered. Callers that rely on a total
+        /// order must make `compare` total.
+        fn par_sort_unstable_by<T, F>(&self, slice: &mut [T], compare: F)
+        where
+            T: Send,
+            F: Fn(&T, &T) -> core::cmp::Ordering + Send + Sync,
+        {
+            slice.sort_unstable_by(compare);
+        }
+
         /// Return the number of threads that are available, as a hint to chunking.
         fn parallelism_hint(&self) -> usize;
     }
@@ -558,6 +571,15 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
             self.thread_pool.install(|| rayon::join(a, b))
         }
 
+        fn par_sort_unstable_by<T, F>(&self, slice: &mut [T], compare: F)
+        where
+            T: Send,
+            F: Fn(&T, &T) -> core::cmp::Ordering + Send + Sync,
+        {
+            self.thread_pool
+                .install(|| slice.par_sort_unstable_by(compare));
+        }
+
         fn parallelism_hint(&self) -> usize {
             self.thread_pool.current_num_threads()
         }
@@ -597,6 +619,16 @@ mod test {
             );
 
             prop_assert_eq!(seq_result, par_result);
+        }
+
+        #[test]
+        fn par_sort_unstable_by_matches_std(data in prop::collection::vec(any::<i64>(), 0..1000)) {
+            let parallel = parallel_strategy();
+            let mut expected = data.clone();
+            expected.sort_unstable();
+            let mut actual = data;
+            parallel.par_sort_unstable_by(&mut actual, |a, b| a.cmp(b));
+            prop_assert_eq!(expected, actual);
         }
 
         #[test]

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -599,12 +599,15 @@ impl<B: Blob> Append<B> {
     /// `buf` must be exactly `offsets.len() * item_size` bytes. All offsets must be sorted,
     /// non-overlapping, and within bounds. This amortizes lock acquisition and avoids
     /// per-item buffer allocation compared to calling [`read_at`](Self::read_at) in a loop.
+    ///
+    /// Returns the number of items fully served without a blob read (from the tip buffer and the
+    /// page cache). The remaining items required at least one blob read.
     pub async fn read_many_into(
         &self,
         buf: &mut [u8],
         offsets: &[u64],
         item_size: usize,
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         assert_eq!(
             buf.len(),
             offsets
@@ -614,7 +617,7 @@ impl<B: Blob> Append<B> {
             "read_many_into requires buf.len() == offsets.len() * item_size"
         );
         if offsets.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
         let last_end = offsets[offsets.len() - 1]
@@ -633,7 +636,7 @@ impl<B: Blob> Append<B> {
         // `chunks_exact_mut` yields disjoint per-item slots, so we never have to
         // reborrow the parent buffer while cache/blob destinations remain live.
         if item_size == 0 {
-            return Ok(());
+            return Ok(offsets.len());
         }
         let mut cache_ranges: Vec<(&mut [u8], u64)> = Vec::new();
         for (item_buf, &offset) in buf.chunks_exact_mut(item_size).zip(offsets.iter()) {
@@ -657,14 +660,15 @@ impl<B: Blob> Append<B> {
         drop(buffer);
 
         if cache_ranges.is_empty() {
-            return Ok(());
+            return Ok(offsets.len());
         }
 
         // Fast path: try page cache for all ranges in a single lock acquisition.
         // Fully-cached ranges are removed from cache_ranges; only misses remain.
         self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
+        let blob_reads = cache_ranges.len();
         if cache_ranges.is_empty() {
-            return Ok(());
+            return Ok(offsets.len());
         }
 
         // Slow path: read only the ranges that had cache misses, concurrently.
@@ -680,7 +684,7 @@ impl<B: Blob> Append<B> {
             result?;
         }
 
-        Ok(())
+        Ok(offsets.len() - blob_reads)
     }
 
     /// Reads bytes starting at `logical_offset` into `buf`.

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -253,24 +253,7 @@ impl CacheRef {
     /// in `ranges` correspond to cache misses that the caller must read from the underlying
     /// blob.
     pub(super) fn read_cached_many(&self, blob_id: u64, ranges: &mut Vec<(&mut [u8], u64)>) {
-        let page_cache = self.cache.read();
-        ranges.retain_mut(|(buf, logical_offset)| {
-            let mut remaining = buf.len();
-            let mut offset = *logical_offset;
-            let mut dst = 0;
-            while remaining > 0 {
-                let count = page_cache.read_at(blob_id, &mut buf[dst..], offset);
-                if count == 0 {
-                    break;
-                }
-                offset += count as u64;
-                dst += count;
-                remaining -= count;
-            }
-
-            // Keep cache misses in `ranges`; drop fully-cached entries.
-            remaining > 0
-        });
+        self.cache.read().read_cached_many_inner(blob_id, ranges);
     }
 
     /// Read the specified bytes, preferentially from the page cache. Bytes not found in the cache
@@ -506,6 +489,57 @@ impl Cache {
         );
 
         bytes_to_copy
+    }
+
+    /// Copy as many sorted disjoint ranges as are cached, dropping fully-cached entries and
+    /// retaining misses. Exploits sorted offsets to resolve consecutive items in the same page with
+    /// a single index lookup, and copies page-contained items in one memcpy.
+    fn read_cached_many_inner(&self, blob_id: u64, ranges: &mut Vec<(&mut [u8], u64)>) {
+        let page_size = self.page_size;
+        let mut cached_page = u64::MAX;
+        let mut cached_slot: Option<usize> = None;
+        ranges.retain_mut(|(buf, logical_offset)| {
+            let len = buf.len();
+            let offset = *logical_offset;
+            let page_num = offset / page_size as u64;
+            let offset_in_page = (offset % page_size as u64) as usize;
+
+            // Reuse the resolved slot for consecutive items in the same page (offsets are sorted).
+            if page_num != cached_page {
+                cached_page = page_num;
+                cached_slot = self.index.get(&(blob_id, page_num)).copied();
+                if let Some(slot) = cached_slot {
+                    self.entries[slot].referenced.store(true, Ordering::Relaxed);
+                }
+            }
+
+            // Common case: the item lives entirely within the resolved page.
+            if let Some(slot) = cached_slot {
+                if offset_in_page + len <= page_size {
+                    buf.copy_from_slice(
+                        &self.slots[slot].as_ref()[offset_in_page..offset_in_page + len],
+                    );
+                    return false;
+                }
+            }
+
+            // The item straddles a page boundary or its first page missed. Fall back to the
+            // page-at-a-time loop, which also handles the multi-page tail.
+            let mut remaining = len;
+            let mut off = offset;
+            let mut dst = 0;
+            while remaining > 0 {
+                let count = self.read_at(blob_id, &mut buf[dst..], off);
+                if count == 0 {
+                    break;
+                }
+                off += count as u64;
+                dst += count;
+                remaining -= count;
+            }
+            cached_page = u64::MAX;
+            remaining > 0
+        });
     }
 
     /// Put the given `page` into the page cache.
@@ -1338,5 +1372,106 @@ mod tests {
         assert!(buf2 == page2);
         // Missed page's buffer should be untouched (still zeroed).
         assert!(buf1.iter().all(|b| *b == 0));
+    }
+
+    #[test_traced]
+    fn test_read_cached_many_multiple_items_same_page() {
+        // Multiple sorted sub-page items resolve from a single page lookup.
+        let pool = test_pool();
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
+        let blob_id = cache_ref.next_id();
+        let page_size = PAGE_SIZE.get() as usize;
+
+        let mut page0 = vec![0u8; page_size];
+        for (i, b) in page0.iter_mut().enumerate() {
+            *b = (i % 251) as u8;
+        }
+        {
+            let mut cache = cache_ref.cache.write();
+            cache.cache(blob_id, &page0, 0);
+        }
+
+        let item = 7usize;
+        let offs = [0u64, 7, 50, (page_size - item) as u64];
+        let mut bufs: Vec<Vec<u8>> = offs.iter().map(|_| vec![0u8; item]).collect();
+        let mut ranges: Vec<(&mut [u8], u64)> = bufs
+            .iter_mut()
+            .zip(offs.iter())
+            .map(|(b, &o)| (b.as_mut_slice(), o))
+            .collect();
+
+        cache_ref.read_cached_many(blob_id, &mut ranges);
+        assert!(ranges.is_empty());
+        drop(ranges);
+
+        for (i, &o) in offs.iter().enumerate() {
+            assert_eq!(bufs[i].as_slice(), &page0[o as usize..o as usize + item]);
+        }
+    }
+
+    #[test_traced]
+    fn test_read_cached_many_straddle_boundary() {
+        // An item that spans pages 0 and 1, mixed with a same-page sibling. Both cached.
+        let pool = test_pool();
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
+        let blob_id = cache_ref.next_id();
+        let page_size = PAGE_SIZE.get() as usize;
+
+        let page0 = vec![0xAB; page_size];
+        let page1 = vec![0xCD; page_size];
+        {
+            let mut cache = cache_ref.cache.write();
+            cache.cache(blob_id, &page0, 0);
+            cache.cache(blob_id, &page1, 1);
+        }
+
+        let item = 8usize;
+        let straddle_off = (page_size - 3) as u64;
+        let mut sib = vec![0u8; item];
+        let mut straddle = vec![0u8; item];
+        let mut ranges: Vec<(&mut [u8], u64)> =
+            vec![(&mut sib, 0), (&mut straddle, straddle_off)];
+
+        cache_ref.read_cached_many(blob_id, &mut ranges);
+        assert!(ranges.is_empty());
+        drop(ranges);
+
+        assert_eq!(sib.as_slice(), &page0[0..item]);
+        let mut expected = vec![0u8; item];
+        expected[..3].copy_from_slice(&page0[page_size - 3..]);
+        expected[3..].copy_from_slice(&page1[..item - 3]);
+        assert_eq!(straddle, expected);
+    }
+
+    #[test_traced]
+    fn test_read_cached_many_straddle_second_page_missing() {
+        // An item straddles into an uncached page. The whole item is a miss and stays in `ranges`,
+        // even though a same-page item before it was served from cache.
+        let pool = test_pool();
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
+        let blob_id = cache_ref.next_id();
+        let page_size = PAGE_SIZE.get() as usize;
+
+        let page0 = vec![0xAB; page_size];
+        {
+            let mut cache = cache_ref.cache.write();
+            cache.cache(blob_id, &page0, 0);
+            // page 1 deliberately not cached
+        }
+
+        let item = 8usize;
+        let straddle_off = (page_size - 3) as u64;
+        let mut sib = vec![0u8; item];
+        let mut straddle = vec![0u8; item];
+        let mut ranges: Vec<(&mut [u8], u64)> =
+            vec![(&mut sib, 0), (&mut straddle, straddle_off)];
+
+        cache_ref.read_cached_many(blob_id, &mut ranges);
+
+        // The straddling item is a miss; the sibling was served.
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].1, straddle_off);
+        drop(ranges);
+        assert_eq!(sib.as_slice(), &page0[0..item]);
     }
 }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -79,6 +79,11 @@ test-traits = []
 bench = false
 
 [[bench]]
+name = "merkbench"
+harness = false
+path = "src/qmdb/benches/merkbench.rs"
+
+[[bench]]
 name = "qmdb"
 harness = false
 path = "src/qmdb/benches/bench.rs"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -74,6 +74,7 @@ arbitrary = [
 ]
 fuzzing = []
 test-traits = []
+sha2-asm = [ "commonware-cryptography/sha2-asm" ]
 
 [lib]
 bench = false

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -127,19 +127,15 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         );
 
         let first = self.inner.leaves();
-        let hasher = &self.hasher;
-        let digests = self.inner.strategy().map_init_collect_vec(
-            items.iter().enumerate(),
-            Vec::new,
-            |buf, (i, item)| {
-                let pos = Position::try_from(first + i as u64).expect("valid leaf location");
-                buf.clear();
-                item.write(buf);
-                hasher.leaf_digest(pos, buf.as_slice())
-            },
-        );
-
-        self.inner = self.inner.add_leaf_digests(digests);
+        let hasher = self.hasher.clone();
+        let items_ref = &items;
+        let n = items.len() as u64;
+        self.inner = self.inner.add_many_leaves(&hasher, n, |i, buf| {
+            let pos = Position::try_from(first + i).expect("valid leaf location");
+            buf.clear();
+            items_ref[i as usize].write(buf);
+            hasher.leaf_digest(pos, buf.as_slice())
+        });
         self.items = items;
         self
     }

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -139,6 +139,11 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         self.items = items;
         self
     }
+
+    /// Return a reference to the merkleization strategy.
+    pub(crate) fn strategy(&self) -> &S {
+        self.inner.strategy()
+    }
 }
 
 /// A speculative batch whose root digest has been computed, in contrast to [`UnmerkleizedBatch`].

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -350,7 +350,12 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         // and reads only true misses from the blob (concurrently). This avoids one lock acquisition
         // per item that a per-item synchronous probe would incur for the warm steady state.
         let mut result: Vec<A> = Vec::with_capacity(positions.len());
-        let mut reusable_buf = vec![0u8; positions.len() * chunk_size];
+        // Scratch decode buffer, allocated uninitialized from the page-cache pool to avoid the
+        // per-call zero-fill of `positions.len() * chunk_size` bytes.
+        let buf_len = positions.len() * chunk_size;
+        // SAFETY: each group slice handed to `get_many` is fully initialized by `read_many_into`
+        // before it is decoded on the `Ok` path; on `Err` the buffer is dropped unread.
+        let mut reusable_buf = unsafe { self.guard.journal.pool().alloc_len(buf_len) };
         let mut hits = 0u64;
 
         let mut group_start = 0;
@@ -369,7 +374,7 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                 .map(|&pos| pos - first_position)
                 .collect();
 
-            let buf = &mut reusable_buf[..group_len * chunk_size];
+            let buf = &mut reusable_buf.as_mut()[..group_len * chunk_size];
             let (items, group_hits) = self
                 .guard
                 .journal
@@ -399,6 +404,27 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
     fn try_read_sync(&self, pos: u64) -> Option<A> {
         self.guard
             .try_read_sync(pos, self.items_per_blob)
+            .map_or_else(
+                || {
+                    self.metrics.record_cache_misses(1);
+                    None
+                },
+                |item| {
+                    self.metrics.record_cache_hits(1);
+                    self.metrics.try_read_sync_hits.inc();
+                    self.metrics.items_read.inc();
+                    Some(item)
+                },
+            )
+    }
+
+    fn try_read_sync_into(&self, pos: u64, scratch: &mut Vec<u8>) -> Option<A> {
+        let chunk_size = SegmentedJournal::<E, A>::CHUNK_SIZE;
+        if scratch.len() < chunk_size {
+            scratch.resize(chunk_size, 0);
+        }
+        self.guard
+            .try_read_sync_into(pos, self.items_per_blob, scratch)
             .map_or_else(
                 || {
                     self.metrics.record_cache_misses(1);

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -96,8 +96,9 @@ use crate::{
     metadata::{Config as MetadataConfig, Metadata},
     Context, Persistable,
 };
-use commonware_codec::CodecFixedShared;
-use commonware_runtime::buffer::paged::CacheRef;
+use commonware_codec::{CodecFixedShared, DecodeExt as _};
+use commonware_parallel::Strategy;
+use commonware_runtime::{buffer::paged::CacheRef, IoBufMut};
 use commonware_utils::{
     sequence::VecU64,
     sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard},
@@ -325,79 +326,48 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         if positions.is_empty() {
             return Ok(Vec::new());
         }
-        let _timer = self.metrics.read_many_timer();
-        self.metrics.read_many_calls.inc();
-        assert!(
-            positions.windows(2).all(|w| w[0] < w[1]),
-            "positions must be strictly increasing"
-        );
-        // Validate all positions.
-        for &pos in positions {
-            if pos >= self.guard.size {
-                return Err(Error::ItemOutOfRange(pos));
-            }
-            if pos < self.guard.pruning_boundary {
-                return Err(Error::ItemPruned(pos));
-            }
-        }
-
-        let items_per_blob = self.items_per_blob;
-        let pruning_boundary = self.guard.pruning_boundary;
         let chunk_size = SegmentedJournal::<E, A>::CHUNK_SIZE;
+        let buf = self.read_many_into_pooled(positions).await?;
 
-        // Read all positions grouped by section. Each group goes through the segmented journal's
-        // batched read, which serves page-cache and tip-buffer hits under a single lock acquisition
-        // and reads only true misses from the blob (concurrently). This avoids one lock acquisition
-        // per item that a per-item synchronous probe would incur for the warm steady state.
         let mut result: Vec<A> = Vec::with_capacity(positions.len());
-        // Scratch decode buffer, allocated uninitialized from the page-cache pool to avoid the
-        // per-call zero-fill of `positions.len() * chunk_size` bytes.
-        let buf_len = positions.len() * chunk_size;
-        // SAFETY: each group slice handed to `get_many` is fully initialized by `read_many_into`
-        // before it is decoded on the `Ok` path; on `Err` the buffer is dropped unread.
-        let mut reusable_buf = unsafe { self.guard.journal.pool().alloc_len(buf_len) };
-        let mut hits = 0u64;
-
-        let mut group_start = 0;
-        while group_start < positions.len() {
-            let section = positions[group_start] / items_per_blob;
-
-            let mut group_end = group_start + 1;
-            while group_end < positions.len() && positions[group_end] / items_per_blob == section {
-                group_end += 1;
-            }
-
-            let group_len = group_end - group_start;
-            let first_position = first_in_section(pruning_boundary, section, items_per_blob)?;
-            let section_positions: Vec<u64> = positions[group_start..group_end]
-                .iter()
-                .map(|&pos| pos - first_position)
-                .collect();
-
-            let buf = &mut reusable_buf.as_mut()[..group_len * chunk_size];
-            let (items, group_hits) = self
-                .guard
-                .journal
-                .get_many(section, &section_positions, buf)
-                .await
-                .map_err(|e| match e {
-                    Error::SectionOutOfRange(e)
-                    | Error::AlreadyPrunedToSection(e)
-                    | Error::ItemOutOfRange(e) => {
-                        Error::Corruption(format!("section/item should be found, but got: {e}"))
-                    }
-                    other => other,
-                })?;
-
-            hits += group_hits as u64;
-            result.extend(items);
-            group_start = group_end;
+        for i in 0..positions.len() {
+            let slice = &buf.as_ref()[i * chunk_size..(i + 1) * chunk_size];
+            result.push(A::decode(slice).map_err(Error::Codec)?);
         }
+        Ok(result)
+    }
 
-        self.metrics.record_cache_hits(hits);
-        self.metrics
-            .record_cache_misses(positions.len() as u64 - hits);
-        self.metrics.items_read.inc_by(positions.len() as u64);
+    async fn read_many_decoded<S: Strategy>(
+        &self,
+        positions: &[u64],
+        strategy: &S,
+    ) -> Result<Vec<A>, Error> {
+        if positions.is_empty() {
+            return Ok(Vec::new());
+        }
+        let chunk_size = SegmentedJournal::<E, A>::CHUNK_SIZE;
+        let buf = self.read_many_into_pooled(positions).await?;
+        let bytes = buf.as_ref();
+
+        let n = positions.len();
+        let workers = strategy.parallelism_hint().clamp(1, n);
+        let span = n.div_ceil(workers);
+
+        let chunks: Vec<Result<Vec<A>, Error>> =
+            strategy.map_collect_vec((0..n).step_by(span), |start| {
+                let end = (start + span).min(n);
+                let mut items = Vec::with_capacity(end - start);
+                for i in start..end {
+                    let slice = &bytes[i * chunk_size..(i + 1) * chunk_size];
+                    items.push(A::decode(slice).map_err(Error::Codec)?);
+                }
+                Ok(items)
+            });
+
+        let mut result = Vec::with_capacity(n);
+        for chunk in chunks {
+            result.extend(chunk?);
+        }
         Ok(result)
     }
 
@@ -488,6 +458,81 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         });
 
         Ok(stream)
+    }
+}
+
+impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
+    /// Fill a pooled buffer with the raw bytes of the items at `positions` and return it.
+    ///
+    /// Item `i` occupies `buf[i * CHUNK_SIZE..(i + 1) * CHUNK_SIZE]`. Positions must be strictly
+    /// increasing and within bounds. Reads are grouped by section so each section is served by a
+    /// single batched read under one lock acquisition.
+    pub(crate) async fn read_many_into_pooled(&self, positions: &[u64]) -> Result<IoBufMut, Error> {
+        let _timer = self.metrics.read_many_timer();
+        self.metrics.read_many_calls.inc();
+        assert!(
+            positions.windows(2).all(|w| w[0] < w[1]),
+            "positions must be strictly increasing"
+        );
+        for &pos in positions {
+            if pos >= self.guard.size {
+                return Err(Error::ItemOutOfRange(pos));
+            }
+            if pos < self.guard.pruning_boundary {
+                return Err(Error::ItemPruned(pos));
+            }
+        }
+
+        let items_per_blob = self.items_per_blob;
+        let pruning_boundary = self.guard.pruning_boundary;
+        let chunk_size = SegmentedJournal::<E, A>::CHUNK_SIZE;
+
+        let buf_len = positions.len() * chunk_size;
+        // SAFETY: every byte handed to a section group is fully initialized by `read_many_into`
+        // before the buffer is read by the caller; on `Err` the buffer is dropped unread.
+        let mut buf = unsafe { self.guard.journal.pool().alloc_len(buf_len) };
+        let mut hits = 0u64;
+
+        let mut group_start = 0;
+        while group_start < positions.len() {
+            let section = positions[group_start] / items_per_blob;
+
+            let mut group_end = group_start + 1;
+            while group_end < positions.len() && positions[group_end] / items_per_blob == section {
+                group_end += 1;
+            }
+
+            let first_position = first_in_section(pruning_boundary, section, items_per_blob)?;
+            let section_positions: Vec<u64> = positions[group_start..group_end]
+                .iter()
+                .map(|&pos| pos - first_position)
+                .collect();
+
+            let group_buf =
+                &mut buf.as_mut()[group_start * chunk_size..group_end * chunk_size];
+            let group_hits = self
+                .guard
+                .journal
+                .read_many_into(section, &section_positions, group_buf)
+                .await
+                .map_err(|e| match e {
+                    Error::SectionOutOfRange(e)
+                    | Error::AlreadyPrunedToSection(e)
+                    | Error::ItemOutOfRange(e) => {
+                        Error::Corruption(format!("section/item should be found, but got: {e}"))
+                    }
+                    other => other,
+                })?;
+
+            hits += group_hits as u64;
+            group_start = group_end;
+        }
+
+        self.metrics.record_cache_hits(hits);
+        self.metrics
+            .record_cache_misses(positions.len() as u64 - hits);
+        self.metrics.items_read.inc_by(positions.len() as u64);
+        Ok(buf)
     }
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -345,59 +345,32 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         let pruning_boundary = self.guard.pruning_boundary;
         let chunk_size = SegmentedJournal::<E, A>::CHUNK_SIZE;
 
-        // Phase 1: Drain page-cache hits synchronously.
-        let mut result: Vec<Option<A>> = Vec::with_capacity(positions.len());
-        let mut miss_indices: Vec<usize> = Vec::new();
-        let mut miss_positions: Vec<u64> = Vec::new();
-
-        let mut sync_buf = vec![0u8; chunk_size];
-        for (i, &pos) in positions.iter().enumerate() {
-            if let Some(item) = self
-                .guard
-                .try_read_sync_into(pos, items_per_blob, &mut sync_buf)
-            {
-                result.push(Some(item));
-            } else {
-                result.push(None);
-                miss_indices.push(i);
-                miss_positions.push(pos);
-            }
-        }
-
-        if miss_positions.is_empty() {
-            self.metrics.record_cache_hits(positions.len() as u64);
-            self.metrics.items_read.inc_by(positions.len() as u64);
-            return Ok(result.into_iter().map(|r| r.unwrap()).collect());
-        }
-        self.metrics
-            .record_cache_hits((positions.len() - miss_positions.len()) as u64);
-        self.metrics
-            .record_cache_misses(miss_positions.len() as u64);
-
-        // Phase 2: Read cache misses grouped by section (sequential).
-        let mut reusable_buf = vec![0u8; miss_positions.len() * chunk_size];
-        let mut disk_offset = 0;
+        // Read all positions grouped by section. Each group goes through the segmented journal's
+        // batched read, which serves page-cache and tip-buffer hits under a single lock acquisition
+        // and reads only true misses from the blob (concurrently). This avoids one lock acquisition
+        // per item that a per-item synchronous probe would incur for the warm steady state.
+        let mut result: Vec<A> = Vec::with_capacity(positions.len());
+        let mut reusable_buf = vec![0u8; positions.len() * chunk_size];
+        let mut hits = 0u64;
 
         let mut group_start = 0;
-        while group_start < miss_positions.len() {
-            let section = miss_positions[group_start] / items_per_blob;
+        while group_start < positions.len() {
+            let section = positions[group_start] / items_per_blob;
 
             let mut group_end = group_start + 1;
-            while group_end < miss_positions.len()
-                && miss_positions[group_end] / items_per_blob == section
-            {
+            while group_end < positions.len() && positions[group_end] / items_per_blob == section {
                 group_end += 1;
             }
 
             let group_len = group_end - group_start;
             let first_position = first_in_section(pruning_boundary, section, items_per_blob)?;
-            let section_positions: Vec<u64> = miss_positions[group_start..group_end]
+            let section_positions: Vec<u64> = positions[group_start..group_end]
                 .iter()
                 .map(|&pos| pos - first_position)
                 .collect();
 
             let buf = &mut reusable_buf[..group_len * chunk_size];
-            let items = self
+            let (items, group_hits) = self
                 .guard
                 .journal
                 .get_many(section, &section_positions, buf)
@@ -411,16 +384,16 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                     other => other,
                 })?;
 
-            for (item, &miss_idx) in items.into_iter().zip(&miss_indices[disk_offset..]) {
-                result[miss_idx] = Some(item);
-            }
-
-            disk_offset += group_len;
+            hits += group_hits as u64;
+            result.extend(items);
             group_start = group_end;
         }
 
+        self.metrics.record_cache_hits(hits);
+        self.metrics
+            .record_cache_misses(positions.len() as u64 - hits);
         self.metrics.items_read.inc_by(positions.len() as u64);
-        Ok(result.into_iter().map(|r| r.unwrap()).collect())
+        Ok(result)
     }
 
     fn try_read_sync(&self, pos: u64) -> Option<A> {
@@ -4381,6 +4354,51 @@ mod tests {
             for &pos in &positions {
                 let single = reader.read(pos).await.unwrap();
                 assert_eq!(batch[pos as usize], single);
+            }
+            drop(reader);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_read_many_warm_matches_read() {
+        // Verify the batched warm path is byte-identical to per-item reads across multiple
+        // sections, with a mid-section pruning boundary and a sparse subset of positions.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(8));
+            let journal = Journal::init(context.child("j"), cfg).await.unwrap();
+
+            for i in 0..50u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            // Prune mid-section so first_in_section differs from section start.
+            journal.prune(11).await.unwrap();
+
+            let reader = journal.reader().await;
+
+            // Warm the page cache so every position is an all-hit batch read.
+            for pos in 11..50u64 {
+                let _ = reader.try_read_sync(pos);
+            }
+
+            // Sparse subset spanning multiple sections, including the pruning boundary.
+            let positions: Vec<u64> = vec![11, 12, 19, 20, 23, 31, 40, 47, 49];
+            let batch = reader.read_many(&positions).await.unwrap();
+            assert_eq!(batch.len(), positions.len());
+            for (i, &pos) in positions.iter().enumerate() {
+                let single = reader.read(pos).await.unwrap();
+                assert_eq!(batch[i], single);
+                assert_eq!(batch[i], test_digest(pos));
+            }
+
+            // Full contiguous range over retained items.
+            let all: Vec<u64> = (11..50).collect();
+            let batch = reader.read_many(&all).await.unwrap();
+            for (i, &pos) in all.iter().enumerate() {
+                assert_eq!(batch[i], reader.read(pos).await.unwrap());
             }
             drop(reader);
 

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -63,6 +63,15 @@ pub trait Reader: Send + Sync {
         None
     }
 
+    /// Like [`try_read_sync`](Self::try_read_sync) but decodes into a caller-provided scratch
+    /// buffer to avoid a per-call allocation. `scratch` must be at least one item wide; the
+    /// implementation may grow it.
+    ///
+    /// Default implementation ignores `scratch` and delegates to [`try_read_sync`](Self::try_read_sync).
+    fn try_read_sync_into(&self, position: u64, _scratch: &mut Vec<u8>) -> Option<Self::Item> {
+        self.try_read_sync(position)
+    }
+
     /// Return a stream of all items starting from `start_pos`.
     ///
     /// Because the reader holds the lock, validation and stream setup happen

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -5,6 +5,7 @@
 //! [variable]-size item journals are supported.
 
 use super::Error;
+use commonware_parallel::Strategy;
 use futures::Stream;
 use std::{future::Future, num::NonZeroUsize, ops::Range};
 use tracing::warn;
@@ -54,6 +55,23 @@ pub trait Reader: Send + Sync {
             }
             Ok(items)
         }
+    }
+
+    /// Read multiple items, decoding the raw payloads in parallel using `strategy`.
+    ///
+    /// The default implementation ignores `strategy` and delegates to
+    /// [`read_many`](Self::read_many). Implementations that copy the raw item bytes into a single
+    /// contiguous buffer override this to decode that buffer lock-free across the strategy's
+    /// parallelism.
+    fn read_many_decoded<S: Strategy>(
+        &self,
+        positions: &[u64],
+        _strategy: &S,
+    ) -> impl Future<Output = Result<Vec<Self::Item>, Error>> + Send
+    where
+        Self::Item: Send,
+    {
+        self.read_many(positions)
     }
 
     /// Read an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -25,7 +25,7 @@ use crate::journal::Error;
 use commonware_codec::{CodecFixed, CodecFixedShared, DecodeExt as _, ReadExt as _};
 use commonware_runtime::{
     buffer::paged::{CacheRef, Replay},
-    Blob, Buf, Metrics, Storage,
+    Blob, Buf, BufferPool, Metrics, Storage,
 };
 use futures::{
     stream::{self, Stream},
@@ -77,6 +77,11 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     /// Size of each entry.
     pub const CHUNK_SIZE: usize = A::SIZE;
     const CHUNK_SIZE_U64: u64 = Self::CHUNK_SIZE as u64;
+
+    /// Returns the buffer pool backing the page cache.
+    pub(crate) const fn pool(&self) -> &BufferPool {
+        self.manager.factory().page_cache_ref.pool()
+    }
 
     /// Initialize a new `Journal` instance.
     ///

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -205,6 +205,34 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         if positions.is_empty() {
             return Ok((Vec::new(), 0));
         }
+
+        let hits = self.read_many_into(section, positions, buf).await?;
+
+        let mut items = Vec::with_capacity(positions.len());
+        for i in 0..positions.len() {
+            let slice = &buf[i * Self::CHUNK_SIZE..(i + 1) * Self::CHUNK_SIZE];
+            items.push(A::decode(slice).map_err(Error::Codec)?);
+        }
+        Ok((items, hits))
+    }
+
+    /// Fill `buf` with the raw bytes of the items at `positions` in the given section without
+    /// decoding them.
+    ///
+    /// `buf` must be at least `positions.len() * CHUNK_SIZE` bytes. All positions must be
+    /// strictly increasing and within the section's bounds. Item `i` occupies
+    /// `buf[i * CHUNK_SIZE..(i + 1) * CHUNK_SIZE]`.
+    ///
+    /// Returns the number served without a blob read (page cache or tip buffer hits).
+    pub async fn read_many_into(
+        &self,
+        section: u64,
+        positions: &[u64],
+        buf: &mut [u8],
+    ) -> Result<usize, Error> {
+        if positions.is_empty() {
+            return Ok(0);
+        }
         let blob = self
             .manager
             .get(section)?
@@ -219,13 +247,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
             .collect::<Result<_, _>>()?;
 
         let hits = blob.read_many_into(buf, &offsets, Self::CHUNK_SIZE).await?;
-
-        let mut items = Vec::with_capacity(positions.len());
-        for i in 0..positions.len() {
-            let slice = &buf[i * Self::CHUNK_SIZE..(i + 1) * Self::CHUNK_SIZE];
-            items.push(A::decode(slice).map_err(Error::Codec)?);
-        }
-        Ok((items, hits))
+        Ok(hits)
     }
 
     /// Get an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -188,14 +188,17 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     ///
     /// `buf` must be at least `positions.len() * CHUNK_SIZE` bytes. All positions must be
     /// strictly increasing and within the section's bounds.
+    ///
+    /// Returns the decoded items and the number served without a blob read (page cache or tip
+    /// buffer hits).
     pub async fn get_many(
         &self,
         section: u64,
         positions: &[u64],
         buf: &mut [u8],
-    ) -> Result<Vec<A>, Error> {
+    ) -> Result<(Vec<A>, usize), Error> {
         if positions.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
         let blob = self
             .manager
@@ -210,14 +213,14 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
             })
             .collect::<Result<_, _>>()?;
 
-        blob.read_many_into(buf, &offsets, Self::CHUNK_SIZE).await?;
+        let hits = blob.read_many_into(buf, &offsets, Self::CHUNK_SIZE).await?;
 
         let mut items = Vec::with_capacity(positions.len());
         for i in 0..positions.len() {
             let slice = &buf[i * Self::CHUNK_SIZE..(i + 1) * Self::CHUNK_SIZE];
             items.push(A::decode(slice).map_err(Error::Codec)?);
         }
-        Ok(items)
+        Ok((items, hits))
     }
 
     /// Get an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
@@ -1432,8 +1435,9 @@ mod tests {
             assert_eq!(journal.section_len(0).await.unwrap(), 1);
 
             let mut buf = [];
-            let items = journal.get_many(0, &[], &mut buf).await.unwrap();
+            let (items, hits) = journal.get_many(0, &[], &mut buf).await.unwrap();
             assert!(items.is_empty());
+            assert_eq!(hits, 0);
 
             journal.destroy().await.unwrap();
         });
@@ -1454,7 +1458,7 @@ mod tests {
             // Read all 5 items in one call.
             let chunk = Journal::<deterministic::Context, Digest>::CHUNK_SIZE;
             let mut buf = vec![0u8; 5 * chunk];
-            let items = journal
+            let (items, _) = journal
                 .get_many(0, &[0, 1, 2, 3, 4], &mut buf)
                 .await
                 .unwrap();
@@ -1483,7 +1487,7 @@ mod tests {
             let chunk = Journal::<deterministic::Context, Digest>::CHUNK_SIZE;
             let positions = [1, 4, 7, 9];
             let mut buf = vec![0u8; positions.len() * chunk];
-            let items = journal.get_many(0, &positions, &mut buf).await.unwrap();
+            let (items, _) = journal.get_many(0, &positions, &mut buf).await.unwrap();
 
             for (i, &pos) in positions.iter().enumerate() {
                 assert_eq!(items[i], test_digest(pos));
@@ -1527,7 +1531,7 @@ mod tests {
             let chunk = Journal::<deterministic::Context, Digest>::CHUNK_SIZE;
             let positions: Vec<u64> = (0..8).collect();
             let mut buf = vec![0u8; positions.len() * chunk];
-            let batch = journal.get_many(0, &positions, &mut buf).await.unwrap();
+            let (batch, _) = journal.get_many(0, &positions, &mut buf).await.unwrap();
 
             for pos in &positions {
                 let single = journal.get(0, *pos).await.unwrap();

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -143,6 +143,11 @@ pub struct Manager<E: Storage + Metrics, F: BufferFactory<E::Blob>> {
 }
 
 impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
+    /// Returns the buffer factory.
+    pub(crate) const fn factory(&self) -> &F {
+        &self.factory
+    }
+
     /// Initialize a new `Manager`.
     ///
     /// Scans the partition for existing blobs and opens them.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -84,7 +84,7 @@ use crate::merkle::{
     hasher::Hasher, mem::Mem, path, proof::Proof, Error, Family, Location, Position, Readable,
 };
 use alloc::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     sync::{Arc, Weak},
     vec::Vec,
 };
@@ -99,6 +99,94 @@ fn push_dirty<F: Family>(buckets: &mut Vec<Vec<Position<F>>>, height: u32, pos: 
         buckets.resize_with(h + 1, Vec::new);
     }
     buckets[h].push(pos);
+}
+
+/// Minimum number of dirty nodes a slice must hold before it is split for parallel hashing. Below
+/// this, the dispatch + slice-boundary deferral overhead dominates the hashing work.
+const PARALLEL_SPLIT_THRESHOLD: usize = 2048;
+
+/// Hash the appended-region dirty interior nodes covering the slice `appended[..]`, which maps to
+/// absolute appended indices `[base, end)`.
+///
+/// `nodes` lists `(absolute_index, height)` pairs sorted by index, restricted to indices in
+/// `[base, end)`. Returns the `(position, height)` of nodes whose left or right child falls before
+/// `base` (the merge path into pre-existing peaks at the top level, plus slice-boundary spans at
+/// deeper levels); the caller computes those against finalized children.
+///
+/// The slice is split at the midpoint index, recursing in parallel via [`Strategy::join`]. Each
+/// child slice owns a disjoint contiguous range, so the two halves never alias. Within a slice,
+/// nodes are processed in index order, and a node's children always precede it, so every in-slice
+/// dependency is finalized before it is read.
+fn merkleize_appended_slice<F: Family, D: Digest, S: Strategy>(
+    strategy: &S,
+    hasher: &impl Hasher<F, Digest = D>,
+    parent_size: u64,
+    base: u64,
+    end: u64,
+    appended: &mut [D],
+    nodes: &[(u64, u32)],
+) -> Vec<(Position<F>, u32)> {
+    if nodes.len() > PARALLEL_SPLIT_THRESHOLD && end - base > 1 {
+        let mid = base + (end - base) / 2;
+        let split = nodes.partition_point(|&(idx, _)| idx < mid);
+        let (left_slice, right_slice) = appended.split_at_mut((mid - base) as usize);
+        let (left_nodes, right_nodes) = nodes.split_at(split);
+        let (mut left_deferred, right_deferred) = strategy.join(
+            || {
+                merkleize_appended_slice::<F, D, S>(
+                    strategy,
+                    hasher,
+                    parent_size,
+                    base,
+                    mid,
+                    left_slice,
+                    left_nodes,
+                )
+            },
+            || {
+                merkleize_appended_slice::<F, D, S>(
+                    strategy,
+                    hasher,
+                    parent_size,
+                    mid,
+                    end,
+                    right_slice,
+                    right_nodes,
+                )
+            },
+        );
+        left_deferred.extend(right_deferred);
+        return left_deferred;
+    }
+
+    let mut deferred = Vec::new();
+    // Track deferred indices within this slice. A node whose child was deferred (e.g. a spine node
+    // merging a committed peak) must also be deferred, since the fast path leaves that child's slot
+    // unwritten. Children always precede their parent in index order, so this set is complete by the
+    // time a parent is visited.
+    let mut deferred_idx: BTreeSet<u64> = BTreeSet::new();
+    for &(idx, height) in nodes {
+        let pos = Position::<F>::new(parent_size + idx);
+        let (left, right) = F::children(pos, height);
+        // Children below `parent_size` are committed; below `base` they live in another slice. In
+        // both cases the fast path cannot read them, so defer. Also defer if a child was itself
+        // deferred within this slice.
+        let li = (*left).wrapping_sub(parent_size).wrapping_sub(base);
+        let ri = (*right).wrapping_sub(parent_size).wrapping_sub(base);
+        let in_slice = *left >= base + parent_size
+            && *right >= base + parent_size
+            && !deferred_idx.contains(&(base + li))
+            && !deferred_idx.contains(&(base + ri));
+        if in_slice {
+            let oi = (idx - base) as usize;
+            let digest = hasher.node_digest(pos, &appended[li as usize], &appended[ri as usize]);
+            appended[oi] = digest;
+        } else {
+            deferred.push((pos, height));
+            deferred_idx.insert(idx);
+        }
+    }
+    deferred
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +204,10 @@ pub struct UnmerkleizedBatch<F: Family, D: Digest, S: Strategy> {
     /// `add_leaf_digest`; may contain duplicates from interleaved `mark_dirty` walks, deduped
     /// in `merkleize`). Avoids the BTreeSet insert cost and a final global sort.
     dirty_nodes: Vec<Vec<Position<F>>>,
+    /// Interior placeholders appended by `append_leaf_digest`, as `(index_into_appended, height)`
+    /// in append order, which is strictly index-ascending. Feeds the parallel appended-region
+    /// hashing pass directly, avoiding a global sort of the dirty-node buckets.
+    appended_interior: Vec<(u64, u32)>,
 }
 
 impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
@@ -126,6 +218,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             appended: Vec::new(),
             overwrites: BTreeMap::new(),
             dirty_nodes: Vec::new(),
+            appended_interior: Vec::new(),
         }
     }
 
@@ -231,8 +324,9 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         size += 1;
 
         for height in F::parent_heights(leaves) {
+            let idx = self.appended.len() as u64;
             self.appended.push(D::EMPTY);
-            push_dirty(&mut self.dirty_nodes, height, size);
+            self.appended_interior.push((idx, height));
             size += 1;
         }
 
@@ -330,10 +424,25 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         base: &Mem<F, D>,
         hasher: &impl Hasher<F, Digest = D>,
     ) -> Arc<MerkleizedBatch<F, D, S>> {
-        // Each bucket accumulates positions in push order, which for `add_leaf_digest` is
-        // already ascending; the stable `sort` is cheap on such near-sorted input. The dedup
-        // then collapses any duplicates that slipped past `mark_dirty`'s last-entry check.
         let mut buckets = core::mem::take(&mut self.dirty_nodes);
+        let parent_size = self.parent.size();
+
+        // Interior nodes created by appends are already recorded in index-ascending order. Hash
+        // them in a single parallel divide-and-conquer pass over the appended Vec. Nodes the pass
+        // cannot resolve (the merge path into pre-existing peaks and slice-boundary spans) are
+        // returned and folded into the serial bucket path.
+        let appended_interior = core::mem::take(&mut self.appended_interior);
+        let deferred = self.merkleize_appended(hasher, parent_size, &appended_interior);
+        for (pos, height) in deferred {
+            push_dirty(&mut buckets, height, pos);
+        }
+
+        // Remaining dirty nodes come from overwrites (`mark_dirty`) plus the deferred spans. They
+        // are computed via the serial bucket path against finalized children. Each bucket
+        // accumulates positions in near-ascending push order; the stable sort is cheap and the
+        // dedup collapses duplicates from interleaved `mark_dirty` walks. Overwrites of
+        // just-appended leaves can re-dirty appended-region nodes already hashed above; recomputing
+        // them here reads the same finalized children and yields identical digests.
         for bucket in &mut buckets {
             bucket.sort();
             bucket.dedup();
@@ -348,7 +457,6 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         // Collect ancestor data by walking the parent chain (strong Arc + Weak walk).
         let (ancestor_appended, ancestor_overwrites) = collect_ancestor_batches(&self.parent);
 
-        let parent_size = self.parent.size();
         Arc::new(MerkleizedBatch {
             parent: Some(Arc::downgrade(&self.parent)),
             appended: Arc::new(self.appended),
@@ -360,6 +468,35 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             ancestor_overwrites,
             strategy: self.parent.strategy.clone(),
         })
+    }
+
+    /// Hash dirty interior nodes that live entirely in the appended region.
+    ///
+    /// `nodes` are `(index_into_appended, height)` pairs sorted by index. Each node is hashed from
+    /// its two children, which always precede it in the appended Vec. The Vec is split into disjoint
+    /// contiguous slices that are hashed in parallel; nodes whose left or right child falls before
+    /// the owning slice (the merge path into pre-existing peaks, and slice-boundary spans) are
+    /// returned for the caller to compute against finalized children.
+    fn merkleize_appended(
+        &mut self,
+        hasher: &impl Hasher<F, Digest = D>,
+        parent_size: Position<F>,
+        nodes: &[(u64, u32)],
+    ) -> Vec<(Position<F>, u32)> {
+        if nodes.is_empty() {
+            return Vec::new();
+        }
+        let strategy = self.parent.strategy.clone();
+        let len = self.appended.len() as u64;
+        merkleize_appended_slice::<F, D, S>(
+            &strategy,
+            hasher,
+            *parent_size,
+            0,
+            len,
+            &mut self.appended,
+            nodes,
+        )
     }
 
     /// Compute digests for one height's dirty nodes via the configured strategy.
@@ -658,6 +795,33 @@ mod tests {
         };
         mem.apply_batch(&batch).unwrap();
         mem
+    }
+
+    fn large_appended_parity<F: Family, S: Strategy>(strategy: S) {
+        let executor = deterministic::Runner::default();
+        executor.start(move |_| async move {
+            let hasher: H = Standard::new(ForwardFold);
+            // base+append totals exceed PARALLEL_SPLIT_THRESHOLD so the divide-and-conquer split
+            // (and its slice-boundary deferral) is exercised. A few base/append shapes hit different
+            // peak counts and merge-path depths.
+            for &(base_n, add_n) in &[(0u64, 5000u64), (1000, 4000), (777, 6001), (3333, 3000)] {
+                let reference = build_reference::<F>(&hasher, base_n + add_n);
+                let base = build_reference::<F>(&hasher, base_n);
+                let mut batch = base.new_batch_with_strategy(strategy.clone());
+                for i in base_n..(base_n + add_n) {
+                    let element = hasher.digest(&i.to_be_bytes());
+                    batch = batch.add(&hasher, &element);
+                }
+                let merkleized = batch.merkleize(&base, &hasher);
+                let mut result = base;
+                result.apply_batch(&merkleized).unwrap();
+                assert_eq!(
+                    mem_root(&result, &hasher),
+                    mem_root(&reference, &hasher),
+                    "root mismatch for base_n={base_n} add_n={add_n}"
+                );
+            }
+        });
     }
 
     fn consistency_with_reference<F: Family>() {
@@ -1198,6 +1362,16 @@ mod tests {
     fn mmr_update_out_of_bounds() {
         update_out_of_bounds::<crate::mmr::Family>();
     }
+    #[test]
+    fn mmr_large_appended_parity_sequential() {
+        large_appended_parity::<crate::mmr::Family, _>(commonware_parallel::Sequential);
+    }
+    #[test]
+    fn mmr_large_appended_parity_rayon() {
+        let strategy =
+            commonware_parallel::Rayon::new(core::num::NonZeroUsize::new(4).unwrap()).unwrap();
+        large_appended_parity::<crate::mmr::Family, _>(strategy);
+    }
 
     // --- MMB tests ---
 
@@ -1272,5 +1446,15 @@ mod tests {
     #[test]
     fn mmb_update_out_of_bounds() {
         update_out_of_bounds::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_large_appended_parity_sequential() {
+        large_appended_parity::<crate::mmb::Family, _>(commonware_parallel::Sequential);
+    }
+    #[test]
+    fn mmb_large_appended_parity_rayon() {
+        let strategy =
+            commonware_parallel::Rayon::new(core::num::NonZeroUsize::new(4).unwrap()).unwrap();
+        large_appended_parity::<crate::mmb::Family, _>(strategy);
     }
 }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -189,6 +189,105 @@ fn merkleize_appended_slice<F: Family, D: Digest, S: Strategy>(
     deferred
 }
 
+/// Fill leaf slots and hash interior nodes for the slice `appended[..]`, which maps to absolute
+/// appended indices `[base, end)`.
+///
+/// `leaves` lists `(slot_index, leaf_index)` pairs for the leaves in this slice, sorted by slot.
+/// `leaf_fn(leaf_index, scratch)` produces the leaf digest, reusing `scratch` for encoding.
+/// `interior` lists `(slot_index, height)` for the interior placeholders in this slice, sorted by
+/// slot. This fuses the leaf hashing pass into the interior pass: each task fills its leaf slots
+/// before computing its interior nodes, so every in-slice child (leaf or interior) is finalized
+/// before it is read.
+///
+/// See [`merkleize_appended_slice`] for the slice-boundary deferral contract; the returned
+/// `(position, height)` list is identical in meaning.
+#[cfg(feature = "std")]
+#[allow(clippy::too_many_arguments)]
+fn fused_appended_slice<F, D, S, L>(
+    strategy: &S,
+    hasher: &impl Hasher<F, Digest = D>,
+    leaf_fn: &L,
+    parent_size: u64,
+    base: u64,
+    end: u64,
+    appended: &mut [D],
+    leaves: &[(u64, u64)],
+    interior: &[(u64, u32)],
+) -> Vec<(Position<F>, u32)>
+where
+    F: Family,
+    D: Digest,
+    S: Strategy,
+    L: Fn(u64, &mut Vec<u8>) -> D + Send + Sync,
+{
+    if interior.len() > PARALLEL_SPLIT_THRESHOLD && end - base > 1 {
+        let mid = base + (end - base) / 2;
+        let leaf_split = leaves.partition_point(|&(slot, _)| slot < mid);
+        let int_split = interior.partition_point(|&(slot, _)| slot < mid);
+        let (left_slice, right_slice) = appended.split_at_mut((mid - base) as usize);
+        let (left_leaves, right_leaves) = leaves.split_at(leaf_split);
+        let (left_int, right_int) = interior.split_at(int_split);
+        let (mut left_deferred, right_deferred) = strategy.join(
+            || {
+                fused_appended_slice::<F, D, S, L>(
+                    strategy,
+                    hasher,
+                    leaf_fn,
+                    parent_size,
+                    base,
+                    mid,
+                    left_slice,
+                    left_leaves,
+                    left_int,
+                )
+            },
+            || {
+                fused_appended_slice::<F, D, S, L>(
+                    strategy,
+                    hasher,
+                    leaf_fn,
+                    parent_size,
+                    mid,
+                    end,
+                    right_slice,
+                    right_leaves,
+                    right_int,
+                )
+            },
+        );
+        left_deferred.extend(right_deferred);
+        return left_deferred;
+    }
+
+    let mut scratch = Vec::new();
+    for &(slot, leaf_index) in leaves {
+        let oi = (slot - base) as usize;
+        appended[oi] = leaf_fn(leaf_index, &mut scratch);
+    }
+
+    let mut deferred = Vec::new();
+    let mut deferred_idx: BTreeSet<u64> = BTreeSet::new();
+    for &(idx, height) in interior {
+        let pos = Position::<F>::new(parent_size + idx);
+        let (left, right) = F::children(pos, height);
+        let li = (*left).wrapping_sub(parent_size).wrapping_sub(base);
+        let ri = (*right).wrapping_sub(parent_size).wrapping_sub(base);
+        let in_slice = *left >= base + parent_size
+            && *right >= base + parent_size
+            && !deferred_idx.contains(&(base + li))
+            && !deferred_idx.contains(&(base + ri));
+        if in_slice {
+            let oi = (idx - base) as usize;
+            let digest = hasher.node_digest(pos, &appended[li as usize], &appended[ri as usize]);
+            appended[oi] = digest;
+        } else {
+            deferred.push((pos, height));
+            deferred_idx.insert(idx);
+        }
+    }
+    deferred
+}
+
 // ---------------------------------------------------------------------------
 // UnmerkleizedBatch
 // ---------------------------------------------------------------------------
@@ -349,6 +448,72 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         for (i, digest) in (0u64..).zip(digests) {
             size = self.append_leaf_digest(digest, leaves + i, size);
         }
+        self
+    }
+
+    /// Append `n` leaves, computing leaf and interior digests in a single fused parallel pass.
+    ///
+    /// `leaf_fn(leaf_index, scratch)` produces the digest for the leaf at the absolute leaf index
+    /// `leaf_index`, reusing `scratch` as a per-task encode buffer. The layout (which appended slots
+    /// hold leaves vs interior nodes) depends only on positions, so it is precomputed serially; the
+    /// fused pass then fills leaf slots and hashes interior nodes together, avoiding the separate
+    /// leaf-hashing pass plus its intermediate digest Vec.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any leaves were already appended to this batch.
+    #[cfg(feature = "std")]
+    pub(crate) fn add_many_leaves<L>(
+        mut self,
+        hasher: &impl Hasher<F, Digest = D>,
+        n: u64,
+        leaf_fn: L,
+    ) -> Self
+    where
+        L: Fn(u64, &mut Vec<u8>) -> D + Send + Sync,
+    {
+        assert!(
+            self.appended.is_empty(),
+            "add_many_leaves expects no prior appends"
+        );
+        if n == 0 {
+            return self;
+        }
+
+        // Precompute the appended-region layout. Each leaf occupies one slot followed by its parent
+        // placeholders; both lists are built in slot-ascending order.
+        let first_leaf = self.leaves();
+        let mut leaf_slots: Vec<(u64, u64)> = Vec::with_capacity(n as usize);
+        let mut interior: Vec<(u64, u32)> = Vec::new();
+        let mut slot = 0u64;
+        for i in 0..n {
+            leaf_slots.push((slot, i));
+            slot += 1;
+            for height in F::parent_heights(first_leaf + i) {
+                interior.push((slot, height));
+                slot += 1;
+            }
+        }
+        let total = slot;
+
+        self.appended.resize(total as usize, D::EMPTY);
+        let parent_size = *self.parent.size();
+        let strategy = self.parent.strategy.clone();
+        let deferred = fused_appended_slice::<F, D, S, L>(
+            &strategy,
+            hasher,
+            &leaf_fn,
+            parent_size,
+            0,
+            total,
+            &mut self.appended,
+            &leaf_slots,
+            &interior,
+        );
+        for (pos, height) in deferred {
+            push_dirty(&mut self.dirty_nodes, height, pos);
+        }
+
         self
     }
 
@@ -819,6 +984,35 @@ mod tests {
                     mem_root(&result, &hasher),
                     mem_root(&reference, &hasher),
                     "root mismatch for base_n={base_n} add_n={add_n}"
+                );
+            }
+        });
+    }
+
+    fn fused_appended_parity<F: Family, S: Strategy>(strategy: S) {
+        let executor = deterministic::Runner::default();
+        executor.start(move |_| async move {
+            let hasher: H = Standard::new(ForwardFold);
+            for &(base_n, add_n) in &[(0u64, 5000u64), (1000, 4000), (777, 6001), (3333, 3000)] {
+                let reference = build_reference::<F>(&hasher, base_n + add_n);
+                let base = build_reference::<F>(&hasher, base_n);
+                let batch = base.new_batch_with_strategy(strategy.clone());
+                let merkleized = batch
+                    .add_many_leaves(&hasher, add_n, |i, buf| {
+                        let pos =
+                            Position::<F>::try_from(Location::new(base_n + i)).expect("valid leaf");
+                        buf.clear();
+                        buf.extend_from_slice(&(base_n + i).to_be_bytes());
+                        let element = hasher.digest(buf.as_slice());
+                        hasher.leaf_digest(pos, element.as_ref())
+                    })
+                    .merkleize(&base, &hasher);
+                let mut result = base;
+                result.apply_batch(&merkleized).unwrap();
+                assert_eq!(
+                    mem_root(&result, &hasher),
+                    mem_root(&reference, &hasher),
+                    "fused root mismatch for base_n={base_n} add_n={add_n}"
                 );
             }
         });
@@ -1372,6 +1566,16 @@ mod tests {
             commonware_parallel::Rayon::new(core::num::NonZeroUsize::new(4).unwrap()).unwrap();
         large_appended_parity::<crate::mmr::Family, _>(strategy);
     }
+    #[test]
+    fn mmr_fused_appended_parity_sequential() {
+        fused_appended_parity::<crate::mmr::Family, _>(commonware_parallel::Sequential);
+    }
+    #[test]
+    fn mmr_fused_appended_parity_rayon() {
+        let strategy =
+            commonware_parallel::Rayon::new(core::num::NonZeroUsize::new(4).unwrap()).unwrap();
+        fused_appended_parity::<crate::mmr::Family, _>(strategy);
+    }
 
     // --- MMB tests ---
 
@@ -1456,5 +1660,15 @@ mod tests {
         let strategy =
             commonware_parallel::Rayon::new(core::num::NonZeroUsize::new(4).unwrap()).unwrap();
         large_appended_parity::<crate::mmb::Family, _>(strategy);
+    }
+    #[test]
+    fn mmb_fused_appended_parity_sequential() {
+        fused_appended_parity::<crate::mmb::Family, _>(commonware_parallel::Sequential);
+    }
+    #[test]
+    fn mmb_fused_appended_parity_rayon() {
+        let strategy =
+            commonware_parallel::Rayon::new(core::num::NonZeroUsize::new(4).unwrap()).unwrap();
+        fused_appended_parity::<crate::mmb::Family, _>(strategy);
     }
 }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -110,9 +110,9 @@ struct ExistingEntry<K, F: Family, V> {
     value: Option<V>,
 }
 
-/// A key's resolved location, as produced by `get_many_with_locations` and consumed by
-/// `merkleize_resolved`. Carries enough provenance to reproduce the op-gen ordering and
-/// `base_old_loc` without re-reading the operation.
+/// A key's resolved location, as produced by `get_many_with_locations` and attached via
+/// `with_resolved`. Carries enough provenance to reproduce the op-gen ordering and `base_old_loc`
+/// without re-reading the operation during `merkleize`.
 #[derive(Clone, Copy, Debug)]
 pub struct ResolvedLocation<F: Family> {
     /// The location used for op-gen ordering. For a key resolved through an ancestor diff this is
@@ -879,7 +879,8 @@ where
     }
 }
 
-// Unordered op-generation tail shared by `merkleize_with_floor_scan` and `merkleize_resolved`.
+// Shared unordered op-generation tail: turns classified existing entries plus remaining
+// create mutations into operations, then runs the floor-raise and journal merkleize.
 impl<F: Family, K, V, H, S: Strategy> Merkleizer<F, H, update::Unordered<K, V>, S>
 where
     K: Key,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -29,7 +29,7 @@ use commonware_parallel::Strategy;
 use commonware_utils::bitmap;
 use core::{cmp::Ordering, ops::Range};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     iter,
     sync::{Arc, Weak},
 };
@@ -211,7 +211,7 @@ where
     /// [`get_many_with_locations`](UnmerkleizedBatch::get_many_with_locations) during state load.
     /// When a mutation key is present here, `merkleize` reuses the location and skips the
     /// redundant journal read. Empty for callers that did not pre-resolve.
-    resolved: BTreeMap<U::Key, Option<ResolvedLocation<F>>>,
+    resolved: HashMap<U::Key, Option<ResolvedLocation<F>>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -1285,7 +1285,7 @@ where
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
-        resolved: BTreeMap<K, Option<ResolvedLocation<F>>>,
+        resolved: HashMap<K, Option<ResolvedLocation<F>>>,
         metadata: Option<V::Value>,
         next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
@@ -1365,7 +1365,7 @@ where
     /// [`get_many_with_locations`](Self::get_many_with_locations)) so [`merkleize`](Self::merkleize)
     /// reuses them instead of re-reading the journal for those keys. Keys absent from `resolved`
     /// are resolved normally; a `None` entry marks a key observed as absent (handled as a create).
-    pub fn with_resolved(mut self, resolved: BTreeMap<K, Option<ResolvedLocation<F>>>) -> Self {
+    pub fn with_resolved(mut self, resolved: HashMap<K, Option<ResolvedLocation<F>>>) -> Self {
         self.resolved = resolved;
         self
     }
@@ -1779,7 +1779,7 @@ where
             journal_batch: self.journal_batch.new_batch::<H>(),
             mutations: BTreeMap::new(),
             base: Base::Child(Arc::clone(self)),
-            resolved: BTreeMap::new(),
+            resolved: HashMap::new(),
         }
     }
 
@@ -1902,7 +1902,7 @@ where
                 inactivity_floor_loc: self.inactivity_floor_loc,
                 active_keys: self.active_keys,
             },
-            resolved: BTreeMap::new(),
+            resolved: HashMap::new(),
         }
     }
 }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -22,14 +22,14 @@ use crate::{
     },
     Context,
 };
-use ahash::AHashSet;
+use ahash::{AHashMap, AHashSet};
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use commonware_utils::bitmap;
 use core::{cmp::Ordering, ops::Range};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     iter,
     sync::{Arc, Weak},
 };
@@ -40,6 +40,63 @@ const MAX_CONCURRENT_READS: u64 = 64;
 
 type DiffVec<K, F, V> = Vec<(K, DiffEntry<F, V>)>;
 type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
+
+/// Pending mutations recorded by [`UnmerkleizedBatch::write`]. `Some(value)` is an upsert,
+/// `None` is a delete.
+///
+/// Writes append to an insertion-ordered `Vec` (cheaper than per-key ordered inserts) and are
+/// resolved to last-write-wins, key-sorted form only when consumed by `merkleize` (see
+/// [`Mutations::into_sorted`]). Read-through (`get`/`get_many`) on a written batch scans the
+/// pending writes in reverse so the latest value for a key wins.
+struct Mutations<K, V> {
+    pending: Vec<(K, Option<V>)>,
+}
+
+impl<K: Ord + Clone, V: Clone> Mutations<K, V> {
+    const fn new() -> Self {
+        Self {
+            pending: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, key: K, value: Option<V>) {
+        self.pending.push((key, value));
+    }
+
+    const fn len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Latest value written for `key`, or `None` if `key` was never written in this batch.
+    fn get(&self, key: &K) -> Option<&Option<V>> {
+        self.pending
+            .iter()
+            .rev()
+            .find_map(|(k, v)| (k == key).then_some(v))
+    }
+
+    /// Resolve to a key-sorted, last-write-wins `BTreeMap`.
+    ///
+    /// A stable sort followed by a reverse-keep dedup preserves last-write-wins: equal keys keep
+    /// their insertion order after the stable sort, and keeping the last of each run keeps the most
+    /// recent write. The result matches the order and final value mapping that successive
+    /// `BTreeMap::insert` calls would produce.
+    fn into_sorted(self) -> BTreeMap<K, Option<V>> {
+        let mut pending = self.pending;
+        pending.sort_by(|a, b| a.0.cmp(&b.0));
+        // Keep the LAST write of each equal-key run. `dedup_by` retains the first of a run, so
+        // swap so the retained slot holds the later (insertion-order-preserved) write.
+        pending.dedup_by(|a, b| {
+            if a.0 == b.0 {
+                core::mem::swap(a, b);
+                true
+            } else {
+                false
+            }
+        });
+        BTreeMap::from_iter(pending)
+    }
+}
 
 /// Sorted `(key, (value, loc))` vec consulted by `find_prev_key` to find the predecessor
 /// of a given key during ordered merkleization.
@@ -135,7 +192,7 @@ pub(crate) struct ResolvedLocation<F: Family> {
 /// database.
 #[derive(Debug)]
 pub struct ResolvedLocations<K, F: Family> {
-    pub(crate) locations: HashMap<K, ResolvedLocation<F>>,
+    pub(crate) locations: AHashMap<K, ResolvedLocation<F>>,
 }
 
 /// Where this batch's inherited state comes from.
@@ -216,7 +273,7 @@ where
     journal_batch: authenticated::UnmerkleizedBatch<F, H, Operation<F, U>, S>,
 
     /// Pending mutations. `Some(value)` for upsert, `None` for delete.
-    mutations: BTreeMap<U::Key, Option<U::Value>>,
+    mutations: Mutations<U::Key, U::Value>,
 
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
@@ -225,7 +282,7 @@ where
     /// [`get_many_with_locations`](UnmerkleizedBatch::get_many_with_locations) during state load.
     /// When a mutation key is present here, `merkleize` reuses the location and skips the
     /// redundant journal read. Empty for callers that did not pre-resolve.
-    resolved: HashMap<U::Key, ResolvedLocation<F>>,
+    resolved: AHashMap<U::Key, ResolvedLocation<F>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -429,32 +486,37 @@ impl<'a, K: Ord, F: Family, V> Iterator for DiffMerge<'a, K, F, V> {
     }
 }
 
-/// Resolves a key's `base_old_loc` by walking parallel cursors over already-applied
-/// ancestor diffs (parent-first). Lookups must be issued in ascending key order because
-/// cursors only advance forward. Returns `Some(Some(loc))` for an active entry,
-/// `Some(None)` for a deletion, and `None` when no already-applied ancestor touched the
-/// key.
-struct AppliedAncestorResolver<'a, K, F: Family, V> {
+/// Resolves a key against parallel cursors over diff slices in priority order (parent-first).
+/// Lookups must be issued in ascending key order because cursors only advance forward.
+/// [`resolve`](Self::resolve) returns the matching entry, mirroring `resolve_in_ancestors`.
+struct AncestorCursors<'a, K, F: Family, V> {
     cursors: Vec<(&'a DiffSlice<K, F, V>, usize)>,
 }
 
-impl<'a, K: Ord, F: Family, V> AppliedAncestorResolver<'a, K, F, V> {
-    fn new(applied: impl IntoIterator<Item = &'a DiffSlice<K, F, V>>) -> Self {
+impl<'a, K: Ord, F: Family, V> AncestorCursors<'a, K, F, V> {
+    fn new(streams: impl IntoIterator<Item = &'a DiffSlice<K, F, V>>) -> Self {
         Self {
-            cursors: applied.into_iter().map(|s| (s, 0)).collect(),
+            cursors: streams.into_iter().map(|s| (s, 0)).collect(),
         }
     }
 
-    fn lookup(&mut self, key: &K) -> Option<Option<Location<F>>> {
+    /// Return the highest-priority entry for `key`, or `None` if no stream holds it.
+    fn resolve(&mut self, key: &K) -> Option<&'a DiffEntry<F, V>> {
         for (slice, idx) in self.cursors.iter_mut() {
             while *idx < slice.len() && slice[*idx].0 < *key {
                 *idx += 1;
             }
             if *idx < slice.len() && slice[*idx].0 == *key {
-                return Some(slice[*idx].1.loc());
+                return Some(&slice[*idx].1);
             }
         }
         None
+    }
+
+    /// Return `Some(loc)` for an active entry, `Some(None)` for a deletion, and `None` when no
+    /// stream touched `key`.
+    fn lookup(&mut self, key: &K) -> Option<Option<Location<F>>> {
+        self.resolve(key).map(DiffEntry::loc)
     }
 }
 
@@ -465,7 +527,9 @@ impl<'a, K: Ord, F: Family, V> AppliedAncestorResolver<'a, K, F, V> {
 /// and remain sequential candidates.
 ///
 /// `current::batch::next_candidate` mirrors this contract over a layered `BitmapBatch` chain;
-/// both must obey it.
+/// both must obey it. Production uses [`fill_candidates`], which produces the same sequence under
+/// a single read guard; this single-step form is retained as the test oracle.
+#[cfg(test)]
 fn next_candidate<F: Family, const N: usize>(
     bitmap: &Shared<N>,
     floor: Location<F>,
@@ -483,6 +547,22 @@ fn next_candidate<F: Family, const N: usize>(
     }
     let candidate = floor.max(bitmap_len);
     (candidate < tip).then(|| Location::new(candidate))
+}
+
+/// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` under a single bitmap
+/// read guard, returning the next `floor`. Produces the same sequence as repeatedly calling
+/// [`next_candidate`].
+fn fill_candidates<F: Family, const N: usize>(
+    bitmap: &Shared<N>,
+    floor: Location<F>,
+    tip: u64,
+    limit: usize,
+    out: &mut Vec<Location<F>>,
+) -> Location<F> {
+    let mut raw: Vec<u64> = Vec::with_capacity(limit);
+    let next = bitmap.fill_candidates(*floor, tip, limit, &mut raw);
+    out.extend(raw.into_iter().map(Location::new));
+    Location::new(next)
 }
 
 /// Resolve `loc` to an op within the in-memory ancestor region
@@ -565,15 +645,17 @@ where
     }
 
     /// Resolve an operation by its location `loc` if it can be done synchronously (e.g. without
-    /// I/O), or return `None` otherwise.
-    fn try_read_op_sync<R: Reader<Item = Operation<F, U>>>(
+    /// I/O), or return `None` otherwise. Decodes journal page-cache hits into `scratch` to avoid a
+    /// per-call allocation.
+    fn try_read_op_sync_into<R: Reader<Item = Operation<F, U>>>(
         &self,
         loc: Location<F>,
         batch_ops: &[Operation<F, U>],
         reader: &R,
+        scratch: &mut Vec<u8>,
     ) -> Option<Operation<F, U>> {
         self.try_read_op_from_uncommitted(loc, batch_ops)
-            .or_else(|| reader.try_read_sync(*loc))
+            .or_else(|| reader.try_read_sync_into(*loc, scratch))
     }
 
     /// Read a single operation by location.
@@ -583,10 +665,13 @@ where
         batch_ops: &[Operation<F, U>],
         reader: &R,
     ) -> Result<Operation<F, U>, crate::qmdb::Error<F>> {
-        match self.try_read_op_sync(loc, batch_ops, reader) {
-            Some(op) => Ok(op),
-            None => Ok(reader.read(*loc).await?),
+        if let Some(op) = self.try_read_op_from_uncommitted(loc, batch_ops) {
+            return Ok(op);
         }
+        if let Some(op) = reader.try_read_sync(*loc) {
+            return Ok(op);
+        }
+        Ok(reader.read(*loc).await?)
     }
 
     /// Read multiple operations by location.
@@ -596,44 +681,44 @@ where
         batch_ops: &[Operation<F, U>],
         reader: &R,
     ) -> Result<Vec<Operation<F, U>>, crate::qmdb::Error<F>> {
-        // Resolve hits synchronously: batch/ancestor first, then journal page cache.
-        let results: Vec<Option<Operation<F, U>>> = locations
-            .iter()
-            .map(|loc| self.try_read_op_sync(*loc, batch_ops, reader))
-            .collect();
+        // First pass: resolve synchronously into an output Vec, recording the positions and output
+        // slots of disk misses. A single scratch buffer is reused across all sync probes. On the
+        // all-hits path (the warm steady state) nothing is reallocated and no second collect runs.
+        let mut out: Vec<Operation<F, U>> = Vec::with_capacity(locations.len());
+        let mut misses: Vec<(usize, u64)> = Vec::new();
+        let mut scratch: Vec<u8> = Vec::new();
+        for (idx, loc) in locations.iter().enumerate() {
+            match self.try_read_op_sync_into(*loc, batch_ops, reader, &mut scratch) {
+                Some(op) => out.push(op),
+                None => {
+                    // Reserve the slot; filled in after the batched disk read below.
+                    out.push(Operation::CommitFloor(None, Location::new(0)));
+                    misses.push((idx, **loc));
+                }
+            }
+        }
+        if misses.is_empty() {
+            return Ok(out);
+        }
 
         // Batch-read disk misses. Reader::read_many requires sorted, unique positions, while this
         // helper preserves the caller's order and permits duplicates.
-        let misses: Vec<(usize, u64)> = locations
-            .iter()
-            .zip(results.iter())
-            .enumerate()
-            .filter_map(|(idx, (loc, cached))| cached.is_none().then_some((idx, **loc)))
-            .collect();
-        if misses.is_empty() {
-            return Ok(results.into_iter().map(Option::unwrap).collect());
-        }
-
         let mut miss_positions: Vec<u64> = misses.iter().map(|(_, loc)| *loc).collect();
         miss_positions.sort_unstable();
         miss_positions.dedup();
 
         let disk_results = reader.read_many(&miss_positions).await?;
 
-        // Merge disk results back in order.
-        let mut results = results;
+        // Merge disk results back into their reserved slots.
         for (idx, loc) in misses {
             // `miss_positions` is sorted and deduped, and `loc` came from it before deduping, so
             // binary search must find the matching read_many result.
             let result_idx = miss_positions
                 .binary_search(&loc)
                 .expect("disk result missing for requested location");
-            results[idx] = Some(disk_results[result_idx].clone());
+            out[idx] = disk_results[result_idx].clone();
         }
-        Ok(results
-            .into_iter()
-            .map(|r| r.expect("operation should be resolved"))
-            .collect())
+        Ok(out)
     }
 
     /// Gather existing-key locations for all keys in `mutations`.
@@ -665,8 +750,12 @@ where
                 locations.extend(db.snapshot.get(key).copied());
             }
         } else {
+            // `mutations` is a BTreeMap, so keys iterate in ascending order; a single forward
+            // cursor sweep over the ancestor diffs replaces a per-key binary search per ancestor.
+            let mut cursors =
+                AncestorCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()));
             for key in mutations.keys() {
-                match resolve_in_ancestors(&self.ancestors, key) {
+                match cursors.resolve(key) {
                     Some(DiffEntry::Deleted { .. }) => {
                         // Stale; handled via extract_parent_deleted_creates.
                     }
@@ -706,10 +795,11 @@ where
             return Vec::new();
         }
         let mut creates = Vec::new();
+        // `retain` visits keys in ascending BTreeMap order, so a forward cursor sweep over the
+        // ancestor diffs replaces a per-key binary search per ancestor.
+        let mut cursors = AncestorCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()));
         mutations.retain(|key, value| {
-            if let Some(DiffEntry::Deleted { base_old_loc }) =
-                resolve_in_ancestors(&self.ancestors, key)
-            {
+            if let Some(DiffEntry::Deleted { base_old_loc }) = cursors.resolve(key) {
                 if let Some(v) = value.take() {
                     creates.push((key.clone(), v, *base_old_loc));
                     return false;
@@ -730,7 +820,7 @@ where
         active_keys_delta: isize,
         user_steps: u64,
         metadata: Option<U::Value>,
-        mut next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
+        mut fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
         reader: R,
         db: &Db<F, E, C, I, H, U, N, S>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U, S>>, crate::qmdb::Error<F>>
@@ -746,27 +836,33 @@ where
         let total_active_keys = self.base_active_keys as isize + active_keys_delta;
         let mut floor = self.base_inactivity_floor_loc;
 
+        // Reserve capacity for the floor-raise ops up front. ~`total_steps` ops are pushed below;
+        // without this the multi-MB `ops` Vec reallocates geometrically as it grows.
+        ops.reserve(total_steps as usize);
+
         if total_active_keys > 0 {
             // Floor raise: advance the inactivity floor by `total_steps` active operations.
             // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let fixed_tip = self.base_size + ops.len() as u64;
+            // Committed boundary. A candidate below this came from a set bit in the committed
+            // bitmap (the candidate source only returns set committed bits). Overlays never set a
+            // committed-prefix bit that the committed bitmap has clear: moves append above the
+            // tip, and supersessions only clear committed bits. So a committed candidate is active
+            // unless an overlay in this chain superseded its key, which the diff/ancestor lookup
+            // below detects.
+            let committed_len = bitmap::Readable::<N>::len(db.bitmap.as_ref());
             let mut moved = 0u64;
             let mut scan_from = floor;
             let mut floor_diff = Vec::with_capacity(total_steps as usize);
+            let mut candidates: Vec<Location<F>> = Vec::with_capacity(MAX_CONCURRENT_READS as usize);
 
             while moved < total_steps {
                 // Collect candidates, capped by the number of active ops still needed.
                 // `scan_from` tracks prefetch progress separately from `floor`, so
                 // early exit cannot leave `floor` past unprocessed candidates.
                 let limit = ((total_steps - moved) as usize).min(MAX_CONCURRENT_READS as usize);
-                let mut candidates = Vec::with_capacity(limit);
-                while candidates.len() < limit {
-                    let Some(candidate) = next_candidate(scan_from, fixed_tip) else {
-                        break;
-                    };
-                    candidates.push(candidate);
-                    scan_from = Location::new(*candidate + 1);
-                }
+                candidates.clear();
+                scan_from = fill_candidates(scan_from, fixed_tip, limit, &mut candidates);
                 if candidates.is_empty() {
                     break;
                 }
@@ -776,9 +872,9 @@ where
                 let resolved = self.read_ops(&candidates, &ops, &reader).await?;
 
                 // Process results in order, moving active ops to the tip.
-                for (candidate, op) in candidates.into_iter().zip(resolved) {
+                for (candidate, op) in candidates.iter().copied().zip(resolved) {
                     floor = Location::new(*candidate + 1);
-                    let Some(key) = op.key().cloned() else {
+                    let Some(key) = op.key() else {
                         continue; // skip CommitFloor and other non-keyed ops
                     };
                     // A single batch-diff lookup drives the activity check, the base
@@ -786,25 +882,25 @@ where
                     // even for candidates whose committed bitmap bit is set: this batch's diff
                     // or an uncommitted ancestor diff may supersede the committed location, and
                     // neither source is reflected in the bitmap.
-                    let search = diff.binary_search_by(|(k, _)| k.cmp(&key));
+                    let search = diff.binary_search_by(|(k, _)| k.cmp(key));
                     let (active, base_old_loc) = match search {
                         Ok(idx) => {
                             let entry = &diff[idx].1;
                             (entry.loc() == Some(candidate), entry.base_old_loc())
                         }
-                        Err(_) => resolve_in_ancestors(&self.ancestors, &key).map_or_else(
-                            || {
-                                (
-                                    db.snapshot.get(&key).any(|&l| l == candidate),
-                                    Some(candidate),
-                                )
-                            },
-                            |entry| (entry.loc() == Some(candidate), entry.base_old_loc()),
-                        ),
+                        Err(_) => match resolve_in_ancestors(&self.ancestors, key) {
+                            Some(entry) => (entry.loc() == Some(candidate), entry.base_old_loc()),
+                            None if *candidate < committed_len => (true, Some(candidate)),
+                            None => (
+                                db.snapshot.get(key).any(|&l| l == candidate),
+                                Some(candidate),
+                            ),
+                        },
                     };
                     if !active {
                         continue;
                     }
+                    let key = key.clone();
                     let new_loc = Location::new(self.base_size + ops.len() as u64);
                     let value = extract_update_value(&op);
                     ops.push(op);
@@ -831,8 +927,26 @@ where
                 // `floor_diff` only accumulates keys that were not already present in `diff`.
                 // A key can only be moved once during this floor raise because, after it is
                 // moved, its new location lies above `fixed_tip` and the scan never revisits it.
-                diff.extend(floor_diff);
-                diff.sort_by(|a, b| a.0.cmp(&b.0));
+                // `floor_diff` keys are disjoint from `diff` keys, so a two-cursor merge of the
+                // two already-sorted runs reproduces the full sort without re-sorting `diff`.
+                floor_diff.sort_by(|a, b| a.0.cmp(&b.0));
+                let mut merged = Vec::with_capacity(diff.len() + floor_diff.len());
+                let mut di = diff.into_iter().peekable();
+                let mut fi = floor_diff.into_iter().peekable();
+                loop {
+                    let take_floor = match (di.peek(), fi.peek()) {
+                        (Some(d), Some(f)) => f.0 < d.0,
+                        (None, Some(_)) => true,
+                        (Some(_), None) => false,
+                        (None, None) => break,
+                    };
+                    if take_floor {
+                        merged.push(fi.next().unwrap());
+                    } else {
+                        merged.push(di.next().unwrap());
+                    }
+                }
+                diff = merged;
                 assert!(diff.is_sorted_by(|a, b| a.0 < b.0));
             }
         } else {
@@ -910,7 +1024,7 @@ where
         existing: Vec<ExistingEntry<K, F, V::Value>>,
         mut mutations: BTreeMap<K, Option<V::Value>>,
         metadata: Option<V::Value>,
-        next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
+        fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
         reader: R,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
@@ -1003,7 +1117,7 @@ where
             active_keys_delta,
             user_steps,
             metadata,
-            next_candidate,
+            fill_candidates,
             reader,
             db,
         )
@@ -1022,7 +1136,7 @@ where
     /// If the same key is written multiple times within a batch, the last
     /// value wins.
     pub fn write(mut self, key: U::Key, value: Option<U::Value>) -> Self {
-        self.mutations.insert(key, value);
+        self.mutations.push(key, value);
         self
     }
 
@@ -1046,7 +1160,7 @@ where
             db_size.max(oldest_base)
         });
         (
-            self.mutations,
+            self.mutations.into_sorted(),
             Merkleizer {
                 journal_batch: self.journal_batch,
                 ancestors,
@@ -1179,56 +1293,55 @@ where
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        let mut values: Vec<Option<U::Value>> = Vec::with_capacity(keys.len());
-        let mut locations: HashMap<U::Key, ResolvedLocation<F>> =
-            HashMap::with_capacity(keys.len());
+        let mut values: Vec<Option<U::Value>> =
+            iter::repeat_with(|| None).take(keys.len()).collect();
+        let mut locations: AHashMap<U::Key, ResolvedLocation<F>> =
+            AHashMap::with_capacity(keys.len());
         let mut db_indices = Vec::new();
         let mut db_keys = Vec::new();
 
-        for (i, key) in keys.iter().enumerate() {
-            // Resolve through the ancestor diff chain (parent first). An Active entry's `loc` is
-            // the uncommitted ancestor location used for op-gen ordering; a Deleted entry means
-            // the key is absent in the chain's view.
-            let mut found = false;
-            if let Some(parent) = self.base.parent() {
-                let mut resolve = |entry: &DiffEntry<F, U::Value>| match entry {
-                    DiffEntry::Active {
+        // Resolve through the ancestor diff chain (parent first). An Active entry's `loc` is the
+        // uncommitted ancestor location used for op-gen ordering; a Deleted entry means the key is
+        // absent in the chain's view. Sweep ancestor diffs with forward cursors in ascending key
+        // order (cursors require it), so the caller's slice is visited via a sorted index
+        // permutation rather than a per-key binary search per ancestor.
+        let chain: Vec<Arc<MerkleizedBatch<F, H::Digest, U, S>>> =
+            self.base.parent().map_or_else(Vec::new, |parent| {
+                let mut v = vec![Arc::clone(parent)];
+                v.extend(parent.ancestors());
+                v
+            });
+        if chain.is_empty() {
+            db_indices.extend(0..keys.len());
+            db_keys.extend_from_slice(keys);
+        } else {
+            let mut order: Vec<usize> = (0..keys.len()).collect();
+            order.sort_unstable_by(|&a, &b| keys[a].cmp(keys[b]));
+            let mut cursors = AncestorCursors::new(chain.iter().map(|a| a.diff.as_slice()));
+            for i in order {
+                let key = keys[i];
+                match cursors.resolve(key) {
+                    Some(DiffEntry::Active {
                         value,
                         loc,
                         base_old_loc,
-                    } => {
+                    }) => {
                         locations.insert(
-                            (**key).clone(),
+                            key.clone(),
                             ResolvedLocation {
                                 iter_loc: *loc,
                                 base_old_loc: *base_old_loc,
                             },
                         );
-                        Some(value.clone())
+                        values[i] = Some(value.clone());
                     }
-                    DiffEntry::Deleted { .. } => None,
-                };
-                if let Some(entry) = lookup_sorted(parent.diff.as_slice(), *key) {
-                    values.push(resolve(entry));
-                    found = true;
-                } else {
-                    for batch in parent.ancestors() {
-                        if let Some(entry) = lookup_sorted(batch.diff.as_slice(), *key) {
-                            values.push(resolve(entry));
-                            found = true;
-                            break;
-                        }
+                    Some(DiffEntry::Deleted { .. }) => {}
+                    None => {
+                        db_indices.push(i);
+                        db_keys.push(key);
                     }
                 }
             }
-
-            if found {
-                continue;
-            }
-
-            db_indices.push(i);
-            db_keys.push(*key);
-            values.push(None);
         }
 
         if !db_keys.is_empty() {
@@ -1281,8 +1394,8 @@ where
         I: UnorderedIndex<Value = Location<F>>,
     {
         let resolved = core::mem::take(&mut self.resolved);
-        self.merkleize_with_floor_scan(db, resolved, metadata, |floor, tip| {
-            next_candidate(&db.bitmap, floor, tip)
+        self.merkleize_with_floor_scan(db, resolved, metadata, |floor, tip, limit, out| {
+            fill_candidates(&db.bitmap, floor, tip, limit, out)
         })
         .await
     }
@@ -1296,9 +1409,9 @@ where
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
-        resolved: HashMap<K, ResolvedLocation<F>>,
+        resolved: AHashMap<K, ResolvedLocation<F>>,
         metadata: Option<V::Value>,
-        next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
+        fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
     where
         E: Context,
@@ -1368,7 +1481,7 @@ where
         // that order, and pre-resolved entries are merged into it here.
         existing.sort_by(|a, b| a.iter_loc.cmp(&b.iter_loc));
 
-        m.finish_unordered(existing, rest, metadata, next_candidate, reader, db)
+        m.finish_unordered(existing, rest, metadata, fill_candidates, reader, db)
             .await
     }
 
@@ -1412,8 +1525,8 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(db, metadata, |floor, tip| {
-            next_candidate(&db.bitmap, floor, tip)
+        self.merkleize_with_floor_scan(db, metadata, |floor, tip, limit, out| {
+            fill_candidates(&db.bitmap, floor, tip, limit, out)
         })
         .await
     }
@@ -1428,7 +1541,7 @@ where
         self,
         db: &Db<F, E, C, I, H, update::Ordered<K, V>, N, S>,
         metadata: Option<V::Value>,
-        next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
+        fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Ordered<K, V>, S>>, crate::qmdb::Error<F>>
     where
         E: Context,
@@ -1734,7 +1847,7 @@ where
             active_keys_delta,
             user_steps,
             metadata,
-            next_candidate,
+            fill_candidates,
             reader,
             db,
         )
@@ -1789,9 +1902,9 @@ where
     {
         UnmerkleizedBatch {
             journal_batch: self.journal_batch.new_batch::<H>(),
-            mutations: BTreeMap::new(),
+            mutations: Mutations::new(),
             base: Base::Child(Arc::clone(self)),
-            resolved: HashMap::new(),
+            resolved: AHashMap::new(),
         }
     }
 
@@ -1908,13 +2021,13 @@ where
         let journal_size = *self.last_commit_loc + 1;
         UnmerkleizedBatch {
             journal_batch: self.log.new_batch(),
-            mutations: BTreeMap::new(),
+            mutations: Mutations::new(),
             base: Base::Db {
                 db_size: journal_size,
                 inactivity_floor_loc: self.inactivity_floor_loc,
                 active_keys: self.active_keys,
             },
-            resolved: HashMap::new(),
+            resolved: AHashMap::new(),
         }
     }
 }
@@ -1993,7 +2106,7 @@ where
                         pending.push(ancestor_diff.as_slice());
                     }
                 }
-                let mut resolver = AppliedAncestorResolver::new(applied);
+                let mut resolver = AncestorCursors::new(applied);
                 let merge = DiffMerge::new(
                     iter::once(batch.diff.as_slice()).chain(pending.iter().copied()),
                 );
@@ -2110,7 +2223,7 @@ mod trait_impls {
         type Merkleized = Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>;
 
         fn write(mut self, key: K, value: Option<V::Value>) -> Self {
-            self.mutations.insert(key, value);
+            self.mutations.push(key, value);
             self
         }
 
@@ -2144,7 +2257,7 @@ mod trait_impls {
         type Merkleized = Arc<MerkleizedBatch<F, H::Digest, update::Ordered<K, V>, S>>;
 
         fn write(mut self, key: K, value: Option<V::Value>) -> Self {
-            self.mutations.insert(key, value);
+            self.mutations.push(key, value);
             self
         }
 
@@ -2366,8 +2479,7 @@ mod tests {
             (4, active(40, 40)),
             (5, active(50, 50)),
         ];
-        let mut resolver =
-            AppliedAncestorResolver::new([parent.as_slice(), grandparent.as_slice()]);
+        let mut resolver = AncestorCursors::new([parent.as_slice(), grandparent.as_slice()]);
 
         // Lookups are issued in ascending order, as they are from DiffMerge in apply_batch.
         assert_eq!(resolver.lookup(&1), None);

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -649,26 +649,6 @@ where
         locations
     }
 
-    /// Check if the operation at `loc` for `key` is still active.
-    fn is_active_at<E, C, I, const N: usize>(
-        &self,
-        key: &U::Key,
-        loc: Location<F>,
-        batch_diff: &DiffSlice<U::Key, F, U::Value>,
-        db: &Db<F, E, C, I, H, U, N, S>,
-    ) -> bool
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        let diff_entry = lookup_sorted(batch_diff, key);
-        if let Some(entry) = diff_entry.or_else(|| resolve_in_ancestors(&self.ancestors, key)) {
-            return entry.loc() == Some(loc);
-        }
-        db.snapshot.get(key).any(|&l| l == loc)
-    }
-
     /// Extract keys that were deleted by a parent batch but are being
     /// re-created by this child batch. Removes those keys from `mutations`
     /// and returns `(key, value, base_old_loc)` entries.
@@ -756,20 +736,31 @@ where
                     let Some(key) = op.key().cloned() else {
                         continue; // skip CommitFloor and other non-keyed ops
                     };
-                    // `is_active_at` is required even for set bits in the committed bitmap
-                    // range: this batch's own diff or an uncommitted ancestor diff may
-                    // supersede the committed location, and neither source is reflected in
-                    // the bitmap.
-                    if !self.is_active_at(&key, candidate, &diff, db) {
+                    // A single batch-diff lookup drives the activity check, the base
+                    // provenance, and the in-place diff update below. Revalidation is required
+                    // even for candidates whose committed bitmap bit is set: this batch's diff
+                    // or an uncommitted ancestor diff may supersede the committed location, and
+                    // neither source is reflected in the bitmap.
+                    let search = diff.binary_search_by(|(k, _)| k.cmp(&key));
+                    let (active, base_old_loc) = match search {
+                        Ok(idx) => {
+                            let entry = &diff[idx].1;
+                            (entry.loc() == Some(candidate), entry.base_old_loc())
+                        }
+                        Err(_) => resolve_in_ancestors(&self.ancestors, &key).map_or_else(
+                            || {
+                                (
+                                    db.snapshot.get(&key).any(|&l| l == candidate),
+                                    Some(candidate),
+                                )
+                            },
+                            |entry| (entry.loc() == Some(candidate), entry.base_old_loc()),
+                        ),
+                    };
+                    if !active {
                         continue;
                     }
                     let new_loc = Location::new(self.base_size + ops.len() as u64);
-                    let search = diff.binary_search_by(|(k, _)| k.cmp(&key));
-                    let base_old_loc = match &search {
-                        Ok(idx) => diff[*idx].1.base_old_loc(),
-                        Err(_) => resolve_in_ancestors(&self.ancestors, &key)
-                            .map_or(Some(candidate), DiffEntry::base_old_loc),
-                    };
                     let value = extract_update_value(&op);
                     ops.push(op);
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -99,6 +99,31 @@ pub(crate) fn lookup_sorted<'a, K: Ord, V>(entries: &'a [(K, V)], key: &K) -> Op
         .map(|idx| &entries[idx].1)
 }
 
+/// A classified existing-key mutation, in op-gen (iter-location) order.
+struct ExistingEntry<K, F: Family, V> {
+    key: K,
+    /// Location used for op-gen ordering.
+    iter_loc: Location<F>,
+    /// Committed-DB provenance.
+    base_old_loc: Option<Location<F>>,
+    /// `Some` for update, `None` for delete.
+    value: Option<V>,
+}
+
+/// A key's resolved location, as produced by `get_many_with_locations` and consumed by
+/// `merkleize_resolved`. Carries enough provenance to reproduce the op-gen ordering and
+/// `base_old_loc` without re-reading the operation.
+#[derive(Clone, Copy, Debug)]
+pub struct ResolvedLocation<F: Family> {
+    /// The location used for op-gen ordering. For a key resolved through an ancestor diff this is
+    /// the uncommitted ancestor location; for a committed-DB key it is the matched committed
+    /// location.
+    pub iter_loc: Location<F>,
+    /// The key's committed-DB location (committed provenance), or `None` if the key was created by
+    /// an ancestor and never existed in the committed DB.
+    pub base_old_loc: Option<Location<F>>,
+}
+
 /// Where this batch's inherited state comes from.
 enum Base<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy>
 where
@@ -848,6 +873,123 @@ where
     }
 }
 
+// Unordered op-generation tail shared by `merkleize_with_floor_scan` and `merkleize_resolved`.
+impl<F: Family, K, V, H, S: Strategy> Merkleizer<F, H, update::Unordered<K, V>, S>
+where
+    K: Key,
+    V: ValueEncoding,
+    H: Hasher,
+    Operation<F, update::Unordered<K, V>>: Codec,
+{
+    /// Generate operations for the (location-sorted) existing entries followed by the creates,
+    /// then run the shared `finish` tail. `existing` must already be in iter-location order.
+    #[allow(clippy::type_complexity)]
+    async fn finish_unordered<E, C, I, R, const N: usize>(
+        self,
+        existing: Vec<ExistingEntry<K, F, V::Value>>,
+        mut mutations: BTreeMap<K, Option<V::Value>>,
+        metadata: Option<V::Value>,
+        next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
+        reader: R,
+        db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
+    ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Contiguous<Item = Operation<F, update::Unordered<K, V>>>,
+        I: UnorderedIndex<Value = Location<F>>,
+        R: Reader<Item = Operation<F, update::Unordered<K, V>>>,
+    {
+        let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
+            Vec::with_capacity(existing.len() + mutations.len() + 1);
+        let mut diff: DiffVec<K, F, V::Value> =
+            Vec::with_capacity(existing.len() + mutations.len());
+        let mut active_keys_delta: isize = 0;
+        let mut user_steps: u64 = 0;
+
+        // Process updates/deletes of existing keys in iter-location order.
+        for ExistingEntry {
+            key,
+            base_old_loc,
+            value,
+            ..
+        } in existing
+        {
+            let new_loc = Location::new(self.base_size + ops.len() as u64);
+            match value {
+                Some(value) => {
+                    ops.push(Operation::Update(update::Unordered(
+                        key.clone(),
+                        value.clone(),
+                    )));
+                    diff.push((
+                        key,
+                        DiffEntry::Active {
+                            value,
+                            loc: new_loc,
+                            base_old_loc,
+                        },
+                    ));
+                    user_steps += 1;
+                }
+                None => {
+                    ops.push(Operation::Delete(key.clone()));
+                    diff.push((key, DiffEntry::Deleted { base_old_loc }));
+                    active_keys_delta -= 1;
+                    user_steps += 1;
+                }
+            }
+        }
+
+        // Handle parent-deleted keys that the child wants to re-create.
+        let parent_deleted_creates = self.extract_parent_deleted_creates(&mut mutations);
+
+        // Process creates: remaining mutations (fresh keys) plus parent-deleted keys being
+        // re-created. Merge into a single key-sorted Vec so iteration order is deterministic
+        // regardless of whether the parent is pending or committed.
+        let mut creates: Vec<(K, V::Value, Option<Location<F>>)> =
+            Vec::with_capacity(mutations.len() + parent_deleted_creates.len());
+        for (key, value) in mutations {
+            if let Some(value) = value {
+                creates.push((key, value, None));
+            }
+        }
+        for (key, value, base_old_loc) in parent_deleted_creates {
+            creates.push((key, value, base_old_loc));
+        }
+        creates.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
+        for (key, value, base_old_loc) in creates {
+            let new_loc = Location::new(self.base_size + ops.len() as u64);
+            ops.push(Operation::Update(update::Unordered(
+                key.clone(),
+                value.clone(),
+            )));
+            diff.push((
+                key,
+                DiffEntry::Active {
+                    value,
+                    loc: new_loc,
+                    base_old_loc,
+                },
+            ));
+            active_keys_delta += 1;
+        }
+
+        diff.sort_by(|a, b| a.0.cmp(&b.0));
+
+        self.finish(
+            ops,
+            diff,
+            active_keys_delta,
+            user_steps,
+            metadata,
+            next_candidate,
+            reader,
+            db,
+        )
+        .await
+    }
+}
+
 impl<F: Family, H, U, S: Strategy> UnmerkleizedBatch<F, H, U, S>
 where
     U: update::Update + Send + Sync,
@@ -995,6 +1137,99 @@ where
 
         Ok(results)
     }
+
+    /// Batch read multiple keys, returning per key both the value and the resolved location to be
+    /// fed into [`merkleize_resolved`](UnmerkleizedBatch::merkleize_resolved).
+    ///
+    /// Resolution matches [`Self::get_many`] (mutations -> ancestor diffs -> committed DB) but is
+    /// intended to be called on a fresh batch (before any mutations are written), so the mutation
+    /// layer is skipped. For each key it returns:
+    /// - `None` if the key is absent (a create) or was deleted by an ancestor.
+    /// - `Some((value, resolved))` otherwise, where `resolved.iter_loc` is the location the
+    ///   merkleize op-gen loop would match the key at and `resolved.base_old_loc` is its committed
+    ///   provenance.
+    ///
+    /// Returns results in the same order as the input keys.
+    #[allow(clippy::type_complexity)]
+    pub async fn get_many_with_locations<E, C, I, const N: usize>(
+        &self,
+        keys: &[&U::Key],
+        db: &Db<F, E, C, I, H, U, N, S>,
+    ) -> Result<Vec<Option<(U::Value, ResolvedLocation<F>)>>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Contiguous<Item = Operation<F, U>>,
+        I: UnorderedIndex<Value = Location<F>> + 'static,
+    {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut results: Vec<Option<(U::Value, ResolvedLocation<F>)>> =
+            Vec::with_capacity(keys.len());
+        let mut db_indices = Vec::new();
+        let mut db_keys = Vec::new();
+
+        for (i, key) in keys.iter().enumerate() {
+            // Resolve through the ancestor diff chain (parent first). An Active entry's `loc` is
+            // the uncommitted ancestor location used for op-gen ordering; a Deleted entry means
+            // the key is absent in the chain's view.
+            let mut found = false;
+            if let Some(parent) = self.base.parent() {
+                let resolve = |entry: &DiffEntry<F, U::Value>| match entry {
+                    DiffEntry::Active {
+                        value,
+                        loc,
+                        base_old_loc,
+                    } => Some((
+                        value.clone(),
+                        ResolvedLocation {
+                            iter_loc: *loc,
+                            base_old_loc: *base_old_loc,
+                        },
+                    )),
+                    DiffEntry::Deleted { .. } => None,
+                };
+                if let Some(entry) = lookup_sorted(parent.diff.as_slice(), *key) {
+                    results.push(resolve(entry));
+                    found = true;
+                } else {
+                    for batch in parent.ancestors() {
+                        if let Some(entry) = lookup_sorted(batch.diff.as_slice(), *key) {
+                            results.push(resolve(entry));
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if found {
+                continue;
+            }
+
+            db_indices.push(i);
+            db_keys.push(*key);
+            results.push(None);
+        }
+
+        if !db_keys.is_empty() {
+            let db_results = db.get_many_with_locations(&db_keys).await?;
+            for (slot, value) in db_indices.into_iter().zip(db_results) {
+                results[slot] = value.map(|(v, loc)| {
+                    (
+                        v,
+                        ResolvedLocation {
+                            iter_loc: loc,
+                            base_old_loc: Some(loc),
+                        },
+                    )
+                });
+            }
+        }
+
+        Ok(results)
+    }
 }
 
 // Unordered-specific methods.
@@ -1056,15 +1291,9 @@ where
         let reader = db.log.reader().await;
         let results = m.read_ops(&locations, &[], &reader).await?;
 
-        // Generate user mutation operations.
-        let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
-            Vec::with_capacity(mutations.len() + 1);
-        let mut diff: DiffVec<K, F, V::Value> = Vec::with_capacity(mutations.len());
-        let mut active_keys_delta: isize = 0;
-        let mut user_steps: u64 = 0;
-
-        // Process updates/deletes of existing keys in location order.
-        // This includes keys from both the committed snapshot and ancestor diffs.
+        // Classify existing-key mutations in location order. Collision/ancestor-mismatch slots
+        // are skipped; their mutation (if any) is handled as a create below.
+        let mut existing: Vec<ExistingEntry<K, F, V::Value>> = Vec::with_capacity(locations.len());
         for (op, &old_loc) in results.iter().zip(&locations) {
             let key = op.key().expect("updates should have a key");
 
@@ -1089,83 +1318,100 @@ where
                 continue;
             };
 
-            // Write the user mutation at the next batch location while
-            // preserving the committed-base provenance computed above.
-            let new_loc = Location::new(m.base_size + ops.len() as u64);
-            match mutation {
-                Some(value) => {
-                    ops.push(Operation::Update(update::Unordered(
-                        key.clone(),
-                        value.clone(),
-                    )));
-                    diff.push((
-                        key.clone(),
-                        DiffEntry::Active {
-                            value,
-                            loc: new_loc,
-                            base_old_loc,
-                        },
-                    ));
-                    user_steps += 1;
-                }
-                None => {
-                    ops.push(Operation::Delete(key.clone()));
-                    diff.push((key.clone(), DiffEntry::Deleted { base_old_loc }));
-                    active_keys_delta -= 1;
-                    user_steps += 1;
-                }
-            }
+            existing.push(ExistingEntry {
+                key: key.clone(),
+                iter_loc: old_loc,
+                base_old_loc,
+                value: mutation,
+            });
         }
 
-        // Handle parent-deleted keys that the child wants to re-create.
-        let parent_deleted_creates = m.extract_parent_deleted_creates(&mut mutations);
+        m.finish_unordered(existing, mutations, metadata, next_candidate, reader, db)
+            .await
+    }
 
-        // Process creates: remaining mutations (fresh keys) plus parent-deleted
-        // keys being re-created. Both get an Update op and active_keys_delta += 1.
-        // Merge into a single sorted Vec so iteration order is deterministic
-        // regardless of whether the parent is pending or committed.
-        let mut creates: Vec<(K, V::Value, Option<Location<F>>)> =
-            Vec::with_capacity(mutations.len() + parent_deleted_creates.len());
-        for (key, value) in mutations {
-            if let Some(value) = value {
-                creates.push((key, value, None));
-            }
-        }
-        for (key, value, base_old_loc) in parent_deleted_creates {
-            creates.push((key, value, base_old_loc));
-        }
-        creates.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
-        for (key, value, base_old_loc) in creates {
-            let new_loc = Location::new(m.base_size + ops.len() as u64);
-            ops.push(Operation::Update(update::Unordered(
-                key.clone(),
-                value.clone(),
-            )));
-            diff.push((
-                key,
-                DiffEntry::Active {
+    /// Resolve, merkleize, and return an `Arc<MerkleizedBatch>`, reusing locations the caller
+    /// already resolved during state load via
+    /// [`get_many_with_locations`](UnmerkleizedBatch::get_many_with_locations).
+    ///
+    /// For each mutation key present (and `Some`) in `resolved`, the committed location and
+    /// provenance are taken from the map, skipping `gather_existing_locations` + `read_ops` for
+    /// that key. Keys absent from `resolved` (creates, or keys the caller chose not to pre-resolve)
+    /// fall back to the normal read-based resolution. A `resolved` entry of `None` indicates the
+    /// caller observed the key as absent; such keys are treated as creates/deletes-of-absent
+    /// without consulting the map.
+    ///
+    /// Produces a byte-identical root to [`merkleize`](Self::merkleize) for the same mutations.
+    #[allow(clippy::type_complexity)]
+    pub async fn merkleize_resolved<E, C, I, const N: usize>(
+        self,
+        db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
+        resolved: &std::collections::HashMap<K, Option<ResolvedLocation<F>>>,
+        metadata: Option<V::Value>,
+    ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
+        I: UnorderedIndex<Value = Location<F>>,
+    {
+        let next_candidate = |floor, tip| next_candidate(&db.bitmap, floor, tip);
+        let (mut mutations, m) = self.into_parts();
+
+        // Partition mutations: pre-resolved existing keys vs. the rest (creates and any keys not
+        // covered by the map). `resolved` entries that are `None` are treated as creates: the key
+        // was observed absent during load, so it carries no committed location.
+        let mut existing: Vec<ExistingEntry<K, F, V::Value>> = Vec::with_capacity(mutations.len());
+        let mut rest: BTreeMap<K, Option<V::Value>> = BTreeMap::new();
+        let keys: Vec<K> = mutations.keys().cloned().collect();
+        for key in keys {
+            let value = mutations.remove(&key).expect("key from mutations");
+            match resolved.get(&key) {
+                Some(Some(loc)) => existing.push(ExistingEntry {
+                    key,
+                    iter_loc: loc.iter_loc,
+                    base_old_loc: loc.base_old_loc,
                     value,
-                    loc: new_loc,
-                    base_old_loc,
-                },
-            ));
-            active_keys_delta += 1;
+                }),
+                _ => {
+                    rest.insert(key, value);
+                }
+            }
         }
 
-        diff.sort_by(|a, b| a.0.cmp(&b.0));
+        // Resolve the rest the normal way. This covers creates and any not-pre-resolved keys,
+        // and preserves the collision/ancestor-mismatch handling for them.
+        let reader = db.log.reader().await;
+        let mut rest_creates = rest;
+        if !rest_creates.is_empty() {
+            let locations = m.gather_existing_locations(&rest_creates, db, false);
+            let results = m.read_ops(&locations, &[], &reader).await?;
+            for (op, &old_loc) in results.iter().zip(&locations) {
+                let key = op.key().expect("updates should have a key");
+                let base_old_loc = if let Some(entry) = resolve_in_ancestors(&m.ancestors, key) {
+                    if entry.loc() != Some(old_loc) {
+                        continue;
+                    }
+                    entry.base_old_loc()
+                } else {
+                    Some(old_loc)
+                };
+                let Some(mutation) = rest_creates.remove(key) else {
+                    continue;
+                };
+                existing.push(ExistingEntry {
+                    key: key.clone(),
+                    iter_loc: old_loc,
+                    base_old_loc,
+                    value: mutation,
+                });
+            }
+        }
 
-        // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(
-            ops,
-            diff,
-            active_keys_delta,
-            user_steps,
-            metadata,
-            next_candidate,
-            reader,
-            db,
-        )
-        .await
+        // Existing-key ops are generated in iter-location order (matching the normal path).
+        existing.sort_by(|a, b| a.iter_loc.cmp(&b.iter_loc));
+
+        m.finish_unordered(existing, rest_creates, metadata, next_candidate, reader, db)
+            .await
     }
 }
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -29,7 +29,6 @@ use commonware_parallel::Strategy;
 use commonware_utils::bitmap;
 use core::{cmp::Ordering, ops::Range};
 use std::{
-    collections::BTreeMap,
     iter,
     sync::{Arc, Weak},
 };
@@ -75,13 +74,13 @@ impl<K: Ord + Clone, V: Clone> Mutations<K, V> {
             .find_map(|(k, v)| (k == key).then_some(v))
     }
 
-    /// Resolve to a key-sorted, last-write-wins `BTreeMap`.
+    /// Resolve to a key-sorted, last-write-wins [`SortedMutations`].
     ///
     /// A stable sort followed by a reverse-keep dedup preserves last-write-wins: equal keys keep
     /// their insertion order after the stable sort, and keeping the last of each run keeps the most
-    /// recent write. The result matches the order and final value mapping that successive
+    /// recent write. The resulting key order and final value mapping match what successive
     /// `BTreeMap::insert` calls would produce.
-    fn into_sorted(self) -> BTreeMap<K, Option<V>> {
+    fn into_sorted(self) -> SortedMutations<K, V> {
         let mut pending = self.pending;
         pending.sort_by(|a, b| a.0.cmp(&b.0));
         // Keep the LAST write of each equal-key run. `dedup_by` retains the first of a run, so
@@ -94,7 +93,71 @@ impl<K: Ord + Clone, V: Clone> Mutations<K, V> {
                 false
             }
         });
-        BTreeMap::from_iter(pending)
+        SortedMutations {
+            entries: pending.into_iter().map(|(k, v)| (k, Some(v))).collect(),
+        }
+    }
+}
+
+/// Key-sorted, last-write-wins mutations consumed by `merkleize`.
+///
+/// Backed by a sorted, deduplicated `Vec<(K, Option<Option<V>>)>`: the outer `Option` is a
+/// tombstone (`None` once the entry has been consumed via [`take`](Self::take) or
+/// [`retain_take`](Self::retain_take)), and the inner `Option<V>` is the mutation (`Some(value)`
+/// upsert, `None` delete). Replaces the prior `BTreeMap` rebuild: classification consumes entries
+/// in place by binary-searching the key, and the residual creates iterate in key order without a
+/// second container.
+struct SortedMutations<K, V> {
+    entries: Vec<(K, Option<Option<V>>)>,
+}
+
+impl<K: Ord, V> SortedMutations<K, V> {
+    const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.iter().all(|(_, slot)| slot.is_none())
+    }
+
+    /// Keys of the live (not yet consumed) entries, in ascending order.
+    fn keys(&self) -> impl Iterator<Item = &K> {
+        self.entries
+            .iter()
+            .filter_map(|(k, slot)| slot.as_ref().map(|_| k))
+    }
+
+    /// Consume and return the mutation for `key`, or `None` if absent or already consumed.
+    fn take(&mut self, key: &K) -> Option<Option<V>> {
+        let idx = self
+            .entries
+            .binary_search_by(|(k, _)| k.cmp(key))
+            .ok()?;
+        self.entries[idx].1.take()
+    }
+
+    /// Visit live entries in ascending key order. When `f` returns `Some`, the entry is consumed
+    /// and the value collected; otherwise it is left in place. `f` receives the mutation
+    /// (`Some(value)` upsert, `None` delete).
+    fn retain_take<T>(&mut self, mut f: impl FnMut(&K, &Option<V>) -> Option<T>) -> Vec<T> {
+        let mut taken = Vec::new();
+        for (key, slot) in self.entries.iter_mut() {
+            let Some(value) = slot.as_ref() else {
+                continue;
+            };
+            if let Some(t) = f(key, value) {
+                slot.take();
+                taken.push(t);
+            }
+        }
+        taken
+    }
+
+    /// Drain the remaining live entries in ascending key order.
+    fn into_creates(self) -> impl Iterator<Item = (K, Option<V>)> {
+        self.entries
+            .into_iter()
+            .filter_map(|(k, slot)| slot.map(|v| (k, v)))
     }
 }
 
@@ -733,7 +796,7 @@ where
     /// deleted; the unordered path can skip them.
     fn gather_existing_locations<E, C, I, const N: usize>(
         &self,
-        mutations: &BTreeMap<U::Key, Option<U::Value>>,
+        mutations: &SortedMutations<U::Key, U::Value>,
         db: &Db<F, E, C, I, H, U, N, S>,
         include_active_collision_siblings: bool,
     ) -> Vec<Location<F>>
@@ -750,8 +813,8 @@ where
                 locations.extend(db.snapshot.get(key).copied());
             }
         } else {
-            // `mutations` is a BTreeMap, so keys iterate in ascending order; a single forward
-            // cursor sweep over the ancestor diffs replaces a per-key binary search per ancestor.
+            // `mutations` keys iterate in ascending order; a single forward cursor sweep over the
+            // ancestor diffs replaces a per-key binary search per ancestor.
             let mut cursors =
                 AncestorCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()));
             for key in mutations.keys() {
@@ -789,25 +852,23 @@ where
     #[allow(clippy::type_complexity)]
     fn extract_parent_deleted_creates(
         &self,
-        mutations: &mut BTreeMap<U::Key, Option<U::Value>>,
+        mutations: &mut SortedMutations<U::Key, U::Value>,
     ) -> Vec<(U::Key, U::Value, Option<Location<F>>)> {
         if self.ancestors.is_empty() {
             return Vec::new();
         }
-        let mut creates = Vec::new();
-        // `retain` visits keys in ascending BTreeMap order, so a forward cursor sweep over the
+        // `retain_take` visits live keys in ascending order, so a forward cursor sweep over the
         // ancestor diffs replaces a per-key binary search per ancestor.
         let mut cursors = AncestorCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()));
-        mutations.retain(|key, value| {
-            if let Some(DiffEntry::Deleted { base_old_loc }) = cursors.resolve(key) {
-                if let Some(v) = value.take() {
-                    creates.push((key.clone(), v, *base_old_loc));
-                    return false;
-                }
+        mutations.retain_take(|key, value| {
+            if let (Some(v), Some(DiffEntry::Deleted { base_old_loc })) =
+                (value.as_ref(), cursors.resolve(key))
+            {
+                Some((key.clone(), v.clone(), *base_old_loc))
+            } else {
+                None
             }
-            true
-        });
-        creates
+        })
     }
 
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
@@ -1022,7 +1083,7 @@ where
     async fn finish_unordered<E, C, I, R, const N: usize>(
         self,
         existing: Vec<ExistingEntry<K, F, V::Value>>,
-        mut mutations: BTreeMap<K, Option<V::Value>>,
+        mut mutations: SortedMutations<K, V::Value>,
         metadata: Option<V::Value>,
         fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
         reader: R,
@@ -1083,7 +1144,7 @@ where
         // regardless of whether the parent is pending or committed.
         let mut creates: Vec<(K, V::Value, Option<Location<F>>)> =
             Vec::with_capacity(mutations.len() + parent_deleted_creates.len());
-        for (key, value) in mutations {
+        for (key, value) in mutations.into_creates() {
             if let Some(value) = value {
                 creates.push((key, value, None));
             }
@@ -1142,7 +1203,7 @@ where
 
     /// Split into pending mutations and the merkleization machinery.
     #[allow(clippy::type_complexity)]
-    fn into_parts(self) -> (BTreeMap<U::Key, Option<U::Value>>, Merkleizer<F, H, U, S>) {
+    fn into_parts(self) -> (SortedMutations<U::Key, U::Value>, Merkleizer<F, H, U, S>) {
         let ancestors: Vec<_> = self.base.parent().map_or_else(Vec::new, |parent| {
             let mut v = vec![Arc::clone(parent)];
             v.extend(parent.ancestors());
@@ -1425,11 +1486,13 @@ where
         // map routes every key through the read path: the behavior when no pre-resolution is
         // supplied.
         let mut existing: Vec<ExistingEntry<K, F, V::Value>> = Vec::with_capacity(mutations.len());
-        let mut rest: BTreeMap<K, Option<V::Value>> = if resolved.is_empty() {
+        let mut rest: SortedMutations<K, V::Value> = if resolved.is_empty() {
             mutations
         } else {
-            let mut rest = BTreeMap::new();
-            for (key, value) in mutations {
+            // `into_creates` drains in ascending key order, so the residual entries stay sorted
+            // without a re-sort; resolved keys are pulled into `existing` instead.
+            let mut entries = Vec::with_capacity(mutations.len());
+            for (key, value) in mutations.into_creates() {
                 match resolved.get(&key).copied() {
                     Some(hint) => existing.push(ExistingEntry {
                         key,
@@ -1437,12 +1500,10 @@ where
                         base_old_loc: hint.base_old_loc,
                         value,
                     }),
-                    None => {
-                        rest.insert(key, value);
-                    }
+                    None => entries.push((key, Some(value))),
                 }
             }
-            rest
+            SortedMutations { entries }
         };
 
         // Resolve the rest from the journal: gather candidate locations, read the ops, and
@@ -1465,7 +1526,7 @@ where
                 } else {
                     Some(old_loc)
                 };
-                let Some(mutation) = rest.remove(key) else {
+                let Some(mutation) = rest.take(key) else {
                     continue;
                 };
                 existing.push(ExistingEntry {
@@ -1578,7 +1639,7 @@ where
             };
             next_candidates.push(next_key);
 
-            let mutation = mutations.remove(&key);
+            let mutation = mutations.take(&key);
             prev_candidates.push((key.clone(), (value, old_loc)));
 
             let Some(mutation) = mutation else {
@@ -1607,7 +1668,7 @@ where
         // regardless of whether the parent is pending or committed.
         let mut created: Vec<(K, V::Value, Option<Location<F>>)> =
             Vec::with_capacity(mutations.len() + parent_deleted_creates.len());
-        for (key, value) in mutations {
+        for (key, value) in mutations.into_creates() {
             let Some(value) = value else {
                 continue; // delete of non-existent key
             };
@@ -2363,6 +2424,7 @@ mod tests {
     use commonware_cryptography::{sha256, Sha256};
     use commonware_parallel::Sequential;
     use commonware_runtime::{deterministic, Runner as _};
+    use std::collections::BTreeMap;
 
     const BITMAP_CHUNK_BITS: u64 = bitmap::Prunable::<BITMAP_CHUNK_BYTES>::CHUNK_SIZE_BITS;
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -206,6 +206,12 @@ where
 
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
+
+    /// Caller-supplied resolution of existing keys' committed locations, populated from
+    /// [`get_many_with_locations`](UnmerkleizedBatch::get_many_with_locations) during state load.
+    /// When a mutation key is present here, `merkleize` reuses the location and skips the
+    /// redundant journal read. Empty for callers that did not pre-resolve.
+    resolved: BTreeMap<U::Key, Option<ResolvedLocation<F>>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -1139,7 +1145,8 @@ where
     }
 
     /// Batch read multiple keys, returning per key both the value and the resolved location to be
-    /// fed into [`merkleize_resolved`](UnmerkleizedBatch::merkleize_resolved).
+    /// attached via [`with_resolved`](UnmerkleizedBatch::with_resolved) so the subsequent
+    /// [`merkleize`](UnmerkleizedBatch::merkleize) can skip re-reading these keys.
     ///
     /// Resolution matches [`Self::get_many`] (mutations -> ancestor diffs -> committed DB) but is
     /// intended to be called on a fresh batch (before any mutations are written), so the mutation
@@ -1252,7 +1259,7 @@ where
         ),
     )]
     pub async fn merkleize<E, C, I, const N: usize>(
-        self,
+        mut self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
         metadata: Option<V::Value>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
@@ -1261,7 +1268,8 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(db, metadata, |floor, tip| {
+        let resolved = core::mem::take(&mut self.resolved);
+        self.merkleize_with_floor_scan(db, resolved, metadata, |floor, tip| {
             next_candidate(&db.bitmap, floor, tip)
         })
         .await
@@ -1276,6 +1284,7 @@ where
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
+        resolved: BTreeMap<K, Option<ResolvedLocation<F>>>,
         metadata: Option<V::Value>,
         next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
@@ -1284,106 +1293,42 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        let (mut mutations, m) = self.into_parts();
+        let (mutations, m) = self.into_parts();
 
-        // Resolve existing keys.
-        let locations = m.gather_existing_locations(&mutations, db, false);
-        let reader = db.log.reader().await;
-        let results = m.read_ops(&locations, &[], &reader).await?;
-
-        // Classify existing-key mutations in location order. Collision/ancestor-mismatch slots
-        // are skipped; their mutation (if any) is handled as a create below.
-        let mut existing: Vec<ExistingEntry<K, F, V::Value>> = Vec::with_capacity(locations.len());
-        for (op, &old_loc) in results.iter().zip(&locations) {
-            let key = op.key().expect("updates should have a key");
-
-            // A key resolved via the ancestor diff must only match at its ancestor-diff
-            // location. Without this guard, a stale snapshot collision (the pre-parent DB
-            // snapshot still containing the key's old location) can consume the mutation at the
-            // wrong sort position, changing the operation order relative to the committed-state
-            // path. When the ancestor diff entry does match, use it to trace `base_old_loc`
-            // back to the key's location in the committed DB snapshot.
-            let base_old_loc = if let Some(entry) = resolve_in_ancestors(&m.ancestors, key) {
-                if entry.loc() != Some(old_loc) {
-                    continue;
-                }
-                entry.base_old_loc()
-            } else {
-                Some(old_loc)
-            };
-
-            let Some(mutation) = mutations.remove(key) else {
-                // Snapshot index collision: this operation's key does not match
-                // any mutation key. The mutation will be handled as a create below.
-                continue;
-            };
-
-            existing.push(ExistingEntry {
-                key: key.clone(),
-                iter_loc: old_loc,
-                base_old_loc,
-                value: mutation,
-            });
-        }
-
-        m.finish_unordered(existing, mutations, metadata, next_candidate, reader, db)
-            .await
-    }
-
-    /// Resolve, merkleize, and return an `Arc<MerkleizedBatch>`, reusing locations the caller
-    /// already resolved during state load via
-    /// [`get_many_with_locations`](UnmerkleizedBatch::get_many_with_locations).
-    ///
-    /// For each mutation key present (and `Some`) in `resolved`, the committed location and
-    /// provenance are taken from the map, skipping `gather_existing_locations` + `read_ops` for
-    /// that key. Keys absent from `resolved` (creates, or keys the caller chose not to pre-resolve)
-    /// fall back to the normal read-based resolution. A `resolved` entry of `None` indicates the
-    /// caller observed the key as absent; such keys are treated as creates/deletes-of-absent
-    /// without consulting the map.
-    ///
-    /// Produces a byte-identical root to [`merkleize`](Self::merkleize) for the same mutations.
-    #[allow(clippy::type_complexity)]
-    pub async fn merkleize_resolved<E, C, I, const N: usize>(
-        self,
-        db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
-        resolved: &std::collections::HashMap<K, Option<ResolvedLocation<F>>>,
-        metadata: Option<V::Value>,
-    ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        let next_candidate = |floor, tip| next_candidate(&db.bitmap, floor, tip);
-        let (mut mutations, m) = self.into_parts();
-
-        // Partition mutations: pre-resolved existing keys vs. the rest (creates and any keys not
-        // covered by the map). `resolved` entries that are `None` are treated as creates: the key
-        // was observed absent during load, so it carries no committed location.
+        // Split mutations into existing keys the caller pre-resolved (location reused from its
+        // state load, skipping the journal read) and the rest, resolved here. An empty `resolved`
+        // map routes every key through the read path: the behavior when no pre-resolution is
+        // supplied.
         let mut existing: Vec<ExistingEntry<K, F, V::Value>> = Vec::with_capacity(mutations.len());
-        let mut rest: BTreeMap<K, Option<V::Value>> = BTreeMap::new();
-        let keys: Vec<K> = mutations.keys().cloned().collect();
-        for key in keys {
-            let value = mutations.remove(&key).expect("key from mutations");
-            match resolved.get(&key) {
-                Some(Some(loc)) => existing.push(ExistingEntry {
-                    key,
-                    iter_loc: loc.iter_loc,
-                    base_old_loc: loc.base_old_loc,
-                    value,
-                }),
-                _ => {
-                    rest.insert(key, value);
+        let mut rest: BTreeMap<K, Option<V::Value>> = if resolved.is_empty() {
+            mutations
+        } else {
+            let mut rest = BTreeMap::new();
+            for (key, value) in mutations {
+                match resolved.get(&key) {
+                    Some(Some(loc)) => existing.push(ExistingEntry {
+                        key,
+                        iter_loc: loc.iter_loc,
+                        base_old_loc: loc.base_old_loc,
+                        value,
+                    }),
+                    _ => {
+                        rest.insert(key, value);
+                    }
                 }
             }
-        }
+            rest
+        };
 
-        // Resolve the rest the normal way. This covers creates and any not-pre-resolved keys,
-        // and preserves the collision/ancestor-mismatch handling for them.
+        // Resolve the rest from the journal: gather candidate locations, read the ops, and
+        // classify in location order. A key resolved via an ancestor diff must only match at its
+        // ancestor-diff location; otherwise a stale snapshot collision (the pre-parent DB snapshot
+        // still holding the key's old location) could consume the mutation at the wrong sort
+        // position and reorder operations. Collision/ancestor-mismatch slots are skipped and their
+        // mutation (if any) is handled as a create by `finish_unordered`.
         let reader = db.log.reader().await;
-        let mut rest_creates = rest;
-        if !rest_creates.is_empty() {
-            let locations = m.gather_existing_locations(&rest_creates, db, false);
+        if !rest.is_empty() {
+            let locations = m.gather_existing_locations(&rest, db, false);
             let results = m.read_ops(&locations, &[], &reader).await?;
             for (op, &old_loc) in results.iter().zip(&locations) {
                 let key = op.key().expect("updates should have a key");
@@ -1395,7 +1340,7 @@ where
                 } else {
                     Some(old_loc)
                 };
-                let Some(mutation) = rest_creates.remove(key) else {
+                let Some(mutation) = rest.remove(key) else {
                     continue;
                 };
                 existing.push(ExistingEntry {
@@ -1407,11 +1352,21 @@ where
             }
         }
 
-        // Existing-key ops are generated in iter-location order (matching the normal path).
+        // Existing-key ops are generated in iter-location order; the read path already yields
+        // that order, and pre-resolved entries are merged into it here.
         existing.sort_by(|a, b| a.iter_loc.cmp(&b.iter_loc));
 
-        m.finish_unordered(existing, rest_creates, metadata, next_candidate, reader, db)
+        m.finish_unordered(existing, rest, metadata, next_candidate, reader, db)
             .await
+    }
+
+    /// Attach existing-key locations the caller already resolved during state load (via
+    /// [`get_many_with_locations`](Self::get_many_with_locations)) so [`merkleize`](Self::merkleize)
+    /// reuses them instead of re-reading the journal for those keys. Keys absent from `resolved`
+    /// are resolved normally; a `None` entry marks a key observed as absent (handled as a create).
+    pub fn with_resolved(mut self, resolved: BTreeMap<K, Option<ResolvedLocation<F>>>) -> Self {
+        self.resolved = resolved;
+        self
     }
 }
 
@@ -1823,6 +1778,7 @@ where
             journal_batch: self.journal_batch.new_batch::<H>(),
             mutations: BTreeMap::new(),
             base: Base::Child(Arc::clone(self)),
+            resolved: BTreeMap::new(),
         }
     }
 
@@ -1945,6 +1901,7 @@ where
                 inactivity_floor_loc: self.inactivity_floor_loc,
                 active_keys: self.active_keys,
             },
+            resolved: BTreeMap::new(),
         }
     }
 }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -345,9 +345,18 @@ where
 
     /// Committed-DB locations resolved by this batch's reads (`get`/`get_many`), consumed by
     /// `merkleize`. When a mutation key is present here, `merkleize` reuses the location and
-    /// skips the redundant journal read. Only committed-snapshot resolutions are retained;
-    /// ancestor-diff resolutions could go stale if a committed ancestor is dropped before
-    /// merkleize. Interior-mutable because reads take `&self`; never held across an await.
+    /// skips the redundant journal read.
+    ///
+    /// Only committed-snapshot resolutions are retained. A key resolved from the committed
+    /// snapshot was in no live ancestor diff, and a legal intervening commit (applying this
+    /// batch's own ancestors) can only relocate keys present in an ancestor diff, so retained
+    /// entries cannot go stale. Ancestor-diff resolutions are NOT retained: their `base_old_loc`
+    /// goes stale if that ancestor is committed and dropped before merkleize, which is covered by
+    /// neither recovery mechanism (merkleize re-resolves non-retained keys against the live
+    /// chain, and `apply_batch`'s applied-ancestor fixup only sees diffs captured at merkleize).
+    /// See `test_unordered_fixed_retention_survives_ancestor_commit`.
+    ///
+    /// Interior-mutable because reads take `&self`; never held across an await.
     resolved: Mutex<AHashMap<U::Key, ResolvedLocation<F>>>,
 }
 
@@ -1420,6 +1429,9 @@ where
     Operation<F, update::Unordered<K, V>>: Codec,
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
+    ///
+    /// Consumes the locations retained by this batch's reads: keys loaded via `get`/`get_many`
+    /// before being written skip the journal re-read their resolution would otherwise require.
     #[allow(clippy::type_complexity)]
     #[tracing::instrument(
         name = "qmdb::any::batch::merkleize",
@@ -1466,10 +1478,9 @@ where
         let resolved = core::mem::take(&mut *self.resolved.lock());
         let (mutations, m) = self.into_parts();
 
-        // Split mutations into existing keys the caller pre-resolved (location reused from its
-        // state load, skipping the journal read) and the rest, resolved here. An empty `resolved`
-        // map routes every key through the read path: the behavior when no pre-resolution is
-        // supplied.
+        // Split mutations into existing keys this batch's reads already resolved (location
+        // reused, skipping the journal read) and the rest, resolved here. A batch that never
+        // read routes every key through the read path.
         let mut existing: Vec<ExistingEntry<K, F, V::Value>> = Vec::with_capacity(mutations.len());
         let mut rest: SortedMutations<K, V::Value> = if resolved.is_empty() {
             mutations

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -67,6 +67,10 @@ impl<K: Ord + Clone, V: Clone> Mutations<K, V> {
         self.pending.len()
     }
 
+    const fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+
     /// Latest value written for `key`, or `None` if `key` was never written in this batch.
     fn get(&self, key: &K) -> Option<&Option<V>> {
         self.pending
@@ -269,6 +273,14 @@ pub(crate) struct ResolvedLocation<F: Family> {
 #[derive(Debug)]
 pub struct ResolvedLocations<K, F: Family> {
     pub(crate) locations: AHashMap<K, ResolvedLocation<F>>,
+}
+
+impl<K: core::hash::Hash + Eq, F: Family> ResolvedLocations<K, F> {
+    /// Absorb `other`, which must have been resolved on the same batch as `self`. Re-resolving a
+    /// key on the same batch yields the same location, so overlapping entries are identical.
+    pub fn merge(&mut self, other: Self) {
+        self.locations.extend(other.locations);
+    }
 }
 
 /// Where this batch's inherited state comes from.
@@ -1403,11 +1415,10 @@ where
     /// attached via [`with_resolved`](UnmerkleizedBatch::with_resolved) so the subsequent
     /// [`merkleize`](UnmerkleizedBatch::merkleize) can skip re-reading these keys.
     ///
-    /// Resolution matches [`Self::get_many`] (mutations -> ancestor diffs -> committed DB) but is
-    /// intended to be called on a fresh batch (before any mutations are written), so the mutation
-    /// layer is skipped. Values are returned in the same order as the input keys, with `None` for
-    /// keys that are absent (a create) or were deleted by an ancestor; only present keys receive
-    /// an entry in the token.
+    /// Resolution matches [`Self::get_many`] (mutations -> ancestor diffs -> committed DB).
+    /// Values are returned in the same order as the input keys, with `None` for keys that are
+    /// absent (a create) or were deleted. Keys answered by this batch's pending mutations receive
+    /// no token entry (merkleize resolves written keys itself).
     #[allow(clippy::type_complexity)]
     pub async fn get_many_with_locations<E, C, I, const N: usize>(
         &self,
@@ -1426,6 +1437,19 @@ where
         let mut db_indices = Vec::new();
         let mut db_keys = Vec::new();
 
+        // Check local mutations.
+        let mut unresolved: Vec<usize> = Vec::with_capacity(keys.len());
+        if self.mutations.is_empty() {
+            unresolved.extend(0..keys.len());
+        } else {
+            for (i, key) in keys.iter().enumerate() {
+                match self.mutations.get(*key) {
+                    Some(value) => values[i] = value.clone(),
+                    None => unresolved.push(i),
+                }
+            }
+        }
+
         // Resolve through the ancestor diff chain (parent first). An Active entry's `loc` is the
         // uncommitted ancestor location used for op-gen ordering; a Deleted entry means the key is
         // absent in the chain's view. Sweep ancestor diffs with forward cursors in ascending key
@@ -1438,10 +1462,10 @@ where
                 v
             });
         if chain.is_empty() {
-            db_indices.extend(0..keys.len());
-            db_keys.extend_from_slice(keys);
+            db_keys.extend(unresolved.iter().map(|&i| keys[i]));
+            db_indices = unresolved;
         } else {
-            let mut order: Vec<usize> = (0..keys.len()).collect();
+            let mut order = unresolved;
             order.sort_unstable_by(|&a, &b| keys[a].cmp(keys[b]));
             let mut cursors = AncestorCursors::new(chain.iter().map(|a| a.diff.as_slice()));
             for i in order {
@@ -1510,7 +1534,7 @@ where
         ),
     )]
     pub async fn merkleize<E, C, I, const N: usize>(
-        mut self,
+        self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
         metadata: Option<V::Value>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
@@ -1519,8 +1543,7 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        let resolved = core::mem::take(&mut self.resolved);
-        self.merkleize_with_floor_scan(db, resolved, metadata, |floor, tip, limit, out| {
+        self.merkleize_with_floor_scan(db, metadata, |floor, tip, limit, out| {
             fill_candidates(&db.bitmap, floor, tip, limit, out)
         })
         .await
@@ -1533,9 +1556,8 @@ where
     /// committed state only -- uncommitted ancestor ops aren't tracked, and bits can be set for
     /// locations superseded by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
-        self,
+        mut self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
-        resolved: AHashMap<K, ResolvedLocation<F>>,
         metadata: Option<V::Value>,
         fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
@@ -1544,6 +1566,7 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
+        let resolved = core::mem::take(&mut self.resolved);
         let (mutations, m) = self.into_parts();
 
         // Split mutations into existing keys the caller pre-resolved (location reused from its

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -110,18 +110,32 @@ struct ExistingEntry<K, F: Family, V> {
     value: Option<V>,
 }
 
-/// A key's resolved location, as produced by `get_many_with_locations` and attached via
-/// `with_resolved`. Carries enough provenance to reproduce the op-gen ordering and `base_old_loc`
-/// without re-reading the operation during `merkleize`.
+/// A key's resolved location. Carries enough provenance to reproduce the op-gen ordering and
+/// `base_old_loc` without re-reading the operation during `merkleize`.
 #[derive(Clone, Copy, Debug)]
-pub struct ResolvedLocation<F: Family> {
+pub(crate) struct ResolvedLocation<F: Family> {
     /// The location used for op-gen ordering. For a key resolved through an ancestor diff this is
     /// the uncommitted ancestor location; for a committed-DB key it is the matched committed
     /// location.
-    pub iter_loc: Location<F>,
+    pub(crate) iter_loc: Location<F>,
     /// The key's committed-DB location (committed provenance), or `None` if the key was created by
     /// an ancestor and never existed in the committed DB.
-    pub base_old_loc: Option<Location<F>>,
+    pub(crate) base_old_loc: Option<Location<F>>,
+}
+
+/// Existing-key locations resolved by
+/// [`get_many_with_locations`](UnmerkleizedBatch::get_many_with_locations), attached to a batch
+/// via [`with_resolved`](UnmerkleizedBatch::with_resolved) so `merkleize` can skip re-reading
+/// those keys.
+///
+/// Entries are keyed internally by the key they were resolved for and must be attached to the
+/// batch they were resolved on. Applying and committing the batch's ancestors between resolution
+/// and merkleization is fine (ancestor-resolved locations are immutable and committed-resolved
+/// keys are untouched by those applies); attaching a token to any other batch may corrupt the
+/// database.
+#[derive(Debug)]
+pub struct ResolvedLocations<K, F: Family> {
+    pub(crate) locations: HashMap<K, ResolvedLocation<F>>,
 }
 
 /// Where this batch's inherited state comes from.
@@ -211,7 +225,7 @@ where
     /// [`get_many_with_locations`](UnmerkleizedBatch::get_many_with_locations) during state load.
     /// When a mutation key is present here, `merkleize` reuses the location and skips the
     /// redundant journal read. Empty for callers that did not pre-resolve.
-    resolved: HashMap<U::Key, Option<ResolvedLocation<F>>>,
+    resolved: HashMap<U::Key, ResolvedLocation<F>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -1145,36 +1159,29 @@ where
         Ok(results)
     }
 
-    /// Batch read multiple keys, returning per key both the value and the resolved location to be
+    /// Batch read multiple keys, returning the values plus a [`ResolvedLocations`] token to be
     /// attached via [`with_resolved`](UnmerkleizedBatch::with_resolved) so the subsequent
     /// [`merkleize`](UnmerkleizedBatch::merkleize) can skip re-reading these keys.
     ///
     /// Resolution matches [`Self::get_many`] (mutations -> ancestor diffs -> committed DB) but is
     /// intended to be called on a fresh batch (before any mutations are written), so the mutation
-    /// layer is skipped. For each key it returns:
-    /// - `None` if the key is absent (a create) or was deleted by an ancestor.
-    /// - `Some((value, resolved))` otherwise, where `resolved.iter_loc` is the location the
-    ///   merkleize op-gen loop would match the key at and `resolved.base_old_loc` is its committed
-    ///   provenance.
-    ///
-    /// Returns results in the same order as the input keys.
+    /// layer is skipped. Values are returned in the same order as the input keys, with `None` for
+    /// keys that are absent (a create) or were deleted by an ancestor; only present keys receive
+    /// an entry in the token.
     #[allow(clippy::type_complexity)]
     pub async fn get_many_with_locations<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
         db: &Db<F, E, C, I, H, U, N, S>,
-    ) -> Result<Vec<Option<(U::Value, ResolvedLocation<F>)>>, crate::qmdb::Error<F>>
+    ) -> Result<(Vec<Option<U::Value>>, ResolvedLocations<U::Key, F>), crate::qmdb::Error<F>>
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        if keys.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let mut results: Vec<Option<(U::Value, ResolvedLocation<F>)>> =
-            Vec::with_capacity(keys.len());
+        let mut values: Vec<Option<U::Value>> = Vec::with_capacity(keys.len());
+        let mut locations: HashMap<U::Key, ResolvedLocation<F>> =
+            HashMap::with_capacity(keys.len());
         let mut db_indices = Vec::new();
         let mut db_keys = Vec::new();
 
@@ -1184,27 +1191,30 @@ where
             // the key is absent in the chain's view.
             let mut found = false;
             if let Some(parent) = self.base.parent() {
-                let resolve = |entry: &DiffEntry<F, U::Value>| match entry {
+                let mut resolve = |entry: &DiffEntry<F, U::Value>| match entry {
                     DiffEntry::Active {
                         value,
                         loc,
                         base_old_loc,
-                    } => Some((
-                        value.clone(),
-                        ResolvedLocation {
-                            iter_loc: *loc,
-                            base_old_loc: *base_old_loc,
-                        },
-                    )),
+                    } => {
+                        locations.insert(
+                            (**key).clone(),
+                            ResolvedLocation {
+                                iter_loc: *loc,
+                                base_old_loc: *base_old_loc,
+                            },
+                        );
+                        Some(value.clone())
+                    }
                     DiffEntry::Deleted { .. } => None,
                 };
                 if let Some(entry) = lookup_sorted(parent.diff.as_slice(), *key) {
-                    results.push(resolve(entry));
+                    values.push(resolve(entry));
                     found = true;
                 } else {
                     for batch in parent.ancestors() {
                         if let Some(entry) = lookup_sorted(batch.diff.as_slice(), *key) {
-                            results.push(resolve(entry));
+                            values.push(resolve(entry));
                             found = true;
                             break;
                         }
@@ -1218,25 +1228,26 @@ where
 
             db_indices.push(i);
             db_keys.push(*key);
-            results.push(None);
+            values.push(None);
         }
 
         if !db_keys.is_empty() {
             let db_results = db.get_many_with_locations(&db_keys).await?;
             for (slot, value) in db_indices.into_iter().zip(db_results) {
-                results[slot] = value.map(|(v, loc)| {
-                    (
-                        v,
+                values[slot] = value.map(|(v, loc)| {
+                    locations.insert(
+                        (*keys[slot]).clone(),
                         ResolvedLocation {
                             iter_loc: loc,
                             base_old_loc: Some(loc),
                         },
-                    )
+                    );
+                    v
                 });
             }
         }
 
-        Ok(results)
+        Ok((values, ResolvedLocations { locations }))
     }
 }
 
@@ -1285,7 +1296,7 @@ where
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
-        resolved: HashMap<K, Option<ResolvedLocation<F>>>,
+        resolved: HashMap<K, ResolvedLocation<F>>,
         metadata: Option<V::Value>,
         next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
@@ -1306,14 +1317,14 @@ where
         } else {
             let mut rest = BTreeMap::new();
             for (key, value) in mutations {
-                match resolved.get(&key) {
-                    Some(Some(loc)) => existing.push(ExistingEntry {
+                match resolved.get(&key).copied() {
+                    Some(hint) => existing.push(ExistingEntry {
                         key,
-                        iter_loc: loc.iter_loc,
-                        base_old_loc: loc.base_old_loc,
+                        iter_loc: hint.iter_loc,
+                        base_old_loc: hint.base_old_loc,
                         value,
                     }),
-                    _ => {
+                    None => {
                         rest.insert(key, value);
                     }
                 }
@@ -1363,10 +1374,11 @@ where
 
     /// Attach existing-key locations the caller already resolved during state load (via
     /// [`get_many_with_locations`](Self::get_many_with_locations)) so [`merkleize`](Self::merkleize)
-    /// reuses them instead of re-reading the journal for those keys. Keys absent from `resolved`
-    /// are resolved normally; a `None` entry marks a key observed as absent (handled as a create).
-    pub fn with_resolved(mut self, resolved: HashMap<K, Option<ResolvedLocation<F>>>) -> Self {
-        self.resolved = resolved;
+    /// reuses them instead of re-reading the journal for those keys. Keys without an entry are
+    /// resolved normally. The token must have been resolved on this batch (see
+    /// [`ResolvedLocations`]).
+    pub fn with_resolved(mut self, resolved: ResolvedLocations<K, F>) -> Self {
+        self.resolved = resolved.locations;
         self
     }
 }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -34,8 +34,9 @@ use std::{
 };
 use tracing::debug;
 
-/// Maximum number of journal reads to issue concurrently during floor raising.
-const MAX_CONCURRENT_READS: u64 = 64;
+/// Maximum number of floor-raise candidates resolved per bulk read. Each batch fills candidates
+/// under one bitmap guard, then bulk-reads and decodes the journal misses in parallel.
+const FLOOR_READ_BATCH: u64 = 4096;
 
 type DiffVec<K, F, V> = Vec<(K, DiffEntry<F, V>)>;
 type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
@@ -76,15 +77,27 @@ impl<K: Ord + Clone, V: Clone> Mutations<K, V> {
 
     /// Resolve to a key-sorted, last-write-wins [`SortedMutations`].
     ///
-    /// A stable sort followed by a reverse-keep dedup preserves last-write-wins: equal keys keep
-    /// their insertion order after the stable sort, and keeping the last of each run keeps the most
+    /// Pairs each write with its insertion index, then sorts by `(key, index)`. The index makes
+    /// the order total so an unstable (and parallelizable) sort still preserves insertion order
+    /// within an equal-key run. Keeping the last of each run keeps the highest index, i.e. the most
     /// recent write. The resulting key order and final value mapping match what successive
     /// `BTreeMap::insert` calls would produce.
-    fn into_sorted(self) -> SortedMutations<K, V> {
-        let mut pending = self.pending;
-        pending.sort_by(|a, b| a.0.cmp(&b.0));
+    fn into_sorted<S: Strategy>(self, strategy: &S) -> SortedMutations<K, V>
+    where
+        K: Send,
+        V: Send,
+    {
+        let mut pending: Vec<(K, Option<V>, u32)> = self
+            .pending
+            .into_iter()
+            .enumerate()
+            .map(|(i, (k, v))| (k, v, i as u32))
+            .collect();
+        strategy.par_sort_unstable_by(&mut pending, |a, b| {
+            a.0.cmp(&b.0).then_with(|| a.2.cmp(&b.2))
+        });
         // Keep the LAST write of each equal-key run. `dedup_by` retains the first of a run, so
-        // swap so the retained slot holds the later (insertion-order-preserved) write.
+        // swap so the retained slot holds the later (highest-index) write.
         pending.dedup_by(|a, b| {
             if a.0 == b.0 {
                 core::mem::swap(a, b);
@@ -94,7 +107,7 @@ impl<K: Ord + Clone, V: Clone> Mutations<K, V> {
             }
         });
         SortedMutations {
-            entries: pending.into_iter().map(|(k, v)| (k, Some(v))).collect(),
+            entries: pending.into_iter().map(|(k, v, _)| (k, Some(v))).collect(),
         }
     }
 }
@@ -738,17 +751,23 @@ where
     }
 
     /// Read multiple operations by location.
+    ///
+    /// `locations` must be strictly increasing (the floor-raise candidate sequence is). Disk misses
+    /// are bulk-read and decoded in parallel via `strategy`.
     async fn read_ops<R: Reader<Item = Operation<F, U>>>(
         &self,
         locations: &[Location<F>],
         batch_ops: &[Operation<F, U>],
         reader: &R,
+        strategy: &S,
     ) -> Result<Vec<Operation<F, U>>, crate::qmdb::Error<F>> {
-        // First pass: resolve synchronously into an output Vec, recording the positions and output
-        // slots of disk misses. A single scratch buffer is reused across all sync probes. On the
-        // all-hits path (the warm steady state) nothing is reallocated and no second collect runs.
+        // First pass: resolve synchronously into an output Vec, recording the output slots and
+        // positions of disk misses. A single scratch buffer is reused across all sync probes. On
+        // the all-hits path (the warm steady state) nothing is reallocated and no second collect
+        // runs.
         let mut out: Vec<Operation<F, U>> = Vec::with_capacity(locations.len());
-        let mut misses: Vec<(usize, u64)> = Vec::new();
+        let mut miss_slots: Vec<usize> = Vec::new();
+        let mut miss_positions: Vec<u64> = Vec::new();
         let mut scratch: Vec<u8> = Vec::new();
         for (idx, loc) in locations.iter().enumerate() {
             match self.try_read_op_sync_into(*loc, batch_ops, reader, &mut scratch) {
@@ -756,30 +775,22 @@ where
                 None => {
                     // Reserve the slot; filled in after the batched disk read below.
                     out.push(Operation::CommitFloor(None, Location::new(0)));
-                    misses.push((idx, **loc));
+                    miss_slots.push(idx);
+                    miss_positions.push(**loc);
                 }
             }
         }
-        if misses.is_empty() {
+        if miss_positions.is_empty() {
             return Ok(out);
         }
 
-        // Batch-read disk misses. Reader::read_many requires sorted, unique positions, while this
-        // helper preserves the caller's order and permits duplicates.
-        let mut miss_positions: Vec<u64> = misses.iter().map(|(_, loc)| *loc).collect();
-        miss_positions.sort_unstable();
-        miss_positions.dedup();
-
-        let disk_results = reader.read_many(&miss_positions).await?;
-
-        // Merge disk results back into their reserved slots.
-        for (idx, loc) in misses {
-            // `miss_positions` is sorted and deduped, and `loc` came from it before deduping, so
-            // binary search must find the matching read_many result.
-            let result_idx = miss_positions
-                .binary_search(&loc)
-                .expect("disk result missing for requested location");
-            out[idx] = disk_results[result_idx].clone();
+        // `locations` is strictly increasing, so misses are a strictly increasing subsequence:
+        // already the sorted, unique positions read_many_decoded requires, with output slots in
+        // one-to-one order.
+        debug_assert!(miss_positions.windows(2).all(|w| w[0] < w[1]));
+        let disk_results = reader.read_many_decoded(&miss_positions, strategy).await?;
+        for (slot, op) in miss_slots.into_iter().zip(disk_results) {
+            out[slot] = op;
         }
         Ok(out)
     }
@@ -915,13 +926,13 @@ where
             let mut moved = 0u64;
             let mut scan_from = floor;
             let mut floor_diff = Vec::with_capacity(total_steps as usize);
-            let mut candidates: Vec<Location<F>> = Vec::with_capacity(MAX_CONCURRENT_READS as usize);
+            let mut candidates: Vec<Location<F>> = Vec::with_capacity(FLOOR_READ_BATCH as usize);
 
             while moved < total_steps {
                 // Collect candidates, capped by the number of active ops still needed.
                 // `scan_from` tracks prefetch progress separately from `floor`, so
                 // early exit cannot leave `floor` past unprocessed candidates.
-                let limit = ((total_steps - moved) as usize).min(MAX_CONCURRENT_READS as usize);
+                let limit = ((total_steps - moved) as usize).min(FLOOR_READ_BATCH as usize);
                 candidates.clear();
                 scan_from = fill_candidates(scan_from, fixed_tip, limit, &mut candidates);
                 if candidates.is_empty() {
@@ -929,8 +940,10 @@ where
                 }
 
                 // Batch-read candidates: cache hits resolve synchronously, disk misses
-                // are fetched concurrently.
-                let resolved = self.read_ops(&candidates, &ops, &reader).await?;
+                // are fetched concurrently and decoded in parallel.
+                let resolved = self
+                    .read_ops(&candidates, &ops, &reader, db.strategy())
+                    .await?;
 
                 // Process results in order, moving active ops to the tip.
                 for (candidate, op) in candidates.iter().copied().zip(resolved) {
@@ -1077,12 +1090,20 @@ where
     H: Hasher,
     Operation<F, update::Unordered<K, V>>: Codec,
 {
-    /// Generate operations for the (location-sorted) existing entries followed by the creates,
-    /// then run the shared `finish` tail. `existing` must already be in iter-location order.
-    #[allow(clippy::type_complexity)]
+    /// Generate operations for the existing entries (location order) followed by the creates
+    /// (key order), then run the shared `finish` tail.
+    ///
+    /// `existing` need not be location-sorted: a cheap `(location, index)` index sort drives op
+    /// emission, so the expensive sort of the wide `ExistingEntry` structs is avoided.
+    /// `existing_key_sorted` asserts `existing` is already in ascending key order (true when the
+    /// resolved-split produced every entry and the journal read path was skipped). When set, the
+    /// key-sorted diff is produced by a two-cursor merge of the existing and create runs instead
+    /// of a full re-sort.
+    #[allow(clippy::type_complexity, clippy::too_many_arguments)]
     async fn finish_unordered<E, C, I, R, const N: usize>(
         self,
         existing: Vec<ExistingEntry<K, F, V::Value>>,
+        existing_key_sorted: bool,
         mut mutations: SortedMutations<K, V::Value>,
         metadata: Option<V::Value>,
         fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
@@ -1097,43 +1118,55 @@ where
     {
         let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
             Vec::with_capacity(existing.len() + mutations.len() + 1);
-        let mut diff: DiffVec<K, F, V::Value> =
-            Vec::with_capacity(existing.len() + mutations.len());
         let mut active_keys_delta: isize = 0;
         let mut user_steps: u64 = 0;
 
-        // Process updates/deletes of existing keys in iter-location order.
-        for ExistingEntry {
-            key,
-            base_old_loc,
-            value,
-            ..
-        } in existing
-        {
-            let new_loc = Location::new(self.base_size + ops.len() as u64);
-            match value {
-                Some(value) => {
-                    ops.push(Operation::Update(update::Unordered(
-                        key.clone(),
-                        value.clone(),
-                    )));
-                    diff.push((
-                        key,
-                        DiffEntry::Active {
-                            value,
-                            loc: new_loc,
-                            base_old_loc,
-                        },
-                    ));
-                    user_steps += 1;
-                }
-                None => {
-                    ops.push(Operation::Delete(key.clone()));
-                    diff.push((key, DiffEntry::Deleted { base_old_loc }));
-                    active_keys_delta -= 1;
-                    user_steps += 1;
-                }
+        // Order existing entries by location for op emission. Sorting compact `(location, index)`
+        // pairs (16 bytes, contiguous) is far cheaper than sorting the wide `ExistingEntry` structs
+        // in place, and locations are unique so the order is total.
+        let mut order: Vec<(u64, u32)> = existing
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (*e.iter_loc, i as u32))
+            .collect();
+        order.sort_unstable();
+
+        // Emit existing-key ops in location order, recording each entry's new (uncommitted)
+        // location so the diff can be produced separately in key order.
+        let mut new_loc: Vec<Location<F>> = vec![Location::new(0); existing.len()];
+        for &(_, idx) in &order {
+            let entry = &existing[idx as usize];
+            let loc = Location::new(self.base_size + ops.len() as u64);
+            new_loc[idx as usize] = loc;
+            match &entry.value {
+                Some(value) => ops.push(Operation::Update(update::Unordered(
+                    entry.key.clone(),
+                    value.clone(),
+                ))),
+                None => ops.push(Operation::Delete(entry.key.clone())),
             }
+        }
+
+        // Existing-key diff entries in `existing`'s native order (key order when
+        // `existing_key_sorted`). Consumes `existing` so keys/values move rather than clone.
+        let mut existing_diff: DiffVec<K, F, V::Value> = Vec::with_capacity(existing.len());
+        for (i, entry) in existing.into_iter().enumerate() {
+            let loc = new_loc[i];
+            user_steps += 1;
+            let diff_entry = match entry.value {
+                Some(value) => DiffEntry::Active {
+                    value,
+                    loc,
+                    base_old_loc: entry.base_old_loc,
+                },
+                None => {
+                    active_keys_delta -= 1;
+                    DiffEntry::Deleted {
+                        base_old_loc: entry.base_old_loc,
+                    }
+                }
+            };
+            existing_diff.push((entry.key, diff_entry));
         }
 
         // Handle parent-deleted keys that the child wants to re-create.
@@ -1153,24 +1186,55 @@ where
             creates.push((key, value, base_old_loc));
         }
         creates.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
+
+        // Create-key ops append after the existing ops in key order. Their diff entries are
+        // collected separately so the final diff can be assembled key-sorted.
+        let mut create_diff: DiffVec<K, F, V::Value> = Vec::with_capacity(creates.len());
         for (key, value, base_old_loc) in creates {
-            let new_loc = Location::new(self.base_size + ops.len() as u64);
+            let loc = Location::new(self.base_size + ops.len() as u64);
             ops.push(Operation::Update(update::Unordered(
                 key.clone(),
                 value.clone(),
             )));
-            diff.push((
+            create_diff.push((
                 key,
                 DiffEntry::Active {
                     value,
-                    loc: new_loc,
+                    loc,
                     base_old_loc,
                 },
             ));
             active_keys_delta += 1;
         }
 
-        diff.sort_by(|a, b| a.0.cmp(&b.0));
+        // Assemble the key-sorted diff. `create_diff` is always key-sorted (creates were sorted by
+        // key). When `existing_key_sorted`, `existing_diff` is also key-sorted and the two runs are
+        // disjoint (a key is either existing or a create), so a two-cursor merge reproduces the full
+        // sort. Otherwise the read path interleaved `existing_diff` out of key order, so concatenate
+        // and sort.
+        let diff: DiffVec<K, F, V::Value> = if existing_key_sorted {
+            let mut merged = Vec::with_capacity(existing_diff.len() + create_diff.len());
+            let mut ei = existing_diff.into_iter().peekable();
+            let mut ci = create_diff.into_iter().peekable();
+            loop {
+                let take_create = match (ei.peek(), ci.peek()) {
+                    (Some(e), Some(c)) => c.0 < e.0,
+                    (None, Some(_)) => true,
+                    (Some(_), None) => false,
+                    (None, None) => break,
+                };
+                if take_create {
+                    merged.push(ci.next().unwrap());
+                } else {
+                    merged.push(ei.next().unwrap());
+                }
+            }
+            merged
+        } else {
+            existing_diff.extend(create_diff);
+            existing_diff.sort_by(|a, b| a.0.cmp(&b.0));
+            existing_diff
+        };
 
         self.finish(
             ops,
@@ -1220,8 +1284,9 @@ where
                 oldest.journal_batch.size() - oldest.journal_batch.items().len() as u64;
             db_size.max(oldest_base)
         });
+        let sorted = self.mutations.into_sorted(self.journal_batch.strategy());
         (
-            self.mutations.into_sorted(),
+            sorted,
             Merkleizer {
                 journal_batch: self.journal_batch,
                 ancestors,
@@ -1506,6 +1571,11 @@ where
             SortedMutations { entries }
         };
 
+        // `existing` is built in ascending key order by the resolved-split above (it drains
+        // `into_creates` in key order). The read path below appends in location order, breaking
+        // key order, so the fast key-sorted diff merge applies only when nothing is read.
+        let existing_key_sorted = rest.is_empty();
+
         // Resolve the rest from the journal: gather candidate locations, read the ops, and
         // classify in location order. A key resolved via an ancestor diff must only match at its
         // ancestor-diff location; otherwise a stale snapshot collision (the pre-parent DB snapshot
@@ -1515,7 +1585,7 @@ where
         let reader = db.log.reader().await;
         if !rest.is_empty() {
             let locations = m.gather_existing_locations(&rest, db, false);
-            let results = m.read_ops(&locations, &[], &reader).await?;
+            let results = m.read_ops(&locations, &[], &reader, db.strategy()).await?;
             for (op, &old_loc) in results.iter().zip(&locations) {
                 let key = op.key().expect("updates should have a key");
                 let base_old_loc = if let Some(entry) = resolve_in_ancestors(&m.ancestors, key) {
@@ -1538,12 +1608,16 @@ where
             }
         }
 
-        // Existing-key ops are generated in iter-location order; the read path already yields
-        // that order, and pre-resolved entries are merged into it here.
-        existing.sort_by(|a, b| a.iter_loc.cmp(&b.iter_loc));
-
-        m.finish_unordered(existing, rest, metadata, fill_candidates, reader, db)
-            .await
+        m.finish_unordered(
+            existing,
+            existing_key_sorted,
+            rest,
+            metadata,
+            fill_candidates,
+            reader,
+            db,
+        )
+        .await
     }
 
     /// Attach existing-key locations the caller already resolved during state load (via
@@ -1624,7 +1698,7 @@ where
         let mut updated: Vec<(K, V::Value, Location<F>)> = Vec::new();
 
         for (op, &old_loc) in m
-            .read_ops(&locations, &[], &reader)
+            .read_ops(&locations, &[], &reader, db.strategy())
             .await?
             .into_iter()
             .zip(&locations)
@@ -1696,7 +1770,9 @@ where
         prev_locations.sort();
         prev_locations.dedup();
 
-        let prev_results = m.read_ops(&prev_locations, &[], &reader).await?;
+        let prev_results = m
+            .read_ops(&prev_locations, &[], &reader, db.strategy())
+            .await?;
 
         for (op, &old_loc) in prev_results.into_iter().zip(&prev_locations) {
             let data = match op {
@@ -2865,14 +2941,16 @@ mod tests {
                 value_current,
             ))];
 
-            // read_ops should resolve all three sources correctly while preserving order and
-            // duplicates across the disk-backed subset.
+            // read_ops should resolve all three sources correctly. Locations are strictly
+            // increasing: committed (disk) < parent (ancestor) < current (this batch).
+            assert!(committed_loc < parent_loc && parent_loc < current_loc);
             let reader = db.log.reader().await;
             let ops = merkleizer
                 .read_ops(
-                    &[current_loc, committed_loc, parent_loc, committed_loc],
+                    &[committed_loc, parent_loc, current_loc],
                     &batch_ops,
                     &reader,
+                    db.strategy(),
                 )
                 .await
                 .unwrap();
@@ -2881,10 +2959,9 @@ mod tests {
             assert_eq!(
                 ops,
                 vec![
-                    Operation::Update(update::Unordered(key_current, value_current)),
                     Operation::Update(update::Unordered(key_db, value_db)),
                     Operation::Update(update::Unordered(key_parent, value_parent)),
-                    Operation::Update(update::Unordered(key_db, value_db)),
+                    Operation::Update(update::Unordered(key_current, value_current)),
                 ]
             );
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -26,7 +26,7 @@ use ahash::{AHashMap, AHashSet};
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
-use commonware_utils::bitmap;
+use commonware_utils::{bitmap, sync::Mutex};
 use core::{cmp::Ordering, ops::Range};
 use std::{
     iter,
@@ -260,29 +260,6 @@ pub(crate) struct ResolvedLocation<F: Family> {
     pub(crate) base_old_loc: Option<Location<F>>,
 }
 
-/// Existing-key locations resolved by
-/// [`get_many_with_locations`](UnmerkleizedBatch::get_many_with_locations), attached to a batch
-/// via [`with_resolved`](UnmerkleizedBatch::with_resolved) so `merkleize` can skip re-reading
-/// those keys.
-///
-/// Entries are keyed internally by the key they were resolved for and must be attached to the
-/// batch they were resolved on. Applying and committing the batch's ancestors between resolution
-/// and merkleization is fine (ancestor-resolved locations are immutable and committed-resolved
-/// keys are untouched by those applies); attaching a token to any other batch may corrupt the
-/// database.
-#[derive(Debug)]
-pub struct ResolvedLocations<K, F: Family> {
-    pub(crate) locations: AHashMap<K, ResolvedLocation<F>>,
-}
-
-impl<K: core::hash::Hash + Eq, F: Family> ResolvedLocations<K, F> {
-    /// Absorb `other`, which must have been resolved on the same batch as `self`. Re-resolving a
-    /// key on the same batch yields the same location, so overlapping entries are identical.
-    pub fn merge(&mut self, other: Self) {
-        self.locations.extend(other.locations);
-    }
-}
-
 /// Where this batch's inherited state comes from.
 enum Base<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy>
 where
@@ -366,11 +343,12 @@ where
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
 
-    /// Caller-supplied resolution of existing keys' committed locations, populated from
-    /// [`get_many_with_locations`](UnmerkleizedBatch::get_many_with_locations) during state load.
-    /// When a mutation key is present here, `merkleize` reuses the location and skips the
-    /// redundant journal read. Empty for callers that did not pre-resolve.
-    resolved: AHashMap<U::Key, ResolvedLocation<F>>,
+    /// Committed-DB locations resolved by this batch's reads (`get`/`get_many`), consumed by
+    /// `merkleize`. When a mutation key is present here, `merkleize` reuses the location and
+    /// skips the redundant journal read. Only committed-snapshot resolutions are retained;
+    /// ancestor-diff resolutions could go stale if a committed ancestor is dropped before
+    /// merkleize. Interior-mutable because reads take `&self`; never held across an await.
+    resolved: Mutex<AHashMap<U::Key, ResolvedLocation<F>>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -1329,25 +1307,16 @@ where
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        if let Some(value) = self.mutations.get(key) {
-            return Ok(value.clone());
-        }
-        if let Some(parent) = self.base.parent() {
-            if let Some(entry) = lookup_sorted(parent.diff.as_slice(), key) {
-                return Ok(entry.value().cloned());
-            }
-            for batch in parent.ancestors() {
-                if let Some(entry) = lookup_sorted(batch.diff.as_slice(), key) {
-                    return Ok(entry.value().cloned());
-                }
-            }
-        }
-        db.get(key).await
+        let mut values = self.get_many(&[key], db).await?;
+        Ok(values.pop().expect("one result per key"))
     }
 
-    /// Batch read multiple keys.
+    /// Batch read multiple keys (mutations -> ancestor diffs -> committed DB).
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys, with `None` for absent or deleted
+    /// keys. Committed-DB locations resolved by the read are retained on the batch and consumed
+    /// by `merkleize`, which skips re-reading those keys. Keys answered by pending mutations or
+    /// ancestor diffs retain nothing (merkleize re-resolves them in memory).
     pub async fn get_many<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
@@ -1361,75 +1330,6 @@ where
         if keys.is_empty() {
             return Ok(Vec::new());
         }
-
-        let mut results: Vec<Option<U::Value>> = Vec::with_capacity(keys.len());
-        let mut db_indices = Vec::new();
-        let mut db_keys = Vec::new();
-
-        for (i, key) in keys.iter().enumerate() {
-            // Check local mutations.
-            if let Some(value) = self.mutations.get(*key) {
-                results.push(value.clone());
-                continue;
-            }
-
-            // Check parent diff chain.
-            let mut found = false;
-            if let Some(parent) = self.base.parent() {
-                if let Some(entry) = lookup_sorted(parent.diff.as_slice(), *key) {
-                    results.push(entry.value().cloned());
-                    found = true;
-                }
-                if !found {
-                    for batch in parent.ancestors() {
-                        if let Some(entry) = lookup_sorted(batch.diff.as_slice(), *key) {
-                            results.push(entry.value().cloned());
-                            found = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if found {
-                continue;
-            }
-
-            // Need DB fallthrough.
-            db_indices.push(i);
-            db_keys.push(*key);
-            results.push(None);
-        }
-
-        if !db_keys.is_empty() {
-            let db_results = db.get_many(&db_keys).await?;
-            for (slot, value) in db_indices.into_iter().zip(db_results) {
-                results[slot] = value;
-            }
-        }
-
-        Ok(results)
-    }
-
-    /// Batch read multiple keys, returning the values plus a [`ResolvedLocations`] token to be
-    /// attached via [`with_resolved`](UnmerkleizedBatch::with_resolved) so the subsequent
-    /// [`merkleize`](UnmerkleizedBatch::merkleize) can skip re-reading these keys.
-    ///
-    /// Resolution matches [`Self::get_many`] (mutations -> ancestor diffs -> committed DB).
-    /// Values are returned in the same order as the input keys, with `None` for keys that are
-    /// absent (a create) or were deleted. Keys answered by this batch's pending mutations receive
-    /// no token entry (merkleize resolves written keys itself).
-    #[allow(clippy::type_complexity)]
-    pub async fn get_many_with_locations<E, C, I, const N: usize>(
-        &self,
-        keys: &[&U::Key],
-        db: &Db<F, E, C, I, H, U, N, S>,
-    ) -> Result<(Vec<Option<U::Value>>, ResolvedLocations<U::Key, F>), crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>> + 'static,
-    {
         let mut values: Vec<Option<U::Value>> =
             iter::repeat_with(|| None).take(keys.len()).collect();
         let mut locations: AHashMap<U::Key, ResolvedLocation<F>> =
@@ -1455,7 +1355,14 @@ where
         // absent in the chain's view. Sweep ancestor diffs with forward cursors in ascending key
         // order (cursors require it), so the caller's slice is visited via a sorted index
         // permutation rather than a per-key binary search per ancestor.
-        let chain: Vec<Arc<MerkleizedBatch<F, H::Digest, U, S>>> =
+        //
+        // Ancestor-resolved keys retain NO location: an ancestor's `base_old_loc` goes stale if
+        // that ancestor is committed and dropped before this batch merkleizes (the merkleize-time
+        // ancestor walk truncates at dropped batches and re-resolves through the committed
+        // snapshot, and `apply_batch`'s applied-ancestor fix-up cannot see a dropped ancestor's
+        // diff). Re-resolving these keys at merkleize is in-memory work; no journal read is saved
+        // by retaining them.
+        let chain: Vec<_> =
             self.base.parent().map_or_else(Vec::new, |parent| {
                 let mut v = vec![Arc::clone(parent)];
                 v.extend(parent.ancestors());
@@ -1471,18 +1378,7 @@ where
             for i in order {
                 let key = keys[i];
                 match cursors.resolve(key) {
-                    Some(DiffEntry::Active {
-                        value,
-                        loc,
-                        base_old_loc,
-                    }) => {
-                        locations.insert(
-                            key.clone(),
-                            ResolvedLocation {
-                                iter_loc: *loc,
-                                base_old_loc: *base_old_loc,
-                            },
-                        );
+                    Some(DiffEntry::Active { value, .. }) => {
                         values[i] = Some(value.clone());
                     }
                     Some(DiffEntry::Deleted { .. }) => {}
@@ -1510,7 +1406,8 @@ where
             }
         }
 
-        Ok((values, ResolvedLocations { locations }))
+        self.resolved.lock().extend(locations);
+        Ok(values)
     }
 }
 
@@ -1556,7 +1453,7 @@ where
     /// committed state only -- uncommitted ancestor ops aren't tracked, and bits can be set for
     /// locations superseded by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
-        mut self,
+        self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
         metadata: Option<V::Value>,
         fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
@@ -1566,7 +1463,7 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        let resolved = core::mem::take(&mut self.resolved);
+        let resolved = core::mem::take(&mut *self.resolved.lock());
         let (mutations, m) = self.into_parts();
 
         // Split mutations into existing keys the caller pre-resolved (location reused from its
@@ -1643,15 +1540,6 @@ where
         .await
     }
 
-    /// Attach existing-key locations the caller already resolved during state load (via
-    /// [`get_many_with_locations`](Self::get_many_with_locations)) so [`merkleize`](Self::merkleize)
-    /// reuses them instead of re-reading the journal for those keys. Keys without an entry are
-    /// resolved normally. The token must have been resolved on this batch (see
-    /// [`ResolvedLocations`]).
-    pub fn with_resolved(mut self, resolved: ResolvedLocations<K, F>) -> Self {
-        self.resolved = resolved.locations;
-        self
-    }
 }
 
 // Ordered-specific methods.
@@ -2064,7 +1952,7 @@ where
             journal_batch: self.journal_batch.new_batch::<H>(),
             mutations: Mutations::new(),
             base: Base::Child(Arc::clone(self)),
-            resolved: AHashMap::new(),
+            resolved: Mutex::new(AHashMap::new()),
         }
     }
 
@@ -2187,7 +2075,7 @@ where
                 inactivity_floor_loc: self.inactivity_floor_loc,
                 active_keys: self.active_keys,
             },
-            resolved: AHashMap::new(),
+            resolved: Mutex::new(AHashMap::new()),
         }
     }
 }

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -281,6 +281,70 @@ where
         Ok(results)
     }
 
+    /// Batch read multiple keys, returning per key both the value and the committed location it
+    /// key-matched (or `None` for absent keys).
+    ///
+    /// Identical resolution to [`Self::get_many`] but additionally returns the snapshot location
+    /// that produced each value. Used by the fused merkleize path to skip re-resolving keys that
+    /// were already located during state load.
+    ///
+    /// Results are returned in the same order as the input keys.
+    #[allow(clippy::type_complexity)]
+    pub async fn get_many_with_locations(
+        &self,
+        keys: &[&U::Key],
+    ) -> Result<Vec<Option<(U::Value, Location<F>)>>, crate::qmdb::Error<F>> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let _timer = self.metrics.reads.get_many_timer();
+        self.metrics.reads.get_many_calls.inc();
+        self.metrics.reads.keys_requested.inc_by(keys.len() as u64);
+
+        let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
+        let mut results: Vec<Option<(U::Value, Location<F>)>> = vec![None; keys.len()];
+
+        for (key_idx, key) in keys.iter().enumerate() {
+            for &loc in self.snapshot.get(key) {
+                candidates.push((key_idx, *loc));
+            }
+        }
+
+        if candidates.is_empty() {
+            return Ok(results);
+        }
+
+        candidates.sort_unstable_by_key(|&(_, pos)| pos);
+
+        let mut positions: Vec<u64> = Vec::with_capacity(candidates.len());
+        for &(_, pos) in &candidates {
+            if positions.last() != Some(&pos) {
+                positions.push(pos);
+            }
+        }
+
+        let reader = self.log.reader().await;
+        let ops = reader.read_many(&positions).await?;
+
+        for &(key_idx, pos) in &candidates {
+            if results[key_idx].is_some() {
+                continue;
+            }
+            let op_idx = positions
+                .binary_search(&pos)
+                .expect("position was deduped from candidates");
+            let Operation::Update(data) = &ops[op_idx] else {
+                panic!("location does not reference update operation. loc={pos}");
+            };
+            if data.key() == keys[key_idx] {
+                results[key_idx] = Some((data.value().clone(), Location::new(pos)));
+            }
+        }
+
+        Ok(results)
+    }
+
     /// Return [start, end) where `start` and `end - 1` are the Locations of the oldest and newest
     /// retained operations respectively.
     pub async fn bounds(&self) -> std::ops::Range<Location<F>> {

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -260,7 +260,9 @@ where
 
         // Phase 3: Batch-read from the journal (one reader acquisition, one I/O batch).
         let reader = self.log.reader().await;
-        let ops = reader.read_many(&positions).await?;
+        let ops = reader
+            .read_many_decoded(&positions, self.log.strategy())
+            .await?;
 
         // Phase 4: Match operations back to keys via binary search (no HashMap).
         for &(key_idx, pos) in &candidates {
@@ -325,7 +327,9 @@ where
         }
 
         let reader = self.log.reader().await;
-        let ops = reader.read_many(&positions).await?;
+        let ops = reader
+            .read_many_decoded(&positions, self.log.strategy())
+            .await?;
 
         for &(key_idx, pos) in &candidates {
             if results[key_idx].is_some() {

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -292,7 +292,7 @@ where
     ///
     /// Results are returned in the same order as the input keys.
     #[allow(clippy::type_complexity)]
-    pub async fn get_many_with_locations(
+    pub(crate) async fn get_many_with_locations(
         &self,
         keys: &[&U::Key],
     ) -> Result<Vec<Option<(U::Value, Location<F>)>>, crate::qmdb::Error<F>> {

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -299,11 +299,11 @@ pub(crate) mod test {
         });
     }
 
-    /// The fused `get_many_with_locations -> merkleize_resolved` path must produce a byte-identical
-    /// root to the normal `merkleize`, across updates/deletes/creates, both with the batch rooted
-    /// directly at the DB (D=0) and through one pending ancestor (D=1).
+    /// The fused `get_many_with_locations -> with_resolved -> merkleize` path must produce a
+    /// byte-identical root to a plain `merkleize` (no hints), across updates/deletes/creates, both
+    /// with the batch rooted directly at the DB (D=0) and through one pending ancestor (D=1).
     #[test_traced("WARN")]
-    fn test_unordered_fixed_merkleize_resolved_parity() {
+    fn test_unordered_fixed_resolved_merkleize_parity() {
         use crate::qmdb::any::batch::ResolvedLocation;
         use std::collections::{BTreeMap, HashMap};
 

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -299,12 +299,24 @@ pub(crate) mod test {
         });
     }
 
-    /// The fused `get_many_with_locations -> with_resolved -> merkleize` path must produce a
-    /// byte-identical root to a plain `merkleize` (no hints), across updates/deletes/creates, both
-    /// with the batch rooted directly at the DB (D=0) and through one pending ancestor (D=1).
+    /// Reads on a batch retain resolved locations that `merkleize` consumes to skip re-reading
+    /// those keys. The root must be byte-identical to a write-only batch's `merkleize` (no
+    /// retained reads), across updates/deletes/creates, both with the batch rooted directly at
+    /// the DB (D=0) and through one pending ancestor (D=1).
     #[test_traced("WARN")]
     fn test_unordered_fixed_resolved_merkleize_parity() {
         use std::collections::HashMap;
+
+        type ParentChain = Vec<
+            std::sync::Arc<
+                crate::qmdb::any::batch::MerkleizedBatch<
+                    mmr::Family,
+                    Digest,
+                    crate::qmdb::any::operation::update::Unordered<Digest, FixedEncoding<Digest>>,
+                    Sequential,
+                >,
+            >,
+        >;
 
         deterministic::Runner::default().start(|ctx| async move {
             let mut db = create_test_db(ctx.child("db")).await;
@@ -342,22 +354,23 @@ pub(crate) mod test {
                 m.into_iter().collect()
             };
 
-            // D=0: batch rooted directly at the DB. D=1: through one pending ancestor.
-            for depth in [0u8, 1u8] {
-                let parent = if depth == 1 {
-                    let mut p = db.new_batch();
-                    for (k, v) in make(900) {
+            // D=0: batch rooted directly at the DB. D=N: through N pending ancestors.
+            for depth in [0u64, 1, 2] {
+                let mut chain: ParentChain = Vec::new();
+                for d in 0..depth {
+                    let mut p = chain
+                        .last()
+                        .map_or_else(|| db.new_batch(), |l| l.new_batch::<Sha256>());
+                    for (k, v) in make(900 + d) {
                         p = p.write(k, v);
                     }
-                    Some(p.merkleize(&db, None).await.unwrap())
-                } else {
-                    None
-                };
+                    chain.push(p.merkleize(&db, None).await.unwrap());
+                }
 
-                let muts = make(depth as u64 + 1);
+                let muts = make(depth + 1);
                 let new_batch = || {
-                    parent
-                        .as_ref()
+                    chain
+                        .last()
                         .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
                 };
 
@@ -368,35 +381,27 @@ pub(crate) mod test {
                 }
                 let normal_root = nb.merkleize(&db, None).await.unwrap().root();
 
-                // Fused path. Values must match a plain `get_many` and the root must match the
-                // normal path.
+                // Read-then-write on one batch: the read retains locations that merkleize
+                // consumes. Values and root must match the write-only path.
                 let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
-                let (values, resolved) = new_batch()
-                    .get_many_with_locations(&keys, &db)
-                    .await
-                    .unwrap();
+                let mut fb = new_batch();
+                let values = fb.get_many(&keys, &db).await.unwrap();
                 let plain = new_batch().get_many(&keys, &db).await.unwrap();
                 assert_eq!(values, plain, "value mismatch at depth={depth}");
-                let mut fb = new_batch();
                 for (k, v) in &muts {
                     fb = fb.write(*k, *v);
                 }
-                let fused_root = fb
-                    .with_resolved(resolved)
-                    .merkleize(&db, None)
-                    .await
-                    .unwrap()
-                    .root();
+                let fused_root = fb.merkleize(&db, None).await.unwrap().root();
                 assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
 
-                // Fused path with reads after writes. Written keys are answered by the pending
-                // mutations and receive no token entry; the root must still match.
+                // Reads after writes: written keys are answered by the pending mutations and
+                // retain nothing; the root must still match.
                 let half = muts.len() / 2;
                 let mut mb = new_batch();
                 for (k, v) in muts.iter().take(half) {
                     mb = mb.write(*k, *v);
                 }
-                let (values, resolved) = mb.get_many_with_locations(&keys, &db).await.unwrap();
+                let values = mb.get_many(&keys, &db).await.unwrap();
                 for (i, (_, v)) in muts.iter().enumerate().take(half) {
                     assert_eq!(values[i], *v, "pending write not visible at depth={depth}");
                 }
@@ -408,37 +413,88 @@ pub(crate) mod test {
                 for (k, v) in muts.iter().skip(half) {
                     mb = mb.write(*k, *v);
                 }
-                let mixed_root = mb
-                    .with_resolved(resolved)
-                    .merkleize(&db, None)
-                    .await
-                    .unwrap()
-                    .root();
+                let mixed_root = mb.merkleize(&db, None).await.unwrap().root();
                 assert_eq!(normal_root, mixed_root, "mixed root mismatch at depth={depth}");
 
-                // Two disjoint reads on the same batch, tokens merged.
-                let gb = new_batch();
-                let (_, mut first) = gb
-                    .get_many_with_locations(&keys[..half], &db)
-                    .await
-                    .unwrap();
-                let (_, second) = gb
-                    .get_many_with_locations(&keys[half..], &db)
-                    .await
-                    .unwrap();
-                first.merge(second);
-                let mut gb = gb;
+                // Multiple disjoint reads accumulate, and single-key gets retain too.
+                let mut gb = new_batch();
+                gb.get_many(&keys[..half], &db).await.unwrap();
+                for key in &keys[half..] {
+                    gb.get(key, &db).await.unwrap();
+                }
                 for (k, v) in &muts {
                     gb = gb.write(*k, *v);
                 }
-                let merged_root = gb
-                    .with_resolved(first)
-                    .merkleize(&db, None)
-                    .await
-                    .unwrap()
-                    .root();
+                let merged_root = gb.merkleize(&db, None).await.unwrap().root();
                 assert_eq!(normal_root, merged_root, "merged root mismatch at depth={depth}");
             }
+        });
+    }
+
+    /// A batch's retained read locations must stay valid when an ancestor is committed and
+    /// dropped between the read and merkleize. Keys resolved through an uncommitted ancestor's
+    /// diff retain nothing, so the merkleize-time re-resolution picks up the post-commit
+    /// location and the final state matches a batch that never read.
+    #[test_traced("WARN")]
+    fn test_unordered_fixed_retention_survives_ancestor_commit() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let mut roots = Vec::new();
+            for read_first in [false, true] {
+                let label = if read_first { "db_read" } else { "db_write" };
+                let mut db = create_test_db(ctx.child(label)).await;
+
+                // Seed and commit keys 0..100.
+                let mut seed = db.new_batch();
+                for i in 0..100u64 {
+                    seed = seed.write(key(i), Some(val(i)));
+                }
+                let seed = seed.merkleize(&db, None).await.unwrap();
+                db.apply_batch(seed).await.unwrap();
+                db.commit().await.unwrap();
+
+                // Grandparent overwrites keys 0..10 (pending), parent touches disjoint keys.
+                let mut gp = db.new_batch();
+                for i in 0..10u64 {
+                    gp = gp.write(key(i), Some(val(i + 1000)));
+                }
+                let gp = gp.merkleize(&db, None).await.unwrap();
+                let mut p = gp.new_batch::<Sha256>();
+                for i in 50..60u64 {
+                    p = p.write(key(i), Some(val(i + 2000)));
+                }
+                let p = p.merkleize(&db, None).await.unwrap();
+
+                // Child reads the grandparent-touched keys (resolving through its diff).
+                let b = p.new_batch::<Sha256>();
+                if read_first {
+                    let keys: Vec<Digest> = (0..10u64).map(key).collect();
+                    let key_refs: Vec<&Digest> = keys.iter().collect();
+                    let values = b.get_many(&key_refs, &db).await.unwrap();
+                    for (i, v) in values.into_iter().enumerate() {
+                        assert_eq!(v, Some(val(i as u64 + 1000)));
+                    }
+                }
+
+                // Commit the grandparent and drop it before the child merkleizes.
+                db.apply_batch(gp).await.unwrap();
+                db.commit().await.unwrap();
+
+                let mut b = b;
+                for i in 0..10u64 {
+                    b = b.write(key(i), Some(val(i + 3000)));
+                }
+                let b = b.merkleize(&db, None).await.unwrap();
+                db.apply_batch(p).await.unwrap();
+                db.apply_batch(b).await.unwrap();
+                db.commit().await.unwrap();
+
+                for i in 0..10u64 {
+                    assert_eq!(db.get(&key(i)).await.unwrap(), Some(val(i + 3000)));
+                }
+                roots.push(db.root());
+                db.destroy().await.unwrap();
+            }
+            assert_eq!(roots[0], roots[1], "read-then-write diverged from write-only");
         });
     }
 
@@ -956,6 +1012,8 @@ pub(crate) mod test {
 
     #[allow(dead_code)]
     fn assert_non_trait_futures_are_send(db: &AnyTest, key: Digest, value: Digest) {
+        let reader = db.new_batch();
+        is_send(reader.get_many(&[&key], db));
         let batch = db.new_batch().write(key, Some(value));
         is_send(batch.merkleize(db, None));
         is_send(db.get_with_loc(&key));

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -305,7 +305,7 @@ pub(crate) mod test {
     #[test_traced("WARN")]
     fn test_unordered_fixed_merkleize_resolved_parity() {
         use crate::qmdb::any::batch::ResolvedLocation;
-        use std::collections::HashMap;
+        use std::collections::{BTreeMap, HashMap};
 
         deterministic::Runner::default().start(|ctx| async move {
             let mut db = create_test_db(ctx.child("db")).await;
@@ -375,8 +375,8 @@ pub(crate) mod test {
                     .get_many_with_locations(&keys, &db)
                     .await
                     .unwrap();
-                let mut resolved: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
-                    HashMap::new();
+                let mut resolved: BTreeMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
+                    BTreeMap::new();
                 for ((k, _), r) in muts.iter().zip(resolved_vec) {
                     resolved.insert(*k, r.map(|(_, loc)| loc));
                 }
@@ -385,7 +385,8 @@ pub(crate) mod test {
                     fb = fb.write(*k, *v);
                 }
                 let fused_root = fb
-                    .merkleize_resolved(&db, &resolved, None)
+                    .with_resolved(resolved)
+                    .merkleize(&db, None)
                     .await
                     .unwrap()
                     .root();
@@ -394,13 +395,15 @@ pub(crate) mod test {
 
                 // Guard: an EMPTY resolved map forces every key through the read-based fallback
                 // and must still match (proves the fallback path is sound).
-                let empty: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> = HashMap::new();
+                let empty: BTreeMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
+                    BTreeMap::new();
                 let mut eb = new_batch();
                 for (k, v) in &muts {
                     eb = eb.write(*k, *v);
                 }
                 let empty_root = eb
-                    .merkleize_resolved(&db, &empty, None)
+                    .with_resolved(empty)
+                    .merkleize(&db, None)
                     .await
                     .unwrap()
                     .root();
@@ -412,8 +415,8 @@ pub(crate) mod test {
                 // Guard: marking existing keys as absent (`None`) must NOT corrupt the root; such
                 // keys fall back to the live snapshot resolution rather than being treated as
                 // creates off a stale hint.
-                let mut none_map: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
-                    HashMap::new();
+                let mut none_map: BTreeMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
+                    BTreeMap::new();
                 for (k, _) in &muts {
                     none_map.insert(*k, None);
                 }
@@ -422,7 +425,8 @@ pub(crate) mod test {
                     gb = gb.write(*k, *v);
                 }
                 let none_root = gb
-                    .merkleize_resolved(&db, &none_map, None)
+                    .with_resolved(none_map)
+                    .merkleize(&db, None)
                     .await
                     .unwrap()
                     .root();

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -299,6 +299,141 @@ pub(crate) mod test {
         });
     }
 
+    /// The fused `get_many_with_locations -> merkleize_resolved` path must produce a byte-identical
+    /// root to the normal `merkleize`, across updates/deletes/creates, both with the batch rooted
+    /// directly at the DB (D=0) and through one pending ancestor (D=1).
+    #[test_traced("WARN")]
+    fn test_unordered_fixed_merkleize_resolved_parity() {
+        use crate::qmdb::any::batch::ResolvedLocation;
+        use std::collections::HashMap;
+
+        deterministic::Runner::default().start(|ctx| async move {
+            let mut db = create_test_db(ctx.child("db")).await;
+
+            // Seed 2000 keys and commit so they live in the committed snapshot.
+            let mut seed = db.new_batch();
+            for i in 0..2000u64 {
+                seed = seed.write(key(i), Some(val(i)));
+            }
+            let seed = seed.merkleize(&db, None).await.unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            // Build a mixed mutation set: updates of existing keys, deletes of existing keys,
+            // and creates of fresh keys. `make` re-derives the set from a seed so both paths and
+            // both depths see identical mutations.
+            let make = |salt: u64| -> Vec<(Digest, Option<Digest>)> {
+                let mut rng = test_rng_seeded(salt);
+                let mut out = Vec::new();
+                for _ in 0..600 {
+                    let r = rng.next_u32() % 100;
+                    if r < 60 {
+                        out.push((key(rng.next_u64() % 2000), Some(val(rng.next_u64()))));
+                    } else if r < 80 {
+                        out.push((key(rng.next_u64() % 2000), None));
+                    } else {
+                        out.push((key(2000 + rng.next_u64() % 2000), Some(val(rng.next_u64()))));
+                    }
+                }
+                // Dedup last-write-wins.
+                let mut m: HashMap<Digest, Option<Digest>> = HashMap::new();
+                for (k, v) in out {
+                    m.insert(k, v);
+                }
+                m.into_iter().collect()
+            };
+
+            // D=0: batch rooted directly at the DB. D=1: through one pending ancestor.
+            for depth in [0u8, 1u8] {
+                let parent = if depth == 1 {
+                    let mut p = db.new_batch();
+                    for (k, v) in make(900) {
+                        p = p.write(k, v);
+                    }
+                    Some(p.merkleize(&db, None).await.unwrap())
+                } else {
+                    None
+                };
+
+                let muts = make(depth as u64 + 1);
+                let new_batch = || {
+                    parent
+                        .as_ref()
+                        .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
+                };
+
+                // Normal path.
+                let mut nb = new_batch();
+                for (k, v) in &muts {
+                    nb = nb.write(*k, *v);
+                }
+                let normal_root = nb.merkleize(&db, None).await.unwrap().root();
+
+                // Fused path.
+                let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
+                let resolved_vec = new_batch()
+                    .get_many_with_locations(&keys, &db)
+                    .await
+                    .unwrap();
+                let mut resolved: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
+                    HashMap::new();
+                for ((k, _), r) in muts.iter().zip(resolved_vec) {
+                    resolved.insert(*k, r.map(|(_, loc)| loc));
+                }
+                let mut fb = new_batch();
+                for (k, v) in &muts {
+                    fb = fb.write(*k, *v);
+                }
+                let fused_root = fb
+                    .merkleize_resolved(&db, &resolved, None)
+                    .await
+                    .unwrap()
+                    .root();
+
+                assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
+
+                // Guard: an EMPTY resolved map forces every key through the read-based fallback
+                // and must still match (proves the fallback path is sound).
+                let empty: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> = HashMap::new();
+                let mut eb = new_batch();
+                for (k, v) in &muts {
+                    eb = eb.write(*k, *v);
+                }
+                let empty_root = eb
+                    .merkleize_resolved(&db, &empty, None)
+                    .await
+                    .unwrap()
+                    .root();
+                assert_eq!(
+                    normal_root, empty_root,
+                    "empty-map fallback mismatch depth={depth}"
+                );
+
+                // Guard: marking existing keys as absent (`None`) must NOT corrupt the root; such
+                // keys fall back to the live snapshot resolution rather than being treated as
+                // creates off a stale hint.
+                let mut none_map: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
+                    HashMap::new();
+                for (k, _) in &muts {
+                    none_map.insert(*k, None);
+                }
+                let mut gb = new_batch();
+                for (k, v) in &muts {
+                    gb = gb.write(*k, *v);
+                }
+                let none_root = gb
+                    .merkleize_resolved(&db, &none_map, None)
+                    .await
+                    .unwrap()
+                    .root();
+                assert_eq!(
+                    normal_root, none_root,
+                    "none-hint fallback mismatch depth={depth}"
+                );
+            }
+        });
+    }
+
     // -- Generic inner functions for parameterized batch tests --
 
     async fn batch_empty_inner<F: Family>(context: deterministic::Context) {

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -388,6 +388,56 @@ pub(crate) mod test {
                     .unwrap()
                     .root();
                 assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
+
+                // Fused path with reads after writes. Written keys are answered by the pending
+                // mutations and receive no token entry; the root must still match.
+                let half = muts.len() / 2;
+                let mut mb = new_batch();
+                for (k, v) in muts.iter().take(half) {
+                    mb = mb.write(*k, *v);
+                }
+                let (values, resolved) = mb.get_many_with_locations(&keys, &db).await.unwrap();
+                for (i, (_, v)) in muts.iter().enumerate().take(half) {
+                    assert_eq!(values[i], *v, "pending write not visible at depth={depth}");
+                }
+                assert_eq!(
+                    values[half..],
+                    plain[half..],
+                    "unwritten value mismatch at depth={depth}"
+                );
+                for (k, v) in muts.iter().skip(half) {
+                    mb = mb.write(*k, *v);
+                }
+                let mixed_root = mb
+                    .with_resolved(resolved)
+                    .merkleize(&db, None)
+                    .await
+                    .unwrap()
+                    .root();
+                assert_eq!(normal_root, mixed_root, "mixed root mismatch at depth={depth}");
+
+                // Two disjoint reads on the same batch, tokens merged.
+                let gb = new_batch();
+                let (_, mut first) = gb
+                    .get_many_with_locations(&keys[..half], &db)
+                    .await
+                    .unwrap();
+                let (_, second) = gb
+                    .get_many_with_locations(&keys[half..], &db)
+                    .await
+                    .unwrap();
+                first.merge(second);
+                let mut gb = gb;
+                for (k, v) in &muts {
+                    gb = gb.write(*k, *v);
+                }
+                let merged_root = gb
+                    .with_resolved(first)
+                    .merkleize(&db, None)
+                    .await
+                    .unwrap()
+                    .root();
+                assert_eq!(normal_root, merged_root, "merged root mismatch at depth={depth}");
             }
         });
     }

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -304,7 +304,6 @@ pub(crate) mod test {
     /// with the batch rooted directly at the DB (D=0) and through one pending ancestor (D=1).
     #[test_traced("WARN")]
     fn test_unordered_fixed_resolved_merkleize_parity() {
-        use crate::qmdb::any::batch::ResolvedLocation;
         use std::collections::HashMap;
 
         deterministic::Runner::default().start(|ctx| async move {
@@ -369,17 +368,15 @@ pub(crate) mod test {
                 }
                 let normal_root = nb.merkleize(&db, None).await.unwrap().root();
 
-                // Fused path.
+                // Fused path. Values must match a plain `get_many` and the root must match the
+                // normal path.
                 let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
-                let resolved_vec = new_batch()
+                let (values, resolved) = new_batch()
                     .get_many_with_locations(&keys, &db)
                     .await
                     .unwrap();
-                let mut resolved: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
-                    HashMap::new();
-                for ((k, _), r) in muts.iter().zip(resolved_vec) {
-                    resolved.insert(*k, r.map(|(_, loc)| loc));
-                }
+                let plain = new_batch().get_many(&keys, &db).await.unwrap();
+                assert_eq!(values, plain, "value mismatch at depth={depth}");
                 let mut fb = new_batch();
                 for (k, v) in &muts {
                     fb = fb.write(*k, *v);
@@ -390,49 +387,7 @@ pub(crate) mod test {
                     .await
                     .unwrap()
                     .root();
-
                 assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
-
-                // Guard: an EMPTY resolved map forces every key through the read-based fallback
-                // and must still match (proves the fallback path is sound).
-                let empty: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> = HashMap::new();
-                let mut eb = new_batch();
-                for (k, v) in &muts {
-                    eb = eb.write(*k, *v);
-                }
-                let empty_root = eb
-                    .with_resolved(empty)
-                    .merkleize(&db, None)
-                    .await
-                    .unwrap()
-                    .root();
-                assert_eq!(
-                    normal_root, empty_root,
-                    "empty-map fallback mismatch depth={depth}"
-                );
-
-                // Guard: marking existing keys as absent (`None`) must NOT corrupt the root; such
-                // keys fall back to the live snapshot resolution rather than being treated as
-                // creates off a stale hint.
-                let mut none_map: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
-                    HashMap::new();
-                for (k, _) in &muts {
-                    none_map.insert(*k, None);
-                }
-                let mut gb = new_batch();
-                for (k, v) in &muts {
-                    gb = gb.write(*k, *v);
-                }
-                let none_root = gb
-                    .with_resolved(none_map)
-                    .merkleize(&db, None)
-                    .await
-                    .unwrap()
-                    .root();
-                assert_eq!(
-                    normal_root, none_root,
-                    "none-hint fallback mismatch depth={depth}"
-                );
             }
         });
     }

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -305,7 +305,7 @@ pub(crate) mod test {
     #[test_traced("WARN")]
     fn test_unordered_fixed_resolved_merkleize_parity() {
         use crate::qmdb::any::batch::ResolvedLocation;
-        use std::collections::{BTreeMap, HashMap};
+        use std::collections::HashMap;
 
         deterministic::Runner::default().start(|ctx| async move {
             let mut db = create_test_db(ctx.child("db")).await;
@@ -375,8 +375,8 @@ pub(crate) mod test {
                     .get_many_with_locations(&keys, &db)
                     .await
                     .unwrap();
-                let mut resolved: BTreeMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
-                    BTreeMap::new();
+                let mut resolved: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
+                    HashMap::new();
                 for ((k, _), r) in muts.iter().zip(resolved_vec) {
                     resolved.insert(*k, r.map(|(_, loc)| loc));
                 }
@@ -395,8 +395,7 @@ pub(crate) mod test {
 
                 // Guard: an EMPTY resolved map forces every key through the read-based fallback
                 // and must still match (proves the fallback path is sound).
-                let empty: BTreeMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
-                    BTreeMap::new();
+                let empty: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> = HashMap::new();
                 let mut eb = new_batch();
                 for (k, v) in &muts {
                     eb = eb.write(*k, *v);
@@ -415,8 +414,8 @@ pub(crate) mod test {
                 // Guard: marking existing keys as absent (`None`) must NOT corrupt the root; such
                 // keys fall back to the live snapshot resolution rather than being treated as
                 // creates off a stale hint.
-                let mut none_map: BTreeMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
-                    BTreeMap::new();
+                let mut none_map: HashMap<Digest, Option<ResolvedLocation<mmr::Family>>> =
+                    HashMap::new();
                 for (k, _) in &muts {
                     none_map.insert(*k, None);
                 }

--- a/storage/src/qmdb/benches/merkbench.rs
+++ b/storage/src/qmdb/benches/merkbench.rs
@@ -1,0 +1,201 @@
+//! Constantinople-shape harness: load+write+merkleize at 32k updates / 1M keys.
+//!
+//! Times the full per-block state pipeline (get_many load, batch writes, merkleize, root) on the
+//! tokio runtime against `any::unordered::fixed::Db<mmr>` with EightCap, matching the production
+//! validator shape. Prints per-iteration latency and the speculative root (a cross-binary parity
+//! check: any optimization must reproduce identical roots).
+//!
+//! Usage:
+//!   cargo bench -p commonware-storage --bench merkbench -- [mode] [depth] [iters] [keys] [updates]
+//!
+//! - mode: "plain" (get_many + merkleize) or "fused" (get_many_with_locations + with_resolved)
+//! - depth: number of pending ancestor batches under the timed batch (0 or 1)
+//! - iters: timed iterations (default 15)
+//! - keys: total seeded keys (default 1,000,000)
+//! - updates: keys written per batch (default 32,768)
+
+use commonware_cryptography::{Hasher, Sha256};
+use commonware_parallel::Rayon;
+use commonware_runtime::{
+    buffer::paged::CacheRef,
+    tokio::{Config as RConfig, Context, Runner},
+    Runner as _, Supervisor as _, ThreadPooler as _,
+};
+use commonware_storage::{
+    journal::contiguous::fixed::Config as FConfig,
+    merkle::{full, mmr},
+    qmdb::any::FixedConfig,
+    translator::EightCap,
+};
+use commonware_utils::{NZUsize, NZU16, NZU64};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use std::{
+    hint::black_box,
+    num::{NonZeroU16, NonZeroU64, NonZeroUsize},
+    time::Instant,
+};
+
+type Digest = <Sha256 as Hasher>::Digest;
+type Db = commonware_storage::qmdb::any::unordered::fixed::Db<
+    mmr::Family,
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    Rayon,
+>;
+type Merkleized = std::sync::Arc<
+    commonware_storage::qmdb::any::batch::MerkleizedBatch<
+        mmr::Family,
+        Digest,
+        commonware_storage::qmdb::any::unordered::fixed::Update<Digest, Digest>,
+        Rayon,
+    >,
+>;
+
+const PAGE_SIZE: NonZeroU16 = NZU16!(4096);
+// 512MB page cache, the production validator config (active window fully warm).
+const PAGE_CACHE_PAGES: NonZeroUsize = NZUsize!(131_072);
+const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(10_000_000);
+const WRITE_BUFFER: NonZeroUsize = NZUsize!(2 * 1024 * 1024);
+const THREADS: NonZeroUsize = NZUsize!(8);
+const CHURN_BATCHES: u64 = 4;
+
+fn key(i: u64) -> Digest {
+    Sha256::hash(&i.to_be_bytes())
+}
+
+fn gen_muts(rng: &mut StdRng, num_updates: u64, num_keys: u64) -> Vec<(Digest, Digest)> {
+    (0..num_updates)
+        .map(|_| {
+            let idx = rng.next_u64() % num_keys;
+            (key(idx), Sha256::hash(&rng.next_u32().to_be_bytes()))
+        })
+        .collect()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().filter(|a| a != "--bench").collect();
+    let mode = args.get(1).cloned().unwrap_or_else(|| "fused".into());
+    let depth: u8 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let iters: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(15);
+    let num_keys: u64 = args
+        .get(4)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1_000_000);
+    let num_updates: u64 = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(32_768);
+    assert!(mode == "plain" || mode == "fused", "mode: plain|fused");
+
+    eprintln!(
+        "merkbench mode={mode} depth={depth} iters={iters} keys={num_keys} updates={num_updates}"
+    );
+
+    Runner::new(RConfig::default()).start(|ctx| async move {
+        let pc = CacheRef::from_pooler(&ctx, PAGE_SIZE, PAGE_CACHE_PAGES);
+        let cfg = FixedConfig {
+            merkle_config: full::Config {
+                journal_partition: "merkbench-merkle-journal".into(),
+                metadata_partition: "merkbench-merkle-metadata".into(),
+                items_per_blob: ITEMS_PER_BLOB,
+                write_buffer: WRITE_BUFFER,
+                strategy: ctx.create_strategy(THREADS).unwrap(),
+                page_cache: pc.clone(),
+            },
+            journal_config: FConfig {
+                partition: "merkbench-log".into(),
+                items_per_blob: ITEMS_PER_BLOB,
+                page_cache: pc,
+                write_buffer: WRITE_BUFFER,
+            },
+            translator: EightCap,
+        };
+        let mut db = Db::init(ctx.child("db"), cfg).await.unwrap();
+
+        // Seed all keys in one committed batch.
+        let seed_start = Instant::now();
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut batch = db.new_batch();
+        for i in 0..num_keys {
+            batch = batch.write(key(i), Some(Sha256::hash(&rng.next_u32().to_be_bytes())));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+
+        // Churn: overwrite batches so inactive ops accumulate above the floor.
+        for _ in 0..CHURN_BATCHES {
+            let mut batch = db.new_batch();
+            for (k, v) in gen_muts(&mut rng, num_updates, num_keys) {
+                batch = batch.write(k, Some(v));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+        }
+        db.commit().await.unwrap();
+        db.sync().await.unwrap();
+        eprintln!("seed+churn done in {:?}", seed_start.elapsed());
+
+        let mut rng = StdRng::seed_from_u64(99);
+        let mut times_ms: Vec<f64> = Vec::with_capacity(iters);
+        for iter in 0..iters {
+            // Pending ancestors are rebuilt per iteration and never applied (untimed).
+            let mut parent: Option<Merkleized> = None;
+            for _ in 0..depth {
+                let mut b = match &parent {
+                    None => db.new_batch(),
+                    Some(p) => p.new_batch::<Sha256>(),
+                };
+                for (k, v) in gen_muts(&mut rng, num_updates, num_keys) {
+                    b = b.write(k, Some(v));
+                }
+                parent = Some(b.merkleize(&db, None).await.unwrap());
+            }
+
+            let muts = gen_muts(&mut rng, num_updates, num_keys);
+            let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
+            let new_batch = || match &parent {
+                None => db.new_batch(),
+                Some(p) => p.new_batch::<Sha256>(),
+            };
+
+            // Timed: load all touched keys, write them, merkleize, read root.
+            let start = Instant::now();
+            let (values, resolved) = if mode == "fused" {
+                let nb = new_batch();
+                let (values, resolved) = nb.get_many_with_locations(&keys, &db).await.unwrap();
+                (values, Some(resolved))
+            } else {
+                let nb = new_batch();
+                (nb.get_many(&keys, &db).await.unwrap(), None)
+            };
+            black_box(&values);
+            let mut b = new_batch();
+            for (k, v) in &muts {
+                b = b.write(*k, Some(*v));
+            }
+            if let Some(resolved) = resolved {
+                b = b.with_resolved(resolved);
+            }
+            let merkleized = b.merkleize(&db, None).await.unwrap();
+            let root = merkleized.root();
+            let elapsed = start.elapsed();
+
+            times_ms.push(elapsed.as_secs_f64() * 1000.0);
+            println!("iter={iter} ms={:.2} root={root}", times_ms[iter]);
+        }
+
+        times_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let p = |q: f64| times_ms[((times_ms.len() - 1) as f64 * q) as usize];
+        let mean: f64 = times_ms.iter().sum::<f64>() / times_ms.len() as f64;
+        println!(
+            "RESULT mode={mode} depth={depth} p10={:.2} p50={:.2} mean={:.2} max={:.2}",
+            p(0.1),
+            p(0.5),
+            mean,
+            times_ms[times_ms.len() - 1]
+        );
+
+        db.destroy().await.unwrap();
+    });
+}

--- a/storage/src/qmdb/benches/merkbench.rs
+++ b/storage/src/qmdb/benches/merkbench.rs
@@ -8,7 +8,8 @@
 //! Usage:
 //!   cargo bench -p commonware-storage --bench merkbench -- [mode] [depth] [iters] [keys] [updates]
 //!
-//! - mode: "plain" (get_many + merkleize) or "fused" (get_many_with_locations + with_resolved)
+//! - mode: "plain" or "fused" (identical since reads always retain resolved locations; both
+//!   accepted for output compatibility with older binaries)
 //! - depth: number of pending ancestor batches under the timed batch (0 or 1)
 //! - iters: timed iterations (default 15)
 //! - keys: total seeded keys (default 1,000,000)
@@ -159,23 +160,15 @@ fn main() {
                 Some(p) => p.new_batch::<Sha256>(),
             };
 
-            // Timed: load all touched keys, write them, merkleize, read root.
+            // Timed: load all touched keys, write them, merkleize, read root. Reads retain
+            // resolved locations on the batch, so merkleize skips re-reading those keys. Load
+            // and writes must share one batch for that retention to apply.
             let start = Instant::now();
-            let (values, resolved) = if mode == "fused" {
-                let nb = new_batch();
-                let (values, resolved) = nb.get_many_with_locations(&keys, &db).await.unwrap();
-                (values, Some(resolved))
-            } else {
-                let nb = new_batch();
-                (nb.get_many(&keys, &db).await.unwrap(), None)
-            };
-            black_box(&values);
             let mut b = new_batch();
+            let values = b.get_many(&keys, &db).await.unwrap();
+            black_box(&values);
             for (k, v) in &muts {
                 b = b.write(*k, Some(*v));
-            }
-            if let Some(resolved) = resolved {
-                b = b.with_resolved(resolved);
             }
             let merkleized = b.merkleize(&db, None).await.unwrap();
             let root = merkleized.root();

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -37,8 +37,52 @@ impl<const N: usize> Shared<N> {
     }
 
     /// Single-lock alternative to `bitmap::Readable::ones_iter_from(from).next()`.
+    #[cfg(test)]
     pub(crate) fn next_one_from(&self, from: u64) -> Option<u64> {
         self.read().ones_iter_from(from).next()
+    }
+
+    /// Fill `out` with up to `limit` floor-raise candidates in `[scan_from, tip)`, holding a single
+    /// read guard for the whole batch. Returns the next `scan_from`.
+    ///
+    /// The candidate sequence is identical to repeatedly calling
+    /// [`next_candidate`](super::any::batch::next_candidate): set bits in the committed prefix are
+    /// returned in order via one `ones_iter_from`, then locations at or beyond the committed
+    /// boundary are returned sequentially.
+    pub(crate) fn fill_candidates(
+        &self,
+        scan_from: u64,
+        tip: u64,
+        limit: usize,
+        out: &mut Vec<u64>,
+    ) -> u64 {
+        let guard = self.read();
+        let bitmap_len = bitmap::Readable::<N>::len(&*guard);
+        let committed_end = bitmap_len.min(tip);
+
+        let mut scan = scan_from;
+        if scan < committed_end {
+            let mut ones = guard.ones_iter_from(scan);
+            while out.len() < limit {
+                match ones.next() {
+                    Some(idx) if idx < committed_end => {
+                        out.push(idx);
+                        scan = idx + 1;
+                    }
+                    _ => break,
+                }
+            }
+        }
+        while out.len() < limit {
+            let candidate = scan.max(bitmap_len);
+            if candidate >= tip {
+                scan = candidate;
+                break;
+            }
+            out.push(candidate);
+            scan = candidate + 1;
+        }
+        scan
     }
 
     /// Return the number of pruned bits. Acquires the read lock briefly.

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -397,9 +397,12 @@ where
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip| {
-                next_candidate(&bitmap_parent, floor, tip)
-            })
+            .merkleize_with_floor_scan(
+                &db.any,
+                std::collections::BTreeMap::new(),
+                metadata,
+                |floor, tip| next_candidate(&bitmap_parent, floor, tip),
+            )
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -386,7 +386,9 @@ where
 
     /// Batch read multiple keys.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Committed-DB locations resolved by
+    /// the read are retained on the batch and consumed by [`merkleize`](Self::merkleize), which
+    /// skips re-reading those keys.
     pub async fn get_many<E, C, I>(
         &self,
         keys: &[&K],

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -400,39 +400,6 @@ where
         self.inner.get_many(keys, &db.any).await
     }
 
-    /// Batch read multiple keys, returning the values plus a
-    /// [`ResolvedLocations`](any::batch::ResolvedLocations) token to be attached via
-    /// [`with_resolved`](Self::with_resolved) so the subsequent [`merkleize`](Self::merkleize)
-    /// can skip re-reading these keys.
-    #[allow(clippy::type_complexity)]
-    pub async fn get_many_with_locations<E, C, I>(
-        &self,
-        keys: &[&K],
-        db: &super::db::Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
-    ) -> Result<
-        (
-            Vec<Option<V::Value>>,
-            any::batch::ResolvedLocations<K, F>,
-        ),
-        Error<F>,
-    >
-    where
-        E: Context,
-        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
-        I: UnorderedIndex<Value = Location<F>> + 'static,
-    {
-        self.inner.get_many_with_locations(keys, &db.any).await
-    }
-
-    /// Attach existing-key locations the caller already resolved during state load (via
-    /// [`get_many_with_locations`](Self::get_many_with_locations)) so
-    /// [`merkleize`](Self::merkleize) reuses them instead of re-reading the journal for those
-    /// keys. The token must have been resolved on this batch.
-    pub fn with_resolved(mut self, resolved: any::batch::ResolvedLocations<K, F>) -> Self {
-        self.inner = self.inner.with_resolved(resolved);
-        self
-    }
-
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     pub async fn merkleize<E, C, I>(
         self,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     Context,
 };
-use ahash::AHasher;
+use ahash::{AHashMap, AHasher};
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
@@ -144,6 +144,27 @@ pub(crate) fn next_candidate<F: Graftable, B: bitmap::Readable<N>, const N: usiz
     }
     let candidate = floor.max(bitmap_len);
     (candidate < tip).then(|| Location::<F>::new(candidate))
+}
+
+/// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` over the layered
+/// `BitmapBatch` chain, returning the next `floor`. Produces the same sequence as repeatedly
+/// calling [`next_candidate`].
+pub(crate) fn fill_candidates<F: Graftable, B: bitmap::Readable<N>, const N: usize>(
+    bitmap: &B,
+    floor: Location<F>,
+    tip: u64,
+    limit: usize,
+    out: &mut Vec<Location<F>>,
+) -> Location<F> {
+    let mut scan = floor;
+    while out.len() < limit {
+        let Some(candidate) = next_candidate(bitmap, scan, tip) else {
+            break;
+        };
+        out.push(candidate);
+        scan = Location::<F>::new(*candidate + 1);
+    }
+    scan
 }
 
 /// Adapter that resolves ops MMR nodes for a batch's `compute_current_layer`.
@@ -399,9 +420,9 @@ where
         let inner = inner
             .merkleize_with_floor_scan(
                 &db.any,
-                std::collections::HashMap::new(),
+                AHashMap::new(),
                 metadata,
-                |floor, tip| next_candidate(&bitmap_parent, floor, tip),
+                |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
             )
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
@@ -465,8 +486,8 @@ where
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip| {
-                next_candidate(&bitmap_parent, floor, tip)
+            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip, limit, out| {
+                fill_candidates(&bitmap_parent, floor, tip, limit, out)
             })
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -399,7 +399,7 @@ where
         let inner = inner
             .merkleize_with_floor_scan(
                 &db.any,
-                std::collections::BTreeMap::new(),
+                std::collections::HashMap::new(),
                 metadata,
                 |floor, tip| next_candidate(&bitmap_parent, floor, tip),
             )

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     Context,
 };
-use ahash::{AHashMap, AHasher};
+use ahash::AHasher;
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
@@ -400,6 +400,39 @@ where
         self.inner.get_many(keys, &db.any).await
     }
 
+    /// Batch read multiple keys, returning the values plus a
+    /// [`ResolvedLocations`](any::batch::ResolvedLocations) token to be attached via
+    /// [`with_resolved`](Self::with_resolved) so the subsequent [`merkleize`](Self::merkleize)
+    /// can skip re-reading these keys.
+    #[allow(clippy::type_complexity)]
+    pub async fn get_many_with_locations<E, C, I>(
+        &self,
+        keys: &[&K],
+        db: &super::db::Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
+    ) -> Result<
+        (
+            Vec<Option<V::Value>>,
+            any::batch::ResolvedLocations<K, F>,
+        ),
+        Error<F>,
+    >
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
+        I: UnorderedIndex<Value = Location<F>> + 'static,
+    {
+        self.inner.get_many_with_locations(keys, &db.any).await
+    }
+
+    /// Attach existing-key locations the caller already resolved during state load (via
+    /// [`get_many_with_locations`](Self::get_many_with_locations)) so
+    /// [`merkleize`](Self::merkleize) reuses them instead of re-reading the journal for those
+    /// keys. The token must have been resolved on this batch.
+    pub fn with_resolved(mut self, resolved: any::batch::ResolvedLocations<K, F>) -> Self {
+        self.inner = self.inner.with_resolved(resolved);
+        self
+    }
+
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     pub async fn merkleize<E, C, I>(
         self,
@@ -418,12 +451,9 @@ where
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(
-                &db.any,
-                AHashMap::new(),
-                metadata,
-                |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
-            )
+            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip, limit, out| {
+                fill_candidates(&bitmap_parent, floor, tip, limit, out)
+            })
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -168,9 +168,9 @@ pub mod test {
         });
     }
 
-    /// The fused `get_many_with_locations -> with_resolved -> merkleize` path must produce a
-    /// byte-identical root to a plain `merkleize`, both rooted at the DB (D=0) and through one
-    /// pending ancestor (D=1).
+    /// Reads on a batch retain resolved locations that `merkleize` consumes to skip re-reading
+    /// those keys. The root must match a write-only batch's `merkleize`, both rooted at the DB
+    /// (D=0) and through one pending ancestor (D=1).
     #[test_traced("WARN")]
     pub fn test_current_unordered_fixed_resolved_merkleize_parity() {
         use commonware_cryptography::Hasher as _;
@@ -241,22 +241,14 @@ pub mod test {
                 let normal_root = nb.merkleize(&db, None).await.unwrap().root();
 
                 let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
-                let (values, resolved) = new_batch()
-                    .get_many_with_locations(&keys, &db)
-                    .await
-                    .unwrap();
+                let mut fb = new_batch();
+                let values = fb.get_many(&keys, &db).await.unwrap();
                 let plain = new_batch().get_many(&keys, &db).await.unwrap();
                 assert_eq!(values, plain, "value mismatch at depth={depth}");
-                let mut fb = new_batch();
                 for (k, v) in &muts {
                     fb = fb.write(*k, *v);
                 }
-                let fused_root = fb
-                    .with_resolved(resolved)
-                    .merkleize(&db, None)
-                    .await
-                    .unwrap()
-                    .root();
+                let fused_root = fb.merkleize(&db, None).await.unwrap().root();
                 assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
             }
         });

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -168,6 +168,100 @@ pub mod test {
         });
     }
 
+    /// The fused `get_many_with_locations -> with_resolved -> merkleize` path must produce a
+    /// byte-identical root to a plain `merkleize`, both rooted at the DB (D=0) and through one
+    /// pending ancestor (D=1).
+    #[test_traced("WARN")]
+    pub fn test_current_unordered_fixed_resolved_merkleize_parity() {
+        use commonware_cryptography::Hasher as _;
+        use commonware_utils::test_rng_seeded;
+        use rand::RngCore as _;
+        use std::collections::HashMap;
+
+        fn key(i: u64) -> Digest {
+            Sha256::hash(&i.to_be_bytes())
+        }
+        fn val(i: u64) -> Digest {
+            Sha256::hash(&(i + 10000).to_be_bytes())
+        }
+
+        deterministic::Runner::default().start(|ctx| async move {
+            let mut db = open_db(ctx.child("current"), "fused-parity".to_string()).await;
+
+            let mut seed = db.new_batch();
+            for i in 0..2000u64 {
+                seed = seed.write(key(i), Some(val(i)));
+            }
+            let seed = seed.merkleize(&db, None).await.unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            let make = |salt: u64| -> Vec<(Digest, Option<Digest>)> {
+                let mut rng = test_rng_seeded(salt);
+                let mut out = Vec::new();
+                for _ in 0..600 {
+                    let r = rng.next_u32() % 100;
+                    if r < 60 {
+                        out.push((key(rng.next_u64() % 2000), Some(val(rng.next_u64()))));
+                    } else if r < 80 {
+                        out.push((key(rng.next_u64() % 2000), None));
+                    } else {
+                        out.push((key(2000 + rng.next_u64() % 2000), Some(val(rng.next_u64()))));
+                    }
+                }
+                let mut m: HashMap<Digest, Option<Digest>> = HashMap::new();
+                for (k, v) in out {
+                    m.insert(k, v);
+                }
+                m.into_iter().collect()
+            };
+
+            for depth in [0u8, 1u8] {
+                let parent = if depth == 1 {
+                    let mut p = db.new_batch();
+                    for (k, v) in make(900) {
+                        p = p.write(k, v);
+                    }
+                    Some(p.merkleize(&db, None).await.unwrap())
+                } else {
+                    None
+                };
+
+                let muts = make(depth as u64 + 1);
+                let new_batch = || {
+                    parent
+                        .as_ref()
+                        .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
+                };
+
+                let mut nb = new_batch();
+                for (k, v) in &muts {
+                    nb = nb.write(*k, *v);
+                }
+                let normal_root = nb.merkleize(&db, None).await.unwrap().root();
+
+                let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
+                let (values, resolved) = new_batch()
+                    .get_many_with_locations(&keys, &db)
+                    .await
+                    .unwrap();
+                let plain = new_batch().get_many(&keys, &db).await.unwrap();
+                assert_eq!(values, plain, "value mismatch at depth={depth}");
+                let mut fb = new_batch();
+                for (k, v) in &muts {
+                    fb = fb.write(*k, *v);
+                }
+                let fused_root = fb
+                    .with_resolved(resolved)
+                    .merkleize(&db, None)
+                    .await
+                    .unwrap()
+                    .root();
+                assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
+            }
+        });
+    }
+
     #[test_traced("DEBUG")]
     pub fn test_current_db_verify_proof_over_bits_in_uncommitted_chunk() {
         shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db);


### PR DESCRIPTION
Optimizes the QMDB `any` merkleize/finalize pipeline for the block-processing workload (32k updated keys per batch over 1M total keys). Roots are byte-identical to main in every configuration: this changes how results are computed, never what is committed.

## Changes

**Fused state load + merkleize (on by default)**
- `UnmerkleizedBatch::get`/`get_many` now retain committed-DB resolved locations on the batch (interior-mutable, consumed by `merkleize`), so any caller that reads then writes on one batch gets a merkleize that skips re-resolving and re-reading those ~32k keys. No new API: `current::Db` batches and glue inherit the behavior through the shared inner batch, and applications need no changes.
- Only committed-snapshot resolutions are retained. Retaining ancestor-diff resolutions is unsound: the recorded `base_old_loc` goes stale when a committed ancestor is dropped before merkleize, corrupting the snapshot on apply (caught by adversarial review, reproduced and pinned by `test_unordered_fixed_retention_survives_ancestor_commit`). Ancestor-resolved keys re-resolve in memory at merkleize, so nothing measurable is lost.
- Root parity for the retention path is covered at depths 0-2 for `any` and 0-1 for `current`, including reads-after-writes, accumulated multi-read and single-`get` retention.

**Floor raise**
- One bitmap read guard per candidate batch (`Shared::fill_candidates`) instead of one lock acquisition per candidate (~33k/batch).
- Snapshot probe skipped for committed-prefix candidates with no diff/ancestor override (the committed bitmap is exact: `apply_diff` sets the new location and clears `base_old_loc` on apply).
- Candidate ops bulk-read and decoded in parallel (`read_many_decoded`), batch size 64 -> 4096; scratch buffers replace per-op `vec![0u8; N]` (~33k allocs/iter removed).
- `floor_diff` merged into the sorted diff with a two-cursor merge instead of a full re-sort.

**Op generation / batch bookkeeping**
- The serial cost here was sorting 32-byte digest keys, not op materialization: location ordering now sorts compact `(u64, u32)` pairs instead of 80B entries, the diff is built pre-sorted via a two-cursor merge, and `commonware-parallel` gains `par_sort_unstable_by`.
- Batch `mutations` is an insertion vec with sort+dedup-last-wins on merkleize (was a `BTreeMap` with per-write ordered inserts), consumed downstream as a tombstoned sorted vec.
- Digest-keyed hot maps use `ahash` (hashing a hash with SipHash was ~2ms/batch).
- Ancestor-diff resolution for pending chains uses forward cursors over sorted queries instead of a binary search per key per ancestor (depth>=1 only).

**Merkle / journal / runtime**
- Leaf encode+hash and interior-node hashing fused into one divide-and-conquer dispatch (was one leaf pass + one rayon barrier per tree height, ~21 barriers).
- `read_many` decodes in parallel from a single pooled fill; scratch buffers come from the page-cache pool uninitialized (no multi-MB zero-fill per call).
- `read_cached_many` resolves `(page, slot)` once per page run instead of per item (~2.15 items/page on this workload).
- New `commonware-storage/sha2-asm` feature forwards to `commonware-cryptography/sha2-asm` (off by default; sha2-asm does not build on Windows MSVC). On stable aarch64 the default sha2 backend is soft (~272ns/hash vs ~41ns with asm, 6.6x); x86_64 already uses SHA-NI at runtime. Constantinople already enables it.

## Benchmarks

`merkbench` harness (committed on this branch): per-iteration `get_many(_with_locations)` + 32,768 writes + `merkleize` + `root` against `any::unordered::fixed::Db<mmr>` seeded with 1M keys, EightCap, Sha256, tokio, 512MB page cache. p50 of 10-12 iters, Apple Silicon, both sides built with `sha2-asm` (matching production). depth = pending ancestor batches below the timed batch.

Rayon=8:

| depth | main | PR (plain API) | PR (fused API) |
|---|---|---|---|
| 0 | 31.5ms | 19.5ms (1.62x) | **13.0ms (2.43x)** |
| 1 | 39.9ms | 25.3ms (1.57x) | **15.0ms (2.65x)** |

Rayon=2 (validator default):

| depth | main | PR (fused API) |
|---|---|---|
| 0 | 32.1ms | **15.3ms (2.09x)** |
| 1 | 40.4ms | **17.3ms (2.33x)** |

Per-iteration roots are byte-identical to main across all configs, modes, and depths (the harness prints them; every optimization was gated on exact parity).

## Verification

- Full `commonware-storage` suite (2558), runtime `buffer::` (137), `commonware-parallel` (6) pass; conformance (87) passes (no format changes); stability check passes; clippy/fmt clean.
- `test_unordered_fixed_resolved_merkleize_parity` covers fused-vs-plain root equality at depth 0 and 1 across updates/deletes/creates.
- Tried and rejected with measurements: routing floor reads through `read_many` without parallel decode (regressed: the reader guard is already held once for the whole floor raise), sorting a materialized interior-node list (regressed vs recording in append order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


