### PR TITLE
[cryptography] Add MAYO scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.46"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1557,6 +1557,7 @@ dependencies = [
  "rayon",
  "rstest",
  "sha2 0.10.9",
+ "sriracha-mayo",
  "thiserror 2.0.17",
  "x25519-dalek",
  "zeroize",
@@ -2820,9 +2821,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -5183,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -5288,6 +5289,20 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sriracha-mayo"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "386585c8bc07644b649bdc81c47f91942bd0e6897f6d381268be6ac32d05368c"
+dependencies = [
+ "bytes",
+ "cc",
+ "rand_core 0.6.4",
+ "serde",
+ "thiserror 2.0.17",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,7 @@ serde = "1.0.218"
 serde_json = "1.0.122"
 serde_yaml = "0.9.34"
 sha2 = { version = "0.10.8", default-features = false }
+sriracha-mayo = { version = "0.0.4", default-features = false }
 syn = "2.0.0"
 sysinfo = "0.37.2"
 thiserror = { version = "2.0.12", default-features = false }

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -51,6 +51,10 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 # aws-lc-rs provides optimized P-256 verification and handshake cipher on x86_64 and aarch64.
 aws-lc-rs.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# sriracha-mayo builds MAYO-C with a C toolchain, which is unavailable on wasm32.
+sriracha-mayo.workspace = true
+
 [target.'cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies.chacha20poly1305]
 workspace = true
 default-features = false
@@ -120,6 +124,7 @@ std = [
 	"rand_chacha/std",
 	"rand_core/std",
 	"sha2/std",
+	"sriracha-mayo/std",
 	"thiserror/std",
 	"zeroize/std",
 ]
@@ -133,6 +138,11 @@ path = "src/bls12381/benches/bench.rs"
 name = "ed25519"
 harness = false
 path = "src/ed25519/benches/bench.rs"
+
+[[bench]]
+name = "mayo"
+harness = false
+path = "src/mayo/benches/bench.rs"
 
 [[bench]]
 name = "secp256r1"

--- a/cryptography/conformance.toml
+++ b/cryptography/conformance.toml
@@ -158,6 +158,54 @@ hash = "b98d0717af705e8b60af88a8337154eaced6659c3cc9f604aa4f55585a28b77f"
 n_cases = 65536
 hash = "47ab8f97f2b9ff2b56e952c4e219c8c95832cf3a58d5b682cdc769c2ecb79daf"
 
+["commonware_cryptography::mayo::scheme::mayo1::tests::conformance::CodecConformance<PrivateKey>"]
+n_cases = 256
+hash = "622ee5dbb2ff7e2c77196be298d33253d970724e55c04bd7cc31503c9fab863e"
+
+["commonware_cryptography::mayo::scheme::mayo1::tests::conformance::CodecConformance<PublicKey>"]
+n_cases = 256
+hash = "069497d7fadaae1af1d74fd2afa0546214e33a81a19b1fd6cd0a4bd6df192028"
+
+["commonware_cryptography::mayo::scheme::mayo1::tests::conformance::CodecConformance<Signature>"]
+n_cases = 1024
+hash = "c2a61e825702d83285f3054be988beaa0311b193049da4d354043c49ebfe2980"
+
+["commonware_cryptography::mayo::scheme::mayo2::tests::conformance::CodecConformance<PrivateKey>"]
+n_cases = 256
+hash = "622ee5dbb2ff7e2c77196be298d33253d970724e55c04bd7cc31503c9fab863e"
+
+["commonware_cryptography::mayo::scheme::mayo2::tests::conformance::CodecConformance<PublicKey>"]
+n_cases = 256
+hash = "36dc72fe7fc5fbeb65b26cd207e3f085bc5dd331b8df84aa4b9aaff21efb4486"
+
+["commonware_cryptography::mayo::scheme::mayo2::tests::conformance::CodecConformance<Signature>"]
+n_cases = 1024
+hash = "a16b2078208a775b645523a924984d8623721a1e3061a2d08d7f11c999f2757c"
+
+["commonware_cryptography::mayo::scheme::mayo3::tests::conformance::CodecConformance<PrivateKey>"]
+n_cases = 256
+hash = "64ac026e5f2d5290343e4620e5b7c9577f34393c882ee4b1794e3f94a39c4bd2"
+
+["commonware_cryptography::mayo::scheme::mayo3::tests::conformance::CodecConformance<PublicKey>"]
+n_cases = 256
+hash = "587e85b5bf7b53cfef3f575c4f7e14a2c60bfd614372541150e64b4d526c3ab9"
+
+["commonware_cryptography::mayo::scheme::mayo3::tests::conformance::CodecConformance<Signature>"]
+n_cases = 1024
+hash = "ed605a7fb31175d584dcb65ce48cc9e7c5e11ff9ecbad25fc98ffe13061d42ec"
+
+["commonware_cryptography::mayo::scheme::mayo5::tests::conformance::CodecConformance<PrivateKey>"]
+n_cases = 256
+hash = "323f187342d633f85924c3d84659219ac431b5cb83923a59bc1e23693412d5f9"
+
+["commonware_cryptography::mayo::scheme::mayo5::tests::conformance::CodecConformance<PublicKey>"]
+n_cases = 256
+hash = "04e7c490db2dac7f6b55c2ca976b983c96bde18fa08f0b49661066b74662652e"
+
+["commonware_cryptography::mayo::scheme::mayo5::tests::conformance::CodecConformance<Signature>"]
+n_cases = 1024
+hash = "f869247b3f9add675d79e847c568fd13dc096bc4dcbffe9254392d57b86e490e"
+
 ["commonware_cryptography::secp256r1::certificate::tests::conformance::CodecConformance<Certificate>"]
 n_cases = 1024
 hash = "c708aa3df9cc2918aaf2d8db673c96729a2d2fd41b470ac5f6843489fc380951"

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -45,6 +45,9 @@ commonware_macros::stability_scope!(ALPHA {
     pub mod lthash;
     pub use crate::lthash::LtHash;
 
+    #[cfg(not(target_arch = "wasm32"))]
+    pub mod mayo;
+
     pub mod zk;
 });
 commonware_macros::stability_scope!(BETA {

--- a/cryptography/src/mayo/benches/bench.rs
+++ b/cryptography/src/mayo/benches/bench.rs
@@ -1,0 +1,9 @@
+use criterion::criterion_main;
+
+mod signature_generation;
+mod signature_verification;
+
+criterion_main!(
+    signature_generation::benches,
+    signature_verification::benches,
+);

--- a/cryptography/src/mayo/benches/signature_generation.rs
+++ b/cryptography/src/mayo/benches/signature_generation.rs
@@ -1,0 +1,41 @@
+use commonware_cryptography::{mayo, Signer as _};
+use commonware_math::algebra::Random;
+use criterion::{criterion_group, BatchSize, Criterion};
+use rand::{thread_rng, Rng};
+use std::hint::black_box;
+
+fn bench_signature_generation(c: &mut Criterion) {
+    let namespace = b"namespace";
+    let mut msg = [0u8; 32];
+    thread_rng().fill(&mut msg);
+
+    macro_rules! bench_param {
+        ($module:ident) => {
+            c.bench_function(
+                &format!(
+                    "{}/param={} ns_len={} msg_len={}",
+                    module_path!(),
+                    stringify!($module),
+                    namespace.len(),
+                    msg.len()
+                ),
+                |b| {
+                    b.iter_batched(
+                        || mayo::$module::PrivateKey::random(&mut thread_rng()),
+                        |private_key| {
+                            black_box(private_key.sign(namespace, &msg));
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        };
+    }
+
+    bench_param!(mayo1);
+    bench_param!(mayo2);
+    bench_param!(mayo3);
+    bench_param!(mayo5);
+}
+
+criterion_group!(benches, bench_signature_generation);

--- a/cryptography/src/mayo/benches/signature_verification.rs
+++ b/cryptography/src/mayo/benches/signature_verification.rs
@@ -1,0 +1,40 @@
+use commonware_cryptography::{mayo, Signer as _, Verifier as _};
+use commonware_math::algebra::Random;
+use criterion::{criterion_group, Criterion};
+use rand::{thread_rng, Rng};
+use std::hint::black_box;
+
+fn bench_signature_verification(c: &mut Criterion) {
+    let namespace = b"namespace";
+    let mut msg = [0u8; 32];
+    thread_rng().fill(&mut msg);
+
+    macro_rules! bench_param {
+        ($module:ident) => {
+            let private_key = mayo::$module::PrivateKey::random(&mut thread_rng());
+            let public_key = private_key.public_key();
+            let signature = private_key.sign(namespace, &msg);
+            c.bench_function(
+                &format!(
+                    "{}/param={} ns_len={} msg_len={}",
+                    module_path!(),
+                    stringify!($module),
+                    namespace.len(),
+                    msg.len()
+                ),
+                |b| {
+                    b.iter(|| {
+                        black_box(public_key.verify(namespace, &msg, &signature));
+                    });
+                },
+            );
+        };
+    }
+
+    bench_param!(mayo1);
+    bench_param!(mayo2);
+    bench_param!(mayo3);
+    bench_param!(mayo5);
+}
+
+criterion_group!(benches, bench_signature_verification);

--- a/cryptography/src/mayo/mod.rs
+++ b/cryptography/src/mayo/mod.rs
@@ -1,0 +1,53 @@
+//! MAYO implementations of the [crate::Verifier] and [crate::Signer] traits.
+//!
+//! MAYO is a multivariate quadratic signature scheme based on the Oil and Vinegar
+//! trapdoor and is a candidate in the NIST post-quantum signature standardization
+//! process. This module wraps the reference MAYO-C implementation via the
+//! [sriracha_mayo] bindings, which build the C library at compile time (a C
+//! toolchain and CMake are required). The module is unavailable on `wasm32`
+//! targets.
+//!
+//! # Parameter Sets
+//!
+//! Each parameter set is exposed as its own submodule with concrete key and
+//! signature types:
+//!
+//! | Module    | NIST Level | Secret Seed | Public Key | Signature |
+//! |-----------|------------|-------------|------------|-----------|
+//! | [mayo1]   | 1          | 24 bytes    | 1420 bytes | 454 bytes |
+//! | [mayo2]   | 1          | 24 bytes    | 4912 bytes | 186 bytes |
+//! | [mayo3]   | 3          | 32 bytes    | 2986 bytes | 681 bytes |
+//! | [mayo5]   | 5          | 40 bytes    | 5554 bytes | 964 bytes |
+//!
+//! MAYO-2 trades a much larger public key for the smallest signatures. A
+//! private key serializes as its secret seed; the public key is re-derived
+//! on decode.
+//!
+//! # Randomized Signatures
+//!
+//! MAYO signing draws a fresh salt (from the operating system, inside MAYO-C)
+//! for every signature, so signing the same message twice produces different
+//! signatures. Verification is deterministic.
+//!
+//! # Example
+//! ```rust
+//! use commonware_cryptography::{mayo::mayo1, PrivateKey, PublicKey, Signature, Verifier as _, Signer as _};
+//! use commonware_math::algebra::Random;
+//! use rand::rngs::OsRng;
+//!
+//! // Generate a new private key
+//! let signer = mayo1::PrivateKey::random(&mut OsRng);
+//!
+//! // Create a message to sign
+//! let namespace = b"demo";
+//! let msg = b"hello, world!";
+//!
+//! // Sign the message
+//! let signature = signer.sign(namespace, msg);
+//!
+//! // Verify the signature
+//! assert!(signer.public_key().verify(namespace, msg, &signature));
+//! ```
+
+mod scheme;
+pub use scheme::{mayo1, mayo2, mayo3, mayo5};

--- a/cryptography/src/mayo/scheme.rs
+++ b/cryptography/src/mayo/scheme.rs
@@ -1,0 +1,618 @@
+macro_rules! impl_mayo {
+    ($module:ident, $parameter_set:ident, $name:literal) => {
+        #[doc = concat!($name, " implementation of the [crate::Signer] and [crate::Verifier] traits.")]
+        pub mod $module {
+            use crate::Secret;
+            #[cfg(not(feature = "std"))]
+            use alloc::borrow::Cow;
+            use bytes::{Buf, BufMut};
+            use commonware_codec::{
+                Error as CodecError, FixedArray, FixedSize, Read, ReadExt, Write,
+            };
+            use commonware_formatting::Hex;
+            use commonware_math::algebra::Random;
+            use commonware_parallel::Strategy;
+            use commonware_utils::{union_unique, Array, Span};
+            use core::{
+                cmp::Ordering,
+                fmt::{Debug, Display},
+                hash::{Hash, Hasher},
+                ops::Deref,
+            };
+            use rand_core::CryptoRngCore;
+            use sriracha_mayo::{$parameter_set, ParameterSet};
+            #[cfg(feature = "std")]
+            use std::borrow::Cow;
+            use zeroize::Zeroizing;
+
+            const SCHEME_NAME: &str = $name;
+            const PRIVATE_KEY_LENGTH: usize = <$parameter_set as ParameterSet>::SECRET_KEY_BYTES;
+            const PUBLIC_KEY_LENGTH: usize = <$parameter_set as ParameterSet>::PUBLIC_KEY_BYTES;
+            const SIGNATURE_LENGTH: usize = <$parameter_set as ParameterSet>::SIGNATURE_BYTES;
+
+            #[doc = concat!($name, " Private Key.")]
+            ///
+            /// Holds the compact secret seed and the public key derived from it. The
+            /// seed alone determines the keypair, so only the seed is serialized and
+            /// the public key is re-derived on decode (one MAYO key expansion).
+            #[derive(Clone, Debug)]
+            pub struct PrivateKey {
+                seed: Secret<[u8; PRIVATE_KEY_LENGTH]>,
+                public: PublicKey,
+            }
+
+            impl crate::PrivateKey for PrivateKey {}
+
+            impl crate::Signer for PrivateKey {
+                type Signature = Signature;
+                type PublicKey = PublicKey;
+
+                fn sign(&self, namespace: &[u8], msg: &[u8]) -> Self::Signature {
+                    self.sign_inner(Some(namespace), msg)
+                }
+
+                fn public_key(&self) -> Self::PublicKey {
+                    self.public.clone()
+                }
+            }
+
+            impl PrivateKey {
+                /// Derives the keypair determined by `seed`.
+                fn from_seed_bytes(
+                    seed: &[u8; PRIVATE_KEY_LENGTH],
+                ) -> Result<Self, sriracha_mayo::Error> {
+                    let (public, _) = sriracha_mayo::SecretKey::<$parameter_set>::from_seed(seed)?;
+                    Ok(Self {
+                        seed: Secret::new(*seed),
+                        public: PublicKey { key: public },
+                    })
+                }
+
+                /// Signs the payload, panicking if MAYO-C fails to produce a signature
+                /// (which only happens if per-signature salt generation fails).
+                #[inline(always)]
+                fn sign_inner(&self, namespace: Option<&[u8]>, msg: &[u8]) -> Signature {
+                    let payload = namespace
+                        .map(|namespace| Cow::Owned(union_unique(namespace, msg)))
+                        .unwrap_or_else(|| Cow::Borrowed(msg));
+                    let signature = self
+                        .seed
+                        .expose(|seed| {
+                            let secret = sriracha_mayo::SecretKey::<$parameter_set>::try_from(
+                                seed.as_slice(),
+                            )
+                            .expect("seed length matches the parameter set");
+                            secret.sign(&payload)
+                        })
+                        .expect("MAYO signing failed");
+                    Signature { signature }
+                }
+            }
+
+            impl Random for PrivateKey {
+                fn random(mut rng: impl CryptoRngCore) -> Self {
+                    let (public, secret) =
+                        sriracha_mayo::SecretKey::<$parameter_set>::random(&mut rng)
+                            .expect("MAYO keypair generation failed");
+                    let mut seed = Zeroizing::new([0u8; PRIVATE_KEY_LENGTH]);
+                    seed.copy_from_slice(secret.as_ref());
+                    Self {
+                        seed: Secret::new(*seed),
+                        public: PublicKey { key: public },
+                    }
+                }
+            }
+
+            impl Write for PrivateKey {
+                fn write(&self, buf: &mut impl BufMut) {
+                    self.seed.expose(|seed| seed.write(buf));
+                }
+            }
+
+            impl Read for PrivateKey {
+                type Cfg = ();
+
+                fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+                    let raw = Zeroizing::new(<[u8; Self::SIZE]>::read(buf)?);
+                    let result = Self::from_seed_bytes(&raw);
+                    #[cfg(feature = "std")]
+                    let key = result.map_err(|e| CodecError::Wrapped(SCHEME_NAME, e.into()))?;
+                    #[cfg(not(feature = "std"))]
+                    let key = result.map_err(|e| {
+                        CodecError::Wrapped(SCHEME_NAME, alloc::format!("{:?}", e).into())
+                    })?;
+
+                    Ok(key)
+                }
+            }
+
+            impl FixedSize for PrivateKey {
+                const SIZE: usize = PRIVATE_KEY_LENGTH;
+            }
+
+            impl Display for PrivateKey {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{:?}", self)
+                }
+            }
+
+            #[cfg(feature = "arbitrary")]
+            impl arbitrary::Arbitrary<'_> for PrivateKey {
+                fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                    use rand::{rngs::StdRng, SeedableRng};
+
+                    let mut rand = StdRng::from_seed(u.arbitrary::<[u8; 32]>()?);
+                    Ok(Self::random(&mut rand))
+                }
+            }
+
+            #[cfg(test)]
+            impl PartialEq for PrivateKey {
+                fn eq(&self, other: &Self) -> bool {
+                    self.seed
+                        .expose(|seed1| other.seed.expose(|seed2| seed1 == seed2))
+                        && self.public == other.public
+                }
+            }
+
+            #[doc = concat!($name, " Public Key.")]
+            #[derive(Clone, Eq, PartialEq, FixedArray)]
+            pub struct PublicKey {
+                key: sriracha_mayo::PublicKey<$parameter_set>,
+            }
+
+            impl From<PrivateKey> for PublicKey {
+                fn from(value: PrivateKey) -> Self {
+                    value.public
+                }
+            }
+
+            impl crate::PublicKey for PublicKey {}
+
+            impl crate::Verifier for PublicKey {
+                type Signature = Signature;
+
+                fn verify(&self, namespace: &[u8], msg: &[u8], sig: &Self::Signature) -> bool {
+                    self.verify_inner(Some(namespace), msg, sig)
+                }
+            }
+
+            impl PublicKey {
+                #[inline(always)]
+                fn verify_inner(
+                    &self,
+                    namespace: Option<&[u8]>,
+                    msg: &[u8],
+                    sig: &Signature,
+                ) -> bool {
+                    let payload = namespace
+                        .map(|namespace| Cow::Owned(union_unique(namespace, msg)))
+                        .unwrap_or_else(|| Cow::Borrowed(msg));
+                    sig.signature.verify(&self.key, &payload)
+                }
+            }
+
+            impl Ord for PublicKey {
+                fn cmp(&self, other: &Self) -> Ordering {
+                    self.key.as_ref().cmp(other.key.as_ref())
+                }
+            }
+
+            impl PartialOrd for PublicKey {
+                fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                    Some(self.cmp(other))
+                }
+            }
+
+            impl Hash for PublicKey {
+                fn hash<H: Hasher>(&self, state: &mut H) {
+                    self.key.as_ref().hash(state);
+                }
+            }
+
+            impl Write for PublicKey {
+                fn write(&self, buf: &mut impl BufMut) {
+                    buf.put_slice(self.key.as_ref());
+                }
+            }
+
+            impl Read for PublicKey {
+                type Cfg = ();
+
+                fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+                    let raw = <[u8; Self::SIZE]>::read(buf)?;
+                    let result = sriracha_mayo::PublicKey::try_from(raw.as_slice());
+                    #[cfg(feature = "std")]
+                    let key = result.map_err(|e| CodecError::Wrapped(SCHEME_NAME, e.into()))?;
+                    #[cfg(not(feature = "std"))]
+                    let key = result.map_err(|e| {
+                        CodecError::Wrapped(SCHEME_NAME, alloc::format!("{:?}", e).into())
+                    })?;
+
+                    Ok(Self { key })
+                }
+            }
+
+            impl FixedSize for PublicKey {
+                const SIZE: usize = PUBLIC_KEY_LENGTH;
+            }
+
+            impl Span for PublicKey {}
+
+            impl Array for PublicKey {}
+
+            impl AsRef<[u8]> for PublicKey {
+                fn as_ref(&self) -> &[u8] {
+                    self.key.as_ref()
+                }
+            }
+
+            impl Deref for PublicKey {
+                type Target = [u8];
+                fn deref(&self) -> &[u8] {
+                    self.key.as_ref()
+                }
+            }
+
+            impl Debug for PublicKey {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{}", Hex(self))
+                }
+            }
+
+            impl Display for PublicKey {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{}", Hex(self))
+                }
+            }
+
+            #[cfg(feature = "arbitrary")]
+            impl arbitrary::Arbitrary<'_> for PublicKey {
+                fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                    use crate::Signer;
+
+                    let private_key = PrivateKey::arbitrary(u)?;
+                    Ok(private_key.public_key())
+                }
+            }
+
+            #[doc = concat!($name, " Signature.")]
+            ///
+            /// MAYO signing draws a fresh salt for every signature, so two signatures
+            /// over the same message by the same key differ. Verification is
+            /// deterministic.
+            #[derive(Clone, Eq, PartialEq, FixedArray)]
+            pub struct Signature {
+                signature: sriracha_mayo::Signature<$parameter_set>,
+            }
+
+            impl crate::Signature for Signature {}
+
+            impl Ord for Signature {
+                fn cmp(&self, other: &Self) -> Ordering {
+                    self.signature.as_ref().cmp(other.signature.as_ref())
+                }
+            }
+
+            impl PartialOrd for Signature {
+                fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                    Some(self.cmp(other))
+                }
+            }
+
+            impl Hash for Signature {
+                fn hash<H: Hasher>(&self, state: &mut H) {
+                    self.signature.as_ref().hash(state);
+                }
+            }
+
+            impl Write for Signature {
+                fn write(&self, buf: &mut impl BufMut) {
+                    buf.put_slice(self.signature.as_ref());
+                }
+            }
+
+            impl Read for Signature {
+                type Cfg = ();
+
+                fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
+                    let raw = <[u8; Self::SIZE]>::read(buf)?;
+                    let signature = sriracha_mayo::Signature::try_from(raw.as_slice())
+                        .expect("length matches the parameter set");
+                    Ok(Self { signature })
+                }
+            }
+
+            impl FixedSize for Signature {
+                const SIZE: usize = SIGNATURE_LENGTH;
+            }
+
+            impl Span for Signature {}
+
+            impl Array for Signature {}
+
+            impl AsRef<[u8]> for Signature {
+                fn as_ref(&self) -> &[u8] {
+                    self.signature.as_ref()
+                }
+            }
+
+            impl Deref for Signature {
+                type Target = [u8];
+                fn deref(&self) -> &[u8] {
+                    self.signature.as_ref()
+                }
+            }
+
+            impl Debug for Signature {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{}", Hex(self))
+                }
+            }
+
+            impl Display for Signature {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{}", Hex(self))
+                }
+            }
+
+            #[cfg(feature = "arbitrary")]
+            impl arbitrary::Arbitrary<'_> for Signature {
+                fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                    // MAYO signing is salted, so signing inside Arbitrary would not be
+                    // reproducible. Any byte string of the correct length decodes, so
+                    // generate raw bytes instead.
+                    let raw = u.arbitrary::<[u8; SIGNATURE_LENGTH]>()?;
+                    let signature = sriracha_mayo::Signature::try_from(raw.as_slice())
+                        .expect("length matches the parameter set");
+                    Ok(Self { signature })
+                }
+            }
+
+            #[doc = concat!($name, " Batch Verifier.")]
+            ///
+            /// MAYO verification expands the compact public key into a much larger
+            /// internal representation before checking. The batch caches each expanded
+            /// key, so verifying many signatures from the same signer amortizes the
+            /// expansion. This is an exact verifier (every tuple is checked
+            /// individually), so the randomness and strategy passed to `verify` are
+            /// unused.
+            pub struct Batch {
+                verifier: sriracha_mayo::BatchVerifier<$parameter_set>,
+            }
+
+            impl crate::BatchVerifier for Batch {
+                type PublicKey = PublicKey;
+
+                fn new() -> Self {
+                    Self {
+                        verifier: sriracha_mayo::BatchVerifier::new(),
+                    }
+                }
+
+                fn add(
+                    &mut self,
+                    namespace: &[u8],
+                    message: &[u8],
+                    public_key: &PublicKey,
+                    signature: &Signature,
+                ) -> bool {
+                    self.add_inner(Some(namespace), message, public_key, signature)
+                }
+
+                fn verify<R: CryptoRngCore>(self, _: &mut R, _: &impl Strategy) -> bool {
+                    self.verifier.verify()
+                }
+            }
+
+            impl Batch {
+                #[inline(always)]
+                fn add_inner(
+                    &mut self,
+                    namespace: Option<&[u8]>,
+                    message: &[u8],
+                    public_key: &PublicKey,
+                    signature: &Signature,
+                ) -> bool {
+                    let payload = namespace
+                        .map(|namespace| Cow::Owned(union_unique(namespace, message)))
+                        .unwrap_or_else(|| Cow::Borrowed(message));
+                    self.verifier
+                        .add(&public_key.key, payload, &signature.signature)
+                        .is_ok()
+                }
+            }
+
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+                use crate::{BatchVerifier as _, Signer as _, Verifier as _};
+                use commonware_codec::{DecodeExt, Encode};
+                use commonware_parallel::Sequential;
+                use commonware_utils::{test_rng, test_rng_seeded};
+
+                #[test]
+                fn test_sign_and_verify() {
+                    let private_key = PrivateKey::random(&mut test_rng());
+                    let public_key = private_key.public_key();
+                    let namespace = b"test_namespace";
+                    let message = b"test_message";
+                    let signature = private_key.sign(namespace, message);
+                    assert!(public_key.verify(namespace, message, &signature));
+                    assert!(!public_key.verify(namespace, b"wrong_message", &signature));
+                    assert!(!public_key.verify(b"wrong_namespace", message, &signature));
+                }
+
+                #[test]
+                fn test_empty_namespace_and_message() {
+                    let private_key = PrivateKey::random(&mut test_rng());
+                    let public_key = private_key.public_key();
+                    let signature = private_key.sign(b"", b"");
+                    assert!(public_key.verify(b"", b"", &signature));
+                }
+
+                #[test]
+                fn test_wrong_key_fails() {
+                    let private_key = PrivateKey::random(&mut test_rng());
+                    let other_public_key = PrivateKey::random(&mut test_rng_seeded(1)).public_key();
+                    let namespace = b"test_namespace";
+                    let message = b"test_message";
+                    let signature = private_key.sign(namespace, message);
+                    assert!(!other_public_key.verify(namespace, message, &signature));
+                }
+
+                #[test]
+                fn test_codec_private_key() {
+                    let private_key = PrivateKey::random(&mut test_rng());
+                    let encoded = private_key.encode();
+                    assert_eq!(encoded.len(), PrivateKey::SIZE);
+                    let decoded = PrivateKey::decode(encoded).unwrap();
+                    assert_eq!(private_key, decoded);
+                    assert_eq!(private_key.public_key(), decoded.public_key());
+                }
+
+                #[test]
+                fn test_codec_public_key() {
+                    let public_key = PrivateKey::random(&mut test_rng()).public_key();
+                    let encoded = public_key.encode();
+                    assert_eq!(encoded.len(), PUBLIC_KEY_LENGTH);
+                    let decoded = PublicKey::decode(encoded).unwrap();
+                    assert_eq!(public_key, decoded);
+                }
+
+                #[test]
+                fn test_codec_signature() {
+                    let private_key = PrivateKey::random(&mut test_rng());
+                    let public_key = private_key.public_key();
+                    let namespace = b"test_namespace";
+                    let message = b"test_message";
+                    let signature = private_key.sign(namespace, message);
+                    let encoded = signature.encode();
+                    assert_eq!(encoded.len(), SIGNATURE_LENGTH);
+                    let decoded = Signature::decode(encoded).unwrap();
+                    assert_eq!(signature, decoded);
+                    assert!(public_key.verify(namespace, message, &decoded));
+                }
+
+                #[test]
+                fn test_decode_invalid_length_fails() {
+                    assert!(PublicKey::decode(vec![0u8; 1024].as_ref()).is_err());
+                    assert!(Signature::decode(vec![0u8; 1024].as_ref()).is_err());
+                }
+
+                #[test]
+                fn test_zero_signature_fails() {
+                    let public_key = PrivateKey::random(&mut test_rng()).public_key();
+                    let zero_sig = Signature::decode(vec![0u8; Signature::SIZE].as_ref()).unwrap();
+                    assert!(!public_key.verify_inner(None, b"test_message", &zero_sig));
+                }
+
+                #[test]
+                fn test_corrupted_signature_fails() {
+                    let private_key = PrivateKey::random(&mut test_rng());
+                    let public_key = private_key.public_key();
+                    let message = b"test_message";
+                    let signature = private_key.sign_inner(None, message);
+                    let mut corrupted = signature.encode().to_vec();
+                    corrupted[0] ^= 0x01;
+                    let corrupted = Signature::decode(corrupted.as_ref()).unwrap();
+                    assert!(!public_key.verify_inner(None, message, &corrupted));
+                }
+
+                #[test]
+                fn test_keypair_derivation_deterministic() {
+                    let private_key_1 = PrivateKey::random(&mut test_rng());
+                    let private_key_2 = PrivateKey::random(&mut test_rng());
+                    assert_eq!(private_key_1, private_key_2);
+                    assert_eq!(private_key_1.public_key(), private_key_2.public_key());
+                }
+
+                #[test]
+                fn test_batch_verify_valid() {
+                    let private_key_1 = PrivateKey::random(&mut test_rng());
+                    let private_key_2 = PrivateKey::random(&mut test_rng_seeded(1));
+                    let namespace = b"test_namespace";
+                    let message_1 = b"first_message";
+                    let message_2 = b"second_message";
+
+                    let mut batch = Batch::new();
+                    assert!(batch.add(
+                        namespace,
+                        message_1,
+                        &private_key_1.public_key(),
+                        &private_key_1.sign(namespace, message_1)
+                    ));
+                    assert!(batch.add(
+                        namespace,
+                        message_2,
+                        &private_key_1.public_key(),
+                        &private_key_1.sign(namespace, message_2)
+                    ));
+                    assert!(batch.add(
+                        namespace,
+                        message_1,
+                        &private_key_2.public_key(),
+                        &private_key_2.sign(namespace, message_1)
+                    ));
+                    assert!(batch.verify(&mut test_rng(), &Sequential));
+                }
+
+                #[test]
+                fn test_batch_verify_invalid() {
+                    let private_key = PrivateKey::random(&mut test_rng());
+                    let namespace = b"test_namespace";
+                    let message = b"test_message";
+                    let signature = private_key.sign(namespace, message);
+
+                    let mut batch = Batch::new();
+                    assert!(batch.add(namespace, message, &private_key.public_key(), &signature));
+                    assert!(batch.add(
+                        namespace,
+                        b"wrong_message",
+                        &private_key.public_key(),
+                        &signature
+                    ));
+                    assert!(!batch.verify(&mut test_rng(), &Sequential));
+                }
+
+                #[test]
+                fn test_batch_verify_empty() {
+                    let batch = Batch::new();
+                    assert!(batch.verify(&mut test_rng(), &Sequential));
+                }
+
+                #[test]
+                fn test_private_key_redacted() {
+                    let private_key = PrivateKey::random(&mut test_rng());
+                    let debug = format!("{:?}", private_key);
+                    let display = format!("{}", private_key);
+                    assert!(debug.contains("REDACTED"));
+                    assert!(display.contains("REDACTED"));
+                }
+
+                #[test]
+                fn test_from_private_key_to_public_key() {
+                    let private_key = PrivateKey::random(&mut test_rng());
+                    assert_eq!(private_key.public_key(), PublicKey::from(private_key));
+                }
+
+                #[cfg(feature = "arbitrary")]
+                mod conformance {
+                    use super::*;
+                    use commonware_codec::conformance::CodecConformance;
+
+                    commonware_conformance::conformance_tests! {
+                        CodecConformance<PrivateKey> => 256,
+                        CodecConformance<PublicKey> => 256,
+                        CodecConformance<Signature> => 1024,
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_mayo!(mayo1, Mayo1, "MAYO-1");
+impl_mayo!(mayo2, Mayo2, "MAYO-2");
+impl_mayo!(mayo3, Mayo3, "MAYO-3");
+impl_mayo!(mayo5, Mayo5, "MAYO-5");


### PR DESCRIPTION
## Overview

Adds a wrapper around the MAYO signature scheme in `commonware-cryptography`.