### PR TITLE
[runtime] key the page cache maps with ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,6 +1974,7 @@ dependencies = [
  "futures",
  "futures-util",
  "governor",
+ "hashbrown 0.16.1",
  "paste",
  "rand 0.8.5",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,6 +1888,7 @@ dependencies = [
 name = "commonware-runtime"
 version = "2026.5.0"
 dependencies = [
+ "ahash",
  "arbitrary",
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ unused-async = "warn"
 suspicious_op_assign_impl = "allow"
 
 [workspace.dependencies]
+ahash = { version = "0.8.12", default-features = false }
 anyhow = { version = "1.0.99", default-features = false }
 arbitrary = "1.4.1"
 ark-ec = { version = "0.5.0", default-features = false }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/commonware-runtime"
 workspace = true
 
 [dependencies]
+ahash = { workspace = true, features = ["std", "runtime-rng"] }
 arbitrary = { workspace = true, optional = true }
 bytes.workspace = true
 cfg-if.workspace = true

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -105,10 +105,6 @@ struct Cache {
     /// The page cache index, with a key composed of (blob id, page number), that maps each cached
     /// page to the index of its slot in `entries` and `slots`.
     ///
-    /// An [AHashMap] (randomly seeded via runtime-rng) rather than std's default SipHash: ahash
-    /// remains DoS-resistant for adversarially influenced page numbers but is several times
-    /// faster on these fixed-width keys, which are hashed on every cached read and insert.
-    ///
     /// # Invariants
     ///
     /// Each `index` entry maps to exactly one `entries` slot, and that entry always has a

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -104,12 +104,17 @@ struct Cache {
     /// The page cache index, with a key composed of (blob id, page number), that maps each cached
     /// page to the index of its slot in `entries` and `slots`.
     ///
+    /// Keyed with [ahash::RandomState] (randomly seeded via runtime-rng) instead of std's default
+    /// SipHash: ahash remains DoS-resistant for adversarially influenced page numbers but is
+    /// several times faster on these fixed-width keys, which are hashed on every cached read and
+    /// insert.
+    ///
     /// # Invariants
     ///
     /// Each `index` entry maps to exactly one `entries` slot, and that entry always has a
     /// matching key. (The converse is not true: after [Self::invalidate_from] a slot may retain
     /// a stale key that is no longer present in `index`.)
-    index: HashMap<(u64, u64), usize>,
+    index: HashMap<(u64, u64), usize, ahash::RandomState>,
 
     /// Metadata for each cache slot.
     ///
@@ -134,7 +139,7 @@ struct Cache {
 
     /// A map of currently executing page fetches to ensure only one task at a time is trying to
     /// fetch a specific page.
-    page_fetches: HashMap<(u64, u64), PageFetchEntry>,
+    page_fetches: HashMap<(u64, u64), PageFetchEntry, ahash::RandomState>,
 }
 
 /// Metadata for a single cache entry (page data stored in per-slot buffers).
@@ -455,13 +460,13 @@ impl Cache {
             slots.push(slot);
         }
         Self {
-            index: HashMap::new(),
+            index: HashMap::with_hasher(ahash::RandomState::new()),
             entries: Vec::with_capacity(capacity),
             slots,
             page_size,
             clock: 0,
             capacity,
-            page_fetches: HashMap::new(),
+            page_fetches: HashMap::with_hasher(ahash::RandomState::new()),
         }
     }
 

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -3,10 +3,11 @@
 
 use super::get_page_from_blob;
 use crate::{Blob, BufferPool, BufferPooler, Error, IoBuf, IoBufMut};
+use ahash::AHashMap;
 use commonware_utils::sync::RwLock;
 use futures::{future::Shared, FutureExt};
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::hash_map::Entry,
     future::Future,
     num::{NonZeroU16, NonZeroUsize},
     pin::Pin,
@@ -104,17 +105,16 @@ struct Cache {
     /// The page cache index, with a key composed of (blob id, page number), that maps each cached
     /// page to the index of its slot in `entries` and `slots`.
     ///
-    /// Keyed with [ahash::RandomState] (randomly seeded via runtime-rng) instead of std's default
-    /// SipHash: ahash remains DoS-resistant for adversarially influenced page numbers but is
-    /// several times faster on these fixed-width keys, which are hashed on every cached read and
-    /// insert.
+    /// An [AHashMap] (randomly seeded via runtime-rng) rather than std's default SipHash: ahash
+    /// remains DoS-resistant for adversarially influenced page numbers but is several times
+    /// faster on these fixed-width keys, which are hashed on every cached read and insert.
     ///
     /// # Invariants
     ///
     /// Each `index` entry maps to exactly one `entries` slot, and that entry always has a
     /// matching key. (The converse is not true: after [Self::invalidate_from] a slot may retain
     /// a stale key that is no longer present in `index`.)
-    index: HashMap<(u64, u64), usize, ahash::RandomState>,
+    index: AHashMap<(u64, u64), usize>,
 
     /// Metadata for each cache slot.
     ///
@@ -139,7 +139,7 @@ struct Cache {
 
     /// A map of currently executing page fetches to ensure only one task at a time is trying to
     /// fetch a specific page.
-    page_fetches: HashMap<(u64, u64), PageFetchEntry, ahash::RandomState>,
+    page_fetches: AHashMap<(u64, u64), PageFetchEntry>,
 }
 
 /// Metadata for a single cache entry (page data stored in per-slot buffers).
@@ -460,13 +460,13 @@ impl Cache {
             slots.push(slot);
         }
         Self {
-            index: HashMap::with_hasher(ahash::RandomState::new()),
+            index: AHashMap::new(),
             entries: Vec::with_capacity(capacity),
             slots,
             page_size,
             clock: 0,
             capacity,
-            page_fetches: HashMap::with_hasher(ahash::RandomState::new()),
+            page_fetches: AHashMap::new(),
         }
     }
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -28,6 +28,7 @@ commonware-runtime = { workspace = true, optional = true }
 commonware-utils = { workspace = true, default-features = false }
 futures = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
+hashbrown.workspace = true
 thiserror.workspace = true
 tracing = { workspace = true, optional = true }
 zstd = { workspace = true, optional = true }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/commonware-storage"
 workspace = true
 
 [dependencies]
-ahash = { version = "0.8.12", default-features = false }
+ahash.workspace = true
 anyhow.workspace = true
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 bytes = { workspace = true, default-features = false }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/commonware-storage"
 workspace = true
 
 [dependencies]
-ahash.workspace = true
+ahash = { workspace = true, features = ["no-rng"] }
 anyhow.workspace = true
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 bytes = { workspace = true, default-features = false }

--- a/storage/src/bitmap/authenticated.rs
+++ b/storage/src/bitmap/authenticated.rs
@@ -24,6 +24,7 @@ use crate::{
     metadata::{Config as MConfig, Metadata},
     Context,
 };
+use ahash::AHashSet;
 use commonware_codec::DecodeExt;
 use commonware_cryptography::Digest;
 use commonware_parallel::Strategy;
@@ -31,7 +32,6 @@ use commonware_utils::{
     bitmap::{BitMap as UtilsBitMap, Prunable as PrunableBitMap},
     sequence::prefixed_u64::U64,
 };
-use std::collections::HashSet;
 use tracing::{debug, error, warn};
 
 /// Returns a root digest that incorporates bits not yet part of the MMR because they
@@ -76,7 +76,7 @@ pub struct Unmerkleized {
     /// Each dirty chunk is identified by its absolute index, including pruned chunks.
     ///
     /// Invariant: Indices are always in the range [pruned_chunks, authenticated_len).
-    dirty_chunks: HashSet<usize>,
+    dirty_chunks: AHashSet<usize>,
 }
 
 impl private::Sealed for Unmerkleized {}
@@ -511,7 +511,7 @@ impl<E: Context, D: Digest, const N: usize, S: Strategy> MerkleizedBitMap<E, D, 
             mmr: self.mmr,
             strategy: self.strategy,
             state: Unmerkleized {
-                dirty_chunks: HashSet::new(),
+                dirty_chunks: AHashSet::new(),
             },
             metadata: self.metadata,
         }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -83,14 +83,19 @@
 use crate::merkle::{
     hasher::Hasher, mem::Mem, path, proof::Proof, Error, Family, Location, Position, Readable,
 };
+use ahash::AHasher;
 use alloc::{
-    collections::BTreeMap,
     sync::{Arc, Weak},
     vec::Vec,
 };
 use commonware_cryptography::Digest;
 use commonware_parallel::{Sequential, Strategy};
-use core::ops::Range;
+use core::{hash::BuildHasherDefault, ops::Range};
+
+/// Overwritten node digests keyed by position. Uses `ahash` (fast on integer keys) with
+/// [BuildHasherDefault] (no per-construction RNG sampling). Iteration order is not observed
+/// by any consumer.
+pub(crate) type Overwrites<F, D> = hashbrown::HashMap<Position<F>, D, BuildHasherDefault<AHasher>>;
 
 /// Push a dirty node position into its height bucket, growing the outer Vec as needed.
 fn push_dirty<F: Family>(buckets: &mut Vec<Vec<Position<F>>>, height: u32, pos: Position<F>) {
@@ -110,7 +115,7 @@ fn push_dirty<F: Family>(buckets: &mut Vec<Vec<Position<F>>>, height: u32, pos: 
 pub struct UnmerkleizedBatch<F: Family, D: Digest, S: Strategy> {
     parent: Arc<MerkleizedBatch<F, D, S>>,
     appended: Vec<D>,
-    overwrites: BTreeMap<Position<F>, D>,
+    overwrites: Overwrites<F, D>,
     /// Dirty internal node positions bucketed by height. Outer index is height; inner Vec
     /// holds positions at that height in push order (monotonically increasing for
     /// `add_leaf_digest`; may contain duplicates from interleaved `mark_dirty` walks, deduped
@@ -120,11 +125,11 @@ pub struct UnmerkleizedBatch<F: Family, D: Digest, S: Strategy> {
 
 impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     /// Create a new batch from `parent`.
-    pub const fn new(parent: Arc<MerkleizedBatch<F, D, S>>) -> Self {
+    pub fn new(parent: Arc<MerkleizedBatch<F, D, S>>) -> Self {
         Self {
             parent,
             appended: Vec::new(),
-            overwrites: BTreeMap::new(),
+            overwrites: Overwrites::default(),
             dirty_nodes: Vec::new(),
         }
     }
@@ -393,7 +398,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 #[allow(clippy::type_complexity)]
 fn collect_ancestor_batches<F: Family, D: Digest, S: Strategy>(
     parent: &Arc<MerkleizedBatch<F, D, S>>,
-) -> (Vec<Arc<Vec<D>>>, Vec<Arc<BTreeMap<Position<F>, D>>>) {
+) -> (Vec<Arc<Vec<D>>>, Vec<Arc<Overwrites<F, D>>>) {
     let mut appended = Vec::new();
     let mut overwrites = Vec::new();
 
@@ -433,7 +438,7 @@ pub struct MerkleizedBatch<F: Family, D: Digest, S: Strategy> {
     pub(crate) appended: Arc<Vec<D>>,
 
     /// This batch's overwrites only (not accumulated from ancestors).
-    pub(crate) overwrites: Arc<BTreeMap<Position<F>, D>>,
+    pub(crate) overwrites: Arc<Overwrites<F, D>>,
 
     /// Number of nodes in the parent batch.
     pub(crate) parent_size: Position<F>,
@@ -452,7 +457,7 @@ pub struct MerkleizedBatch<F: Family, D: Digest, S: Strategy> {
 
     /// Arc refs to each ancestor's overwrites, collected during merkleize while
     /// ancestors are alive. Root-to-tip order.
-    pub(crate) ancestor_overwrites: Vec<Arc<BTreeMap<Position<F>, D>>>,
+    pub(crate) ancestor_overwrites: Vec<Arc<Overwrites<F, D>>>,
 
     pub(crate) strategy: S,
 }
@@ -472,7 +477,7 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
         Arc::new(Self {
             parent: None,
             appended: Arc::new(Vec::new()),
-            overwrites: Arc::new(BTreeMap::new()),
+            overwrites: Arc::new(Overwrites::default()),
             parent_size: mem.size(),
             base_size: mem.size(),
             pruning_boundary: Readable::pruning_boundary(mem),

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -92,9 +92,7 @@ use commonware_cryptography::Digest;
 use commonware_parallel::{Sequential, Strategy};
 use core::{hash::BuildHasherDefault, ops::Range};
 
-/// Overwritten node digests keyed by position. Uses `ahash` (fast on integer keys) with
-/// [BuildHasherDefault] (no per-construction RNG sampling). Iteration order is not observed
-/// by any consumer.
+/// Overwritten node digests keyed by position.
 pub(crate) type Overwrites<F, D> = hashbrown::HashMap<Position<F>, D, BuildHasherDefault<AHasher>>;
 
 /// Push a dirty node position into its height bucket, growing the outer Vec as needed.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -83,17 +83,17 @@
 use crate::merkle::{
     hasher::Hasher, mem::Mem, path, proof::Proof, Error, Family, Location, Position, Readable,
 };
-use ahash::AHasher;
+use ahash::RandomState;
 use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
 use commonware_cryptography::Digest;
 use commonware_parallel::{Sequential, Strategy};
-use core::{hash::BuildHasherDefault, ops::Range};
+use core::ops::Range;
 
 /// Overwritten node digests keyed by position.
-pub(crate) type Overwrites<F, D> = hashbrown::HashMap<Position<F>, D, BuildHasherDefault<AHasher>>;
+pub(crate) type Overwrites<F, D> = hashbrown::HashMap<Position<F>, D, RandomState>;
 
 /// Push a dirty node position into its height bucket, growing the outer Vec as needed.
 fn push_dirty<F: Family>(buckets: &mut Vec<Vec<Position<F>>>, height: u32, pos: Position<F>) {

--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -17,15 +17,16 @@ use crate::merkle::{
     storage::Storage,
     Bagging, Error, Family, Location, Position, Proof,
 };
+use ahash::AHashMap;
 use commonware_cryptography::Digest;
 use core::ops::Range;
 use futures::future::try_join_all;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
 /// A store derived from a [Proof] that can be used to generate proofs over any sub-range of the
 /// original range.
 pub struct ProofStore<F: Family, D> {
-    digests: HashMap<Position<F>, D>,
+    digests: AHashMap<Position<F>, D>,
     size: Position<F>,
     /// The fold prefix accumulator from the original proof, if any peaks preceded the proven range.
     fold_acc: Option<D>,
@@ -64,7 +65,7 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
         let bagging = hasher.root_bagging();
         let digests =
             proof.verify_range_inclusion_and_extract_digests(hasher, elements, start_loc, root)?;
-        let map: HashMap<Position<F>, D> = digests.into_iter().collect();
+        let map: AHashMap<Position<F>, D> = digests.into_iter().collect();
 
         let size = Position::try_from(proof.leaves)?;
 
@@ -236,7 +237,7 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
             locations,
         )?;
 
-        let peak_map: HashMap<Position<F>, D> = peaks.iter().copied().collect();
+        let peak_map: AHashMap<Position<F>, D> = peaks.iter().copied().collect();
 
         let mut digests = Vec::with_capacity(node_positions.len());
         for &pos in &node_positions {
@@ -336,7 +337,7 @@ pub async fn historical_range_proof<
         .await?
         .into_iter()
         .map(|(pos, digest)| digest.ok_or(Error::ElementPruned(pos)).map(|d| (pos, d)))
-        .collect::<Result<HashMap<_, _>, _>>()?;
+        .collect::<Result<AHashMap<_, _>, _>>()?;
 
     bp.build_proof(
         hasher,

--- a/storage/src/qmdb/benches/apply_batch.rs
+++ b/storage/src/qmdb/benches/apply_batch.rs
@@ -1,6 +1,8 @@
 //! Benchmarks for applying already-merkleized QMDB batches.
 
-use crate::common::{any_fix_cfg_with, make_fixed_value, seed_db, AnyUFixDb, CHUNK_SIZE};
+use crate::common::{
+    any_fix_cfg_with, imm_fix_cfg_with, make_fixed_value, seed_db, AnyUFixDb, ImmFixDb, CHUNK_SIZE,
+};
 use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_runtime::{
     benchmarks::{context, tokio},
@@ -21,6 +23,7 @@ const UPDATES: [u64; 1] = [16_384];
 const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(10_000_000);
 
 type Db = AnyUFixDb<Mmb>;
+type ImmDb = ImmFixDb<Mmb>;
 
 fn write_updates(
     mut batch: <Db as BatchableDb>::Batch,
@@ -148,6 +151,80 @@ async fn bench_apply_multi_uncommitted(ctx: &Context, updates: u64) -> Duration 
     elapsed
 }
 
+// Immutable databases are insert-only, so every batch writes fresh keys drawn from `counter`.
+async fn seed_imm_db(db: &mut ImmDb, keys: u64, counter: &mut u64, rng: &mut StdRng) {
+    let mut batch = db.new_batch();
+    for _ in 0..keys {
+        let key = Sha256::hash(&counter.to_be_bytes());
+        *counter += 1;
+        batch = batch.set(key, make_fixed_value(rng));
+    }
+    let floor = db.inactivity_floor_loc();
+    let batch = batch.merkleize(db, None, floor);
+    db.apply_batch(batch).await.unwrap();
+    db.commit().await.unwrap();
+}
+
+async fn open_imm_db(ctx: &Context) -> ImmDb {
+    ImmDb::init(ctx.child("storage"), imm_fix_cfg_with(ctx, ITEMS_PER_BLOB))
+        .await
+        .unwrap()
+}
+
+async fn bench_imm_direct_apply(ctx: &Context, updates: u64) -> Duration {
+    let mut db = open_imm_db(ctx).await;
+    let mut rng = StdRng::seed_from_u64(7);
+    let mut counter = 0u64;
+    seed_imm_db(&mut db, NUM_KEYS, &mut counter, &mut rng).await;
+
+    let mut batch = db.new_batch();
+    for _ in 0..updates {
+        let key = Sha256::hash(&counter.to_be_bytes());
+        counter += 1;
+        batch = batch.set(key, make_fixed_value(&mut rng));
+    }
+    let floor = db.inactivity_floor_loc();
+    let batch = batch.merkleize(&db, None, floor);
+
+    let start = Instant::now();
+    db.apply_batch(batch).await.unwrap();
+    let elapsed = start.elapsed();
+
+    db.destroy().await.unwrap();
+    elapsed
+}
+
+async fn bench_imm_apply_with_uncommitted_ancestor(ctx: &Context, updates: u64) -> Duration {
+    let mut db = open_imm_db(ctx).await;
+    let mut rng = StdRng::seed_from_u64(7);
+    let mut counter = 0u64;
+    seed_imm_db(&mut db, NUM_KEYS, &mut counter, &mut rng).await;
+    let floor = db.inactivity_floor_loc();
+
+    let mut parent = db.new_batch();
+    for _ in 0..updates {
+        let key = Sha256::hash(&counter.to_be_bytes());
+        counter += 1;
+        parent = parent.set(key, make_fixed_value(&mut rng));
+    }
+    let parent = parent.merkleize(&db, None, floor);
+
+    let mut child = parent.new_batch();
+    for _ in 0..updates {
+        let key = Sha256::hash(&counter.to_be_bytes());
+        counter += 1;
+        child = child.set(key, make_fixed_value(&mut rng));
+    }
+    let child = child.merkleize(&db, None, floor);
+
+    let start = Instant::now();
+    db.apply_batch(child).await.unwrap();
+    let elapsed = start.elapsed();
+
+    db.destroy().await.unwrap();
+    elapsed
+}
+
 fn bench_apply_batch(c: &mut Criterion) {
     let runner = tokio::Runner::new(Config::default());
 
@@ -231,6 +308,40 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
                         total += bench_apply_multi_uncommitted(&ctx, updates).await;
+                    }
+                    total
+                });
+            },
+        );
+
+        c.bench_function(
+            &format!(
+                "{}/case=direct variant=immutable::fixed::mmb chunk={CHUNK_SIZE} updates={updates}",
+                module_path!(),
+            ),
+            |b| {
+                b.to_async(&runner).iter_custom(|iters| async move {
+                    let ctx = context::get::<Context>();
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        total += bench_imm_direct_apply(&ctx, updates).await;
+                    }
+                    total
+                });
+            },
+        );
+
+        c.bench_function(
+            &format!(
+                "{}/case=uncomm_ancestor variant=immutable::fixed::mmb chunk={CHUNK_SIZE} updates={updates}",
+                module_path!(),
+            ),
+            |b| {
+                b.to_async(&runner).iter_custom(|iters| async move {
+                    let ctx = context::get::<Context>();
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        total += bench_imm_apply_with_uncommitted_ancestor(&ctx, updates).await;
                     }
                     total
                 });

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -19,6 +19,7 @@ use commonware_storage::{
             unordered::{fixed::Db as UCFixed, variable::Db as UCVariable},
             FixedConfig as CurrentFixedConfig, VariableConfig as CurrentVariableConfig,
         },
+        immutable::fixed::{Config as ImmutableFixedConfig, Db as IFixed},
         keyless::variable::{Config as KeylessConfig, Db as Keyless},
     },
     translator::EightCap,
@@ -67,6 +68,10 @@ pub type CurUVarVecDb<F> =
 pub type CurOVarVecDb<F> =
     OCVariable<F, Context, Digest, Vec<u8>, Sha256, EightCap, CHUNK_SIZE, Rayon>;
 
+// -- Immutable --
+
+pub type ImmFixDb<F> = IFixed<F, Context, Digest, Digest, Sha256, EightCap, Rayon>;
+
 // -- Keyless --
 
 pub type KeylessDb<F> = Keyless<F, Context, Vec<u8>, Sha256, Rayon>;
@@ -82,6 +87,7 @@ pub async fn open_keyless_db<F: Family>(ctx: Context) -> KeylessDb<F> {
 const PARTITION_FIX: &str = "bench-fixed";
 const PARTITION_VAR: &str = "bench-variable";
 const PARTITION_KEYLESS: &str = "bench-keyless";
+const PARTITION_IMM: &str = "bench-immutable";
 
 fn merkle_cfg(
     suffix: &str,
@@ -136,6 +142,18 @@ pub fn any_fix_cfg_with(
     AnyFixedConfig {
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
+        translator: EightCap,
+    }
+}
+
+pub fn imm_fix_cfg_with(
+    ctx: &(impl BufferPooler + ThreadPooler),
+    items_per_blob: NonZeroU64,
+) -> ImmutableFixedConfig<EightCap, Rayon> {
+    let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
+    ImmutableFixedConfig {
+        merkle_config: merkle_cfg(PARTITION_IMM, ctx, page_cache.clone(), items_per_blob),
+        log: fix_log_cfg(PARTITION_IMM, page_cache, items_per_blob),
         translator: EightCap,
     }
 }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -95,10 +95,11 @@ use crate::{
     translator::Translator,
     Context, Persistable,
 };
+use ahash::AHashSet;
 use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher as CHasher;
 use commonware_parallel::Strategy;
-use std::{collections::HashSet, num::NonZeroU64, ops::Range, sync::Arc};
+use std::{num::NonZeroU64, ops::Range, sync::Arc};
 use tracing::warn;
 
 /// Metrics for Immutable QMDBs.
@@ -700,10 +701,21 @@ where
 
         // Apply snapshot inserts. Child first (child wins via `seen`), then
         // uncommitted ancestor batches.
+        //
+        // `seen` is only consulted when at least one ancestor diff will be applied, so it is
+        // skipped entirely otherwise. Keys are borrowed from the diffs to avoid cloning.
         let bounds = self.journal.reader().await.bounds();
-        let mut seen = HashSet::new();
+        let track_shadow = batch.bounds.ancestors.iter().any(|a| a.end > db_size);
+        let seen_cap = if track_shadow {
+            batch.diff.len() + batch.ancestor_diffs.iter().map(|d| d.len()).sum::<usize>()
+        } else {
+            0
+        };
+        let mut seen: AHashSet<&K> = AHashSet::with_capacity(seen_cap);
         for (key, entry) in batch.diff.iter() {
-            seen.insert(key.clone());
+            if track_shadow {
+                seen.insert(key);
+            }
             self.snapshot
                 .insert_and_retain(key, entry.loc, |v| *v >= bounds.start);
         }
@@ -712,7 +724,7 @@ where
                 continue;
             }
             for (key, entry) in ancestor_diff.iter() {
-                if seen.insert(key.clone()) {
+                if seen.insert(key) {
                     self.snapshot
                         .insert_and_retain(key, entry.loc, |v| *v >= bounds.start);
                 }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -703,11 +703,19 @@ where
         // uncommitted ancestor batches.
         //
         // `seen` is only consulted when at least one ancestor diff will be applied, so it is
-        // skipped entirely otherwise. Keys are borrowed from the diffs to avoid cloning.
+        // skipped entirely otherwise.
         let bounds = self.journal.reader().await.bounds();
         let track_shadow = batch.bounds.ancestors.iter().any(|a| a.end > db_size);
         let seen_cap = if track_shadow {
-            batch.diff.len() + batch.ancestor_diffs.iter().map(|d| d.len()).sum::<usize>()
+            batch.diff.len()
+                + batch
+                    .bounds
+                    .ancestors
+                    .iter()
+                    .zip(&batch.ancestor_diffs)
+                    .filter(|(a, _)| a.end > db_size)
+                    .map(|(_, d)| d.len())
+                    .sum::<usize>()
         } else {
             0
         };


### PR DESCRIPTION
 ## [runtime] Key the page cache maps with ahash

  The page cache's `index` and `page_fetches` maps hash a `(blob id, page number)` key on every cached read and insert. Swap std's SipHash for `ahash::RandomState`, which is several times faster on short fixed-width keys while remaining DoS-resistant (seeded from OS entropy via `runtime-rng`, same as `storage`'s existing `Hashed` translator).

Cached reads (`buffer_paged::read`) improve up to ~37-39% for small reads, where the per-page map lookup dominates, tapering to noise at page-sized reads where the copy dominates:
  
  | read size | deterministic | tokio |
  |---|---|---|
  | 64 B | -37.4% | -26.5% |
  | 256 B | -39.2% | -26.5% |
  | 1 KiB | -10.9% | -8.9% |
  | 4 KiB | -1.3% (noise) | -2.0% |


  Paged buffer appends improve ~10-12% on both backends:

  ```
  buffer_paged::append/backend=deterministic chunk=64
    time:   [197.91 ms 198.18 ms 198.49 ms]
    change: [-13.250% -11.684% -10.186%] (p = 0.00 < 0.05)
  
  buffer_paged::append/backend=tokio chunk=64
    time:   [112.70 ms 113.06 ms 113.52 ms]
    change: [-18.474% -10.729% -4.1737%] (p = 0.00 < 0.05)
  ```
  
  Since `runtime` and `storage` now both depend on ahash, the pin is hoisted to `[workspace.dependencies]`; feature resolution (and `Cargo.lock`) is unchanged.
