### PR TITLE
[storage] [glue] Use contiguous journal in compact QMDB to support rewind

### DIFF
--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -249,7 +249,7 @@ where
 
     let target = {
         let database = state.database.read().await;
-        database.current_target().await
+        database.target().await
     };
     let response = wire::GetCompactTargetResponse::<Key> {
         request_id: request.request_id,
@@ -590,7 +590,7 @@ where
     );
     database.add_operations(initial_ops).await?;
 
-    let target = database.current_target().await;
+    let target = database.target().await;
     let root = target.root;
     info!(
         leaf_count = ?target.leaf_count,

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -172,7 +172,7 @@ impl<E> super::CompactSyncable for Database<E>
 where
     E: Storage + Clock + Metrics,
 {
-    async fn current_target(&self) -> compact::Target<Self::Family, Key> {
+    async fn target(&self) -> compact::Target<Self::Family, Key> {
         compact::Target::new(self.root(), self.bounds().await.end)
     }
 }

--- a/examples/sync/src/databases/immutable_compact.rs
+++ b/examples/sync/src/databases/immutable_compact.rs
@@ -95,7 +95,7 @@ impl<E> super::CompactSyncable for Database<E>
 where
     E: Storage + Clock + Metrics,
 {
-    async fn current_target(&self) -> compact::Target<Self::Family, Key> {
+    async fn target(&self) -> compact::Target<Self::Family, Key> {
         Self::target(self)
     }
 }

--- a/examples/sync/src/databases/immutable_compact.rs
+++ b/examples/sync/src/databases/immutable_compact.rs
@@ -2,18 +2,17 @@
 
 use crate::{Hasher, Key, Value};
 use commonware_parallel::Sequential;
-use commonware_runtime::{BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::{buffer::paged::CacheRef, BufferPooler, Clock, Metrics, Storage};
 use commonware_storage::{
-    merkle::{
-        compact::Config as MerkleConfig,
-        mmr::{self},
-    },
+    journal::contiguous::variable,
+    merkle::mmr,
     qmdb::{
         self,
         immutable::fixed::{self, CompactConfig},
         sync::compact,
     },
 };
+use commonware_utils::{NZUsize, NZU16, NZU64};
 use tracing::error;
 
 /// Database type alias.
@@ -23,11 +22,16 @@ pub type Database<E> = fixed::CompactDb<mmr::Family, E, Key, Value, Hasher, Sequ
 pub type Operation = fixed::Operation<mmr::Family, Key, Value>;
 
 /// Create a database configuration for the compact immutable variant.
-pub fn create_config(_context: &impl BufferPooler) -> CompactConfig<Sequential> {
+pub fn create_config(context: &impl BufferPooler) -> CompactConfig<Sequential> {
     CompactConfig {
-        merkle: MerkleConfig {
-            partition: "compact-immutable".into(),
-            strategy: Sequential,
+        strategy: Sequential,
+        witness: variable::Config {
+            partition: "compact-immutable-witness".into(),
+            items_per_section: NZU64!(4096),
+            compression: None,
+            codec_config: (),
+            page_cache: CacheRef::from_pooler(context, NZU16!(1024), NZUsize!(64)),
+            write_buffer: NZUsize!(1024),
         },
         commit_codec_config: (),
     }
@@ -66,7 +70,7 @@ where
                 Operation::Commit(metadata, floor) => {
                     let merkleized = batch.merkleize(self, metadata, floor);
                     self.apply_batch(merkleized)?;
-                    self.commit().await?;
+                    self.sync().await?;
                     batch = self.new_batch();
                 }
             }
@@ -92,6 +96,6 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn current_target(&self) -> compact::Target<Self::Family, Key> {
-        Self::current_target(self)
+        Self::target(self)
     }
 }

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -163,7 +163,7 @@ impl<E> super::CompactSyncable for Database<E>
 where
     E: Storage + Clock + Metrics,
 {
-    async fn current_target(&self) -> compact::Target<Self::Family, Key> {
+    async fn target(&self) -> compact::Target<Self::Family, Key> {
         compact::Target::new(self.root(), self.bounds().await.end)
     }
 }

--- a/examples/sync/src/databases/keyless_compact.rs
+++ b/examples/sync/src/databases/keyless_compact.rs
@@ -2,18 +2,17 @@
 
 use crate::{Hasher, Key, Value};
 use commonware_parallel::Sequential;
-use commonware_runtime::{BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::{buffer::paged::CacheRef, BufferPooler, Clock, Metrics, Storage};
 use commonware_storage::{
-    merkle::{
-        compact::Config as MerkleConfig,
-        mmr::{self},
-    },
+    journal::contiguous::variable,
+    merkle::mmr,
     qmdb::{
         self,
         keyless::fixed::{self, CompactConfig},
         sync::compact,
     },
 };
+use commonware_utils::{NZUsize, NZU16, NZU64};
 use tracing::error;
 
 /// Database type alias.
@@ -23,11 +22,16 @@ pub type Database<E> = fixed::CompactDb<mmr::Family, E, Value, Hasher, Sequentia
 pub type Operation = fixed::Operation<mmr::Family, Value>;
 
 /// Create a database configuration for the compact keyless variant.
-pub fn create_config(_context: &impl BufferPooler) -> CompactConfig<Sequential> {
+pub fn create_config(context: &impl BufferPooler) -> CompactConfig<Sequential> {
     CompactConfig {
-        merkle: MerkleConfig {
-            partition: "compact-keyless".into(),
-            strategy: Sequential,
+        strategy: Sequential,
+        witness: variable::Config {
+            partition: "compact-keyless-witness".into(),
+            items_per_section: NZU64!(4096),
+            compression: None,
+            codec_config: (),
+            page_cache: CacheRef::from_pooler(context, NZU16!(1024), NZUsize!(64)),
+            write_buffer: NZUsize!(1024),
         },
         commit_codec_config: (),
     }
@@ -66,7 +70,7 @@ where
                 Operation::Commit(metadata, floor) => {
                     let merkleized = batch.merkleize(self, metadata, floor);
                     self.apply_batch(merkleized)?;
-                    self.commit().await?;
+                    self.sync().await?;
                     batch = self.new_batch();
                 }
             }
@@ -92,6 +96,6 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn current_target(&self) -> compact::Target<Self::Family, Key> {
-        Self::current_target(self)
+        Self::target(self)
     }
 }

--- a/examples/sync/src/databases/keyless_compact.rs
+++ b/examples/sync/src/databases/keyless_compact.rs
@@ -95,7 +95,7 @@ impl<E> super::CompactSyncable for Database<E>
 where
     E: Storage + Clock + Metrics,
 {
-    async fn current_target(&self) -> compact::Target<Self::Family, Key> {
+    async fn target(&self) -> compact::Target<Self::Family, Key> {
         Self::target(self)
     }
 }

--- a/examples/sync/src/databases/mod.rs
+++ b/examples/sync/src/databases/mod.rs
@@ -274,7 +274,7 @@ mod tests {
 
                 assert_eq!(full.root(), compact.root());
                 assert_eq!(full.current_floor(), compact.current_floor());
-                assert_eq!(compact.current_target().root, full.root());
+                assert_eq!(compact.target().root, full.root());
             }
 
             full.destroy().await.unwrap();
@@ -308,7 +308,7 @@ mod tests {
 
                 assert_eq!(full.root(), compact.root());
                 assert_eq!(full.current_floor(), compact.current_floor());
-                assert_eq!(compact.current_target().root, full.root());
+                assert_eq!(compact.target().root, full.root());
             }
 
             full.destroy().await.unwrap();

--- a/examples/sync/src/databases/mod.rs
+++ b/examples/sync/src/databases/mod.rs
@@ -212,7 +212,7 @@ pub trait CompactSyncable: ExampleDatabase {
     /// Full databases implement this so they can act as compact-sync sources, and compact-storage
     /// databases implement it so compact nodes can sync from each other. The client still
     /// materializes into compact storage in both cases.
-    fn current_target(&self) -> impl Future<Output = compact::Target<Self::Family, Key>> + Send;
+    fn target(&self) -> impl Future<Output = compact::Target<Self::Family, Key>> + Send;
 }
 
 #[cfg(test)]

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -10,10 +10,7 @@ use crate::stateful::{
         processor::{Processor, ProcessorMetrics},
         syncer::{self, SyncPlan, SyncResult},
     },
-    db::{
-        assert_rewind_window_safety, AttachableResolverSet, DatabaseSet, StateSyncSet,
-        SyncEngineConfig,
-    },
+    db::{AttachableResolverSet, DatabaseSet, StateSyncSet, SyncEngineConfig},
     Application,
 };
 use commonware_actor::mailbox::{self as actor_mailbox};
@@ -42,6 +39,11 @@ type BlockDigest<A, E> = <<A as Application<E>>::Block as Digestible>::Digest;
 /// Periodic pruning configuration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PruneConfig {
+    /// Marshal's ack window. Must match the marshal config used to construct the marshal
+    /// mailbox: pruning retains at least the last `max_pending_acks + 1` finalized blocks so
+    /// that any state a restart may need to rewind to is never pruned.
+    pub max_pending_acks: NonZeroUsize,
+
     /// Prune databases and marshal every `maintenance_interval` finalized blocks.
     ///
     /// This controls only how often pruning runs, not how much history is retained. Each prune
@@ -94,11 +96,6 @@ where
 
     /// Marshal mailbox used for startup anchoring and lazy recovery.
     pub marshal: MarshalMailbox<S, V>,
-
-    /// Marshal ack window used by the provided marshal mailbox.
-    ///
-    /// This must match the marshal config used to construct [`Self::marshal`].
-    pub max_pending_acks: NonZeroUsize,
 
     /// Capacity of the stateful actor mailbox channel.
     pub mailbox_size: NonZeroUsize,
@@ -159,9 +156,6 @@ where
     /// Sync engine tuning knobs.
     sync_config: SyncEngineConfig,
 
-    /// Marshal ack window, used to derive automatic prune retention.
-    max_pending_acks: NonZeroUsize,
-
     /// Periodic prune configuration.
     prune_config: Option<PruneConfig>,
 }
@@ -181,7 +175,6 @@ where
     /// This only wires dependencies and allocates the mailbox. The actor does
     /// not process messages until [`Stateful::start`] is called.
     pub fn init(context: E, config: Config<E, A, S, V, R>) -> (Self, Mailbox<E, A>) {
-        assert_rewind_window_safety::<E, A::Databases>(config.max_pending_acks);
         if let Some(prune_config) = config.prune_config {
             prune_config.assert_valid();
         }
@@ -198,7 +191,6 @@ where
                 plan: config.plan,
                 resolvers: config.resolvers,
                 sync_config: config.sync_config,
-                max_pending_acks: config.max_pending_acks,
                 prune_config: config.prune_config,
             },
             Mailbox::new(sender),
@@ -247,7 +239,6 @@ where
             artifact: None,
             resolvers: self.resolvers,
             sync_completed,
-            max_pending_acks: self.max_pending_acks,
             prune_config: self.prune_config,
         };
         let _ = join!(syncer.start(), syncing.start());
@@ -276,7 +267,6 @@ where
             databases,
             anchor,
             processor_metrics,
-            self.max_pending_acks,
             self.prune_config,
         );
         Processing {
@@ -443,7 +433,6 @@ mod tests {
                     db_config: (),
                     input_provider: (),
                     marshal,
-                    max_pending_acks: NZUsize!(1),
                     mailbox_size: NZUsize!(8),
                     plan: plan.with_floor(finalization),
                     resolvers: NoopResolver,

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -28,7 +28,7 @@ use commonware_utils::{
     Acknowledgement,
 };
 use rand::Rng;
-use std::{num::NonZeroUsize, sync::Arc};
+use std::sync::Arc;
 use tracing::{debug, error};
 
 /// Verify request buffered while state sync is still in progress.
@@ -90,9 +90,6 @@ where
 
     /// Signals that the syncer has produced a usable artifact.
     pub(super) sync_completed: oneshot::Receiver<SyncResult<E, A>>,
-
-    /// Marshal ack window, used to derive automatic prune retention.
-    pub(super) max_pending_acks: NonZeroUsize,
 
     /// Periodic prune configuration.
     pub(super) prune_config: Option<PruneConfig>,
@@ -232,7 +229,6 @@ where
             artifact.databases,
             artifact.anchor,
             metrics,
-            self.max_pending_acks,
             self.prune_config,
         );
 
@@ -373,7 +369,6 @@ mod tests {
                     }),
                     resolvers: NoopResolver,
                     sync_completed,
-                    max_pending_acks: NZUsize!(1),
                     prune_config: None,
                 },
             }

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -113,16 +113,17 @@ impl<T> Prune<T> {
 /// Tracks the configured prune cadence and finalized sync targets needed to
 /// make pruning safe.
 struct Pruning<T> {
-    config: PruneConfig,
+    maintenance_interval: NonZeroUsize,
     marshal_retention_window: usize,
     qmdb_retention_window: usize,
     retained_targets: VecDeque<(Height, T)>,
 }
 
 impl<T: Clone> Pruning<T> {
-    const fn new(config: PruneConfig, max_pending_acks: NonZeroUsize) -> Self {
+    const fn new(config: PruneConfig) -> Self {
         config.assert_valid();
-        let base_retention_window = max_pending_acks
+        let base_retention_window = config
+            .max_pending_acks
             .get()
             .checked_add(1)
             .expect("max_pending_acks retention window overflowed");
@@ -133,7 +134,7 @@ impl<T: Clone> Pruning<T> {
             .checked_add(config.retained_qmdb_blocks)
             .expect("qmdb prune retention window overflowed");
         Self {
-            config,
+            maintenance_interval: config.maintenance_interval,
             marshal_retention_window,
             qmdb_retention_window,
             retained_targets: VecDeque::new(),
@@ -152,7 +153,7 @@ impl<T: Clone> Pruning<T> {
             self.retained_targets.pop_front();
         }
 
-        let interval = u64::try_from(self.config.maintenance_interval.get())
+        let interval = u64::try_from(self.maintenance_interval.get())
             .expect("prune interval should fit in u64");
         if !height.get().is_multiple_of(interval) {
             return None;
@@ -214,7 +215,6 @@ where
         databases: A::Databases,
         last_processed: Anchor<PendingDigest<A, E>>,
         metrics: ProcessorMetrics,
-        max_pending_acks: NonZeroUsize,
         prune_config: Option<PruneConfig>,
     ) -> Self {
         Self {
@@ -223,7 +223,7 @@ where
             pending: BTreeMap::new(),
             last_processed,
             metrics,
-            pruning: prune_config.map(|config| Pruning::new(config, max_pending_acks)),
+            pruning: prune_config.map(Pruning::new),
         }
     }
 
@@ -1337,7 +1337,6 @@ mod tests {
                         digest: Block::genesis().digest(),
                     },
                     metrics,
-                    NZUsize!(1),
                     None,
                 ),
                 provider,
@@ -1551,12 +1550,12 @@ mod tests {
 
     #[test]
     fn pruning_waits_for_full_retention_window() {
-        let config = PruneConfig {
+        let mut pruning = Pruning::new(PruneConfig {
+            max_pending_acks: NZUsize!(2),
             maintenance_interval: NZUsize!(1),
             retained_marshal_blocks: 1,
             retained_qmdb_blocks: 1,
-        };
-        let mut pruning = Pruning::new(config, NZUsize!(2));
+        });
 
         assert_eq!(pruning.observe_finalized(Height::new(1), 10_u64), None,);
         assert_eq!(pruning.observe_finalized(Height::new(2), 20_u64), None,);
@@ -1572,12 +1571,12 @@ mod tests {
 
     #[test]
     fn pruning_uses_oldest_retained_target() {
-        let config = PruneConfig {
+        let mut pruning = Pruning::new(PruneConfig {
+            max_pending_acks: NZUsize!(1),
             maintenance_interval: NZUsize!(1),
             retained_marshal_blocks: 1,
             retained_qmdb_blocks: 1,
-        };
-        let mut pruning = Pruning::new(config, NZUsize!(1));
+        });
 
         assert_eq!(pruning.observe_finalized(Height::new(1), 10_u64), None,);
         assert_eq!(pruning.observe_finalized(Height::new(2), 20_u64), None,);
@@ -1599,12 +1598,12 @@ mod tests {
 
     #[test]
     fn pruning_can_retain_more_marshal_history_than_qmdb() {
-        let config = PruneConfig {
+        let mut pruning = Pruning::new(PruneConfig {
+            max_pending_acks: NZUsize!(1),
             maintenance_interval: NZUsize!(3),
             retained_marshal_blocks: 3,
             retained_qmdb_blocks: 1,
-        };
-        let mut pruning = Pruning::new(config, NZUsize!(1));
+        });
 
         assert_eq!(pruning.observe_finalized(Height::new(1), 10_u64), None);
         assert_eq!(pruning.observe_finalized(Height::new(2), 20_u64), None);
@@ -1622,12 +1621,12 @@ mod tests {
 
     #[test]
     fn pruning_only_runs_on_maintenance_interval() {
-        let config = PruneConfig {
+        let mut pruning = Pruning::new(PruneConfig {
+            max_pending_acks: NZUsize!(1),
             maintenance_interval: NZUsize!(5),
             retained_marshal_blocks: 1,
             retained_qmdb_blocks: 0,
-        };
-        let mut pruning = Pruning::new(config, NZUsize!(1));
+        });
 
         // Window fills at height 3, but pruning only fires on multiples of the
         // maintenance interval regardless of how small the retention window is.
@@ -1663,6 +1662,7 @@ mod tests {
     #[should_panic(expected = "marshal must retain at least as many blocks as QMDB")]
     fn prune_config_rejects_less_marshal_retention_than_qmdb() {
         PruneConfig {
+            max_pending_acks: NZUsize!(1),
             maintenance_interval: NZUsize!(1),
             retained_marshal_blocks: 1,
             retained_qmdb_blocks: 2,
@@ -1673,6 +1673,7 @@ mod tests {
     #[test]
     fn prune_config_accepts_zero_retention() {
         PruneConfig {
+            max_pending_acks: NZUsize!(1),
             maintenance_interval: NZUsize!(1),
             retained_marshal_blocks: 0,
             retained_qmdb_blocks: 0,
@@ -1696,8 +1697,8 @@ mod tests {
                     digest: Block::genesis().digest(),
                 },
                 ProcessorMetrics::new(harness.context_cell.child("staged_processor_metrics")),
-                NZUsize!(1),
                 Some(PruneConfig {
+                    max_pending_acks: NZUsize!(1),
                     maintenance_interval: NZUsize!(1),
                     retained_marshal_blocks: 1,
                     retained_qmdb_blocks: 1,

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -254,24 +254,24 @@ where
         self.sync().await
     }
 
+    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+        Self::prune(self, target.leaf_count).await
+    }
+
     async fn sync_target(&self) -> Self::SyncTarget {
-        self.current_target()
+        self.target()
     }
 
     async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        // Compact storage only retains the previous logical commit range.
-        self.rewind().await?;
+        // `rewind` makes the rewind durable, so no follow-up sync is needed.
+        self.rewind(target.leaf_count).await?;
 
         let rewound_target = self.sync_target().await;
         assert_eq!(
             rewound_target, target,
-            "rewound database target mismatch after one-step rewind",
+            "rewound database target mismatch after rewind",
         );
         Ok(())
-    }
-
-    fn max_rewind_depth() -> Option<usize> {
-        Some(1)
     }
 }
 
@@ -315,24 +315,24 @@ where
         self.sync().await
     }
 
+    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+        Self::prune(self, target.leaf_count).await
+    }
+
     async fn sync_target(&self) -> Self::SyncTarget {
-        self.current_target()
+        self.target()
     }
 
     async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        // Compact storage only retains the previous logical commit range.
-        self.rewind().await?;
+        // `rewind` makes the rewind durable, so no follow-up sync is needed.
+        self.rewind(target.leaf_count).await?;
 
         let rewound_target = self.sync_target().await;
         assert_eq!(
             rewound_target, target,
-            "rewound database target mismatch after one-step rewind",
+            "rewound database target mismatch after rewind",
         );
         Ok(())
-    }
-
-    fn max_rewind_depth() -> Option<usize> {
-        Some(1)
     }
 }
 
@@ -530,7 +530,7 @@ mod tests {
     };
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedJournalConfig,
-        merkle::{compact::Config as MerkleConfig, full::Config as FullMerkleConfig, mmr},
+        merkle::{full::Config as MerkleConfig, mmr},
         translator::TwoCap,
     };
     use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -550,11 +550,16 @@ mod tests {
         Sequential,
     >;
 
-    fn fixed_config(suffix: &str) -> fixed::CompactConfig<Sequential> {
+    fn fixed_config(suffix: &str, pooler: &impl BufferPooler) -> fixed::CompactConfig<Sequential> {
         fixed::CompactConfig {
-            merkle: MerkleConfig {
-                partition: format!("stateful-immutable-unjournaled-{suffix}"),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: commonware_storage::journal::contiguous::variable::Config {
+                partition: format!("stateful-immutable-unjournaled-{suffix}-witness"),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(pooler, NZU16!(101), NZUsize!(11)),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: (),
         }
@@ -566,7 +571,7 @@ mod tests {
     ) -> fixed::Config<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, NZU16!(101), NZUsize!(11));
         fixed::Config {
-            merkle_config: FullMerkleConfig {
+            merkle_config: MerkleConfig {
                 journal_partition: format!("stateful-immutable-full-journal-{suffix}"),
                 metadata_partition: format!("stateful-immutable-full-metadata-{suffix}"),
                 items_per_blob: NZU64!(11),
@@ -640,7 +645,7 @@ mod tests {
     #[test]
     fn managed_db_finalize_commits_fixed_immutable_unjournaled_batches() {
         deterministic::Runner::default().start(|context| async move {
-            let config = fixed_config("managed-db");
+            let config = fixed_config("managed-db", &context);
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
             let db = Arc::new(AsyncRwLock::new(db));
             let key = Sha256::hash(&[1]);
@@ -677,9 +682,10 @@ mod tests {
     #[test]
     fn state_sync_fetches_fixed_immutable_compact_state() {
         deterministic::Runner::default().start(|context| async move {
-            let mut source = FixedDb::init(context.child("source"), fixed_config("source"))
-                .await
-                .unwrap();
+            let mut source =
+                FixedDb::init(context.child("source"), fixed_config("source", &context))
+                    .await
+                    .unwrap();
             let metadata = Sha256::hash(&[3]);
             let floor = source.inactivity_floor_loc();
             let batch = source
@@ -689,11 +695,11 @@ mod tests {
             source.apply_batch(batch).unwrap();
             source.sync().await.unwrap();
 
-            let target = source.current_target();
+            let target = source.target();
             let (_update_tx, update_rx) = mpsc::channel(1);
             let synced = <FixedDb as StateSyncDb<_, Arc<FixedDb>>>::sync_db(
                 context.child("target"),
-                fixed_config("target"),
+                fixed_config("target", &context),
                 Arc::new(source),
                 target.clone(),
                 update_rx,
@@ -704,7 +710,7 @@ mod tests {
             .await
             .unwrap();
 
-            assert_eq!(synced.current_target(), target);
+            assert_eq!(synced.target(), target);
             assert_eq!(synced.get_metadata(), Some(metadata));
         });
     }
@@ -754,7 +760,7 @@ mod tests {
             let sync_handle = context.child("sync").spawn(move |context| async move {
                 <FixedDb as StateSyncDb<_, _>>::sync_db(
                     context.child("target"),
-                    fixed_config("supersede-target"),
+                    fixed_config("supersede-target", &context),
                     resolver,
                     stale_target,
                     update_rx,
@@ -780,15 +786,15 @@ mod tests {
                 .expect("spawned sync task should complete")
                 .unwrap();
 
-            assert_eq!(synced.current_target(), latest_target);
+            assert_eq!(synced.target(), latest_target);
             assert_eq!(synced.get_metadata(), Some(Sha256::hash(&[10])));
         });
     }
 
     #[test]
-    fn managed_db_rewinds_fixed_immutable_unjournaled_one_commit_range() {
+    fn managed_db_rewinds_fixed_immutable_unjournaled_multiple_commit_ranges() {
         deterministic::Runner::default().start(|context| async move {
-            let config = fixed_config("rewind");
+            let config = fixed_config("rewind", &context);
             let mut db = FixedDb::init(context.child("db"), config).await.unwrap();
 
             let floor = db.inactivity_floor_loc();
@@ -800,15 +806,18 @@ mod tests {
             db.sync().await.unwrap();
             let first_target = <FixedDb as ManagedDb<_>>::sync_target(&db).await;
 
-            let floor = db.inactivity_floor_loc();
-            let batch = db
-                .new_batch()
-                .set(Sha256::hash(&[3]), Sha256::hash(&[4]))
-                .merkleize(&db, Some(Sha256::hash(&[22])), floor);
-            db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
-            let second_target = <FixedDb as ManagedDb<_>>::sync_target(&db).await;
-            assert_ne!(second_target, first_target);
+            // Commit two more ranges so the rewind below spans multiple commits.
+            for i in [3u8, 5] {
+                let floor = db.inactivity_floor_loc();
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[i]), Sha256::hash(&[i + 1]))
+                    .merkleize(&db, Some(Sha256::hash(&[i * 11])), floor);
+                db.apply_batch(batch).unwrap();
+                db.sync().await.unwrap();
+            }
+            let third_target = <FixedDb as ManagedDb<_>>::sync_target(&db).await;
+            assert_ne!(third_target, first_target);
 
             <FixedDb as ManagedDb<_>>::rewind_to_target(&mut db, first_target.clone())
                 .await
@@ -817,6 +826,50 @@ mod tests {
             let rewound_target = <FixedDb as ManagedDb<_>>::sync_target(&db).await;
             assert_eq!(rewound_target, first_target);
             assert_eq!(db.get_metadata(), Some(Sha256::hash(&[11])));
+        });
+    }
+
+    #[test]
+    fn managed_db_prune_bounds_fixed_immutable_unjournaled_rewind_history() {
+        deterministic::Runner::default().start(|context| async move {
+            // One witness entry per section so pruning takes effect at entry granularity.
+            let mut config = fixed_config("prune", &context);
+            config.witness.items_per_section = NZU64!(1);
+            let mut db = FixedDb::init(context.child("db"), config).await.unwrap();
+
+            // Commit three ranges, recording each target.
+            let mut targets = Vec::new();
+            for i in [1u8, 3, 5] {
+                let floor = db.inactivity_floor_loc();
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[i]), Sha256::hash(&[i + 1]))
+                    .merkleize(&db, Some(Sha256::hash(&[i * 11])), floor);
+                db.apply_batch(batch).unwrap();
+                db.sync().await.unwrap();
+                targets.push(<FixedDb as ManagedDb<_>>::sync_target(&db).await);
+            }
+
+            assert_ne!(targets[0], targets[1]);
+
+            // Prune to the second target: the first is no longer a rewind target, but the
+            // second still is.
+            <FixedDb as ManagedDb<_>>::prune(&mut db, &targets[1])
+                .await
+                .unwrap();
+            assert!(matches!(
+                db.rewind(targets[0].leaf_count).await,
+                Err(Error::Merkle(
+                    commonware_storage::merkle::Error::RewindBeyondHistory
+                ))
+            ));
+            <FixedDb as ManagedDb<_>>::rewind_to_target(&mut db, targets[1].clone())
+                .await
+                .unwrap();
+            assert_eq!(
+                <FixedDb as ManagedDb<_>>::sync_target(&db).await,
+                targets[1]
+            );
         });
     }
 }

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -263,7 +263,6 @@ where
     }
 
     async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        // `rewind` makes the rewind durable, so no follow-up sync is needed.
         self.rewind(target.leaf_count).await?;
 
         let rewound_target = self.sync_target().await;
@@ -324,7 +323,6 @@ where
     }
 
     async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        // `rewind` makes the rewind durable, so no follow-up sync is needed.
         self.rewind(target.leaf_count).await?;
 
         let rewound_target = self.sync_target().await;

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -243,24 +243,24 @@ where
         self.sync().await
     }
 
+    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+        Self::prune(self, target.leaf_count).await
+    }
+
     async fn sync_target(&self) -> Self::SyncTarget {
-        self.current_target()
+        self.target()
     }
 
     async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        // Compact storage only retains the previous logical commit range.
-        self.rewind().await?;
+        // `rewind` makes the rewind durable, so no follow-up sync is needed.
+        self.rewind(target.leaf_count).await?;
 
         let rewound_target = self.sync_target().await;
         assert_eq!(
             rewound_target, target,
-            "rewound database target mismatch after one-step rewind",
+            "rewound database target mismatch after rewind",
         );
         Ok(())
-    }
-
-    fn max_rewind_depth() -> Option<usize> {
-        Some(1)
     }
 }
 
@@ -303,24 +303,24 @@ where
         self.sync().await
     }
 
+    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+        Self::prune(self, target.leaf_count).await
+    }
+
     async fn sync_target(&self) -> Self::SyncTarget {
-        self.current_target()
+        self.target()
     }
 
     async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        // Compact storage only retains the previous logical commit range.
-        self.rewind().await?;
+        // `rewind` makes the rewind durable, so no follow-up sync is needed.
+        self.rewind(target.leaf_count).await?;
 
         let rewound_target = self.sync_target().await;
         assert_eq!(
             rewound_target, target,
-            "rewound database target mismatch after one-step rewind",
+            "rewound database target mismatch after rewind",
         );
         Ok(())
-    }
-
-    fn max_rewind_depth() -> Option<usize> {
-        Some(1)
     }
 }
 
@@ -512,7 +512,7 @@ mod tests {
     };
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedJournalConfig,
-        merkle::{compact::Config as MerkleConfig, full::Config as FullMerkleConfig, mmr},
+        merkle::{full::Config as MerkleConfig, mmr},
         qmdb::keyless as storage_keyless,
     };
     use commonware_utils::{sequence::U64, NZUsize, NZU16, NZU64};
@@ -557,11 +557,16 @@ mod tests {
         }
     }
 
-    fn fixed_config(suffix: &str) -> fixed::CompactConfig<Sequential> {
+    fn fixed_config(suffix: &str, pooler: &impl BufferPooler) -> fixed::CompactConfig<Sequential> {
         fixed::CompactConfig {
-            merkle: MerkleConfig {
-                partition: format!("stateful-keyless-unjournaled-{suffix}"),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: commonware_storage::journal::contiguous::variable::Config {
+                partition: format!("stateful-keyless-unjournaled-{suffix}-witness"),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(pooler, NZU16!(101), NZUsize!(11)),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: (),
         }
@@ -573,7 +578,7 @@ mod tests {
     ) -> storage_keyless::fixed::Config<Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, NZU16!(101), NZUsize!(11));
         storage_keyless::fixed::Config {
-            merkle: FullMerkleConfig {
+            merkle: MerkleConfig {
                 journal_partition: format!("stateful-keyless-full-journal-{suffix}"),
                 metadata_partition: format!("stateful-keyless-full-metadata-{suffix}"),
                 items_per_blob: NZU64!(11),
@@ -619,7 +624,7 @@ mod tests {
     #[test]
     fn managed_db_finalize_commits_fixed_keyless_unjournaled_batches() {
         deterministic::Runner::default().start(|context| async move {
-            let config = fixed_config("managed-db");
+            let config = fixed_config("managed-db", &context);
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
             let db = Arc::new(AsyncRwLock::new(db));
 
@@ -653,7 +658,7 @@ mod tests {
     #[test]
     fn managed_db_matches_sync_target_rejects_wrong_leaf_count() {
         deterministic::Runner::default().start(|context| async move {
-            let config = fixed_config("matches-sync-target");
+            let config = fixed_config("matches-sync-target", &context);
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
             let db = Arc::new(AsyncRwLock::new(db));
 
@@ -689,9 +694,10 @@ mod tests {
     #[test]
     fn state_sync_fetches_fixed_keyless_compact_state() {
         deterministic::Runner::default().start(|context| async move {
-            let mut source = FixedDb::init(context.child("source"), fixed_config("source"))
-                .await
-                .unwrap();
+            let mut source =
+                FixedDb::init(context.child("source"), fixed_config("source", &context))
+                    .await
+                    .unwrap();
             let floor = source.inactivity_floor_loc();
             let batch =
                 source
@@ -701,11 +707,11 @@ mod tests {
             source.apply_batch(batch).unwrap();
             source.sync().await.unwrap();
 
-            let target = source.current_target();
+            let target = source.target();
             let (_update_tx, update_rx) = mpsc::channel(1);
             let synced = <FixedDb as StateSyncDb<_, Arc<FixedDb>>>::sync_db(
                 context.child("target"),
-                fixed_config("target"),
+                fixed_config("target", &context),
                 Arc::new(source),
                 target.clone(),
                 update_rx,
@@ -716,7 +722,7 @@ mod tests {
             .await
             .unwrap();
 
-            assert_eq!(synced.current_target(), target);
+            assert_eq!(synced.target(), target);
             assert_eq!(synced.get_metadata(), Some(U64::new(9)));
         });
     }
@@ -762,7 +768,7 @@ mod tests {
             let (reached_tx, mut reached_rx) = mpsc::channel(1);
             let synced = <FixedDb as StateSyncDb<_, Arc<FullFixedDb>>>::sync_db(
                 context.child("target"),
-                fixed_config("target"),
+                fixed_config("target", &context),
                 Arc::new(source),
                 first_target,
                 update_rx,
@@ -774,7 +780,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(reached_rx.recv().await, Some(second_target.clone()));
-            assert_eq!(synced.current_target(), second_target);
+            assert_eq!(synced.target(), second_target);
             assert_eq!(synced.get_metadata(), Some(U64::new(10)));
         });
     }
@@ -782,10 +788,12 @@ mod tests {
     #[test]
     fn state_sync_supersedes_in_flight_stale_compact_target() {
         deterministic::Runner::default().start(|context| async move {
-            let mut source =
-                FixedDb::init(context.child("source"), fixed_config("supersede-source"))
-                    .await
-                    .unwrap();
+            let mut source = FixedDb::init(
+                context.child("source"),
+                fixed_config("supersede-source", &context),
+            )
+            .await
+            .unwrap();
 
             let floor = source.inactivity_floor_loc();
             let batch =
@@ -795,7 +803,7 @@ mod tests {
                     .merkleize(&source, Some(U64::new(9)), floor);
             source.apply_batch(batch).unwrap();
             source.sync().await.unwrap();
-            let stale_target = source.current_target();
+            let stale_target = source.target();
 
             let floor = source.inactivity_floor_loc();
             let batch = source.new_batch().append(U64::new(8)).merkleize(
@@ -805,7 +813,7 @@ mod tests {
             );
             source.apply_batch(batch).unwrap();
             source.sync().await.unwrap();
-            let latest_target = source.current_target();
+            let latest_target = source.target();
 
             let (stale_request_tx, mut stale_request_rx) = mpsc::channel(1);
             let resolver = SupersedingCompactResolver {
@@ -818,7 +826,7 @@ mod tests {
             let sync_handle = context.child("sync").spawn(move |context| async move {
                 <FixedDb as StateSyncDb<_, _>>::sync_db(
                     context.child("target"),
-                    fixed_config("supersede-target"),
+                    fixed_config("supersede-target", &context),
                     resolver,
                     stale_target,
                     update_rx,
@@ -844,15 +852,15 @@ mod tests {
                 .expect("spawned sync task should complete")
                 .unwrap();
 
-            assert_eq!(synced.current_target(), latest_target);
+            assert_eq!(synced.target(), latest_target);
             assert_eq!(synced.get_metadata(), Some(U64::new(10)));
         });
     }
 
     #[test]
-    fn managed_db_rewinds_fixed_keyless_unjournaled_one_commit_range() {
+    fn managed_db_rewinds_fixed_keyless_unjournaled_multiple_commit_ranges() {
         deterministic::Runner::default().start(|context| async move {
-            let config = fixed_config("rewind");
+            let config = fixed_config("rewind", &context);
             let mut db = FixedDb::init(context.child("db"), config).await.unwrap();
 
             let floor = db.inactivity_floor_loc();
@@ -864,15 +872,19 @@ mod tests {
             db.sync().await.unwrap();
             let first_target = <FixedDb as ManagedDb<_>>::sync_target(&db).await;
 
-            let floor = db.inactivity_floor_loc();
-            let batch =
-                db.new_batch()
-                    .append(U64::new(2))
-                    .merkleize(&db, Some(U64::new(22)), floor);
-            db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
-            let second_target = <FixedDb as ManagedDb<_>>::sync_target(&db).await;
-            assert_ne!(second_target, first_target);
+            // Commit two more ranges so the rewind below spans multiple commits.
+            for i in [2u64, 3] {
+                let floor = db.inactivity_floor_loc();
+                let batch = db.new_batch().append(U64::new(i)).merkleize(
+                    &db,
+                    Some(U64::new(i * 11)),
+                    floor,
+                );
+                db.apply_batch(batch).unwrap();
+                db.sync().await.unwrap();
+            }
+            let third_target = <FixedDb as ManagedDb<_>>::sync_target(&db).await;
+            assert_ne!(third_target, first_target);
 
             <FixedDb as ManagedDb<_>>::rewind_to_target(&mut db, first_target.clone())
                 .await
@@ -881,6 +893,51 @@ mod tests {
             let rewound_target = <FixedDb as ManagedDb<_>>::sync_target(&db).await;
             assert_eq!(rewound_target, first_target);
             assert_eq!(db.get_metadata(), Some(U64::new(11)));
+        });
+    }
+
+    #[test]
+    fn managed_db_prune_bounds_fixed_keyless_unjournaled_rewind_history() {
+        deterministic::Runner::default().start(|context| async move {
+            // One witness entry per section so pruning takes effect at entry granularity.
+            let mut config = fixed_config("prune", &context);
+            config.witness.items_per_section = NZU64!(1);
+            let mut db = FixedDb::init(context.child("db"), config).await.unwrap();
+
+            // Commit three ranges, recording each target.
+            let mut targets = Vec::new();
+            for i in [1u64, 2, 3] {
+                let floor = db.inactivity_floor_loc();
+                let batch = db.new_batch().append(U64::new(i)).merkleize(
+                    &db,
+                    Some(U64::new(i * 11)),
+                    floor,
+                );
+                db.apply_batch(batch).unwrap();
+                db.sync().await.unwrap();
+                targets.push(<FixedDb as ManagedDb<_>>::sync_target(&db).await);
+            }
+
+            assert_ne!(targets[0], targets[1]);
+
+            // Prune to the second target: the first is no longer a rewind target, but the
+            // second still is.
+            <FixedDb as ManagedDb<_>>::prune(&mut db, &targets[1])
+                .await
+                .unwrap();
+            assert!(matches!(
+                db.rewind(targets[0].leaf_count).await,
+                Err(Error::Merkle(
+                    commonware_storage::merkle::Error::RewindBeyondHistory
+                ))
+            ));
+            <FixedDb as ManagedDb<_>>::rewind_to_target(&mut db, targets[1].clone())
+                .await
+                .unwrap();
+            assert_eq!(
+                <FixedDb as ManagedDb<_>>::sync_target(&db).await,
+                targets[1]
+            );
         });
     }
 }

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -252,7 +252,6 @@ where
     }
 
     async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        // `rewind` makes the rewind durable, so no follow-up sync is needed.
         self.rewind(target.leaf_count).await?;
 
         let rewound_target = self.sync_target().await;
@@ -312,7 +311,6 @@ where
     }
 
     async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        // `rewind` makes the rewind durable, so no follow-up sync is needed.
         self.rewind(target.leaf_count).await?;
 
         let rewound_target = self.sync_target().await;

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -224,13 +224,6 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
         &mut self,
         target: Self::SyncTarget,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
-
-    /// Return the maximum number of finalized commits this database can rewind.
-    ///
-    /// `None` means rewind depth is not bounded by a known finite limit.
-    fn max_rewind_depth() -> Option<usize> {
-        None
-    }
 }
 
 /// A collection of individually locked [`ManagedDb`] instances.
@@ -296,27 +289,6 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     ///
     /// Rewind failures are fatal for startup recovery and therefore panic.
     fn rewind_to_targets(&self, targets: Self::SyncTargets) -> impl Future<Output = ()> + Send;
-
-    /// Return the most restrictive finite rewind depth across the database set.
-    ///
-    /// `None` means every database in the set is unbounded.
-    fn max_rewind_depth() -> Option<usize>;
-}
-
-pub(crate) fn assert_rewind_window_safety<E, D>(max_pending_acks: NonZeroUsize)
-where
-    D: DatabaseSet<E>,
-{
-    let Some(max_rewind_depth) = D::max_rewind_depth() else {
-        return;
-    };
-
-    assert!(
-        max_pending_acks.get() <= max_rewind_depth,
-        "marshal max_pending_acks={} exceeds database_set.max_rewind_depth={}",
-        max_pending_acks,
-        max_rewind_depth,
-    );
 }
 
 /// Parameters for a one-time state-sync pass.
@@ -498,10 +470,6 @@ impl<E: Send + Sync, T: ManagedDb<E> + 'static> DatabaseSet<E> for Arc<AsyncRwLo
             return;
         }
         rewind_or_panic(&mut *database, target, None).await;
-    }
-
-    fn max_rewind_depth() -> Option<usize> {
-        T::max_rewind_depth()
     }
 }
 
@@ -744,19 +712,6 @@ macro_rules! impl_database_set {
                         rewind_or_panic(&mut *database, targets.$idx, Some($idx)).await;
                     },
                 )+);
-            }
-
-            fn max_rewind_depth() -> Option<usize> {
-                let mut max_rewind_depth: Option<usize> = None;
-                $(
-                    max_rewind_depth = match (max_rewind_depth, $T::max_rewind_depth()) {
-                        (Some(current), Some(next)) => Some(current.min(next)),
-                        (Some(current), None) => Some(current),
-                        (None, Some(next)) => Some(next),
-                        (None, None) => None,
-                    };
-                )+
-                max_rewind_depth
             }
         }
     };
@@ -1509,9 +1464,9 @@ impl_attachable_resolver_set!(
 #[cfg(test)]
 mod tests {
     use super::{
-        assert_rewind_window_safety, drain_single_tip_updates, Anchor, AttachableResolver,
-        AttachableResolverSet, CoordinatorAction, CoordinatorState, DatabaseSet, ManagedDb,
-        StateSyncDb, StateSyncSet, SyncEngineConfig, TipUpdate, MAX_CHANNEL_DRAIN_PER_TICK,
+        drain_single_tip_updates, Anchor, AttachableResolver, AttachableResolverSet,
+        CoordinatorAction, CoordinatorState, DatabaseSet, ManagedDb, StateSyncDb, StateSyncSet,
+        SyncEngineConfig, TipUpdate, MAX_CHANNEL_DRAIN_PER_TICK,
     };
     use crate::stateful::tests::mocks::{anchor as mock_anchor, TestMerkleized, TestUnmerkleized};
     use commonware_cryptography::sha256;
@@ -1536,12 +1491,6 @@ mod tests {
 
     #[derive(Default)]
     struct TestDb;
-
-    #[derive(Default)]
-    struct OneStepRewindDb;
-
-    #[derive(Default)]
-    struct ThreeStepRewindDb;
 
     struct CountingRewindDb {
         current_target: u64,
@@ -1580,74 +1529,6 @@ mod tests {
 
         async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
             Ok(())
-        }
-    }
-
-    impl<E: Send> ManagedDb<E> for OneStepRewindDb {
-        type Unmerkleized = TestUnmerkleized;
-        type Merkleized = TestMerkleized;
-        type Error = Infallible;
-        type Config = ();
-        type SyncTarget = ();
-
-        async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
-            Ok(Self)
-        }
-
-        async fn new_batch(_db: &Arc<AsyncRwLock<Self>>) -> Self::Unmerkleized {
-            TestUnmerkleized
-        }
-
-        fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
-            true
-        }
-
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn sync_target(&self) -> Self::SyncTarget {}
-
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        fn max_rewind_depth() -> Option<usize> {
-            Some(1)
-        }
-    }
-
-    impl<E: Send> ManagedDb<E> for ThreeStepRewindDb {
-        type Unmerkleized = TestUnmerkleized;
-        type Merkleized = TestMerkleized;
-        type Error = Infallible;
-        type Config = ();
-        type SyncTarget = ();
-
-        async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
-            Ok(Self)
-        }
-
-        async fn new_batch(_db: &Arc<AsyncRwLock<Self>>) -> Self::Unmerkleized {
-            TestUnmerkleized
-        }
-
-        fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
-            true
-        }
-
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        async fn sync_target(&self) -> Self::SyncTarget {}
-
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
-        }
-
-        fn max_rewind_depth() -> Option<usize> {
-            Some(3)
         }
     }
 
@@ -1818,48 +1699,6 @@ mod tests {
         async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
             Ok(())
         }
-    }
-
-    #[test]
-    fn single_db_set_reports_unbounded_rewind_depth() {
-        let rewind_depth =
-            <Arc<AsyncRwLock<TestDb>> as DatabaseSet<deterministic::Context>>::max_rewind_depth();
-        assert_eq!(rewind_depth, None);
-    }
-
-    #[test]
-    fn single_db_set_reports_one_step_rewind_depth() {
-        let rewind_depth = <Arc<AsyncRwLock<OneStepRewindDb>> as DatabaseSet<
-            deterministic::Context,
-        >>::max_rewind_depth();
-        assert_eq!(rewind_depth, Some(1));
-    }
-
-    #[test]
-    fn tuple_db_set_uses_most_restrictive_finite_rewind_depth() {
-        type DbSet = (
-            Arc<AsyncRwLock<TestDb>>,
-            Arc<AsyncRwLock<ThreeStepRewindDb>>,
-            Arc<AsyncRwLock<OneStepRewindDb>>,
-        );
-
-        let rewind_depth = <DbSet as DatabaseSet<deterministic::Context>>::max_rewind_depth();
-        assert_eq!(rewind_depth, Some(1));
-    }
-
-    #[test]
-    fn rewind_window_assertion_accepts_equal_pending_acks_and_rewind_depth() {
-        assert_rewind_window_safety::<deterministic::Context, Arc<AsyncRwLock<OneStepRewindDb>>>(
-            NonZeroUsize::new(1).unwrap(),
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "marshal max_pending_acks=2 exceeds database_set.max_rewind_depth=1")]
-    fn rewind_window_assertion_panics_when_pending_acks_exceed_rewind_depth() {
-        assert_rewind_window_safety::<deterministic::Context, Arc<AsyncRwLock<OneStepRewindDb>>>(
-            NonZeroUsize::new(2).unwrap(),
-        );
     }
 
     #[test]

--- a/glue/src/stateful/db/p2p/compact/actor.rs
+++ b/glue/src/stateful/db/p2p/compact/actor.rs
@@ -423,13 +423,23 @@ mod tests {
     }
 
     async fn init_db(context: deterministic::Context) -> TestDb {
+        let witness = commonware_storage::journal::contiguous::variable::Config {
+            partition: "compact-p2p-test-witness".into(),
+            items_per_section: commonware_utils::NZU64!(64),
+            compression: None,
+            codec_config: (),
+            page_cache: commonware_runtime::buffer::paged::CacheRef::from_pooler(
+                &context,
+                commonware_utils::NZU16!(1024),
+                NZUsize!(64),
+            ),
+            write_buffer: NZUsize!(1024),
+        };
         TestDb::init(
             context,
             keyless_fixed::CompactConfig {
-                merkle: commonware_storage::merkle::compact::Config {
-                    partition: "compact-p2p-test".into(),
-                    strategy: Sequential,
-                },
+                strategy: Sequential,
+                witness,
                 commit_codec_config: (),
             },
         )
@@ -452,7 +462,7 @@ mod tests {
         .unwrap();
         db.sync().await.unwrap();
 
-        let target = db.current_target();
+        let target = db.target();
         let fetch =
             compact::Resolver::get_compact_state(&Arc::new(AsyncRwLock::new(db)), target.clone())
                 .await
@@ -565,7 +575,7 @@ mod tests {
     fn produce_serves_attached_database() {
         deterministic::Runner::default().start(|context| async move {
             let db = init_db(context.child("db")).await;
-            let target = db.current_target();
+            let target = db.target();
             let db = Arc::new(AsyncRwLock::new(db));
             let (mut actor, _mailbox) = TestActor::new(context, test_config(Some(db)));
             let request = handler::Request::from_target(target.clone());

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     stateful::{
         db::{
-            p2p::standard as qmdb_resolver, DatabaseSet, Merkleized as _, SyncEngineConfig,
-            Unmerkleized as _,
+            p2p::{compact as compact_resolver, standard as qmdb_resolver},
+            DatabaseSet, Merkleized as _, SyncEngineConfig, Unmerkleized as _,
         },
         probe::{Config as ProbeConfig, Probe},
         Application, Config as StatefulConfig, Proposed, PruneConfig, Stateful as StatefulActor,
@@ -48,11 +48,12 @@ use commonware_runtime::{
 };
 use commonware_storage::{
     archive::prunable,
-    journal::contiguous::fixed::Config as FixedLogConfig,
+    journal::contiguous::{fixed::Config as FixedLogConfig, variable::Config as VariableLogConfig},
     mmr::{self, full::Config as MmrJournalConfig, Location},
     qmdb::{
         any::{unordered::fixed, FixedConfig},
-        sync::Target,
+        immutable,
+        sync::{compact as compact_sync, Target},
     },
     translator::TwoCap,
 };
@@ -66,15 +67,21 @@ use futures::{Stream, StreamExt};
 use rand::Rng;
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
-/// The QMDB database type used by the multi-db e2e tests.
-type Qmdb<E> =
+/// The full (journaled) QMDB used as DB-A in the multi-db e2e tests.
+type QmdbA<E> =
     fixed::Db<mmr::Family, E, sha256::Digest, sha256::Digest, Sha256, TwoCap, Sequential>;
 
-/// A single QMDB database behind a lock.
-type SingleDb<E> = Arc<AsyncRwLock<Qmdb<E>>>;
+/// The compact (witness-only) QMDB used as DB-B, so the suite drives deep rewind,
+/// pruning, and state sync through the compact path as well.
+type QmdbB<E> =
+    immutable::fixed::CompactDb<mmr::Family, E, sha256::Digest, sha256::Digest, Sha256, Sequential>;
 
-/// Two QMDB databases as a tuple.
-pub(crate) type MultiDatabaseSet<E> = (SingleDb<E>, SingleDb<E>);
+/// A single QMDB database behind a lock.
+type DbA<E> = Arc<AsyncRwLock<QmdbA<E>>>;
+type DbB<E> = Arc<AsyncRwLock<QmdbB<E>>>;
+
+/// A full and a compact QMDB as a tuple.
+pub(crate) type MultiDatabaseSet<E> = (DbA<E>, DbB<E>);
 
 /// A block carrying state from two QMDB databases.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -197,16 +204,17 @@ impl App {
     async fn execute<E: Rng + Spawner + Metrics + Clock + Storage>(
         height: Height,
         batches: (
-            <SingleDb<E> as DatabaseSet<E>>::Unmerkleized,
-            <SingleDb<E> as DatabaseSet<E>>::Unmerkleized,
+            <DbA<E> as DatabaseSet<E>>::Unmerkleized,
+            <DbB<E> as DatabaseSet<E>>::Unmerkleized,
         ),
     ) -> (
-        <SingleDb<E> as DatabaseSet<E>>::Merkleized,
-        <SingleDb<E> as DatabaseSet<E>>::Merkleized,
+        <DbA<E> as DatabaseSet<E>>::Merkleized,
+        <DbB<E> as DatabaseSet<E>>::Merkleized,
     ) {
-        let (mut batch_a, mut batch_b) = batches;
+        let (mut batch_a, batch_b) = batches;
 
-        // DB-A: increment counter
+        // DB-A: increment counter and write a height marker, mirroring the single-db app's
+        // per-block operation count so its state sync spans the same crash windows.
         let counter = Sha256::hash(b"counter");
         let current: u64 = batch_a
             .get(&counter)
@@ -214,11 +222,15 @@ impl App {
             .unwrap()
             .map_or(0, |v| digest_to_u64(&v));
         batch_a = batch_a.write(counter, Some(u64_to_digest(current + 1)));
-
-        // DB-B: write height marker
-        batch_b = batch_b.write(
+        batch_a = batch_a.write(
             Sha256::hash(&height.get().to_be_bytes()),
             Some(u64_to_digest(height.get())),
+        );
+
+        // DB-B: write height marker
+        let batch_b = batch_b.set(
+            Sha256::hash(&height.get().to_be_bytes()),
+            u64_to_digest(height.get()),
         );
 
         let merkleized_a = batch_a.merkleize().await.unwrap();
@@ -311,7 +323,10 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage> Application<E> for App {
     fn sync_targets(block: &Self::Block) -> <Self::Databases as DatabaseSet<E>>::SyncTargets {
         (
             Target::new(block.root_a, block.range_a.clone()),
-            Target::new(block.root_b, block.range_b.clone()),
+            compact_sync::Target {
+                root: block.root_b,
+                leaf_count: block.range_b.end(),
+            },
         )
     }
 }
@@ -426,22 +441,19 @@ impl EngineDefinition for MultiDbEngine {
             },
             translator: TwoCap,
         };
-        let db_config_b = FixedConfig {
-            merkle_config: MmrJournalConfig {
-                journal_partition: format!("{partition_prefix}-qmdb-b-mmr-journal"),
-                metadata_partition: format!("{partition_prefix}-qmdb-b-mmr-metadata"),
-                items_per_blob: NZU64!(11),
-                write_buffer: IO_BUFFER_SIZE,
-                strategy: Sequential,
-                page_cache: page_cache.clone(),
-            },
-            journal_config: FixedLogConfig {
-                partition: format!("{partition_prefix}-qmdb-b-log-journal"),
-                items_per_blob: NZU64!(7),
+        // One witness entry per section so the periodic prune actually drops entries
+        // (pruning is section-aligned).
+        let db_config_b = immutable::fixed::CompactConfig {
+            strategy: Sequential,
+            witness: VariableLogConfig {
+                partition: format!("{partition_prefix}-qmdb-b-witness"),
+                items_per_section: NZU64!(1),
+                compression: None,
+                codec_config: (),
                 page_cache: page_cache.clone(),
                 write_buffer: IO_BUFFER_SIZE,
             },
-            translator: TwoCap,
+            commit_codec_config: (),
         };
         let db_config = (db_config_a, db_config_b);
 
@@ -515,10 +527,13 @@ impl EngineDefinition for MultiDbEngine {
             let empty_db_root = Sha256Digest::from(hex!(
                 "ea6e0567a525372add5e4ef4d0600c18ed47fa5dd041a0ab0d25b60ea8c35978"
             ));
+            let empty_compact_db_root = Sha256Digest::from(hex!(
+                "290cbd39f3eaaca7cb4a92f4a2740fc438cabb99144258b24ba0cf54b3f4cfec"
+            ));
             Block::genesis(
                 empty_db_root,
                 non_empty_range!(Location::new(0), Location::new(1)),
-                empty_db_root,
+                empty_compact_db_root,
                 non_empty_range!(Location::new(0), Location::new(1)),
             )
         };
@@ -577,7 +592,7 @@ impl EngineDefinition for MultiDbEngine {
 
         // QMDB state-sync resolvers (one per database).
         let (qmdb_resolver_actor_a, qmdb_sync_resolver_a) =
-            qmdb_resolver::Actor::<_, ed25519::PublicKey, _, _, mmr::Family, Qmdb<_>>::new(
+            qmdb_resolver::Actor::<_, ed25519::PublicKey, _, _, mmr::Family, QmdbA<_>>::new(
                 context.child("qmdb_resolver_a"),
                 qmdb_resolver::Config {
                     peer_provider: oracle.manager(),
@@ -595,23 +610,29 @@ impl EngineDefinition for MultiDbEngine {
             );
         qmdb_resolver_actor_a.start(qmdb_a_resolver_network);
 
-        let (qmdb_resolver_actor_b, qmdb_sync_resolver_b) =
-            qmdb_resolver::Actor::<_, ed25519::PublicKey, _, _, mmr::Family, Qmdb<_>>::new(
-                context.child("qmdb_resolver_b"),
-                qmdb_resolver::Config {
-                    peer_provider: oracle.manager(),
-                    blocker: oracle.control(public_key.clone()),
-                    database: None,
-                    mailbox_size: NZUsize!(100),
-                    me: Some(public_key.clone()),
-                    initial: Duration::from_secs(1),
-                    timeout: Duration::from_secs(2),
-                    fetch_retry_timeout: Duration::from_millis(100),
-                    max_serve_ops: NZU64!(16),
-                    priority_requests: false,
-                    priority_responses: false,
-                },
-            );
+        let (qmdb_resolver_actor_b, qmdb_sync_resolver_b) = compact_resolver::Actor::<
+            _,
+            ed25519::PublicKey,
+            _,
+            _,
+            mmr::Family,
+            QmdbB<_>,
+            Sha256,
+        >::new(
+            context.child("qmdb_resolver_b"),
+            compact_resolver::Config {
+                peer_provider: oracle.manager(),
+                blocker: oracle.control(public_key.clone()),
+                database: None,
+                mailbox_size: NZUsize!(100),
+                me: Some(public_key.clone()),
+                initial: Duration::from_secs(1),
+                timeout: Duration::from_secs(2),
+                fetch_retry_timeout: Duration::from_millis(100),
+                priority_requests: false,
+                priority_responses: false,
+            },
+        );
         qmdb_resolver_actor_b.start(qmdb_b_resolver_network);
 
         // Stateful actor
@@ -636,15 +657,15 @@ impl EngineDefinition for MultiDbEngine {
             },
         );
 
-        // Observe the oldest operation either QMDB still retains, to assert pruning ran.
+        // Observe the oldest operation the full QMDB still retains, to assert pruning ran.
+        // The compact db keeps no operation history to observe.
         let prune_observer = stateful_mailbox.clone();
         let oldest_retained: OldestRetained = Arc::new(move || {
             let mailbox = prune_observer.clone();
             Box::pin(async move {
-                let (a, b) = mailbox.subscribe_databases().await;
+                let (a, _b) = mailbox.subscribe_databases().await;
                 let oldest_a = *a.read().await.bounds().await.start;
-                let oldest_b = *b.read().await.bounds().await.start;
-                oldest_a.min(oldest_b)
+                oldest_a
             })
         });
 

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -623,12 +623,12 @@ impl EngineDefinition for MultiDbEngine {
                 db_config,
                 input_provider: (),
                 marshal: marshal_mailbox.clone(),
-                max_pending_acks,
                 mailbox_size: NZUsize!(100),
                 plan,
                 resolvers: (qmdb_sync_resolver_a, qmdb_sync_resolver_b),
                 sync_config: self.sync_config,
                 prune_config: Some(PruneConfig {
+                    max_pending_acks,
                     maintenance_interval: NZUsize!(5),
                     retained_marshal_blocks: 10,
                     retained_qmdb_blocks: 0,

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -514,12 +514,12 @@ impl EngineDefinition for SingleDbEngine {
                 db_config,
                 input_provider: (),
                 marshal: marshal_mailbox.clone(),
-                max_pending_acks,
                 mailbox_size: NZUsize!(100),
                 plan,
                 resolvers: qmdb_sync_resolver,
                 sync_config: self.sync_config,
                 prune_config: Some(PruneConfig {
+                    max_pending_acks,
                     maintenance_interval: NZUsize!(5),
                     retained_marshal_blocks: 10,
                     retained_qmdb_blocks: 0,

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -134,6 +134,14 @@ hash = "f5456580eb69727a23bfb0281e33f467acc0c91273efebd334d3e82c9770ae76"
 n_cases = 65536
 hash = "a3fbb5f749fa5b73a684e9f0bebd8973c456e5ee43a0a3db75a99aa550dee302"
 
+["commonware_storage::qmdb::compact::witness::tests::conformance::CodecConformance<Witness<mmb::Family,sha256::Digest>>"]
+n_cases = 65536
+hash = "ffc3a9f974c710e714a78629af00a32d6e7afef28757a5d5a818206e9049745f"
+
+["commonware_storage::qmdb::compact::witness::tests::conformance::CodecConformance<Witness<mmr::Family,sha256::Digest>>"]
+n_cases = 65536
+hash = "75d4969d0ba96bbfaac96c59464f1cadbb779b4ed6e85b1984f4ff8eee544cfc"
+
 ["commonware_storage::qmdb::conformance::AnyMmbOrderedFixedConf"]
 n_cases = 200
 hash = "b3c1e2f17435b89294b6fc2f9b779574dc3fe9cc1d9e86a0ba76f3bd3f9361a0"

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -7,8 +7,8 @@
 //! `(leaf_count, pinned_nodes)` snapshot has the same root and the same future append
 //! behavior as the original.
 //!
-//! Nodes created by appends are retained only until a prune or reset; after that they are no
-//! longer readable.
+//! Nodes created by appends are retained only until the structure is pruned to its frontier or
+//! reset to a snapshot; after that they are no longer readable.
 
 use crate::merkle::{
     batch,

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -1,41 +1,30 @@
-//! A compact Merkle structure.
+//! A compact, in-memory Merkle structure.
 //!
-//! Unlike [`crate::merkle::full`], this type persists only the minimum state required to
-//! recover the current root and continue appending after restart. Historical nodes are discarded
-//! on sync and are not readable after reopen.
+//! Unlike [`crate::merkle::full`], this type retains only the minimum state required to compute
+//! the current root and continue appending: the leaf count plus the pinned frontier nodes.
+//! Historical nodes are discarded by `Merkle::prune_to_peaks` and are not readable afterward.
 //!
 //! # Why peaks are enough
 //!
 //! An MMR/MMB root is computed from the current peaks, and appending a new leaf only touches
-//! peaks. Persisting `(leaf_count, pinned_peaks)` and rebuilding [`Mem`] on reopen with no
-//! retained nodes and those peaks as pinned values reconstructs an equivalent tree: same root,
-//! same future append behavior.
+//! peaks. Rebuilding [`Mem`] from `(leaf_count, pinned_nodes)` with no retained nodes
+//! reconstructs an equivalent tree: same root, same future append behavior.
 //!
-//! # One-step rewind
+//! # Durability
 //!
-//! State is persisted into one of two slots on disk, with a generation pointer identifying the
-//! active slot. Each `sync` writes the new state to the *other* slot and flips the pointer
-//! atomically. The `rewind` entry point flips the pointer back and clears the now-stale slot,
-//! restoring the state as of the sync before the most recent one. Rewind is one-shot until the
-//! next `sync`.
+//! This structure persists nothing. The owning database journals a snapshot of
+//! `(leaf_count, pinned_nodes)` with every commit and rebuilds the tree on open and rewind via
+//! `Merkle::reset_to`.
 
-use crate::{
-    merkle::{
-        batch,
-        hasher::Hasher,
-        mem::{Config as MemConfig, Mem},
-        Error, Family, Location, Position,
-    },
-    metadata::{Config as MConfig, Metadata},
-    Context,
+use crate::merkle::{
+    batch,
+    hasher::Hasher,
+    mem::{Config as MemConfig, Mem},
+    Error, Family, Location,
 };
-use commonware_codec::DecodeExt;
 use commonware_cryptography::Digest;
 use commonware_parallel::Strategy;
-use commonware_utils::{
-    sequence::prefixed_u64::U64,
-    sync::{AsyncMutex, RwLock},
-};
+use commonware_utils::sync::RwLock;
 use std::sync::Arc;
 
 /// Append-only wrapper around [`batch::UnmerkleizedBatch`].
@@ -53,13 +42,6 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     pub fn add(self, hasher: &impl Hasher<F, Digest = D>, element: &[u8]) -> Self {
         Self {
             inner: self.inner.add(hasher, element),
-        }
-    }
-
-    /// Add a pre-computed leaf digest.
-    pub fn add_leaf_digest(self, digest: D) -> Self {
-        Self {
-            inner: self.inner.add_leaf_digest(digest),
         }
     }
 
@@ -85,224 +67,86 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     }
 }
 
-/// Configuration for a compact Merkle structure.
-#[derive(Clone)]
-pub struct Config<S: Strategy> {
-    /// Metadata partition used to persist the current compact state.
-    pub partition: String,
-
-    /// Strategy used to parallelize batch operations.
-    pub strategy: S,
-}
-
-/// A Merkle structure that persists only the state required to continue appending.
-pub struct Merkle<F: Family, E: Context, D: Digest, S: Strategy> {
-    inner: RwLock<Mem<F, D>>,
-    metadata: AsyncMutex<Metadata<E, U64, Vec<u8>>>,
-    sync_lock: AsyncMutex<()>,
+/// A Merkle structure that retains only the state required to continue appending.
+pub struct Merkle<F: Family, D: Digest, S: Strategy> {
+    mem: RwLock<Mem<F, D>>,
     strategy: S,
-    /// Active slot (0 or 1). Source of truth lives on disk under `GEN_PTR_PREFIX`; this is an
-    /// in-memory cache refreshed on every `sync_with` and `rewind`.
-    active_slot: RwLock<u8>,
 }
 
-// Metadata key prefixes. The Merkle persists into one of two slots (A=0, B=1); `GEN_PTR_PREFIX`
-// records which slot is currently active. Each `sync` writes to the other slot and flips the
-// pointer atomically, giving one-step rewind.
-const GEN_PTR_PREFIX: u8 = 0;
-const SLOT_A_SIZE_PREFIX: u8 = 1;
-const SLOT_A_NODE_PREFIX: u8 = 2;
-const SLOT_B_SIZE_PREFIX: u8 = 3;
-const SLOT_B_NODE_PREFIX: u8 = 4;
-
-const fn size_prefix(slot: u8) -> u8 {
-    if slot == 0 {
-        SLOT_A_SIZE_PREFIX
-    } else {
-        SLOT_B_SIZE_PREFIX
-    }
-}
-
-const fn node_prefix(slot: u8) -> u8 {
-    if slot == 0 {
-        SLOT_A_NODE_PREFIX
-    } else {
-        SLOT_B_NODE_PREFIX
-    }
-}
-
-impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
-    const fn validate_persisted_leaves(leaves: Location<F>) -> Result<(), Error<F>> {
-        if !leaves.is_valid() {
-            return Err(Error::DataCorrupted("slot size exceeds MAX_LEAVES"));
-        }
-        Ok(())
-    }
-
-    /// Read the active slot pointer, defaulting to 0 if absent.
-    fn read_gen_ptr(metadata: &Metadata<E, U64, Vec<u8>>) -> Result<Option<u8>, Error<F>> {
-        let Some(raw) = metadata.get(&U64::new(GEN_PTR_PREFIX, 0)) else {
-            return Ok(None);
-        };
-        if raw.len() != 1 || (raw[0] != 0 && raw[0] != 1) {
-            return Err(Error::DataCorrupted("invalid generation pointer"));
-        }
-        Ok(Some(raw[0]))
-    }
-
-    /// Read the size key for a given slot, returning `None` if the slot is unpopulated.
-    fn read_slot_size(
-        metadata: &Metadata<E, U64, Vec<u8>>,
-        slot: u8,
-    ) -> Result<Option<Location<F>>, Error<F>> {
-        let Some(raw) = metadata.get(&U64::new(size_prefix(slot), 0)) else {
-            return Ok(None);
-        };
-        let bytes: [u8; 8] = raw
-            .as_slice()
-            .try_into()
-            .map_err(|_| Error::DataCorrupted("slot size is not 8 bytes"))?;
-        let leaves = Location::new(u64::from_be_bytes(bytes));
-        Self::validate_persisted_leaves(leaves)?;
-        Ok(Some(leaves))
-    }
-
-    /// Remove all pin entries for a given slot.
-    fn clear_slot_pins(metadata: &mut Metadata<E, U64, Vec<u8>>, slot: u8, leaves: Location<F>) {
-        let pin_count = F::nodes_to_pin(leaves).count();
-        for i in 0..pin_count {
-            metadata.remove(&U64::new(node_prefix(slot), i as u64));
+impl<F: Family, D: Digest, S: Strategy> Merkle<F, D, S> {
+    /// Create an empty `Merkle`.
+    pub const fn new(strategy: S) -> Self {
+        Self {
+            mem: RwLock::new(Mem::new()),
+            strategy,
         }
     }
 
-    /// Clear both the pins and the size key for a slot, marking it as unpopulated so that
-    /// subsequent rewinds targeting it will fail with `RewindBeyondHistory`.
-    fn clear_slot(metadata: &mut Metadata<E, U64, Vec<u8>>, slot: u8, leaves: Location<F>) {
-        Self::clear_slot_pins(metadata, slot, leaves);
-        metadata.remove(&U64::new(size_prefix(slot), 0));
-    }
-
-    fn load_slot_pins(
-        metadata: &Metadata<E, U64, Vec<u8>>,
-        slot: u8,
-        leaves: Location<F>,
-    ) -> Result<Vec<D>, Error<F>> {
-        let mut pinned = Vec::new();
-        for (idx, pos) in F::nodes_to_pin(leaves).enumerate() {
-            let bytes = metadata
-                .get(&U64::new(node_prefix(slot), idx as u64))
-                .ok_or(Error::MissingNode(pos))?;
-            let digest = D::decode(bytes.as_ref())
-                .map_err(|_| Error::DataCorrupted("invalid pinned node"))?;
-            pinned.push(digest);
-        }
-        Ok(pinned)
-    }
-
-    /// Initialize a new `Merkle` instance, rebuilding in-memory state from the last sync.
-    pub async fn init(context: E, cfg: Config<S>) -> Result<Self, Error<F>> {
-        let metadata = Metadata::<_, U64, Vec<u8>>::init(
-            context.child("compact_metadata"),
-            MConfig {
-                partition: cfg.partition,
-                codec_config: ((0..).into(), ()),
-            },
-        )
-        .await?;
-
-        let active_slot = Self::read_gen_ptr(&metadata)?.unwrap_or(0);
-        let leaves = Self::read_slot_size(&metadata, active_slot)?.unwrap_or(Location::new(0));
-        let mem = if leaves == 0 {
-            Mem::new()
-        } else {
-            Mem::init(MemConfig {
-                nodes: vec![],
-                pruning_boundary: leaves,
-                pinned_nodes: Self::load_slot_pins(&metadata, active_slot, leaves)?,
-            })?
-        };
-
-        Ok(Self {
-            inner: RwLock::new(mem),
-            metadata: AsyncMutex::new(metadata),
-            sync_lock: AsyncMutex::new(()),
-            strategy: cfg.strategy,
-            active_slot: RwLock::new(active_slot),
-        })
-    }
-
-    /// Initialize from compact state without persisting it.
-    ///
-    /// Callers use this to reconstruct a compact tree in memory, verify that its root
-    /// matches an authenticated target, and only then persist it with [`Self::sync_with_witness`].
-    /// Starting from a cleared metadata view means the first persistence populates exactly one
-    /// slot, so `rewind` will return [`Error::RewindBeyondHistory`] until a later sync overwrites
-    /// the alternate slot.
-    ///
-    /// This path is intended for a fresh or disposable compact partition. Existing metadata is
-    /// cleared only in memory here; if verification fails before a later successful
-    /// [`Self::sync_with_witness`], the on-disk state remains untouched. Once persistence succeeds,
-    /// the previous compact history in this partition is replaced by the newly initialized state.
-    /// Root verification itself happens at the QMDB layer after reconstruction, because that layer
-    /// owns the typed final commit operation needed to authenticate the caller's requested target.
-    pub(crate) async fn init_from_compact_state(
-        context: E,
-        cfg: Config<S>,
+    /// Create a `Merkle` from a compact state snapshot.
+    pub(crate) fn from_compact_state(
+        strategy: S,
         leaves: Location<F>,
         pinned_nodes: Vec<D>,
     ) -> Result<Self, Error<F>> {
-        Self::validate_persisted_leaves(leaves)?;
+        let mem = Self::mem_from_compact_state(leaves, pinned_nodes)?;
+        Ok(Self {
+            mem: RwLock::new(mem),
+            strategy,
+        })
+    }
+
+    /// Build a [`Mem`] with no retained nodes from a compact state snapshot.
+    fn mem_from_compact_state(
+        leaves: Location<F>,
+        pinned_nodes: Vec<D>,
+    ) -> Result<Mem<F, D>, Error<F>> {
+        if !leaves.is_valid() {
+            return Err(Error::DataCorrupted("leaf count exceeds MAX_LEAVES"));
+        }
         if pinned_nodes.len() != F::nodes_to_pin(leaves).count() {
             return Err(Error::InvalidPinnedNodes);
         }
-
-        let mut metadata = Metadata::<_, U64, Vec<u8>>::init(
-            context.child("compact_metadata"),
-            MConfig {
-                partition: cfg.partition,
-                codec_config: ((0..).into(), ()),
-            },
-        )
-        .await?;
-        metadata.clear();
-
-        let mem = if leaves == 0 {
-            Mem::new()
+        if leaves == 0 {
+            Ok(Mem::new())
         } else {
             Mem::init(MemConfig {
                 nodes: vec![],
                 pruning_boundary: leaves,
                 pinned_nodes,
-            })?
-        };
-
-        let merkle = Self {
-            inner: RwLock::new(mem),
-            metadata: AsyncMutex::new(metadata),
-            sync_lock: AsyncMutex::new(()),
-            strategy: cfg.strategy,
-            active_slot: RwLock::new(0),
-        };
-        Ok(merkle)
+            })
+        }
     }
 
-    /// Return the root digest of the current committed state.
+    /// Replace the in-memory tree with one rebuilt from a compact state snapshot.
+    ///
+    /// Any state applied since the snapshot was taken is discarded.
+    pub(crate) fn reset_to(
+        &self,
+        leaves: Location<F>,
+        pinned_nodes: Vec<D>,
+    ) -> Result<(), Error<F>> {
+        let mem = Self::mem_from_compact_state(leaves, pinned_nodes)?;
+        *self.mem.write() = mem;
+        Ok(())
+    }
+
+    /// Discard all retained nodes except the pinned frontier.
+    pub(crate) fn prune_to_peaks(&self) {
+        self.mem.write().prune_all();
+    }
+
+    /// Return the root digest of the current state.
     pub fn root(
         &self,
         hasher: &impl Hasher<F, Digest = D>,
         inactive_peaks: usize,
     ) -> Result<D, Error<F>> {
-        self.inner.read().root(hasher, inactive_peaks)
-    }
-
-    /// Return the total number of nodes (MMR position count, not leaf count).
-    pub fn size(&self) -> Position<F> {
-        self.inner.read().size()
+        self.mem.read().root(hasher, inactive_peaks)
     }
 
     /// Return the number of leaves in the structure.
     pub fn leaves(&self) -> Location<F> {
-        self.inner.read().leaves()
+        self.mem.read().leaves()
     }
 
     /// Return a reference to the merkleization strategy.
@@ -310,215 +154,43 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         &self.strategy
     }
 
-    /// Return the index of the slot currently holding the committed state.
-    pub(crate) fn active_slot(&self) -> u8 {
-        *self.active_slot.read()
-    }
-
-    /// Borrow the committed in-memory [`Mem`].
+    /// Borrow the in-memory [`Mem`].
+    ///
+    /// The closure runs under the tree's read lock, which is not re-entrant: do not call other
+    /// methods of this [`Merkle`] from within it.
     pub fn with_mem<R>(&self, f: impl FnOnce(&Mem<F, D>) -> R) -> R {
-        let inner = self.inner.read();
-        f(&inner)
+        let mem = self.mem.read();
+        f(&mem)
     }
 
     /// Create a new speculative batch with this structure as its parent.
     pub fn new_batch(&self) -> UnmerkleizedBatch<F, D, S> {
-        let inner = self.inner.read();
-        UnmerkleizedBatch::wrap(inner.new_batch_with_strategy(self.strategy.clone()))
+        let mem = self.mem.read();
+        UnmerkleizedBatch::wrap(mem.new_batch_with_strategy(self.strategy.clone()))
     }
 
-    /// Create an owned merkleized batch representing the current committed state.
+    /// Create an owned merkleized batch representing the current state.
     pub(crate) fn to_batch(&self) -> Arc<batch::MerkleizedBatch<F, D, S>> {
-        let inner = self.inner.read();
-        batch::MerkleizedBatch::from_mem_with_strategy(&inner, self.strategy.clone())
+        let mem = self.mem.read();
+        batch::MerkleizedBatch::from_mem_with_strategy(&mem, self.strategy.clone())
     }
 
     /// Apply a merkleized batch to the in-memory structure.
     pub fn apply_batch(&mut self, batch: &batch::MerkleizedBatch<F, D, S>) -> Result<(), Error<F>> {
-        self.inner.get_mut().apply_batch(batch)
-    }
-
-    /// Read a metadata key from the Db's "extras" keyspace for the given slot. Used by the
-    /// qmdb `CompactDb` layer to read back its own per-slot state on reopen or rewind.
-    pub(crate) async fn read_metadata_key(&self, key: &U64) -> Option<Vec<u8>> {
-        let metadata = self.metadata.lock().await;
-        metadata.get(key).cloned()
-    }
-
-    /// Persist the tree state to the inactive slot together with a caller-provided witness.
-    ///
-    /// This is the only safe way to durably persist state from this Merkle. The `build_witness`
-    /// closure is the caller's one chance to capture anything that depends on the unpruned
-    /// [`Mem`]; after this method completes, the in-memory tree is pruned to peaks only and that
-    /// information is no longer recoverable locally.
-    ///
-    /// The `build_witness` closure runs against the unpruned [`Mem`] under `sync_lock`, making it
-    /// the only safe place to capture data that would be lost by peak-only pruning. The `update`
-    /// closure then receives both the mutable [`Metadata`] store and the built witness so caller
-    /// metadata and the witness are written in the same atomic transaction before the generation
-    /// pointer flips. `build_witness` must stay fully synchronous and non-blocking: it runs while a
-    /// read lock is held on the committed in-memory tree, so it must not `.await` or do
-    /// unexpectedly heavy work. In practice this closure is where callers capture a last-leaf
-    /// proof or other small authenticated snapshot that would be impossible to reconstruct once the
-    /// tree is pruned back to peaks.
-    pub(crate) async fn sync_with_witness<W, R>(
-        &self,
-        build_witness: impl FnOnce(&Mem<F, D>) -> Result<W, Error<F>>,
-        update: impl FnOnce(&mut Metadata<E, U64, Vec<u8>>, u8, W) -> Result<R, Error<F>>,
-    ) -> Result<R, Error<F>> {
-        let _sync_guard = self.sync_lock.lock().await;
-
-        let current_slot = *self.active_slot.read();
-        let target_slot = 1 - current_slot;
-
-        let (leaves, pinned_nodes, witness) = {
-            let inner = self.inner.read();
-            let leaves = inner.leaves();
-            let pinned_nodes = F::nodes_to_pin(leaves)
-                .map(|pos| *inner.get_node_unchecked(pos))
-                .collect::<Vec<_>>();
-            let witness = build_witness(&inner)?;
-            (leaves, pinned_nodes, witness)
-        };
-
-        let result = {
-            let mut metadata = self.metadata.lock().await;
-            let old_target_leaves =
-                Self::read_slot_size(&metadata, target_slot)?.unwrap_or(Location::new(0));
-            Self::clear_slot_pins(&mut metadata, target_slot, old_target_leaves);
-            metadata.put(
-                U64::new(size_prefix(target_slot), 0),
-                leaves.as_u64().to_be_bytes().to_vec(),
-            );
-            for (idx, digest) in pinned_nodes.iter().enumerate() {
-                metadata.put(
-                    U64::new(node_prefix(target_slot), idx as u64),
-                    digest.to_vec(),
-                );
-            }
-            let result = update(&mut metadata, target_slot, witness)?;
-            metadata
-                .put_sync(U64::new(GEN_PTR_PREFIX, 0), vec![target_slot])
-                .await?;
-            result
-        };
-
-        *self.active_slot.write() = target_slot;
-        self.inner.write().prune_all();
-        Ok(result)
-    }
-
-    /// Restore the state as of the sync before the most recent one.
-    ///
-    /// Flips the generation pointer back to the previous slot and rebuilds the in-memory
-    /// structure from the (size, peaks) persisted there. Any uncommitted `apply_batch` calls
-    /// since the last `sync` are discarded. The pre-rewind slot is cleared, making rewind
-    /// one-shot until the next `sync` (a second rewind without an intervening sync returns
-    /// [`Error::RewindBeyondHistory`]).
-    ///
-    /// Returns the slot index now active (caller uses this to repopulate its own per-slot
-    /// caches from the matching slot).
-    pub(crate) async fn rewind(&mut self) -> Result<u8, Error<F>> {
-        let _sync_guard = self.sync_lock.lock().await;
-
-        let current_slot = *self.active_slot.read();
-        let target_slot = 1 - current_slot;
-
-        let (new_leaves, pinned_nodes) = {
-            let metadata = self.metadata.lock().await;
-            let Some(new_leaves) = Self::read_slot_size(&metadata, target_slot)? else {
-                return Err(Error::RewindBeyondHistory);
-            };
-            let pinned_nodes = if new_leaves == 0 {
-                Vec::new()
-            } else {
-                Self::load_slot_pins(&metadata, target_slot, new_leaves)?
-            };
-            (new_leaves, pinned_nodes)
-        };
-
-        // Rebuild Mem from the rewound slot's state. This discards any uncommitted appends.
-        let new_mem = if new_leaves == 0 {
-            Mem::new()
-        } else {
-            Mem::init(MemConfig {
-                nodes: vec![],
-                pruning_boundary: new_leaves,
-                pinned_nodes,
-            })?
-        };
-
-        // Atomically clear this layer's state in the pre-rewind slot (size + pins) and flip the
-        // generation pointer. Removing the size key is what makes the slot "no longer a valid
-        // rewind target": subsequent rewinds read `None` for its size and fail with
-        // `RewindBeyondHistory`. Any caller-specific extras written alongside under separate
-        // prefixes remain on disk but are harmless, since the next `sync_with` into this slot
-        // overwrites them before they can be read.
-        {
-            let mut metadata = self.metadata.lock().await;
-            let old_current_leaves =
-                Self::read_slot_size(&metadata, current_slot)?.unwrap_or(Location::new(0));
-            Self::clear_slot(&mut metadata, current_slot, old_current_leaves);
-            metadata
-                .put_sync(U64::new(GEN_PTR_PREFIX, 0), vec![target_slot])
-                .await?;
-        }
-
-        *self.inner.write() = new_mem;
-        *self.active_slot.write() = target_slot;
-        Ok(target_slot)
-    }
-
-    /// Durably persist the current tree state to disk.
-    pub async fn sync(&self) -> Result<(), Error<F>> {
-        self.sync_with_witness(|_| Ok(()), |_, _, ()| Ok(()))
-            .await
-            .map(|_| ())
-    }
-
-    /// Durably persist the current tree state to disk (alias for [`Self::sync`]).
-    pub async fn commit(&self) -> Result<(), Error<F>> {
-        self.sync().await
-    }
-
-    /// Destroy all persisted state associated with this structure.
-    pub async fn destroy(self) -> Result<(), Error<F>> {
-        self.metadata.into_inner().destroy().await?;
-        Ok(())
+        self.mem.get_mut().apply_batch(batch)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        merkle::{hasher::Standard as StandardHasher, mmb, mmr, Bagging::ForwardFold},
-        metadata::{Config as MConfig, Metadata},
-    };
+    use crate::merkle::{hasher::Standard as StandardHasher, mmb, mmr, Bagging::ForwardFold};
     use commonware_cryptography::Sha256;
     use commonware_parallel::Sequential;
-    use commonware_runtime::{deterministic, Runner as _, Supervisor as _};
 
-    type TestMerkle<F> = Merkle<
-        F,
-        deterministic::Context,
-        <Sha256 as commonware_cryptography::Hasher>::Digest,
-        Sequential,
-    >;
+    type TestMerkle<F> = Merkle<F, <Sha256 as commonware_cryptography::Hasher>::Digest, Sequential>;
 
-    async fn open<F: Family>(context: deterministic::Context, partition: &str) -> TestMerkle<F> {
-        TestMerkle::<F>::init(
-            context,
-            Config {
-                partition: partition.into(),
-                strategy: Sequential,
-            },
-        )
-        .await
-        .unwrap()
-    }
-
-    async fn append_and_sync<F: Family>(merkle: &mut TestMerkle<F>, values: &[&[u8]]) {
+    fn append<F: Family>(merkle: &mut TestMerkle<F>, values: &[&[u8]]) {
         let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let batch = {
             let mut b = merkle.new_batch();
@@ -528,248 +200,77 @@ mod tests {
             merkle.with_mem(|mem| b.merkleize(mem, &hasher))
         };
         merkle.apply_batch(&batch).unwrap();
-        merkle.sync().await.unwrap();
     }
 
-    async fn assert_reopen_and_continue<F: Family>(
-        context: deterministic::Context,
-        partition: &str,
-    ) {
+    fn pinned_nodes<F: Family>(
+        merkle: &TestMerkle<F>,
+    ) -> Vec<<Sha256 as commonware_cryptography::Hasher>::Digest> {
+        merkle.with_mem(|mem| {
+            F::nodes_to_pin(mem.leaves())
+                .map(|pos| *mem.get_node_unchecked(pos))
+                .collect()
+        })
+    }
+
+    fn assert_reset_to_round_trip<F: Family>() {
         let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-        let cfg = Config {
-            partition: partition.into(),
-            strategy: Sequential,
-        };
+        let mut merkle = TestMerkle::<F>::new(Sequential);
+        append(&mut merkle, &[b"a", b"b", b"c"]);
+        let root = merkle.root(&hasher, 0).unwrap();
+        let leaves = merkle.leaves();
+        let pins = pinned_nodes(&merkle);
 
-        let mut merkle = TestMerkle::<F>::init(context.child("first"), cfg.clone())
-            .await
-            .unwrap();
-        let batch = {
-            let batch = merkle.new_batch().add(&hasher, b"a").add(&hasher, b"b");
-            merkle.with_mem(|mem| batch.merkleize(mem, &hasher))
-        };
-        merkle.apply_batch(&batch).unwrap();
-        let root_before = merkle.root(&hasher, 0).unwrap();
-        let leaves_before = merkle.leaves();
-        merkle.sync().await.unwrap();
-        drop(merkle);
+        // Pruning to peaks does not change the root.
+        merkle.prune_to_peaks();
+        assert_eq!(merkle.root(&hasher, 0).unwrap(), root);
 
-        let mut reopened = TestMerkle::<F>::init(context.child("second"), cfg)
-            .await
-            .unwrap();
-        assert_eq!(reopened.root(&hasher, 0).unwrap(), root_before);
-        assert_eq!(reopened.leaves(), leaves_before);
+        // A fresh tree reset to the snapshot reproduces the same state.
+        let mut restored = TestMerkle::<F>::new(Sequential);
+        append(&mut restored, &[b"x"]);
+        restored.reset_to(leaves, pins.clone()).unwrap();
+        assert_eq!(restored.root(&hasher, 0).unwrap(), root);
+        assert_eq!(restored.leaves(), leaves);
 
-        let batch = {
-            let batch = reopened.new_batch().add(&hasher, b"c");
-            reopened.with_mem(|mem| batch.merkleize(mem, &hasher))
-        };
-        reopened.apply_batch(&batch).unwrap();
-        reopened.sync().await.unwrap();
+        // Both trees evolve identically from the snapshot.
+        append(&mut merkle, &[b"d"]);
+        append(&mut restored, &[b"d"]);
+        assert_eq!(
+            restored.root(&hasher, 0).unwrap(),
+            merkle.root(&hasher, 0).unwrap()
+        );
+
+        // from_compact_state builds the same tree as reset_to.
+        let from_state = TestMerkle::<F>::from_compact_state(Sequential, leaves, pins).unwrap();
+        assert_eq!(from_state.root(&hasher, 0).unwrap(), root);
     }
 
     #[test]
-    fn test_compact_reopen_and_continue_mmr() {
-        deterministic::Runner::default().start(|context| async move {
-            assert_reopen_and_continue::<mmr::Family>(context, "compact-mmr").await;
-        });
+    fn test_reset_to_round_trip_mmr() {
+        assert_reset_to_round_trip::<mmr::Family>();
     }
 
     #[test]
-    fn test_compact_reopen_and_continue_mmb() {
-        deterministic::Runner::default().start(|context| async move {
-            assert_reopen_and_continue::<mmb::Family>(context, "compact-mmb").await;
-        });
-    }
-
-    async fn assert_rewind_restores_prior_state<F: Family>(
-        context: deterministic::Context,
-        partition: &str,
-    ) {
-        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-        let mut merkle = open::<F>(context, partition).await;
-
-        append_and_sync(&mut merkle, &[b"a", b"b"]).await;
-        let root_after_first = merkle.root(&hasher, 0).unwrap();
-        let leaves_after_first = merkle.leaves();
-
-        append_and_sync(&mut merkle, &[b"c"]).await;
-        assert_ne!(merkle.root(&hasher, 0).unwrap(), root_after_first);
-
-        merkle.rewind().await.unwrap();
-        assert_eq!(merkle.root(&hasher, 0).unwrap(), root_after_first);
-        assert_eq!(merkle.leaves(), leaves_after_first);
-
-        merkle.destroy().await.unwrap();
+    fn test_reset_to_round_trip_mmb() {
+        assert_reset_to_round_trip::<mmb::Family>();
     }
 
     #[test]
-    fn test_rewind_restores_prior_state_mmr() {
-        deterministic::Runner::default().start(|context| async move {
-            assert_rewind_restores_prior_state::<mmr::Family>(context, "rewind-prior-mmr").await;
-        });
-    }
+    fn test_reset_to_rejects_invalid_snapshot() {
+        let mut merkle = TestMerkle::<mmr::Family>::new(Sequential);
+        append(&mut merkle, &[b"a", b"b"]);
+        let leaves = merkle.leaves();
 
-    #[test]
-    fn test_rewind_restores_prior_state_mmb() {
-        deterministic::Runner::default().start(|context| async move {
-            assert_rewind_restores_prior_state::<mmb::Family>(context, "rewind-prior-mmb").await;
-        });
-    }
+        // Wrong pin count.
+        assert!(matches!(
+            merkle.reset_to(leaves, vec![]),
+            Err(Error::InvalidPinnedNodes)
+        ));
 
-    #[test]
-    fn test_rewind_beyond_history_errors() {
-        deterministic::Runner::default().start(|context| async move {
-            let mut merkle = open::<mmr::Family>(context, "rewind-beyond").await;
-            // No prior sync: rewind should fail with RewindBeyondHistory.
-            assert!(matches!(
-                merkle.rewind().await,
-                Err(Error::RewindBeyondHistory)
-            ));
-            // After one sync, the previous slot is still empty (nothing has been overwritten);
-            // a rewind should still fail.
-            append_and_sync(&mut merkle, &[b"a"]).await;
-            assert!(matches!(
-                merkle.rewind().await,
-                Err(Error::RewindBeyondHistory)
-            ));
-            merkle.destroy().await.unwrap();
-        });
-    }
-
-    #[test]
-    fn test_rewind_discards_uncommitted() {
-        deterministic::Runner::default().start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-            let mut merkle = open::<mmr::Family>(context, "rewind-uncommitted").await;
-
-            append_and_sync(&mut merkle, &[b"a"]).await;
-            append_and_sync(&mut merkle, &[b"b"]).await;
-            let root_after_two = merkle.root(&hasher, 0).unwrap();
-            let leaves_after_two = merkle.leaves();
-
-            // Apply a batch but do not sync. State is ahead of the last persisted slot.
-            let batch = {
-                let b = merkle.new_batch().add(&hasher, b"c");
-                merkle.with_mem(|mem| b.merkleize(mem, &hasher))
-            };
-            merkle.apply_batch(&batch).unwrap();
-            assert_ne!(merkle.root(&hasher, 0).unwrap(), root_after_two);
-
-            // Rewind reverts to the state as of the sync before the most recent sync, discarding
-            // both the uncommitted append and the most recent sync.
-            merkle.rewind().await.unwrap();
-            assert_ne!(merkle.root(&hasher, 0).unwrap(), root_after_two);
-            assert_ne!(merkle.leaves(), leaves_after_two);
-
-            merkle.destroy().await.unwrap();
-        });
-    }
-
-    #[test]
-    fn test_rewind_persists_across_reopen() {
-        deterministic::Runner::default().start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-            let partition = "rewind-reopen";
-            let cfg = Config {
-                partition: partition.into(),
-                strategy: Sequential,
-            };
-
-            let mut merkle = open::<mmr::Family>(context.child("first"), partition).await;
-            append_and_sync(&mut merkle, &[b"a"]).await;
-            let root_after_first = merkle.root(&hasher, 0).unwrap();
-            append_and_sync(&mut merkle, &[b"b"]).await;
-            merkle.rewind().await.unwrap();
-            drop(merkle);
-
-            let reopened: TestMerkle<mmr::Family> =
-                Merkle::<mmr::Family, _, _, Sequential>::init(context.child("second"), cfg)
-                    .await
-                    .unwrap();
-            assert_eq!(reopened.root(&hasher, 0).unwrap(), root_after_first);
-            reopened.destroy().await.unwrap();
-        });
-    }
-
-    #[test]
-    fn test_double_rewind_errors() {
-        deterministic::Runner::default().start(|context| async move {
-            let mut merkle = open::<mmr::Family>(context, "rewind-double").await;
-            append_and_sync(&mut merkle, &[b"a"]).await;
-            append_and_sync(&mut merkle, &[b"b"]).await;
-            merkle.rewind().await.unwrap();
-            assert!(matches!(
-                merkle.rewind().await,
-                Err(Error::RewindBeyondHistory)
-            ));
-            merkle.destroy().await.unwrap();
-        });
-    }
-
-    #[test]
-    fn test_rewind_then_sync_then_rewind() {
-        deterministic::Runner::default().start(|context| async move {
-            let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-            let mut merkle = open::<mmr::Family>(context, "rewind-resumable").await;
-
-            append_and_sync(&mut merkle, &[b"a"]).await;
-            let root_after_first = merkle.root(&hasher, 0).unwrap();
-            append_and_sync(&mut merkle, &[b"b"]).await;
-            merkle.rewind().await.unwrap();
-            assert_eq!(merkle.root(&hasher, 0).unwrap(), root_after_first);
-
-            // Now sync a different branch. Rewind should restore `root_after_first` again.
-            append_and_sync(&mut merkle, &[b"c"]).await;
-            let root_abc = merkle.root(&hasher, 0).unwrap();
-            assert_ne!(root_abc, root_after_first);
-            merkle.rewind().await.unwrap();
-            assert_eq!(merkle.root(&hasher, 0).unwrap(), root_after_first);
-
-            merkle.destroy().await.unwrap();
-        });
-    }
-
-    #[test]
-    fn test_reopen_rejects_invalid_persisted_leaf_count() {
-        deterministic::Runner::default().start(|context| async move {
-            let partition = "compact-invalid-leaf-count";
-            let cfg = Config {
-                partition: partition.into(),
-                strategy: Sequential,
-            };
-
-            let mut merkle = TestMerkle::<mmr::Family>::init(context.child("first"), cfg.clone())
-                .await
-                .unwrap();
-            append_and_sync(&mut merkle, &[b"a"]).await;
-            let slot = merkle.active_slot();
-            drop(merkle);
-
-            let mut metadata = Metadata::<_, U64, Vec<u8>>::init(
-                context.child("tamper"),
-                MConfig {
-                    partition: partition.into(),
-                    codec_config: ((0..).into(), ()),
-                },
-            )
-            .await
-            .unwrap();
-            metadata
-                .put_sync(
-                    U64::new(size_prefix(slot), 0),
-                    (mmr::Family::MAX_LEAVES.as_u64() + 1)
-                        .to_be_bytes()
-                        .to_vec(),
-                )
-                .await
-                .unwrap();
-
-            let reopened = TestMerkle::<mmr::Family>::init(context.child("second"), cfg).await;
-            assert!(matches!(
-                reopened,
-                Err(Error::DataCorrupted("slot size exceeds MAX_LEAVES"))
-            ));
-        });
+        // Leaf count beyond the family maximum.
+        let too_many = Location::new(mmr::Family::MAX_LEAVES.as_u64() + 1);
+        assert!(matches!(
+            merkle.reset_to(too_many, vec![]),
+            Err(Error::DataCorrupted("leaf count exceeds MAX_LEAVES"))
+        ));
     }
 }

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -1,21 +1,14 @@
 //! A compact, in-memory Merkle structure.
 //!
-//! Unlike [`crate::merkle::full`], this type retains only the minimum state required to compute
-//! the current root and continue appending: the leaf count plus the pinned frontier nodes.
-//! Historical nodes accumulate only while mutations are non-durable; once the owning database
-//! persists them, the nodes are discarded and are no longer readable.
+//! Unlike [`crate::merkle::full`], this type retains only the state needed to compute the
+//! current root and append new leaves: the leaf count and the pinned frontier nodes (the
+//! tree's peaks). These suffice because the root is computed by folding the peaks and an
+//! append reads only the peaks it merges with, so a tree rebuilt from a
+//! `(leaf_count, pinned_nodes)` snapshot has the same root and the same future append
+//! behavior as the original.
 //!
-//! # Why peaks are enough
-//!
-//! An MMR/MMB root is computed from the current peaks, and appending a new leaf only touches
-//! peaks. Rebuilding [`Mem`] from `(leaf_count, pinned_nodes)` with no retained nodes
-//! reconstructs an equivalent tree: same root, same future append behavior.
-//!
-//! # Durability
-//!
-//! This structure persists nothing. The owning database journals a snapshot of
-//! `(leaf_count, pinned_nodes)` with every sync and rebuilds the tree on open and rewind via
-//! `Merkle::reset_to`.
+//! Nodes created by appends are retained only until a prune or reset; after that they are no
+//! longer readable.
 
 use crate::merkle::{
     batch,
@@ -102,7 +95,7 @@ impl<F: Family, D: Digest, S: Strategy> Merkle<F, D, S> {
         pinned_nodes: Vec<D>,
     ) -> Result<Mem<F, D>, Error<F>> {
         if !leaves.is_valid() {
-            return Err(Error::DataCorrupted("leaf count exceeds MAX_LEAVES"));
+            return Err(Error::LocationOverflow(leaves));
         }
         if pinned_nodes.len() != F::nodes_to_pin(leaves).count() {
             return Err(Error::InvalidPinnedNodes);
@@ -118,9 +111,8 @@ impl<F: Family, D: Digest, S: Strategy> Merkle<F, D, S> {
         }
     }
 
-    /// Replace the in-memory tree with one rebuilt from a compact state snapshot.
-    ///
-    /// Any state applied since the snapshot was taken is discarded.
+    /// Replace the in-memory tree with one rebuilt from a compact state snapshot, discarding
+    /// the current state.
     pub(crate) fn reset_to(
         &self,
         leaves: Location<F>,
@@ -271,7 +263,7 @@ mod tests {
         let too_many = Location::new(mmr::Family::MAX_LEAVES.as_u64() + 1);
         assert!(matches!(
             merkle.reset_to(too_many, vec![]),
-            Err(Error::DataCorrupted("leaf count exceeds MAX_LEAVES"))
+            Err(Error::LocationOverflow(loc)) if loc == too_many
         ));
     }
 }

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -14,7 +14,7 @@
 //! # Durability
 //!
 //! This structure persists nothing. The owning database journals a snapshot of
-//! `(leaf_count, pinned_nodes)` with every commit and rebuilds the tree on open and rewind via
+//! `(leaf_count, pinned_nodes)` with every sync and rebuilds the tree on open and rewind via
 //! `Merkle::reset_to`.
 
 use crate::merkle::{

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -2,7 +2,8 @@
 //!
 //! Unlike [`crate::merkle::full`], this type retains only the minimum state required to compute
 //! the current root and continue appending: the leaf count plus the pinned frontier nodes.
-//! Historical nodes are discarded by `Merkle::prune_to_peaks` and are not readable afterward.
+//! Historical nodes accumulate only while mutations are non-durable; once the owning database
+//! persists them, the nodes are discarded and are no longer readable.
 //!
 //! # Why peaks are enough
 //!
@@ -69,7 +70,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 
 /// A Merkle structure that retains only the state required to continue appending.
 pub struct Merkle<F: Family, D: Digest, S: Strategy> {
-    mem: RwLock<Mem<F, D>>,
+    inner: RwLock<Mem<F, D>>,
     strategy: S,
 }
 
@@ -77,7 +78,7 @@ impl<F: Family, D: Digest, S: Strategy> Merkle<F, D, S> {
     /// Create an empty `Merkle`.
     pub const fn new(strategy: S) -> Self {
         Self {
-            mem: RwLock::new(Mem::new()),
+            inner: RwLock::new(Mem::new()),
             strategy,
         }
     }
@@ -90,7 +91,7 @@ impl<F: Family, D: Digest, S: Strategy> Merkle<F, D, S> {
     ) -> Result<Self, Error<F>> {
         let mem = Self::mem_from_compact_state(leaves, pinned_nodes)?;
         Ok(Self {
-            mem: RwLock::new(mem),
+            inner: RwLock::new(mem),
             strategy,
         })
     }
@@ -126,13 +127,13 @@ impl<F: Family, D: Digest, S: Strategy> Merkle<F, D, S> {
         pinned_nodes: Vec<D>,
     ) -> Result<(), Error<F>> {
         let mem = Self::mem_from_compact_state(leaves, pinned_nodes)?;
-        *self.mem.write() = mem;
+        *self.inner.write() = mem;
         Ok(())
     }
 
     /// Discard all retained nodes except the pinned frontier.
-    pub(crate) fn prune_to_peaks(&self) {
-        self.mem.write().prune_all();
+    pub(crate) fn prune_to_frontier(&self) {
+        self.inner.write().prune_all();
     }
 
     /// Return the root digest of the current state.
@@ -141,12 +142,12 @@ impl<F: Family, D: Digest, S: Strategy> Merkle<F, D, S> {
         hasher: &impl Hasher<F, Digest = D>,
         inactive_peaks: usize,
     ) -> Result<D, Error<F>> {
-        self.mem.read().root(hasher, inactive_peaks)
+        self.inner.read().root(hasher, inactive_peaks)
     }
 
     /// Return the number of leaves in the structure.
     pub fn leaves(&self) -> Location<F> {
-        self.mem.read().leaves()
+        self.inner.read().leaves()
     }
 
     /// Return a reference to the merkleization strategy.
@@ -159,25 +160,25 @@ impl<F: Family, D: Digest, S: Strategy> Merkle<F, D, S> {
     /// The closure runs under the tree's read lock, which is not re-entrant: do not call other
     /// methods of this [`Merkle`] from within it.
     pub fn with_mem<R>(&self, f: impl FnOnce(&Mem<F, D>) -> R) -> R {
-        let mem = self.mem.read();
-        f(&mem)
+        let inner = self.inner.read();
+        f(&inner)
     }
 
     /// Create a new speculative batch with this structure as its parent.
     pub fn new_batch(&self) -> UnmerkleizedBatch<F, D, S> {
-        let mem = self.mem.read();
-        UnmerkleizedBatch::wrap(mem.new_batch_with_strategy(self.strategy.clone()))
+        let inner = self.inner.read();
+        UnmerkleizedBatch::wrap(inner.new_batch_with_strategy(self.strategy.clone()))
     }
 
     /// Create an owned merkleized batch representing the current state.
     pub(crate) fn to_batch(&self) -> Arc<batch::MerkleizedBatch<F, D, S>> {
-        let mem = self.mem.read();
-        batch::MerkleizedBatch::from_mem_with_strategy(&mem, self.strategy.clone())
+        let inner = self.inner.read();
+        batch::MerkleizedBatch::from_mem_with_strategy(&inner, self.strategy.clone())
     }
 
     /// Apply a merkleized batch to the in-memory structure.
     pub fn apply_batch(&mut self, batch: &batch::MerkleizedBatch<F, D, S>) -> Result<(), Error<F>> {
-        self.mem.get_mut().apply_batch(batch)
+        self.inner.get_mut().apply_batch(batch)
     }
 }
 
@@ -220,8 +221,8 @@ mod tests {
         let leaves = merkle.leaves();
         let pins = pinned_nodes(&merkle);
 
-        // Pruning to peaks does not change the root.
-        merkle.prune_to_peaks();
+        // Pruning to the frontier does not change the root.
+        merkle.prune_to_frontier();
         assert_eq!(merkle.root(&hasher, 0).unwrap(), root);
 
         // A fresh tree reset to the snapshot reproduces the same state.

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     merkle::{batch, compact, hasher::Hasher as _, Family},
-    qmdb, Context,
+    qmdb,
 };
 use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher;
@@ -10,14 +10,13 @@ use commonware_parallel::Strategy;
 use std::sync::Arc;
 
 /// Encode operations, append them to a compact Merkle batch, and compute its root.
-pub(crate) fn merkleize_ops<F, E, H, S, Op>(
-    merkle: &compact::Merkle<F, E, H::Digest, S>,
+pub(crate) fn merkleize_ops<F, H, S, Op>(
+    merkle: &compact::Merkle<F, H::Digest, S>,
     batch: compact::UnmerkleizedBatch<F, H::Digest, S>,
     ops: &[Op],
 ) -> Arc<batch::MerkleizedBatch<F, H::Digest, S>>
 where
     F: Family,
-    E: Context,
     H: Hasher,
     S: Strategy,
     Op: EncodeShared,

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -33,7 +33,7 @@ use crate::{
     qmdb::{self, sync::compact::Target, Error},
     Context,
 };
-use commonware_codec::{Decode as _, EncodeSize, RangeCfg, Read, Write};
+use commonware_codec::{Decode as _, EncodeSize, Read, Write};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use commonware_utils::sync::{AsyncMutex, RwLock};
@@ -42,24 +42,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// Upper bound on the encoded last-commit operation, enforced before any witness is built and
 /// as a decode guard against corrupted length prefixes.
 pub(crate) const MAX_OP_BYTES: usize = 1 << 24;
-
-/// Codec configuration for decoding a [`WitnessEntry`] read back from the journal.
-#[derive(Clone)]
-pub(crate) struct WitnessEntryCfg {
-    op_bytes: RangeCfg<usize>,
-    proof_digests: usize,
-    pinned_nodes: RangeCfg<usize>,
-}
-
-impl Default for WitnessEntryCfg {
-    fn default() -> Self {
-        Self {
-            op_bytes: (..=MAX_OP_BYTES).into(),
-            proof_digests: MAX_PROOF_DIGESTS_PER_ELEMENT,
-            pinned_nodes: (..=MAX_PINNED_NODES).into(),
-        }
-    }
-}
 
 /// A single durably persisted witness: a complete snapshot of one synced commit.
 ///
@@ -92,15 +74,12 @@ impl<F: Family, D: Digest> Write for WitnessEntry<F, D> {
 }
 
 impl<F: Family, D: Digest> Read for WitnessEntry<F, D> {
-    type Cfg = WitnessEntryCfg;
+    type Cfg = ();
 
-    fn read_cfg(
-        buf: &mut impl bytes::Buf,
-        cfg: &Self::Cfg,
-    ) -> Result<Self, commonware_codec::Error> {
-        let op_bytes = Vec::<u8>::read_cfg(buf, &(cfg.op_bytes, ()))?;
-        let proof = Proof::<F, D>::read_cfg(buf, &cfg.proof_digests)?;
-        let pinned_nodes = Vec::<D>::read_cfg(buf, &(cfg.pinned_nodes, ()))?;
+    fn read_cfg(buf: &mut impl bytes::Buf, _: &()) -> Result<Self, commonware_codec::Error> {
+        let op_bytes = Vec::<u8>::read_cfg(buf, &((..=MAX_OP_BYTES).into(), ()))?;
+        let proof = Proof::<F, D>::read_cfg(buf, &MAX_PROOF_DIGESTS_PER_ELEMENT)?;
+        let pinned_nodes = Vec::<D>::read_cfg(buf, &((..=MAX_PINNED_NODES).into(), ()))?;
         Ok(Self {
             op_bytes,
             proof,
@@ -127,8 +106,6 @@ pub(crate) type Journal<E, F, D> = variable::Journal<E, WitnessEntry<F, D>>;
 pub(crate) struct Witness<F: Family, D: Digest> {
     /// Root committed by the tip witness entry.
     pub(crate) root: D,
-    /// Total leaves in the committed Merkle, which also identifies the tip commit location.
-    pub(crate) leaf_count: Location<F>,
     /// Pinned frontier nodes of the committed Merkle; not the proof path.
     pub(crate) pinned_nodes: Vec<D>,
     /// Encoded last-commit operation bytes used for root verification and serving.
@@ -138,36 +115,18 @@ pub(crate) struct Witness<F: Family, D: Digest> {
 }
 
 impl<F: Family, D: Digest> Witness<F, D> {
+    /// Total leaves in the committed Merkle, which also identifies the tip commit location.
+    pub(crate) const fn leaf_count(&self) -> Location<F> {
+        self.last_commit_proof.leaves
+    }
+
     /// The compact-sync target this witness can serve: its root and leaf count.
     pub(crate) const fn target(&self) -> Target<F, D> {
         Target {
             root: self.root,
-            leaf_count: self.leaf_count,
+            leaf_count: self.leaf_count(),
         }
     }
-}
-
-/// Open the witness journal for a compact db.
-pub(crate) async fn open_journal<E, F, D>(
-    context: E,
-    cfg: variable::Config<()>,
-) -> Result<Journal<E, F, D>, Error<F>>
-where
-    E: Context,
-    F: Family,
-    D: Digest,
-{
-    let cfg = variable::Config {
-        partition: cfg.partition,
-        items_per_section: cfg.items_per_section,
-        compression: cfg.compression,
-        // The caller's config carries `()` as a placeholder codec config; the real entry codec
-        // config is private to this module and substituted here.
-        codec_config: WitnessEntryCfg::default(),
-        page_cache: cfg.page_cache,
-        write_buffer: cfg.write_buffer,
-    };
-    Ok(variable::Journal::init(context, cfg).await?)
 }
 
 /// A contiguous journal plus an in-memory cache of the tip witness.
@@ -236,7 +195,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         // Normally the cache mirrors the journal tip, so the state is already durable and there
         // is nothing to do. During a pending import the cached witness is not in the journal
         // yet, so it is exactly what must be persisted: replace the journal's contents with it.
-        let cached_leaves = self.with(|w| w.leaf_count);
+        let cached_leaves = self.with(|w| w.leaf_count());
         if cached_leaves == merkle.leaves() {
             if self.import_pending.load(Ordering::Relaxed) {
                 self.journal.clear_to_size(0).await?;
@@ -409,7 +368,6 @@ where
         let last_commit_proof = mem.proof(&hasher, last_commit_loc, inactive_peaks)?;
         Ok(Witness {
             root,
-            leaf_count,
             pinned_nodes,
             last_commit_op_bytes,
             last_commit_proof,
@@ -457,11 +415,13 @@ where
         return Err(Error::DataCorrupted("missing final commit"));
     }
     let leaf_count = merkle.leaves();
+    if last_commit_proof.leaves != leaf_count {
+        return Err(Error::DataCorrupted("invalid compact witness"));
+    }
     let last_commit_loc = Location::<F>::new(*leaf_count - 1);
     validate_inactivity_floor(inactivity_floor_loc, last_commit_loc)?;
     Ok(Witness {
         root,
-        leaf_count,
         pinned_nodes,
         last_commit_op_bytes,
         last_commit_proof,
@@ -533,7 +493,6 @@ where
     }
     let witness = Witness {
         root,
-        leaf_count,
         pinned_nodes,
         last_commit_op_bytes,
         last_commit_proof,

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -72,6 +72,20 @@ impl<F: Family, D: Digest> Read for Witness<F, D> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<F: Family, D: Digest> arbitrary::Arbitrary<'_> for Witness<F, D>
+where
+    D: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            op_bytes: u.arbitrary()?,
+            proof: u.arbitrary()?,
+            pinned_nodes: u.arbitrary()?,
+        })
+    }
+}
+
 /// A witness and the root it was verified against.
 #[derive(Clone)]
 pub(crate) struct VerifiedWitness<F: Family, D: Digest> {
@@ -523,6 +537,19 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+
+    #[cfg(feature = "arbitrary")]
+    mod conformance {
+        use super::*;
+        use crate::merkle::{mmb, mmr};
+        use commonware_codec::conformance::CodecConformance;
+        use commonware_cryptography::sha256;
+
+        commonware_conformance::conformance_tests! {
+            CodecConformance<Witness<mmr::Family, sha256::Digest>>,
+            CodecConformance<Witness<mmb::Family, sha256::Digest>>,
+        }
+    }
 
     /// Corrupt the entry at `pos` with `f`, preserving the entries above it.
     pub(crate) async fn corrupt_entry<E, F, D>(

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -39,10 +39,6 @@ use commonware_parallel::Strategy;
 use commonware_utils::sync::{AsyncMutex, RwLock};
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// Upper bound on the encoded last-commit operation, enforced before any witness is built and
-/// as a decode guard against corrupted length prefixes.
-pub(crate) const MAX_OP_BYTES: usize = 1 << 24;
-
 /// A single durably persisted witness: a complete snapshot of one synced commit.
 ///
 /// The root is not stored: it is recomputed from the rebuilt frontier and authenticated against
@@ -77,7 +73,7 @@ impl<F: Family, D: Digest> Read for WitnessEntry<F, D> {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl bytes::Buf, _: &()) -> Result<Self, commonware_codec::Error> {
-        let op_bytes = Vec::<u8>::read_cfg(buf, &((..=MAX_OP_BYTES).into(), ()))?;
+        let op_bytes = Vec::<u8>::read_cfg(buf, &((..).into(), ()))?;
         let proof = Proof::<F, D>::read_cfg(buf, &MAX_PROOF_DIGESTS_PER_ELEMENT)?;
         let pinned_nodes = Vec::<D>::read_cfg(buf, &((..=MAX_PINNED_NODES).into(), ()))?;
         Ok(Self {
@@ -210,14 +206,8 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             return Err(Error::DataCorrupted("witness ahead of in-memory state"));
         }
 
-        let last_commit_op_bytes = last_commit_op_bytes();
-        if last_commit_op_bytes.len() > MAX_OP_BYTES {
-            return Err(Error::CommitTooLarge(
-                last_commit_op_bytes.len(),
-                MAX_OP_BYTES,
-            ));
-        }
-        let witness = build_witness::<F, H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)?;
+        let witness =
+            build_witness::<F, H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes())?;
         if self.import_pending.load(Ordering::Relaxed) {
             self.journal.clear_to_size(0).await?;
         }
@@ -405,12 +395,6 @@ where
     D: Digest,
     S: Strategy,
 {
-    if last_commit_op_bytes.len() > MAX_OP_BYTES {
-        return Err(Error::CommitTooLarge(
-            last_commit_op_bytes.len(),
-            MAX_OP_BYTES,
-        ));
-    }
     if merkle.leaves() == 0 {
         return Err(Error::DataCorrupted("missing final commit"));
     }
@@ -541,12 +525,6 @@ where
     H: Hasher,
     S: Strategy,
 {
-    if last_commit_op_bytes.len() > MAX_OP_BYTES {
-        return Err(Error::CommitTooLarge(
-            last_commit_op_bytes.len(),
-            MAX_OP_BYTES,
-        ));
-    }
     let hasher = qmdb::hasher::<H>();
     let batch = {
         let batch = merkle.new_batch().add(&hasher, &last_commit_op_bytes);

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -124,7 +124,9 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     }
 
     /// Create a store from a verified compact-sync import that has not been persisted yet. The
-    /// journal is untouched until the first persist replaces its contents with `witness`.
+    /// journal is untouched until the first persist replaces its contents with `witness`. A
+    /// crash during that replacement leaves a journal that fails to reopen; re-syncing
+    /// recovers it.
     pub(crate) fn from_import(journal: Journal<E, F, D>, witness: VerifiedWitness<F, D>) -> Self {
         Self {
             journal,
@@ -168,7 +170,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         let cached_leaves = self.with(|w| w.leaf_count());
         if cached_leaves == merkle.leaves() {
             if self.import_pending.load(Ordering::Relaxed) {
-                self.journal.clear_to_size(0).await?;
+                self.clear_for_import().await?;
                 let entry = self.with(|w| w.entry.clone());
                 self.append_and_sync(&entry).await?;
             }
@@ -181,7 +183,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         let witness =
             build_witness::<F, H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes())?;
         if self.import_pending.load(Ordering::Relaxed) {
-            self.journal.clear_to_size(0).await?;
+            self.clear_for_import().await?;
         }
         self.append_and_sync(&witness.entry).await?;
         merkle.prune_to_frontier();
@@ -290,6 +292,16 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             }
         }
         Ok(lo)
+    }
+
+    /// Clear the journal so the imported witness becomes its only entry.
+    ///
+    /// Clears to a nonzero size: if a crash interrupts the import, reopen sees a non-empty
+    /// journal with an unreadable tip and fails, instead of mistaking it for a fresh db.
+    async fn clear_for_import(&self) -> Result<(), Error<F>> {
+        let size = self.journal.size().await;
+        self.journal.clear_to_size(size.max(1)).await?;
+        Ok(())
     }
 
     /// Append `entry` and sync it, making it the durable tip.

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -368,9 +368,8 @@ where
 /// Validate that a decoded commit floor does not point past the commit it authenticates.
 ///
 /// The inactivity floor of a commit must sit at or below the commit's own location. A higher
-/// floor would reference operations that do not exist yet, which indicates either disk corruption
-/// when reloading a persisted witness or malformed compact-sync input when validating reconstructed
-/// state from a remote source.
+/// floor would reference operations that do not exist yet, which indicates disk corruption in
+/// the persisted witness.
 pub(crate) fn validate_inactivity_floor<F: Family>(
     inactivity_floor_loc: Location<F>,
     last_commit_loc: Location<F>,
@@ -379,37 +378,6 @@ pub(crate) fn validate_inactivity_floor<F: Family>(
         return Err(Error::DataCorrupted("invalid compact witness"));
     }
     Ok(())
-}
-
-/// Build a witness from compact state that was already authenticated by the caller.
-pub(crate) fn witness_from_authenticated_state<F, D, S>(
-    merkle: &compact::Merkle<F, D, S>,
-    root: D,
-    inactivity_floor_loc: Location<F>,
-    last_commit_op_bytes: Vec<u8>,
-    last_commit_proof: Proof<F, D>,
-    pinned_nodes: Vec<D>,
-) -> Result<Witness<F, D>, Error<F>>
-where
-    F: Family,
-    D: Digest,
-    S: Strategy,
-{
-    if merkle.leaves() == 0 {
-        return Err(Error::DataCorrupted("missing final commit"));
-    }
-    let leaf_count = merkle.leaves();
-    if last_commit_proof.leaves != leaf_count {
-        return Err(Error::DataCorrupted("invalid compact witness"));
-    }
-    let last_commit_loc = Location::<F>::new(*leaf_count - 1);
-    validate_inactivity_floor(inactivity_floor_loc, last_commit_loc)?;
-    Ok(Witness {
-        root,
-        pinned_nodes,
-        last_commit_op_bytes,
-        last_commit_proof,
-    })
 }
 
 /// Load the tip witness from the journal and rebuild the Merkle from it.
@@ -542,13 +510,6 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-
-    impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
-        /// Mutate the cached witness.
-        pub(crate) fn mutate(&self, f: impl FnOnce(&mut Witness<F, D>)) {
-            f(&mut self.cache.write());
-        }
-    }
 
     /// Read the tip witness entry's components.
     pub(crate) async fn tip<E, F, D>(journal: &Journal<E, F, D>) -> (Vec<u8>, Proof<F, D>, Vec<D>)

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -15,14 +15,12 @@
 //!
 //! # Journal layout and crash consistency
 //!
-//! Entries are strictly increasing in committed leaf count (`proof.leaves`); every append path
-//! upholds this invariant. Since journal positions are also stable across pruning, rewind and
-//! prune targets are located by binary search on leaf count.
+//! Entries are strictly increasing in committed leaf count (`proof.leaves`), and journal
+//! positions are stable across pruning, so rewind and prune targets are located by binary
+//! search on leaf count.
 //!
 //! The journal `sync` after an append is the commit point: a crash before it drops the unsynced
-//! tail on reopen, recovering the previous commit. The Merkle persists nothing, so there is
-//! nothing else to reconcile. Rewind truncates the journal to the target entry and syncs. Only
-//! the tip entry is ever verified: on reopen, or when a rewind makes an older entry the tip.
+//! tail on reopen, recovering the previous commit.
 //!
 //! [`Store::prune`] bounds how far back [`Store::rewind`] can reach; the tip entry is never
 //! pruned.
@@ -41,9 +39,8 @@ use commonware_parallel::Strategy;
 use commonware_utils::sync::{AsyncMutex, RwLock};
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// Upper bound on the encoded last-commit operation, enforced at commit time and as a decode
-/// guard against corrupted length prefixes. Commit operations are small; this bound is
-/// intentionally generous because the commit carries optional caller metadata.
+/// Upper bound on the encoded last-commit operation, enforced before any witness is built and
+/// as a decode guard against corrupted length prefixes.
 pub(crate) const MAX_OP_BYTES: usize = 1 << 24;
 
 /// Codec configuration for decoding a [`WitnessEntry`] read back from the journal.
@@ -64,16 +61,19 @@ impl Default for WitnessEntryCfg {
     }
 }
 
-/// A single durably persisted witness: the encoded last-commit operation, its inclusion proof,
-/// and the pinned frontier nodes of the committed Merkle.
+/// A single durably persisted witness: a complete snapshot of one synced commit.
 ///
-/// The proof's `leaves` field identifies the committed leaf count; together with `pinned_nodes`
-/// it is everything required to rebuild the in-memory Merkle for this commit. The root is not
-/// stored: it is recomputed from the rebuilt frontier and authenticated against the proof.
+/// The root is not stored: it is recomputed from the rebuilt frontier and authenticated against
+/// `proof`.
 #[derive(Clone)]
 pub(crate) struct WitnessEntry<F: Family, D: Digest> {
+    /// The encoded last-commit operation.
     op_bytes: Vec<u8>,
+    /// Inclusion proof for the last-commit leaf; its `leaves` field identifies the committed
+    /// leaf count.
     proof: Proof<F, D>,
+    /// Pinned frontier nodes of the committed Merkle; with `proof.leaves`, everything needed
+    /// to rebuild the in-memory Merkle for this commit.
     pinned_nodes: Vec<D>,
 }
 
@@ -129,7 +129,7 @@ pub(crate) struct Witness<F: Family, D: Digest> {
     pub(crate) root: D,
     /// Total leaves in the committed Merkle, which also identifies the tip commit location.
     pub(crate) leaf_count: Location<F>,
-    /// Frontier nodes pinned by compact sync; these are the persisted peaks, not the proof path.
+    /// Pinned frontier nodes of the committed Merkle; not the proof path.
     pub(crate) pinned_nodes: Vec<D>,
     /// Encoded last-commit operation bytes used for root verification and serving.
     pub(crate) last_commit_op_bytes: Vec<u8>,
@@ -161,7 +161,8 @@ where
         partition: cfg.partition,
         items_per_section: cfg.items_per_section,
         compression: cfg.compression,
-        // Callers pass `()` because [`WitnessEntryCfg`] is internal to this module.
+        // The caller's config carries `()` as a placeholder codec config; the real entry codec
+        // config is private to this module and substituted here.
         codec_config: WitnessEntryCfg::default(),
         page_cache: cfg.page_cache,
         write_buffer: cfg.write_buffer,
@@ -193,7 +194,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         }
     }
 
-    /// Wrap a journal and a verified compact-sync import that has not been persisted yet; the
+    /// Create a store from a verified compact-sync import that has not been persisted yet. The
     /// journal is untouched until the first persist replaces its contents with `witness`.
     pub(crate) fn from_import(journal: Journal<E, F, D>, witness: Witness<F, D>) -> Self {
         Self {
@@ -383,8 +384,8 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
 
 /// Build a witness for the last commit from the current unpruned Merkle state.
 ///
-/// This must run before the Merkle is pruned to its frontier, because the single-leaf inclusion proof is
-/// only computable while the proof path is still retained.
+/// This must run before the Merkle is pruned to its frontier, because the single-leaf inclusion
+/// proof is only computable while the proof path is still retained.
 fn build_witness<F, H, S>(
     merkle: &compact::Merkle<F, H::Digest, S>,
     inactivity_floor_loc: Location<F>,
@@ -469,9 +470,9 @@ where
 
 /// Load the tip witness from the journal and rebuild the Merkle from it.
 ///
-/// The tip entry is a complete snapshot: the Merkle is reset to its `(leaf_count, pinned_nodes)`,
-/// the root is recomputed from the rebuilt frontier, and the persisted proof is verified against
-/// that root before anything is served.
+/// The Merkle is reset to the entry's `(leaf_count, pinned_nodes)`, the root is recomputed from
+/// the rebuilt frontier, and the persisted proof is verified against that root before anything
+/// is served.
 async fn load_tip<E, F, H, S, Op>(
     journal: &Journal<E, F, H::Digest>,
     merkle: &compact::Merkle<F, H::Digest, S>,
@@ -540,14 +541,12 @@ where
     Ok((witness, last_commit_op))
 }
 
-/// Open the witness store for an existing or new compact db.
+/// Open the witness store for an existing or new compact db, returning it with the decoded
+/// last-commit operation.
 ///
-/// Fresh compact databases begin with exactly one committed operation: the initial commit. This
-/// inserts that commit into the compact Merkle, builds its one-leaf proof, and persists the
-/// resulting witness so later reopen and rewind paths use the same recovery logic as every
-/// subsequent commit. An existing db instead reloads and re-verifies its tip witness.
-///
-/// Returns the store together with the decoded last-commit operation.
+/// A new db starts with one committed operation, the initial commit: it is inserted into the
+/// compact Merkle and persisted as the first witness entry, so reopen and rewind never see an
+/// empty journal. An existing db reloads and re-verifies its tip witness.
 pub(crate) async fn init<E, F, H, S, Op>(
     journal: Journal<E, F, H::Digest>,
     merkle: &mut compact::Merkle<F, H::Digest, S>,
@@ -608,13 +607,13 @@ pub(crate) mod tests {
     use super::*;
 
     impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
-        /// Mutate the cache in tests that intentionally corrupt witness state.
+        /// Mutate the cached witness.
         pub(crate) fn mutate(&self, f: impl FnOnce(&mut Witness<F, D>)) {
             f(&mut self.cache.write());
         }
     }
 
-    /// Read the tip witness entry's components. Used by db tests that tamper with persisted state.
+    /// Read the tip witness entry's components.
     pub(crate) async fn tip<E, F, D>(journal: &Journal<E, F, D>) -> (Vec<u8>, Proof<F, D>, Vec<D>)
     where
         E: Context,
@@ -629,8 +628,7 @@ pub(crate) mod tests {
         (entry.op_bytes, entry.proof, entry.pinned_nodes)
     }
 
-    /// Append a witness entry without syncing it. Used by db tests that simulate a commit
-    /// interrupted before its journal sync.
+    /// Append a witness entry without syncing it.
     pub(crate) async fn append_unsynced<E, F, D>(
         journal: &Journal<E, F, D>,
         op_bytes: Vec<u8>,
@@ -651,7 +649,7 @@ pub(crate) mod tests {
             .unwrap();
     }
 
-    /// Replace the tip witness entry. Used by db tests that tamper with persisted state.
+    /// Replace the tip witness entry.
     pub(crate) async fn overwrite_tip<E, F, D>(
         journal: &Journal<E, F, D>,
         op_bytes: Vec<u8>,

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -19,14 +19,13 @@
 //! upholds this invariant. Since journal positions are also stable across pruning, rewind and
 //! prune targets are located by binary search on leaf count.
 //!
-//! The journal `sync` after an append is the commit point. A crash before it drops the unsynced
-//! tail on reopen, recovering the previous commit; nothing else needs reconciliation because the
-//! Merkle has no persistence of its own. Rewind truncates the journal to the target entry and
-//! syncs before returning. Only the tip entry is verified on reopen; an older entry is verified
-//! when a rewind makes it the tip.
+//! The journal `sync` after an append is the commit point: a crash before it drops the unsynced
+//! tail on reopen, recovering the previous commit. The Merkle persists nothing, so there is
+//! nothing else to reconcile. Rewind truncates the journal to the target entry and syncs. Only
+//! the tip entry is ever verified: on reopen, or when a rewind makes an older entry the tip.
 //!
-//! History is retained until [`Store::prune`], which bounds how far back [`Store::rewind`]
-//! can reach. The tip entry is never pruned.
+//! [`Store::prune`] bounds how far back [`Store::rewind`] can reach; the tip entry is never
+//! pruned.
 
 use crate::{
     journal::contiguous::{variable, Reader as _},
@@ -148,19 +147,6 @@ impl<F: Family, D: Digest> Witness<F, D> {
     }
 }
 
-/// Db-owned persistent store for the compact witness: a contiguous journal plus an in-memory
-/// cache of the tip witness.
-pub(crate) struct Store<E: Context, F: Family, D: Digest> {
-    journal: Journal<E, F, D>,
-    cache: RwLock<Witness<F, D>>,
-    /// Whether the cached witness came from compact sync and has not been written to the
-    /// journal yet. While set, the journal still holds the partition's previous contents; the
-    /// first persist replaces them with the cached witness and clears this flag.
-    import_pending: AtomicBool,
-    /// Serializes persist/rewind/prune so concurrent calls on a shared handle do not interleave.
-    sync_lock: AsyncMutex<()>,
-}
-
 /// Open the witness journal for a compact db.
 pub(crate) async fn open_journal<E, F, D>(
     context: E,
@@ -183,6 +169,19 @@ where
     Ok(variable::Journal::init(context, cfg).await?)
 }
 
+/// A contiguous journal plus an in-memory cache of the tip witness.
+pub(crate) struct Store<E: Context, F: Family, D: Digest> {
+    journal: Journal<E, F, D>,
+    cache: RwLock<Witness<F, D>>,
+    /// Whether the cached witness came from compact sync and has not been written to the
+    /// journal yet. While set, the journal still holds the partition's previous contents; the
+    /// first persist replaces them with the cached witness and clears this flag. Accessed only
+    /// under `sync_lock`, so loads and stores are `Relaxed`.
+    import_pending: AtomicBool,
+    /// Serializes persist/rewind/prune so concurrent calls on a shared handle do not interleave.
+    sync_lock: AsyncMutex<()>,
+}
+
 impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Wrap an opened journal and a verified witness into a store.
     pub(crate) fn new(journal: Journal<E, F, D>, witness: Witness<F, D>) -> Self {
@@ -196,7 +195,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
 
     /// Wrap a journal and a verified compact-sync import that has not been persisted yet; the
     /// journal is untouched until the first persist replaces its contents with `witness`.
-    pub(crate) fn new_import(journal: Journal<E, F, D>, witness: Witness<F, D>) -> Self {
+    pub(crate) fn from_import(journal: Journal<E, F, D>, witness: Witness<F, D>) -> Self {
         Self {
             journal,
             cache: RwLock::new(witness),
@@ -218,8 +217,8 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Persist the current compact state as a new witness journal entry.
     ///
     /// No-op if the cached witness already matches the Merkle (the witness is already durable).
-    /// Otherwise appends a witness built from the unpruned Merkle, prunes the Merkle to peaks,
-    /// and refreshes the cache.
+    /// Otherwise appends a witness built from the unpruned Merkle, prunes the Merkle to its
+    /// frontier, and refreshes the cache.
     pub(crate) async fn persist<H, S>(
         &self,
         merkle: &compact::Merkle<F, D, S>,
@@ -232,10 +231,10 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     {
         let _guard = self.sync_lock.lock().await;
 
-        // Outside a pending import, the cache always matches the journal tip, so an equal leaf
-        // count means the current state is already durable. During an import it instead means
-        // the cached witness must replace the journal's old contents. `sync_lock` orders the
-        // flag accesses.
+        // An equal leaf count means no commit has been applied since the cache was set.
+        // Normally the cache mirrors the journal tip, so the state is already durable and there
+        // is nothing to do. During a pending import the cached witness is not in the journal
+        // yet, so it is exactly what must be persisted: replace the journal's contents with it.
         let cached_leaves = self.with(|w| w.leaf_count);
         if cached_leaves == merkle.leaves() {
             if self.import_pending.load(Ordering::Relaxed) {
@@ -264,7 +263,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         }
         self.append_and_sync(&WitnessEntry::from(&witness)).await?;
         self.import_pending.store(false, Ordering::Relaxed);
-        merkle.prune_to_peaks();
+        merkle.prune_to_frontier();
         self.replace(witness);
         Ok(())
     }
@@ -274,7 +273,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// of the restored tip.
     ///
     /// Rewinding to a pruned leaf count, or one no entry commits, returns
-    /// [`merkle::Error::RewindBeyondHistory`]. The truncation is synced before returning.
+    /// [`merkle::Error::RewindBeyondHistory`]. The rewind is synced before returning.
     pub(crate) async fn rewind<H, S, Op>(
         &self,
         merkle: &compact::Merkle<F, D, S>,
@@ -384,7 +383,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
 
 /// Build a witness for the last commit from the current unpruned Merkle state.
 ///
-/// This must run before the Merkle is pruned to peaks, because the single-leaf inclusion proof is
+/// This must run before the Merkle is pruned to its frontier, because the single-leaf inclusion proof is
 /// only computable while the proof path is still retained.
 fn build_witness<F, H, S>(
     merkle: &compact::Merkle<F, H::Digest, S>,

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -105,8 +105,8 @@ pub(crate) struct Store<E: Context, F: Family, D: Digest> {
     cache: RwLock<VerifiedWitness<F, D>>,
     /// Whether the cached witness came from compact sync and has not been written to the
     /// journal yet. While set, the journal still holds the partition's previous contents; the
-    /// first persist replaces them with the cached witness and clears this flag. Accessed only
-    /// under `sync_lock`, so loads and stores are `Relaxed`.
+    /// first persist replaces them with the cached witness and clears this flag. Mutated only
+    /// under `sync_lock`; reads hold `sync_lock` or the db's `&mut`, so `Relaxed` suffices.
     import_pending: AtomicBool,
     /// Serializes persist/rewind/prune.
     sync_lock: AsyncMutex<()>,
@@ -196,7 +196,9 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// of the restored tip.
     ///
     /// Rewinding to a pruned leaf count, or one no entry commits, returns
-    /// [`merkle::Error::RewindBeyondHistory`]. The rewind is made durable before returning.
+    /// [`merkle::Error::RewindBeyondHistory`]. The target entry is verified before the journal
+    /// is truncated, so a corrupt entry fails the rewind with the journal intact. The rewind is
+    /// made durable before returning.
     pub(crate) async fn rewind<H, S, Op>(
         &self,
         merkle: &compact::Merkle<F, D, S>,
@@ -212,26 +214,25 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         let _guard = self.sync_lock.lock().await;
         self.check_import_persisted()?;
 
-        let pos = self
+        let (pos, entry) = self
             .position_of(target)
             .await?
             .ok_or(Error::Merkle(merkle::Error::RewindBeyondHistory))?;
-        self.journal.rewind(pos + 1).await?;
-        self.journal.sync().await?;
-
-        let (witness, op) = load_tip::<E, F, H, S, Op>(
-            &self.journal,
+        let (witness, op) = rebuild_and_verify::<F, D, H, S, Op>(
+            entry,
             merkle,
             commit_codec_config,
             last_commit_floor,
-        )
-        .await?;
+        )?;
+        self.journal.rewind(pos + 1).await?;
+        self.journal.sync().await?;
         self.replace(witness);
         Ok(op)
     }
 
     /// Drop all entries committing fewer than `pruning_boundary` leaves, bounding how far back
-    /// [`Self::rewind`] can reach. The tip entry always survives.
+    /// [`Self::rewind`] can reach. The tip entry always survives. Only whole journal sections
+    /// are dropped, so some entries below the boundary may survive.
     pub(crate) async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         let _guard = self.sync_lock.lock().await;
         self.check_import_persisted()?;
@@ -252,6 +253,11 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         Ok(())
     }
 
+    /// Whether a compact-sync import is not yet durable.
+    pub(crate) fn import_pending(&self) -> bool {
+        self.import_pending.load(Ordering::Relaxed)
+    }
+
     /// Reject operations on a journal whose contents an unpersisted compact-sync import is
     /// about to replace.
     fn check_import_persisted(&self) -> Result<(), Error<F>> {
@@ -261,16 +267,19 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         Ok(())
     }
 
-    /// Find the journal position of the entry committing exactly `target` leaves, or `None`
-    /// if no retained entry does.
-    async fn position_of(&self, target: Location<F>) -> Result<Option<u64>, Error<F>> {
+    /// Find the journal position and entry committing exactly `target` leaves, or `None` if
+    /// no retained entry does.
+    async fn position_of(
+        &self,
+        target: Location<F>,
+    ) -> Result<Option<(u64, Witness<F, D>)>, Error<F>> {
         let reader = self.journal.reader().await;
         let pos = Self::first_at_or_above(&reader, target).await?;
         if pos >= reader.bounds().end {
             return Ok(None);
         }
         let entry = reader.read(pos).await?;
-        Ok((entry.proof.leaves == target).then_some(pos))
+        Ok((entry.proof.leaves == target).then_some((pos, entry)))
     }
 
     /// Binary search for the first retained position whose entry commits at least `leaf_count`
@@ -374,10 +383,6 @@ pub(crate) fn validate_inactivity_floor<F: Family>(
 }
 
 /// Load the tip witness from the journal and rebuild the Merkle from it.
-///
-/// The Merkle is reset to the entry's `(leaf_count, pinned_nodes)`, the root is recomputed from
-/// the rebuilt frontier, and the persisted proof is verified against that root before anything
-/// is served.
 async fn load_tip<E, F, H, S, Op>(
     journal: &Journal<E, F, H::Digest>,
     merkle: &compact::Merkle<F, H::Digest, S>,
@@ -399,8 +404,32 @@ where
         let reader = journal.reader().await;
         reader.read(size - 1).await?
     };
+    rebuild_and_verify::<F, H::Digest, H, S, Op>(
+        entry,
+        merkle,
+        commit_codec_config,
+        last_commit_floor,
+    )
+}
 
-    let leaf_count = entry.proof.leaves;
+/// Rebuild the Merkle from `witness` and verify the witness against it.
+///
+/// The Merkle is reset to the witness's `(leaf_count, pinned_nodes)`, the root is recomputed
+/// from the rebuilt frontier, and the witness's proof is verified against that root.
+fn rebuild_and_verify<F, D, H, S, Op>(
+    witness: Witness<F, D>,
+    merkle: &compact::Merkle<F, D, S>,
+    commit_codec_config: &Op::Cfg,
+    last_commit_floor: impl FnOnce(&Op) -> Option<Location<F>>,
+) -> Result<(VerifiedWitness<F, D>, Op), Error<F>>
+where
+    F: Family,
+    D: Digest,
+    H: Hasher<Digest = D>,
+    S: Strategy,
+    Op: Read,
+{
+    let leaf_count = witness.proof.leaves;
     if leaf_count == 0 {
         return Err(Error::DataCorrupted("invalid compact witness"));
     }
@@ -408,14 +437,14 @@ where
     // Decode the commit op to get the inactivity floor, which determines the inactive peak
     // boundary used for root computation.
     let last_commit_loc = Location::new(*leaf_count - 1);
-    let last_commit_op = Op::decode_cfg(entry.op_bytes.as_ref(), commit_codec_config)
+    let last_commit_op = Op::decode_cfg(witness.op_bytes.as_ref(), commit_codec_config)
         .map_err(|_| Error::DataCorrupted("invalid commit operation"))?;
     let inactivity_floor_loc = last_commit_floor(&last_commit_op)
         .ok_or(Error::DataCorrupted("last operation was not a commit"))?;
     validate_inactivity_floor(inactivity_floor_loc, last_commit_loc)?;
 
     merkle
-        .reset_to(leaf_count, entry.pinned_nodes.clone())
+        .reset_to(leaf_count, witness.pinned_nodes.clone())
         .map_err(|_| Error::DataCorrupted("invalid compact witness"))?;
     let inactive_peaks =
         F::inactive_peaks(F::location_to_position(leaf_count), inactivity_floor_loc);
@@ -423,15 +452,21 @@ where
     let root = merkle
         .root(&hasher, inactive_peaks)
         .map_err(|_| Error::DataCorrupted("failed to compute compact witness root"))?;
-    if !entry.proof.verify_range_inclusion(
+    if !witness.proof.verify_range_inclusion(
         &hasher,
-        &[entry.op_bytes.as_slice()],
+        &[witness.op_bytes.as_slice()],
         last_commit_loc,
         &root,
     ) {
         return Err(Error::DataCorrupted("invalid compact witness"));
     }
-    Ok((VerifiedWitness { entry, root }, last_commit_op))
+    Ok((
+        VerifiedWitness {
+            entry: witness,
+            root,
+        },
+        last_commit_op,
+    ))
 }
 
 /// Open the witness store for an existing or new compact db, returning it with the decoded
@@ -492,6 +527,31 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+
+    /// Corrupt the entry at `pos` with `f`, preserving the entries above it.
+    pub(crate) async fn corrupt_entry<E, F, D>(
+        journal: &Journal<E, F, D>,
+        pos: u64,
+        f: impl FnOnce(&mut Witness<F, D>),
+    ) where
+        E: Context,
+        F: Family,
+        D: Digest,
+    {
+        let mut entries = Vec::new();
+        {
+            let reader = journal.reader().await;
+            for p in pos..reader.bounds().end {
+                entries.push(reader.read(p).await.unwrap());
+            }
+        }
+        f(&mut entries[0]);
+        journal.rewind(pos).await.unwrap();
+        for entry in &entries {
+            journal.append(entry).await.unwrap();
+        }
+        journal.sync().await.unwrap();
+    }
 
     /// Read the tip witness entry's components.
     pub(crate) async fn tip<E, F, D>(journal: &Journal<E, F, D>) -> (Vec<u8>, Proof<F, D>, Vec<D>)

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -72,22 +72,18 @@ impl<F: Family, D: Digest> Read for Witness<F, D> {
     }
 }
 
-/// The contiguous variable journal that backs a witness [`Store`].
-pub(crate) type Journal<E, F, D> = variable::Journal<E, Witness<F, D>>;
-
-/// In-memory snapshot of the tip witness: the tip entry plus its verified root.
+/// A witness and the root it was verified against.
 #[derive(Clone)]
 pub(crate) struct VerifiedWitness<F: Family, D: Digest> {
-    /// The tip witness entry.
-    pub(crate) entry: Witness<F, D>,
-    /// Root committed by `entry`.
+    pub(crate) witness: Witness<F, D>,
+    /// Root committed by `witness`.
     pub(crate) root: D,
 }
 
 impl<F: Family, D: Digest> VerifiedWitness<F, D> {
-    /// Total leaves in the committed Merkle, which also identifies the tip commit location.
+    /// Total leaves in the committed Merkle, which also identifies the last commit's location.
     pub(crate) const fn leaf_count(&self) -> Location<F> {
-        self.entry.proof.leaves
+        self.witness.proof.leaves
     }
 
     /// The compact-sync target this witness can serve: its root and leaf count.
@@ -99,15 +95,21 @@ impl<F: Family, D: Digest> VerifiedWitness<F, D> {
     }
 }
 
+/// The contiguous variable journal that backs a witness [`Store`].
+pub(crate) type Journal<E, F, D> = variable::Journal<E, Witness<F, D>>;
+
 /// A contiguous journal plus an in-memory cache of the tip witness.
 pub(crate) struct Store<E: Context, F: Family, D: Digest> {
     journal: Journal<E, F, D>,
-    cache: RwLock<VerifiedWitness<F, D>>,
+
+    tip_witness: RwLock<VerifiedWitness<F, D>>,
+
     /// Whether the cached witness came from compact sync and has not been written to the
     /// journal yet. While set, the journal still holds the partition's previous contents; the
     /// first persist replaces them with the cached witness and clears this flag. Mutated only
     /// under `sync_lock`; reads hold `sync_lock` or the db's `&mut`, so `Relaxed` suffices.
     import_pending: AtomicBool,
+
     /// Serializes persist/rewind/prune.
     sync_lock: AsyncMutex<()>,
 }
@@ -117,20 +119,20 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     pub(crate) fn new(journal: Journal<E, F, D>, witness: VerifiedWitness<F, D>) -> Self {
         Self {
             journal,
-            cache: RwLock::new(witness),
+            tip_witness: RwLock::new(witness),
             import_pending: AtomicBool::new(false),
             sync_lock: AsyncMutex::new(()),
         }
     }
 
-    /// Create a store from a verified compact-sync import that has not been persisted yet. The
+    /// Create a store from a validated compact-sync import that has not been persisted yet. The
     /// journal is untouched until the first persist replaces its contents with `witness`. A
     /// crash during that replacement leaves a journal that fails to reopen; re-syncing
     /// recovers it.
     pub(crate) fn from_import(journal: Journal<E, F, D>, witness: VerifiedWitness<F, D>) -> Self {
         Self {
             journal,
-            cache: RwLock::new(witness),
+            tip_witness: RwLock::new(witness),
             import_pending: AtomicBool::new(true),
             sync_lock: AsyncMutex::new(()),
         }
@@ -138,12 +140,12 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
 
     /// Read the cached witness without exposing the underlying lock to db code.
     pub(crate) fn with<R>(&self, f: impl FnOnce(&VerifiedWitness<F, D>) -> R) -> R {
-        f(&self.cache.read())
+        f(&self.tip_witness.read())
     }
 
     /// Replace the cached witness after the matching compact Merkle state is persisted or loaded.
     pub(crate) fn replace(&self, witness: VerifiedWitness<F, D>) {
-        *self.cache.write() = witness;
+        *self.tip_witness.write() = witness;
     }
 
     /// Persist the current compact state as a new witness journal entry.
@@ -171,8 +173,8 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         if cached_leaves == merkle.leaves() {
             if self.import_pending.load(Ordering::Relaxed) {
                 self.clear_for_import().await?;
-                let entry = self.with(|w| w.entry.clone());
-                self.append_and_sync(&entry).await?;
+                let witness = self.with(|w| w.witness.clone());
+                self.append_and_sync(&witness).await?;
             }
             return Ok(());
         }
@@ -180,14 +182,14 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             return Err(Error::DataCorrupted("witness ahead of in-memory state"));
         }
 
-        let witness =
+        let verified =
             build_witness::<F, H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes())?;
         if self.import_pending.load(Ordering::Relaxed) {
             self.clear_for_import().await?;
         }
-        self.append_and_sync(&witness.entry).await?;
+        self.append_and_sync(&verified.witness).await?;
         merkle.prune_to_frontier();
-        self.replace(witness);
+        self.replace(verified);
         Ok(())
     }
 
@@ -231,8 +233,8 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     }
 
     /// Drop all entries committing fewer than `pruning_boundary` leaves, bounding how far back
-    /// [`Self::rewind`] can reach. The tip entry always survives. Only whole journal sections
-    /// are dropped, so some entries below the boundary may survive.
+    /// [`Self::rewind`] can reach. The tip entry always survives. Some entries
+    /// below the boundary may survive.
     pub(crate) async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         let _guard = self.sync_lock.lock().await;
         self.check_import_persisted()?;
@@ -357,7 +359,7 @@ where
             .collect::<Vec<_>>();
         let proof = mem.proof(&hasher, last_commit_loc, inactive_peaks)?;
         Ok(VerifiedWitness {
-            entry: Witness {
+            witness: Witness {
                 op_bytes: last_commit_op_bytes,
                 proof,
                 pinned_nodes,
@@ -460,13 +462,7 @@ where
     ) {
         return Err(Error::DataCorrupted("invalid compact witness"));
     }
-    Ok((
-        VerifiedWitness {
-            entry: witness,
-            root,
-        },
-        last_commit_op,
-    ))
+    Ok((VerifiedWitness { witness, root }, last_commit_op))
 }
 
 /// Open the witness store for an existing or new compact db, returning it with the decoded
@@ -518,8 +514,8 @@ where
     merkle.apply_batch(&batch)?;
 
     // The initial commit has one leaf and an inactivity floor of 0.
-    let witness = build_witness::<F, H, S>(merkle, Location::new(0), last_commit_op_bytes)?;
-    journal.append(&witness.entry).await?;
+    let verified = build_witness::<F, H, S>(merkle, Location::new(0), last_commit_op_bytes)?;
+    journal.append(&verified.witness).await?;
     journal.sync().await?;
     Ok(())
 }

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -1,87 +1,132 @@
-//! Shared machinery for the compact-db compact-sync witness.
+//! Shared machinery for the compact-db witness journal.
 //!
-//! The witness is the encoded last-commit operation together with its single-leaf inclusion proof
-//! against the current root. Persisting that witness alongside the compact Merkle frontier lets a
-//! compact database serve compact sync for its latest committed state without retaining the full
-//! historical operation log.
+//! The witness journal is the single durable source of truth for a compact database. Every
+//! durable sync appends exactly one [`WitnessEntry`]: the encoded commit operation, its
+//! single-leaf inclusion proof against the committed root, and the pinned frontier nodes of the
+//! compact Merkle. An entry is therefore a complete snapshot of one synced commit: the in-memory
+//! Merkle is rebuilt from the tip entry on reopen and from an older entry on rewind.
 //!
 //! This state lives at the db layer rather than the Merkle layer because only the db knows how to
 //! encode and decode the typed commit operation. Both [`crate::qmdb::immutable::CompactDb`] and
-//! [`crate::qmdb::keyless::CompactDb`] store the witness in the same ping-pong slots as the
-//! frontier state, then re-verify it against the current root on every reopen and rewind. If those
-//! bytes no longer describe a valid witness for the stored root, reopening fails with
-//! [`Error::DataCorrupted`].
+//! [`crate::qmdb::keyless::CompactDb`] keep the witness in a db-owned [`Store`] backed by a
+//! contiguous variable journal, then re-verify the tip proof against the recomputed root on every
+//! reopen and rewind. If the tip entry no longer describes a valid witness for the rebuilt
+//! frontier, reopening fails with [`Error::DataCorrupted`].
 //!
-//! The lifecycle in this file is:
+//! # Journal layout and crash consistency
 //!
-//! 1. Build a [`ServeState`] from the current in-memory tip.
-//! 2. Persist its witness bytes into the same active/inactive slot scheme used by the compact
-//!    Merkle frontier.
-//! 3. Reload that witness on reopen or rewind, re-verify it against the currently loaded root, and
-//!    rebuild the cache.
-//! 4. Use the cache to answer compact-sync requests without re-encoding the commit or recomputing
-//!    its proof on every serve.
+//! Entries are strictly increasing in committed leaf count (`proof.leaves`); every append path
+//! upholds this invariant. Since journal positions are also stable across pruning, rewind and
+//! prune targets are located by binary search on leaf count.
+//!
+//! The journal `sync` after an append is the commit point. A crash before it drops the unsynced
+//! tail on reopen, recovering the previous commit; nothing else needs reconciliation because the
+//! Merkle has no persistence of its own. Rewind truncates the journal to the target entry and
+//! syncs before returning. Only the tip entry is verified on reopen; an older entry is verified
+//! when a rewind makes it the tip.
+//!
+//! History is retained until [`Store::prune`], which bounds how far back [`Store::rewind`]
+//! can reach. The tip entry is never pruned.
 
 use crate::{
-    merkle::{compact, Family, Location, Proof},
-    metadata::Metadata,
+    journal::contiguous::{variable, Reader as _},
+    merkle::{
+        self, compact, Family, Location, Proof, MAX_PINNED_NODES, MAX_PROOF_DIGESTS_PER_ELEMENT,
+    },
     qmdb::{self, sync::compact::Target, Error},
     Context,
 };
-use commonware_codec::{Decode as _, Encode as _, FixedSize, Read};
+use commonware_codec::{Decode as _, EncodeSize, RangeCfg, Read, Write};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
-use commonware_utils::{sequence::prefixed_u64::U64, sync::RwLock};
+use commonware_utils::sync::{AsyncMutex, RwLock};
+use std::sync::atomic::{AtomicBool, Ordering};
 
-// Per-slot db-extra layout. A "slot" is one side of the compact Merkle's ping-pong persistence
-// scheme: each sync writes the next committed state into the inactive slot and then flips which
-// slot is active. Slots 0-4 belong to the Merkle layer; slots 5-8 mirror that scheme for the
-// db-level compact-sync witness. Only the active slot is ever consulted on reopen, rewind, or
-// serving; stale witness bytes left behind in the inactive slot are harmless until the next sync
-// overwrites them.
-//   (5, 0) slot A last commit op bytes     (7, 0) slot B last commit op bytes
-//   (6, 0) slot A last commit proof bytes  (8, 0) slot B last commit proof bytes
-const SLOT_A_LAST_COMMIT_OP_PREFIX: u8 = 5;
-const SLOT_A_LAST_COMMIT_PROOF_PREFIX: u8 = 6;
-const SLOT_B_LAST_COMMIT_OP_PREFIX: u8 = 7;
-const SLOT_B_LAST_COMMIT_PROOF_PREFIX: u8 = 8;
+/// Upper bound on the encoded last-commit operation, enforced at commit time and as a decode
+/// guard against corrupted length prefixes. Commit operations are small; this bound is
+/// intentionally generous because the commit carries optional caller metadata.
+pub(crate) const MAX_OP_BYTES: usize = 1 << 24;
 
-/// Return the metadata prefix used for last-commit op bytes in the given ping-pong slot.
-const fn last_commit_op_prefix(slot: u8) -> u8 {
-    if slot == 0 {
-        SLOT_A_LAST_COMMIT_OP_PREFIX
-    } else {
-        SLOT_B_LAST_COMMIT_OP_PREFIX
-    }
-}
-
-/// Return the metadata prefix used for last-commit proof bytes in the given ping-pong slot.
-const fn last_commit_proof_prefix(slot: u8) -> u8 {
-    if slot == 0 {
-        SLOT_A_LAST_COMMIT_PROOF_PREFIX
-    } else {
-        SLOT_B_LAST_COMMIT_PROOF_PREFIX
-    }
-}
-
-/// Metadata key for the encoded last-commit operation in `slot`.
-pub(crate) const fn last_commit_op_key(slot: u8) -> U64 {
-    U64::new(last_commit_op_prefix(slot), 0)
-}
-
-/// Metadata key for the last-commit inclusion proof in `slot`.
-pub(crate) const fn last_commit_proof_key(slot: u8) -> U64 {
-    U64::new(last_commit_proof_prefix(slot), 0)
-}
-
-/// In-memory cache of the witness currently associated with the active compact state.
-///
-/// Compact sync serving needs the current root, frontier pins, last commit bytes, and proof as one
-/// coherent unit. Keeping them together here avoids repeated re-encoding and re-proofing during
-/// steady-state serving while still letting reopen/rewind rebuild the cache from persisted bytes.
+/// Codec configuration for decoding a [`WitnessEntry`] read back from the journal.
 #[derive(Clone)]
-pub(crate) struct ServeState<F: Family, D: Digest> {
-    /// Root committed by the current persisted frontier/witness pair.
+pub(crate) struct WitnessEntryCfg {
+    op_bytes: RangeCfg<usize>,
+    proof_digests: usize,
+    pinned_nodes: RangeCfg<usize>,
+}
+
+impl Default for WitnessEntryCfg {
+    fn default() -> Self {
+        Self {
+            op_bytes: (..=MAX_OP_BYTES).into(),
+            proof_digests: MAX_PROOF_DIGESTS_PER_ELEMENT,
+            pinned_nodes: (..=MAX_PINNED_NODES).into(),
+        }
+    }
+}
+
+/// A single durably persisted witness: the encoded last-commit operation, its inclusion proof,
+/// and the pinned frontier nodes of the committed Merkle.
+///
+/// The proof's `leaves` field identifies the committed leaf count; together with `pinned_nodes`
+/// it is everything required to rebuild the in-memory Merkle for this commit. The root is not
+/// stored: it is recomputed from the rebuilt frontier and authenticated against the proof.
+#[derive(Clone)]
+pub(crate) struct WitnessEntry<F: Family, D: Digest> {
+    op_bytes: Vec<u8>,
+    proof: Proof<F, D>,
+    pinned_nodes: Vec<D>,
+}
+
+impl<F: Family, D: Digest> EncodeSize for WitnessEntry<F, D> {
+    fn encode_size(&self) -> usize {
+        self.op_bytes.encode_size() + self.proof.encode_size() + self.pinned_nodes.encode_size()
+    }
+}
+
+impl<F: Family, D: Digest> Write for WitnessEntry<F, D> {
+    fn write(&self, buf: &mut impl bytes::BufMut) {
+        self.op_bytes.write(buf);
+        self.proof.write(buf);
+        self.pinned_nodes.write(buf);
+    }
+}
+
+impl<F: Family, D: Digest> Read for WitnessEntry<F, D> {
+    type Cfg = WitnessEntryCfg;
+
+    fn read_cfg(
+        buf: &mut impl bytes::Buf,
+        cfg: &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        let op_bytes = Vec::<u8>::read_cfg(buf, &(cfg.op_bytes, ()))?;
+        let proof = Proof::<F, D>::read_cfg(buf, &cfg.proof_digests)?;
+        let pinned_nodes = Vec::<D>::read_cfg(buf, &(cfg.pinned_nodes, ()))?;
+        Ok(Self {
+            op_bytes,
+            proof,
+            pinned_nodes,
+        })
+    }
+}
+
+impl<F: Family, D: Digest> From<&Witness<F, D>> for WitnessEntry<F, D> {
+    fn from(witness: &Witness<F, D>) -> Self {
+        Self {
+            op_bytes: witness.last_commit_op_bytes.clone(),
+            proof: witness.last_commit_proof.clone(),
+            pinned_nodes: witness.pinned_nodes.clone(),
+        }
+    }
+}
+
+/// The contiguous variable journal that backs a witness [`Store`].
+pub(crate) type Journal<E, F, D> = variable::Journal<E, WitnessEntry<F, D>>;
+
+/// In-memory snapshot of the tip witness.
+#[derive(Clone)]
+pub(crate) struct Witness<F: Family, D: Digest> {
+    /// Root committed by the tip witness entry.
     pub(crate) root: D,
     /// Total leaves in the committed Merkle, which also identifies the tip commit location.
     pub(crate) leaf_count: Location<F>,
@@ -93,11 +138,8 @@ pub(crate) struct ServeState<F: Family, D: Digest> {
     pub(crate) last_commit_proof: Proof<F, D>,
 }
 
-impl<F: Family, D: Digest> ServeState<F, D> {
-    /// Convert the cached witness into the compact-sync target this source can currently serve.
-    ///
-    /// Compact sources only serve their current committed tip, so the target is just the root plus
-    /// the total committed leaf count.
+impl<F: Family, D: Digest> Witness<F, D> {
+    /// The compact-sync target this witness can serve: its root and leaf count.
     pub(crate) const fn target(&self) -> Target<F, D> {
         Target {
             root: self.root,
@@ -106,60 +148,273 @@ impl<F: Family, D: Digest> ServeState<F, D> {
     }
 }
 
-/// Synchronous cache for the compact witness currently safe to serve.
-///
-/// The cache is intentionally tiny: it only hides the lock used to read and replace the witness.
-/// Higher-level persistence and serving logic stays explicit at call sites.
-pub(crate) struct Cache<F: Family, D: Digest> {
-    witness: RwLock<ServeState<F, D>>,
+/// Db-owned persistent store for the compact witness: a contiguous journal plus an in-memory
+/// cache of the tip witness.
+pub(crate) struct Store<E: Context, F: Family, D: Digest> {
+    journal: Journal<E, F, D>,
+    cache: RwLock<Witness<F, D>>,
+    /// Whether the cached witness came from compact sync and has not been written to the
+    /// journal yet. While set, the journal still holds the partition's previous contents; the
+    /// first persist replaces them with the cached witness and clears this flag.
+    import_pending: AtomicBool,
+    /// Serializes persist/rewind/prune so concurrent calls on a shared handle do not interleave.
+    sync_lock: AsyncMutex<()>,
 }
 
-impl<F: Family, D: Digest> Cache<F, D> {
-    /// Create a cache from the witness loaded or bootstrapped during db initialization.
-    pub(crate) const fn new(witness: ServeState<F, D>) -> Self {
-        Self {
-            witness: RwLock::new(witness),
-        }
-    }
-
-    /// Read the cached witness without exposing the underlying lock to db code.
-    pub(crate) fn with<R>(&self, f: impl FnOnce(&ServeState<F, D>) -> R) -> R {
-        f(&self.witness.read())
-    }
-
-    /// Replace the cached witness after the matching compact Merkle state is persisted or loaded.
-    pub(crate) fn replace(&self, witness: ServeState<F, D>) {
-        *self.witness.write() = witness;
-    }
-
-    /// Mutate the cache in tests that intentionally corrupt witness state.
-    #[cfg(test)]
-    pub(crate) fn mutate(&self, f: impl FnOnce(&mut ServeState<F, D>)) {
-        f(&mut self.witness.write());
-    }
-}
-
-/// Write the witness portion of `witness` into the given ping-pong slot's db metadata.
-///
-/// The compact Merkle layer persists the frontier itself. This helper persists the db-owned
-/// witness bytes that must move in lockstep with that frontier.
-pub(crate) fn write_witness_metadata<E, F, D>(
-    metadata: &mut Metadata<E, U64, Vec<u8>>,
-    slot: u8,
-    witness: &ServeState<F, D>,
-) where
+/// Open the witness journal for a compact db.
+pub(crate) async fn open_journal<E, F, D>(
+    context: E,
+    cfg: variable::Config<()>,
+) -> Result<Journal<E, F, D>, Error<F>>
+where
     E: Context,
     F: Family,
     D: Digest,
 {
-    metadata.put(
-        last_commit_op_key(slot),
-        witness.last_commit_op_bytes.clone(),
-    );
-    metadata.put(
-        last_commit_proof_key(slot),
-        witness.last_commit_proof.encode().to_vec(),
-    );
+    let cfg = variable::Config {
+        partition: cfg.partition,
+        items_per_section: cfg.items_per_section,
+        compression: cfg.compression,
+        // Callers pass `()` because [`WitnessEntryCfg`] is internal to this module.
+        codec_config: WitnessEntryCfg::default(),
+        page_cache: cfg.page_cache,
+        write_buffer: cfg.write_buffer,
+    };
+    Ok(variable::Journal::init(context, cfg).await?)
+}
+
+impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
+    /// Wrap an opened journal and a verified witness into a store.
+    pub(crate) fn new(journal: Journal<E, F, D>, witness: Witness<F, D>) -> Self {
+        Self {
+            journal,
+            cache: RwLock::new(witness),
+            import_pending: AtomicBool::new(false),
+            sync_lock: AsyncMutex::new(()),
+        }
+    }
+
+    /// Wrap a journal and a verified compact-sync import that has not been persisted yet; the
+    /// journal is untouched until the first persist replaces its contents with `witness`.
+    pub(crate) fn new_import(journal: Journal<E, F, D>, witness: Witness<F, D>) -> Self {
+        Self {
+            journal,
+            cache: RwLock::new(witness),
+            import_pending: AtomicBool::new(true),
+            sync_lock: AsyncMutex::new(()),
+        }
+    }
+
+    /// Read the cached witness without exposing the underlying lock to db code.
+    pub(crate) fn with<R>(&self, f: impl FnOnce(&Witness<F, D>) -> R) -> R {
+        f(&self.cache.read())
+    }
+
+    /// Replace the cached witness after the matching compact Merkle state is persisted or loaded.
+    pub(crate) fn replace(&self, witness: Witness<F, D>) {
+        *self.cache.write() = witness;
+    }
+
+    /// Persist the current compact state as a new witness journal entry.
+    ///
+    /// No-op if the cached witness already matches the Merkle (the witness is already durable).
+    /// Otherwise appends a witness built from the unpruned Merkle, prunes the Merkle to peaks,
+    /// and refreshes the cache.
+    pub(crate) async fn persist<H, S>(
+        &self,
+        merkle: &compact::Merkle<F, D, S>,
+        inactivity_floor_loc: Location<F>,
+        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
+    ) -> Result<(), Error<F>>
+    where
+        H: Hasher<Digest = D>,
+        S: Strategy,
+    {
+        let _guard = self.sync_lock.lock().await;
+
+        // Outside a pending import, the cache always matches the journal tip, so an equal leaf
+        // count means the current state is already durable. During an import it instead means
+        // the cached witness must replace the journal's old contents. `sync_lock` orders the
+        // flag accesses.
+        let cached_leaves = self.with(|w| w.leaf_count);
+        if cached_leaves == merkle.leaves() {
+            if self.import_pending.load(Ordering::Relaxed) {
+                self.journal.clear_to_size(0).await?;
+                let entry = self.with(|w| WitnessEntry::from(w));
+                self.append_and_sync(&entry).await?;
+                // Cleared only after the replacement completes so an interrupted one is retried.
+                self.import_pending.store(false, Ordering::Relaxed);
+            }
+            return Ok(());
+        }
+        if cached_leaves > merkle.leaves() {
+            return Err(Error::DataCorrupted("witness ahead of in-memory state"));
+        }
+
+        let last_commit_op_bytes = last_commit_op_bytes();
+        if last_commit_op_bytes.len() > MAX_OP_BYTES {
+            return Err(Error::CommitTooLarge(
+                last_commit_op_bytes.len(),
+                MAX_OP_BYTES,
+            ));
+        }
+        let witness = build_witness::<F, H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)?;
+        if self.import_pending.load(Ordering::Relaxed) {
+            self.journal.clear_to_size(0).await?;
+        }
+        self.append_and_sync(&WitnessEntry::from(&witness)).await?;
+        self.import_pending.store(false, Ordering::Relaxed);
+        merkle.prune_to_peaks();
+        self.replace(witness);
+        Ok(())
+    }
+
+    /// Rewind the journal so the entry committing exactly `target` leaves becomes the tip, then
+    /// rebuild and re-verify the Merkle and cache from it. Returns the decoded commit operation
+    /// of the restored tip.
+    ///
+    /// Rewinding to a pruned leaf count, or one no entry commits, returns
+    /// [`merkle::Error::RewindBeyondHistory`]. The truncation is synced before returning.
+    pub(crate) async fn rewind<H, S, Op>(
+        &self,
+        merkle: &compact::Merkle<F, D, S>,
+        target: Location<F>,
+        commit_codec_config: &Op::Cfg,
+        last_commit_floor: impl FnOnce(&Op) -> Option<Location<F>>,
+    ) -> Result<Op, Error<F>>
+    where
+        H: Hasher<Digest = D>,
+        S: Strategy,
+        Op: Read,
+    {
+        let _guard = self.sync_lock.lock().await;
+        self.check_import_persisted()?;
+
+        let pos = self
+            .position_of(target)
+            .await?
+            .ok_or(Error::Merkle(merkle::Error::RewindBeyondHistory))?;
+        self.journal.rewind(pos + 1).await?;
+        self.journal.sync().await?;
+
+        let (witness, op) = load_tip::<E, F, H, S, Op>(
+            &self.journal,
+            merkle,
+            commit_codec_config,
+            last_commit_floor,
+        )
+        .await?;
+        self.replace(witness);
+        Ok(op)
+    }
+
+    /// Drop all entries committing fewer than `pruning_boundary` leaves, bounding how far back
+    /// [`Self::rewind`] can reach. The tip entry always survives.
+    pub(crate) async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
+        let _guard = self.sync_lock.lock().await;
+        self.check_import_persisted()?;
+
+        let bounds = self.journal.reader().await.bounds();
+        if bounds.is_empty() {
+            return Ok(());
+        }
+        // Clamp below the tip so the journal never empties: the tip is the current state.
+        let pos = self
+            .first_at_or_above(pruning_boundary)
+            .await?
+            .min(bounds.end - 1);
+        self.journal.prune(pos).await?;
+        self.journal.sync().await?;
+        Ok(())
+    }
+
+    /// Reject operations on a journal whose contents an unpersisted compact-sync import is
+    /// about to replace.
+    fn check_import_persisted(&self) -> Result<(), Error<F>> {
+        if self.import_pending.load(Ordering::Relaxed) {
+            return Err(Error::DataCorrupted("compact-sync import not persisted"));
+        }
+        Ok(())
+    }
+
+    /// Find the journal position of the entry committing exactly `target` leaves, or `None`
+    /// if no retained entry does.
+    async fn position_of(&self, target: Location<F>) -> Result<Option<u64>, Error<F>> {
+        let pos = self.first_at_or_above(target).await?;
+        let reader = self.journal.reader().await;
+        if pos >= reader.bounds().end {
+            return Ok(None);
+        }
+        let entry = reader.read(pos).await?;
+        Ok((entry.proof.leaves == target).then_some(pos))
+    }
+
+    /// Binary search for the first retained position whose entry commits at least `leaf_count`
+    /// leaves, or the end of the journal if none does.
+    async fn first_at_or_above(&self, leaf_count: Location<F>) -> Result<u64, Error<F>> {
+        let reader = self.journal.reader().await;
+        let bounds = reader.bounds();
+        let (mut lo, mut hi) = (bounds.start, bounds.end);
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            if reader.read(mid).await?.proof.leaves < leaf_count {
+                // The entry at `mid` is below `leaf_count`, so the answer is after it.
+                lo = mid + 1;
+            } else {
+                // The entry at `mid` qualifies, so the answer is `mid` or before it.
+                hi = mid;
+            }
+        }
+        Ok(lo)
+    }
+
+    /// Append an entry to the journal and sync it.
+    async fn append_and_sync(&self, entry: &WitnessEntry<F, D>) -> Result<(), Error<F>> {
+        self.journal.append(entry).await?;
+        self.journal.sync().await?;
+        Ok(())
+    }
+
+    /// Destroy all persisted witness state.
+    pub(crate) async fn destroy(self) -> Result<(), Error<F>> {
+        self.journal.destroy().await?;
+        Ok(())
+    }
+}
+
+/// Build a witness for the last commit from the current unpruned Merkle state.
+///
+/// This must run before the Merkle is pruned to peaks, because the single-leaf inclusion proof is
+/// only computable while the proof path is still retained.
+fn build_witness<F, H, S>(
+    merkle: &compact::Merkle<F, H::Digest, S>,
+    inactivity_floor_loc: Location<F>,
+    last_commit_op_bytes: Vec<u8>,
+) -> Result<Witness<F, H::Digest>, Error<F>>
+where
+    F: Family,
+    H: Hasher,
+    S: Strategy,
+{
+    let hasher = qmdb::hasher::<H>();
+    merkle.with_mem(|mem| {
+        let leaf_count = mem.leaves();
+        let last_commit_loc = Location::new(*leaf_count - 1);
+        let inactive_peaks =
+            F::inactive_peaks(F::location_to_position(leaf_count), inactivity_floor_loc);
+        let root = mem.root(&hasher, inactive_peaks)?;
+        let pinned_nodes = F::nodes_to_pin(leaf_count)
+            .map(|pos| *mem.get_node_unchecked(pos))
+            .collect::<Vec<_>>();
+        let last_commit_proof = mem.proof(&hasher, last_commit_loc, inactive_peaks)?;
+        Ok(Witness {
+            root,
+            leaf_count,
+            pinned_nodes,
+            last_commit_op_bytes,
+            last_commit_proof,
+        })
+    })
 }
 
 /// Validate that a decoded commit floor does not point past the commit it authenticates.
@@ -179,79 +434,72 @@ pub(crate) fn validate_inactivity_floor<F: Family>(
 }
 
 /// Build a witness from compact state that was already authenticated by the caller.
-#[allow(clippy::type_complexity)]
-pub(crate) fn witness_from_authenticated_state<F, E, D, S>(
-    merkle: &compact::Merkle<F, E, D, S>,
+pub(crate) fn witness_from_authenticated_state<F, D, S>(
+    merkle: &compact::Merkle<F, D, S>,
     root: D,
     inactivity_floor_loc: Location<F>,
     last_commit_op_bytes: Vec<u8>,
     last_commit_proof: Proof<F, D>,
     pinned_nodes: Vec<D>,
-) -> Result<(Location<F>, ServeState<F, D>), Error<F>>
+) -> Result<Witness<F, D>, Error<F>>
 where
     F: Family,
-    E: Context,
     D: Digest,
     S: Strategy,
 {
+    if last_commit_op_bytes.len() > MAX_OP_BYTES {
+        return Err(Error::CommitTooLarge(
+            last_commit_op_bytes.len(),
+            MAX_OP_BYTES,
+        ));
+    }
     if merkle.leaves() == 0 {
         return Err(Error::DataCorrupted("missing final commit"));
     }
     let leaf_count = merkle.leaves();
     let last_commit_loc = Location::<F>::new(*leaf_count - 1);
     validate_inactivity_floor(inactivity_floor_loc, last_commit_loc)?;
-    let witness = ServeState {
+    Ok(Witness {
         root,
         leaf_count,
         pinned_nodes,
         last_commit_op_bytes,
         last_commit_proof,
-    };
-    Ok((last_commit_loc, witness))
+    })
 }
 
-/// Rebuild the in-memory witness cache from the active slot's persisted witness.
+/// Load the tip witness from the journal and rebuild the Merkle from it.
 ///
-/// This is the authoritative recovery path after reopen and rewind. It:
-///
-/// 1. reads the active slot's commit bytes and proof bytes,
-/// 2. decodes the proof,
-/// 3. re-verifies that proof against the Merkle currently loaded in memory,
-/// 4. reconstructs the frontier pins for serving, and
-/// 5. decodes the typed last commit operation needed by the caller's db state.
-///
-/// Any missing metadata, decode failure, or proof/root mismatch is treated as
-/// [`Error::DataCorrupted`], because the persisted frontier and witness no longer describe the same
-/// committed state.
-pub(crate) async fn load_active_witness<F, E, H, S, C, Op, LastCommitFloor>(
-    merkle: &compact::Merkle<F, E, H::Digest, S>,
-    commit_codec_config: &C,
-    last_commit_floor: LastCommitFloor,
-) -> Result<(ServeState<F, H::Digest>, Op), Error<F>>
+/// The tip entry is a complete snapshot: the Merkle is reset to its `(leaf_count, pinned_nodes)`,
+/// the root is recomputed from the rebuilt frontier, and the persisted proof is verified against
+/// that root before anything is served.
+async fn load_tip<E, F, H, S, Op>(
+    journal: &Journal<E, F, H::Digest>,
+    merkle: &compact::Merkle<F, H::Digest, S>,
+    commit_codec_config: &Op::Cfg,
+    last_commit_floor: impl FnOnce(&Op) -> Option<Location<F>>,
+) -> Result<(Witness<F, H::Digest>, Op), Error<F>>
 where
-    F: Family,
     E: Context,
+    F: Family,
     H: Hasher,
     S: Strategy,
-    Op: Read<Cfg = C>,
-    LastCommitFloor: FnOnce(&Op) -> Option<Location<F>>,
+    Op: Read,
 {
-    let slot = merkle.active_slot();
-    let last_commit_op_bytes = merkle
-        .read_metadata_key(&last_commit_op_key(slot))
-        .await
-        .ok_or(Error::DataCorrupted("missing compact witness"))?;
-    let last_commit_proof_bytes = merkle
-        .read_metadata_key(&last_commit_proof_key(slot))
-        .await
-        .ok_or(Error::DataCorrupted("missing compact witness"))?;
-    // Every encoded digest is at least `D::SIZE` bytes on the wire, so `proof_bytes.len() /
-    // D::SIZE` is a hard upper bound on the digest count. Using this as the decode cap prevents a
-    // malformed length prefix from forcing a large preallocation.
-    let max_digests = last_commit_proof_bytes.len() / H::Digest::SIZE;
-    let last_commit_proof =
-        Proof::<F, H::Digest>::decode_cfg(last_commit_proof_bytes.as_ref(), &max_digests)
-            .map_err(|_| Error::DataCorrupted("invalid compact witness"))?;
+    let size = journal.size().await;
+    if size == 0 {
+        return Err(Error::DataCorrupted("missing compact witness"));
+    }
+    let entry = {
+        let reader = journal.reader().await;
+        reader.read(size - 1).await?
+    };
+
+    let WitnessEntry {
+        op_bytes: last_commit_op_bytes,
+        proof: last_commit_proof,
+        pinned_nodes,
+    } = entry;
     let leaf_count = last_commit_proof.leaves;
     if leaf_count == 0 {
         return Err(Error::DataCorrupted("invalid compact witness"));
@@ -266,6 +514,9 @@ where
         .ok_or(Error::DataCorrupted("last operation was not a commit"))?;
     validate_inactivity_floor(inactivity_floor_loc, last_commit_loc)?;
 
+    merkle
+        .reset_to(leaf_count, pinned_nodes.clone())
+        .map_err(|_| Error::DataCorrupted("invalid compact witness"))?;
     let inactive_peaks =
         F::inactive_peaks(F::location_to_position(leaf_count), inactivity_floor_loc);
     let hasher = qmdb::hasher::<H>();
@@ -280,12 +531,7 @@ where
     ) {
         return Err(Error::DataCorrupted("invalid compact witness"));
     }
-    let pinned_nodes = merkle.with_mem(|mem| {
-        F::nodes_to_pin(leaf_count)
-            .map(|pos| *mem.get_node_unchecked(pos))
-            .collect::<Vec<_>>()
-    });
-    let witness = ServeState {
+    let witness = Witness {
         root,
         leaf_count,
         pinned_nodes,
@@ -295,22 +541,55 @@ where
     Ok((witness, last_commit_op))
 }
 
-/// Bootstrap the first persisted witness for a brand-new compact db.
+/// Open the witness store for an existing or new compact db.
 ///
 /// Fresh compact databases begin with exactly one committed operation: the initial commit. This
-/// helper inserts that commit into the compact Merkle, builds its one-leaf proof, and persists the
-/// resulting witness into the active slot so later reopen and rewind paths can use the
-/// same recovery logic as every subsequent commit.
-pub(crate) async fn bootstrap_initial_commit<F, E, H, S>(
-    merkle: &mut compact::Merkle<F, E, H::Digest, S>,
+/// inserts that commit into the compact Merkle, builds its one-leaf proof, and persists the
+/// resulting witness so later reopen and rewind paths use the same recovery logic as every
+/// subsequent commit. An existing db instead reloads and re-verifies its tip witness.
+///
+/// Returns the store together with the decoded last-commit operation.
+pub(crate) async fn init<E, F, H, S, Op>(
+    journal: Journal<E, F, H::Digest>,
+    merkle: &mut compact::Merkle<F, H::Digest, S>,
+    commit_codec_config: &Op::Cfg,
+    initial_commit_op_bytes: Vec<u8>,
+    last_commit_floor: impl FnOnce(&Op) -> Option<Location<F>>,
+) -> Result<(Store<E, F, H::Digest>, Op), Error<F>>
+where
+    E: Context,
+    F: Family,
+    H: Hasher,
+    S: Strategy,
+    Op: Read,
+{
+    if journal.size().await == 0 {
+        bootstrap_initial_commit::<E, F, H, S>(&journal, merkle, initial_commit_op_bytes).await?;
+    }
+    let (witness, op) =
+        load_tip::<E, F, H, S, Op>(&journal, merkle, commit_codec_config, last_commit_floor)
+            .await?;
+    Ok((Store::new(journal, witness), op))
+}
+
+/// Insert and persist the initial `Commit(None, 0)` for a new compact db.
+async fn bootstrap_initial_commit<E, F, H, S>(
+    journal: &Journal<E, F, H::Digest>,
+    merkle: &mut compact::Merkle<F, H::Digest, S>,
     last_commit_op_bytes: Vec<u8>,
 ) -> Result<(), Error<F>>
 where
-    F: Family,
     E: Context,
+    F: Family,
     H: Hasher,
     S: Strategy,
 {
+    if last_commit_op_bytes.len() > MAX_OP_BYTES {
+        return Err(Error::CommitTooLarge(
+            last_commit_op_bytes.len(),
+            MAX_OP_BYTES,
+        ));
+    }
     let hasher = qmdb::hasher::<H>();
     let batch = {
         let batch = merkle.new_batch().add(&hasher, &last_commit_op_bytes);
@@ -318,112 +597,82 @@ where
     };
     merkle.apply_batch(&batch)?;
 
-    // The initial commit has one leaf and an inactivity floor of 0, giving 0 inactive peaks.
-    let leaf_count = merkle.leaves();
-    let inactive_peaks = F::inactive_peaks(F::location_to_position(leaf_count), Location::new(0));
-    merkle
-        .sync_with_witness(
-            |mem| {
-                let root = mem.root(&hasher, inactive_peaks)?;
-                let last_commit_proof = mem.proof(&hasher, Location::new(0), inactive_peaks)?;
-                Ok(ServeState {
-                    root,
-                    leaf_count: Location::new(1),
-                    pinned_nodes: Vec::new(),
-                    last_commit_op_bytes: last_commit_op_bytes.clone(),
-                    last_commit_proof,
-                })
-            },
-            |metadata, slot, witness| {
-                write_witness_metadata(metadata, slot, &witness);
-                Ok(())
-            },
-        )
-        .await?;
+    // The initial commit has one leaf and an inactivity floor of 0.
+    let witness = build_witness::<F, H, S>(merkle, Location::new(0), last_commit_op_bytes)?;
+    journal.append(&WitnessEntry::from(&witness)).await?;
+    journal.sync().await?;
     Ok(())
 }
 
-/// Persist the current compact witness for a compact db.
-///
-/// If the cached witness already matches the Merkle leaf count being synced, it is copied into
-/// the Merkle slot being activated. Otherwise, a new witness is built from the unpruned Merkle
-/// before sync prunes it. The cache check runs inside `sync_with_witness` so concurrent syncs
-/// observe the latest witness cache after each persisted slot flip.
-pub(crate) async fn persist_witness<F, E, H, S>(
-    merkle: &compact::Merkle<F, E, H::Digest, S>,
-    cache: &Cache<F, H::Digest>,
-    last_commit_loc: Location<F>,
-    inactivity_floor_loc: Location<F>,
-    last_commit_op_bytes: Vec<u8>,
-) -> Result<(), Error<F>>
-where
-    F: Family,
-    E: Context,
-    H: Hasher,
-    S: Strategy,
-{
-    let hasher = qmdb::hasher::<H>();
-    merkle
-        .sync_with_witness(
-            |mem| {
-                let mem_leaves = mem.leaves();
-                if let Some(cached) = cache
-                    .with(|witness| (witness.leaf_count == mem_leaves).then(|| witness.clone()))
-                {
-                    return Ok(cached);
-                }
-                let inactive_peaks =
-                    F::inactive_peaks(F::location_to_position(mem_leaves), inactivity_floor_loc);
-                let mem_root = mem.root(&hasher, inactive_peaks)?;
-                let pinned_nodes = F::nodes_to_pin(mem_leaves)
-                    .map(|pos| *mem.get_node_unchecked(pos))
-                    .collect::<Vec<_>>();
-                let last_commit_proof = mem.proof(&hasher, last_commit_loc, inactive_peaks)?;
-                Ok(ServeState {
-                    root: mem_root,
-                    leaf_count: mem_leaves,
-                    pinned_nodes,
-                    last_commit_op_bytes: last_commit_op_bytes.clone(),
-                    last_commit_proof,
-                })
-            },
-            |metadata, slot, witness| {
-                write_witness_metadata(metadata, slot, &witness);
-                cache.replace(witness);
-                Ok(())
-            },
-        )
-        .await?;
-    Ok(())
-}
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
 
-/// Re-persist the already-verified cached witness into the newly active slot.
-///
-/// This is used when a compact db has reconstructed and verified state from persisted data and only
-/// needs to move that known-good witness into the Merkle's slot layout, without recomputing the
-/// proof from a fresh tip commit.
-pub(crate) async fn persist_cached_witness<F, E, H, S>(
-    merkle: &compact::Merkle<F, E, H::Digest, S>,
-    cache: &Cache<F, H::Digest>,
-) -> Result<(), Error<F>>
-where
-    F: Family,
-    E: Context,
-    H: Hasher,
-    S: Strategy,
-{
-    // Re-persist the already-verified cached witness after the Merkle slot changes (for example,
-    // after root verification on compact sync initialization) without recomputing proofs.
-    let witness = cache.with(Clone::clone);
-    merkle
-        .sync_with_witness(
-            |_| Ok(witness),
-            |metadata, slot, witness| {
-                write_witness_metadata(metadata, slot, &witness);
-                Ok(())
-            },
-        )
-        .await
-        .map(|_| ())
-        .map_err(Into::into)
+    impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
+        /// Mutate the cache in tests that intentionally corrupt witness state.
+        pub(crate) fn mutate(&self, f: impl FnOnce(&mut Witness<F, D>)) {
+            f(&mut self.cache.write());
+        }
+    }
+
+    /// Read the tip witness entry's components. Used by db tests that tamper with persisted state.
+    pub(crate) async fn tip<E, F, D>(journal: &Journal<E, F, D>) -> (Vec<u8>, Proof<F, D>, Vec<D>)
+    where
+        E: Context,
+        F: Family,
+        D: Digest,
+    {
+        let size = journal.size().await;
+        let entry = {
+            let reader = journal.reader().await;
+            reader.read(size - 1).await.unwrap()
+        };
+        (entry.op_bytes, entry.proof, entry.pinned_nodes)
+    }
+
+    /// Append a witness entry without syncing it. Used by db tests that simulate a commit
+    /// interrupted before its journal sync.
+    pub(crate) async fn append_unsynced<E, F, D>(
+        journal: &Journal<E, F, D>,
+        op_bytes: Vec<u8>,
+        proof: Proof<F, D>,
+        pinned_nodes: Vec<D>,
+    ) where
+        E: Context,
+        F: Family,
+        D: Digest,
+    {
+        journal
+            .append(&WitnessEntry {
+                op_bytes,
+                proof,
+                pinned_nodes,
+            })
+            .await
+            .unwrap();
+    }
+
+    /// Replace the tip witness entry. Used by db tests that tamper with persisted state.
+    pub(crate) async fn overwrite_tip<E, F, D>(
+        journal: &Journal<E, F, D>,
+        op_bytes: Vec<u8>,
+        proof: Proof<F, D>,
+        pinned_nodes: Vec<D>,
+    ) where
+        E: Context,
+        F: Family,
+        D: Digest,
+    {
+        let size = journal.size().await;
+        journal.rewind(size - 1).await.unwrap();
+        journal
+            .append(&WitnessEntry {
+                op_bytes,
+                proof,
+                pinned_nodes,
+            })
+            .await
+            .unwrap();
+        journal.sync().await.unwrap();
+    }
 }

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -1,29 +1,17 @@
 //! Shared machinery for the compact-db witness journal.
 //!
-//! The witness journal is the single durable source of truth for a compact database. Every
-//! durable sync appends exactly one [`WitnessEntry`]: the encoded commit operation, its
-//! single-leaf inclusion proof against the committed root, and the pinned frontier nodes of the
-//! compact Merkle. An entry is therefore a complete snapshot of one synced commit: the in-memory
-//! Merkle is rebuilt from the tip entry on reopen and from an older entry on rewind.
+//! The witness journal is the single durable source of truth for a compact database. Each
+//! [`Witness`] is a complete snapshot of one synced commit: the encoded commit operation,
+//! its single-leaf inclusion proof against the committed root, and the pinned frontier nodes of
+//! the compact Merkle. On open and rewind, the in-memory Merkle is rebuilt from an entry and the
+//! entry's proof is re-verified against the root recomputed from the rebuilt frontier; a
+//! mismatch fails with [`Error::DataCorrupted`].
 //!
-//! This state lives at the db layer rather than the Merkle layer because only the db knows how to
-//! encode and decode the typed commit operation. Both [`crate::qmdb::immutable::CompactDb`] and
-//! [`crate::qmdb::keyless::CompactDb`] keep the witness in a db-owned [`Store`] backed by a
-//! contiguous variable journal, then re-verify the tip proof against the recomputed root on every
-//! reopen and rewind. If the tip entry no longer describes a valid witness for the rebuilt
-//! frontier, reopening fails with [`Error::DataCorrupted`].
-//!
-//! # Journal layout and crash consistency
-//!
-//! Entries are strictly increasing in committed leaf count (`proof.leaves`), and journal
-//! positions are stable across pruning, so rewind and prune targets are located by binary
-//! search on leaf count.
-//!
-//! The journal `sync` after an append is the commit point: a crash before it drops the unsynced
-//! tail on reopen, recovering the previous commit.
-//!
-//! [`Store::prune`] bounds how far back [`Store::rewind`] can reach; the tip entry is never
-//! pruned.
+//! Entries are strictly increasing in committed leaf count (`proof.leaves`), so a leaf count
+//! uniquely identifies a rewind or prune target. The journal `sync` after an append is the
+//! commit point: a crash before it drops the unsynced tail on reopen, recovering the previous
+//! commit. [`Store::prune`] bounds how far back [`Store::rewind`] can reach; the tip entry is
+//! never pruned.
 
 use crate::{
     journal::contiguous::{variable, Reader as _},
@@ -44,24 +32,24 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// The root is not stored: it is recomputed from the rebuilt frontier and authenticated against
 /// `proof`.
 #[derive(Clone)]
-pub(crate) struct WitnessEntry<F: Family, D: Digest> {
+pub(crate) struct Witness<F: Family, D: Digest> {
     /// The encoded last-commit operation.
-    op_bytes: Vec<u8>,
+    pub(crate) op_bytes: Vec<u8>,
     /// Inclusion proof for the last-commit leaf; its `leaves` field identifies the committed
     /// leaf count.
-    proof: Proof<F, D>,
+    pub(crate) proof: Proof<F, D>,
     /// Pinned frontier nodes of the committed Merkle; with `proof.leaves`, everything needed
     /// to rebuild the in-memory Merkle for this commit.
-    pinned_nodes: Vec<D>,
+    pub(crate) pinned_nodes: Vec<D>,
 }
 
-impl<F: Family, D: Digest> EncodeSize for WitnessEntry<F, D> {
+impl<F: Family, D: Digest> EncodeSize for Witness<F, D> {
     fn encode_size(&self) -> usize {
         self.op_bytes.encode_size() + self.proof.encode_size() + self.pinned_nodes.encode_size()
     }
 }
 
-impl<F: Family, D: Digest> Write for WitnessEntry<F, D> {
+impl<F: Family, D: Digest> Write for Witness<F, D> {
     fn write(&self, buf: &mut impl bytes::BufMut) {
         self.op_bytes.write(buf);
         self.proof.write(buf);
@@ -69,7 +57,7 @@ impl<F: Family, D: Digest> Write for WitnessEntry<F, D> {
     }
 }
 
-impl<F: Family, D: Digest> Read for WitnessEntry<F, D> {
+impl<F: Family, D: Digest> Read for Witness<F, D> {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl bytes::Buf, _: &()) -> Result<Self, commonware_codec::Error> {
@@ -84,36 +72,22 @@ impl<F: Family, D: Digest> Read for WitnessEntry<F, D> {
     }
 }
 
-impl<F: Family, D: Digest> From<&Witness<F, D>> for WitnessEntry<F, D> {
-    fn from(witness: &Witness<F, D>) -> Self {
-        Self {
-            op_bytes: witness.last_commit_op_bytes.clone(),
-            proof: witness.last_commit_proof.clone(),
-            pinned_nodes: witness.pinned_nodes.clone(),
-        }
-    }
-}
-
 /// The contiguous variable journal that backs a witness [`Store`].
-pub(crate) type Journal<E, F, D> = variable::Journal<E, WitnessEntry<F, D>>;
+pub(crate) type Journal<E, F, D> = variable::Journal<E, Witness<F, D>>;
 
-/// In-memory snapshot of the tip witness.
+/// In-memory snapshot of the tip witness: the tip entry plus its verified root.
 #[derive(Clone)]
-pub(crate) struct Witness<F: Family, D: Digest> {
-    /// Root committed by the tip witness entry.
+pub(crate) struct VerifiedWitness<F: Family, D: Digest> {
+    /// The tip witness entry.
+    pub(crate) entry: Witness<F, D>,
+    /// Root committed by `entry`.
     pub(crate) root: D,
-    /// Pinned frontier nodes of the committed Merkle; not the proof path.
-    pub(crate) pinned_nodes: Vec<D>,
-    /// Encoded last-commit operation bytes used for root verification and serving.
-    pub(crate) last_commit_op_bytes: Vec<u8>,
-    /// Inclusion proof for the last-commit leaf against `root`.
-    pub(crate) last_commit_proof: Proof<F, D>,
 }
 
-impl<F: Family, D: Digest> Witness<F, D> {
+impl<F: Family, D: Digest> VerifiedWitness<F, D> {
     /// Total leaves in the committed Merkle, which also identifies the tip commit location.
     pub(crate) const fn leaf_count(&self) -> Location<F> {
-        self.last_commit_proof.leaves
+        self.entry.proof.leaves
     }
 
     /// The compact-sync target this witness can serve: its root and leaf count.
@@ -128,19 +102,19 @@ impl<F: Family, D: Digest> Witness<F, D> {
 /// A contiguous journal plus an in-memory cache of the tip witness.
 pub(crate) struct Store<E: Context, F: Family, D: Digest> {
     journal: Journal<E, F, D>,
-    cache: RwLock<Witness<F, D>>,
+    cache: RwLock<VerifiedWitness<F, D>>,
     /// Whether the cached witness came from compact sync and has not been written to the
     /// journal yet. While set, the journal still holds the partition's previous contents; the
     /// first persist replaces them with the cached witness and clears this flag. Accessed only
     /// under `sync_lock`, so loads and stores are `Relaxed`.
     import_pending: AtomicBool,
-    /// Serializes persist/rewind/prune so concurrent calls on a shared handle do not interleave.
+    /// Serializes persist/rewind/prune.
     sync_lock: AsyncMutex<()>,
 }
 
 impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Wrap an opened journal and a verified witness into a store.
-    pub(crate) fn new(journal: Journal<E, F, D>, witness: Witness<F, D>) -> Self {
+    pub(crate) fn new(journal: Journal<E, F, D>, witness: VerifiedWitness<F, D>) -> Self {
         Self {
             journal,
             cache: RwLock::new(witness),
@@ -151,7 +125,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
 
     /// Create a store from a verified compact-sync import that has not been persisted yet. The
     /// journal is untouched until the first persist replaces its contents with `witness`.
-    pub(crate) fn from_import(journal: Journal<E, F, D>, witness: Witness<F, D>) -> Self {
+    pub(crate) fn from_import(journal: Journal<E, F, D>, witness: VerifiedWitness<F, D>) -> Self {
         Self {
             journal,
             cache: RwLock::new(witness),
@@ -161,12 +135,12 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     }
 
     /// Read the cached witness without exposing the underlying lock to db code.
-    pub(crate) fn with<R>(&self, f: impl FnOnce(&Witness<F, D>) -> R) -> R {
+    pub(crate) fn with<R>(&self, f: impl FnOnce(&VerifiedWitness<F, D>) -> R) -> R {
         f(&self.cache.read())
     }
 
     /// Replace the cached witness after the matching compact Merkle state is persisted or loaded.
-    pub(crate) fn replace(&self, witness: Witness<F, D>) {
+    pub(crate) fn replace(&self, witness: VerifiedWitness<F, D>) {
         *self.cache.write() = witness;
     }
 
@@ -195,10 +169,8 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         if cached_leaves == merkle.leaves() {
             if self.import_pending.load(Ordering::Relaxed) {
                 self.journal.clear_to_size(0).await?;
-                let entry = self.with(|w| WitnessEntry::from(w));
+                let entry = self.with(|w| w.entry.clone());
                 self.append_and_sync(&entry).await?;
-                // Cleared only after the replacement completes so an interrupted one is retried.
-                self.import_pending.store(false, Ordering::Relaxed);
             }
             return Ok(());
         }
@@ -211,8 +183,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         if self.import_pending.load(Ordering::Relaxed) {
             self.journal.clear_to_size(0).await?;
         }
-        self.append_and_sync(&WitnessEntry::from(&witness)).await?;
-        self.import_pending.store(false, Ordering::Relaxed);
+        self.append_and_sync(&witness.entry).await?;
         merkle.prune_to_frontier();
         self.replace(witness);
         Ok(())
@@ -223,7 +194,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// of the restored tip.
     ///
     /// Rewinding to a pruned leaf count, or one no entry commits, returns
-    /// [`merkle::Error::RewindBeyondHistory`]. The rewind is synced before returning.
+    /// [`merkle::Error::RewindBeyondHistory`]. The rewind is made durable before returning.
     pub(crate) async fn rewind<H, S, Op>(
         &self,
         merkle: &compact::Merkle<F, D, S>,
@@ -263,15 +234,17 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         let _guard = self.sync_lock.lock().await;
         self.check_import_persisted()?;
 
-        let bounds = self.journal.reader().await.bounds();
+        let reader = self.journal.reader().await;
+        let bounds = reader.bounds();
         if bounds.is_empty() {
             return Ok(());
         }
         // Clamp below the tip so the journal never empties: the tip is the current state.
-        let pos = self
-            .first_at_or_above(pruning_boundary)
+        let pos = Self::first_at_or_above(&reader, pruning_boundary)
             .await?
             .min(bounds.end - 1);
+        // Release the read guard before mutating the journal.
+        drop(reader);
         self.journal.prune(pos).await?;
         self.journal.sync().await?;
         Ok(())
@@ -289,8 +262,8 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Find the journal position of the entry committing exactly `target` leaves, or `None`
     /// if no retained entry does.
     async fn position_of(&self, target: Location<F>) -> Result<Option<u64>, Error<F>> {
-        let pos = self.first_at_or_above(target).await?;
         let reader = self.journal.reader().await;
+        let pos = Self::first_at_or_above(&reader, target).await?;
         if pos >= reader.bounds().end {
             return Ok(None);
         }
@@ -300,8 +273,10 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
 
     /// Binary search for the first retained position whose entry commits at least `leaf_count`
     /// leaves, or the end of the journal if none does.
-    async fn first_at_or_above(&self, leaf_count: Location<F>) -> Result<u64, Error<F>> {
-        let reader = self.journal.reader().await;
+    async fn first_at_or_above(
+        reader: &variable::Reader<'_, E, Witness<F, D>>,
+        leaf_count: Location<F>,
+    ) -> Result<u64, Error<F>> {
         let bounds = reader.bounds();
         let (mut lo, mut hi) = (bounds.start, bounds.end);
         while lo < hi {
@@ -317,10 +292,14 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         Ok(lo)
     }
 
-    /// Append an entry to the journal and sync it.
-    async fn append_and_sync(&self, entry: &WitnessEntry<F, D>) -> Result<(), Error<F>> {
+    /// Append `entry` and sync it, making it the durable tip.
+    ///
+    /// A pending import is cleared only after the sync completes, so an interrupted journal
+    /// replacement is retried by the next persist.
+    async fn append_and_sync(&self, entry: &Witness<F, D>) -> Result<(), Error<F>> {
         self.journal.append(entry).await?;
         self.journal.sync().await?;
+        self.import_pending.store(false, Ordering::Relaxed);
         Ok(())
     }
 
@@ -331,15 +310,15 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     }
 }
 
-/// Build a witness for the last commit from the current unpruned Merkle state.
+/// Build a witness for the last commit.
 ///
-/// This must run before the Merkle is pruned to its frontier, because the single-leaf inclusion
-/// proof is only computable while the proof path is still retained.
+/// The tip operation's inclusion proof is only computable before the Merkle is pruned to its
+/// frontier.
 fn build_witness<F, H, S>(
     merkle: &compact::Merkle<F, H::Digest, S>,
     inactivity_floor_loc: Location<F>,
     last_commit_op_bytes: Vec<u8>,
-) -> Result<Witness<F, H::Digest>, Error<F>>
+) -> Result<VerifiedWitness<F, H::Digest>, Error<F>>
 where
     F: Family,
     H: Hasher,
@@ -355,12 +334,14 @@ where
         let pinned_nodes = F::nodes_to_pin(leaf_count)
             .map(|pos| *mem.get_node_unchecked(pos))
             .collect::<Vec<_>>();
-        let last_commit_proof = mem.proof(&hasher, last_commit_loc, inactive_peaks)?;
-        Ok(Witness {
+        let proof = mem.proof(&hasher, last_commit_loc, inactive_peaks)?;
+        Ok(VerifiedWitness {
+            entry: Witness {
+                op_bytes: last_commit_op_bytes,
+                proof,
+                pinned_nodes,
+            },
             root,
-            pinned_nodes,
-            last_commit_op_bytes,
-            last_commit_proof,
         })
     })
 }
@@ -390,7 +371,7 @@ async fn load_tip<E, F, H, S, Op>(
     merkle: &compact::Merkle<F, H::Digest, S>,
     commit_codec_config: &Op::Cfg,
     last_commit_floor: impl FnOnce(&Op) -> Option<Location<F>>,
-) -> Result<(Witness<F, H::Digest>, Op), Error<F>>
+) -> Result<(VerifiedWitness<F, H::Digest>, Op), Error<F>>
 where
     E: Context,
     F: Family,
@@ -407,12 +388,7 @@ where
         reader.read(size - 1).await?
     };
 
-    let WitnessEntry {
-        op_bytes: last_commit_op_bytes,
-        proof: last_commit_proof,
-        pinned_nodes,
-    } = entry;
-    let leaf_count = last_commit_proof.leaves;
+    let leaf_count = entry.proof.leaves;
     if leaf_count == 0 {
         return Err(Error::DataCorrupted("invalid compact witness"));
     }
@@ -420,14 +396,14 @@ where
     // Decode the commit op to get the inactivity floor, which determines the inactive peak
     // boundary used for root computation.
     let last_commit_loc = Location::new(*leaf_count - 1);
-    let last_commit_op = Op::decode_cfg(last_commit_op_bytes.as_ref(), commit_codec_config)
+    let last_commit_op = Op::decode_cfg(entry.op_bytes.as_ref(), commit_codec_config)
         .map_err(|_| Error::DataCorrupted("invalid commit operation"))?;
     let inactivity_floor_loc = last_commit_floor(&last_commit_op)
         .ok_or(Error::DataCorrupted("last operation was not a commit"))?;
     validate_inactivity_floor(inactivity_floor_loc, last_commit_loc)?;
 
     merkle
-        .reset_to(leaf_count, pinned_nodes.clone())
+        .reset_to(leaf_count, entry.pinned_nodes.clone())
         .map_err(|_| Error::DataCorrupted("invalid compact witness"))?;
     let inactive_peaks =
         F::inactive_peaks(F::location_to_position(leaf_count), inactivity_floor_loc);
@@ -435,21 +411,15 @@ where
     let root = merkle
         .root(&hasher, inactive_peaks)
         .map_err(|_| Error::DataCorrupted("failed to compute compact witness root"))?;
-    if !last_commit_proof.verify_range_inclusion(
+    if !entry.proof.verify_range_inclusion(
         &hasher,
-        &[last_commit_op_bytes.as_slice()],
+        &[entry.op_bytes.as_slice()],
         last_commit_loc,
         &root,
     ) {
         return Err(Error::DataCorrupted("invalid compact witness"));
     }
-    let witness = Witness {
-        root,
-        pinned_nodes,
-        last_commit_op_bytes,
-        last_commit_proof,
-    };
-    Ok((witness, last_commit_op))
+    Ok((VerifiedWitness { entry, root }, last_commit_op))
 }
 
 /// Open the witness store for an existing or new compact db, returning it with the decoded
@@ -502,7 +472,7 @@ where
 
     // The initial commit has one leaf and an inactivity floor of 0.
     let witness = build_witness::<F, H, S>(merkle, Location::new(0), last_commit_op_bytes)?;
-    journal.append(&WitnessEntry::from(&witness)).await?;
+    journal.append(&witness.entry).await?;
     journal.sync().await?;
     Ok(())
 }
@@ -538,7 +508,7 @@ pub(crate) mod tests {
         D: Digest,
     {
         journal
-            .append(&WitnessEntry {
+            .append(&Witness {
                 op_bytes,
                 proof,
                 pinned_nodes,
@@ -561,7 +531,7 @@ pub(crate) mod tests {
         let size = journal.size().await;
         journal.rewind(size - 1).await.unwrap();
         journal
-            .append(&WitnessEntry {
+            .append(&Witness {
                 op_bytes,
                 proof,
                 pinned_nodes,

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -274,49 +274,60 @@ fn keyless_variable_config(
     }
 }
 
-fn compact_merkle_config(suffix: &str) -> crate::merkle::compact::Config<Sequential> {
-    crate::merkle::compact::Config {
-        partition: format!("{suffix}-compact"),
-        strategy: Sequential,
+fn compact_witness_config(
+    suffix: &str,
+    pooler: &impl BufferPooler,
+) -> crate::journal::contiguous::variable::Config<()> {
+    crate::journal::contiguous::variable::Config {
+        partition: format!("{suffix}-compact-witness"),
+        items_per_section: NZU64!(64),
+        compression: None,
+        codec_config: (),
+        page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
+        write_buffer: NZUsize!(1024),
     }
 }
 
 fn immutable_fixed_compact_config(
     suffix: &str,
-    _pooler: &impl BufferPooler,
+    pooler: &impl BufferPooler,
 ) -> immutable::fixed::CompactConfig<Sequential> {
     immutable::CompactConfig {
-        merkle: compact_merkle_config(suffix),
+        strategy: Sequential,
+        witness: compact_witness_config(suffix, pooler),
         commit_codec_config: (),
     }
 }
 
 fn immutable_variable_compact_config(
     suffix: &str,
-    _pooler: &impl BufferPooler,
+    pooler: &impl BufferPooler,
 ) -> immutable::variable::CompactConfig<((), ()), Sequential> {
     immutable::CompactConfig {
-        merkle: compact_merkle_config(suffix),
+        strategy: Sequential,
+        witness: compact_witness_config(suffix, pooler),
         commit_codec_config: ((), ()),
     }
 }
 
 fn keyless_fixed_compact_config(
     suffix: &str,
-    _pooler: &impl BufferPooler,
+    pooler: &impl BufferPooler,
 ) -> keyless::fixed::CompactConfig<Sequential> {
     keyless::CompactConfig {
-        merkle: compact_merkle_config(suffix),
+        strategy: Sequential,
+        witness: compact_witness_config(suffix, pooler),
         commit_codec_config: (),
     }
 }
 
 fn keyless_variable_compact_config(
     suffix: &str,
-    _pooler: &impl BufferPooler,
+    pooler: &impl BufferPooler,
 ) -> keyless::variable::CompactConfig<(commonware_codec::RangeCfg<usize>, ()), Sequential> {
     keyless::CompactConfig {
-        merkle: compact_merkle_config(suffix),
+        strategy: Sequential,
+        witness: compact_witness_config(suffix, pooler),
         commit_codec_config: ((0..=10000usize).into(), ()),
     }
 }

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -303,7 +303,7 @@ where
         )?;
 
         let last_commit_loc = Location::new(*merkle.leaves() - 1);
-        let witness = witness::Store::new_import(journal, imported);
+        let witness = witness::Store::from_import(journal, imported);
         Ok(Self {
             merkle,
             last_commit_loc,

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -513,8 +513,8 @@ where
     }
 
     /// Rewind the db to the synced commit with exactly `target` operations, discarding any
-    /// uncommitted batches and any later commits. The rewind is synced before this method
-    /// returns.
+    /// uncommitted batches and any later commits. The rewind is made durable before this
+    /// method returns.
     ///
     /// # Errors
     ///
@@ -525,8 +525,11 @@ where
     where
         F: Family,
     {
-        // Fast path: already exactly at `target` with no uncommitted state.
-        if self.size() == target && self.witness.with(|w| w.leaf_count()) == target {
+        // Fast path: already durably at `target` with no uncommitted state.
+        if self.size() == target
+            && self.witness.with(|w| w.leaf_count()) == target
+            && !self.witness.import_pending()
+        {
             return Ok(());
         }
 
@@ -548,7 +551,8 @@ where
         Ok(())
     }
 
-    /// Drop witnesses for commits with fewer than `pruning_boundary` operations.
+    /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Only whole
+    /// journal sections are dropped, so some witness below the boundary may survive.
     pub async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
     }
@@ -937,6 +941,71 @@ mod tests {
             )
             .await;
             assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_rejects_corrupt_target_entry() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "immutable-corrupt-rewind-target";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                    .merkleize(&db, None, Location::new(1)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            let rewind_target = db.target().leaf_count;
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[2]), Sha256::fill(2u8))
+                    .merkleize(&db, None, Location::new(1)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            let tip_target = db.target();
+            drop(db);
+
+            // Corrupt the rewind target's entry (the journal holds bootstrap, target, tip).
+            let journal = open_witness_journal(context.child("corrupt"), partition).await;
+            witness::tests::corrupt_entry(&journal, 1, |entry| {
+                entry.pinned_nodes[0] = Sha256::fill(0xff);
+            })
+            .await;
+            drop(journal);
+
+            // The tip entry is intact, so reopen succeeds.
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let mut reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen"),
+                witness_config(partition, &context),
+                (),
+            )
+            .await
+            .unwrap();
+            assert_eq!(reopened.target(), tip_target);
+
+            // The corrupt entry fails the rewind before any truncation.
+            assert!(matches!(
+                reopened.rewind(rewind_target).await,
+                Err(Error::DataCorrupted(_))
+            ));
+            drop(reopened);
+
+            // The newer history survives: reopen still lands on the original tip.
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen2"),
+                witness_config(partition, &context),
+                (),
+            )
+            .await
+            .unwrap();
+            assert_eq!(reopened.target(), tip_target);
+            reopened.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -25,8 +25,8 @@
 
 use super::operation::Operation;
 use crate::{
-    journal::contiguous::variable::Config as JournalConfig,
-    merkle::{batch, compact as compact_merkle, Family, Location, Proof},
+    journal::contiguous::variable::{self, Config as JournalConfig},
+    merkle::{batch, compact as compact_merkle, Family, Location},
     qmdb::{
         self,
         any::value::ValueEncoding,
@@ -274,28 +274,42 @@ where
     /// supplied witness/root pair. The import lives only in memory until the first
     /// [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
     /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn init_from_verified_state(
-        merkle: compact_merkle::Merkle<F, H::Digest, S>,
+        strategy: S,
         journal: witness::Journal<E, F, H::Digest>,
         commit_codec_config: C,
-        last_commit_metadata: Option<V::Value>,
-        inactivity_floor_loc: Location<F>,
-        root: H::Digest,
-        last_commit_op_bytes: Vec<u8>,
-        last_commit_proof: Proof<F, H::Digest>,
-        pinned_nodes: Vec<H::Digest>,
+        validated: compact_sync::ValidatedState<F, Operation<F, K, V>, H::Digest>,
     ) -> Result<Self, Error<F>> {
+        let compact_sync::ValidatedState {
+            state:
+                compact_sync::State {
+                    leaf_count,
+                    pinned_nodes,
+                    last_commit_op,
+                    last_commit_proof,
+                },
+            root,
+            inactivity_floor: inactivity_floor_loc,
+        } = validated;
+        let last_commit_loc = Location::new(*leaf_count - 1);
+        let Operation::Commit(last_commit_metadata, op_floor) = last_commit_op else {
+            return Err(Error::UnexpectedData(last_commit_loc));
+        };
+        if op_floor != inactivity_floor_loc {
+            return Err(Error::DataCorrupted("inactivity floor mismatch"));
+        }
+
+        let merkle =
+            compact_merkle::Merkle::from_compact_state(strategy, leaf_count, pinned_nodes.clone())?;
         let imported = witness::witness_from_authenticated_state(
             &merkle,
             root,
             inactivity_floor_loc,
-            last_commit_op_bytes,
+            Self::encode_commit_op(last_commit_metadata.clone(), inactivity_floor_loc),
             last_commit_proof,
             pinned_nodes,
         )?;
 
-        let last_commit_loc = Location::new(*merkle.leaves() - 1);
         let witness = witness::Store::from_import(journal, imported);
         Ok(Self {
             merkle,
@@ -323,8 +337,8 @@ where
         Operation<F, K, V>: Read<Cfg = C>,
     {
         // Bootstrap: append an initial Commit(None, 0) on first open.
-        let journal =
-            witness::open_journal::<E, F, H::Digest>(witness_context, witness_config).await?;
+        let journal: witness::Journal<E, F, H::Digest> =
+            variable::Journal::init(witness_context, witness_config).await?;
         let (witness, last_commit_op) = witness::init::<E, F, H, S, Operation<F, K, V>>(
             journal,
             &mut merkle,
@@ -338,7 +352,7 @@ where
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
-        let last_commit_loc = Location::new(*witness.with(|w| w.leaf_count) - 1);
+        let last_commit_loc = Location::new(*witness.with(|w| w.leaf_count()) - 1);
 
         Ok(Self {
             merkle,
@@ -411,7 +425,7 @@ where
         // Hold the witness lock only long enough to verify the requested target and snapshot the
         // entry; decode outside it so concurrent readers do not contend.
         let (op_bytes, last_commit_proof, pinned_nodes, leaf_count) = self.witness.with(|w| {
-            if target.root != w.root || target.leaf_count != w.leaf_count {
+            if target.root != w.root || target.leaf_count != w.leaf_count() {
                 return Err(compact_sync::ServeError::StaleTarget {
                     requested: target.clone(),
                     current: w.target(),
@@ -421,7 +435,7 @@ where
                 w.last_commit_op_bytes.clone(),
                 w.last_commit_proof.clone(),
                 w.pinned_nodes.clone(),
-                w.leaf_count,
+                w.leaf_count(),
             ))
         })?;
         let op = Operation::<F, K, V>::decode_cfg(op_bytes.as_ref(), &self.commit_codec_config)
@@ -521,7 +535,7 @@ where
         F: Family,
     {
         // Fast path: already exactly at `target` with no uncommitted state.
-        if self.size() == target && self.witness.with(|w| w.leaf_count) == target {
+        if self.size() == target && self.witness.with(|w| w.leaf_count()) == target {
             return Ok(());
         }
 
@@ -559,7 +573,6 @@ where
 mod tests {
     use super::*;
     use crate::{
-        journal::contiguous::variable,
         merkle::mmr,
         qmdb::{any::value::FixedEncoding, compact::witness},
     };
@@ -603,9 +616,7 @@ mod tests {
         partition: &str,
     ) -> witness::Journal<deterministic::Context, mmr::Family, Digest> {
         let cfg = witness_config(partition, &context);
-        witness::open_journal::<_, mmr::Family, Digest>(context, cfg)
-            .await
-            .unwrap()
+        variable::Journal::init(context, cfg).await.unwrap()
     }
 
     #[test_traced("INFO")]

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -8,12 +8,11 @@
 //!
 //! # Witness journal
 //!
-//! On every durable sync, this db appends a complete snapshot of the committed state to its
-//! witness journal, so [`Db::rewind`] can restore any synced commit still retained there (history
-//! is bounded only by [`Db::prune`]). Reopen and rewind re-verify the persisted snapshot;
-//! corruption surfaces as [`Error::DataCorrupted`]. The witness (the last-commit operation plus
-//! its inclusion proof) is also what lets compact nodes serve compact sync without retaining
-//! historical operations.
+//! The witness journal holds a complete snapshot of every synced commit, so [`Db::rewind`] can
+//! restore any commit still retained there (history is bounded only by [`Db::prune`]). Reopen
+//! and rewind re-verify the persisted snapshot; corruption surfaces as [`Error::DataCorrupted`].
+//! The witness (the last-commit operation plus its inclusion proof) is also what lets compact
+//! nodes serve compact sync without retaining historical operations.
 //!
 //! # Inactivity floor
 //!
@@ -33,7 +32,7 @@ use crate::{
         batch_chain::{self, Bounds},
         compact::{
             batch as compact_batch,
-            witness::{self, Witness},
+            witness::{self, VerifiedWitness, Witness},
         },
         operation::Key,
         sync::compact as compact_sync,
@@ -56,9 +55,7 @@ pub struct Config<C, S: Strategy> {
     /// Strategy used to parallelize merkleization.
     pub strategy: S,
 
-    /// Configuration for the journal that persists the compact-sync witness. Its `codec_config` is
-    /// ignored; the witness entry codec configuration is supplied internally because the entry
-    /// type and its decode bounds are private to the witness module.
+    /// Configuration for the journal that persists the witness.
     pub witness: JournalConfig<()>,
 
     /// Codec config used to decode the persisted last commit operation on reopen.
@@ -297,14 +294,16 @@ where
 
         let merkle =
             compact_merkle::Merkle::from_compact_state(strategy, leaf_count, pinned_nodes.clone())?;
-        let imported = Witness {
+        let imported = VerifiedWitness {
+            entry: Witness {
+                op_bytes: Self::encode_commit_op(
+                    last_commit_metadata.clone(),
+                    inactivity_floor_loc,
+                ),
+                proof: last_commit_proof,
+                pinned_nodes,
+            },
             root,
-            pinned_nodes,
-            last_commit_op_bytes: Self::encode_commit_op(
-                last_commit_metadata.clone(),
-                inactivity_floor_loc,
-            ),
-            last_commit_proof,
         };
 
         let witness = witness::Store::from_import(journal, imported);
@@ -407,7 +406,7 @@ where
     /// This reflects the last durably persisted commit, which may lag behind live in-memory
     /// mutations until [`Self::sync`] is called.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
-        self.witness.with(Witness::target)
+        self.witness.with(VerifiedWitness::target)
     }
 
     /// Return the compact-sync state for `target`, or a stale-target error if the source's
@@ -421,20 +420,20 @@ where
     {
         // Hold the witness lock only long enough to verify the requested target and snapshot the
         // entry; decode outside it so concurrent readers do not contend.
-        let (op_bytes, last_commit_proof, pinned_nodes, leaf_count) = self.witness.with(|w| {
+        let (entry, leaf_count) = self.witness.with(|w| {
             if target.root != w.root || target.leaf_count != w.leaf_count() {
                 return Err(compact_sync::ServeError::StaleTarget {
                     requested: target.clone(),
                     current: w.target(),
                 });
             }
-            Ok((
-                w.last_commit_op_bytes.clone(),
-                w.last_commit_proof.clone(),
-                w.pinned_nodes.clone(),
-                w.leaf_count(),
-            ))
+            Ok((w.entry.clone(), w.leaf_count()))
         })?;
+        let Witness {
+            op_bytes,
+            proof: last_commit_proof,
+            pinned_nodes,
+        } = entry;
         let op = Operation::<F, K, V>::decode_cfg(op_bytes.as_ref(), &self.commit_codec_config)
             .map_err(|_| {
                 compact_sync::ServeError::Database(Error::DataCorrupted("invalid commit operation"))

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -1,27 +1,31 @@
-//! An immutable authenticated db that does not retain historical operations after sync.
+//! An immutable authenticated db that discards historical operations, retaining only a
+//! per-sync witness: the state required to rewind and to serve compact sync.
 //!
 //! Mirrors the API of [`crate::qmdb::immutable::Immutable`] (`new_batch -> merkleize ->
 //! apply_batch -> sync`, pipelined batch chains, `StaleBatch` validation) but is backed by
 //! the peak-only [`crate::merkle::compact`]. Because history is discarded, there are no
 //! `get` / `proof` / `bounds` methods; use the full variant if you need them.
 //!
-//! # Compact serving witness
+//! # Witness journal
 //!
-//! On every durable sync, this db persists the encoded last-commit operation together with its
-//! inclusion proof against the current root. Reopen and rewind re-verify that proof; corruption
-//! surfaces as [`Error::DataCorrupted`]. This authenticated witness is what lets compact nodes
-//! serve compact sync without retaining historical operations.
+//! On every durable sync, this db appends a complete snapshot of the committed state to its
+//! witness journal, so [`Db::rewind`] can restore any synced commit still retained there (history
+//! is bounded only by [`Db::prune`]). Reopen and rewind re-verify the persisted snapshot;
+//! corruption surfaces as [`Error::DataCorrupted`]. The witness (the last-commit operation plus
+//! its inclusion proof) is also what lets compact nodes serve compact sync without retaining
+//! historical operations.
 //!
 //! # Inactivity floor
 //!
-//! Commits still carry an inactivity floor, but only for wire-format compatibility with
+//! Commits carry an inactivity floor for wire-format compatibility with
 //! [`crate::qmdb::immutable::Immutable`]: the root is computed over the encoded operation
 //! sequence, and that sequence must include the same floor to produce the same root as the
-//! full variant. Here the floor has no effect on pruning or snapshot rebuilding. All
-//! historical in-memory state is discarded on every `sync`.
+//! full variant. The floor has no effect on pruning or snapshot rebuilding here; all
+//! historical in-memory state is discarded on every sync.
 
 use super::operation::Operation;
 use crate::{
+    journal::contiguous::variable::Config as JournalConfig,
     merkle::{batch, compact as compact_merkle, Family, Location, Proof},
     qmdb::{
         self,
@@ -29,7 +33,7 @@ use crate::{
         batch_chain::{self, Bounds},
         compact::{
             batch as compact_batch,
-            witness::{self, ServeState},
+            witness::{self, Witness},
         },
         operation::Key,
         sync::compact as compact_sync,
@@ -49,14 +53,23 @@ use std::{
 /// Configuration for a compact immutable authenticated db.
 #[derive(Clone)]
 pub struct Config<C, S: Strategy> {
-    /// Configuration for the backing compact Merkle structure.
-    pub merkle: compact_merkle::Config<S>,
+    /// Strategy used to parallelize merkleization.
+    pub strategy: S,
+
+    /// Configuration for the journal that persists the compact-sync witness. Its `codec_config` is
+    /// ignored; the witness entry codec configuration is supplied internally because the entry
+    /// type and its decode bounds are private to the witness module.
+    pub witness: JournalConfig<()>,
 
     /// Codec config used to decode the persisted last commit operation on reopen.
+    ///
+    /// Committed metadata must round-trip under this config: a commit whose encoded operation
+    /// does not decode under it fails on the next reopen.
     pub commit_codec_config: C,
 }
 
-/// An immutable authenticated db that does not retain historical operations after sync.
+/// An immutable authenticated db that discards historical operations, retaining only a
+/// per-sync witness: the state required to rewind and to serve compact sync.
 pub struct Db<F, E, K, V, H, C, S: Strategy>
 where
     F: Family,
@@ -68,17 +81,15 @@ where
     Operation<F, K, V>: Read<Cfg = C>,
     C: Clone + Send + Sync + 'static,
 {
-    merkle: compact_merkle::Merkle<F, E, H::Digest, S>,
+    merkle: compact_merkle::Merkle<F, H::Digest, S>,
     last_commit_loc: Location<F>,
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
     commit_codec_config: C,
-    /// Cache of the last durably persisted compact witness.
-    ///
-    /// This cache is rebuilt from persisted witness bytes on reopen/rewind and refreshed on
-    /// [`Self::sync`]. It intentionally does not track unsynced in-memory mutations, so compact
-    /// serving never advertises state that has not been durably persisted.
-    witness: witness::Cache<F, H::Digest>,
+    /// Durable witness history: a journal with one entry per sync, plus a cache of the tip
+    /// witness used to serve compact sync. The cache tracks the durable tip, not unsynced
+    /// in-memory mutations.
+    witness: witness::Store<E, F, H::Digest>,
     _key: PhantomData<K>,
 }
 
@@ -204,7 +215,7 @@ where
         ops.push(Operation::Commit(metadata.clone(), inactivity_floor));
 
         let total_size = self.base_size + ops.len() as u64;
-        let merkle = compact_batch::merkleize_ops::<F, E, H, S, _>(
+        let merkle = compact_batch::merkleize_ops::<F, H, S, _>(
             &db.merkle,
             self.merkle_batch,
             ops.as_slice(),
@@ -262,27 +273,18 @@ where
             .to_vec()
     }
 
-    async fn load_active_witness(
-        merkle: &compact_merkle::Merkle<F, E, H::Digest, S>,
-        commit_codec_config: &C,
-    ) -> Result<(ServeState<F, H::Digest>, Operation<F, K, V>), Error<F>> {
-        witness::load_active_witness::<F, E, H, S, _, Operation<F, K, V>, _>(
-            merkle,
-            commit_codec_config,
-            Operation::has_floor,
-        )
-        .await
-    }
-
     /// Build a compact db handle from already-verified compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
-    /// supplied witness/root pair. This seeds the in-memory witness cache from that verified witness
-    /// but does not itself persist anything; persistence happens only after the caller finishes the
-    /// root check for the reconstructed db.
+    /// supplied witness/root pair. Nothing is written to disk until the first [`Self::sync`],
+    /// which replaces the journal's previous contents with the imported witness; abandoning the
+    /// handle before then leaves the prior state intact, and rewind/prune are rejected until it
+    /// runs. A crash during that first sync can leave the journal empty, in which case
+    /// reopening yields a fresh db and the caller must re-sync.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn init_from_verified_state(
-        merkle: compact_merkle::Merkle<F, E, H::Digest, S>,
+        merkle: compact_merkle::Merkle<F, H::Digest, S>,
+        journal: witness::Journal<E, F, H::Digest>,
         commit_codec_config: C,
         last_commit_metadata: Option<V::Value>,
         inactivity_floor_loc: Location<F>,
@@ -291,7 +293,7 @@ where
         last_commit_proof: Proof<F, H::Digest>,
         pinned_nodes: Vec<H::Digest>,
     ) -> Result<Self, Error<F>> {
-        let (last_commit_loc, witness) = witness::witness_from_authenticated_state(
+        let imported = witness::witness_from_authenticated_state(
             &merkle,
             root,
             inactivity_floor_loc,
@@ -300,62 +302,60 @@ where
             pinned_nodes,
         )?;
 
+        let last_commit_loc = Location::new(*merkle.leaves() - 1);
+        let witness = witness::Store::new_import(journal, imported);
         Ok(Self {
             merkle,
             last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
-            witness: witness::Cache::new(witness),
+            witness,
             _key: PhantomData,
         })
     }
 
-    /// Open a compact db from persisted compact state and rebuild its witness cache.
+    /// Open a compact db from persisted compact state and rebuild its witness store.
     ///
     /// On first open, this bootstraps the initial commit and its witness so every later reopen and
-    /// rewind can assume "the active slot has a complete compact witness".
+    /// rewind can assume the journal tip is a complete compact witness.
     pub(crate) async fn init_from_merkle(
-        mut merkle: compact_merkle::Merkle<F, E, H::Digest, S>,
+        mut merkle: compact_merkle::Merkle<F, H::Digest, S>,
+        witness_context: E,
+        witness_config: JournalConfig<()>,
         commit_codec_config: C,
     ) -> Result<Self, Error<F>>
     where
         F: Family,
         Operation<F, K, V>: Read<Cfg = C>,
     {
-        // Bootstrap: append an initial Commit(None, 0) on first open. This establishes the
-        // invariant that every merkleized batch ends with a Commit op, so `last_commit_loc =
-        // leaves - 1` is always correct without replaying the log (which we can't, since we
-        // don't retain it).
-        //
-        // We also persist that initial commit's witness immediately so every later reopen or
-        // rewind can uniformly assume "the active slot has a current tip witness".
-        if merkle.leaves() == 0 {
-            witness::bootstrap_initial_commit::<F, E, H, S>(
-                &mut merkle,
-                Operation::<F, K, V>::Commit(None, Location::new(0))
-                    .encode()
-                    .to_vec(),
-            )
-            .await?;
-        }
-
-        let (witness, last_commit_op) =
-            Self::load_active_witness(&merkle, &commit_codec_config).await?;
+        // Bootstrap: append an initial Commit(None, 0) on first open.
+        let journal =
+            witness::open_journal::<E, F, H::Digest>(witness_context, witness_config).await?;
+        let (witness, last_commit_op) = witness::init::<E, F, H, S, Operation<F, K, V>>(
+            journal,
+            &mut merkle,
+            &commit_codec_config,
+            Operation::<F, K, V>::Commit(None, Location::new(0))
+                .encode()
+                .to_vec(),
+            Operation::has_floor,
+        )
+        .await?;
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
+        let last_commit_loc = Location::new(*witness.with(|w| w.leaf_count) - 1);
 
-        Self::init_from_verified_state(
+        Ok(Self {
             merkle,
-            commit_codec_config,
+            last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
-            witness.root,
-            witness.last_commit_op_bytes,
-            witness.last_commit_proof,
-            witness.pinned_nodes,
-        )
+            commit_codec_config,
+            witness,
+            _key: PhantomData,
+        })
     }
 
     /// Return the root of the db.
@@ -400,18 +400,14 @@ where
 
     /// Return the compact-sync target described by the current witness.
     ///
-    /// This reflects the last state for which both frontier and witness were durably captured,
-    /// which may lag behind live in-memory mutations until [`Self::sync`] is called.
-    pub fn current_target(&self) -> compact_sync::Target<F, H::Digest> {
-        self.witness.with(ServeState::target)
+    /// This reflects the last durably persisted commit, which may lag behind live in-memory
+    /// mutations until [`Self::sync`] is called.
+    pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
+        self.witness.with(Witness::target)
     }
 
     /// Return the compact-sync state for `target`, or a stale-target error if the source's
     /// current witness no longer matches.
-    ///
-    /// The witness lock is held only long enough to verify the requested target and snapshot
-    /// the bytes, proof, and pinned nodes needed for [`compact_sync::State`]. Decoding the
-    /// commit operation runs outside the lock so concurrent readers do not contend on it.
     pub(crate) fn compact_state(
         &self,
         target: compact_sync::Target<F, H::Digest>,
@@ -419,6 +415,8 @@ where
     where
         Operation<F, K, V>: Read<Cfg = C>,
     {
+        // Hold the witness lock only long enough to verify the requested target and snapshot the
+        // entry; decode outside it so concurrent readers do not contend.
         let (op_bytes, last_commit_proof, pinned_nodes, leaf_count) = self.witness.with(|w| {
             if target.root != w.root || target.leaf_count != w.leaf_count {
                 return Err(compact_sync::ServeError::StaleTarget {
@@ -456,7 +454,7 @@ where
         UnmerkleizedBatch::new(self, committed_size)
     }
 
-    /// Create an owned merkleized batch representing the current committed state.
+    /// Create an owned merkleized batch representing the current applied state.
     pub fn to_batch(&self) -> Arc<MerkleizedBatch<F, H::Digest, K, V, S>>
     where
         F: Family,
@@ -481,15 +479,15 @@ where
     /// Apply a merkleized batch to the database.
     ///
     /// Returns the range of locations written. The state is updated in memory only; call
-    /// [`Self::sync`] or [`Self::commit`] to persist.
+    /// [`Self::sync`] to persist.
     ///
     /// # Errors
     ///
     /// - [`Error::StaleBatch`] if the batch was created from a stale DB state.
-    /// - [`Error::FloorRegressed`] if any unapplied commit's floor is below the running floor
-    ///   (walking ancestors oldest-first, then the tip).
-    /// - [`Error::FloorBeyondSize`] if any unapplied commit's floor exceeds its own commit
-    ///   location.
+    /// - [`Error::FloorRegressed`] if any commit in the chain declares a floor below the
+    ///   previous commit's floor.
+    /// - [`Error::FloorBeyondSize`] if any commit in the chain declares a floor beyond its own
+    ///   commit location.
     pub fn apply_batch(
         &mut self,
         batch: Arc<MerkleizedBatch<F, H::Digest, K, V, S>>,
@@ -508,79 +506,59 @@ where
     }
 
     /// Durably persist the current db state to disk.
-    ///
-    /// This is the point at which in-memory mutations become servable via compact sync. The compact
-    /// Merkle frontier and last-commit witness are written into the same slot, reusing the cached
-    /// witness when the current state has already been persisted.
     pub async fn sync(&self) -> Result<(), Error<F>> {
-        witness::persist_witness::<F, E, H, S>(
-            &self.merkle,
-            &self.witness,
-            self.last_commit_loc,
-            self.inactivity_floor_loc,
-            Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc),
-        )
-        .await
+        self.witness
+            .persist::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
+                Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
+            })
+            .await
     }
 
-    /// Durably persist the current db state to disk (alias for [`Self::sync`]).
-    pub async fn commit(&self) -> Result<(), Error<F>>
-    where
-        F: Family,
-    {
-        self.sync().await
-    }
-
-    /// Restore the state as of the sync before the most recent one.
-    ///
-    /// Discards any uncommitted batches, flips the db back to the previous persisted state,
-    /// and reloads the cached commit metadata and inactivity floor from that slot.
-    ///
-    /// Callers must drop any [`Arc<MerkleizedBatch>`] merkleized against state that this rewind
-    /// discards. [`Self::apply_batch`] validates batches by size only: a discarded-branch batch
-    /// will usually trip the size-mismatch check, but if the db later regrows to the same size
-    /// along an alternate branch, the stale batch becomes admissible again and applying it will
-    /// corrupt the committed root. Batches merkleized against the state this rewind restores to
-    /// (for example, a batch built before an advance that is then discarded by the rewind)
-    /// remain compatible and apply cleanly.
+    /// Rewind the db to the synced commit with exactly `target` operations, discarding any
+    /// uncommitted batches and any later commits. The rewind is synced before this method
+    /// returns.
     ///
     /// # Errors
     ///
     /// Returns [`crate::merkle::Error::RewindBeyondHistory`] (wrapped as [`Error::Merkle`]) if
-    /// no prior state exists — either no sync has occurred yet, or the previous state was
-    /// already consumed by a rewind with no intervening sync.
-    ///
-    /// Any error from this method is fatal for this handle. The Merkle layer may have already
-    /// flipped its generation pointer and rebuilt its in-memory state before a later step (e.g.
-    /// reloading the cached commit metadata or inactivity floor) fails, leaving this `Db`'s
-    /// in-memory fields out of sync with the persisted slot. Callers must drop this handle
-    /// after any `Err` from `rewind` and reopen from storage.
-    pub async fn rewind(&mut self) -> Result<(), Error<F>>
+    /// no retained commit has exactly `target` operations (never synced, or pruned). Any error
+    /// is fatal for this handle: drop it and reopen from storage.
+    pub async fn rewind(&mut self, target: Location<F>) -> Result<(), Error<F>>
     where
         F: Family,
     {
-        self.merkle.rewind().await?;
-        // Reload the witness from the reverted slot as well, so compact serving stays aligned with
-        // the same frontier/root that `rewind` restored.
-        let (witness, last_commit_op) =
-            Self::load_active_witness(&self.merkle, &self.commit_codec_config).await?;
+        // Fast path: already exactly at `target` with no uncommitted state.
+        if self.size() == target && self.witness.with(|w| w.leaf_count) == target {
+            return Ok(());
+        }
+
+        let last_commit_op = self
+            .witness
+            .rewind::<H, S, Operation<F, K, V>>(
+                &self.merkle,
+                target,
+                &self.commit_codec_config,
+                Operation::has_floor,
+            )
+            .await?;
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
-        self.last_commit_loc = Location::new(*witness.leaf_count - 1);
-        self.witness.replace(witness);
+        self.last_commit_loc = Location::new(*target - 1);
         Ok(())
+    }
+
+    /// Drop witnesses for commits with fewer than `pruning_boundary` operations.
+    pub async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
+        self.witness.prune(pruning_boundary).await
     }
 
     /// Destroy all persisted state associated with this database.
     pub async fn destroy(self) -> Result<(), Error<F>> {
-        self.merkle.destroy().await.map_err(Into::into)
-    }
-
-    pub(crate) async fn persist_cached_witness(&self) -> Result<(), Error<F>> {
-        witness::persist_cached_witness::<F, E, H, S>(&self.merkle, &self.witness).await
+        self.witness.destroy().await?;
+        Ok(())
     }
 }
 
@@ -588,66 +566,53 @@ where
 mod tests {
     use super::*;
     use crate::{
+        journal::contiguous::variable,
         merkle::mmr,
-        metadata::{Config as MConfig, Metadata},
-        qmdb::any::value::FixedEncoding,
+        qmdb::{any::value::FixedEncoding, compact::witness},
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_parallel::Sequential;
-    use commonware_runtime::{deterministic, Runner as _, Supervisor as _};
-    use commonware_utils::sequence::prefixed_u64::U64 as MetadataKey;
+    use commonware_runtime::{
+        buffer::paged::CacheRef, deterministic, BufferPooler, Runner as _, Supervisor as _,
+    };
+    use commonware_utils::{NZUsize, NZU16, NZU64};
+    use std::num::{NonZeroU16, NonZeroUsize};
 
     type TestDb<F> =
         Db<F, deterministic::Context, Digest, FixedEncoding<Digest>, Sha256, (), Sequential>;
 
+    const WITNESS_PAGE_SIZE: NonZeroU16 = NZU16!(77);
+    const WITNESS_PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
+
+    fn witness_config(partition: &str, pooler: &impl BufferPooler) -> variable::Config<()> {
+        variable::Config {
+            partition: format!("{partition}-witness"),
+            items_per_section: NZU64!(64),
+            compression: None,
+            codec_config: (),
+            page_cache: CacheRef::from_pooler(pooler, WITNESS_PAGE_SIZE, WITNESS_PAGE_CACHE_SIZE),
+            write_buffer: NZUsize!(1024),
+        }
+    }
+
     async fn open_db<F: Family>(context: deterministic::Context, partition: &str) -> TestDb<F> {
-        let merkle = crate::merkle::compact::Merkle::init(
-            context,
-            crate::merkle::compact::Config {
-                partition: partition.into(),
-                strategy: Sequential,
-            },
-        )
-        .await
-        .unwrap();
-        Db::init_from_merkle(merkle, ()).await.unwrap()
+        let witness_cfg = witness_config(partition, &context);
+        let merkle = crate::merkle::compact::Merkle::new(Sequential);
+        Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+            .await
+            .unwrap()
     }
 
-    async fn tamper_metadata_key(
+    /// Open the persisted witness journal directly so tests can corrupt the tip entry.
+    async fn open_witness_journal(
         context: deterministic::Context,
         partition: &str,
-        key: MetadataKey,
-    ) {
-        let mut metadata = open_metadata(context, partition).await;
-        let mut bytes = metadata.get(&key).cloned().expect("metadata entry missing");
-        *bytes.last_mut().expect("metadata entry empty") ^= 0x01;
-        metadata.put_sync(key, bytes).await.unwrap();
-    }
-
-    async fn open_metadata(
-        context: deterministic::Context,
-        partition: &str,
-    ) -> Metadata<deterministic::Context, MetadataKey, Vec<u8>> {
-        Metadata::<_, MetadataKey, Vec<u8>>::init(
-            context.child("meta_write"),
-            MConfig {
-                partition: partition.into(),
-                codec_config: ((0..).into(), ()),
-            },
-        )
-        .await
-        .unwrap()
-    }
-
-    async fn overwrite_metadata_key(
-        context: deterministic::Context,
-        partition: &str,
-        key: MetadataKey,
-        bytes: Vec<u8>,
-    ) {
-        let mut metadata = open_metadata(context, partition).await;
-        metadata.put_sync(key, bytes).await.unwrap();
+    ) -> witness::Journal<deterministic::Context, mmr::Family, Digest> {
+        let cfg = witness_config(partition, &context);
+        witness::open_journal::<_, mmr::Family, Digest>(context, cfg)
+            .await
+            .unwrap()
     }
 
     #[test_traced("INFO")]
@@ -681,11 +646,8 @@ mod tests {
         });
     }
 
-    /// Regression: `to_batch()` must reflect the live in-memory state, not the lagging durable
-    /// serve-state cache. Compact dbs intentionally keep the serve-state cache behind unsynced
-    /// mutations, so a snapshot built without `sync()` / `commit()` between
-    /// `apply_batch()` and `to_batch()` previously bound its cached root to the stale serve
-    /// state.
+    /// Regression: `to_batch()` must snapshot the live in-memory state, not the lagging witness
+    /// cache.
     #[test_traced("INFO")]
     fn test_compact_to_batch_reflects_live_state() {
         deterministic::Runner::default().start(|context| async move {
@@ -709,8 +671,7 @@ mod tests {
             )
             .unwrap();
 
-            // Deliberately skip `sync()` / `commit()` so the durable serve-state cache lags the
-            // live merkle state.
+            // Leave the witness cache behind the live Merkle state.
             let live_root = db.root();
             assert_ne!(
                 live_root, pre_apply_root,
@@ -721,7 +682,7 @@ mod tests {
             assert_eq!(
                 snapshot.root(),
                 live_root,
-                "to_batch().root() must match the live db.root() even before sync/commit"
+                "to_batch().root() must match the live db.root() even before sync"
             );
 
             db.destroy().await.unwrap();
@@ -800,7 +761,7 @@ mod tests {
 
             db.apply_batch(parent).unwrap();
             db.apply_batch(child).unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
 
             assert_eq!(db.root(), expected_root);
 
@@ -874,8 +835,9 @@ mod tests {
                     .merkleize(&db, Some(meta1), floor1),
             )
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             let root_after_first = db.root();
+            let size_after_first = db.size();
 
             let k2 = Sha256::hash(&[2]);
             let v2 = Sha256::fill(22u8);
@@ -888,11 +850,11 @@ mod tests {
                     .merkleize(&db, Some(meta2), floor2),
             )
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             assert_eq!(db.get_metadata(), Some(meta2));
             assert_eq!(db.inactivity_floor_loc(), floor2);
 
-            db.rewind().await.unwrap();
+            db.rewind(size_after_first).await.unwrap();
             assert_eq!(db.root(), root_after_first);
             assert_eq!(db.get_metadata(), Some(meta1));
             assert_eq!(db.inactivity_floor_loc(), floor1);
@@ -918,8 +880,9 @@ mod tests {
                         .merkleize(&db, Some(meta1), floor1),
                 )
                 .unwrap();
-                db.commit().await.unwrap();
+                db.sync().await.unwrap();
                 let root = db.root();
+                let size_after_first = db.size();
 
                 db.apply_batch(
                     db.new_batch()
@@ -927,9 +890,9 @@ mod tests {
                         .merkleize(&db, Some(meta2), floor2),
                 )
                 .unwrap();
-                db.commit().await.unwrap();
+                db.sync().await.unwrap();
 
-                db.rewind().await.unwrap();
+                db.rewind(size_after_first).await.unwrap();
                 root
             };
 
@@ -953,28 +916,28 @@ mod tests {
                     .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1)),
             )
             .unwrap();
-            db.commit().await.unwrap();
-            let slot = db.merkle.active_slot();
+            db.sync().await.unwrap();
             drop(db);
 
-            tamper_metadata_key(
-                context.child("tamper"),
-                partition,
-                crate::qmdb::compact::witness::last_commit_proof_key(slot),
+            // Corrupt the persisted proof so it no longer verifies against the stored root.
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
+            let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
+            if let Some(digest) = proof.digests.first_mut() {
+                *digest = Sha256::fill(0xff);
+            } else {
+                proof.leaves = Location::new(*proof.leaves + 1);
+            }
+            witness::tests::overwrite_tip(&journal, op_bytes, proof, pinned_nodes).await;
+            drop(journal);
+
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen_witness"),
+                witness_config(partition, &context),
+                (),
             )
             .await;
-
-            let merkle: crate::merkle::compact::Merkle<mmr::Family, _, _, Sequential> =
-                crate::merkle::compact::Merkle::init(
-                    context.child("reopen"),
-                    crate::merkle::compact::Config {
-                        partition: partition.into(),
-                        strategy: Sequential,
-                    },
-                )
-                .await
-                .unwrap();
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(merkle, ()).await;
             assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
         });
     }
@@ -990,35 +953,30 @@ mod tests {
                     .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1)),
             )
             .unwrap();
-            db.commit().await.unwrap();
-            let slot = db.merkle.active_slot();
+            db.sync().await.unwrap();
             drop(db);
             let oversized_floor = Location::new(10);
 
-            overwrite_metadata_key(
-                context.child("tamper"),
-                partition,
-                crate::qmdb::compact::witness::last_commit_op_key(slot),
-                Operation::<mmr::Family, Digest, FixedEncoding<Digest>>::Commit(
-                    Some(Sha256::fill(0xaa)),
-                    oversized_floor,
-                )
-                .encode()
-                .to_vec(),
+            // Overwrite the persisted commit op with a floor beyond its own commit location.
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
+            let (_, proof, pinned_nodes) = witness::tests::tip(&journal).await;
+            let bad_op = Operation::<mmr::Family, Digest, FixedEncoding<Digest>>::Commit(
+                Some(Sha256::fill(0xaa)),
+                oversized_floor,
+            )
+            .encode()
+            .to_vec();
+            witness::tests::overwrite_tip(&journal, bad_op, proof, pinned_nodes).await;
+            drop(journal);
+
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen_witness"),
+                witness_config(partition, &context),
+                (),
             )
             .await;
-
-            let merkle: crate::merkle::compact::Merkle<mmr::Family, _, _, Sequential> =
-                crate::merkle::compact::Merkle::init(
-                    context.child("reopen"),
-                    crate::merkle::compact::Config {
-                        partition: partition.into(),
-                        strategy: Sequential,
-                    },
-                )
-                .await
-                .unwrap();
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(merkle, ()).await;
             assert!(matches!(
                 reopened,
                 Err(Error::DataCorrupted("invalid compact witness"))
@@ -1027,17 +985,221 @@ mod tests {
     }
 
     #[test_traced("INFO")]
+    fn test_compact_reopen_rejects_tampered_pinned_nodes() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "immutable-pins-tamper";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[7]), Sha256::fill(7u8))
+                    .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            drop(db);
+
+            // Corrupt one pinned frontier node: the root recomputed from the rebuilt Merkle no
+            // longer matches the proof stored in the same entry.
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
+            let (op_bytes, proof, mut pinned_nodes) = witness::tests::tip(&journal).await;
+            pinned_nodes[0] = Sha256::fill(0xff);
+            witness::tests::overwrite_tip(&journal, op_bytes, proof, pinned_nodes).await;
+            drop(journal);
+
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen_witness"),
+                witness_config(partition, &context),
+                (),
+            )
+            .await;
+            assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
+        });
+    }
+
+    /// A witness entry appended but not synced (a commit interrupted before its journal sync)
+    /// must be dropped on reopen, recovering the last synced commit.
+    #[test_traced("INFO")]
+    fn test_compact_reopen_drops_unsynced_witness() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "immutable-witness-unsynced";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+
+            // Commit state A.
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(1)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            let target_a = db.target();
+            drop(db);
+
+            // Simulate the crash window: append an entry ahead of the tip without syncing it,
+            // then drop the journal. The unsynced tail must not survive reopen.
+            let journal = open_witness_journal(context.child("crash"), partition).await;
+            let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
+            proof.leaves = Location::new(*proof.leaves + 2);
+            witness::tests::append_unsynced(&journal, op_bytes, proof, pinned_nodes).await;
+            drop(journal);
+
+            // Reopen must drop the unsynced entry and recover state A.
+            let reopened = open_db::<mmr::Family>(context.child("reopen"), partition).await;
+            assert_eq!(reopened.target(), target_a);
+            reopened.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
     fn test_compact_rewind_beyond_history() {
         deterministic::Runner::default().start(|context| async move {
             let mut db =
                 open_db::<mmr::Family>(context.child("db"), "immutable-rewind-beyond").await;
-            // Bootstrap sync flipped the pointer from the default slot 0 to slot 1; slot 0 is
-            // still empty, so there is no prior state to rewind to.
+            // The bootstrap commit is the oldest retained state (one leaf); no commit with zero
+            // operations exists to rewind to.
             assert!(matches!(
-                db.rewind().await,
+                db.rewind(Location::new(0)).await,
+                Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
+            ));
+            // A target past the tip is not a commit either.
+            assert!(matches!(
+                db.rewind(Location::new(*db.size() + 100)).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
             db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_multiple_commits() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "immutable-rewind-multi";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+
+            // Commit A, B, C, recording the state after A.
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            let root_a = db.root();
+            let size_a = db.size();
+            let target_a = db.target();
+
+            for i in [2u8, 3] {
+                db.apply_batch(
+                    db.new_batch()
+                        .set(Sha256::hash(&[i]), Sha256::fill(i))
+                        .merkleize(&db, Some(Sha256::fill(i)), Location::new(0)),
+                )
+                .unwrap();
+                db.sync().await.unwrap();
+            }
+            assert_ne!(db.root(), root_a);
+
+            // Rewind two commits in one call.
+            db.rewind(size_a).await.unwrap();
+            assert_eq!(db.root(), root_a);
+            assert_eq!(db.size(), size_a);
+            assert_eq!(db.get_metadata(), Some(Sha256::fill(0xa1)));
+            assert_eq!(db.target(), target_a);
+            drop(db);
+
+            // The rewind is durable: reopen recovers state A.
+            let db = open_db::<mmr::Family>(context.child("reopen"), partition).await;
+            assert_eq!(db.root(), root_a);
+            assert_eq!(db.target(), target_a);
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_to_current_is_noop() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db = open_db::<mmr::Family>(context.child("db"), "immutable-rewind-noop").await;
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            let root = db.root();
+            let size = db.size();
+
+            db.rewind(size).await.unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.size(), size);
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_prune_then_rewind() {
+        deterministic::Runner::default().start(|context| async move {
+            // One entry per section so pruning takes effect at entry granularity (pruning is
+            // section-aligned and never drops a partial section).
+            let mut witness_cfg = witness_config("immutable-prune-rewind", &context);
+            witness_cfg.items_per_section = NZU64!(1);
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let mut db: TestDb<mmr::Family> =
+                Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+                    .await
+                    .unwrap();
+
+            // Commit A, B, C.
+            let mut sizes = Vec::new();
+            for i in [1u8, 2, 3] {
+                db.apply_batch(
+                    db.new_batch()
+                        .set(Sha256::hash(&[i]), Sha256::fill(i))
+                        .merkleize(&db, Some(Sha256::fill(i)), Location::new(0)),
+                )
+                .unwrap();
+                db.sync().await.unwrap();
+                sizes.push(db.size());
+            }
+
+            // Prune history below B: rewinding to B still works, rewinding to A does not.
+            db.prune(sizes[1]).await.unwrap();
+            assert!(matches!(
+                db.rewind(sizes[0]).await,
+                Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
+            ));
+            db.rewind(sizes[1]).await.unwrap();
+            assert_eq!(db.size(), sizes[1]);
+            assert_eq!(db.get_metadata(), Some(Sha256::fill(2)));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_prune_past_tip_keeps_tip() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "immutable-prune-past-tip";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            let target = db.target();
+
+            // Prune with a boundary beyond the tip: the tip entry must survive.
+            db.prune(Location::new(*db.size() + 100)).await.unwrap();
+            assert_eq!(db.target(), target);
+            drop(db);
+
+            let reopened = open_db::<mmr::Family>(context.child("reopen"), partition).await;
+            assert_eq!(reopened.target(), target);
+            reopened.destroy().await.unwrap();
         });
     }
 
@@ -1056,7 +1218,8 @@ mod tests {
                     .merkleize(&db, None, Location::new(0)),
             )
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
+            let size_after_first = db.size();
 
             // Merkleize a batch against the post-commit-A state.
             let held = db
@@ -1071,8 +1234,8 @@ mod tests {
                     .merkleize(&db, None, Location::new(0)),
             )
             .unwrap();
-            db.commit().await.unwrap();
-            db.rewind().await.unwrap();
+            db.sync().await.unwrap();
+            db.rewind(size_after_first).await.unwrap();
 
             // The rewind restored the state that `held` was merkleized against, so it still
             // matches the Merkle size and applies cleanly.
@@ -1098,14 +1261,14 @@ mod tests {
                 Location::new(0),
             ))
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             let root_after_first = db.root();
             let size_after_first = db.size();
 
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             assert_eq!(db.size(), size_after_first);
             assert_eq!(db.root(), root_after_first);
-            assert_eq!(db.current_target().root, db.root());
+            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -1128,7 +1291,7 @@ mod tests {
                     Location::new(0),
                 ))
                 .unwrap();
-                db.commit().await.unwrap();
+                db.sync().await.unwrap();
                 (db.root(), db.size())
             };
 
@@ -1136,10 +1299,10 @@ mod tests {
             assert_eq!(db.root(), root_before_drop);
             assert_eq!(db.size(), size_before_drop);
 
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             assert_eq!(db.size(), size_before_drop);
             assert_eq!(db.root(), root_before_drop);
-            assert_eq!(db.current_target().root, db.root());
+            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -1161,7 +1324,7 @@ mod tests {
                 Location::new(0),
             ))
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             let root_after_first = db.root();
             let size_after_first = db.size();
 
@@ -1173,16 +1336,16 @@ mod tests {
                 Location::new(1),
             ))
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
 
-            db.rewind().await.unwrap();
+            db.rewind(size_after_first).await.unwrap();
             assert_eq!(db.size(), size_after_first);
             assert_eq!(db.root(), root_after_first);
 
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             assert_eq!(db.size(), size_after_first);
             assert_eq!(db.root(), root_after_first);
-            assert_eq!(db.current_target().root, db.root());
+            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -1200,7 +1363,8 @@ mod tests {
                     .merkleize(&db, None, Location::new(0)),
             )
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
+            let size_after_first = db.size();
 
             db.apply_batch(
                 db.new_batch()
@@ -1208,7 +1372,7 @@ mod tests {
                     .merkleize(&db, None, Location::new(0)),
             )
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
 
             // Merkleize a batch against the post-commit-B state, which the rewind will discard.
             let held = db
@@ -1216,7 +1380,7 @@ mod tests {
                 .set(Sha256::hash(&[3]), Sha256::fill(3u8))
                 .merkleize(&db, None, Location::new(0));
 
-            db.rewind().await.unwrap();
+            db.rewind(size_after_first).await.unwrap();
 
             // After rewind, mem.size reflects post-commit-A, but the held batch starts after
             // post-commit-B. Apply must be rejected with StaleBatch.
@@ -1230,11 +1394,11 @@ mod tests {
     }
 
     #[test_traced("INFO")]
-    fn test_witness_state_reports_cached_commit_corruption() {
+    fn test_compact_state_reports_cached_commit_corruption() {
         deterministic::Runner::default().start(|context| async move {
             let db =
                 open_db::<mmr::Family>(context.child("db"), "immutable-serve-corruption").await;
-            let target = db.current_target();
+            let target = db.target();
             db.witness
                 .mutate(|witness| witness.last_commit_op_bytes.clear());
 

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -289,26 +289,23 @@ where
                     last_commit_proof,
                 },
             root,
-            inactivity_floor: inactivity_floor_loc,
         } = validated;
         let last_commit_loc = Location::new(*leaf_count - 1);
-        let Operation::Commit(last_commit_metadata, op_floor) = last_commit_op else {
+        let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::UnexpectedData(last_commit_loc));
         };
-        if op_floor != inactivity_floor_loc {
-            return Err(Error::DataCorrupted("inactivity floor mismatch"));
-        }
 
         let merkle =
             compact_merkle::Merkle::from_compact_state(strategy, leaf_count, pinned_nodes.clone())?;
-        let imported = witness::witness_from_authenticated_state(
-            &merkle,
+        let imported = Witness {
             root,
-            inactivity_floor_loc,
-            Self::encode_commit_op(last_commit_metadata.clone(), inactivity_floor_loc),
-            last_commit_proof,
             pinned_nodes,
-        )?;
+            last_commit_op_bytes: Self::encode_commit_op(
+                last_commit_metadata.clone(),
+                inactivity_floor_loc,
+            ),
+            last_commit_proof,
+        };
 
         let witness = witness::Store::from_import(journal, imported);
         Ok(Self {
@@ -442,11 +439,6 @@ where
             .map_err(|_| {
                 compact_sync::ServeError::Database(Error::DataCorrupted("invalid commit operation"))
             })?;
-        if !matches!(&op, Operation::Commit(_, _)) {
-            return Err(compact_sync::ServeError::Database(Error::DataCorrupted(
-                "last operation was not a commit",
-            )));
-        }
         Ok(compact_sync::State {
             leaf_count,
             pinned_nodes,
@@ -1394,26 +1386,6 @@ mod tests {
             assert!(matches!(
                 db.apply_batch(held),
                 Err(Error::StaleBatch { .. })
-            ));
-
-            db.destroy().await.unwrap();
-        });
-    }
-
-    #[test_traced("INFO")]
-    fn test_compact_state_reports_cached_commit_corruption() {
-        deterministic::Runner::default().start(|context| async move {
-            let db =
-                open_db::<mmr::Family>(context.child("db"), "immutable-serve-corruption").await;
-            let target = db.target();
-            db.witness
-                .mutate(|witness| witness.last_commit_op_bytes.clear());
-
-            assert!(matches!(
-                db.compact_state(target),
-                Err(compact_sync::ServeError::Database(Error::DataCorrupted(
-                    "invalid commit operation"
-                )))
             ));
 
             db.destroy().await.unwrap();

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -62,9 +62,6 @@ pub struct Config<C, S: Strategy> {
     pub witness: JournalConfig<()>,
 
     /// Codec config used to decode the persisted last commit operation on reopen.
-    ///
-    /// Committed metadata must round-trip under this config: a commit whose encoded operation
-    /// does not decode under it fails on the next reopen.
     pub commit_codec_config: C,
 }
 
@@ -86,9 +83,6 @@ where
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
     commit_codec_config: C,
-    /// Durable witness history: a journal with one entry per sync, plus a cache of the tip
-    /// witness used to serve compact sync. The cache tracks the durable tip, not unsynced
-    /// in-memory mutations.
     witness: witness::Store<E, F, H::Digest>,
     _key: PhantomData<K>,
 }
@@ -113,7 +107,7 @@ where
     db_size: u64,
 }
 
-/// A merkleized batch for a compact immutable db.
+/// A speculative batch whose root digest has been computed.
 #[derive(Clone)]
 pub struct MerkleizedBatch<F: Family, D: Digest, K: Key, V: ValueEncoding, S: Strategy>
 where
@@ -256,13 +250,14 @@ where
     }
 }
 
-impl<F, E, K, V, H, C, S: Strategy> Db<F, E, K, V, H, C, S>
+impl<F, E, K, V, H, C, S> Db<F, E, K, V, H, C, S>
 where
     F: Family,
     E: Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
+    S: Strategy,
     Operation<F, K, V>: EncodeShared,
     Operation<F, K, V>: Read<Cfg = C>,
     C: Clone + Send + Sync + 'static,
@@ -276,11 +271,9 @@ where
     /// Build a compact db handle from already-verified compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
-    /// supplied witness/root pair. Nothing is written to disk until the first [`Self::sync`],
-    /// which replaces the journal's previous contents with the imported witness; abandoning the
-    /// handle before then leaves the prior state intact, and rewind/prune are rejected until it
-    /// runs. A crash during that first sync can leave the journal empty, in which case
-    /// reopening yields a fresh db and the caller must re-sync.
+    /// supplied witness/root pair. The import lives only in memory until the first
+    /// [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
+    /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn init_from_verified_state(
         merkle: compact_merkle::Merkle<F, H::Digest, S>,
@@ -794,8 +787,11 @@ mod tests {
         });
     }
 
+    // A chained batch whose tip floor is below its parent's floor must be rejected:
+    // the parent's Commit participates in the per-commit monotonicity invariant even
+    // before it is applied.
     #[test_traced("INFO")]
-    fn test_compact_rejects_regressed_ancestor_floor() {
+    fn test_compact_ancestor_floor_regressed() {
         deterministic::Runner::default().start(|context| async move {
             let mut db =
                 open_db::<mmr::Family>(context.child("db"), "immutable-regressed-ancestor-floor")
@@ -1425,6 +1421,36 @@ mod tests {
                 db.apply_batch(batch),
                 Err(Error::FloorBeyondSize(floor, tip))
                     if floor == Location::new(2) && tip == Location::new(1)
+            ));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    // A chained batch whose ancestor's floor exceeds that ancestor's own commit location
+    // must be rejected, identifying the ancestor's bound rather than the tip's.
+    #[test_traced("INFO")]
+    fn test_compact_ancestor_floor_beyond_size() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db =
+                open_db::<mmr::Family>(context.child("db"), "immutable-ancestor-floor-beyond")
+                    .await;
+
+            // parent: set + commit at loc 2, floor=3 (one past parent's commit).
+            let parent = db
+                .new_batch()
+                .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                .merkleize(&db, None, Location::new(3));
+            // child: valid on its own (floor=0), but parent's floor is bad.
+            let child = parent
+                .new_batch::<Sha256>()
+                .set(Sha256::hash(&[2]), Sha256::fill(2u8))
+                .merkleize(&db, None, Location::new(0));
+
+            assert!(matches!(
+                db.apply_batch(child),
+                Err(Error::FloorBeyondSize(floor, commit))
+                    if floor == Location::new(3) && commit == Location::new(2)
             ));
 
             db.destroy().await.unwrap();

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -1,5 +1,5 @@
-//! An immutable authenticated db that discards historical operations, retaining only a
-//! per-sync witness: the state required to rewind and to serve compact sync.
+//! An immutable authenticated db that discards historical operations, retaining only a witness
+//! for each synced commit.
 //!
 //! Mirrors the API of [`crate::qmdb::immutable::Immutable`] (`new_batch -> merkleize ->
 //! apply_batch -> sync`, pipelined batch chains, `StaleBatch` validation) but is backed by
@@ -62,8 +62,8 @@ pub struct Config<C, S: Strategy> {
     pub commit_codec_config: C,
 }
 
-/// An immutable authenticated db that discards historical operations, retaining only a
-/// per-sync witness: the state required to rewind and to serve compact sync.
+/// An immutable authenticated db that discards historical operations, retaining only a witness
+/// for each synced commit.
 pub struct Db<F, E, K, V, H, C, S: Strategy>
 where
     F: Family,
@@ -937,6 +937,40 @@ mod tests {
             )
             .await;
             assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_reopen_rejects_interrupted_import() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "immutable-interrupted-import";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[7]), Sha256::fill(7u8))
+                    .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            drop(db);
+
+            // Simulate a crash between an import's journal clear and its entry append: the
+            // journal is empty but its size is nonzero.
+            let journal = open_witness_journal(context.child("clear"), partition).await;
+            let size = journal.size().await;
+            journal.clear_to_size(size.max(1)).await.unwrap();
+            drop(journal);
+
+            // Reopen must fail rather than bootstrap a fresh db.
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen_witness"),
+                witness_config(partition, &context),
+                (),
+            )
+            .await;
+            assert!(matches!(reopened, Err(Error::Journal(_))));
         });
     }
 

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -553,7 +553,15 @@ where
 
     /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Some witness
     /// below the boundary may survive.
-    pub async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
+    ///
+    /// Pruning bounds how far back [`Self::rewind`] can reach; the current commit's witness
+    /// always survives. The prune is made durable before this method returns.
+    ///
+    /// # Errors
+    ///
+    /// Fails if a compact-sync import has not yet been persisted by [`Self::sync`]. Any error
+    /// is fatal for this handle: drop it and reopen from storage.
+    pub async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
     }
 
@@ -1169,6 +1177,53 @@ mod tests {
                 db.rewind(Location::new(*db.size() + 100)).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_between_commits() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db =
+                open_db::<mmr::Family>(context.child("db"), "immutable-rewind-between").await;
+
+            // A multi-op commit jumps the committed size from 1 (bootstrap) to 4.
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                    .set(Sha256::hash(&[2]), Sha256::fill(2u8))
+                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            let root_a = db.root();
+            let size_a = db.size();
+            assert_eq!(size_a, Location::new(4));
+
+            // A second commit moves the size to 6.
+            db.apply_batch(
+                db.new_batch()
+                    .set(Sha256::hash(&[3]), Sha256::fill(3u8))
+                    .merkleize(&db, Some(Sha256::fill(0xb1)), Location::new(0)),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            let root_b = db.root();
+
+            // Targets inside a commit's span match no entry, even though entries exist on
+            // both sides.
+            for target in [2u64, 3, 5] {
+                assert!(matches!(
+                    db.rewind(Location::new(target)).await,
+                    Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
+                ));
+            }
+            assert_eq!(db.root(), root_b);
+
+            // The exact commit boundary remains a valid target.
+            db.rewind(size_a).await.unwrap();
+            assert_eq!(db.root(), root_a);
+            assert_eq!(db.get_metadata(), Some(Sha256::fill(0xa1)));
             db.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -265,13 +265,13 @@ where
             .to_vec()
     }
 
-    /// Build a compact db handle from already-verified compact state.
+    /// Build a compact db handle from already-validated compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
     /// supplied witness/root pair. The import lives only in memory until the first
     /// [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
     /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
-    pub(crate) fn init_from_verified_state(
+    pub(crate) fn init_from_validated_state(
         strategy: S,
         journal: witness::Journal<E, F, H::Digest>,
         commit_codec_config: C,
@@ -295,7 +295,7 @@ where
         let merkle =
             compact_merkle::Merkle::from_compact_state(strategy, leaf_count, pinned_nodes.clone())?;
         let imported = VerifiedWitness {
-            entry: Witness {
+            witness: Witness {
                 op_bytes: Self::encode_commit_op(
                     last_commit_metadata.clone(),
                     inactivity_floor_loc,
@@ -427,7 +427,7 @@ where
                     current: w.target(),
                 });
             }
-            Ok((w.entry.clone(), w.leaf_count()))
+            Ok((w.witness.clone(), w.leaf_count()))
         })?;
         let Witness {
             op_bytes,
@@ -551,8 +551,8 @@ where
         Ok(())
     }
 
-    /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Only whole
-    /// journal sections are dropped, so some witness below the boundary may survive.
+    /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Some witness
+    /// below the boundary may survive.
     pub async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
     }

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -69,8 +69,8 @@ impl<F: Family, E: Storage + Clock + Metrics, K: Array, V: FixedValue, H: Hasher
 {
     /// Returns a [CompactDb] initialized from `cfg`.
     pub async fn init(context: E, cfg: CompactConfig<S>) -> Result<Self, Error<F>> {
-        let merkle = crate::merkle::compact::Merkle::init(context, cfg.merkle).await?;
-        Self::init_from_merkle(merkle, ()).await
+        let merkle = crate::merkle::compact::Merkle::new(cfg.strategy);
+        Self::init_from_merkle(merkle, context.child("witness"), cfg.witness, ()).await
     }
 }
 
@@ -127,9 +127,14 @@ mod tests {
         context: deterministic::Context,
     ) -> CompactDb<F, deterministic::Context, Digest, Digest, Sha256, Sequential> {
         let cfg = CompactConfig {
-            merkle: crate::merkle::compact::Config {
-                partition: "compact-immutable-fixed".into(),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: crate::journal::contiguous::variable::Config {
+                partition: "compact-immutable-fixed-witness".into(),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: (),
         };
@@ -408,7 +413,7 @@ mod tests {
         db.apply_batch(retained).await.unwrap();
         compact.apply_batch(compact_batch).unwrap();
         db.commit().await.unwrap();
-        compact.commit().await.unwrap();
+        compact.sync().await.unwrap();
 
         assert_eq!(db.root(), compact.root());
         assert_eq!(compact.get_metadata(), Some(metadata));

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -177,7 +177,7 @@ where
                 config.witness,
             )
             .await?;
-        Self::init_from_verified_state(config.strategy, journal, config.commit_codec_config, state)
+        Self::init_from_validated_state(config.strategy, journal, config.commit_codec_config, state)
     }
 
     fn inactivity_floor(op: &Self::Op) -> Option<Location<Self::Family>> {

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     translator::Translator,
     Context,
 };
-use commonware_codec::{Encode, EncodeShared, Read};
+use commonware_codec::{EncodeShared, Read};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use commonware_utils::range::NonEmptyRange;
@@ -171,50 +171,13 @@ where
         config: Self::Config,
         state: sync::compact::ValidatedState<Self::Family, Self::Op, Self::Digest>,
     ) -> Result<Self, Error<F>> {
-        let sync::compact::ValidatedState {
-            state,
-            root,
-            inactivity_floor: inactivity_floor_loc,
-        } = state;
-        let sync::compact::State {
-            leaf_count,
-            pinned_nodes,
-            last_commit_op,
-            last_commit_proof,
-        } = state;
-        let last_commit_loc = Location::new(*leaf_count - 1);
-        let Operation::Commit(last_commit_metadata, op_floor) = last_commit_op else {
-            return Err(Error::UnexpectedData(last_commit_loc));
-        };
-        if op_floor != inactivity_floor_loc {
-            return Err(Error::DataCorrupted("inactivity floor mismatch"));
-        }
-        let commit_codec_config = config.commit_codec_config.clone();
-        let last_commit_op_bytes =
-            Operation::<F, K, V>::Commit(last_commit_metadata.clone(), inactivity_floor_loc)
-                .encode()
-                .to_vec();
-        let merkle = crate::merkle::compact::Merkle::from_compact_state(
-            config.strategy,
-            leaf_count,
-            pinned_nodes.clone(),
-        )?;
-        let journal = crate::qmdb::compact::witness::open_journal::<E, F, H::Digest>(
-            context.child("witness"),
-            config.witness,
-        )
-        .await?;
-        Self::init_from_verified_state(
-            merkle,
-            journal,
-            commit_codec_config,
-            last_commit_metadata,
-            inactivity_floor_loc,
-            root,
-            last_commit_op_bytes,
-            last_commit_proof,
-            pinned_nodes,
-        )
+        let journal: crate::qmdb::compact::witness::Journal<E, F, H::Digest> =
+            crate::journal::contiguous::variable::Journal::init(
+                context.child("witness"),
+                config.witness,
+            )
+            .await?;
+        Self::init_from_verified_state(config.strategy, journal, config.commit_codec_config, state)
     }
 
     fn inactivity_floor(op: &Self::Op) -> Option<Location<Self::Family>> {

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -186,21 +186,27 @@ where
         let Operation::Commit(last_commit_metadata, op_floor) = last_commit_op else {
             return Err(Error::UnexpectedData(last_commit_loc));
         };
-        assert_eq!(op_floor, inactivity_floor_loc, "inactivity floor mismatch");
+        if op_floor != inactivity_floor_loc {
+            return Err(Error::DataCorrupted("inactivity floor mismatch"));
+        }
         let commit_codec_config = config.commit_codec_config.clone();
         let last_commit_op_bytes =
             Operation::<F, K, V>::Commit(last_commit_metadata.clone(), inactivity_floor_loc)
                 .encode()
                 .to_vec();
-        let merkle = crate::merkle::compact::Merkle::init_from_compact_state(
-            context.child("merkle"),
-            config.merkle,
+        let merkle = crate::merkle::compact::Merkle::from_compact_state(
+            config.strategy,
             leaf_count,
             pinned_nodes.clone(),
+        )?;
+        let journal = crate::qmdb::compact::witness::open_journal::<E, F, H::Digest>(
+            context.child("witness"),
+            config.witness,
         )
         .await?;
         Self::init_from_verified_state(
             merkle,
+            journal,
             commit_codec_config,
             last_commit_metadata,
             inactivity_floor_loc,
@@ -220,7 +226,7 @@ where
     }
 
     async fn persist_compact_state(&self) -> Result<(), Error<F>> {
-        self.persist_cached_witness().await
+        self.sync().await
     }
 }
 

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -1774,6 +1774,79 @@ mod compact_variable_mmr {
             reopened.destroy().await.unwrap();
         });
     }
+
+    /// Dropping a compact-sync import before its first persist leaves the previous witness
+    /// journal untouched.
+    #[test_traced("WARN")]
+    fn test_compact_sync_dropped_import_preserves_existing_state() {
+        deterministic::Runner::default().start(|mut context| async move {
+            let suffix = format!("compact-immutable-dropped-{}", context.next_u64());
+
+            // Seed the client partition with committed state A.
+            let client_cfg = client_config(&suffix, &context);
+            let mut seeded = ClientDb::init(context.child("seed"), client_cfg.clone())
+                .await
+                .unwrap();
+            let batch = seeded
+                .new_batch()
+                .set(sha256::Digest::from([1; 32]), vec![1])
+                .merkleize(&seeded, Some(vec![1]), Location::new(0));
+            seeded.apply_batch(batch).unwrap();
+            seeded.sync().await.unwrap();
+            let target_a = seeded.target();
+            drop(seeded);
+
+            // Reconstruct state B into the same partition, then drop it before the first
+            // persist (as a cancelled sync would).
+            let mut source =
+                SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                    .await
+                    .unwrap();
+            let batch = source
+                .new_batch()
+                .set(sha256::Digest::from([9; 32]), vec![9])
+                .merkleize(&source, Some(vec![9]), Location::new(0));
+            source.apply_batch(batch).await.unwrap();
+            source.commit().await.unwrap();
+            let bounds = source.bounds().await;
+            let target_b = sync::compact::Target {
+                root: source.root(),
+                leaf_count: bounds.end,
+            };
+            assert_ne!(target_b, target_a);
+            let source = Arc::new(source);
+            let fetched = sync::compact::Resolver::get_compact_state(&source, target_b.clone())
+                .await
+                .unwrap();
+            let validated = sync::compact::ValidatedState {
+                state: fetched.state,
+                root: target_b.root,
+            };
+            let mut imported = <ClientDb as sync::compact::Database>::from_validated_state(
+                context.child("import"),
+                client_cfg.clone(),
+                validated,
+            )
+            .await
+            .unwrap();
+            assert_eq!(imported.target(), target_b);
+
+            // Rewind is rejected until the import is persisted, even to the imported leaf
+            // count itself: the fast path must not report unpersisted state as durable.
+            assert!(imported.rewind(target_b.leaf_count).await.is_err());
+
+            // Prune is likewise rejected while the import is pending.
+            assert!(imported.prune(target_b.leaf_count).await.is_err());
+            drop(imported);
+
+            // The dropped import never touched the journal: state A is still there.
+            let reopened = ClientDb::init(context.child("reopen"), client_cfg)
+                .await
+                .unwrap();
+            assert_eq!(reopened.target(), target_a);
+            reopened.destroy().await.unwrap();
+        });
+    }
 }
 
 mod compact_variable_mmb {

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -1196,12 +1196,18 @@ mod compact_variable_mmr {
 
     fn client_config(
         suffix: &str,
+        pooler: &impl BufferPooler,
     ) -> immutable::variable::CompactConfig<((), (commonware_codec::RangeCfg<usize>, ())), Sequential>
     {
         immutable::CompactConfig {
-            merkle: crate::merkle::compact::Config {
-                partition: format!("compact-{suffix}"),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: crate::journal::contiguous::variable::Config {
+                partition: format!("compact-{suffix}-witness"),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: ((), ((0..=10000).into(), ())),
         }
@@ -1279,7 +1285,7 @@ mod compact_variable_mmr {
                 leaf_count: bounds.end,
             };
             let source = Arc::new(source);
-            let client_cfg = client_config(&suffix);
+            let client_cfg = client_config(&suffix, &context);
             let client: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("client"),
                 resolver: source.clone(),
@@ -1344,7 +1350,7 @@ mod compact_variable_mmr {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -1406,7 +1412,7 @@ mod compact_variable_mmr {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -1452,7 +1458,7 @@ mod compact_variable_mmr {
             let mut bad_state = good_state.clone();
             bad_state.pinned_nodes[0] = sha256::Digest::from([0xaa; 32]);
 
-            let client_cfg = client_config(&suffix);
+            let client_cfg = client_config(&suffix, &context);
             let synced: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("client"),
                 resolver: SequenceResolver {
@@ -1519,7 +1525,7 @@ mod compact_variable_mmr {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -1580,7 +1586,7 @@ mod compact_variable_mmr {
     fn test_compact_source_reopen_rewind_regrow_and_stale_target() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-unj-source-{}", context.next_u64());
-            let source_cfg = client_config(&format!("{suffix}-source"));
+            let source_cfg = client_config(&format!("{suffix}-source"), &context);
             let mut source = ClientDb::init(context.child("source_init"), source_cfg.clone())
                 .await
                 .unwrap();
@@ -1593,19 +1599,19 @@ mod compact_variable_mmr {
                 .merkleize(&source, Some(metadata1.clone()), floor1);
             source.apply_batch(batch1).unwrap();
             source.sync().await.unwrap();
-            let target1 = source.current_target();
+            let target1 = source.target();
             drop(source);
 
             let source = ClientDb::init(context.child("source_reopen"), source_cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(source.current_target(), target1);
+            assert_eq!(source.target(), target1);
 
             let served1: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 1),
                 resolver: Arc::new(source),
                 target: target1.clone(),
-                db_config: client_config(&format!("{suffix}-serve1")),
+                db_config: client_config(&format!("{suffix}-serve1"), &context),
             })
             .await
             .unwrap();
@@ -1625,17 +1631,17 @@ mod compact_variable_mmr {
                 .merkleize(&source, Some(metadata2.clone()), floor2);
             source.apply_batch(batch2).unwrap();
             source.sync().await.unwrap();
-            let target2 = source.current_target();
+            let target2 = source.target();
             assert_ne!(target2, target1);
 
-            source.rewind().await.unwrap();
-            assert_eq!(source.current_target(), target1);
+            source.rewind(target1.leaf_count).await.unwrap();
+            assert_eq!(source.target(), target1);
 
             let served2: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 2),
                 resolver: Arc::new(source),
                 target: target1.clone(),
-                db_config: client_config(&format!("{suffix}-serve2")),
+                db_config: client_config(&format!("{suffix}-serve2"), &context),
             })
             .await
             .unwrap();
@@ -1647,7 +1653,7 @@ mod compact_variable_mmr {
             let mut source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(source.current_target(), target1);
+            assert_eq!(source.target(), target1);
             let metadata3 = vec![3, 3, 3];
             let floor3 = Location::new(2);
             let batch3 = source
@@ -1656,7 +1662,7 @@ mod compact_variable_mmr {
                 .merkleize(&source, Some(metadata3.clone()), floor3);
             source.apply_batch(batch3).unwrap();
             source.sync().await.unwrap();
-            let target3 = source.current_target();
+            let target3 = source.target();
             assert_ne!(target3, target1);
             assert_ne!(target3, target2);
 
@@ -1664,7 +1670,7 @@ mod compact_variable_mmr {
                 context: context.child("serve").with_attribute("index", 3),
                 resolver: Arc::new(source),
                 target: target3.clone(),
-                db_config: client_config(&format!("{suffix}-serve3")),
+                db_config: client_config(&format!("{suffix}-serve3"), &context),
             })
             .await
             .unwrap();
@@ -1682,7 +1688,7 @@ mod compact_variable_mmr {
                 context: context.child("stale_client"),
                 resolver: source.clone(),
                 target: target2.clone(),
-                db_config: client_config(&format!("{suffix}-stale")),
+                db_config: client_config(&format!("{suffix}-stale"), &context),
             })
             .await;
             assert!(matches!(
@@ -1695,6 +1701,77 @@ mod compact_variable_mmr {
 
             let source = Arc::try_unwrap(source).unwrap_or_else(|_| panic!("single source ref"));
             source.destroy().await.unwrap();
+        });
+    }
+
+    /// Compact sync must reinitialize a partition whose witness journal was previously pruned
+    /// (the journal reset must clear the nonzero pruning boundary).
+    #[test_traced("WARN")]
+    fn test_compact_sync_reuses_pruned_partition() {
+        deterministic::Runner::default().start(|mut context| async move {
+            let suffix = format!("compact-immutable-pruned-{}", context.next_u64());
+
+            // Seed the client partition with several commits, then prune its witness journal.
+            let mut client_cfg = client_config(&suffix, &context);
+            client_cfg.witness.items_per_section = NZU64!(1);
+            let mut seeded = ClientDb::init(context.child("seed"), client_cfg.clone())
+                .await
+                .unwrap();
+            let mut first_size = None;
+            for i in 1u8..=3 {
+                let floor = seeded.inactivity_floor_loc();
+                let batch = seeded
+                    .new_batch()
+                    .set(sha256::Digest::from([i; 32]), vec![i])
+                    .merkleize(&seeded, Some(vec![i]), floor);
+                seeded.apply_batch(batch).unwrap();
+                seeded.sync().await.unwrap();
+                first_size.get_or_insert(seeded.size());
+            }
+            seeded.prune(seeded.size()).await.unwrap();
+            // The prune moved the journal's pruning boundary: the first commit is unreachable.
+            assert!(matches!(
+                seeded.rewind(first_size.unwrap()).await,
+                Err(crate::qmdb::Error::Merkle(
+                    crate::merkle::Error::RewindBeyondHistory
+                ))
+            ));
+            drop(seeded);
+
+            // Sync different state into the same partition.
+            let mut source =
+                SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                    .await
+                    .unwrap();
+            let metadata = vec![9, 9, 9];
+            let batch = source
+                .new_batch()
+                .set(sha256::Digest::from([9; 32]), vec![9])
+                .merkleize(&source, Some(metadata.clone()), Location::new(0));
+            source.apply_batch(batch).await.unwrap();
+            source.commit().await.unwrap();
+            let bounds = source.bounds().await;
+            let target = sync::compact::Target {
+                root: source.root(),
+                leaf_count: bounds.end,
+            };
+
+            let synced: ClientDb = sync::compact::sync(sync::compact::Config {
+                context: context.child("client"),
+                resolver: Arc::new(source),
+                target: target.clone(),
+                db_config: client_cfg.clone(),
+            })
+            .await
+            .unwrap();
+            assert_eq!(synced.root(), target.root);
+            drop(synced);
+
+            let reopened = ClientDb::init(context.child("reopen"), client_cfg)
+                .await
+                .unwrap();
+            assert_eq!(reopened.root(), target.root);
+            reopened.destroy().await.unwrap();
         });
     }
 }
@@ -1752,12 +1829,18 @@ mod compact_variable_mmb {
 
     fn client_config(
         suffix: &str,
+        pooler: &impl BufferPooler,
     ) -> immutable::variable::CompactConfig<((), (commonware_codec::RangeCfg<usize>, ())), Sequential>
     {
         immutable::CompactConfig {
-            merkle: crate::merkle::compact::Config {
-                partition: format!("compact-{suffix}"),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: crate::journal::contiguous::variable::Config {
+                partition: format!("compact-{suffix}-witness"),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: ((), ((0..=10000).into(), ())),
         }
@@ -1835,7 +1918,7 @@ mod compact_variable_mmb {
                 leaf_count: bounds.end,
             };
             let source = Arc::new(source);
-            let client_cfg = client_config(&suffix);
+            let client_cfg = client_config(&suffix, &context);
             let client: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("client"),
                 resolver: source.clone(),
@@ -1900,7 +1983,7 @@ mod compact_variable_mmb {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -1962,7 +2045,7 @@ mod compact_variable_mmb {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -2008,7 +2091,7 @@ mod compact_variable_mmb {
             let mut bad_state = good_state.clone();
             bad_state.pinned_nodes[0] = sha256::Digest::from([0xaa; 32]);
 
-            let client_cfg = client_config(&suffix);
+            let client_cfg = client_config(&suffix, &context);
             let synced: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("client"),
                 resolver: SequenceResolver {
@@ -2078,7 +2161,7 @@ mod compact_variable_mmb {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -2139,7 +2222,7 @@ mod compact_variable_mmb {
     fn test_compact_source_reopen_rewind_regrow_and_stale_target() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-mmb-unj-source-{}", context.next_u64());
-            let source_cfg = client_config(&format!("{suffix}-source"));
+            let source_cfg = client_config(&format!("{suffix}-source"), &context);
             let mut source = ClientDb::init(context.child("source_init"), source_cfg.clone())
                 .await
                 .unwrap();
@@ -2152,19 +2235,19 @@ mod compact_variable_mmb {
                 .merkleize(&source, Some(metadata1.clone()), floor1);
             source.apply_batch(batch1).unwrap();
             source.sync().await.unwrap();
-            let target1 = source.current_target();
+            let target1 = source.target();
             drop(source);
 
             let source = ClientDb::init(context.child("source_reopen"), source_cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(source.current_target(), target1);
+            assert_eq!(source.target(), target1);
 
             let served1: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 1),
                 resolver: Arc::new(source),
                 target: target1.clone(),
-                db_config: client_config(&format!("{suffix}-serve1")),
+                db_config: client_config(&format!("{suffix}-serve1"), &context),
             })
             .await
             .unwrap();
@@ -2184,17 +2267,17 @@ mod compact_variable_mmb {
                 .merkleize(&source, Some(metadata2.clone()), floor2);
             source.apply_batch(batch2).unwrap();
             source.sync().await.unwrap();
-            let target2 = source.current_target();
+            let target2 = source.target();
             assert_ne!(target2, target1);
 
-            source.rewind().await.unwrap();
-            assert_eq!(source.current_target(), target1);
+            source.rewind(target1.leaf_count).await.unwrap();
+            assert_eq!(source.target(), target1);
 
             let served2: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 2),
                 resolver: Arc::new(source),
                 target: target1.clone(),
-                db_config: client_config(&format!("{suffix}-serve2")),
+                db_config: client_config(&format!("{suffix}-serve2"), &context),
             })
             .await
             .unwrap();
@@ -2206,7 +2289,7 @@ mod compact_variable_mmb {
             let mut source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(source.current_target(), target1);
+            assert_eq!(source.target(), target1);
             let metadata3 = vec![3, 3, 3];
             let floor3 = Location::new(2);
             let batch3 = source
@@ -2215,7 +2298,7 @@ mod compact_variable_mmb {
                 .merkleize(&source, Some(metadata3.clone()), floor3);
             source.apply_batch(batch3).unwrap();
             source.sync().await.unwrap();
-            let target3 = source.current_target();
+            let target3 = source.target();
             assert_ne!(target3, target1);
             assert_ne!(target3, target2);
 
@@ -2223,7 +2306,7 @@ mod compact_variable_mmb {
                 context: context.child("serve").with_attribute("index", 3),
                 resolver: Arc::new(source),
                 target: target3.clone(),
-                db_config: client_config(&format!("{suffix}-serve3")),
+                db_config: client_config(&format!("{suffix}-serve3"), &context),
             })
             .await
             .unwrap();
@@ -2237,12 +2320,12 @@ mod compact_variable_mmb {
                     .await
                     .unwrap(),
             );
-            assert_eq!(source.current_target(), target3);
+            assert_eq!(source.target(), target3);
             let stale_result: Result<ClientDb, _> = sync::compact::sync(sync::compact::Config {
                 context: context.child("stale_client"),
                 resolver: source.clone(),
                 target: target2.clone(),
-                db_config: client_config(&format!("{suffix}-stale")),
+                db_config: client_config(&format!("{suffix}-stale"), &context),
             })
             .await;
             assert!(matches!(

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -82,8 +82,14 @@ where
 {
     /// Returns a [CompactDb] initialized from `cfg`.
     pub async fn init(context: E, cfg: CompactConfig<C, S>) -> Result<Self, Error<F>> {
-        let merkle = crate::merkle::compact::Merkle::init(context, cfg.merkle).await?;
-        Self::init_from_merkle(merkle, cfg.commit_codec_config).await
+        let merkle = crate::merkle::compact::Merkle::new(cfg.strategy);
+        Self::init_from_merkle(
+            merkle,
+            context.child("witness"),
+            cfg.witness,
+            cfg.commit_codec_config,
+        )
+        .await
     }
 }
 
@@ -143,9 +149,14 @@ mod tests {
         context: deterministic::Context,
     ) -> CompactDb<F, deterministic::Context, Digest, Digest, Sha256, ((), ()), Sequential> {
         let cfg = CompactConfig {
-            merkle: crate::merkle::compact::Config {
-                partition: "compact-immutable-variable".into(),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: crate::journal::contiguous::variable::Config {
+                partition: "compact-immutable-variable-witness".into(),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: ((), ()),
         };
@@ -350,7 +361,7 @@ mod tests {
         db.apply_batch(retained).await.unwrap();
         compact.apply_batch(compact_batch).unwrap();
         db.commit().await.unwrap();
-        compact.commit().await.unwrap();
+        compact.sync().await.unwrap();
 
         assert_eq!(db.root(), compact.root());
         assert_eq!(compact.get_metadata(), Some(metadata));

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -1,27 +1,31 @@
-//! A keyless authenticated db that does not retain historical operations after sync.
+//! A keyless authenticated db that discards historical operations, retaining only a
+//! per-sync witness: the state required to rewind and to serve compact sync.
 //!
 //! Mirrors the API of [`crate::qmdb::keyless::Keyless`] (`new_batch -> merkleize ->
 //! apply_batch -> sync`, pipelined batch chains, `StaleBatch` validation) but is backed by
 //! the peak-only [`crate::merkle::compact`]. Because history is discarded, there are no
 //! `get` / `proof` / `bounds` methods; use the full variant if you need them.
 //!
-//! # Compact serving witness
+//! # Witness journal
 //!
-//! On every durable sync, this db persists the encoded last-commit operation together with its
-//! inclusion proof against the current root. Reopen and rewind re-verify that proof; corruption
-//! surfaces as [`Error::DataCorrupted`]. This authenticated witness is what lets compact nodes
-//! serve compact sync without retaining historical operations.
+//! On every durable sync, this db appends a complete snapshot of the committed state to its
+//! witness journal, so [`Db::rewind`] can restore any synced commit still retained there (history
+//! is bounded only by [`Db::prune`]). Reopen and rewind re-verify the persisted snapshot;
+//! corruption surfaces as [`Error::DataCorrupted`]. The witness (the last-commit operation plus
+//! its inclusion proof) is also what lets compact nodes serve compact sync without retaining
+//! historical operations.
 //!
 //! # Inactivity floor
 //!
-//! Commits still carry an inactivity floor, but only for wire-format compatibility with
+//! Commits carry an inactivity floor for wire-format compatibility with
 //! [`crate::qmdb::keyless::Keyless`]: the root is computed over the encoded operation
 //! sequence, and that sequence must include the same floor to produce the same root as the
-//! full variant. Here the floor has no effect on pruning or snapshot rebuilding. All
-//! historical in-memory state is discarded on every `sync`.
+//! full variant. The floor has no effect on pruning or snapshot rebuilding here; all
+//! historical in-memory state is discarded on every sync.
 
 use super::operation::Operation;
 use crate::{
+    journal::contiguous::variable::Config as JournalConfig,
     merkle::{batch, compact as compact_merkle, Family, Location, Proof},
     qmdb::{
         self,
@@ -29,7 +33,7 @@ use crate::{
         batch_chain::{self, Bounds},
         compact::{
             batch as compact_batch,
-            witness::{self, ServeState},
+            witness::{self, Witness},
         },
         sync::compact as compact_sync,
         Error,
@@ -44,14 +48,23 @@ use std::sync::{Arc, Weak};
 /// Configuration for a compact keyless authenticated db.
 #[derive(Clone)]
 pub struct Config<C, S: Strategy> {
-    /// Configuration for the backing compact Merkle structure.
-    pub merkle: compact_merkle::Config<S>,
+    /// Strategy used to parallelize merkleization.
+    pub strategy: S,
+
+    /// Configuration for the journal that persists the compact-sync witness. Its `codec_config` is
+    /// ignored; the witness entry codec configuration is supplied internally because the entry
+    /// type and its decode bounds are private to the witness module.
+    pub witness: JournalConfig<()>,
 
     /// Codec config used to decode the persisted last commit operation on reopen.
+    ///
+    /// Committed metadata must round-trip under this config: a commit whose encoded operation
+    /// does not decode under it fails on the next reopen.
     pub commit_codec_config: C,
 }
 
-/// A keyless authenticated db that does not retain historical operations after sync.
+/// A keyless authenticated db that discards historical operations, retaining only a
+/// per-sync witness: the state required to rewind and to serve compact sync.
 pub struct Db<F, E, V, H, C, S: Strategy>
 where
     F: Family,
@@ -62,17 +75,15 @@ where
     Operation<F, V>: Read<Cfg = C>,
     C: Clone + Send + Sync + 'static,
 {
-    merkle: compact_merkle::Merkle<F, E, H::Digest, S>,
+    merkle: compact_merkle::Merkle<F, H::Digest, S>,
     last_commit_loc: Location<F>,
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
     commit_codec_config: C,
-    /// Cache of the last durably persisted compact witness.
-    ///
-    /// This cache is rebuilt from persisted witness bytes on reopen/rewind and refreshed on
-    /// [`Self::sync`]. It intentionally does not track unsynced in-memory mutations, so compact
-    /// serving never advertises state that has not been durably persisted.
-    witness: witness::Cache<F, H::Digest>,
+    /// Durable witness history: a journal with one entry per sync, plus a cache of the tip
+    /// witness used to serve compact sync. The cache tracks the durable tip, not unsynced
+    /// in-memory mutations.
+    witness: witness::Store<E, F, H::Digest>,
 }
 
 type CompactStateResult<F, V, D> =
@@ -194,7 +205,7 @@ where
         ops.push(Operation::Commit(metadata.clone(), inactivity_floor));
 
         let total_size = self.base_size + ops.len() as u64;
-        let merkle = compact_batch::merkleize_ops::<F, E, H, S, _>(
+        let merkle = compact_batch::merkleize_ops::<F, H, S, _>(
             &db.merkle,
             self.merkle_batch,
             ops.as_slice(),
@@ -251,27 +262,18 @@ where
             .to_vec()
     }
 
-    async fn load_active_witness(
-        merkle: &compact_merkle::Merkle<F, E, H::Digest, S>,
-        commit_codec_config: &C,
-    ) -> Result<(ServeState<F, H::Digest>, Operation<F, V>), Error<F>> {
-        witness::load_active_witness::<F, E, H, S, _, Operation<F, V>, _>(
-            merkle,
-            commit_codec_config,
-            Operation::has_floor,
-        )
-        .await
-    }
-
     /// Build a compact db handle from already-verified compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
-    /// supplied witness/root pair. This seeds the in-memory witness cache from that verified witness
-    /// but does not itself persist anything; persistence happens only after the caller finishes the
-    /// root check for the reconstructed db.
+    /// supplied witness/root pair. Nothing is written to disk until the first [`Self::sync`],
+    /// which replaces the journal's previous contents with the imported witness; abandoning the
+    /// handle before then leaves the prior state intact, and rewind/prune are rejected until it
+    /// runs. A crash during that first sync can leave the journal empty, in which case
+    /// reopening yields a fresh db and the caller must re-sync.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn init_from_verified_state(
-        merkle: compact_merkle::Merkle<F, E, H::Digest, S>,
+        merkle: compact_merkle::Merkle<F, H::Digest, S>,
+        journal: witness::Journal<E, F, H::Digest>,
         commit_codec_config: C,
         last_commit_metadata: Option<V::Value>,
         inactivity_floor_loc: Location<F>,
@@ -280,7 +282,7 @@ where
         last_commit_proof: Proof<F, H::Digest>,
         pinned_nodes: Vec<H::Digest>,
     ) -> Result<Self, Error<F>> {
-        let (last_commit_loc, witness) = witness::witness_from_authenticated_state(
+        let imported = witness::witness_from_authenticated_state(
             &merkle,
             root,
             inactivity_floor_loc,
@@ -289,61 +291,58 @@ where
             pinned_nodes,
         )?;
 
+        let last_commit_loc = Location::new(*merkle.leaves() - 1);
+        let witness = witness::Store::new_import(journal, imported);
         Ok(Self {
             merkle,
             last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
-            witness: witness::Cache::new(witness),
+            witness,
         })
     }
 
-    /// Open a compact db from persisted compact state and rebuild its witness cache.
+    /// Open a compact db from persisted compact state and rebuild its witness store.
     ///
     /// On first open, this bootstraps the initial commit and its witness so every later reopen and
-    /// rewind can assume "the active slot has a complete compact witness".
+    /// rewind can assume the journal tip is a complete compact witness.
     pub(crate) async fn init_from_merkle(
-        mut merkle: compact_merkle::Merkle<F, E, H::Digest, S>,
+        mut merkle: compact_merkle::Merkle<F, H::Digest, S>,
+        witness_context: E,
+        witness_config: JournalConfig<()>,
         commit_codec_config: C,
     ) -> Result<Self, Error<F>>
     where
         F: Family,
         Operation<F, V>: Read<Cfg = C>,
     {
-        // Bootstrap: append an initial Commit(None, 0) on first open. This establishes the
-        // invariant that every merkleized batch ends with a Commit op, so `last_commit_loc =
-        // leaves - 1` is always correct without replaying the log (which we can't, since we
-        // don't retain it).
-        //
-        // We also persist that initial commit's witness immediately so every later reopen or
-        // rewind can uniformly assume "the active slot has a current tip witness".
-        if merkle.leaves() == 0 {
-            witness::bootstrap_initial_commit::<F, E, H, S>(
-                &mut merkle,
-                Operation::<F, V>::Commit(None, Location::new(0))
-                    .encode()
-                    .to_vec(),
-            )
-            .await?;
-        }
-
-        let (witness, last_commit_op) =
-            Self::load_active_witness(&merkle, &commit_codec_config).await?;
+        // Bootstrap: append an initial Commit(None, 0) on first open.
+        let journal =
+            witness::open_journal::<E, F, H::Digest>(witness_context, witness_config).await?;
+        let (witness, last_commit_op) = witness::init::<E, F, H, S, Operation<F, V>>(
+            journal,
+            &mut merkle,
+            &commit_codec_config,
+            Operation::<F, V>::Commit(None, Location::new(0))
+                .encode()
+                .to_vec(),
+            Operation::has_floor,
+        )
+        .await?;
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
+        let last_commit_loc = Location::new(*witness.with(|w| w.leaf_count) - 1);
 
-        Self::init_from_verified_state(
+        Ok(Self {
             merkle,
-            commit_codec_config,
+            last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
-            witness.root,
-            witness.last_commit_op_bytes,
-            witness.last_commit_proof,
-            witness.pinned_nodes,
-        )
+            commit_codec_config,
+            witness,
+        })
     }
 
     /// Return the root of the db.
@@ -388,18 +387,14 @@ where
 
     /// Return the compact-sync target described by the current witness.
     ///
-    /// This reflects the last state for which both frontier and witness were durably captured,
-    /// which may lag behind live in-memory mutations until [`Self::sync`] is called.
-    pub fn current_target(&self) -> compact_sync::Target<F, H::Digest> {
-        self.witness.with(ServeState::target)
+    /// This reflects the last durably persisted commit, which may lag behind live in-memory
+    /// mutations until [`Self::sync`] is called.
+    pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
+        self.witness.with(Witness::target)
     }
 
     /// Return the compact-sync state for `target`, or a stale-target error if the source's
     /// current witness no longer matches.
-    ///
-    /// The witness lock is held only long enough to verify the requested target and snapshot
-    /// the bytes, proof, and pinned nodes needed for [`compact_sync::State`]. Decoding the
-    /// commit operation runs outside the lock so concurrent readers do not contend on it.
     pub(crate) fn compact_state(
         &self,
         target: compact_sync::Target<F, H::Digest>,
@@ -407,6 +402,8 @@ where
     where
         Operation<F, V>: Read<Cfg = C>,
     {
+        // Hold the witness lock only long enough to verify the requested target and snapshot the
+        // entry; decode outside it so concurrent readers do not contend.
         let (op_bytes, last_commit_proof, pinned_nodes, leaf_count) = self.witness.with(|w| {
             if target.root != w.root || target.leaf_count != w.leaf_count {
                 return Err(compact_sync::ServeError::StaleTarget {
@@ -444,7 +441,7 @@ where
         UnmerkleizedBatch::new(self, committed_size)
     }
 
-    /// Create an owned merkleized batch representing the current committed state.
+    /// Create an owned merkleized batch representing the current applied state.
     pub fn to_batch(&self) -> Arc<MerkleizedBatch<F, H::Digest, V, S>>
     where
         F: Family,
@@ -468,15 +465,15 @@ where
     /// Apply a merkleized batch to the database.
     ///
     /// Returns the range of locations written. The state is updated in memory only; call
-    /// [`Self::sync`] or [`Self::commit`] to persist.
+    /// [`Self::sync`] to persist.
     ///
     /// # Errors
     ///
     /// - [`Error::StaleBatch`] if the batch was created from a stale DB state.
-    /// - [`Error::FloorRegressed`] if any unapplied commit's floor is below the running floor
-    ///   (walking ancestors oldest-first, then the tip).
-    /// - [`Error::FloorBeyondSize`] if any unapplied commit's floor exceeds its own commit
-    ///   location.
+    /// - [`Error::FloorRegressed`] if any commit in the chain declares a floor below the
+    ///   previous commit's floor.
+    /// - [`Error::FloorBeyondSize`] if any commit in the chain declares a floor beyond its own
+    ///   commit location.
     pub fn apply_batch(
         &mut self,
         batch: Arc<MerkleizedBatch<F, H::Digest, V, S>>,
@@ -495,79 +492,59 @@ where
     }
 
     /// Durably persist the current db state to disk.
-    ///
-    /// This is the point at which in-memory mutations become servable via compact sync. The compact
-    /// Merkle frontier and last-commit witness are written into the same slot, reusing the cached
-    /// witness when the current state has already been persisted.
     pub async fn sync(&self) -> Result<(), Error<F>> {
-        witness::persist_witness::<F, E, H, S>(
-            &self.merkle,
-            &self.witness,
-            self.last_commit_loc,
-            self.inactivity_floor_loc,
-            Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc),
-        )
-        .await
+        self.witness
+            .persist::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
+                Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
+            })
+            .await
     }
 
-    /// Durably persist the current db state to disk (alias for [`Self::sync`]).
-    pub async fn commit(&self) -> Result<(), Error<F>>
-    where
-        F: Family,
-    {
-        self.sync().await
-    }
-
-    /// Restore the state as of the sync before the most recent one.
-    ///
-    /// Discards any uncommitted batches, flips the db back to the previous persisted state,
-    /// and reloads the cached commit metadata and inactivity floor from that slot.
-    ///
-    /// Callers must drop any [`Arc<MerkleizedBatch>`] merkleized against state that this rewind
-    /// discards. [`Self::apply_batch`] validates batches by size only: a discarded-branch batch
-    /// will usually trip the size-mismatch check, but if the db later regrows to the same size
-    /// along an alternate branch, the stale batch becomes admissible again and applying it will
-    /// corrupt the committed root. Batches merkleized against the state this rewind restores to
-    /// (for example, a batch built before an advance that is then discarded by the rewind)
-    /// remain compatible and apply cleanly.
+    /// Rewind the db to the synced commit with exactly `target` operations, discarding any
+    /// uncommitted batches and any later commits. The rewind is synced before this method
+    /// returns.
     ///
     /// # Errors
     ///
     /// Returns [`crate::merkle::Error::RewindBeyondHistory`] (wrapped as [`Error::Merkle`]) if
-    /// no prior state exists — either no sync has occurred yet, or the previous state was
-    /// already consumed by a rewind with no intervening sync.
-    ///
-    /// Any error from this method is fatal for this handle. The Merkle layer may have already
-    /// flipped its generation pointer and rebuilt its in-memory state before a later step (e.g.
-    /// reloading the cached commit metadata or inactivity floor) fails, leaving this `Db`'s
-    /// in-memory fields out of sync with the persisted slot. Callers must drop this handle
-    /// after any `Err` from `rewind` and reopen from storage.
-    pub async fn rewind(&mut self) -> Result<(), Error<F>>
+    /// no retained commit has exactly `target` operations (never synced, or pruned). Any error
+    /// is fatal for this handle: drop it and reopen from storage.
+    pub async fn rewind(&mut self, target: Location<F>) -> Result<(), Error<F>>
     where
         F: Family,
     {
-        self.merkle.rewind().await?;
-        // Reload the witness from the reverted slot as well, so compact serving stays aligned with
-        // the same frontier/root that `rewind` restored.
-        let (witness, last_commit_op) =
-            Self::load_active_witness(&self.merkle, &self.commit_codec_config).await?;
+        // Fast path: already exactly at `target` with no uncommitted state.
+        if self.size() == target && self.witness.with(|w| w.leaf_count) == target {
+            return Ok(());
+        }
+
+        let last_commit_op = self
+            .witness
+            .rewind::<H, S, Operation<F, V>>(
+                &self.merkle,
+                target,
+                &self.commit_codec_config,
+                Operation::has_floor,
+            )
+            .await?;
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
-        self.last_commit_loc = Location::new(*witness.leaf_count - 1);
-        self.witness.replace(witness);
+        self.last_commit_loc = Location::new(*target - 1);
         Ok(())
+    }
+
+    /// Drop witnesses for commits with fewer than `pruning_boundary` operations.
+    pub async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
+        self.witness.prune(pruning_boundary).await
     }
 
     /// Destroy all persisted state associated with this database.
     pub async fn destroy(self) -> Result<(), Error<F>> {
-        self.merkle.destroy().await.map_err(Into::into)
-    }
-
-    pub(crate) async fn persist_cached_witness(&self) -> Result<(), Error<F>> {
-        witness::persist_cached_witness::<F, E, H, S>(&self.merkle, &self.witness).await
+        self.witness.destroy().await?;
+        Ok(())
     }
 }
 
@@ -575,65 +552,52 @@ where
 mod tests {
     use super::*;
     use crate::{
+        journal::contiguous::variable,
         merkle::mmr,
-        metadata::{Config as MConfig, Metadata},
-        qmdb::any::value::FixedEncoding,
+        qmdb::{any::value::FixedEncoding, compact::witness},
     };
-    use commonware_cryptography::Sha256;
+    use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_parallel::Sequential;
-    use commonware_runtime::{deterministic, Runner as _, Supervisor as _};
-    use commonware_utils::sequence::{prefixed_u64::U64 as MetadataKey, U64};
+    use commonware_runtime::{
+        buffer::paged::CacheRef, deterministic, BufferPooler, Runner as _, Supervisor as _,
+    };
+    use commonware_utils::{sequence::U64, NZUsize, NZU16, NZU64};
+    use std::num::{NonZeroU16, NonZeroUsize};
 
     type TestDb<F> = Db<F, deterministic::Context, FixedEncoding<U64>, Sha256, (), Sequential>;
 
+    const WITNESS_PAGE_SIZE: NonZeroU16 = NZU16!(77);
+    const WITNESS_PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
+
+    fn witness_config(partition: &str, pooler: &impl BufferPooler) -> variable::Config<()> {
+        variable::Config {
+            partition: format!("{partition}-witness"),
+            items_per_section: NZU64!(64),
+            compression: None,
+            codec_config: (),
+            page_cache: CacheRef::from_pooler(pooler, WITNESS_PAGE_SIZE, WITNESS_PAGE_CACHE_SIZE),
+            write_buffer: NZUsize!(1024),
+        }
+    }
+
     async fn open_db<F: Family>(context: deterministic::Context, partition: &str) -> TestDb<F> {
-        let merkle = crate::merkle::compact::Merkle::init(
-            context,
-            crate::merkle::compact::Config {
-                partition: partition.into(),
-                strategy: Sequential,
-            },
-        )
-        .await
-        .unwrap();
-        Db::init_from_merkle(merkle, ()).await.unwrap()
+        let witness_cfg = witness_config(partition, &context);
+        let merkle = crate::merkle::compact::Merkle::new(Sequential);
+        Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+            .await
+            .unwrap()
     }
 
-    async fn tamper_metadata_key(
+    /// Open the persisted witness journal directly so tests can corrupt the tip entry.
+    async fn open_witness_journal(
         context: deterministic::Context,
         partition: &str,
-        key: MetadataKey,
-    ) {
-        let mut metadata = open_metadata(context, partition).await;
-        let mut bytes = metadata.get(&key).cloned().expect("metadata entry missing");
-        *bytes.last_mut().expect("metadata entry empty") ^= 0x01;
-        metadata.put_sync(key, bytes).await.unwrap();
-    }
-
-    async fn open_metadata(
-        context: deterministic::Context,
-        partition: &str,
-    ) -> Metadata<deterministic::Context, MetadataKey, Vec<u8>> {
-        Metadata::<_, MetadataKey, Vec<u8>>::init(
-            context.child("meta_write"),
-            MConfig {
-                partition: partition.into(),
-                codec_config: ((0..).into(), ()),
-            },
-        )
-        .await
-        .unwrap()
-    }
-
-    async fn overwrite_metadata_key(
-        context: deterministic::Context,
-        partition: &str,
-        key: MetadataKey,
-        bytes: Vec<u8>,
-    ) {
-        let mut metadata = open_metadata(context, partition).await;
-        metadata.put_sync(key, bytes).await.unwrap();
+    ) -> witness::Journal<deterministic::Context, mmr::Family, Digest> {
+        let cfg = witness_config(partition, &context);
+        witness::open_journal::<_, mmr::Family, Digest>(context, cfg)
+            .await
+            .unwrap()
     }
 
     #[test_traced("INFO")]
@@ -663,7 +627,7 @@ mod tests {
         });
     }
 
-    /// Regression: `to_batch()` must snapshot the live in-memory state, not the durable serve
+    /// Regression: `to_batch()` must snapshot the live in-memory state, not the lagging witness
     /// cache.
     #[test_traced("INFO")]
     fn test_compact_to_batch_reflects_live_state() {
@@ -686,7 +650,7 @@ mod tests {
             ))
             .unwrap();
 
-            // Leave the durable serve cache behind the live Merkle state.
+            // Leave the witness cache behind the live Merkle state.
             let live_root = db.root();
             assert_ne!(
                 live_root, pre_apply_root,
@@ -697,7 +661,7 @@ mod tests {
             assert_eq!(
                 snapshot.root(),
                 live_root,
-                "to_batch().root() must match the live db.root() even before sync/commit"
+                "to_batch().root() must match the live db.root() even before sync"
             );
 
             db.destroy().await.unwrap();
@@ -781,7 +745,7 @@ mod tests {
 
             db.apply_batch(parent).unwrap();
             db.apply_batch(child).unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
 
             assert_eq!(db.root(), expected_root);
 
@@ -835,8 +799,9 @@ mod tests {
                     .merkleize(&db, Some(meta1.clone()), floor1),
             )
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             let root_after_first = db.root();
+            let size_after_first = db.size();
 
             let v2 = U64::new(2);
             let meta2 = U64::new(22);
@@ -847,11 +812,11 @@ mod tests {
                     .merkleize(&db, Some(meta2.clone()), floor2),
             )
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             assert_eq!(db.get_metadata(), Some(meta2));
             assert_eq!(db.inactivity_floor_loc(), floor2);
 
-            db.rewind().await.unwrap();
+            db.rewind(size_after_first).await.unwrap();
             assert_eq!(db.root(), root_after_first);
             assert_eq!(db.get_metadata(), Some(meta1));
             assert_eq!(db.inactivity_floor_loc(), floor1);
@@ -877,8 +842,9 @@ mod tests {
                     floor1,
                 ))
                 .unwrap();
-                db.commit().await.unwrap();
+                db.sync().await.unwrap();
                 let root = db.root();
+                let size_after_first = db.size();
 
                 db.apply_batch(db.new_batch().append(U64::new(2)).merkleize(
                     &db,
@@ -886,9 +852,9 @@ mod tests {
                     floor2,
                 ))
                 .unwrap();
-                db.commit().await.unwrap();
+                db.sync().await.unwrap();
 
-                db.rewind().await.unwrap();
+                db.rewind(size_after_first).await.unwrap();
                 root
             };
 
@@ -912,28 +878,28 @@ mod tests {
                 Location::new(1),
             ))
             .unwrap();
-            db.commit().await.unwrap();
-            let slot = db.merkle.active_slot();
+            db.sync().await.unwrap();
             drop(db);
 
-            tamper_metadata_key(
-                context.child("tamper"),
-                partition,
-                crate::qmdb::compact::witness::last_commit_proof_key(slot),
+            // Corrupt the persisted proof so it no longer verifies against the stored root.
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
+            let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
+            if let Some(digest) = proof.digests.first_mut() {
+                *digest = Sha256::fill(0xff);
+            } else {
+                proof.leaves = Location::new(*proof.leaves + 1);
+            }
+            witness::tests::overwrite_tip(&journal, op_bytes, proof, pinned_nodes).await;
+            drop(journal);
+
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen_witness"),
+                witness_config(partition, &context),
+                (),
             )
             .await;
-
-            let merkle: crate::merkle::compact::Merkle<mmr::Family, _, _, Sequential> =
-                crate::merkle::compact::Merkle::init(
-                    context.child("reopen"),
-                    crate::merkle::compact::Config {
-                        partition: partition.into(),
-                        strategy: Sequential,
-                    },
-                )
-                .await
-                .unwrap();
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(merkle, ()).await;
             assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
         });
     }
@@ -949,35 +915,30 @@ mod tests {
                 Location::new(1),
             ))
             .unwrap();
-            db.commit().await.unwrap();
-            let slot = db.merkle.active_slot();
+            db.sync().await.unwrap();
             drop(db);
             let oversized_floor = Location::new(10);
 
-            overwrite_metadata_key(
-                context.child("tamper"),
-                partition,
-                crate::qmdb::compact::witness::last_commit_op_key(slot),
-                Operation::<mmr::Family, FixedEncoding<U64>>::Commit(
-                    Some(U64::new(11)),
-                    oversized_floor,
-                )
-                .encode()
-                .to_vec(),
+            // Overwrite the persisted commit op with a floor beyond its own commit location.
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
+            let (_, proof, pinned_nodes) = witness::tests::tip(&journal).await;
+            let bad_op = Operation::<mmr::Family, FixedEncoding<U64>>::Commit(
+                Some(U64::new(11)),
+                oversized_floor,
+            )
+            .encode()
+            .to_vec();
+            witness::tests::overwrite_tip(&journal, bad_op, proof, pinned_nodes).await;
+            drop(journal);
+
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen_witness"),
+                witness_config(partition, &context),
+                (),
             )
             .await;
-
-            let merkle: crate::merkle::compact::Merkle<mmr::Family, _, _, Sequential> =
-                crate::merkle::compact::Merkle::init(
-                    context.child("reopen"),
-                    crate::merkle::compact::Config {
-                        partition: partition.into(),
-                        strategy: Sequential,
-                    },
-                )
-                .await
-                .unwrap();
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(merkle, ()).await;
             assert!(matches!(
                 reopened,
                 Err(Error::DataCorrupted("invalid compact witness"))
@@ -986,13 +947,219 @@ mod tests {
     }
 
     #[test_traced("INFO")]
+    fn test_compact_reopen_rejects_tampered_pinned_nodes() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "keyless-pins-tamper";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            db.apply_batch(db.new_batch().append(U64::new(7)).merkleize(
+                &db,
+                Some(U64::new(11)),
+                Location::new(1),
+            ))
+            .unwrap();
+            db.sync().await.unwrap();
+            drop(db);
+
+            // Corrupt one pinned frontier node: the root recomputed from the rebuilt Merkle no
+            // longer matches the proof stored in the same entry.
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
+            let (op_bytes, proof, mut pinned_nodes) = witness::tests::tip(&journal).await;
+            pinned_nodes[0] = Sha256::fill(0xff);
+            witness::tests::overwrite_tip(&journal, op_bytes, proof, pinned_nodes).await;
+            drop(journal);
+
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen_witness"),
+                witness_config(partition, &context),
+                (),
+            )
+            .await;
+            assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_to_current_is_noop() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-rewind-noop").await;
+            db.apply_batch(db.new_batch().append(U64::new(1)).merkleize(
+                &db,
+                Some(U64::new(11)),
+                Location::new(0),
+            ))
+            .unwrap();
+            db.sync().await.unwrap();
+            let root = db.root();
+            let size = db.size();
+
+            db.rewind(size).await.unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.size(), size);
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_prune_past_tip_keeps_tip() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "keyless-prune-past-tip";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            db.apply_batch(db.new_batch().append(U64::new(1)).merkleize(
+                &db,
+                Some(U64::new(11)),
+                Location::new(0),
+            ))
+            .unwrap();
+            db.sync().await.unwrap();
+            let target = db.target();
+
+            // Prune with a boundary beyond the tip: the tip entry must survive.
+            db.prune(Location::new(*db.size() + 100)).await.unwrap();
+            assert_eq!(db.target(), target);
+            drop(db);
+
+            let reopened = open_db::<mmr::Family>(context.child("reopen"), partition).await;
+            assert_eq!(reopened.target(), target);
+            reopened.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
     fn test_compact_rewind_beyond_history() {
         deterministic::Runner::default().start(|context| async move {
             let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-rewind-beyond").await;
+            // The bootstrap commit is the oldest retained state (one leaf); no commit with zero
+            // operations exists to rewind to.
             assert!(matches!(
-                db.rewind().await,
+                db.rewind(Location::new(0)).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
+            // A target past the tip is not a commit either.
+            assert!(matches!(
+                db.rewind(Location::new(*db.size() + 100)).await,
+                Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
+            ));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A witness entry appended but not synced (a commit interrupted before its journal sync)
+    /// must be dropped on reopen, recovering the last synced commit.
+    #[test_traced("INFO")]
+    fn test_compact_reopen_drops_unsynced_witness() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "keyless-witness-unsynced";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+
+            // Commit state A.
+            db.apply_batch(db.new_batch().append(U64::new(1)).merkleize(
+                &db,
+                Some(U64::new(11)),
+                Location::new(1),
+            ))
+            .unwrap();
+            db.sync().await.unwrap();
+            let target_a = db.target();
+            drop(db);
+
+            // Simulate the crash window: append an entry ahead of the tip without syncing it,
+            // then drop the journal. The unsynced tail must not survive reopen.
+            let journal = open_witness_journal(context.child("crash"), partition).await;
+            let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
+            proof.leaves = Location::new(*proof.leaves + 2);
+            witness::tests::append_unsynced(&journal, op_bytes, proof, pinned_nodes).await;
+            drop(journal);
+
+            // Reopen must drop the unsynced entry and recover state A.
+            let reopened = open_db::<mmr::Family>(context.child("reopen"), partition).await;
+            assert_eq!(reopened.target(), target_a);
+            reopened.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_multiple_commits() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "keyless-rewind-multi";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+
+            // Commit A, B, C, recording the state after A.
+            db.apply_batch(db.new_batch().append(U64::new(1)).merkleize(
+                &db,
+                Some(U64::new(11)),
+                Location::new(0),
+            ))
+            .unwrap();
+            db.sync().await.unwrap();
+            let root_a = db.root();
+            let size_a = db.size();
+            let target_a = db.target();
+
+            for i in [2u64, 3] {
+                db.apply_batch(db.new_batch().append(U64::new(i)).merkleize(
+                    &db,
+                    Some(U64::new(i * 11)),
+                    Location::new(0),
+                ))
+                .unwrap();
+                db.sync().await.unwrap();
+            }
+            assert_ne!(db.root(), root_a);
+
+            // Rewind two commits in one call.
+            db.rewind(size_a).await.unwrap();
+            assert_eq!(db.root(), root_a);
+            assert_eq!(db.size(), size_a);
+            assert_eq!(db.get_metadata(), Some(U64::new(11)));
+            assert_eq!(db.target(), target_a);
+            drop(db);
+
+            // The rewind is durable: reopen recovers state A.
+            let db = open_db::<mmr::Family>(context.child("reopen"), partition).await;
+            assert_eq!(db.root(), root_a);
+            assert_eq!(db.target(), target_a);
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_prune_then_rewind() {
+        deterministic::Runner::default().start(|context| async move {
+            // One entry per section so pruning takes effect at entry granularity (pruning is
+            // section-aligned and never drops a partial section).
+            let mut witness_cfg = witness_config("keyless-prune-rewind", &context);
+            witness_cfg.items_per_section = NZU64!(1);
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let mut db: TestDb<mmr::Family> =
+                Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+                    .await
+                    .unwrap();
+
+            // Commit A, B, C.
+            let mut sizes = Vec::new();
+            for i in [1u64, 2, 3] {
+                db.apply_batch(db.new_batch().append(U64::new(i)).merkleize(
+                    &db,
+                    Some(U64::new(i * 11)),
+                    Location::new(0),
+                ))
+                .unwrap();
+                db.sync().await.unwrap();
+                sizes.push(db.size());
+            }
+
+            // Prune history below B: rewinding to B still works, rewinding to A does not.
+            db.prune(sizes[1]).await.unwrap();
+            assert!(matches!(
+                db.rewind(sizes[0]).await,
+                Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
+            ));
+            db.rewind(sizes[1]).await.unwrap();
+            assert_eq!(db.size(), sizes[1]);
+            assert_eq!(db.get_metadata(), Some(U64::new(22)));
+
             db.destroy().await.unwrap();
         });
     }
@@ -1010,7 +1177,8 @@ mod tests {
                 Location::new(0),
             ))
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
+            let size_after_first = db.size();
 
             // Merkleize a batch against the post-commit-A state.
             let held = db
@@ -1025,8 +1193,8 @@ mod tests {
                 Location::new(0),
             ))
             .unwrap();
-            db.commit().await.unwrap();
-            db.rewind().await.unwrap();
+            db.sync().await.unwrap();
+            db.rewind(size_after_first).await.unwrap();
 
             // The rewind restored the state that `held` was merkleized against, so it still
             // matches the Merkle size and applies cleanly.
@@ -1049,14 +1217,14 @@ mod tests {
                     .merkleize(&db, Some(U64::new(11)), Location::new(0)),
             )
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             let root_after_first = db.root();
             assert_eq!(db.size(), Location::new(4));
 
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_after_first);
-            assert_eq!(db.current_target().root, db.root());
+            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -1076,7 +1244,7 @@ mod tests {
                         .merkleize(&db, Some(U64::new(11)), Location::new(0)),
                 )
                 .unwrap();
-                db.commit().await.unwrap();
+                db.sync().await.unwrap();
                 let root = db.root();
                 assert_eq!(db.size(), Location::new(4));
                 root
@@ -1086,10 +1254,10 @@ mod tests {
             assert_eq!(db.root(), root_before_drop);
             assert_eq!(db.size(), Location::new(4));
 
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_before_drop);
-            assert_eq!(db.current_target().root, db.root());
+            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -1108,7 +1276,7 @@ mod tests {
                     .merkleize(&db, Some(U64::new(11)), Location::new(0)),
             )
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             let root_after_first = db.root();
 
             db.apply_batch(db.new_batch().append(U64::new(3)).merkleize(
@@ -1117,16 +1285,16 @@ mod tests {
                 Location::new(1),
             ))
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
 
-            db.rewind().await.unwrap();
+            db.rewind(Location::new(4)).await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_after_first);
 
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_after_first);
-            assert_eq!(db.current_target().root, db.root());
+            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -1144,7 +1312,8 @@ mod tests {
                 Location::new(0),
             ))
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
+            let size_after_first = db.size();
 
             db.apply_batch(db.new_batch().append(U64::new(2)).merkleize(
                 &db,
@@ -1152,7 +1321,7 @@ mod tests {
                 Location::new(0),
             ))
             .unwrap();
-            db.commit().await.unwrap();
+            db.sync().await.unwrap();
 
             // Merkleize a batch against the post-commit-B state, which the rewind will discard.
             let held = db
@@ -1160,7 +1329,7 @@ mod tests {
                 .append(U64::new(3))
                 .merkleize(&db, None, Location::new(0));
 
-            db.rewind().await.unwrap();
+            db.rewind(size_after_first).await.unwrap();
 
             // After rewind, mem.size reflects post-commit-A, but the held batch starts after
             // post-commit-B. Apply must be rejected with StaleBatch.
@@ -1174,10 +1343,10 @@ mod tests {
     }
 
     #[test_traced("INFO")]
-    fn test_witness_state_reports_cached_commit_corruption() {
+    fn test_compact_state_reports_cached_commit_corruption() {
         deterministic::Runner::default().start(|context| async move {
             let db = open_db::<mmr::Family>(context.child("db"), "keyless-serve-corruption").await;
-            let target = db.current_target();
+            let target = db.target();
             db.witness
                 .mutate(|witness| witness.last_commit_op_bytes.clear());
 

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -292,7 +292,7 @@ where
         )?;
 
         let last_commit_loc = Location::new(*merkle.leaves() - 1);
-        let witness = witness::Store::new_import(journal, imported);
+        let witness = witness::Store::from_import(journal, imported);
         Ok(Self {
             merkle,
             last_commit_loc,

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -57,9 +57,6 @@ pub struct Config<C, S: Strategy> {
     pub witness: JournalConfig<()>,
 
     /// Codec config used to decode the persisted last commit operation on reopen.
-    ///
-    /// Committed metadata must round-trip under this config: a commit whose encoded operation
-    /// does not decode under it fails on the next reopen.
     pub commit_codec_config: C,
 }
 
@@ -80,9 +77,6 @@ where
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
     commit_codec_config: C,
-    /// Durable witness history: a journal with one entry per sync, plus a cache of the tip
-    /// witness used to serve compact sync. The cache tracks the durable tip, not unsynced
-    /// in-memory mutations.
     witness: witness::Store<E, F, H::Digest>,
 }
 
@@ -265,11 +259,9 @@ where
     /// Build a compact db handle from already-verified compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
-    /// supplied witness/root pair. Nothing is written to disk until the first [`Self::sync`],
-    /// which replaces the journal's previous contents with the imported witness; abandoning the
-    /// handle before then leaves the prior state intact, and rewind/prune are rejected until it
-    /// runs. A crash during that first sync can leave the journal empty, in which case
-    /// reopening yields a fresh db and the caller must re-sync.
+    /// supplied witness/root pair. The import lives only in memory until the first
+    /// [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
+    /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn init_from_verified_state(
         merkle: compact_merkle::Merkle<F, H::Digest, S>,
@@ -753,11 +745,36 @@ mod tests {
         });
     }
 
+    #[test_traced("INFO")]
+    fn test_compact_floor_regressed() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db =
+                open_db::<mmr::Family>(context.child("db"), "keyless-floor-regressed").await;
+
+            let advance_floor = db.new_batch().append(U64::new(1));
+            let advance_floor = advance_floor.merkleize(&db, None, Location::new(1));
+            db.apply_batch(advance_floor).unwrap();
+
+            let regressed =
+                db.new_batch()
+                    .append(U64::new(2))
+                    .merkleize(&db, None, Location::new(0));
+
+            assert!(matches!(
+                db.apply_batch(regressed),
+                Err(Error::FloorRegressed(new, current))
+                    if new == Location::new(0) && current == Location::new(1)
+            ));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     // A chained batch whose tip floor is below its parent's floor must be rejected:
     // the parent's Commit participates in the per-commit monotonicity invariant even
     // before it is applied.
     #[test_traced("INFO")]
-    fn test_compact_ancestor_floor_regression_rejected() {
+    fn test_compact_ancestor_floor_regressed() {
         deterministic::Runner::default().start(|context| async move {
             let mut db =
                 open_db::<mmr::Family>(context.child("db"), "keyless-ancestor-floor-regressed")
@@ -1361,10 +1378,27 @@ mod tests {
         });
     }
 
+    #[test_traced("INFO")]
+    fn test_compact_floor_beyond_size() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-floor-beyond").await;
+
+            let batch = db.new_batch().merkleize(&db, None, Location::new(2));
+
+            assert!(matches!(
+                db.apply_batch(batch),
+                Err(Error::FloorBeyondSize(floor, tip))
+                    if floor == Location::new(2) && tip == Location::new(1)
+            ));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     // A chained batch whose ancestor's floor exceeds that ancestor's own commit location
     // must be rejected, identifying the ancestor's bound rather than the tip's.
     #[test_traced("INFO")]
-    fn test_compact_ancestor_floor_beyond_commit_loc_rejected() {
+    fn test_compact_ancestor_floor_beyond_size() {
         deterministic::Runner::default().start(|context| async move {
             let mut db =
                 open_db::<mmr::Family>(context.child("db"), "keyless-ancestor-floor-beyond").await;

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -277,26 +277,23 @@ where
                     last_commit_proof,
                 },
             root,
-            inactivity_floor: inactivity_floor_loc,
         } = validated;
         let last_commit_loc = Location::new(*leaf_count - 1);
-        let Operation::Commit(last_commit_metadata, op_floor) = last_commit_op else {
+        let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::UnexpectedData(last_commit_loc));
         };
-        if op_floor != inactivity_floor_loc {
-            return Err(Error::DataCorrupted("inactivity floor mismatch"));
-        }
 
         let merkle =
             compact_merkle::Merkle::from_compact_state(strategy, leaf_count, pinned_nodes.clone())?;
-        let imported = witness::witness_from_authenticated_state(
-            &merkle,
+        let imported = Witness {
             root,
-            inactivity_floor_loc,
-            Self::encode_commit_op(last_commit_metadata.clone(), inactivity_floor_loc),
-            last_commit_proof,
             pinned_nodes,
-        )?;
+            last_commit_op_bytes: Self::encode_commit_op(
+                last_commit_metadata.clone(),
+                inactivity_floor_loc,
+            ),
+            last_commit_proof,
+        };
 
         let witness = witness::Store::from_import(journal, imported);
         Ok(Self {
@@ -428,11 +425,6 @@ where
             .map_err(|_| {
                 compact_sync::ServeError::Database(Error::DataCorrupted("invalid commit operation"))
             })?;
-        if !matches!(&op, Operation::Commit(_, _)) {
-            return Err(compact_sync::ServeError::Database(Error::DataCorrupted(
-                "last operation was not a commit",
-            )));
-        }
         Ok(compact_sync::State {
             leaf_count,
             pinned_nodes,
@@ -1364,25 +1356,6 @@ mod tests {
             assert!(matches!(
                 db.apply_batch(held),
                 Err(Error::StaleBatch { .. })
-            ));
-
-            db.destroy().await.unwrap();
-        });
-    }
-
-    #[test_traced("INFO")]
-    fn test_compact_state_reports_cached_commit_corruption() {
-        deterministic::Runner::default().start(|context| async move {
-            let db = open_db::<mmr::Family>(context.child("db"), "keyless-serve-corruption").await;
-            let target = db.target();
-            db.witness
-                .mutate(|witness| witness.last_commit_op_bytes.clear());
-
-            assert!(matches!(
-                db.compact_state(target),
-                Err(compact_sync::ServeError::Database(Error::DataCorrupted(
-                    "invalid commit operation"
-                )))
             ));
 
             db.destroy().await.unwrap();

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -1,5 +1,5 @@
-//! A keyless authenticated db that discards historical operations, retaining only a
-//! per-sync witness: the state required to rewind and to serve compact sync.
+//! A keyless authenticated db that discards historical operations, retaining only a witness
+//! for each synced commit.
 //!
 //! Mirrors the API of [`crate::qmdb::keyless::Keyless`] (`new_batch -> merkleize ->
 //! apply_batch -> sync`, pipelined batch chains, `StaleBatch` validation) but is backed by
@@ -57,8 +57,8 @@ pub struct Config<C, S: Strategy> {
     pub commit_codec_config: C,
 }
 
-/// A keyless authenticated db that discards historical operations, retaining only a
-/// per-sync witness: the state required to rewind and to serve compact sync.
+/// A keyless authenticated db that discards historical operations, retaining only a witness
+/// for each synced commit.
 pub struct Db<F, E, V, H, C, S: Strategy>
 where
     F: Family,
@@ -920,6 +920,40 @@ mod tests {
             )
             .await;
             assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_reopen_rejects_interrupted_import() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "keyless-interrupted-import";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            db.apply_batch(db.new_batch().append(U64::new(7)).merkleize(
+                &db,
+                Some(U64::new(11)),
+                Location::new(1),
+            ))
+            .unwrap();
+            db.sync().await.unwrap();
+            drop(db);
+
+            // Simulate a crash between an import's journal clear and its entry append: the
+            // journal is empty but its size is nonzero.
+            let journal = open_witness_journal(context.child("clear"), partition).await;
+            let size = journal.size().await;
+            journal.clear_to_size(size.max(1)).await.unwrap();
+            drop(journal);
+
+            // Reopen must fail rather than bootstrap a fresh db.
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen_witness"),
+                witness_config(partition, &context),
+                (),
+            )
+            .await;
+            assert!(matches!(reopened, Err(Error::Journal(_))));
         });
     }
 

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -253,13 +253,13 @@ where
             .to_vec()
     }
 
-    /// Build a compact db handle from already-verified compact state.
+    /// Build a compact db handle from already-validated compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
     /// supplied witness/root pair. The import lives only in memory until the first
     /// [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
     /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
-    pub(crate) fn init_from_verified_state(
+    pub(crate) fn init_from_validated_state(
         strategy: S,
         journal: witness::Journal<E, F, H::Digest>,
         commit_codec_config: C,
@@ -283,7 +283,7 @@ where
         let merkle =
             compact_merkle::Merkle::from_compact_state(strategy, leaf_count, pinned_nodes.clone())?;
         let imported = VerifiedWitness {
-            entry: Witness {
+            witness: Witness {
                 op_bytes: Self::encode_commit_op(
                     last_commit_metadata.clone(),
                     inactivity_floor_loc,
@@ -413,7 +413,7 @@ where
                     current: w.target(),
                 });
             }
-            Ok((w.entry.clone(), w.leaf_count()))
+            Ok((w.witness.clone(), w.leaf_count()))
         })?;
         let Witness {
             op_bytes,
@@ -536,8 +536,8 @@ where
         Ok(())
     }
 
-    /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Only whole
-    /// journal sections are dropped, so some witness below the boundary may survive.
+    /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Some witness
+    /// below the boundary may survive.
     pub async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
     }

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -498,8 +498,8 @@ where
     }
 
     /// Rewind the db to the synced commit with exactly `target` operations, discarding any
-    /// uncommitted batches and any later commits. The rewind is synced before this method
-    /// returns.
+    /// uncommitted batches and any later commits. The rewind is made durable before this
+    /// method returns.
     ///
     /// # Errors
     ///
@@ -510,8 +510,11 @@ where
     where
         F: Family,
     {
-        // Fast path: already exactly at `target` with no uncommitted state.
-        if self.size() == target && self.witness.with(|w| w.leaf_count()) == target {
+        // Fast path: already durably at `target` with no uncommitted state.
+        if self.size() == target
+            && self.witness.with(|w| w.leaf_count()) == target
+            && !self.witness.import_pending()
+        {
             return Ok(());
         }
 
@@ -533,7 +536,8 @@ where
         Ok(())
     }
 
-    /// Drop witnesses for commits with fewer than `pruning_boundary` operations.
+    /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Only whole
+    /// journal sections are dropped, so some witness below the boundary may survive.
     pub async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
     }
@@ -920,6 +924,71 @@ mod tests {
             )
             .await;
             assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_rejects_corrupt_target_entry() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "keyless-corrupt-rewind-target";
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            db.apply_batch(db.new_batch().append(U64::new(1)).merkleize(
+                &db,
+                None,
+                Location::new(1),
+            ))
+            .unwrap();
+            db.sync().await.unwrap();
+            let rewind_target = db.target().leaf_count;
+            db.apply_batch(db.new_batch().append(U64::new(2)).merkleize(
+                &db,
+                None,
+                Location::new(1),
+            ))
+            .unwrap();
+            db.sync().await.unwrap();
+            let tip_target = db.target();
+            drop(db);
+
+            // Corrupt the rewind target's entry (the journal holds bootstrap, target, tip).
+            let journal = open_witness_journal(context.child("corrupt"), partition).await;
+            witness::tests::corrupt_entry(&journal, 1, |entry| {
+                entry.pinned_nodes[0] = Sha256::fill(0xff);
+            })
+            .await;
+            drop(journal);
+
+            // The tip entry is intact, so reopen succeeds.
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let mut reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen"),
+                witness_config(partition, &context),
+                (),
+            )
+            .await
+            .unwrap();
+            assert_eq!(reopened.target(), tip_target);
+
+            // The corrupt entry fails the rewind before any truncation.
+            assert!(matches!(
+                reopened.rewind(rewind_target).await,
+                Err(Error::DataCorrupted(_))
+            ));
+            drop(reopened);
+
+            // The newer history survives: reopen still lands on the original tip.
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
+                merkle,
+                context.child("reopen2"),
+                witness_config(partition, &context),
+                (),
+            )
+            .await
+            .unwrap();
+            assert_eq!(reopened.target(), tip_target);
+            reopened.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -25,8 +25,8 @@
 
 use super::operation::Operation;
 use crate::{
-    journal::contiguous::variable::Config as JournalConfig,
-    merkle::{batch, compact as compact_merkle, Family, Location, Proof},
+    journal::contiguous::variable::{self, Config as JournalConfig},
+    merkle::{batch, compact as compact_merkle, Family, Location},
     qmdb::{
         self,
         any::value::ValueEncoding,
@@ -262,28 +262,42 @@ where
     /// supplied witness/root pair. The import lives only in memory until the first
     /// [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
     /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn init_from_verified_state(
-        merkle: compact_merkle::Merkle<F, H::Digest, S>,
+        strategy: S,
         journal: witness::Journal<E, F, H::Digest>,
         commit_codec_config: C,
-        last_commit_metadata: Option<V::Value>,
-        inactivity_floor_loc: Location<F>,
-        root: H::Digest,
-        last_commit_op_bytes: Vec<u8>,
-        last_commit_proof: Proof<F, H::Digest>,
-        pinned_nodes: Vec<H::Digest>,
+        validated: compact_sync::ValidatedState<F, Operation<F, V>, H::Digest>,
     ) -> Result<Self, Error<F>> {
+        let compact_sync::ValidatedState {
+            state:
+                compact_sync::State {
+                    leaf_count,
+                    pinned_nodes,
+                    last_commit_op,
+                    last_commit_proof,
+                },
+            root,
+            inactivity_floor: inactivity_floor_loc,
+        } = validated;
+        let last_commit_loc = Location::new(*leaf_count - 1);
+        let Operation::Commit(last_commit_metadata, op_floor) = last_commit_op else {
+            return Err(Error::UnexpectedData(last_commit_loc));
+        };
+        if op_floor != inactivity_floor_loc {
+            return Err(Error::DataCorrupted("inactivity floor mismatch"));
+        }
+
+        let merkle =
+            compact_merkle::Merkle::from_compact_state(strategy, leaf_count, pinned_nodes.clone())?;
         let imported = witness::witness_from_authenticated_state(
             &merkle,
             root,
             inactivity_floor_loc,
-            last_commit_op_bytes,
+            Self::encode_commit_op(last_commit_metadata.clone(), inactivity_floor_loc),
             last_commit_proof,
             pinned_nodes,
         )?;
 
-        let last_commit_loc = Location::new(*merkle.leaves() - 1);
         let witness = witness::Store::from_import(journal, imported);
         Ok(Self {
             merkle,
@@ -310,8 +324,8 @@ where
         Operation<F, V>: Read<Cfg = C>,
     {
         // Bootstrap: append an initial Commit(None, 0) on first open.
-        let journal =
-            witness::open_journal::<E, F, H::Digest>(witness_context, witness_config).await?;
+        let journal: witness::Journal<E, F, H::Digest> =
+            variable::Journal::init(witness_context, witness_config).await?;
         let (witness, last_commit_op) = witness::init::<E, F, H, S, Operation<F, V>>(
             journal,
             &mut merkle,
@@ -325,7 +339,7 @@ where
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
-        let last_commit_loc = Location::new(*witness.with(|w| w.leaf_count) - 1);
+        let last_commit_loc = Location::new(*witness.with(|w| w.leaf_count()) - 1);
 
         Ok(Self {
             merkle,
@@ -397,7 +411,7 @@ where
         // Hold the witness lock only long enough to verify the requested target and snapshot the
         // entry; decode outside it so concurrent readers do not contend.
         let (op_bytes, last_commit_proof, pinned_nodes, leaf_count) = self.witness.with(|w| {
-            if target.root != w.root || target.leaf_count != w.leaf_count {
+            if target.root != w.root || target.leaf_count != w.leaf_count() {
                 return Err(compact_sync::ServeError::StaleTarget {
                     requested: target.clone(),
                     current: w.target(),
@@ -407,7 +421,7 @@ where
                 w.last_commit_op_bytes.clone(),
                 w.last_commit_proof.clone(),
                 w.pinned_nodes.clone(),
-                w.leaf_count,
+                w.leaf_count(),
             ))
         })?;
         let op = Operation::<F, V>::decode_cfg(op_bytes.as_ref(), &self.commit_codec_config)
@@ -506,7 +520,7 @@ where
         F: Family,
     {
         // Fast path: already exactly at `target` with no uncommitted state.
-        if self.size() == target && self.witness.with(|w| w.leaf_count) == target {
+        if self.size() == target && self.witness.with(|w| w.leaf_count()) == target {
             return Ok(());
         }
 
@@ -544,7 +558,6 @@ where
 mod tests {
     use super::*;
     use crate::{
-        journal::contiguous::variable,
         merkle::mmr,
         qmdb::{any::value::FixedEncoding, compact::witness},
     };
@@ -587,9 +600,7 @@ mod tests {
         partition: &str,
     ) -> witness::Journal<deterministic::Context, mmr::Family, Digest> {
         let cfg = witness_config(partition, &context);
-        witness::open_journal::<_, mmr::Family, Digest>(context, cfg)
-            .await
-            .unwrap()
+        variable::Journal::init(context, cfg).await.unwrap()
     }
 
     #[test_traced("INFO")]

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -538,7 +538,15 @@ where
 
     /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Some witness
     /// below the boundary may survive.
-    pub async fn prune(&self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
+    ///
+    /// Pruning bounds how far back [`Self::rewind`] can reach; the current commit's witness
+    /// always survives. The prune is made durable before this method returns.
+    ///
+    /// # Errors
+    ///
+    /// Fails if a compact-sync import has not yet been persisted by [`Self::sync`]. Any error
+    /// is fatal for this handle: drop it and reopen from storage.
+    pub async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
     }
 
@@ -1163,6 +1171,54 @@ mod tests {
                 db.rewind(Location::new(*db.size() + 100)).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_between_commits() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut db =
+                open_db::<mmr::Family>(context.child("db"), "keyless-rewind-between").await;
+            let floor = db.inactivity_floor_loc();
+
+            // A multi-op commit jumps the committed size from 1 (bootstrap) to 4.
+            db.apply_batch(
+                db.new_batch()
+                    .append(U64::new(1))
+                    .append(U64::new(2))
+                    .merkleize(&db, Some(U64::new(11)), floor),
+            )
+            .unwrap();
+            db.sync().await.unwrap();
+            let root_a = db.root();
+            let size_a = db.size();
+            assert_eq!(size_a, Location::new(4));
+
+            // A second commit moves the size to 6.
+            db.apply_batch(db.new_batch().append(U64::new(3)).merkleize(
+                &db,
+                Some(U64::new(22)),
+                floor,
+            ))
+            .unwrap();
+            db.sync().await.unwrap();
+            let root_b = db.root();
+
+            // Targets inside a commit's span match no entry, even though entries exist on
+            // both sides.
+            for target in [2u64, 3, 5] {
+                assert!(matches!(
+                    db.rewind(Location::new(target)).await,
+                    Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
+                ));
+            }
+            assert_eq!(db.root(), root_b);
+
+            // The exact commit boundary remains a valid target.
+            db.rewind(size_a).await.unwrap();
+            assert_eq!(db.root(), root_a);
+            assert_eq!(db.get_metadata(), Some(U64::new(11)));
             db.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -8,12 +8,11 @@
 //!
 //! # Witness journal
 //!
-//! On every durable sync, this db appends a complete snapshot of the committed state to its
-//! witness journal, so [`Db::rewind`] can restore any synced commit still retained there (history
-//! is bounded only by [`Db::prune`]). Reopen and rewind re-verify the persisted snapshot;
-//! corruption surfaces as [`Error::DataCorrupted`]. The witness (the last-commit operation plus
-//! its inclusion proof) is also what lets compact nodes serve compact sync without retaining
-//! historical operations.
+//! The witness journal holds a complete snapshot of every synced commit, so [`Db::rewind`] can
+//! restore any commit still retained there (history is bounded only by [`Db::prune`]). Reopen
+//! and rewind re-verify the persisted snapshot; corruption surfaces as [`Error::DataCorrupted`].
+//! The witness (the last-commit operation plus its inclusion proof) is also what lets compact
+//! nodes serve compact sync without retaining historical operations.
 //!
 //! # Inactivity floor
 //!
@@ -33,7 +32,7 @@ use crate::{
         batch_chain::{self, Bounds},
         compact::{
             batch as compact_batch,
-            witness::{self, Witness},
+            witness::{self, VerifiedWitness, Witness},
         },
         sync::compact as compact_sync,
         Error,
@@ -51,9 +50,7 @@ pub struct Config<C, S: Strategy> {
     /// Strategy used to parallelize merkleization.
     pub strategy: S,
 
-    /// Configuration for the journal that persists the compact-sync witness. Its `codec_config` is
-    /// ignored; the witness entry codec configuration is supplied internally because the entry
-    /// type and its decode bounds are private to the witness module.
+    /// Configuration for the journal that persists the witness.
     pub witness: JournalConfig<()>,
 
     /// Codec config used to decode the persisted last commit operation on reopen.
@@ -285,14 +282,16 @@ where
 
         let merkle =
             compact_merkle::Merkle::from_compact_state(strategy, leaf_count, pinned_nodes.clone())?;
-        let imported = Witness {
+        let imported = VerifiedWitness {
+            entry: Witness {
+                op_bytes: Self::encode_commit_op(
+                    last_commit_metadata.clone(),
+                    inactivity_floor_loc,
+                ),
+                proof: last_commit_proof,
+                pinned_nodes,
+            },
             root,
-            pinned_nodes,
-            last_commit_op_bytes: Self::encode_commit_op(
-                last_commit_metadata.clone(),
-                inactivity_floor_loc,
-            ),
-            last_commit_proof,
         };
 
         let witness = witness::Store::from_import(journal, imported);
@@ -393,7 +392,7 @@ where
     /// This reflects the last durably persisted commit, which may lag behind live in-memory
     /// mutations until [`Self::sync`] is called.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
-        self.witness.with(Witness::target)
+        self.witness.with(VerifiedWitness::target)
     }
 
     /// Return the compact-sync state for `target`, or a stale-target error if the source's
@@ -407,20 +406,20 @@ where
     {
         // Hold the witness lock only long enough to verify the requested target and snapshot the
         // entry; decode outside it so concurrent readers do not contend.
-        let (op_bytes, last_commit_proof, pinned_nodes, leaf_count) = self.witness.with(|w| {
+        let (entry, leaf_count) = self.witness.with(|w| {
             if target.root != w.root || target.leaf_count != w.leaf_count() {
                 return Err(compact_sync::ServeError::StaleTarget {
                     requested: target.clone(),
                     current: w.target(),
                 });
             }
-            Ok((
-                w.last_commit_op_bytes.clone(),
-                w.last_commit_proof.clone(),
-                w.pinned_nodes.clone(),
-                w.leaf_count(),
-            ))
+            Ok((w.entry.clone(), w.leaf_count()))
         })?;
+        let Witness {
+            op_bytes,
+            proof: last_commit_proof,
+            pinned_nodes,
+        } = entry;
         let op = Operation::<F, V>::decode_cfg(op_bytes.as_ref(), &self.commit_codec_config)
             .map_err(|_| {
                 compact_sync::ServeError::Database(Error::DataCorrupted("invalid commit operation"))

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -61,8 +61,8 @@ impl<F: Family, E: Storage + Clock + Metrics, V: FixedValue, H: Hasher, S: Strat
 {
     /// Returns a [CompactDb] initialized from `cfg`.
     pub async fn init(context: E, cfg: CompactConfig<S>) -> Result<Self, Error<F>> {
-        let merkle = crate::merkle::compact::Merkle::init(context, cfg.merkle).await?;
-        Self::init_from_merkle(merkle, ()).await
+        let merkle = crate::merkle::compact::Merkle::new(cfg.strategy);
+        Self::init_from_merkle(merkle, context.child("witness"), cfg.witness, ()).await
     }
 }
 
@@ -133,9 +133,14 @@ mod test {
         context: deterministic::Context,
     ) -> TestCompactDb<F> {
         let cfg = CompactConfig {
-            merkle: crate::merkle::compact::Config {
-                partition: "compact-keyless-fixed".into(),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: crate::journal::contiguous::variable::Config {
+                partition: "compact-keyless-fixed-witness".into(),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: (),
         };
@@ -327,7 +332,7 @@ mod test {
         db.apply_batch(retained).await.unwrap();
         compact.apply_batch(compact_batch).unwrap();
         db.commit().await.unwrap();
-        compact.commit().await.unwrap();
+        compact.sync().await.unwrap();
 
         assert_eq!(db.root(), compact.root());
         assert_eq!(compact.get_metadata(), Some(metadata.clone()));

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -152,7 +152,7 @@ where
                 config.witness,
             )
             .await?;
-        Self::init_from_verified_state(config.strategy, journal, config.commit_codec_config, state)
+        Self::init_from_validated_state(config.strategy, journal, config.commit_codec_config, state)
     }
 
     fn inactivity_floor(op: &Self::Op) -> Option<Location<Self::Family>> {

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     Context,
 };
-use commonware_codec::{Encode, EncodeShared, Read};
+use commonware_codec::{EncodeShared, Read};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use commonware_utils::range::NonEmptyRange;
@@ -146,50 +146,13 @@ where
         config: Self::Config,
         state: sync::compact::ValidatedState<Self::Family, Self::Op, Self::Digest>,
     ) -> Result<Self, qmdb::Error<F>> {
-        let sync::compact::ValidatedState {
-            state,
-            root,
-            inactivity_floor: inactivity_floor_loc,
-        } = state;
-        let sync::compact::State {
-            leaf_count,
-            pinned_nodes,
-            last_commit_op,
-            last_commit_proof,
-        } = state;
-        let last_commit_loc = Location::new(*leaf_count - 1);
-        let Operation::Commit(last_commit_metadata, op_floor) = last_commit_op else {
-            return Err(qmdb::Error::UnexpectedData(last_commit_loc));
-        };
-        if op_floor != inactivity_floor_loc {
-            return Err(qmdb::Error::DataCorrupted("inactivity floor mismatch"));
-        }
-        let commit_codec_config = config.commit_codec_config.clone();
-        let last_commit_op_bytes =
-            Operation::<F, V>::Commit(last_commit_metadata.clone(), inactivity_floor_loc)
-                .encode()
-                .to_vec();
-        let merkle = crate::merkle::compact::Merkle::from_compact_state(
-            config.strategy,
-            leaf_count,
-            pinned_nodes.clone(),
-        )?;
-        let journal = crate::qmdb::compact::witness::open_journal::<E, F, H::Digest>(
-            context.child("witness"),
-            config.witness,
-        )
-        .await?;
-        Self::init_from_verified_state(
-            merkle,
-            journal,
-            commit_codec_config,
-            last_commit_metadata,
-            inactivity_floor_loc,
-            root,
-            last_commit_op_bytes,
-            last_commit_proof,
-            pinned_nodes,
-        )
+        let journal: crate::qmdb::compact::witness::Journal<E, F, H::Digest> =
+            crate::journal::contiguous::variable::Journal::init(
+                context.child("witness"),
+                config.witness,
+            )
+            .await?;
+        Self::init_from_verified_state(config.strategy, journal, config.commit_codec_config, state)
     }
 
     fn inactivity_floor(op: &Self::Op) -> Option<Location<Self::Family>> {

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -161,21 +161,27 @@ where
         let Operation::Commit(last_commit_metadata, op_floor) = last_commit_op else {
             return Err(qmdb::Error::UnexpectedData(last_commit_loc));
         };
-        assert_eq!(op_floor, inactivity_floor_loc, "inactivity floor mismatch");
+        if op_floor != inactivity_floor_loc {
+            return Err(qmdb::Error::DataCorrupted("inactivity floor mismatch"));
+        }
         let commit_codec_config = config.commit_codec_config.clone();
         let last_commit_op_bytes =
             Operation::<F, V>::Commit(last_commit_metadata.clone(), inactivity_floor_loc)
                 .encode()
                 .to_vec();
-        let merkle = crate::merkle::compact::Merkle::init_from_compact_state(
-            context.child("merkle"),
-            config.merkle,
+        let merkle = crate::merkle::compact::Merkle::from_compact_state(
+            config.strategy,
             leaf_count,
             pinned_nodes.clone(),
+        )?;
+        let journal = crate::qmdb::compact::witness::open_journal::<E, F, H::Digest>(
+            context.child("witness"),
+            config.witness,
         )
         .await?;
         Self::init_from_verified_state(
             merkle,
+            journal,
             commit_codec_config,
             last_commit_metadata,
             inactivity_floor_loc,
@@ -195,7 +201,7 @@ where
     }
 
     async fn persist_compact_state(&self) -> Result<(), qmdb::Error<F>> {
-        self.persist_cached_witness().await
+        self.sync().await
     }
 }
 

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -1768,12 +1768,9 @@ mod compact_variable_mmr {
             let fetched = sync::compact::Resolver::get_compact_state(&source, target_b.clone())
                 .await
                 .unwrap();
-            let state = fetched.state;
-            let inactivity_floor = state.last_commit_op.has_floor().unwrap();
             let validated = sync::compact::ValidatedState {
-                state,
+                state: fetched.state,
                 root: target_b.root,
-                inactivity_floor,
             };
             let imported = <ClientDb as sync::compact::Database>::from_validated_state(
                 context.child("import"),

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -1723,12 +1723,12 @@ mod compact_variable_mmr {
         });
     }
 
-    /// Abandoning a compact-sync reconstruction before its first persist leaves the previous
-    /// witness journal untouched.
+    /// Dropping a compact-sync import before its first persist leaves the previous witness
+    /// journal untouched.
     #[test_traced("WARN")]
-    fn test_compact_sync_abandoned_import_preserves_existing_state() {
+    fn test_compact_sync_dropped_import_preserves_existing_state() {
         deterministic::Runner::default().start(|mut context| async move {
-            let suffix = format!("compact-keyless-abandoned-{}", context.next_u64());
+            let suffix = format!("compact-keyless-dropped-{}", context.next_u64());
 
             // Seed the client partition with committed state A.
             let client_cfg = client_config(&suffix, &context);
@@ -1745,7 +1745,7 @@ mod compact_variable_mmr {
             let target_a = seeded.target();
             drop(seeded);
 
-            // Reconstruct state B into the same partition, then abandon it before the first
+            // Reconstruct state B into the same partition, then drop it before the first
             // persist (as a cancelled sync would).
             let mut source =
                 SourceDb::init(context.child("source"), source_config(&suffix, &context))
@@ -1782,7 +1782,7 @@ mod compact_variable_mmr {
             assert_eq!(imported.target(), target_b);
             drop(imported);
 
-            // The abandoned import never touched the journal: state A is still there.
+            // The dropped import never touched the journal: state A is still there.
             let reopened = ClientDb::init(context.child("reopen"), client_cfg)
                 .await
                 .unwrap();

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -1723,60 +1723,6 @@ mod compact_variable_mmr {
         });
     }
 
-    /// A peer commit whose encoded operation exceeds the witness entry decode bound must fail
-    /// the sync instead of persisting a witness that the next reopen cannot decode.
-    #[test_traced("WARN")]
-    fn test_compact_sync_rejects_oversized_commit() {
-        deterministic::Runner::default().start(|mut context| async move {
-            let suffix = format!("compact-keyless-oversized-{}", context.next_u64());
-            let max_op_bytes = crate::qmdb::compact::witness::MAX_OP_BYTES;
-
-            // A full source can commit metadata larger than the witness entry bound.
-            let mut source_cfg = source_config(&suffix, &context);
-            source_cfg.log.codec_config = ((0..=max_op_bytes + 1024).into(), ());
-            let mut source = SourceDb::init(context.child("source"), source_cfg)
-                .await
-                .unwrap();
-            let metadata = vec![0u8; max_op_bytes + 1];
-            let batch = source.new_batch().append(vec![1]).merkleize(
-                &source,
-                Some(metadata),
-                Location::new(0),
-            );
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
-            let bounds = source.bounds().await;
-            let target = sync::compact::Target {
-                root: source.root(),
-                leaf_count: bounds.end,
-            };
-
-            let client_cfg = client_config(&suffix, &context);
-            let result: Result<ClientDb, _> = sync::compact::sync(sync::compact::Config {
-                context: context.child("client"),
-                resolver: Arc::new(source),
-                target,
-                db_config: client_cfg.clone(),
-            })
-            .await;
-            let err = result.err().expect("oversized commit must fail sync");
-            assert!(
-                matches!(
-                    err,
-                    sync::Error::Database(crate::qmdb::Error::CommitTooLarge(_, _))
-                ),
-                "sync must fail with CommitTooLarge: {err:?}",
-            );
-
-            // The failed import left no witness behind: the partition opens as a fresh db.
-            let reopened = ClientDb::init(context.child("reopen"), client_cfg)
-                .await
-                .unwrap();
-            assert_eq!(reopened.size(), Location::new(1));
-            reopened.destroy().await.unwrap();
-        });
-    }
-
     /// Abandoning a compact-sync reconstruction before its first persist leaves the previous
     /// witness journal untouched.
     #[test_traced("WARN")]

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -1772,7 +1772,7 @@ mod compact_variable_mmr {
                 state: fetched.state,
                 root: target_b.root,
             };
-            let imported = <ClientDb as sync::compact::Database>::from_validated_state(
+            let mut imported = <ClientDb as sync::compact::Database>::from_validated_state(
                 context.child("import"),
                 client_cfg.clone(),
                 validated,
@@ -1780,6 +1780,10 @@ mod compact_variable_mmr {
             .await
             .unwrap();
             assert_eq!(imported.target(), target_b);
+
+            // Rewind is rejected until the import is persisted, even to the imported leaf
+            // count itself: the fast path must not report unpersisted state as durable.
+            assert!(imported.rewind(target_b.leaf_count).await.is_err());
             drop(imported);
 
             // The dropped import never touched the journal: state A is still there.

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -1068,11 +1068,17 @@ mod compact_variable_mmr {
 
     fn client_config(
         suffix: &str,
+        pooler: &impl BufferPooler,
     ) -> variable::CompactConfig<(commonware_codec::RangeCfg<usize>, ()), Sequential> {
         keyless::CompactConfig {
-            merkle: crate::merkle::compact::Config {
-                partition: format!("compact-{suffix}"),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: crate::journal::contiguous::variable::Config {
+                partition: format!("compact-{suffix}-witness"),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: ((0..=10000).into(), ()),
         }
@@ -1148,7 +1154,7 @@ mod compact_variable_mmr {
                 leaf_count: bounds.end,
             };
             let source = Arc::new(source);
-            let client_cfg = client_config(&suffix);
+            let client_cfg = client_config(&suffix, &context);
             let client: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("client"),
                 resolver: source.clone(),
@@ -1214,7 +1220,7 @@ mod compact_variable_mmr {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -1275,7 +1281,7 @@ mod compact_variable_mmr {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -1319,7 +1325,7 @@ mod compact_variable_mmr {
             let mut bad_state = good_state.clone();
             bad_state.pinned_nodes[0] = sha256::Digest::from([0xaa; 32]);
 
-            let client_cfg = client_config(&suffix);
+            let client_cfg = client_config(&suffix, &context);
             let synced: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("client"),
                 resolver: SequenceResolver {
@@ -1333,13 +1339,13 @@ mod compact_variable_mmr {
             })
             .await
             .unwrap();
-            assert_eq!(synced.current_target(), target);
+            assert_eq!(synced.target(), target);
             drop(synced);
 
             let reopened = ClientDb::init(context.child("reopen"), client_cfg)
                 .await
                 .unwrap();
-            assert_eq!(reopened.current_target(), target);
+            assert_eq!(reopened.target(), target);
             assert_eq!(reopened.get_metadata(), Some(vec![7]));
 
             reopened.destroy().await.unwrap();
@@ -1386,7 +1392,7 @@ mod compact_variable_mmr {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -1442,7 +1448,7 @@ mod compact_variable_mmr {
                 ]))),
             };
 
-            let client_cfg = client_config(&suffix);
+            let client_cfg = client_config(&suffix, &context);
             let synced: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("client"),
                 resolver,
@@ -1454,13 +1460,13 @@ mod compact_variable_mmr {
 
             assert!(!bad_rx.await.unwrap());
             assert!(good_rx.await.unwrap());
-            assert_eq!(synced.current_target(), target);
+            assert_eq!(synced.target(), target);
             assert_eq!(synced.get_metadata(), Some(vec![7]));
 
             let reopened = ClientDb::init(context.child("reopen"), client_cfg)
                 .await
                 .unwrap();
-            assert_eq!(reopened.current_target(), target);
+            assert_eq!(reopened.target(), target);
             assert_eq!(reopened.get_metadata(), Some(vec![7]));
 
             reopened.destroy().await.unwrap();
@@ -1520,7 +1526,7 @@ mod compact_variable_mmr {
     fn test_compact_source_reopen_rewind_regrow_and_stale_target() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-unj-source-{}", context.next_u64());
-            let source_cfg = client_config(&format!("{suffix}-source"));
+            let source_cfg = client_config(&format!("{suffix}-source"), &context);
             let mut source = ClientDb::init(context.child("source_init"), source_cfg.clone())
                 .await
                 .unwrap();
@@ -1534,15 +1540,15 @@ mod compact_variable_mmr {
             );
             source.apply_batch(batch1).unwrap();
             source.sync().await.unwrap();
-            let target1 = source.current_target();
+            let target1 = source.target();
             drop(source);
 
             let source = ClientDb::init(context.child("source_reopen"), source_cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(source.current_target(), target1);
+            assert_eq!(source.target(), target1);
 
-            let serve1_cfg = client_config(&format!("{suffix}-serve1"));
+            let serve1_cfg = client_config(&format!("{suffix}-serve1"), &context);
             let served1: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 1),
                 resolver: Arc::new(source),
@@ -1568,13 +1574,13 @@ mod compact_variable_mmr {
             );
             source.apply_batch(batch2).unwrap();
             source.sync().await.unwrap();
-            let target2 = source.current_target();
+            let target2 = source.target();
             assert_ne!(target2, target1);
 
-            source.rewind().await.unwrap();
-            assert_eq!(source.current_target(), target1);
+            source.rewind(target1.leaf_count).await.unwrap();
+            assert_eq!(source.target(), target1);
 
-            let serve2_cfg = client_config(&format!("{suffix}-serve2"));
+            let serve2_cfg = client_config(&format!("{suffix}-serve2"), &context);
             let served2: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 2),
                 resolver: Arc::new(source),
@@ -1591,7 +1597,7 @@ mod compact_variable_mmr {
             let mut source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(source.current_target(), target1);
+            assert_eq!(source.target(), target1);
             let metadata3 = vec![3, 3, 3];
             let floor3 = Location::new(2);
             let batch3 = source.new_batch().append(vec![30, 31, 32]).merkleize(
@@ -1601,11 +1607,11 @@ mod compact_variable_mmr {
             );
             source.apply_batch(batch3).unwrap();
             source.sync().await.unwrap();
-            let target3 = source.current_target();
+            let target3 = source.target();
             assert_ne!(target3, target1);
             assert_ne!(target3, target2);
 
-            let serve3_cfg = client_config(&format!("{suffix}-serve3"));
+            let serve3_cfg = client_config(&format!("{suffix}-serve3"), &context);
             let served3: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 3),
                 resolver: Arc::new(source),
@@ -1628,7 +1634,7 @@ mod compact_variable_mmr {
                 context: context.child("stale_client"),
                 resolver: source.clone(),
                 target: target2.clone(),
-                db_config: client_config(&format!("{suffix}-stale")),
+                db_config: client_config(&format!("{suffix}-stale"), &context),
             })
             .await;
             assert!(matches!(
@@ -1641,6 +1647,204 @@ mod compact_variable_mmr {
 
             let source = Arc::try_unwrap(source).unwrap_or_else(|_| panic!("single source ref"));
             source.destroy().await.unwrap();
+        });
+    }
+
+    /// Compact sync must reinitialize a partition whose witness journal was previously pruned
+    /// (the journal reset must clear the nonzero pruning boundary).
+    #[test_traced("WARN")]
+    fn test_compact_sync_reuses_pruned_partition() {
+        deterministic::Runner::default().start(|mut context| async move {
+            let suffix = format!("compact-keyless-pruned-{}", context.next_u64());
+
+            // Seed the client partition with several commits, then prune its witness journal.
+            let mut client_cfg = client_config(&suffix, &context);
+            client_cfg.witness.items_per_section = NZU64!(1);
+            let mut seeded = ClientDb::init(context.child("seed"), client_cfg.clone())
+                .await
+                .unwrap();
+            let mut first_size = None;
+            for i in 1u8..=3 {
+                let floor = seeded.inactivity_floor_loc();
+                let batch =
+                    seeded
+                        .new_batch()
+                        .append(vec![i])
+                        .merkleize(&seeded, Some(vec![i]), floor);
+                seeded.apply_batch(batch).unwrap();
+                seeded.sync().await.unwrap();
+                first_size.get_or_insert(seeded.size());
+            }
+            seeded.prune(seeded.size()).await.unwrap();
+            // The prune moved the journal's pruning boundary: the first commit is unreachable.
+            assert!(matches!(
+                seeded.rewind(first_size.unwrap()).await,
+                Err(crate::qmdb::Error::Merkle(
+                    crate::merkle::Error::RewindBeyondHistory
+                ))
+            ));
+            drop(seeded);
+
+            // Sync different state into the same partition.
+            let mut source =
+                SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                    .await
+                    .unwrap();
+            let metadata = vec![9, 9, 9];
+            let batch = source.new_batch().append(vec![1, 2, 3]).merkleize(
+                &source,
+                Some(metadata.clone()),
+                Location::new(0),
+            );
+            source.apply_batch(batch).await.unwrap();
+            source.commit().await.unwrap();
+            let bounds = source.bounds().await;
+            let target = sync::compact::Target {
+                root: source.root(),
+                leaf_count: bounds.end,
+            };
+
+            let synced: ClientDb = sync::compact::sync(sync::compact::Config {
+                context: context.child("client"),
+                resolver: Arc::new(source),
+                target: target.clone(),
+                db_config: client_cfg.clone(),
+            })
+            .await
+            .unwrap();
+            assert_eq!(synced.root(), target.root);
+            drop(synced);
+
+            let reopened = ClientDb::init(context.child("reopen"), client_cfg)
+                .await
+                .unwrap();
+            assert_eq!(reopened.root(), target.root);
+            reopened.destroy().await.unwrap();
+        });
+    }
+
+    /// A peer commit whose encoded operation exceeds the witness entry decode bound must fail
+    /// the sync instead of persisting a witness that the next reopen cannot decode.
+    #[test_traced("WARN")]
+    fn test_compact_sync_rejects_oversized_commit() {
+        deterministic::Runner::default().start(|mut context| async move {
+            let suffix = format!("compact-keyless-oversized-{}", context.next_u64());
+            let max_op_bytes = crate::qmdb::compact::witness::MAX_OP_BYTES;
+
+            // A full source can commit metadata larger than the witness entry bound.
+            let mut source_cfg = source_config(&suffix, &context);
+            source_cfg.log.codec_config = ((0..=max_op_bytes + 1024).into(), ());
+            let mut source = SourceDb::init(context.child("source"), source_cfg)
+                .await
+                .unwrap();
+            let metadata = vec![0u8; max_op_bytes + 1];
+            let batch = source.new_batch().append(vec![1]).merkleize(
+                &source,
+                Some(metadata),
+                Location::new(0),
+            );
+            source.apply_batch(batch).await.unwrap();
+            source.commit().await.unwrap();
+            let bounds = source.bounds().await;
+            let target = sync::compact::Target {
+                root: source.root(),
+                leaf_count: bounds.end,
+            };
+
+            let client_cfg = client_config(&suffix, &context);
+            let result: Result<ClientDb, _> = sync::compact::sync(sync::compact::Config {
+                context: context.child("client"),
+                resolver: Arc::new(source),
+                target,
+                db_config: client_cfg.clone(),
+            })
+            .await;
+            let err = result.err().expect("oversized commit must fail sync");
+            assert!(
+                matches!(
+                    err,
+                    sync::Error::Database(crate::qmdb::Error::CommitTooLarge(_, _))
+                ),
+                "sync must fail with CommitTooLarge: {err:?}",
+            );
+
+            // The failed import left no witness behind: the partition opens as a fresh db.
+            let reopened = ClientDb::init(context.child("reopen"), client_cfg)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), Location::new(1));
+            reopened.destroy().await.unwrap();
+        });
+    }
+
+    /// Abandoning a compact-sync reconstruction before its first persist leaves the previous
+    /// witness journal untouched.
+    #[test_traced("WARN")]
+    fn test_compact_sync_abandoned_import_preserves_existing_state() {
+        deterministic::Runner::default().start(|mut context| async move {
+            let suffix = format!("compact-keyless-abandoned-{}", context.next_u64());
+
+            // Seed the client partition with committed state A.
+            let client_cfg = client_config(&suffix, &context);
+            let mut seeded = ClientDb::init(context.child("seed"), client_cfg.clone())
+                .await
+                .unwrap();
+            let batch = seeded.new_batch().append(vec![1]).merkleize(
+                &seeded,
+                Some(vec![1]),
+                Location::new(0),
+            );
+            seeded.apply_batch(batch).unwrap();
+            seeded.sync().await.unwrap();
+            let target_a = seeded.target();
+            drop(seeded);
+
+            // Reconstruct state B into the same partition, then abandon it before the first
+            // persist (as a cancelled sync would).
+            let mut source =
+                SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                    .await
+                    .unwrap();
+            let batch = source.new_batch().append(vec![9]).merkleize(
+                &source,
+                Some(vec![9]),
+                Location::new(0),
+            );
+            source.apply_batch(batch).await.unwrap();
+            source.commit().await.unwrap();
+            let bounds = source.bounds().await;
+            let target_b = sync::compact::Target {
+                root: source.root(),
+                leaf_count: bounds.end,
+            };
+            assert_ne!(target_b, target_a);
+            let source = Arc::new(source);
+            let fetched = sync::compact::Resolver::get_compact_state(&source, target_b.clone())
+                .await
+                .unwrap();
+            let state = fetched.state;
+            let inactivity_floor = state.last_commit_op.has_floor().unwrap();
+            let validated = sync::compact::ValidatedState {
+                state,
+                root: target_b.root,
+                inactivity_floor,
+            };
+            let imported = <ClientDb as sync::compact::Database>::from_validated_state(
+                context.child("import"),
+                client_cfg.clone(),
+                validated,
+            )
+            .await
+            .unwrap();
+            assert_eq!(imported.target(), target_b);
+            drop(imported);
+
+            // The abandoned import never touched the journal: state A is still there.
+            let reopened = ClientDb::init(context.child("reopen"), client_cfg)
+                .await
+                .unwrap();
+            assert_eq!(reopened.target(), target_a);
+            reopened.destroy().await.unwrap();
         });
     }
 }
@@ -1688,11 +1892,17 @@ mod compact_variable_mmb {
 
     fn client_config(
         suffix: &str,
+        pooler: &impl BufferPooler,
     ) -> variable::CompactConfig<(commonware_codec::RangeCfg<usize>, ()), Sequential> {
         keyless::CompactConfig {
-            merkle: crate::merkle::compact::Config {
-                partition: format!("compact-{suffix}"),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: crate::journal::contiguous::variable::Config {
+                partition: format!("compact-{suffix}-witness"),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: ((0..=10000).into(), ()),
         }
@@ -1768,7 +1978,7 @@ mod compact_variable_mmb {
                 leaf_count: bounds.end,
             };
             let source = Arc::new(source);
-            let client_cfg = client_config(&suffix);
+            let client_cfg = client_config(&suffix, &context);
             let client: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("client"),
                 resolver: source.clone(),
@@ -1834,7 +2044,7 @@ mod compact_variable_mmb {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -1895,7 +2105,7 @@ mod compact_variable_mmb {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -1939,7 +2149,7 @@ mod compact_variable_mmb {
             let mut bad_state = good_state.clone();
             bad_state.pinned_nodes[0] = sha256::Digest::from([0xaa; 32]);
 
-            let client_cfg = client_config(&suffix);
+            let client_cfg = client_config(&suffix, &context);
             let synced: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("client"),
                 resolver: SequenceResolver {
@@ -1953,13 +2163,13 @@ mod compact_variable_mmb {
             })
             .await
             .unwrap();
-            assert_eq!(synced.current_target(), target);
+            assert_eq!(synced.target(), target);
             drop(synced);
 
             let reopened = ClientDb::init(context.child("reopen"), client_cfg)
                 .await
                 .unwrap();
-            assert_eq!(reopened.current_target(), target);
+            assert_eq!(reopened.target(), target);
             assert_eq!(reopened.get_metadata(), Some(vec![7]));
 
             reopened.destroy().await.unwrap();
@@ -2006,7 +2216,7 @@ mod compact_variable_mmb {
                     ]))),
                 },
                 target: target.clone(),
-                db_config: client_config(&suffix),
+                db_config: client_config(&suffix, &context),
             })
             .await
             .unwrap();
@@ -2069,7 +2279,7 @@ mod compact_variable_mmb {
     fn test_compact_source_reopen_rewind_regrow_and_stale_target() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-mmb-unj-source-{}", context.next_u64());
-            let source_cfg = client_config(&format!("{suffix}-source"));
+            let source_cfg = client_config(&format!("{suffix}-source"), &context);
             let mut source = ClientDb::init(context.child("source_init"), source_cfg.clone())
                 .await
                 .unwrap();
@@ -2083,15 +2293,15 @@ mod compact_variable_mmb {
             );
             source.apply_batch(batch1).unwrap();
             source.sync().await.unwrap();
-            let target1 = source.current_target();
+            let target1 = source.target();
             drop(source);
 
             let source = ClientDb::init(context.child("source_reopen"), source_cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(source.current_target(), target1);
+            assert_eq!(source.target(), target1);
 
-            let serve1_cfg = client_config(&format!("{suffix}-serve1"));
+            let serve1_cfg = client_config(&format!("{suffix}-serve1"), &context);
             let served1: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 1),
                 resolver: Arc::new(source),
@@ -2117,13 +2327,13 @@ mod compact_variable_mmb {
             );
             source.apply_batch(batch2).unwrap();
             source.sync().await.unwrap();
-            let target2 = source.current_target();
+            let target2 = source.target();
             assert_ne!(target2, target1);
 
-            source.rewind().await.unwrap();
-            assert_eq!(source.current_target(), target1);
+            source.rewind(target1.leaf_count).await.unwrap();
+            assert_eq!(source.target(), target1);
 
-            let serve2_cfg = client_config(&format!("{suffix}-serve2"));
+            let serve2_cfg = client_config(&format!("{suffix}-serve2"), &context);
             let served2: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 2),
                 resolver: Arc::new(source),
@@ -2140,7 +2350,7 @@ mod compact_variable_mmb {
             let mut source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(source.current_target(), target1);
+            assert_eq!(source.target(), target1);
             let metadata3 = vec![3, 3, 3];
             let floor3 = Location::new(2);
             let batch3 = source.new_batch().append(vec![30, 31, 32]).merkleize(
@@ -2150,11 +2360,11 @@ mod compact_variable_mmb {
             );
             source.apply_batch(batch3).unwrap();
             source.sync().await.unwrap();
-            let target3 = source.current_target();
+            let target3 = source.target();
             assert_ne!(target3, target1);
             assert_ne!(target3, target2);
 
-            let serve3_cfg = client_config(&format!("{suffix}-serve3"));
+            let serve3_cfg = client_config(&format!("{suffix}-serve3"), &context);
             let served3: ClientDb = sync::compact::sync(sync::compact::Config {
                 context: context.child("serve").with_attribute("index", 3),
                 resolver: Arc::new(source),
@@ -2173,12 +2383,12 @@ mod compact_variable_mmb {
                     .await
                     .unwrap(),
             );
-            assert_eq!(source.current_target(), target3);
+            assert_eq!(source.target(), target3);
             let stale_result: Result<ClientDb, _> = sync::compact::sync(sync::compact::Config {
                 context: context.child("stale_client"),
                 resolver: source.clone(),
                 target: target2.clone(),
-                db_config: client_config(&format!("{suffix}-stale")),
+                db_config: client_config(&format!("{suffix}-stale"), &context),
             })
             .await;
             assert!(matches!(

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -1784,6 +1784,9 @@ mod compact_variable_mmr {
             // Rewind is rejected until the import is persisted, even to the imported leaf
             // count itself: the fast path must not report unpersisted state as durable.
             assert!(imported.rewind(target_b.leaf_count).await.is_err());
+
+            // Prune is likewise rejected while the import is pending.
+            assert!(imported.prune(target_b.leaf_count).await.is_err());
             drop(imported);
 
             // The dropped import never touched the journal: state A is still there.

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -390,25 +390,6 @@ mod test {
         });
     }
 
-    /// A commit whose encoded operation exceeds the witness entry decode bound must be rejected
-    /// at commit time, not discovered as corruption on the next reopen.
-    #[test_traced("INFO")]
-    fn test_keyless_variable_compact_rejects_oversized_commit() {
-        deterministic::Runner::default().start(|ctx| async move {
-            let mut compact = open_compact::<mmr::Family>(ctx.child("compact")).await;
-            let floor = compact.inactivity_floor_loc();
-            let metadata = vec![0u8; crate::qmdb::compact::witness::MAX_OP_BYTES + 1];
-            let batch = compact
-                .new_batch()
-                .merkleize(&compact, Some(metadata), floor);
-            compact.apply_batch(batch).unwrap();
-            assert!(matches!(
-                compact.sync().await,
-                Err(crate::qmdb::Error::CommitTooLarge(_, _))
-            ));
-        });
-    }
-
     #[test_traced("INFO")]
     fn test_keyless_db_pruning() {
         deterministic::Runner::default().start(|ctx| async move {

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -73,8 +73,14 @@ where
 {
     /// Returns a [CompactDb] initialized from `cfg`.
     pub async fn init(context: E, cfg: CompactConfig<C, S>) -> Result<Self, Error<F>> {
-        let merkle = crate::merkle::compact::Merkle::init(context, cfg.merkle).await?;
-        Self::init_from_merkle(merkle, cfg.commit_codec_config).await
+        let merkle = crate::merkle::compact::Merkle::new(cfg.strategy);
+        Self::init_from_merkle(
+            merkle,
+            context.child("witness"),
+            cfg.witness,
+            cfg.commit_codec_config,
+        )
+        .await
     }
 }
 
@@ -150,9 +156,14 @@ mod test {
         context: deterministic::Context,
     ) -> TestCompactDb<F> {
         let cfg = CompactConfig {
-            merkle: crate::merkle::compact::Config {
-                partition: "compact-keyless-variable".into(),
-                strategy: Sequential,
+            strategy: Sequential,
+            witness: crate::journal::contiguous::variable::Config {
+                partition: "compact-keyless-variable-witness".into(),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
             },
             commit_codec_config: ((0..=10000usize).into(), ()),
         };
@@ -351,7 +362,7 @@ mod test {
         db.apply_batch(retained).await.unwrap();
         compact.apply_batch(compact_batch).unwrap();
         db.commit().await.unwrap();
-        compact.commit().await.unwrap();
+        compact.sync().await.unwrap();
 
         assert_eq!(db.root(), compact.root());
         assert_eq!(compact.get_metadata(), Some(metadata.clone()));
@@ -376,6 +387,25 @@ mod test {
     fn test_keyless_variable_compact_root_compatibility_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             assert_compact_root_compatibility::<mmb::Family>(ctx).await;
+        });
+    }
+
+    /// A commit whose encoded operation exceeds the witness entry decode bound must be rejected
+    /// at commit time, not discovered as corruption on the next reopen.
+    #[test_traced("INFO")]
+    fn test_keyless_variable_compact_rejects_oversized_commit() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let mut compact = open_compact::<mmr::Family>(ctx.child("compact")).await;
+            let floor = compact.inactivity_floor_loc();
+            let metadata = vec![0u8; crate::qmdb::compact::witness::MAX_OP_BYTES + 1];
+            let batch = compact
+                .new_batch()
+                .merkleize(&compact, Some(metadata), floor);
+            compact.apply_batch(batch).unwrap();
+            assert!(matches!(
+                compact.sync().await,
+                Err(crate::qmdb::Error::CommitTooLarge(_, _))
+            ));
         });
     }
 

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -177,6 +177,9 @@ pub enum Error<F: Family> {
     #[error("location out of bounds: {0} >= {1}")]
     LocationOutOfBounds(Location<F>, Location<F>),
 
+    #[error("commit operation too large: {0} bytes > {1}")]
+    CommitTooLarge(usize, usize),
+
     #[error("prune location {0} beyond minimum required location {1}")]
     PruneBeyondMinRequired(Location<F>, Location<F>),
 

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -177,9 +177,6 @@ pub enum Error<F: Family> {
     #[error("location out of bounds: {0} >= {1}")]
     LocationOutOfBounds(Location<F>, Location<F>),
 
-    #[error("commit operation too large: {0} bytes > {1}")]
-    CommitTooLarge(usize, usize),
-
     #[error("prune location {0} beyond minimum required location {1}")]
     PruneBeyondMinRequired(Location<F>, Location<F>),
 

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -370,8 +370,7 @@ where
 /// 4. Build the compact db from that already-validated state.
 /// 5. Assert the db root still matches and persist the state.
 ///
-/// A failure (or abandoned sync) before the final persist leaves the local compact db unopened or
-/// unchanged on disk.
+/// A failure before the final persist leaves on-disk state untouched.
 pub async fn sync<DB, R>(
     config: Config<DB, R>,
 ) -> Result<DB, Error<DB::Family, R::Error, DB::Digest>>

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -28,7 +28,7 @@
 //! - `rewind` restores the frontier and the witness from the target journal entry.
 //!
 //! Unsynced in-memory mutations are therefore intentionally not servable: `target()` and
-//! compact-state responses lag behind `apply_batch()` until the next durable sync.
+//! compact-state responses lag behind `apply_batch()` until the db's next sync.
 //!
 //! # Safety and invariants
 //!

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -11,8 +11,8 @@
 //!
 //! # What compact dbs store
 //!
-//! A compact db persists one piece of state: a db-level witness journal (`qmdb::compact::witness`)
-//! whose entries each snapshot one committed state (commit operation, proof, and frontier pins).
+//! A compact db's only persistent state is its witness journal (`qmdb::compact::witness`), whose
+//! entries each snapshot one committed state (commit operation, proof, and frontier pins).
 //! The in-memory compact Merkle ([`crate::merkle::compact`]) is rebuilt from the journal tip on
 //! reopen. Without the witness, a compact db could recover its root and continue appending, but
 //! it could not serve compact sync to another node.
@@ -387,8 +387,7 @@ where
 /// 5. Assert the db root still matches and persist the state.
 ///
 /// A failure (or abandoned sync) before the final persist leaves the local compact db unopened or
-/// unchanged on disk. A failure during the final persist may leave the target partition cleared,
-/// requiring a re-sync; it never leaves a verifiable but wrong state.
+/// unchanged on disk.
 pub async fn sync<DB, R>(
     config: Config<DB, R>,
 ) -> Result<DB, Error<DB::Family, R::Error, DB::Digest>>

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -11,25 +11,23 @@
 //!
 //! # What compact dbs store
 //!
-//! A compact db persists two pieces of state that must always describe the same committed tip:
-//!
-//! 1. the compact Merkle frontier (persisted by [`crate::merkle::compact`]), and
-//! 2. a db-level witness for the last commit (persisted by `qmdb::compact::witness`).
-//!
-//! The witness exists because only the db layer knows how to encode and decode the typed commit
-//! operation. Without it, a compact db could recover its root and continue appending, but it could
-//! not serve compact sync to another node.
+//! A compact db persists one piece of state: a db-level witness journal (`qmdb::compact::witness`)
+//! whose entries each snapshot one committed state (commit operation, proof, and frontier pins).
+//! The in-memory compact Merkle ([`crate::merkle::compact`]) is rebuilt from the journal tip on
+//! reopen. Without the witness, a compact db could recover its root and continue appending, but
+//! it could not serve compact sync to another node.
 //!
 //! # When compact state changes
 //!
 //! The servable compact state advances only on durable persistence:
 //!
 //! - [`sync`] verifies the final commit proof and compact frontier before database construction.
-//! - [`Database::from_validated_state`] reconstructs the already-validated state in memory only.
-//! - Compact db-local commits persist the frontier and witness together during `sync`/`commit`.
-//! - `rewind` restores both the frontier and the witness from the previous slot together.
+//! - [`Database::from_validated_state`] reconstructs the already-validated state without
+//!   persisting it.
+//! - Compact db-local commits append one witness entry during `sync`.
+//! - `rewind` restores the frontier and the witness from the target journal entry.
 //!
-//! Unsynced in-memory mutations are therefore intentionally not servable: `current_target()` and
+//! Unsynced in-memory mutations are therefore intentionally not servable: `target()` and
 //! compact-state responses lag behind `apply_batch()` until the next durable sync.
 //!
 //! # Safety and invariants
@@ -37,9 +35,8 @@
 //! The compact path relies on these invariants:
 //!
 //! - the served commit proof must authenticate the final commit at `leaf_count - 1`,
-//! - the frontier pins and witness must move together in the same ping-pong slot,
-//! - reopen and rewind must re-verify the persisted witness against the root restored from that
-//!   slot, and
+//! - reopen and rewind must re-verify the persisted witness against the root recomputed from the
+//!   frontier rebuilt from the same journal entry, and
 //! - reconstructed state must not be persisted until the db recomputes the requested root locally.
 //!
 //! If those invariants are violated by missing or corrupted persisted data, compact db reopen fails
@@ -389,7 +386,9 @@ where
 /// 4. Build the compact db from that already-validated state.
 /// 5. Assert the db root still matches and persist the state.
 ///
-/// Any failure leaves the local compact db unopened or unchanged on disk.
+/// A failure (or abandoned sync) before the final persist leaves the local compact db unopened or
+/// unchanged on disk. A failure during the final persist may leave the target partition cleared,
+/// requiring a re-sync; it never leaves a verifiable but wrong state.
 pub async fn sync<DB, R>(
     config: Config<DB, R>,
 ) -> Result<DB, Error<DB::Family, R::Error, DB::Digest>>

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -172,28 +172,12 @@ pub struct State<F: Family, Op, D: Digest> {
 }
 
 /// Compact state that has been validated against a target root.
-///
-/// This carries the original compact state plus the values derived while validating it. Compact
-/// database constructors still build their storage-backed Merkle state and witness cache, but they
-/// should use these values instead of re-deriving them from peer-provided state.
 #[derive(Clone, Debug)]
 pub struct ValidatedState<F: Family, Op, D: Digest> {
     /// The compact state fetched from a peer after validation.
     pub state: State<F, Op, D>,
     /// The target root that `state` was validated against.
     pub root: D,
-    /// The inactivity floor derived from the final commit operation.
-    pub inactivity_floor: Location<F>,
-}
-
-impl<F: Family, Op, D: Digest> ValidatedState<F, Op, D> {
-    const fn new(state: State<F, Op, D>, root: D, inactivity_floor: Location<F>) -> Self {
-        Self {
-            state,
-            root,
-            inactivity_floor,
-        }
-    }
 }
 
 impl<F: Family, Op, D: Digest> Write for State<F, Op, D>
@@ -212,7 +196,7 @@ where
 pub struct FetchResult<F: Family, Op, D: Digest> {
     /// The fetched compact state.
     pub state: State<F, Op, D>,
-    /// Callback used to report whether downstream accepted the state.
+    /// Callback used to report whether downstream validated the state.
     pub callback: Option<oneshot::Sender<bool>>,
 }
 
@@ -523,11 +507,10 @@ where
         });
     }
 
-    Ok(ValidatedState::new(
+    Ok(ValidatedState {
         state,
-        target.root,
-        inactivity_floor_loc,
-    ))
+        root: target.root,
+    })
 }
 
 async fn fetch_state_from_full_source<F, Op, D, Current, CurrentFut, Hist, HistFut, Pins, PinsFut>(


### PR DESCRIPTION

## Why

Compact QMDBs could only rewind a single commit: their persistence kept exactly one prior state, so anything older was gone. Callers that need to roll back further (for example, crash recovery that rewinds a database to an earlier committed state) had to treat compact databases as a special case with a rewind depth of one. This PR makes compact QMDBs rewind arbitrarily deep, like the other variants. Rewind depth is now bounded only by pruning.

## Before

A compact db persisted its state in two places that had to stay in lockstep:

- The compact Merkle wrote its frontier (leaf count + pinned peaks) into one of two metadata slots, flipping a generation pointer on every commit. Rewind flipped the pointer back, which is why only one step was possible: there was only one old slot.
- The witness (the encoded last-commit operation plus its inclusion proof, needed to serve compact sync) was stored in those same slots.

Reopen had to reconcile the two stores against each other to handle crashes between their writes.

## After

There is now a single persistent store: a contiguous journal owned by the db. Every durable sync appends one entry containing the commit operation, its inclusion proof, and the pinned frontier nodes. Each entry is a complete snapshot of one synced commit, and the journal keeps all of them (until pruned), so the db can rewind to any retained sync point.

The compact Merkle keeps no state on disk anymore. It is rebuilt in memory from the journal's tip entry on reopen, and from the target entry on rewind. Its two-slot persistence, metadata partition, and `E: Context` type parameter are deleted.

Properties:

- **One commit point.** The journal syncs after an append. Crash before it and the unsynced entry is dropped on reopen, recovering the previous commit. There is no second store to reconcile.
- **Rewind to any retained commit.** Entries are strictly ordered by committed leaf count, so `rewind(target)` binary-searches for the matching entry, truncates the journal to it, syncs, and rebuilds the Merkle from it. A target below the pruning boundary (or one that was never synced) returns `RewindBeyondHistory`.
- **Verification on load.** Reopen and rewind recompute the root from the rebuilt frontier and check the stored proof against it. Corruption fails with `DataCorrupted` instead of serving bad state.
- **Explicit pruning.** The journal grows by one entry per sync until `prune(pruning_boundary)` drops entries below the boundary. The current commit's entry always survives.

## API changes

- `CompactDb::rewind(&mut self)` (always one step) is now `rewind(&mut self, target)`.
- `CompactDb::prune(&self, pruning_boundary)` is new.
- Commits whose encoded operation exceeds the witness entry decode bound are rejected with the new `Error::CommitTooLarge`, both at commit time and on compact-sync import, instead of persisting an entry that the next reopen cannot decode.
- `CompactConfig` is now `{ strategy, witness, commit_codec_config }`; the merkle config (and its partition) is gone.
- `merkle::compact::Merkle<F, D, S>` lost its `E` parameter and its async `init(context, config)`; it is now constructed synchronously with `new(strategy)`.
- `CompactDb::commit()` (an alias of `sync()`) is removed; `current_target()` is renamed to `target()`.
- Compact-sync import no longer touches the target partition until its first persist: an abandoned or cancelled sync leaves the previous state intact, and rewind/prune on the imported handle are rejected until that persist runs.
- The rewind-depth reporting machinery in glue (`ManagedDb::max_rewind_depth`, `DatabaseSet::max_rewind_depth`, `assert_rewind_window_safety`) is removed: every database now rewinds arbitrarily deep, so there is no depth to report or assert on.
- glue's `Config.max_pending_acks` moved into `PruneConfig`. Glue only used it to seed the prune retention windows (marshal keeps its own copy for dispatch tracking), so the value is now carried only when pruning is enabled.