### PR TITLE
[parallel] add Strategy::run_async for offloading CPU work from worker thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,6 +1827,7 @@ version = "2026.5.0"
 dependencies = [
  "cfg-if",
  "commonware-macros",
+ "futures",
  "proptest",
  "rayon",
 ]

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 cfg-if.workspace = true
 commonware-macros.workspace = true
+futures = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -22,4 +23,4 @@ proptest.workspace = true
 
 [features]
 default = [ "std" ]
-std = [ "commonware-macros/std", "dep:rayon" ]
+std = [ "commonware-macros/std", "dep:futures", "dep:rayon" ]

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -62,7 +62,7 @@
 
 commonware_macros::stability_scope!(BETA {
     use cfg_if::cfg_if;
-    use core::fmt;
+    use core::{fmt, future::Future};
 
     cfg_if! {
         if #[cfg(feature = "std")] {
@@ -228,6 +228,24 @@ commonware_macros::stability_scope!(BETA {
                     a
                 },
             )
+        }
+
+        /// Runs `f` to completion and returns its result.
+        ///
+        /// When the strategy owns a thread pool, the returned future suspends the caller while
+        /// the work executes on the pool; otherwise the work runs inline when the future is
+        /// first polled. Use this to keep CPU-intensive work off async executor threads.
+        /// Strategy methods invoked within `f` execute with this strategy's parallelism.
+        ///
+        /// # Panics
+        ///
+        /// The returned future panics if `f` panics.
+        fn run_async<F, R>(&self, f: F) -> impl Future<Output = R> + Send
+        where
+            F: FnOnce() -> R + Send + 'static,
+            R: Send + 'static,
+        {
+            async move { f() }
         }
 
         /// Maps each element with per-partition state and collects results into a `Vec`.
@@ -558,6 +576,19 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
             self.thread_pool.install(|| rayon::join(a, b))
         }
 
+        fn run_async<F, R>(&self, f: F) -> impl Future<Output = R> + Send
+        where
+            F: FnOnce() -> R + Send + 'static,
+            R: Send + 'static,
+        {
+            let (tx, rx) = futures::channel::oneshot::channel();
+            self.thread_pool.spawn(move || {
+                // The receiver may have been dropped; sending then fails harmlessly.
+                let _ = tx.send(f());
+            });
+            async move { rx.await.expect("work panicked on the strategy's thread pool") }
+        }
+
         fn parallelism_hint(&self) -> usize {
             self.thread_pool.current_num_threads()
         }
@@ -572,6 +603,25 @@ mod test {
 
     fn parallel_strategy() -> Rayon {
         Rayon::new(NonZeroUsize::new(4).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn run_async_returns_result() {
+        let sequential = Sequential;
+        assert_eq!(futures::executor::block_on(sequential.run_async(|| 7)), 7);
+
+        let parallel = parallel_strategy();
+        assert_eq!(futures::executor::block_on(parallel.run_async(|| 7)), 7);
+
+        // Nested strategy calls within the offloaded work execute correctly.
+        let parallel = parallel_strategy();
+        let result = futures::executor::block_on(parallel.clone().run_async(move || {
+            parallel
+                .map_collect_vec(0..100u64, |x| x * x)
+                .iter()
+                .sum::<u64>()
+        }));
+        assert_eq!(result, (0..100u64).map(|x| x * x).sum::<u64>());
     }
 
     proptest! {


### PR DESCRIPTION
## Offload batch leaf hashing onto the strategy

  The authenticated journal's `add_many` hashes every appended item into a leaf digest (roughly half of merkleization CPU for a qmdb batch). It was already parallelized, but
  `Rayon::install` blocks the calling thread, pinning a tokio worker for tens of milliseconds on large batches. It now runs through `Strategy::run_async`: still parallel,
  but the calling task suspends instead of blocking its thread. First production use of `run_async`, to evaluate on a busy validator before converting parent-node hashing
  (blocked on off-lock merkleization).

  ### API changes (ALPHA)

  - `add_many` and the keyless/immutable batch `merkleize` fns are now async.
  - `ValueEncoding`/`FixedValue`/`VariableValue` gain `'static` bounds so owned items can cross the offload boundary (`Key` already had one).
  - A test pairing `Rayon` with the deterministic runner moved to the tokio runner: the deterministic runtime cannot observe wakeups from external pool threads.

  ### Validation

  Full storage/glue/sync suites pass; conformance roots are unchanged, confirming the relocation is behavior-preserving. The caller still awaits the root, so merkleize
  benches won't move — the win is co-scheduled tasks no longer stalling behind hashing on executor threads, visible in validator tail latency rather than throughput.