### PR TITLE
[storage/qmdb] expose pending batch overlay

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1004,6 +1004,28 @@ where
 
         Ok(results)
     }
+
+    /// Return this batch and its uncommitted ancestors as one pending overlay.
+    ///
+    /// The map has the same priority as `get`: local mutations override parent
+    /// diffs, which override older ancestor diffs. `Some(value)` shadows the
+    /// committed value for that key, and `None` hides it.
+    pub fn pending_overlay(&self) -> BTreeMap<U::Key, Option<U::Value>> {
+        let mut overlay = BTreeMap::new();
+        if let Some(parent) = self.base.parent() {
+            let mut chain = vec![Arc::clone(parent)];
+            chain.extend(parent.ancestors());
+            for batch in chain.into_iter().rev() {
+                for (key, entry) in batch.diff.iter() {
+                    overlay.insert(key.clone(), entry.value().cloned());
+                }
+            }
+        }
+        for (key, value) in &self.mutations {
+            overlay.insert(key.clone(), value.clone());
+        }
+        overlay
+    }
 }
 
 // Unordered-specific methods.

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -1564,6 +1564,60 @@ pub(crate) mod test {
         });
     }
 
+    /// batch.pending_overlay() snapshots own mutations + uncommitted ancestor
+    /// diffs with get()'s priority: newest wins, None hides, committed state
+    /// is excluded.
+    #[test_traced("INFO")]
+    fn test_any_batch_pending_overlay() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let ctx = context.child("db");
+            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+                ctx.child("storage"),
+                variable_db_config::<OneCap>("po", &ctx),
+            )
+            .await
+            .unwrap();
+
+            // Committed state is NOT part of the overlay.
+            let ka = key(0);
+            commit_writes(&mut db, [(ka, Some(val(0)))], None).await;
+            let batch = db.new_batch();
+            assert!(batch.pending_overlay().is_empty());
+
+            // A parentless batch's overlay is exactly its own mutations:
+            // Some shadows the committed value, None hides it.
+            let kb = key(1);
+            let vb = val(1);
+            let batch = batch.write(kb, Some(vb)).write(ka, None);
+            let overlay = batch.pending_overlay();
+            assert_eq!(overlay.len(), 2);
+            assert_eq!(overlay.get(&kb), Some(&Some(vb)));
+            assert_eq!(overlay.get(&ka), Some(&None));
+
+            // A child forked from an uncommitted parent sees the parent's
+            // diff under its own mutations.
+            let kc = key(2);
+            let vc = val(2);
+            let parent = batch.merkleize(&db, None).await.unwrap();
+            let child = parent.new_batch().write(kc, Some(vc));
+            let overlay = child.pending_overlay();
+            assert_eq!(overlay.get(&kb), Some(&Some(vb)));
+            assert_eq!(overlay.get(&ka), Some(&None));
+            assert_eq!(overlay.get(&kc), Some(&Some(vc)));
+
+            // Across a deeper chain the newest write wins.
+            let vb2 = val(100);
+            let middle = child.merkleize(&db, None).await.unwrap();
+            let grandchild = middle.new_batch::<Sha256>().write(kb, Some(vb2));
+            let overlay = grandchild.pending_overlay();
+            assert_eq!(overlay.get(&kb), Some(&Some(vb2)));
+            assert_eq!(overlay.get(&kc), Some(&Some(vc)));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// merkleized.get() reflects the resolved diff after merkleize.
     #[test_traced("INFO")]
     fn test_any_batch_get_on_merkleized() {

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -34,7 +34,7 @@ use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use commonware_utils::bitmap::{self, Readable as _};
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     hash::BuildHasherDefault,
     sync::Arc,
 };
@@ -337,6 +337,13 @@ where
     pub fn write(mut self, key: U::Key, value: Option<U::Value>) -> Self {
         self.inner = self.inner.write(key, value);
         self
+    }
+
+    /// Return this batch and its uncommitted ancestors as one pending overlay.
+    ///
+    /// `Some(value)` shadows the committed value for that key, and `None` hides it.
+    pub fn pending_overlay(&self) -> BTreeMap<U::Key, Option<U::Value>> {
+        self.inner.pending_overlay()
     }
 }
 


### PR DESCRIPTION
Closes #4058

Adds a read-only `pending_overlay()` accessor to `UnmerkleizedBatch` (any + current): the batch's own mutations overlaid on its uncommitted ancestors' diffs, as one `BTreeMap<Key, Option<Value>>`.

The traversal and priority are exactly `get()`'s read-through (`mutations -> parent diff -> ancestor diffs`, newest wins, `Some` shadows the committed value, `None` hides it) — including the documented Weak-chain behavior: an ancestor that was committed and freed drops out of the overlay, and reads for its keys correctly fall through to the committed database.

### Motivation

A `glue::stateful` application whose execution must be anchored at the parent block's state (committed + uncommitted ancestors) can resolve point reads through `batch.get()`, but has no way to **enumerate** pending keys — e.g. to merge the pending write-set with a committed-db range stream for ordered prefix scans. Every internal that would allow building this view externally (`mutations`, `base`, `MerkleizedBatch::{diff, ancestor_diffs, ancestors}`) is crate-private, so applications with scan-shaped state currently have no way to obtain it. The accessor closes that gap.

### Notes

- Read-only borrow; no change to batch lifecycle or merkleization. The `current` impl delegates to the inner `any` batch.
- Like ancestor diffs themselves, the overlay may include value-identical entries for keys relocated by an inactivity-floor raise — consistent with `get()` resolving through the same diffs.
- Unit test `test_any_batch_pending_overlay` mirrors `test_any_batch_get_read_through`: committed state excluded, parentless batch = own mutations exactly, child/grandchild chains with newest-wins shadowing and `None` hiding.
