### PR TITLE
[qmdb] Minimal Merkle Tweaks

### DIFF
--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -92,8 +92,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys. Locations resolved by the read are
-    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
+    /// Returns results in the same order as the input keys. Each unique read is cached on the
+    /// batch for reuse at merkleize, so memory grows with the number of unique keys read.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await
@@ -187,8 +187,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys. Locations resolved by the read are
-    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
+    /// Returns results in the same order as the input keys. Each unique read is cached on the
+    /// batch for reuse at merkleize, so memory grows with the number of unique keys read.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -92,7 +92,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Locations resolved by the read are
+    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -187,7 +187,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Locations resolved by the read are
+    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -187,8 +187,7 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys. Each unique read is cached on the
-    /// batch for reuse at merkleize, so memory grows with the number of unique keys read.
+    /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -93,8 +93,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys. Locations resolved by the read are
-    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
+    /// Returns results in the same order as the input keys. Each unique read is cached on the
+    /// batch for reuse at merkleize, so memory grows with the number of unique keys read.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await
@@ -189,8 +189,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys. Locations resolved by the read are
-    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
+    /// Returns results in the same order as the input keys. Each unique read is cached on the
+    /// batch for reuse at merkleize, so memory grows with the number of unique keys read.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -189,8 +189,7 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys. Each unique read is cached on the
-    /// batch for reuse at merkleize, so memory grows with the number of unique keys read.
+    /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -93,7 +93,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Locations resolved by the read are
+    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -189,7 +189,8 @@ where
 
     /// Read multiple values by key, falling back to committed state.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Locations resolved by the read are
+    /// retained on the batch, so the subsequent merkleize skips re-reading those keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
         self.batch.get_many(keys, &*db).await

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -611,9 +611,6 @@ impl<B: Blob> Append<B> {
         offsets: &[u64],
         item_size: usize,
     ) -> Result<usize, Error> {
-        if offsets.is_empty() {
-            return Ok(0);
-        }
         assert_eq!(
             buf.len(),
             offsets
@@ -626,6 +623,9 @@ impl<B: Blob> Append<B> {
             offsets.windows(2).all(|w| w[0] < w[1]),
             "offsets must be strictly increasing"
         );
+        if offsets.is_empty() {
+            return Ok(0);
+        }
 
         let last_end = offsets[offsets.len() - 1]
             .checked_add(item_size as u64)

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -616,6 +616,10 @@ impl<B: Blob> Append<B> {
                 .expect("read_many_into buffer length overflow"),
             "read_many_into requires buf.len() == offsets.len() * item_size"
         );
+        assert!(
+            offsets.windows(2).all(|w| w[0] < w[1]),
+            "offsets must be strictly increasing"
+        );
         if offsets.is_empty() {
             return Ok(0);
         }

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -599,12 +599,15 @@ impl<B: Blob> Append<B> {
     /// `buf` must be exactly `offsets.len() * item_size` bytes. All offsets must be sorted,
     /// non-overlapping, and within bounds. This amortizes lock acquisition and avoids
     /// per-item buffer allocation compared to calling [`read_at`](Self::read_at) in a loop.
+    ///
+    /// Returns the number of items fully served without a blob read (from the tip buffer and the
+    /// page cache). The remaining items required at least one blob read.
     pub async fn read_many_into(
         &self,
         buf: &mut [u8],
         offsets: &[u64],
         item_size: usize,
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         assert_eq!(
             buf.len(),
             offsets
@@ -614,7 +617,7 @@ impl<B: Blob> Append<B> {
             "read_many_into requires buf.len() == offsets.len() * item_size"
         );
         if offsets.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
         let last_end = offsets[offsets.len() - 1]
@@ -633,7 +636,7 @@ impl<B: Blob> Append<B> {
         // `chunks_exact_mut` yields disjoint per-item slots, so we never have to
         // reborrow the parent buffer while cache/blob destinations remain live.
         if item_size == 0 {
-            return Ok(());
+            return Ok(offsets.len());
         }
         let mut cache_ranges: Vec<(&mut [u8], u64)> = Vec::new();
         for (item_buf, &offset) in buf.chunks_exact_mut(item_size).zip(offsets.iter()) {
@@ -657,14 +660,15 @@ impl<B: Blob> Append<B> {
         drop(buffer);
 
         if cache_ranges.is_empty() {
-            return Ok(());
+            return Ok(offsets.len());
         }
 
         // Fast path: try page cache for all ranges in a single lock acquisition.
         // Fully-cached ranges are removed from cache_ranges; only misses remain.
         self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
+        let blob_reads = cache_ranges.len();
         if cache_ranges.is_empty() {
-            return Ok(());
+            return Ok(offsets.len());
         }
 
         // Slow path: read only the ranges that had cache misses, concurrently.
@@ -680,7 +684,7 @@ impl<B: Blob> Append<B> {
             result?;
         }
 
-        Ok(())
+        Ok(offsets.len() - blob_reads)
     }
 
     /// Reads bytes starting at `logical_offset` into `buf`.

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -36,12 +36,15 @@ use crate::{
 use bytes::BufMut;
 use commonware_cryptography::Crc32;
 use commonware_utils::sync::{AsyncRwLock, AsyncRwLockWriteGuard};
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::stream::StreamExt;
 use std::{
     num::{NonZeroU16, NonZeroUsize},
     sync::Arc,
 };
 use tracing::warn;
+
+/// Maximum number of blob reads issued concurrently by [`Append::read_many_into`].
+const MAX_CONCURRENT_BLOB_READS: usize = 64;
 
 /// Indicates which CRC slot in a page record must not be overwritten.
 #[derive(Clone, Copy)]
@@ -608,6 +611,9 @@ impl<B: Blob> Append<B> {
         offsets: &[u64],
         item_size: usize,
     ) -> Result<usize, Error> {
+        if offsets.is_empty() {
+            return Ok(0);
+        }
         assert_eq!(
             buf.len(),
             offsets
@@ -620,9 +626,6 @@ impl<B: Blob> Append<B> {
             offsets.windows(2).all(|w| w[0] < w[1]),
             "offsets must be strictly increasing"
         );
-        if offsets.is_empty() {
-            return Ok(0);
-        }
 
         let last_end = offsets[offsets.len() - 1]
             .checked_add(item_size as u64)
@@ -675,15 +678,17 @@ impl<B: Blob> Append<B> {
             return Ok(offsets.len());
         }
 
-        // Slow path: read only the ranges that had cache misses, concurrently.
+        // Slow path: read only the ranges that had cache misses, concurrently. Concurrency is
+        // bounded so a large cold batch cannot flood the blob with in-flight reads.
         let blob_guard = self.blob_state.read().await;
-        let mut reads = cache_ranges
+        let reads: Vec<_> = cache_ranges
             .iter_mut()
             .map(|(item_buf, offset)| {
                 self.cache_ref
                     .read(&blob_guard.blob, self.id, item_buf, *offset)
             })
-            .collect::<FuturesUnordered<_>>();
+            .collect();
+        let mut reads = futures::stream::iter(reads).buffer_unordered(MAX_CONCURRENT_BLOB_READS);
         while let Some(result) = reads.next().await {
             result?;
         }
@@ -1531,6 +1536,62 @@ mod tests {
                 .await
                 .unwrap();
 
+            let read: Vec<u8> = synced.iter().chain(tip.iter()).copied().collect();
+            for (i, &off) in offsets.iter().enumerate() {
+                assert_eq!(
+                    &buf[i * item_size..(i + 1) * item_size],
+                    &read[off as usize..off as usize + item_size],
+                );
+            }
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_read_many_into_straddle_prefix_miss() {
+        // A straddling item whose synced prefix page is NOT in the page cache: the
+        // suffix is copied from the tip buffer and the prefix is read from the blob
+        // without clobbering it, and the item is counted as a blob read.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"rmany_smiss")
+                .await
+                .unwrap();
+            // Single-page cache so residency is deterministic.
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(1));
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            // Write 3 pages and sync, then a partial page that stays in the tip.
+            let synced: Vec<u8> = (0u8..=255)
+                .cycle()
+                .take(PAGE_SIZE.get() as usize * 3)
+                .collect();
+            append.append(&synced).await.unwrap();
+            append.sync().await.unwrap();
+            let item_size = 10;
+            let tip: Vec<u8> = (100u8..=255)
+                .cycle()
+                .take(PAGE_SIZE.get() as usize / 2)
+                .collect();
+            append.append(&tip).await.unwrap();
+
+            // Fault page 0 in, evicting whatever sync left resident, so the straddle
+            // prefix page (page 2) is guaranteed not cached.
+            let _ = append.read_at(0, item_size).await.unwrap();
+
+            let straddle_off = synced.len() as u64 - (item_size as u64 / 2);
+            let tip_off = synced.len() as u64 + item_size as u64;
+            let offsets = [straddle_off, tip_off];
+            let mut buf = vec![0u8; offsets.len() * item_size];
+            let hits = append
+                .read_many_into(&mut buf, &offsets, item_size)
+                .await
+                .unwrap();
+
+            // The tip-only item is a hit; the straddle item required a blob read.
+            assert_eq!(hits, 1);
             let read: Vec<u8> = synced.iter().chain(tip.iter()).copied().collect();
             for (i, &off) in offsets.iter().enumerate() {
                 assert_eq!(

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -36,15 +36,12 @@ use crate::{
 use bytes::BufMut;
 use commonware_cryptography::Crc32;
 use commonware_utils::sync::{AsyncRwLock, AsyncRwLockWriteGuard};
-use futures::stream::StreamExt;
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::{
     num::{NonZeroU16, NonZeroUsize},
     sync::Arc,
 };
 use tracing::warn;
-
-/// Maximum number of blob reads issued concurrently by [`Append::read_many_into`].
-const MAX_CONCURRENT_BLOB_READS: usize = 64;
 
 /// Indicates which CRC slot in a page record must not be overwritten.
 #[derive(Clone, Copy)]
@@ -678,17 +675,15 @@ impl<B: Blob> Append<B> {
             return Ok(offsets.len());
         }
 
-        // Slow path: read only the ranges that had cache misses, concurrently. Concurrency is
-        // bounded so a large cold batch cannot flood the blob with in-flight reads.
+        // Slow path: read only the ranges that had cache misses, concurrently.
         let blob_guard = self.blob_state.read().await;
-        let reads: Vec<_> = cache_ranges
+        let mut reads = cache_ranges
             .iter_mut()
             .map(|(item_buf, offset)| {
                 self.cache_ref
                     .read(&blob_guard.blob, self.id, item_buf, *offset)
             })
-            .collect();
-        let mut reads = futures::stream::iter(reads).buffer_unordered(MAX_CONCURRENT_BLOB_READS);
+            .collect::<FuturesUnordered<_>>();
         while let Some(result) = reads.next().await {
             result?;
         }

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -247,49 +247,31 @@ impl CacheRef {
         original_len - buf.len()
     }
 
-    /// Read multiple disjoint byte ranges from the page cache, amortizing lock acquisition.
+    /// Read multiple disjoint byte ranges from the page cache in a single lock acquisition.
     ///
     /// Each element of `ranges` is `(dest_slice, logical_offset)`. Fully-cached ranges have
     /// their data written to the destination slice and are removed from `ranges`. Entries left
     /// in `ranges` correspond to cache misses that the caller must read from the underlying
     /// blob.
-    ///
-    /// Ranges are probed in fixed-size windows with the lock re-acquired per window, bounding
-    /// how long any one batch holds the cache lock: the lock is write-preferring, so a long
-    /// uninterrupted hold would stall a queued writer and every reader behind it.
     pub(super) fn read_cached_many(&self, blob_id: u64, ranges: &mut Vec<(&mut [u8], u64)>) {
-        const WINDOW: usize = 1024;
-        let len = ranges.len();
-        let mut kept = 0;
-        let mut start = 0;
-        while start < len {
-            let end = (start + WINDOW).min(len);
-            let page_cache = self.cache.read();
-            for i in start..end {
-                let (buf, logical_offset) = &mut ranges[i];
-                let mut remaining = buf.len();
-                let mut offset = *logical_offset;
-                let mut dst = 0;
-                while remaining > 0 {
-                    let count = page_cache.read_at(blob_id, &mut buf[dst..], offset);
-                    if count == 0 {
-                        break;
-                    }
-                    offset += count as u64;
-                    dst += count;
-                    remaining -= count;
+        let page_cache = self.cache.read();
+        ranges.retain_mut(|(buf, logical_offset)| {
+            let mut remaining = buf.len();
+            let mut offset = *logical_offset;
+            let mut dst = 0;
+            while remaining > 0 {
+                let count = page_cache.read_at(blob_id, &mut buf[dst..], offset);
+                if count == 0 {
+                    break;
                 }
-
-                // Compact cache misses to the front, preserving order; fully-cached
-                // entries are dropped by the final truncate
-                if remaining > 0 {
-                    ranges.swap(kept, i);
-                    kept += 1;
-                }
+                offset += count as u64;
+                dst += count;
+                remaining -= count;
             }
-            start = end;
-        }
-        ranges.truncate(kept);
+
+            // Keep cache misses in `ranges`; drop fully-cached entries.
+            remaining > 0
+        });
     }
 
     /// Read the specified bytes, preferentially from the page cache. Bytes not found in the cache
@@ -1357,52 +1339,5 @@ mod tests {
         assert!(buf2 == page2);
         // Missed page's buffer should be untouched (still zeroed).
         assert!(buf1.iter().all(|b| *b == 0));
-    }
-
-    #[test_traced]
-    fn test_read_cached_many_window_boundaries() {
-        // Exercise the windowed probe (WINDOW = 1024) with hits and misses mixed
-        // across multiple windows: hits must be served and miss compaction must
-        // preserve order regardless of which window an entry falls in.
-        const TOTAL: usize = 2500;
-        let pool = test_pool();
-        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(4096));
-        let blob_id = cache_ref.next_id();
-
-        // Cache even pages; odd pages miss.
-        {
-            let mut cache = cache_ref.cache.write();
-            for page in (0..TOTAL).step_by(2) {
-                let data = vec![(page % 251) as u8; PAGE_SIZE.get() as usize];
-                cache.cache(blob_id, &data, page as u64);
-            }
-        }
-
-        let mut bufs: Vec<Vec<u8>> = vec![vec![0u8; PAGE_SIZE_U64 as usize]; TOTAL];
-        let mut ranges: Vec<(&mut [u8], u64)> = bufs
-            .iter_mut()
-            .enumerate()
-            .map(|(page, buf)| (buf.as_mut_slice(), page as u64 * PAGE_SIZE_U64))
-            .collect();
-
-        cache_ref.read_cached_many(blob_id, &mut ranges);
-
-        // Odd pages remain as misses, in their original order.
-        let expected: Vec<u64> = (0..TOTAL as u64)
-            .filter(|p| p % 2 == 1)
-            .map(|p| p * PAGE_SIZE_U64)
-            .collect();
-        let actual: Vec<u64> = ranges.iter().map(|(_, offset)| *offset).collect();
-        assert_eq!(actual, expected);
-        drop(ranges);
-
-        // Even pages were filled from cache; odd pages untouched.
-        for (page, buf) in bufs.iter().enumerate() {
-            if page % 2 == 0 {
-                assert!(buf.iter().all(|b| *b == (page % 251) as u8));
-            } else {
-                assert!(buf.iter().all(|b| *b == 0));
-            }
-        }
     }
 }

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -247,31 +247,49 @@ impl CacheRef {
         original_len - buf.len()
     }
 
-    /// Read multiple disjoint byte ranges from the page cache in a single lock acquisition.
+    /// Read multiple disjoint byte ranges from the page cache, amortizing lock acquisition.
     ///
     /// Each element of `ranges` is `(dest_slice, logical_offset)`. Fully-cached ranges have
     /// their data written to the destination slice and are removed from `ranges`. Entries left
     /// in `ranges` correspond to cache misses that the caller must read from the underlying
     /// blob.
+    ///
+    /// Ranges are probed in fixed-size windows with the lock re-acquired per window, bounding
+    /// how long any one batch holds the cache lock: the lock is write-preferring, so a long
+    /// uninterrupted hold would stall a queued writer and every reader behind it.
     pub(super) fn read_cached_many(&self, blob_id: u64, ranges: &mut Vec<(&mut [u8], u64)>) {
-        let page_cache = self.cache.read();
-        ranges.retain_mut(|(buf, logical_offset)| {
-            let mut remaining = buf.len();
-            let mut offset = *logical_offset;
-            let mut dst = 0;
-            while remaining > 0 {
-                let count = page_cache.read_at(blob_id, &mut buf[dst..], offset);
-                if count == 0 {
-                    break;
+        const WINDOW: usize = 1024;
+        let len = ranges.len();
+        let mut kept = 0;
+        let mut start = 0;
+        while start < len {
+            let end = (start + WINDOW).min(len);
+            let page_cache = self.cache.read();
+            for i in start..end {
+                let (buf, logical_offset) = &mut ranges[i];
+                let mut remaining = buf.len();
+                let mut offset = *logical_offset;
+                let mut dst = 0;
+                while remaining > 0 {
+                    let count = page_cache.read_at(blob_id, &mut buf[dst..], offset);
+                    if count == 0 {
+                        break;
+                    }
+                    offset += count as u64;
+                    dst += count;
+                    remaining -= count;
                 }
-                offset += count as u64;
-                dst += count;
-                remaining -= count;
-            }
 
-            // Keep cache misses in `ranges`; drop fully-cached entries.
-            remaining > 0
-        });
+                // Compact cache misses to the front, preserving order; fully-cached
+                // entries are dropped by the final truncate
+                if remaining > 0 {
+                    ranges.swap(kept, i);
+                    kept += 1;
+                }
+            }
+            start = end;
+        }
+        ranges.truncate(kept);
     }
 
     /// Read the specified bytes, preferentially from the page cache. Bytes not found in the cache
@@ -1339,5 +1357,52 @@ mod tests {
         assert!(buf2 == page2);
         // Missed page's buffer should be untouched (still zeroed).
         assert!(buf1.iter().all(|b| *b == 0));
+    }
+
+    #[test_traced]
+    fn test_read_cached_many_window_boundaries() {
+        // Exercise the windowed probe (WINDOW = 1024) with hits and misses mixed
+        // across multiple windows: hits must be served and miss compaction must
+        // preserve order regardless of which window an entry falls in.
+        const TOTAL: usize = 2500;
+        let pool = test_pool();
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(4096));
+        let blob_id = cache_ref.next_id();
+
+        // Cache even pages; odd pages miss.
+        {
+            let mut cache = cache_ref.cache.write();
+            for page in (0..TOTAL).step_by(2) {
+                let data = vec![(page % 251) as u8; PAGE_SIZE.get() as usize];
+                cache.cache(blob_id, &data, page as u64);
+            }
+        }
+
+        let mut bufs: Vec<Vec<u8>> = vec![vec![0u8; PAGE_SIZE_U64 as usize]; TOTAL];
+        let mut ranges: Vec<(&mut [u8], u64)> = bufs
+            .iter_mut()
+            .enumerate()
+            .map(|(page, buf)| (buf.as_mut_slice(), page as u64 * PAGE_SIZE_U64))
+            .collect();
+
+        cache_ref.read_cached_many(blob_id, &mut ranges);
+
+        // Odd pages remain as misses, in their original order.
+        let expected: Vec<u64> = (0..TOTAL as u64)
+            .filter(|p| p % 2 == 1)
+            .map(|p| p * PAGE_SIZE_U64)
+            .collect();
+        let actual: Vec<u64> = ranges.iter().map(|(_, offset)| *offset).collect();
+        assert_eq!(actual, expected);
+        drop(ranges);
+
+        // Even pages were filled from cache; odd pages untouched.
+        for (page, buf) in bufs.iter().enumerate() {
+            if page % 2 == 0 {
+                assert!(buf.iter().all(|b| *b == (page % 251) as u8));
+            } else {
+                assert!(buf.iter().all(|b| *b == 0));
+            }
+        }
     }
 }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -79,6 +79,11 @@ test-traits = []
 bench = false
 
 [[bench]]
+name = "constantinople"
+harness = false
+path = "src/qmdb/benches/constantinople.rs"
+
+[[bench]]
 name = "qmdb"
 harness = false
 path = "src/qmdb/benches/bench.rs"

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -375,6 +375,61 @@ mod tests {
         });
     }
 
+    fn run_index_get_many<I: Unordered<Value = u64>>(index: &mut I) {
+        // "ab" and "abX" share a translated bucket; "zz" lives in a different bucket (and a
+        // different partition for partitioned indexes).
+        index.insert(b"ab", 1);
+        index.insert(b"ab", 2);
+        index.insert(b"abX", 3);
+        index.insert(b"zz", 4);
+
+        // Visits must be attributed to the requesting slot regardless of probe order, missing
+        // keys produce no visits, and duplicate input keys are visited once per slot.
+        let keys: Vec<&[u8]> = vec![b"zz", b"missing", b"ab", b"zz"];
+        let mut visits: Vec<Vec<u64>> = vec![Vec::new(); keys.len()];
+        index.get_many(&keys, |key_idx, value| visits[key_idx].push(*value));
+        assert_eq!(visits[0], vec![4]);
+        assert!(visits[1].is_empty());
+        assert_eq!(visits[2], vec![3, 2, 1]);
+        assert_eq!(visits[3], vec![4]);
+
+        // Empty input visits nothing.
+        index.get_many::<&[u8]>(&[], |_, _| panic!("no visits expected"));
+    }
+
+    #[test_traced]
+    fn test_hash_index_get_many() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let mut index = new_unordered(context);
+            run_index_get_many(&mut index);
+        });
+    }
+
+    #[test_traced]
+    fn test_ordered_index_get_many() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let mut index = new_ordered(context);
+            run_index_get_many(&mut index);
+        });
+    }
+
+    #[test_traced]
+    fn test_partitioned_index_get_many() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            {
+                let mut index = new_partitioned_unordered(context.child("unordered"));
+                run_index_get_many(&mut index);
+            }
+            {
+                let mut index = new_partitioned_ordered(context.child("ordered"));
+                run_index_get_many(&mut index);
+            }
+        });
+    }
+
     fn run_index_cursor_find<I: Unordered<Value = u64>>(index: &mut I) {
         let key = b"test_key";
 

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -127,6 +127,24 @@ pub trait Unordered: Send + Sync {
     where
         Self::Value: 'a;
 
+    /// Visits every value associated with each key, calling `visit(key_idx, value)`.
+    ///
+    /// Probe order is implementation-defined: implementations may reorder probes for locality,
+    /// so visits are identified by `key_idx` rather than issued in input order.
+    fn get_many<'a, K: AsRef<[u8]>>(
+        &'a self,
+        keys: &[K],
+        mut visit: impl FnMut(usize, &'a Self::Value),
+    ) where
+        Self::Value: 'a,
+    {
+        for (key_idx, key) in keys.iter().enumerate() {
+            for value in self.get(key.as_ref()) {
+                visit(key_idx, value);
+            }
+        }
+    }
+
     /// Provides mutable access to the values associated with a translated key, if the key exists.
     fn get_mut<'a>(&'a mut self, key: &[u8]) -> Option<Self::Cursor<'a>>;
 

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -153,6 +153,25 @@ impl<T: Translator, V: Send + Sync> super::Factory<T> for Index<T, V> {
 
 impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     type Value = V;
+
+    fn get_many<'a, K: AsRef<[u8]>>(&'a self, keys: &[K], mut visit: impl FnMut(usize, &'a V))
+    where
+        V: 'a,
+    {
+        // Probe in translated-key order: consecutive tree descents share upper node paths,
+        // which stay cache-resident across the batch.
+        let mut order: Vec<(T::Key, usize)> = keys
+            .iter()
+            .enumerate()
+            .map(|(key_idx, key)| (self.translator.transform(key.as_ref()), key_idx))
+            .collect();
+        order.sort_unstable();
+        for (_, key_idx) in order {
+            for value in self.get(keys[key_idx].as_ref()) {
+                visit(key_idx, value);
+            }
+        }
+    }
     type Cursor<'a>
         = Cursor<'a, T::Key, V>
     where

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -51,6 +51,19 @@ pub struct Index<T: Translator, V: Send + Sync> {
 }
 
 impl<T: Translator, V: Send + Sync> Index<T, V> {
+    /// Translate a key without probing.
+    pub(super) fn translate(&self, key: &[u8]) -> T::Key {
+        self.translator.transform(key)
+    }
+
+    /// Returns an iterator over all values associated with an already-translated key.
+    pub(super) fn get_translated<'a>(&'a self, key: T::Key) -> impl Iterator<Item = &'a V> + 'a
+    where
+        V: 'a,
+    {
+        self.map.get(&key).into_iter().flat_map(iter_chain)
+    }
+
     /// Create a new entry in the index.
     fn create(keys: &Gauge, items: &Gauge, vacant: BTreeVacantEntry<'_, T::Key, Record<V>>, v: V) {
         keys.inc();
@@ -166,8 +179,8 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
             .map(|(key_idx, key)| (self.translator.transform(key.as_ref()), key_idx))
             .collect();
         order.sort_unstable();
-        for (_, key_idx) in order {
-            for value in self.get(keys[key_idx].as_ref()) {
+        for (translated, key_idx) in order {
+            for value in self.get_translated(translated) {
                 visit(key_idx, value);
             }
         }
@@ -181,8 +194,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     where
         V: 'a,
     {
-        let k = self.translator.transform(key);
-        self.map.get(&k).into_iter().flat_map(iter_chain)
+        self.get_translated(self.translator.transform(key))
     }
 
     fn get_mut<'a>(&'a mut self, key: &[u8]) -> Option<Self::Cursor<'a>> {

--- a/storage/src/index/partitioned/ordered.rs
+++ b/storage/src/index/partitioned/ordered.rs
@@ -75,6 +75,32 @@ impl<T: Translator, V: Send + Sync, const P: usize> super::super::Factory<T> for
 
 impl<T: Translator, V: Send + Sync, const P: usize> UnorderedTrait for Index<T, V, P> {
     type Value = V;
+
+    fn get_many<'a, K: AsRef<[u8]>>(&'a self, keys: &[K], mut visit: impl FnMut(usize, &'a V))
+    where
+        V: 'a,
+    {
+        // Probe in key-prefix order so consecutive probes hit the same partition and descend
+        // through shared upper tree nodes within it. Sixteen bytes cover the partition prefix
+        // (P <= 2) plus the largest cap translator (8 bytes).
+        let mut order: Vec<(u128, usize)> = keys
+            .iter()
+            .enumerate()
+            .map(|(key_idx, key)| {
+                let bytes = key.as_ref();
+                let mut prefix = [0u8; 16];
+                let n = bytes.len().min(16);
+                prefix[..n].copy_from_slice(&bytes[..n]);
+                (u128::from_be_bytes(prefix), key_idx)
+            })
+            .collect();
+        order.sort_unstable();
+        for (_, key_idx) in order {
+            for value in self.get(keys[key_idx].as_ref()) {
+                visit(key_idx, value);
+            }
+        }
+    }
     type Cursor<'a>
         = <OrderedIndex<T, V> as UnorderedTrait>::Cursor<'a>
     where

--- a/storage/src/index/partitioned/ordered.rs
+++ b/storage/src/index/partitioned/ordered.rs
@@ -82,7 +82,9 @@ impl<T: Translator, V: Send + Sync, const P: usize> UnorderedTrait for Index<T, 
     {
         // Probe in key-prefix order so consecutive probes hit the same partition and descend
         // through shared upper tree nodes within it. Sixteen bytes cover the partition prefix
-        // (P <= 2) plus the largest cap translator (8 bytes).
+        // (P <= 2) plus the largest cap translator (8 bytes). The locality holds only for
+        // prefix-preserving translators (raw-key order then matches translated-key order); for
+        // any other translator this is just an arbitrary, still-correct probe order.
         let mut order: Vec<(u128, usize)> = keys
             .iter()
             .enumerate()

--- a/storage/src/index/partitioned/ordered.rs
+++ b/storage/src/index/partitioned/ordered.rs
@@ -80,25 +80,23 @@ impl<T: Translator, V: Send + Sync, const P: usize> UnorderedTrait for Index<T, 
     where
         V: 'a,
     {
-        // Probe in key-prefix order so consecutive probes hit the same partition and descend
-        // through shared upper tree nodes within it. Sixteen bytes cover the partition prefix
-        // (P <= 2) plus the largest cap translator (8 bytes). The locality holds only for
-        // prefix-preserving translators (raw-key order then matches translated-key order); for
-        // any other translator this is just an arbitrary, still-correct probe order.
-        let mut order: Vec<(u128, usize)> = keys
+        // Probe in (partition, translated-key) order so consecutive probes hit the same
+        // partition and descend through shared upper tree nodes within it.
+        let mut order: Vec<(usize, T::Key, usize)> = keys
             .iter()
             .enumerate()
             .map(|(key_idx, key)| {
-                let bytes = key.as_ref();
-                let mut prefix = [0u8; 16];
-                let n = bytes.len().min(16);
-                prefix[..n].copy_from_slice(&bytes[..n]);
-                (u128::from_be_bytes(prefix), key_idx)
+                let (partition, sub_key) = partition_index_and_sub_key::<P>(key.as_ref());
+                (
+                    partition,
+                    self.partitions[partition].translate(sub_key),
+                    key_idx,
+                )
             })
             .collect();
         order.sort_unstable();
-        for (_, key_idx) in order {
-            for value in self.get(keys[key_idx].as_ref()) {
+        for (partition, translated, key_idx) in order {
+            for value in self.partitions[partition].get_translated(translated) {
                 visit(key_idx, value);
             }
         }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -353,59 +353,32 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         let pruning_boundary = self.guard.pruning_boundary;
         let chunk_size = SegmentedJournal::<E, A>::CHUNK_SIZE;
 
-        // Phase 1: Drain page-cache hits synchronously.
-        let mut result: Vec<Option<A>> = Vec::with_capacity(positions.len());
-        let mut miss_indices: Vec<usize> = Vec::new();
-        let mut miss_positions: Vec<u64> = Vec::new();
-
-        let mut sync_buf = vec![0u8; chunk_size];
-        for (i, &pos) in positions.iter().enumerate() {
-            if let Some(item) = self
-                .guard
-                .try_read_sync_into(pos, items_per_blob, &mut sync_buf)
-            {
-                result.push(Some(item));
-            } else {
-                result.push(None);
-                miss_indices.push(i);
-                miss_positions.push(pos);
-            }
-        }
-
-        if miss_positions.is_empty() {
-            self.metrics.record_cache_hits(positions.len() as u64);
-            self.metrics.items_read.inc_by(positions.len() as u64);
-            return Ok(result.into_iter().map(|r| r.unwrap()).collect());
-        }
-        self.metrics
-            .record_cache_hits((positions.len() - miss_positions.len()) as u64);
-        self.metrics
-            .record_cache_misses(miss_positions.len() as u64);
-
-        // Phase 2: Read cache misses grouped by section (sequential).
-        let mut reusable_buf = vec![0u8; miss_positions.len() * chunk_size];
-        let mut disk_offset = 0;
+        // Read all positions grouped by section. Each group goes through the segmented journal's
+        // batched read, which serves page-cache and tip-buffer hits under a single lock acquisition
+        // and reads only true misses from the blob (concurrently). This avoids one lock acquisition
+        // per item that a per-item synchronous probe would incur for the warm steady state.
+        let mut result: Vec<A> = Vec::with_capacity(positions.len());
+        let mut reusable_buf = vec![0u8; positions.len() * chunk_size];
+        let mut hits = 0u64;
 
         let mut group_start = 0;
-        while group_start < miss_positions.len() {
-            let section = miss_positions[group_start] / items_per_blob;
+        while group_start < positions.len() {
+            let section = positions[group_start] / items_per_blob;
 
             let mut group_end = group_start + 1;
-            while group_end < miss_positions.len()
-                && miss_positions[group_end] / items_per_blob == section
-            {
+            while group_end < positions.len() && positions[group_end] / items_per_blob == section {
                 group_end += 1;
             }
 
             let group_len = group_end - group_start;
             let first_position = first_in_section(pruning_boundary, section, items_per_blob)?;
-            let section_positions: Vec<u64> = miss_positions[group_start..group_end]
+            let section_positions: Vec<u64> = positions[group_start..group_end]
                 .iter()
                 .map(|&pos| pos - first_position)
                 .collect();
 
             let buf = &mut reusable_buf[..group_len * chunk_size];
-            let items = self
+            let (items, group_hits) = self
                 .guard
                 .journal
                 .get_many(section, &section_positions, buf)
@@ -419,16 +392,16 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
                     other => other,
                 })?;
 
-            for (item, &miss_idx) in items.into_iter().zip(&miss_indices[disk_offset..]) {
-                result[miss_idx] = Some(item);
-            }
-
-            disk_offset += group_len;
+            hits += group_hits as u64;
+            result.extend(items);
             group_start = group_end;
         }
 
+        self.metrics.record_cache_hits(hits);
+        self.metrics
+            .record_cache_misses(positions.len() as u64 - hits);
         self.metrics.items_read.inc_by(positions.len() as u64);
-        Ok(result.into_iter().map(|r| r.unwrap()).collect())
+        Ok(result)
     }
 
     fn try_read_sync(&self, pos: u64) -> Option<A> {
@@ -4406,6 +4379,51 @@ mod tests {
             for &pos in &positions {
                 let single = reader.read(pos).await.unwrap();
                 assert_eq!(batch[pos as usize], single);
+            }
+            drop(reader);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_read_many_warm_matches_read() {
+        // Verify the batched warm path is byte-identical to per-item reads across multiple
+        // sections, with a mid-section pruning boundary and a sparse subset of positions.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(8));
+            let journal = Journal::init(context.child("j"), cfg).await.unwrap();
+
+            for i in 0..50u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            // Prune mid-section so first_in_section differs from section start.
+            journal.prune(11).await.unwrap();
+
+            let reader = journal.reader().await;
+
+            // Warm the page cache so every position is an all-hit batch read.
+            for pos in 11..50u64 {
+                let _ = reader.try_read_sync(pos);
+            }
+
+            // Sparse subset spanning multiple sections, including the pruning boundary.
+            let positions: Vec<u64> = vec![11, 12, 19, 20, 23, 31, 40, 47, 49];
+            let batch = reader.read_many(&positions).await.unwrap();
+            assert_eq!(batch.len(), positions.len());
+            for (i, &pos) in positions.iter().enumerate() {
+                let single = reader.read(pos).await.unwrap();
+                assert_eq!(batch[i], single);
+                assert_eq!(batch[i], test_digest(pos));
+            }
+
+            // Full contiguous range over retained items.
+            let all: Vec<u64> = (11..50).collect();
+            let batch = reader.read_many(&all).await.unwrap();
+            for (i, &pos) in all.iter().enumerate() {
+                assert_eq!(batch[i], reader.read(pos).await.unwrap());
             }
             drop(reader);
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -4387,9 +4387,10 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_read_many_warm_matches_read() {
-        // Verify the batched warm path is byte-identical to per-item reads across multiple
-        // sections, with a mid-section pruning boundary and a sparse subset of positions.
+    fn test_read_many_sparse_sections_and_hit_accounting() {
+        // Verify the batched read path is byte-identical to per-item reads across multiple
+        // sections, with a mid-section pruning boundary, a sparse subset of positions, and
+        // exact hit/miss accounting over a mixed cached/uncached batch.
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(8));
@@ -4404,15 +4405,38 @@ mod tests {
 
             let reader = journal.reader().await;
 
-            // Warm the page cache so every position is an all-hit batch read.
-            for pos in 11..50u64 {
-                let _ = reader.try_read_sync(pos);
+            fn counter(buffer: &str, name: &str) -> u64 {
+                buffer
+                    .lines()
+                    .find(|l| l.contains(name) && !l.starts_with('#'))
+                    .and_then(|l| l.split_whitespace().last())
+                    .and_then(|v| v.parse().ok())
+                    .expect("counter missing")
             }
 
             // Sparse subset spanning multiple sections, including the pruning boundary.
+            // `try_read_sync` probes do not populate the cache, so the cached subset is
+            // whatever the append path left resident; derive the expected hit count from
+            // probes so the batch read's hit/miss accounting is asserted exactly.
             let positions: Vec<u64> = vec![11, 12, 19, 20, 23, 31, 40, 47, 49];
+            let expected_hits = positions
+                .iter()
+                .filter(|&&pos| reader.try_read_sync(pos).is_some())
+                .count() as u64;
+            let before = context.encode();
             let batch = reader.read_many(&positions).await.unwrap();
+            let after = context.encode();
             assert_eq!(batch.len(), positions.len());
+            assert_eq!(
+                counter(&after, "cache_hits") - counter(&before, "cache_hits"),
+                expected_hits,
+                "batch read hit count should match the cached subset"
+            );
+            assert_eq!(
+                counter(&after, "cache_misses") - counter(&before, "cache_misses"),
+                positions.len() as u64 - expected_hits,
+                "batch read miss count should cover the rest"
+            );
             for (i, &pos) in positions.iter().enumerate() {
                 let single = reader.read(pos).await.unwrap();
                 assert_eq!(batch[i], single);

--- a/storage/src/journal/contiguous/metrics.rs
+++ b/storage/src/journal/contiguous/metrics.rs
@@ -217,12 +217,11 @@ impl<E: RuntimeMetrics + Clock> FixedMetrics<E> {
         let context = Arc::new(context);
         let hits = context.as_ref().counter(
             "cache_hits",
-            "Number of fixed items served without a blob read (tip buffer or page cache)",
+            "Number of fixed items served without a blob read",
         );
         let misses = context.as_ref().counter(
             "cache_misses",
-            "Number of fixed items requiring a blob read, including pruned or out-of-range \
-             try_read_sync probes that returned None",
+            "Number of fixed items requiring a blob read",
         );
         let calls = context
             .as_ref()

--- a/storage/src/journal/contiguous/metrics.rs
+++ b/storage/src/journal/contiguous/metrics.rs
@@ -215,13 +215,14 @@ impl<E: RuntimeMetrics + Clock> FixedMetrics<E> {
     /// Create and register metrics for a fixed-size journal.
     pub(super) fn new(context: E) -> Self {
         let context = Arc::new(context);
-        let hits = context
-            .as_ref()
-            .counter("cache_hits", "Number of fixed items read synchronously");
+        let hits = context.as_ref().counter(
+            "cache_hits",
+            "Number of fixed items served without a blob read (tip buffer or page cache)",
+        );
         let misses = context.as_ref().counter(
             "cache_misses",
-            "Number of fixed items not satisfied synchronously by read or read_many, including \
-             pruned or out-of-range try_read_sync probes that returned None",
+            "Number of fixed items requiring a blob read, including pruned or out-of-range \
+             try_read_sync probes that returned None",
         );
         let calls = context
             .as_ref()

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -197,6 +197,10 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         positions: &[u64],
         buf: &mut [u8],
     ) -> Result<(Vec<A>, usize), Error> {
+        assert!(
+            positions.windows(2).all(|w| w[0] < w[1]),
+            "positions must be strictly increasing"
+        );
         if positions.is_empty() {
             return Ok((Vec::new(), 0));
         }

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -188,14 +188,17 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     ///
     /// `buf` must be at least `positions.len() * CHUNK_SIZE` bytes. All positions must be
     /// strictly increasing and within the section's bounds.
+    ///
+    /// Returns the decoded items and the number served without a blob read (page cache or tip
+    /// buffer hits).
     pub async fn get_many(
         &self,
         section: u64,
         positions: &[u64],
         buf: &mut [u8],
-    ) -> Result<Vec<A>, Error> {
+    ) -> Result<(Vec<A>, usize), Error> {
         if positions.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
         let blob = self
             .manager
@@ -210,14 +213,14 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
             })
             .collect::<Result<_, _>>()?;
 
-        blob.read_many_into(buf, &offsets, Self::CHUNK_SIZE).await?;
+        let hits = blob.read_many_into(buf, &offsets, Self::CHUNK_SIZE).await?;
 
         let mut items = Vec::with_capacity(positions.len());
         for i in 0..positions.len() {
             let slice = &buf[i * Self::CHUNK_SIZE..(i + 1) * Self::CHUNK_SIZE];
             items.push(A::decode(slice).map_err(Error::Codec)?);
         }
-        Ok(items)
+        Ok((items, hits))
     }
 
     /// Get an item if it can be done synchronously (e.g. without I/O), returning `None` otherwise.
@@ -1432,8 +1435,9 @@ mod tests {
             assert_eq!(journal.section_len(0).await.unwrap(), 1);
 
             let mut buf = [];
-            let items = journal.get_many(0, &[], &mut buf).await.unwrap();
+            let (items, hits) = journal.get_many(0, &[], &mut buf).await.unwrap();
             assert!(items.is_empty());
+            assert_eq!(hits, 0);
 
             journal.destroy().await.unwrap();
         });
@@ -1454,7 +1458,7 @@ mod tests {
             // Read all 5 items in one call.
             let chunk = Journal::<deterministic::Context, Digest>::CHUNK_SIZE;
             let mut buf = vec![0u8; 5 * chunk];
-            let items = journal
+            let (items, _) = journal
                 .get_many(0, &[0, 1, 2, 3, 4], &mut buf)
                 .await
                 .unwrap();
@@ -1483,7 +1487,7 @@ mod tests {
             let chunk = Journal::<deterministic::Context, Digest>::CHUNK_SIZE;
             let positions = [1, 4, 7, 9];
             let mut buf = vec![0u8; positions.len() * chunk];
-            let items = journal.get_many(0, &positions, &mut buf).await.unwrap();
+            let (items, _) = journal.get_many(0, &positions, &mut buf).await.unwrap();
 
             for (i, &pos) in positions.iter().enumerate() {
                 assert_eq!(items[i], test_digest(pos));
@@ -1527,7 +1531,7 @@ mod tests {
             let chunk = Journal::<deterministic::Context, Digest>::CHUNK_SIZE;
             let positions: Vec<u64> = (0..8).collect();
             let mut buf = vec![0u8; positions.len() * chunk];
-            let batch = journal.get_many(0, &positions, &mut buf).await.unwrap();
+            let (batch, _) = journal.get_many(0, &positions, &mut buf).await.unwrap();
 
             for pos in &positions {
                 let single = journal.get(0, *pos).await.unwrap();

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -192,12 +192,12 @@ where
     /// next key, and re-reading them costs more in cache upkeep than it saves.
     ///
     /// Only committed-snapshot resolutions are cached. A cached location doubles as the
-    /// key's committed provenance (`base_old_loc`), which holds because a committed-resolved
-    /// key was in no live ancestor diff and a legal intervening commit (applying this batch's
-    /// own ancestors) can only relocate keys present in an ancestor diff. Ancestor-diff
-    /// resolutions are never cached: their op-gen position is an uncommitted location whose
-    /// committed provenance differs, and re-resolving them at merkleize is in-memory work (no
-    /// journal read is saved).
+    /// key's previous committed location (`base_old_loc`), which holds because a
+    /// committed-resolved key was in no live ancestor diff and a legal intervening commit
+    /// (applying this batch's own ancestors) can only relocate keys present in an ancestor
+    /// diff. Ancestor-diff resolutions are never cached: their op-gen position is an
+    /// uncommitted location, and re-resolving them at merkleize is in-memory work (no journal
+    /// read is saved).
     ///
     /// Interior-mutable because reads take `&self`; never held across an await.
     resolved: Mutex<ResolvedReads<F, U>>,
@@ -435,11 +435,6 @@ impl<'a, K: Ord, F: Family, V> AppliedAncestorResolver<'a, K, F, V> {
 
 /// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` under a single bitmap
 /// read guard, returning the next `floor`.
-///
-/// The committed prefix is indexed by `bitmap`, so unset bits can be skipped without reading
-/// their operations. Locations beyond the bitmap's length are uncommitted ancestor operations
-/// and remain sequential candidates. `current::batch::fill_candidates` mirrors this contract
-/// over a layered `BitmapBatch` chain; both must obey it.
 fn fill_candidates<F: Family, const N: usize>(
     bitmap: &Shared<N>,
     floor: Location<F>,
@@ -743,8 +738,8 @@ where
                     let Some(key) = op.key().cloned() else {
                         continue; // skip CommitFloor and other non-keyed ops
                     };
-                    // A single batch-diff lookup drives the activity check, the base
-                    // provenance, and the in-place diff update below. Revalidation is required
+                    // A single batch-diff lookup drives the activity check, the previous
+                    // committed location, and the in-place diff update below. Revalidation is required
                     // even for candidates whose committed bitmap bit is set: this batch's diff
                     // or an uncommitted ancestor diff may supersede the committed location, and
                     // neither source is reflected in the bitmap.
@@ -928,9 +923,8 @@ where
     /// Batch read multiple keys (mutations -> ancestor diffs -> committed DB).
     ///
     /// Returns results in the same order as the input keys, with `None` for absent or deleted
-    /// keys. Committed-DB locations resolved by the read are cached on the batch; unordered
-    /// `merkleize` consumes them to skip re-reading those keys. Keys answered by pending
-    /// mutations or ancestor diffs cache nothing (merkleize re-resolves them in memory).
+    /// keys. Each unique read resolved from the committed DB is cached on the batch for reuse
+    /// at merkleize.
     pub async fn get_many<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
@@ -1082,8 +1076,8 @@ where
         let mut active_keys_delta: isize = 0;
         let mut user_steps: u64 = 0;
 
-        // Write a user mutation at the next batch location, preserving the committed-base
-        // provenance of the operation it supersedes.
+        // Write a user mutation at the next batch location, preserving the previous committed
+        // location of the key it supersedes.
         let mut emit = |key: K, base_old_loc: Option<Location<F>>, mutation: Option<V::Value>| {
             let new_loc = Location::new(m.base_size + ops.len() as u64);
             match mutation {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -35,9 +35,6 @@ use std::{
 };
 use tracing::debug;
 
-/// Maximum number of journal reads to issue concurrently during floor raising.
-const MAX_CONCURRENT_READS: u64 = 64;
-
 type DiffVec<K, F, V> = Vec<(K, DiffEntry<F, V>)>;
 type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 
@@ -721,7 +718,7 @@ where
                 // Collect candidates, capped by the number of active ops still needed.
                 // `scan_from` tracks prefetch progress separately from `floor`, so
                 // early exit cannot leave `floor` past unprocessed candidates.
-                let limit = ((total_steps - moved) as usize).min(MAX_CONCURRENT_READS as usize);
+                let limit = (total_steps - moved) as usize;
                 let mut candidates = Vec::with_capacity(limit);
                 scan_from = fill_candidates(scan_from, fixed_tip, limit, &mut candidates);
                 if candidates.is_empty() {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1252,7 +1252,9 @@ where
     ///
     /// Consumes the operations retained by this batch's reads: keys loaded via `get`/`get_many`
     /// before being updated skip the journal re-read their resolution would otherwise require.
-    /// Deleted keys are always re-read for predecessor linkage.
+    /// Only the retained keys' own reads are skipped; collision siblings surfaced by their
+    /// committed bucket walks are still read for linkage. Deleted keys are always re-read for
+    /// predecessor linkage.
     #[allow(clippy::type_complexity)]
     #[tracing::instrument(
         name = "qmdb::any::batch::merkleize",
@@ -1299,15 +1301,24 @@ where
         let resolved = core::mem::take(&mut *self.resolved.lock());
         let (mut mutations, m) = self.into_parts();
 
-        // Pull updates whose committed operation this batch's reads already resolved. They
-        // skip the journal re-read; the retained operation supplies the linkage candidates the
-        // read would have produced. Deletes stay on the read path: a deleted key's own-bucket
+        // Resolve existing keys. The gather must see every mutation key, including those whose
+        // reads were retained: a retained key's committed bucket walk surfaces collision
+        // siblings, and the committed location of a key deleted by a pending ancestor and
+        // re-written by this batch is only readable through such a sibling's walk.
+        let locations = m.gather_existing_locations(&mutations, db, true);
+
+        // Pull updates whose committed operation this batch's reads already resolved, and drop
+        // exactly their own locations from the read set. The retained operation supplies the
+        // linkage candidates the read would have produced; sibling locations surfaced by the
+        // bucket walk are still read. Deletes stay on the read path: a deleted key's own-bucket
         // read also discovers same-bucket predecessors for the linkage rewrite below.
         let mut retained: RetainedOrdered<F, K, V> = Vec::with_capacity(resolved.len());
+        let mut retained_locs: Vec<Location<F>> = Vec::with_capacity(resolved.len());
         for (key, (loc, (old_value, old_next_key))) in resolved {
             match mutations.remove(&key) {
                 Some(Some(new_value)) => {
-                    retained.push((key, new_value, loc, old_value, old_next_key))
+                    retained_locs.push(loc);
+                    retained.push((key, new_value, loc, old_value, old_next_key));
                 }
                 Some(None) => {
                     mutations.insert(key, None);
@@ -1315,9 +1326,11 @@ where
                 None => {}
             }
         }
-
-        // Resolve existing keys.
-        let locations = m.gather_existing_locations(&mutations, db, true);
+        retained_locs.sort_unstable();
+        let locations: Vec<Location<F>> = locations
+            .into_iter()
+            .filter(|loc| retained_locs.binary_search(loc).is_err())
+            .collect();
         let reader = db.log.reader().await;
 
         // Classify mutations into deleted, created, updated. `next_candidates` and

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -45,6 +45,21 @@ type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 /// of a given key during ordered merkleization.
 type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
 
+/// Committed-DB resolutions retained by a batch's reads, keyed by the resolved key and carrying
+/// the location they were read from plus the variant's retained payload.
+type ResolvedReads<F, U> =
+    AHashMap<<U as update::Update>::Key, (Location<F>, <U as update::Update>::Retained)>;
+
+/// Updates pulled out of `mutations` because a read already resolved them:
+/// `(key, new value, old location, old value, old next key)`.
+type RetainedOrdered<F, K, V> = Vec<(
+    K,
+    <V as ValueEncoding>::Value,
+    Location<F>,
+    <V as ValueEncoding>::Value,
+    K,
+)>;
+
 /// What happened to a key in this batch.
 #[derive(Clone)]
 pub(crate) enum DiffEntry<F: Family, V> {
@@ -182,9 +197,10 @@ where
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
 
-    /// Committed-DB locations resolved by this batch's reads (`get`/`get_many`), consumed by
-    /// `merkleize`. When a mutation key is present here, `merkleize` reuses the location and
-    /// skips the redundant journal read.
+    /// Committed-DB resolutions retained by this batch's reads (`get`/`get_many`), keyed by the
+    /// key they matched and carrying the location they were read from plus the variant's
+    /// retained payload. Consumed by `merkleize`: when a mutation key is present here,
+    /// `merkleize` reuses the resolution and skips the redundant journal read.
     ///
     /// Only committed-snapshot resolutions are retained. A retained location doubles as the
     /// key's committed provenance (`base_old_loc`), which holds because a committed-resolved
@@ -196,7 +212,7 @@ where
     /// `test_unordered_fixed_retention_survives_ancestor_commit`.
     ///
     /// Interior-mutable because reads take `&self`; never held across an await.
-    resolved: Mutex<AHashMap<U::Key, Location<F>>>,
+    resolved: Mutex<ResolvedReads<F, U>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -436,7 +452,9 @@ impl<'a, K: Ord, F: Family, V> AppliedAncestorResolver<'a, K, F, V> {
 /// and remain sequential candidates.
 ///
 /// `current::batch::next_candidate` mirrors this contract over a layered `BitmapBatch` chain;
-/// both must obey it.
+/// both must obey it. Production uses [`fill_candidates`], which produces the same sequence under
+/// a single read guard; this single-step form is retained as the test oracle.
+#[cfg(test)]
 fn next_candidate<F: Family, const N: usize>(
     bitmap: &Shared<N>,
     floor: Location<F>,
@@ -454,6 +472,22 @@ fn next_candidate<F: Family, const N: usize>(
     }
     let candidate = floor.max(bitmap_len);
     (candidate < tip).then(|| Location::new(candidate))
+}
+
+/// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` under a single bitmap
+/// read guard, returning the next `floor`. Produces the same sequence as repeatedly calling
+/// `next_candidate` (the test oracle above).
+fn fill_candidates<F: Family, const N: usize>(
+    bitmap: &Shared<N>,
+    floor: Location<F>,
+    tip: u64,
+    limit: usize,
+    out: &mut Vec<Location<F>>,
+) -> Location<F> {
+    let mut raw: Vec<u64> = Vec::with_capacity(limit);
+    let next = bitmap.fill_candidates(*floor, tip, limit, &mut raw);
+    out.extend(raw.into_iter().map(Location::new));
+    Location::new(next)
 }
 
 /// Resolve `loc` to an op within the in-memory ancestor region
@@ -701,7 +735,7 @@ where
         active_keys_delta: isize,
         user_steps: u64,
         metadata: Option<U::Value>,
-        mut next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
+        mut fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
         reader: R,
         db: &Db<F, E, C, I, H, U, N, S>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U, S>>, crate::qmdb::Error<F>>
@@ -731,13 +765,7 @@ where
                 // early exit cannot leave `floor` past unprocessed candidates.
                 let limit = ((total_steps - moved) as usize).min(MAX_CONCURRENT_READS as usize);
                 let mut candidates = Vec::with_capacity(limit);
-                while candidates.len() < limit {
-                    let Some(candidate) = next_candidate(scan_from, fixed_tip) else {
-                        break;
-                    };
-                    candidates.push(candidate);
-                    scan_from = Location::new(*candidate + 1);
-                }
+                scan_from = fill_candidates(scan_from, fixed_tip, limit, &mut candidates);
                 if candidates.is_empty() {
                     break;
                 }
@@ -937,9 +965,9 @@ where
     /// Batch read multiple keys (mutations -> ancestor diffs -> committed DB).
     ///
     /// Returns results in the same order as the input keys, with `None` for absent or deleted
-    /// keys. Committed-DB locations resolved by the read are retained on the batch and consumed
-    /// by `merkleize`, which skips re-reading those keys. Keys answered by pending mutations or
-    /// ancestor diffs retain nothing (merkleize re-resolves them in memory).
+    /// keys. Committed-DB operations resolved by the read are retained on the batch and
+    /// consumed by `merkleize`, which skips re-reading those keys. Keys answered by pending
+    /// mutations or ancestor diffs retain nothing (merkleize re-resolves them in memory).
     pub async fn get_many<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
@@ -996,9 +1024,10 @@ where
         if !db_keys.is_empty() {
             let db_results = db.get_many_with_locations(&db_keys).await?;
             let mut resolved = self.resolved.lock();
+            resolved.reserve(db_keys.len());
             for (slot, result) in db_indices.into_iter().zip(db_results) {
-                results[slot] = result.map(|(value, loc)| {
-                    resolved.insert((*keys[slot]).clone(), loc);
+                results[slot] = result.map(|(value, loc, retained)| {
+                    resolved.insert((*keys[slot]).clone(), (loc, retained));
                     value
                 });
             }
@@ -1040,8 +1069,8 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(db, metadata, |floor, tip| {
-            next_candidate(&db.bitmap, floor, tip)
+        self.merkleize_with_floor_scan(db, metadata, |floor, tip, limit, out| {
+            fill_candidates(&db.bitmap, floor, tip, limit, out)
         })
         .await
     }
@@ -1056,7 +1085,7 @@ where
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
         metadata: Option<V::Value>,
-        next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
+        fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Unordered<K, V>, S>>, crate::qmdb::Error<F>>
     where
         E: Context,
@@ -1071,7 +1100,7 @@ where
         // below, exactly where the read path would have emitted them.
         let mut retained: Vec<(K, Location<F>, Option<V::Value>)> =
             Vec::with_capacity(resolved.len());
-        for (key, loc) in resolved {
+        for (key, (loc, ())) in resolved {
             if let Some(mutation) = mutations.remove(&key) {
                 retained.push((key, loc, mutation));
             }
@@ -1203,7 +1232,7 @@ where
             active_keys_delta,
             user_steps,
             metadata,
-            next_candidate,
+            fill_candidates,
             reader,
             db,
         )
@@ -1220,6 +1249,10 @@ where
     Operation<F, update::Ordered<K, V>>: Codec,
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
+    ///
+    /// Consumes the operations retained by this batch's reads: keys loaded via `get`/`get_many`
+    /// before being updated skip the journal re-read their resolution would otherwise require.
+    /// Deleted keys are always re-read for predecessor linkage.
     #[allow(clippy::type_complexity)]
     #[tracing::instrument(
         name = "qmdb::any::batch::merkleize",
@@ -1240,8 +1273,8 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(db, metadata, |floor, tip| {
-            next_candidate(&db.bitmap, floor, tip)
+        self.merkleize_with_floor_scan(db, metadata, |floor, tip, limit, out| {
+            fill_candidates(&db.bitmap, floor, tip, limit, out)
         })
         .await
     }
@@ -1256,14 +1289,32 @@ where
         self,
         db: &Db<F, E, C, I, H, update::Ordered<K, V>, N, S>,
         metadata: Option<V::Value>,
-        next_candidate: impl FnMut(Location<F>, u64) -> Option<Location<F>>,
+        fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, update::Ordered<K, V>, S>>, crate::qmdb::Error<F>>
     where
         E: Context,
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
+        let resolved = core::mem::take(&mut *self.resolved.lock());
         let (mut mutations, m) = self.into_parts();
+
+        // Pull updates whose committed operation this batch's reads already resolved. They
+        // skip the journal re-read; the retained operation supplies the linkage candidates the
+        // read would have produced. Deletes stay on the read path: a deleted key's own-bucket
+        // read also discovers same-bucket predecessors for the linkage rewrite below.
+        let mut retained: RetainedOrdered<F, K, V> = Vec::with_capacity(resolved.len());
+        for (key, (loc, (old_value, old_next_key))) in resolved {
+            match mutations.remove(&key) {
+                Some(Some(new_value)) => {
+                    retained.push((key, new_value, loc, old_value, old_next_key))
+                }
+                Some(None) => {
+                    mutations.insert(key, None);
+                }
+                None => {}
+            }
+        }
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);
@@ -1308,6 +1359,13 @@ where
             } else {
                 deleted.push((key, old_loc));
             }
+        }
+
+        // Emit the contributions the skipped reads would have produced.
+        for (key, new_value, old_loc, old_value, old_next_key) in retained {
+            next_candidates.push(old_next_key);
+            prev_candidates.push((key.clone(), (old_value, old_loc)));
+            updated.push((key, new_value, old_loc));
         }
 
         deleted.sort_by(|a, b| a.0.cmp(&b.0));
@@ -1562,7 +1620,7 @@ where
             active_keys_delta,
             user_steps,
             metadata,
-            next_candidate,
+            fill_candidates,
             reader,
             db,
         )

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -45,14 +45,14 @@ type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 /// of a given key during ordered merkleization.
 type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
 
-/// Committed-DB resolutions retained by a batch's reads, keyed by the resolved key and carrying
-/// the location they were read from plus the variant's retained payload.
+/// Committed-DB resolutions cached by a batch's reads, keyed by the resolved key and carrying
+/// the location they were read from and its value.
 type ResolvedReads<F, U> =
-    AHashMap<<U as update::Update>::Key, (Location<F>, <U as update::Update>::Retained)>;
+    AHashMap<<U as update::Update>::Key, (Location<F>, <U as update::Update>::Cached)>;
 
 /// Updates pulled out of `mutations` because a read already resolved them:
 /// `(key, new value, old location, old value, old next key)`.
-type RetainedOrdered<F, K, V> = Vec<(
+type CachedOrdered<F, K, V> = Vec<(
     K,
     <V as ValueEncoding>::Value,
     Location<F>,
@@ -197,19 +197,18 @@ where
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
 
-    /// Committed-DB resolutions retained by this batch's reads (`get`/`get_many`), keyed by the
-    /// key they matched and carrying the location they were read from plus the variant's
-    /// retained payload. Consumed by `merkleize`: when a mutation key is present here,
-    /// `merkleize` reuses the resolution and skips the redundant journal read.
+    /// Committed-DB resolutions cached by this batch's reads (`get`/`get_many`), keyed by the
+    /// key they matched and carrying the location they were read from and its value. Consumed
+    /// by `merkleize`: when a mutation key is present here, `merkleize` reuses the resolution
+    /// and skips the redundant journal read.
     ///
-    /// Only committed-snapshot resolutions are retained. A retained location doubles as the
+    /// Only committed-snapshot resolutions are cached. A cached location doubles as the
     /// key's committed provenance (`base_old_loc`), which holds because a committed-resolved
     /// key was in no live ancestor diff and a legal intervening commit (applying this batch's
     /// own ancestors) can only relocate keys present in an ancestor diff. Ancestor-diff
-    /// resolutions are never retained: their op-gen position is an uncommitted location whose
+    /// resolutions are never cached: their op-gen position is an uncommitted location whose
     /// committed provenance differs, and re-resolving them at merkleize is in-memory work (no
-    /// journal read is saved). The dropped-ancestor flow is covered end-to-end by
-    /// `test_unordered_fixed_retention_survives_ancestor_commit`.
+    /// journal read is saved).
     ///
     /// Interior-mutable because reads take `&self`; never held across an await.
     resolved: Mutex<ResolvedReads<F, U>>,
@@ -445,38 +444,13 @@ impl<'a, K: Ord, F: Family, V> AppliedAncestorResolver<'a, K, F, V> {
     }
 }
 
-/// Return the next floor-raise candidate in `[floor, tip)`.
+/// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` under a single bitmap
+/// read guard, returning the next `floor`.
 ///
 /// The committed prefix is indexed by `bitmap`, so unset bits can be skipped without reading
 /// their operations. Locations beyond the bitmap's length are uncommitted ancestor operations
-/// and remain sequential candidates.
-///
-/// `current::batch::next_candidate` mirrors this contract over a layered `BitmapBatch` chain;
-/// both must obey it. Production uses [`fill_candidates`], which produces the same sequence under
-/// a single read guard; this single-step form is retained as the test oracle.
-#[cfg(test)]
-fn next_candidate<F: Family, const N: usize>(
-    bitmap: &Shared<N>,
-    floor: Location<F>,
-    tip: u64,
-) -> Option<Location<F>> {
-    let floor = *floor;
-    let bitmap_len = bitmap::Readable::<N>::len(bitmap);
-    let committed_end = bitmap_len.min(tip);
-    if floor < committed_end {
-        if let Some(idx) = bitmap.next_one_from(floor) {
-            if idx < committed_end {
-                return Some(Location::new(idx));
-            }
-        }
-    }
-    let candidate = floor.max(bitmap_len);
-    (candidate < tip).then(|| Location::new(candidate))
-}
-
-/// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` under a single bitmap
-/// read guard, returning the next `floor`. Produces the same sequence as repeatedly calling
-/// `next_candidate` (the test oracle above).
+/// and remain sequential candidates. `current::batch::fill_candidates` mirrors this contract
+/// over a layered `BitmapBatch` chain; both must obey it.
 fn fill_candidates<F: Family, const N: usize>(
     bitmap: &Shared<N>,
     floor: Location<F>,
@@ -965,9 +939,9 @@ where
     /// Batch read multiple keys (mutations -> ancestor diffs -> committed DB).
     ///
     /// Returns results in the same order as the input keys, with `None` for absent or deleted
-    /// keys. Committed-DB operations resolved by the read are retained on the batch and
+    /// keys. Committed-DB operations resolved by the read are cached on the batch and
     /// consumed by `merkleize`, which skips re-reading those keys. Keys answered by pending
-    /// mutations or ancestor diffs retain nothing (merkleize re-resolves them in memory).
+    /// mutations or ancestor diffs cache nothing (merkleize re-resolves them in memory).
     pub async fn get_many<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
@@ -1026,8 +1000,8 @@ where
             let mut resolved = self.resolved.lock();
             resolved.reserve(db_keys.len());
             for (slot, result) in db_indices.into_iter().zip(db_results) {
-                results[slot] = result.map(|(value, loc, retained)| {
-                    resolved.insert((*keys[slot]).clone(), (loc, retained));
+                results[slot] = result.map(|(value, loc, cached)| {
+                    resolved.insert((*keys[slot]).clone(), (loc, cached));
                     value
                 });
             }
@@ -1047,7 +1021,7 @@ where
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     ///
-    /// Consumes the locations retained by this batch's reads: keys loaded via `get`/`get_many`
+    /// Consumes the locations cached by this batch's reads: keys loaded via `get`/`get_many`
     /// before being written skip the journal re-read their resolution would otherwise require.
     #[allow(clippy::type_complexity)]
     #[tracing::instrument(
@@ -1096,16 +1070,16 @@ where
         let (mut mutations, m) = self.into_parts();
 
         // Pull mutations whose committed location this batch's reads already resolved. They
-        // skip the journal re-read and are emitted at their retained location by the merge
+        // skip the journal re-read and are emitted at their cached location by the merge
         // below, exactly where the read path would have emitted them.
-        let mut retained: Vec<(K, Location<F>, Option<V::Value>)> =
+        let mut cached: Vec<(K, Location<F>, Option<V::Value>)> =
             Vec::with_capacity(resolved.len());
         for (key, (loc, ())) in resolved {
             if let Some(mutation) = mutations.remove(&key) {
-                retained.push((key, loc, mutation));
+                cached.push((key, loc, mutation));
             }
         }
-        retained.sort_unstable_by_key(|&(_, loc, _)| loc);
+        cached.sort_unstable_by_key(|&(_, loc, _)| loc);
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, false);
@@ -1114,9 +1088,8 @@ where
 
         // Generate user mutation operations.
         let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
-            Vec::with_capacity(mutations.len() + retained.len() + 1);
-        let mut diff: DiffVec<K, F, V::Value> =
-            Vec::with_capacity(mutations.len() + retained.len());
+            Vec::with_capacity(mutations.len() + cached.len() + 1);
+        let mut diff: DiffVec<K, F, V::Value> = Vec::with_capacity(mutations.len() + cached.len());
         let mut active_keys_delta: isize = 0;
         let mut user_steps: u64 = 0;
 
@@ -1148,14 +1121,14 @@ where
             user_steps += 1;
         };
 
-        // Process updates/deletes of existing keys in location order, merging retained
+        // Process updates/deletes of existing keys in location order, merging cached
         // entries into the read-resolved stream so the operation order matches the
         // read-only path. This includes keys from both the committed snapshot and
         // ancestor diffs.
-        let mut retained = retained.into_iter().peekable();
+        let mut cached = cached.into_iter().peekable();
         for (op, &old_loc) in results.iter().zip(&locations) {
-            while retained.peek().is_some_and(|&(_, loc, _)| loc < old_loc) {
-                let (key, loc, mutation) = retained.next().expect("peeked entry exists");
+            while cached.peek().is_some_and(|&(_, loc, _)| loc < old_loc) {
+                let (key, loc, mutation) = cached.next().expect("peeked entry exists");
                 emit(key, Some(loc), mutation);
             }
 
@@ -1184,7 +1157,7 @@ where
 
             emit(key.clone(), base_old_loc, mutation);
         }
-        for (key, loc, mutation) in retained {
+        for (key, loc, mutation) in cached {
             emit(key, Some(loc), mutation);
         }
 
@@ -1250,9 +1223,9 @@ where
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     ///
-    /// Consumes the operations retained by this batch's reads: keys loaded via `get`/`get_many`
+    /// Consumes the operations cached by this batch's reads: keys loaded via `get`/`get_many`
     /// before being updated skip the journal re-read their resolution would otherwise require.
-    /// Only the retained keys' own reads are skipped; collision siblings surfaced by their
+    /// Only the cached keys' own reads are skipped; collision siblings surfaced by their
     /// committed bucket walks are still read for linkage. Deleted keys are always re-read for
     /// predecessor linkage.
     #[allow(clippy::type_complexity)]
@@ -1302,23 +1275,23 @@ where
         let (mut mutations, m) = self.into_parts();
 
         // Resolve existing keys. The gather must see every mutation key, including those whose
-        // reads were retained: a retained key's committed bucket walk surfaces collision
+        // reads were cached: a cached key's committed bucket walk surfaces collision
         // siblings, and the committed location of a key deleted by a pending ancestor and
         // re-written by this batch is only readable through such a sibling's walk.
         let locations = m.gather_existing_locations(&mutations, db, true);
 
         // Pull updates whose committed operation this batch's reads already resolved, and drop
-        // exactly their own locations from the read set. The retained operation supplies the
+        // exactly their own locations from the read set. The cached operation supplies the
         // linkage candidates the read would have produced; sibling locations surfaced by the
         // bucket walk are still read. Deletes stay on the read path: a deleted key's own-bucket
         // read also discovers same-bucket predecessors for the linkage rewrite below.
-        let mut retained: RetainedOrdered<F, K, V> = Vec::with_capacity(resolved.len());
-        let mut retained_locs: Vec<Location<F>> = Vec::with_capacity(resolved.len());
+        let mut cached: CachedOrdered<F, K, V> = Vec::with_capacity(resolved.len());
+        let mut cached_locs: Vec<Location<F>> = Vec::with_capacity(resolved.len());
         for (key, (loc, (old_value, old_next_key))) in resolved {
             match mutations.remove(&key) {
                 Some(Some(new_value)) => {
-                    retained_locs.push(loc);
-                    retained.push((key, new_value, loc, old_value, old_next_key));
+                    cached_locs.push(loc);
+                    cached.push((key, new_value, loc, old_value, old_next_key));
                 }
                 Some(None) => {
                     mutations.insert(key, None);
@@ -1326,10 +1299,10 @@ where
                 None => {}
             }
         }
-        retained_locs.sort_unstable();
+        cached_locs.sort_unstable();
         let locations: Vec<Location<F>> = locations
             .into_iter()
-            .filter(|loc| retained_locs.binary_search(loc).is_err())
+            .filter(|loc| cached_locs.binary_search(loc).is_err())
             .collect();
         let reader = db.log.reader().await;
 
@@ -1375,7 +1348,7 @@ where
         }
 
         // Emit the contributions the skipped reads would have produced.
-        for (key, new_value, old_loc, old_value, old_next_key) in retained {
+        for (key, new_value, old_loc, old_value, old_next_key) in cached {
             next_candidates.push(old_next_key);
             prev_candidates.push((key.clone(), (old_value, old_loc)));
             updated.push((key, new_value, old_loc));
@@ -2161,6 +2134,28 @@ mod tests {
         let mut bm = bitmap::Prunable::<BITMAP_CHUNK_BYTES>::new();
         build(&mut bm);
         Shared::new(bm)
+    }
+
+    /// Single-step oracle for [`fill_candidates`]: return the next floor-raise candidate in
+    /// `[floor, tip)`. `bitmap_fill_candidates_matches_oracle` proves the production batch
+    /// fill produces this exact sequence.
+    fn next_candidate<F: Family, const N: usize>(
+        bitmap: &Shared<N>,
+        floor: Location<F>,
+        tip: u64,
+    ) -> Option<Location<F>> {
+        let floor = *floor;
+        let bitmap_len = bitmap::Readable::<N>::len(bitmap);
+        let committed_end = bitmap_len.min(tip);
+        if floor < committed_end {
+            if let Some(idx) = bitmap.next_one_from(floor) {
+                if idx < committed_end {
+                    return Some(Location::new(idx));
+                }
+            }
+        }
+        let candidate = floor.max(bitmap_len);
+        (candidate < tip).then(|| Location::new(candidate))
     }
 
     fn active(value: u64, location: u64) -> DiffEntry<mmr::Family, u64> {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -45,20 +45,8 @@ type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 /// of a given key during ordered merkleization.
 type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
 
-/// Committed-DB resolutions cached by a batch's reads, keyed by the resolved key and carrying
-/// the location they were read from and its value.
-type ResolvedReads<F, U> =
-    AHashMap<<U as update::Update>::Key, (Location<F>, <U as update::Update>::Cached)>;
-
-/// Updates pulled out of `mutations` because a read already resolved them:
-/// `(key, new value, old location, old value, old next key)`.
-type CachedOrdered<F, K, V> = Vec<(
-    K,
-    <V as ValueEncoding>::Value,
-    Location<F>,
-    <V as ValueEncoding>::Value,
-    K,
-)>;
+/// Committed-DB locations cached by a batch's reads, keyed by the resolved key.
+type ResolvedReads<F, U> = AHashMap<<U as update::Update>::Key, Location<F>>;
 
 /// What happened to a key in this batch.
 #[derive(Clone)]
@@ -197,10 +185,11 @@ where
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
 
-    /// Committed-DB resolutions cached by this batch's reads (`get`/`get_many`), keyed by the
-    /// key they matched and carrying the location they were read from and its value. Consumed
-    /// by `merkleize`: when a mutation key is present here, `merkleize` reuses the resolution
-    /// and skips the redundant journal read.
+    /// Committed-DB locations cached by this batch's reads (`get`/`get_many`), keyed by the
+    /// key they matched. Consumed by unordered `merkleize`: when a mutation key is present
+    /// here, `merkleize` reuses the location and skips the redundant journal read. Ordered
+    /// `merkleize` ignores this cache: its op generation needs the read operation's value and
+    /// next key, and re-reading them costs more in cache upkeep than it saves.
     ///
     /// Only committed-snapshot resolutions are cached. A cached location doubles as the
     /// key's committed provenance (`base_old_loc`), which holds because a committed-resolved
@@ -939,8 +928,8 @@ where
     /// Batch read multiple keys (mutations -> ancestor diffs -> committed DB).
     ///
     /// Returns results in the same order as the input keys, with `None` for absent or deleted
-    /// keys. Committed-DB operations resolved by the read are cached on the batch and
-    /// consumed by `merkleize`, which skips re-reading those keys. Keys answered by pending
+    /// keys. Committed-DB locations resolved by the read are cached on the batch; unordered
+    /// `merkleize` consumes them to skip re-reading those keys. Keys answered by pending
     /// mutations or ancestor diffs cache nothing (merkleize re-resolves them in memory).
     pub async fn get_many<E, C, I, const N: usize>(
         &self,
@@ -1000,8 +989,8 @@ where
             let mut resolved = self.resolved.lock();
             resolved.reserve(db_keys.len());
             for (slot, result) in db_indices.into_iter().zip(db_results) {
-                results[slot] = result.map(|(value, loc, cached)| {
-                    resolved.insert((*keys[slot]).clone(), (loc, cached));
+                results[slot] = result.map(|(value, loc)| {
+                    resolved.insert((*keys[slot]).clone(), loc);
                     value
                 });
             }
@@ -1074,7 +1063,7 @@ where
         // below, exactly where the read path would have emitted them.
         let mut cached: Vec<(K, Location<F>, Option<V::Value>)> =
             Vec::with_capacity(resolved.len());
-        for (key, (loc, ())) in resolved {
+        for (key, loc) in resolved {
             if let Some(mutation) = mutations.remove(&key) {
                 cached.push((key, loc, mutation));
             }
@@ -1223,11 +1212,9 @@ where
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     ///
-    /// Consumes the operations cached by this batch's reads: keys loaded via `get`/`get_many`
-    /// before being updated skip the journal re-read their resolution would otherwise require.
-    /// Only the cached keys' own reads are skipped; collision siblings surfaced by their
-    /// committed bucket walks are still read for linkage. Deleted keys are always re-read for
-    /// predecessor linkage.
+    /// Locations cached by this batch's reads are ignored: ordered op generation needs each
+    /// read operation's value and next key for linkage, and re-reading them through the
+    /// journal's page cache is cheaper than caching the payloads at read time.
     #[allow(clippy::type_complexity)]
     #[tracing::instrument(
         name = "qmdb::any::batch::merkleize",
@@ -1271,39 +1258,10 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
-        let resolved = core::mem::take(&mut *self.resolved.lock());
         let (mut mutations, m) = self.into_parts();
 
-        // Resolve existing keys. The gather must see every mutation key, including those whose
-        // reads were cached: a cached key's committed bucket walk surfaces collision
-        // siblings, and the committed location of a key deleted by a pending ancestor and
-        // re-written by this batch is only readable through such a sibling's walk.
+        // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);
-
-        // Pull updates whose committed operation this batch's reads already resolved, and drop
-        // exactly their own locations from the read set. The cached operation supplies the
-        // linkage candidates the read would have produced; sibling locations surfaced by the
-        // bucket walk are still read. Deletes stay on the read path: a deleted key's own-bucket
-        // read also discovers same-bucket predecessors for the linkage rewrite below.
-        let mut cached: CachedOrdered<F, K, V> = Vec::with_capacity(resolved.len());
-        let mut cached_locs: Vec<Location<F>> = Vec::with_capacity(resolved.len());
-        for (key, (loc, (old_value, old_next_key))) in resolved {
-            match mutations.remove(&key) {
-                Some(Some(new_value)) => {
-                    cached_locs.push(loc);
-                    cached.push((key, new_value, loc, old_value, old_next_key));
-                }
-                Some(None) => {
-                    mutations.insert(key, None);
-                }
-                None => {}
-            }
-        }
-        cached_locs.sort_unstable();
-        let locations: Vec<Location<F>> = locations
-            .into_iter()
-            .filter(|loc| cached_locs.binary_search(loc).is_err())
-            .collect();
         let reader = db.log.reader().await;
 
         // Classify mutations into deleted, created, updated. `next_candidates` and
@@ -1345,13 +1303,6 @@ where
             } else {
                 deleted.push((key, old_loc));
             }
-        }
-
-        // Emit the contributions the skipped reads would have produced.
-        for (key, new_value, old_loc, old_value, old_next_key) in cached {
-            next_candidates.push(old_next_key);
-            prev_candidates.push((key.clone(), (old_value, old_loc)));
-            updated.push((key, new_value, old_loc));
         }
 
         deleted.sort_by(|a, b| a.0.cmp(&b.0));

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -22,11 +22,11 @@ use crate::{
     },
     Context,
 };
-use ahash::AHashSet;
+use ahash::{AHashMap, AHashSet};
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
-use commonware_utils::bitmap;
+use commonware_utils::{bitmap, sync::Mutex};
 use core::{cmp::Ordering, ops::Range};
 use std::{
     collections::BTreeMap,
@@ -181,6 +181,22 @@ where
 
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
+
+    /// Committed-DB locations resolved by this batch's reads (`get`/`get_many`), consumed by
+    /// `merkleize`. When a mutation key is present here, `merkleize` reuses the location and
+    /// skips the redundant journal read.
+    ///
+    /// Only committed-snapshot resolutions are retained. A retained location doubles as the
+    /// key's committed provenance (`base_old_loc`), which holds because a committed-resolved
+    /// key was in no live ancestor diff and a legal intervening commit (applying this batch's
+    /// own ancestors) can only relocate keys present in an ancestor diff. Ancestor-diff
+    /// resolutions are never retained: their op-gen position is an uncommitted location whose
+    /// committed provenance differs, and re-resolving them at merkleize is in-memory work (no
+    /// journal read is saved). The dropped-ancestor flow is covered end-to-end by
+    /// `test_unordered_fixed_retention_survives_ancestor_commit`.
+    ///
+    /// Interior-mutable because reads take `&self`; never held across an await.
+    resolved: Mutex<AHashMap<U::Key, Location<F>>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -649,26 +665,6 @@ where
         locations
     }
 
-    /// Check if the operation at `loc` for `key` is still active.
-    fn is_active_at<E, C, I, const N: usize>(
-        &self,
-        key: &U::Key,
-        loc: Location<F>,
-        batch_diff: &DiffSlice<U::Key, F, U::Value>,
-        db: &Db<F, E, C, I, H, U, N, S>,
-    ) -> bool
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        let diff_entry = lookup_sorted(batch_diff, key);
-        if let Some(entry) = diff_entry.or_else(|| resolve_in_ancestors(&self.ancestors, key)) {
-            return entry.loc() == Some(loc);
-        }
-        db.snapshot.get(key).any(|&l| l == loc)
-    }
-
     /// Extract keys that were deleted by a parent batch but are being
     /// re-created by this child batch. Removes those keys from `mutations`
     /// and returns `(key, value, base_old_loc)` entries.
@@ -756,20 +752,31 @@ where
                     let Some(key) = op.key().cloned() else {
                         continue; // skip CommitFloor and other non-keyed ops
                     };
-                    // `is_active_at` is required even for set bits in the committed bitmap
-                    // range: this batch's own diff or an uncommitted ancestor diff may
-                    // supersede the committed location, and neither source is reflected in
-                    // the bitmap.
-                    if !self.is_active_at(&key, candidate, &diff, db) {
+                    // A single batch-diff lookup drives the activity check, the base
+                    // provenance, and the in-place diff update below. Revalidation is required
+                    // even for candidates whose committed bitmap bit is set: this batch's diff
+                    // or an uncommitted ancestor diff may supersede the committed location, and
+                    // neither source is reflected in the bitmap.
+                    let search = diff.binary_search_by(|(k, _)| k.cmp(&key));
+                    let (active, base_old_loc) = match search {
+                        Ok(idx) => {
+                            let entry = &diff[idx].1;
+                            (entry.loc() == Some(candidate), entry.base_old_loc())
+                        }
+                        Err(_) => resolve_in_ancestors(&self.ancestors, &key).map_or_else(
+                            || {
+                                (
+                                    db.snapshot.get(&key).any(|&l| l == candidate),
+                                    Some(candidate),
+                                )
+                            },
+                            |entry| (entry.loc() == Some(candidate), entry.base_old_loc()),
+                        ),
+                    };
+                    if !active {
                         continue;
                     }
                     let new_loc = Location::new(self.base_size + ops.len() as u64);
-                    let search = diff.binary_search_by(|(k, _)| k.cmp(&key));
-                    let base_old_loc = match &search {
-                        Ok(idx) => diff[*idx].1.base_old_loc(),
-                        Err(_) => resolve_in_ancestors(&self.ancestors, &key)
-                            .map_or(Some(candidate), DiffEntry::base_old_loc),
-                    };
                     let value = extract_update_value(&op);
                     ops.push(op);
 
@@ -923,25 +930,16 @@ where
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        if let Some(value) = self.mutations.get(key) {
-            return Ok(value.clone());
-        }
-        if let Some(parent) = self.base.parent() {
-            if let Some(entry) = lookup_sorted(parent.diff.as_slice(), key) {
-                return Ok(entry.value().cloned());
-            }
-            for batch in parent.ancestors() {
-                if let Some(entry) = lookup_sorted(batch.diff.as_slice(), key) {
-                    return Ok(entry.value().cloned());
-                }
-            }
-        }
-        db.get(key).await
+        let mut values = self.get_many(&[key], db).await?;
+        Ok(values.pop().expect("one result per key"))
     }
 
-    /// Batch read multiple keys.
+    /// Batch read multiple keys (mutations -> ancestor diffs -> committed DB).
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys, with `None` for absent or deleted
+    /// keys. Committed-DB locations resolved by the read are retained on the batch and consumed
+    /// by `merkleize`, which skips re-reading those keys. Keys answered by pending mutations or
+    /// ancestor diffs retain nothing (merkleize re-resolves them in memory).
     pub async fn get_many<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
@@ -996,9 +994,13 @@ where
         }
 
         if !db_keys.is_empty() {
-            let db_results = db.get_many(&db_keys).await?;
-            for (slot, value) in db_indices.into_iter().zip(db_results) {
-                results[slot] = value;
+            let db_results = db.get_many_with_locations(&db_keys).await?;
+            let mut resolved = self.resolved.lock();
+            for (slot, result) in db_indices.into_iter().zip(db_results) {
+                results[slot] = result.map(|(value, loc)| {
+                    resolved.insert((*keys[slot]).clone(), loc);
+                    value
+                });
             }
         }
 
@@ -1015,6 +1017,9 @@ where
     Operation<F, update::Unordered<K, V>>: Codec,
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
+    ///
+    /// Consumes the locations retained by this batch's reads: keys loaded via `get`/`get_many`
+    /// before being written skip the journal re-read their resolution would otherwise require.
     #[allow(clippy::type_complexity)]
     #[tracing::instrument(
         name = "qmdb::any::batch::merkleize",
@@ -1044,9 +1049,9 @@ where
     /// Like [`merkleize`](Self::merkleize), but accepts the floor-raise candidate source.
     ///
     /// The callback may skip locations only when it knows they are inactive. The floor-raise
-    /// loop revalidates each returned candidate via `is_active_at` because the bitmap reflects
-    /// committed state only -- uncommitted ancestor ops aren't tracked, and bits can be set for
-    /// locations superseded by an overlay in this chain.
+    /// loop revalidates each returned candidate against the batch diff, ancestor diffs, and
+    /// snapshot because the bitmap reflects committed state only -- uncommitted ancestor ops
+    /// aren't tracked, and bits can be set for locations superseded by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
@@ -1058,7 +1063,20 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
+        let resolved = core::mem::take(&mut *self.resolved.lock());
         let (mut mutations, m) = self.into_parts();
+
+        // Pull mutations whose committed location this batch's reads already resolved. They
+        // skip the journal re-read and are emitted at their retained location by the merge
+        // below, exactly where the read path would have emitted them.
+        let mut retained: Vec<(K, Location<F>, Option<V::Value>)> =
+            Vec::with_capacity(resolved.len());
+        for (key, loc) in resolved {
+            if let Some(mutation) = mutations.remove(&key) {
+                retained.push((key, loc, mutation));
+            }
+        }
+        retained.sort_unstable_by_key(|&(_, loc, _)| loc);
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, false);
@@ -1067,14 +1085,51 @@ where
 
         // Generate user mutation operations.
         let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
-            Vec::with_capacity(mutations.len() + 1);
-        let mut diff: DiffVec<K, F, V::Value> = Vec::with_capacity(mutations.len());
+            Vec::with_capacity(mutations.len() + retained.len() + 1);
+        let mut diff: DiffVec<K, F, V::Value> =
+            Vec::with_capacity(mutations.len() + retained.len());
         let mut active_keys_delta: isize = 0;
         let mut user_steps: u64 = 0;
 
-        // Process updates/deletes of existing keys in location order.
-        // This includes keys from both the committed snapshot and ancestor diffs.
+        // Write a user mutation at the next batch location, preserving the committed-base
+        // provenance of the operation it supersedes.
+        let mut emit = |key: K, base_old_loc: Option<Location<F>>, mutation: Option<V::Value>| {
+            let new_loc = Location::new(m.base_size + ops.len() as u64);
+            match mutation {
+                Some(value) => {
+                    ops.push(Operation::Update(update::Unordered(
+                        key.clone(),
+                        value.clone(),
+                    )));
+                    diff.push((
+                        key,
+                        DiffEntry::Active {
+                            value,
+                            loc: new_loc,
+                            base_old_loc,
+                        },
+                    ));
+                }
+                None => {
+                    ops.push(Operation::Delete(key.clone()));
+                    diff.push((key, DiffEntry::Deleted { base_old_loc }));
+                    active_keys_delta -= 1;
+                }
+            }
+            user_steps += 1;
+        };
+
+        // Process updates/deletes of existing keys in location order, merging retained
+        // entries into the read-resolved stream so the operation order matches the
+        // read-only path. This includes keys from both the committed snapshot and
+        // ancestor diffs.
+        let mut retained = retained.into_iter().peekable();
         for (op, &old_loc) in results.iter().zip(&locations) {
+            while retained.peek().is_some_and(|&(_, loc, _)| loc < old_loc) {
+                let (key, loc, mutation) = retained.next().expect("peeked entry exists");
+                emit(key, Some(loc), mutation);
+            }
+
             let key = op.key().expect("updates should have a key");
 
             // A key resolved via the ancestor diff must only match at its ancestor-diff
@@ -1098,32 +1153,10 @@ where
                 continue;
             };
 
-            // Write the user mutation at the next batch location while
-            // preserving the committed-base provenance computed above.
-            let new_loc = Location::new(m.base_size + ops.len() as u64);
-            match mutation {
-                Some(value) => {
-                    ops.push(Operation::Update(update::Unordered(
-                        key.clone(),
-                        value.clone(),
-                    )));
-                    diff.push((
-                        key.clone(),
-                        DiffEntry::Active {
-                            value,
-                            loc: new_loc,
-                            base_old_loc,
-                        },
-                    ));
-                    user_steps += 1;
-                }
-                None => {
-                    ops.push(Operation::Delete(key.clone()));
-                    diff.push((key.clone(), DiffEntry::Deleted { base_old_loc }));
-                    active_keys_delta -= 1;
-                    user_steps += 1;
-                }
-            }
+            emit(key.clone(), base_old_loc, mutation);
+        }
+        for (key, loc, mutation) in retained {
+            emit(key, Some(loc), mutation);
         }
 
         // Handle parent-deleted keys that the child wants to re-create.
@@ -1216,9 +1249,9 @@ where
     /// Like [`merkleize`](Self::merkleize), but accepts the floor-raise candidate source.
     ///
     /// The callback may skip locations only when it knows they are inactive. The floor-raise
-    /// loop revalidates each returned candidate via `is_active_at` because the bitmap reflects
-    /// committed state only -- uncommitted ancestor ops aren't tracked, and bits can be set for
-    /// locations superseded by an overlay in this chain.
+    /// loop revalidates each returned candidate against the batch diff, ancestor diffs, and
+    /// snapshot because the bitmap reflects committed state only -- uncommitted ancestor ops
+    /// aren't tracked, and bits can be set for locations superseded by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Ordered<K, V>, N, S>,
@@ -1586,6 +1619,7 @@ where
             journal_batch: self.journal_batch.new_batch::<H>(),
             mutations: BTreeMap::new(),
             base: Base::Child(Arc::clone(self)),
+            resolved: Mutex::new(AHashMap::new()),
         }
     }
 
@@ -1708,6 +1742,7 @@ where
                 inactivity_floor_loc: self.inactivity_floor_loc,
                 active_keys: self.active_keys,
             },
+            resolved: Mutex::new(AHashMap::new()),
         }
     }
 }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2337,6 +2337,84 @@ mod tests {
         assert_eq!(next_candidate(&bitmap, loc(0), BITMAP_CHUNK_BITS), None);
     }
 
+    /// `fill_candidates` must produce the exact candidate sequence of repeatedly calling the
+    /// `next_candidate` oracle, across committed bits, the committed-to-tail transition, pruned
+    /// and truncated bitmaps, every batch limit, and tips below the bitmap length.
+    #[test]
+    fn bitmap_fill_candidates_matches_oracle() {
+        let shapes: Vec<(&str, Shared<BITMAP_CHUNK_BYTES>)> = vec![
+            ("empty", shared_with(|_| {})),
+            (
+                "committed_bits",
+                shared_with(|bm| {
+                    bm.extend_to(10);
+                    bm.set_bit(3, true);
+                    bm.set_bit(7, true);
+                }),
+            ),
+            (
+                "transition_into_tail",
+                shared_with(|bm| {
+                    bm.extend_to(5);
+                    bm.set_bit(2, true);
+                }),
+            ),
+            (
+                "pruned",
+                shared_with(|bm| {
+                    bm.extend_to(BITMAP_CHUNK_BITS * 3);
+                    bm.set_bit(BITMAP_CHUNK_BITS * 2 + 5, true);
+                    bm.prune_to_bit(BITMAP_CHUNK_BITS * 2);
+                }),
+            ),
+            (
+                "truncated",
+                shared_with(|bm| {
+                    bm.extend_to(BITMAP_CHUNK_BITS * 2);
+                    bm.set_bit(BITMAP_CHUNK_BITS + 3, true);
+                    bm.truncate(BITMAP_CHUNK_BITS);
+                }),
+            ),
+        ];
+
+        for (name, bitmap) in shapes {
+            let bitmap_len = bitmap::Readable::<BITMAP_CHUNK_BYTES>::len(&bitmap);
+            let start = commonware_utils::bitmap::Readable::pruned_chunks(&bitmap) as u64
+                * BITMAP_CHUNK_BITS;
+            for tip in [
+                start,
+                bitmap_len.saturating_sub(2),
+                bitmap_len,
+                bitmap_len + 6,
+            ] {
+                // Oracle sequence: advance the floor one candidate at a time.
+                let mut expected = Vec::new();
+                let mut floor = loc(start);
+                while let Some(candidate) = next_candidate(&bitmap, floor, tip) {
+                    expected.push(candidate);
+                    floor = loc(*candidate + 1);
+                }
+
+                for limit in 1..=expected.len().max(1) + 1 {
+                    let mut actual = Vec::new();
+                    let mut scan = loc(start);
+                    loop {
+                        let mut batch = Vec::new();
+                        scan = fill_candidates(&bitmap, scan, tip, limit, &mut batch);
+                        if batch.is_empty() {
+                            break;
+                        }
+                        actual.extend(batch);
+                    }
+                    assert_eq!(
+                        actual, expected,
+                        "shape={name} tip={tip} limit={limit} diverged from oracle"
+                    );
+                }
+            }
+        }
+    }
+
     /// Test helper: same logic as `Merkleizer::extract_parent_deleted_creates`
     /// but without requiring a full Merkleizer instance.
     fn extract_parent_deleted_creates<K: Ord + Clone, V: Clone>(

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -186,10 +186,10 @@ where
     base: Base<F, H::Digest, U, S>,
 
     /// Committed-DB locations cached by this batch's reads (`get`/`get_many`), keyed by the
-    /// key they matched. Consumed by unordered `merkleize`: when a mutation key is present
-    /// here, `merkleize` reuses the location and skips the redundant journal read. Ordered
-    /// `merkleize` ignores this cache: its op generation needs the read operation's value and
-    /// next key, and re-reading them costs more in cache upkeep than it saves.
+    /// key they matched. Populated only when `U::CACHES_READS` and consumed by `merkleize`:
+    /// when a mutation key is present here, `merkleize` reuses the location and skips the
+    /// redundant journal read. Ordered batches cache nothing: their op generation needs each
+    /// read operation's value and next key, so merkleize re-reads ops regardless.
     ///
     /// Only committed-snapshot resolutions are cached. A cached location doubles as the
     /// key's previous committed location (`base_old_loc`), which holds because a
@@ -923,8 +923,8 @@ where
     /// Batch read multiple keys (mutations -> ancestor diffs -> committed DB).
     ///
     /// Returns results in the same order as the input keys, with `None` for absent or deleted
-    /// keys. Each unique read resolved from the committed DB is cached on the batch for reuse
-    /// at merkleize.
+    /// keys. When the update kind caches reads, each unique read resolved from the committed
+    /// DB is cached on the batch for reuse at merkleize.
     pub async fn get_many<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
@@ -980,11 +980,15 @@ where
 
         if !db_keys.is_empty() {
             let db_results = db.get_many_with_locations(&db_keys).await?;
-            let mut resolved = self.resolved.lock();
-            resolved.reserve(db_keys.len());
+            let mut resolved = U::CACHES_READS.then(|| self.resolved.lock());
+            if let Some(resolved) = resolved.as_deref_mut() {
+                resolved.reserve(db_keys.len());
+            }
             for (slot, result) in db_indices.into_iter().zip(db_results) {
                 results[slot] = result.map(|(value, loc)| {
-                    resolved.insert((*keys[slot]).clone(), loc);
+                    if let Some(resolved) = resolved.as_deref_mut() {
+                        resolved.insert((*keys[slot]).clone(), loc);
+                    }
                     value
                 });
             }
@@ -1206,8 +1210,8 @@ where
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     ///
-    /// Locations cached by this batch's reads are ignored: ordered op generation needs each
-    /// read operation's value and next key for linkage, and re-reading them through the
+    /// Reads on ordered batches cache nothing (`CACHES_READS` is false): op generation needs
+    /// each read operation's value and next key for linkage, and re-reading them through the
     /// journal's page cache is cheaper than caching the payloads at read time.
     #[allow(clippy::type_complexity)]
     #[tracing::instrument(

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -234,17 +234,17 @@ where
     }
 
     /// Batch read multiple keys, returning per key the value, the committed location it was
-    /// read from, and the variant's retained payload (or `None` for absent keys).
+    /// read from, and the variant's cached payload (or `None` for absent keys).
     ///
     /// Identical resolution to [`Self::get_many`] but additionally returns the snapshot
-    /// location and retained payload, letting batch reads retain them for reuse at merkleize.
+    /// location and cached payload, letting batch reads cache them for reuse at merkleize.
     ///
     /// Results are returned in the same order as the input keys.
     #[allow(clippy::type_complexity)]
     pub(crate) async fn get_many_with_locations(
         &self,
         keys: &[&U::Key],
-    ) -> Result<Vec<Option<(U::Value, Location<F>, U::Retained)>>, crate::qmdb::Error<F>> {
+    ) -> Result<Vec<Option<(U::Value, Location<F>, U::Cached)>>, crate::qmdb::Error<F>> {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -256,7 +256,7 @@ where
         // Phase 1: Collect candidate locations from the in-memory index.
         // Each key may map to multiple locations due to hash collisions.
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
-        let mut results: Vec<Option<(U::Value, Location<F>, U::Retained)>> = vec![None; keys.len()];
+        let mut results: Vec<Option<(U::Value, Location<F>, U::Cached)>> = vec![None; keys.len()];
 
         self.snapshot
             .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
@@ -291,8 +291,7 @@ where
                 panic!("location does not reference update operation. loc={pos}");
             };
             if data.key() == keys[key_idx] {
-                results[key_idx] =
-                    Some((data.value().clone(), Location::new(pos), data.retained()));
+                results[key_idx] = Some((data.value().clone(), Location::new(pos), data.cached()));
             }
         }
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -229,22 +229,22 @@ where
         let results = self.get_many_with_locations(keys).await?;
         Ok(results
             .into_iter()
-            .map(|result| result.map(|(value, _, _)| value))
+            .map(|result| result.map(|(value, _)| value))
             .collect())
     }
 
-    /// Batch read multiple keys, returning per key the value, the committed location it was
-    /// read from, and the variant's cached payload (or `None` for absent keys).
+    /// Batch read multiple keys, returning per key the value and the committed location it was
+    /// read from (or `None` for absent keys).
     ///
     /// Identical resolution to [`Self::get_many`] but additionally returns the snapshot
-    /// location and cached payload, letting batch reads cache them for reuse at merkleize.
+    /// location, letting batch reads cache it for reuse at merkleize.
     ///
     /// Results are returned in the same order as the input keys.
     #[allow(clippy::type_complexity)]
     pub(crate) async fn get_many_with_locations(
         &self,
         keys: &[&U::Key],
-    ) -> Result<Vec<Option<(U::Value, Location<F>, U::Cached)>>, crate::qmdb::Error<F>> {
+    ) -> Result<Vec<Option<(U::Value, Location<F>)>>, crate::qmdb::Error<F>> {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -256,7 +256,7 @@ where
         // Phase 1: Collect candidate locations from the in-memory index.
         // Each key may map to multiple locations due to hash collisions.
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
-        let mut results: Vec<Option<(U::Value, Location<F>, U::Cached)>> = vec![None; keys.len()];
+        let mut results: Vec<Option<(U::Value, Location<F>)>> = vec![None; keys.len()];
 
         self.snapshot
             .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
@@ -291,7 +291,7 @@ where
                 panic!("location does not reference update operation. loc={pos}");
             };
             if data.key() == keys[key_idx] {
-                results[key_idx] = Some((data.value().clone(), Location::new(pos), data.cached()));
+                results[key_idx] = Some((data.value().clone(), Location::new(pos)));
             }
         }
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -225,6 +225,26 @@ where
         &self,
         keys: &[&U::Key],
     ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>> {
+        let results = self.get_many_with_locations(keys).await?;
+        Ok(results
+            .into_iter()
+            .map(|result| result.map(|(value, _)| value))
+            .collect())
+    }
+
+    /// Batch read multiple keys, returning per key both the value and the committed location
+    /// it key-matched (or `None` for absent keys).
+    ///
+    /// Identical resolution to [`Self::get_many`] but additionally returns the snapshot
+    /// location that produced each value, letting batch reads retain locations for reuse at
+    /// merkleize.
+    ///
+    /// Results are returned in the same order as the input keys.
+    #[allow(clippy::type_complexity)]
+    pub(crate) async fn get_many_with_locations(
+        &self,
+        keys: &[&U::Key],
+    ) -> Result<Vec<Option<(U::Value, Location<F>)>>, crate::qmdb::Error<F>> {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -236,7 +256,7 @@ where
         // Phase 1: Collect candidate locations from the in-memory index.
         // Each key may map to multiple locations due to hash collisions.
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
-        let mut results: Vec<Option<U::Value>> = vec![None; keys.len()];
+        let mut results: Vec<Option<(U::Value, Location<F>)>> = vec![None; keys.len()];
 
         for (key_idx, key) in keys.iter().enumerate() {
             for &loc in self.snapshot.get(key) {
@@ -274,7 +294,7 @@ where
                 panic!("location does not reference update operation. loc={pos}");
             };
             if data.key() == keys[key_idx] {
-                results[key_idx] = Some(data.value().clone());
+                results[key_idx] = Some((data.value().clone(), Location::new(pos)));
             }
         }
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -228,23 +228,22 @@ where
         let results = self.get_many_with_locations(keys).await?;
         Ok(results
             .into_iter()
-            .map(|result| result.map(|(value, _)| value))
+            .map(|result| result.map(|(value, _, _)| value))
             .collect())
     }
 
-    /// Batch read multiple keys, returning per key both the value and the committed location
-    /// it key-matched (or `None` for absent keys).
+    /// Batch read multiple keys, returning per key the value, the committed location it was
+    /// read from, and the variant's retained payload (or `None` for absent keys).
     ///
     /// Identical resolution to [`Self::get_many`] but additionally returns the snapshot
-    /// location that produced each value, letting batch reads retain locations for reuse at
-    /// merkleize.
+    /// location and retained payload, letting batch reads retain them for reuse at merkleize.
     ///
     /// Results are returned in the same order as the input keys.
     #[allow(clippy::type_complexity)]
     pub(crate) async fn get_many_with_locations(
         &self,
         keys: &[&U::Key],
-    ) -> Result<Vec<Option<(U::Value, Location<F>)>>, crate::qmdb::Error<F>> {
+    ) -> Result<Vec<Option<(U::Value, Location<F>, U::Retained)>>, crate::qmdb::Error<F>> {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -256,7 +255,7 @@ where
         // Phase 1: Collect candidate locations from the in-memory index.
         // Each key may map to multiple locations due to hash collisions.
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
-        let mut results: Vec<Option<(U::Value, Location<F>)>> = vec![None; keys.len()];
+        let mut results: Vec<Option<(U::Value, Location<F>, U::Retained)>> = vec![None; keys.len()];
 
         for (key_idx, key) in keys.iter().enumerate() {
             for &loc in self.snapshot.get(key) {
@@ -294,7 +293,8 @@ where
                 panic!("location does not reference update operation. loc={pos}");
             };
             if data.key() == keys[key_idx] {
-                results[key_idx] = Some((data.value().clone(), Location::new(pos)));
+                results[key_idx] =
+                    Some((data.value().clone(), Location::new(pos), data.retained()));
             }
         }
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -119,7 +119,8 @@ pub struct Db<
     pub(crate) active_keys: usize,
 
     /// Activity bitmap over committed operations. Rebuilt from the journal on init; never
-    /// persisted. A hint for floor-raise scans; merkleization re-verifies via `is_active_at`.
+    /// persisted. A hint for floor-raise scans; merkleization re-verifies each candidate
+    /// against the batch diff, ancestor diffs, and snapshot in the floor-raise loop.
     /// When wrapped by `current::Db`, this is also the bitmap that `current` reads for grafted-
     /// tree leaves and proofs.
     ///

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -233,13 +233,8 @@ where
             .collect())
     }
 
-    /// Batch read multiple keys, returning per key the value and the committed location it was
-    /// read from (or `None` for absent keys).
-    ///
-    /// Identical resolution to [`Self::get_many`] but additionally returns the snapshot
-    /// location, letting batch reads cache it for reuse at merkleize.
-    ///
-    /// Results are returned in the same order as the input keys.
+    /// Like [`Self::get_many`] but additionally returns the committed location each value was
+    /// read from.
     #[allow(clippy::type_complexity)]
     pub(crate) async fn get_many_with_locations(
         &self,

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -258,11 +258,8 @@ where
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
         let mut results: Vec<Option<(U::Value, Location<F>, U::Retained)>> = vec![None; keys.len()];
 
-        for (key_idx, key) in keys.iter().enumerate() {
-            for &loc in self.snapshot.get(key) {
-                candidates.push((key_idx, *loc));
-            }
-        }
+        self.snapshot
+            .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
 
         if candidates.is_empty() {
             return Ok(results);

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2768,7 +2768,7 @@ mod bitmap_tests {
     ///
     /// `next_candidate` returns set-bit locations within `[floor, bitmap.len)` (skipping inactive
     /// ones), then sequential candidates beyond `bitmap.len` (uncommitted ancestor ops not
-    /// tracked in the bitmap). `is_active_at` revalidation in the floor-raise loop is the only
+    /// tracked in the bitmap). The floor-raise loop's per-candidate revalidation is the only
     /// thing that prevents stale ancestor locations from being moved when a child batch
     /// supersedes the same key.
     ///
@@ -2779,7 +2779,7 @@ mod bitmap_tests {
     ///
     /// Failure modes caught:
     /// - tail-fallthrough boundary off-by-one → wrong root,
-    /// - missing `is_active_at` revalidation → parent's superseded loc gets moved → divergent
+    /// - missing floor-raise revalidation → parent's superseded loc gets moved → divergent
     ///   root,
     /// - bitmap state inconsistent with `init_from_log` → oracle reopen mismatch.
     #[test_traced]

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -23,6 +23,9 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     /// The value encoding (fixed or variable).
     type ValueEncoding: ValueEncoding<Value = Self::Value>;
 
+    /// Whether batch reads cache resolved committed locations for merkleize to consume.
+    const CACHES_READS: bool;
+
     /// The updated key.
     fn key(&self) -> &Self::Key;
 

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -23,12 +23,6 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     /// The value encoding (fixed or variable).
     type ValueEncoding: ValueEncoding<Value = Self::Value>;
 
-    /// Data cached from a committed-DB read for reuse at merkleize, alongside the location.
-    type Cached: Clone + Send + Sync;
-
-    /// Extract the cached payload from a read operation.
-    fn cached(&self) -> Self::Cached;
-
     /// The updated key.
     fn key(&self) -> &Self::Key;
 

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -23,15 +23,11 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     /// The value encoding (fixed or variable).
     type ValueEncoding: ValueEncoding<Value = Self::Value>;
 
-    /// Data retained from a committed-DB read for reuse at merkleize, alongside the location.
-    ///
-    /// Unordered op generation needs only the location, so it retains nothing extra. Ordered op
-    /// generation also consumes the read operation's linkage payload (prior value and next key),
-    /// so it retains both.
-    type Retained: Clone + Send + Sync;
+    /// Data cached from a committed-DB read for reuse at merkleize, alongside the location.
+    type Cached: Clone + Send + Sync;
 
-    /// Extract the retained payload from a read operation.
-    fn retained(&self) -> Self::Retained;
+    /// Extract the cached payload from a read operation.
+    fn cached(&self) -> Self::Cached;
 
     /// The updated key.
     fn key(&self) -> &Self::Key;

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -23,6 +23,16 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     /// The value encoding (fixed or variable).
     type ValueEncoding: ValueEncoding<Value = Self::Value>;
 
+    /// Data retained from a committed-DB read for reuse at merkleize, alongside the location.
+    ///
+    /// Unordered op generation needs only the location, so it retains nothing extra. Ordered op
+    /// generation also consumes the read operation's linkage payload (prior value and next key),
+    /// so it retains both.
+    type Retained: Clone + Send + Sync;
+
+    /// Extract the retained payload from a read operation.
+    fn retained(&self) -> Self::Retained;
+
     /// The updated key.
     fn key(&self) -> &Self::Key;
 

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -42,9 +42,9 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    type Retained = (V::Value, K);
+    type Cached = (V::Value, K);
 
-    fn retained(&self) -> Self::Retained {
+    fn cached(&self) -> Self::Cached {
         (self.value.clone(), self.next_key.clone())
     }
 

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -42,6 +42,8 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
+    const CACHES_READS: bool = false;
+
     fn key(&self) -> &K {
         &self.key
     }

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -42,6 +42,11 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
+    type Retained = (V::Value, K);
+
+    fn retained(&self) -> Self::Retained {
+        (self.value.clone(), self.next_key.clone())
+    }
 
     fn key(&self) -> &K {
         &self.key

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -42,12 +42,6 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    type Cached = (V::Value, K);
-
-    fn cached(&self) -> Self::Cached {
-        (self.value.clone(), self.next_key.clone())
-    }
-
     fn key(&self) -> &K {
         &self.key
     }

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -34,9 +34,9 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    type Retained = ();
+    type Cached = ();
 
-    fn retained(&self) -> Self::Retained {}
+    fn cached(&self) -> Self::Cached {}
 
     fn key(&self) -> &K {
         &self.0

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -34,6 +34,8 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
+    const CACHES_READS: bool = true;
+
     fn key(&self) -> &K {
         &self.0
     }

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -34,6 +34,9 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
+    type Retained = ();
+
+    fn retained(&self) -> Self::Retained {}
 
     fn key(&self) -> &K {
         &self.0

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -34,10 +34,6 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    type Cached = ();
-
-    fn cached(&self) -> Self::Cached {}
-
     fn key(&self) -> &K {
         &self.0
     }

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -345,6 +345,14 @@ pub(crate) mod test {
                 // consumes. Values and root must match the write-only path.
                 let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
                 let mut fb = new_batch();
+                // Keys read but never written (existing and absent) retain entries that
+                // merkleize must drop without affecting the root.
+                let unwritten: Vec<Digest> = (0..40u64)
+                    .map(|i| key(i * 12))
+                    .chain((0..5).map(|i| key(8000 + i)))
+                    .collect();
+                let unwritten_refs: Vec<&Digest> = unwritten.iter().collect();
+                fb.get_many(&unwritten_refs, &db).await.unwrap();
                 let values = fb.get_many(&keys, &db).await.unwrap();
                 let plain = new_batch().get_many(&keys, &db).await.unwrap();
                 assert_eq!(values, plain, "value mismatch at depth={depth}");

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -253,6 +253,126 @@ pub(crate) mod test {
         db.apply_batch(merkleized).await.unwrap();
     }
 
+    /// Reads on a batch retain resolved operations that `merkleize` consumes to skip re-reading
+    /// updated keys (deletes are always re-read for predecessor linkage). The root must be
+    /// byte-identical to a write-only batch's `merkleize` across updates/deletes/creates, both
+    /// with the batch rooted directly at the DB (D=0) and through pending ancestors (D=1, D=2).
+    #[test_traced("WARN")]
+    fn test_ordered_fixed_resolved_merkleize_parity() {
+        type ParentChain = Vec<
+            std::sync::Arc<
+                crate::qmdb::any::batch::MerkleizedBatch<
+                    mmr::Family,
+                    Digest,
+                    crate::qmdb::any::operation::update::Ordered<Digest, FixedEncoding<Digest>>,
+                    Sequential,
+                >,
+            >,
+        >;
+
+        fn key(i: u64) -> Digest {
+            Sha256::hash(&i.to_be_bytes())
+        }
+        fn val(i: u64) -> Digest {
+            Sha256::hash(&i.to_le_bytes())
+        }
+
+        deterministic::Runner::default().start(|ctx| async move {
+            let mut db = create_test_db(ctx.child("db")).await;
+
+            // Seed 500 keys and commit so they live in the committed snapshot. TwoCap makes
+            // translated-bucket collisions common, stressing the sibling-read paths.
+            let mut seed = db.new_batch();
+            for i in 0..500u64 {
+                seed = seed.write(key(i), Some(val(i)));
+            }
+            let seed = seed.merkleize(&db, None).await.unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            // Build a mixed mutation set: updates of existing keys, deletes of existing keys,
+            // and creates of fresh keys. `make` re-derives the set from a seed so both paths
+            // and all depths see identical mutations.
+            let make = |salt: u64| -> Vec<(Digest, Option<Digest>)> {
+                let mut rng = test_rng_seeded(salt);
+                let mut out = Vec::new();
+                for _ in 0..200 {
+                    let r = rng.next_u32() % 100;
+                    if r < 60 {
+                        out.push((key(rng.next_u64() % 500), Some(val(rng.next_u64()))));
+                    } else if r < 80 {
+                        out.push((key(rng.next_u64() % 500), None));
+                    } else {
+                        out.push((key(500 + rng.next_u64() % 500), Some(val(rng.next_u64()))));
+                    }
+                }
+                // Dedup last-write-wins.
+                let mut m: HashMap<Digest, Option<Digest>> = HashMap::new();
+                for (k, v) in out {
+                    m.insert(k, v);
+                }
+                m.into_iter().collect()
+            };
+
+            // D=0: batch rooted directly at the DB. D=N: through N pending ancestors.
+            for depth in [0u64, 1, 2] {
+                let mut chain: ParentChain = Vec::new();
+                for d in 0..depth {
+                    let mut p = chain
+                        .last()
+                        .map_or_else(|| db.new_batch(), |l| l.new_batch::<Sha256>());
+                    for (k, v) in make(900 + d) {
+                        p = p.write(k, v);
+                    }
+                    chain.push(p.merkleize(&db, None).await.unwrap());
+                }
+
+                let muts = make(depth + 1);
+                let new_batch = || {
+                    chain
+                        .last()
+                        .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
+                };
+
+                // Normal path.
+                let mut nb = new_batch();
+                for (k, v) in &muts {
+                    nb = nb.write(*k, *v);
+                }
+                let normal_root = nb.merkleize(&db, None).await.unwrap().root();
+
+                // Read-then-write on one batch: the read retains operations that merkleize
+                // consumes. Values and root must match the write-only path.
+                let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
+                let mut fb = new_batch();
+                let values = fb.get_many(&keys, &db).await.unwrap();
+                let plain = new_batch().get_many(&keys, &db).await.unwrap();
+                assert_eq!(values, plain, "value mismatch at depth={depth}");
+                for (k, v) in &muts {
+                    fb = fb.write(*k, *v);
+                }
+                let fused_root = fb.merkleize(&db, None).await.unwrap().root();
+                assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
+
+                // Multiple disjoint reads accumulate, and single-key gets retain too.
+                let half = muts.len() / 2;
+                let mut gb = new_batch();
+                gb.get_many(&keys[..half], &db).await.unwrap();
+                for key in &keys[half..] {
+                    gb.get(key, &db).await.unwrap();
+                }
+                for (k, v) in &muts {
+                    gb = gb.write(*k, *v);
+                }
+                let merged_root = gb.merkleize(&db, None).await.unwrap().root();
+                assert_eq!(
+                    normal_root, merged_root,
+                    "merged root mismatch at depth={depth}"
+                );
+            }
+        });
+    }
+
     #[test_traced("WARN")]
     // Test the edge case that arises where we're inserting the second key and it precedes the first
     // key, but shares the same translated key.

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -253,7 +253,7 @@ pub(crate) mod test {
         db.apply_batch(merkleized).await.unwrap();
     }
 
-    /// Reads on a batch retain resolved operations that `merkleize` consumes to skip re-reading
+    /// Reads on a batch cache resolved operations that `merkleize` consumes to skip re-reading
     /// updated keys (deletes are always re-read for predecessor linkage). The root must be
     /// byte-identical to a write-only batch's `merkleize` across updates/deletes/creates, both
     /// with the batch rooted directly at the DB (D=0) and through pending ancestors (D=1, D=2).
@@ -341,11 +341,11 @@ pub(crate) mod test {
                 }
                 let normal_root = nb.merkleize(&db, None).await.unwrap().root();
 
-                // Read-then-write on one batch: the read retains operations that merkleize
+                // Read-then-write on one batch: the read caches operations that merkleize
                 // consumes. Values and root must match the write-only path.
                 let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
                 let mut fb = new_batch();
-                // Keys read but never written (existing and absent) retain entries that
+                // Keys read but never written (existing and absent) cache entries that
                 // merkleize must drop without affecting the root.
                 let unwritten: Vec<Digest> = (0..40u64)
                     .map(|i| key(i * 12))
@@ -362,7 +362,7 @@ pub(crate) mod test {
                 let fused_root = fb.merkleize(&db, None).await.unwrap().root();
                 assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
 
-                // Multiple disjoint reads accumulate, and single-key gets retain too.
+                // Multiple disjoint reads accumulate, and single-key gets populate the cache too.
                 let half = muts.len() / 2;
                 let mut gb = new_batch();
                 gb.get_many(&keys[..half], &db).await.unwrap();
@@ -384,10 +384,10 @@ pub(crate) mod test {
     /// A key deleted by a pending ancestor and re-written by the child must merkleize
     /// identically whether or not its committed bucket siblings were read first. Its committed
     /// location only surfaces through a sibling's bucket walk (gather skips ancestor-deleted
-    /// keys), so if retention suppressed the walk for read-then-updated siblings, the key would
+    /// keys), so if caching suppressed the walk for read-then-updated siblings, the key would
     /// be emitted as a create instead of an update and the root would diverge.
     #[test_traced("WARN")]
-    fn test_ordered_fixed_retained_sibling_bucket_parity() {
+    fn test_ordered_fixed_cached_sibling_bucket_parity() {
         fn dkey(bucket: u16, tail: u64) -> Digest {
             let mut b = [0u8; 32];
             b[..2].copy_from_slice(&bucket.to_be_bytes());
@@ -401,7 +401,7 @@ pub(crate) mod test {
         deterministic::Runner::default().start(|ctx| async move {
             // Filler keys occupy the lowest committed locations so the ancestor's floor raise
             // moves them, not the dense bucket. The sibling reads then resolve through the
-            // committed snapshot (and are retained) rather than through an ancestor diff.
+            // committed snapshot (and are cached) rather than through an ancestor diff.
             let mut db = create_test_db(ctx.child("db")).await;
             let mut seed = db.new_batch();
             for i in 0..10u64 {
@@ -434,7 +434,7 @@ pub(crate) mod test {
             }
             let normal_root = nb.merkleize(&db, None).await.unwrap().root();
 
-            // Read all committed siblings first (retaining their resolutions), then write.
+            // Read all committed siblings first (caching their resolutions), then write.
             let mut fb = ancestor.new_batch::<Sha256>();
             let siblings: Vec<Digest> = (1..4u64).map(|i| dkey(1, i)).collect();
             let sibling_refs: Vec<&Digest> = siblings.iter().collect();
@@ -448,11 +448,11 @@ pub(crate) mod test {
     }
 
     /// Randomized dense-bucket parity sweep: prefix-controlled keys force every translated
-    /// bucket to be dense, so retained reads, ancestor deletes, rewrites of ancestor-deleted
+    /// bucket to be dense, so cached reads, ancestor deletes, rewrites of ancestor-deleted
     /// keys, and collision siblings constantly interact. The read-then-write root must match
     /// the write-only root for every seed and ancestor depth.
     #[test_traced("WARN")]
-    fn test_ordered_fixed_dense_bucket_retention_parity_sweep() {
+    fn test_ordered_fixed_dense_bucket_caching_parity_sweep() {
         type Merkleized = std::sync::Arc<
             crate::qmdb::any::batch::MerkleizedBatch<
                 mmr::Family,
@@ -478,7 +478,7 @@ pub(crate) mod test {
         deterministic::Runner::default().start(|ctx| async move {
             // Fillers occupy the lowest committed locations so pending ancestors' floor raises
             // consume them first, leaving most dense-bucket keys committed-resolved (and thus
-            // retained when read).
+            // cached when read).
             let mut db = create_test_db(ctx.child("db")).await;
             let mut seed = db.new_batch();
             for i in 0..16u64 {
@@ -738,7 +738,7 @@ pub(crate) mod test {
             }
 
             // Make sure size-constrained batches of operations are provable from the oldest
-            // retained op to tip.
+            // cached op to tip.
             let max_ops = NZU64!(4);
             let end_loc = db.bounds().await.end;
             let start_loc = db.log.merkle.bounds().start;

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -253,10 +253,9 @@ pub(crate) mod test {
         db.apply_batch(merkleized).await.unwrap();
     }
 
-    /// Reads on a batch cache resolved operations that `merkleize` consumes to skip re-reading
-    /// updated keys (deletes are always re-read for predecessor linkage). The root must be
-    /// byte-identical to a write-only batch's `merkleize` across updates/deletes/creates, both
-    /// with the batch rooted directly at the DB (D=0) and through pending ancestors (D=1, D=2).
+    /// Reads on a batch must not perturb `merkleize`: the root must be byte-identical to a
+    /// write-only batch's `merkleize` across updates/deletes/creates, both with the batch
+    /// rooted directly at the DB (D=0) and through pending ancestors (D=1, D=2).
     #[test_traced("WARN")]
     fn test_ordered_fixed_resolved_merkleize_parity() {
         type ParentChain = Vec<
@@ -341,12 +340,12 @@ pub(crate) mod test {
                 }
                 let normal_root = nb.merkleize(&db, None).await.unwrap().root();
 
-                // Read-then-write on one batch: the read caches operations that merkleize
-                // consumes. Values and root must match the write-only path.
+                // Read-then-write on one batch: values and root must match the write-only
+                // path.
                 let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
                 let mut fb = new_batch();
-                // Keys read but never written (existing and absent) cache entries that
-                // merkleize must drop without affecting the root.
+                // Keys read but never written (existing and absent) must not affect the
+                // root.
                 let unwritten: Vec<Digest> = (0..40u64)
                     .map(|i| key(i * 12))
                     .chain((0..5).map(|i| key(8000 + i)))
@@ -362,7 +361,7 @@ pub(crate) mod test {
                 let fused_root = fb.merkleize(&db, None).await.unwrap().root();
                 assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
 
-                // Multiple disjoint reads accumulate, and single-key gets populate the cache too.
+                // Multiple disjoint reads and single-key gets must not affect the root.
                 let half = muts.len() / 2;
                 let mut gb = new_batch();
                 gb.get_many(&keys[..half], &db).await.unwrap();
@@ -377,180 +376,6 @@ pub(crate) mod test {
                     normal_root, merged_root,
                     "merged root mismatch at depth={depth}"
                 );
-            }
-        });
-    }
-
-    /// A key deleted by a pending ancestor and re-written by the child must merkleize
-    /// identically whether or not its committed bucket siblings were read first. Its committed
-    /// location only surfaces through a sibling's bucket walk (gather skips ancestor-deleted
-    /// keys), so if caching suppressed the walk for read-then-updated siblings, the key would
-    /// be emitted as a create instead of an update and the root would diverge.
-    #[test_traced("WARN")]
-    fn test_ordered_fixed_cached_sibling_bucket_parity() {
-        fn dkey(bucket: u16, tail: u64) -> Digest {
-            let mut b = [0u8; 32];
-            b[..2].copy_from_slice(&bucket.to_be_bytes());
-            b[2..10].copy_from_slice(&tail.to_be_bytes());
-            Digest(b)
-        }
-        fn val(i: u64) -> Digest {
-            Sha256::hash(&i.to_le_bytes())
-        }
-
-        deterministic::Runner::default().start(|ctx| async move {
-            // Filler keys occupy the lowest committed locations so the ancestor's floor raise
-            // moves them, not the dense bucket. The sibling reads then resolve through the
-            // committed snapshot (and are cached) rather than through an ancestor diff.
-            let mut db = create_test_db(ctx.child("db")).await;
-            let mut seed = db.new_batch();
-            for i in 0..10u64 {
-                seed = seed.write(dkey(0, i), Some(val(i)));
-            }
-            for i in 0..4u64 {
-                seed = seed.write(dkey(1, i), Some(val(100 + i)));
-            }
-            let seed = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
-
-            // A pending ancestor deletes one key in the dense bucket.
-            let ancestor = db
-                .new_batch()
-                .write(dkey(1, 0), None)
-                .merkleize(&db, None)
-                .await
-                .unwrap();
-
-            // The child re-writes the deleted key and updates every committed sibling in its
-            // bucket.
-            let muts: Vec<(Digest, Option<Digest>)> = (0..4u64)
-                .map(|i| (dkey(1, i), Some(val(200 + i))))
-                .collect();
-
-            let mut nb = ancestor.new_batch::<Sha256>();
-            for (k, v) in &muts {
-                nb = nb.write(*k, *v);
-            }
-            let normal_root = nb.merkleize(&db, None).await.unwrap().root();
-
-            // Read all committed siblings first (caching their resolutions), then write.
-            let mut fb = ancestor.new_batch::<Sha256>();
-            let siblings: Vec<Digest> = (1..4u64).map(|i| dkey(1, i)).collect();
-            let sibling_refs: Vec<&Digest> = siblings.iter().collect();
-            fb.get_many(&sibling_refs, &db).await.unwrap();
-            for (k, v) in &muts {
-                fb = fb.write(*k, *v);
-            }
-            let fused_root = fb.merkleize(&db, None).await.unwrap().root();
-            assert_eq!(normal_root, fused_root, "root mismatch");
-        });
-    }
-
-    /// Randomized dense-bucket parity sweep: prefix-controlled keys force every translated
-    /// bucket to be dense, so cached reads, ancestor deletes, rewrites of ancestor-deleted
-    /// keys, and collision siblings constantly interact. The read-then-write root must match
-    /// the write-only root for every seed and ancestor depth.
-    #[test_traced("WARN")]
-    fn test_ordered_fixed_dense_bucket_caching_parity_sweep() {
-        type Merkleized = std::sync::Arc<
-            crate::qmdb::any::batch::MerkleizedBatch<
-                mmr::Family,
-                Digest,
-                crate::qmdb::any::operation::update::Ordered<Digest, FixedEncoding<Digest>>,
-                Sequential,
-            >,
-        >;
-
-        const BUCKETS: u16 = 4;
-        const KEYS_PER_BUCKET: u64 = 6;
-
-        fn dkey(bucket: u16, tail: u64) -> Digest {
-            let mut b = [0u8; 32];
-            b[..2].copy_from_slice(&bucket.to_be_bytes());
-            b[2..10].copy_from_slice(&tail.to_be_bytes());
-            Digest(b)
-        }
-        fn val(i: u64) -> Digest {
-            Sha256::hash(&i.to_le_bytes())
-        }
-
-        deterministic::Runner::default().start(|ctx| async move {
-            // Fillers occupy the lowest committed locations so pending ancestors' floor raises
-            // consume them first, leaving most dense-bucket keys committed-resolved (and thus
-            // cached when read).
-            let mut db = create_test_db(ctx.child("db")).await;
-            let mut seed = db.new_batch();
-            for i in 0..16u64 {
-                seed = seed.write(dkey(u16::MAX, i), Some(val(i)));
-            }
-            for bucket in 0..BUCKETS {
-                for tail in 0..KEYS_PER_BUCKET {
-                    seed = seed.write(dkey(bucket, tail), Some(val(1000 + tail)));
-                }
-            }
-            let seed = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
-
-            // Random mutations over the dense space: updates, deletes, and creates of fresh
-            // tails. Rewrites of ancestor-deleted keys arise by chance at high density.
-            let make = |salt: u64| -> Vec<(Digest, Option<Digest>)> {
-                let mut rng = test_rng_seeded(salt);
-                let mut m: BTreeMap<Digest, Option<Digest>> = BTreeMap::new();
-                for _ in 0..12 {
-                    let bucket = (rng.next_u32() as u16) % BUCKETS;
-                    let r = rng.next_u32() % 100;
-                    if r < 55 {
-                        let k = dkey(bucket, rng.next_u64() % KEYS_PER_BUCKET);
-                        m.insert(k, Some(val(rng.next_u64())));
-                    } else if r < 80 {
-                        let k = dkey(bucket, rng.next_u64() % KEYS_PER_BUCKET);
-                        m.insert(k, None);
-                    } else {
-                        let k = dkey(bucket, KEYS_PER_BUCKET + rng.next_u64() % KEYS_PER_BUCKET);
-                        m.insert(k, Some(val(rng.next_u64())));
-                    }
-                }
-                m.into_iter().collect()
-            };
-
-            for salt in 0..40u64 {
-                for depth in [1u64, 2] {
-                    // Hold every ancestor: a merkleized batch only weakly references its
-                    // parent, so dropping an uncommitted ancestor truncates the chain.
-                    let mut chain: Vec<Merkleized> = Vec::new();
-                    for d in 0..depth {
-                        let mut b = chain
-                            .last()
-                            .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>());
-                        for (k, v) in make(salt * 10 + d) {
-                            b = b.write(k, v);
-                        }
-                        chain.push(b.merkleize(&db, None).await.unwrap());
-                    }
-                    let parent = chain.last().unwrap();
-
-                    let muts = make(salt * 10 + 7);
-
-                    let mut nb = parent.new_batch::<Sha256>();
-                    for (k, v) in &muts {
-                        nb = nb.write(*k, *v);
-                    }
-                    let normal_root = nb.merkleize(&db, None).await.unwrap().root();
-
-                    let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
-                    let mut fb = parent.new_batch::<Sha256>();
-                    fb.get_many(&keys, &db).await.unwrap();
-                    for (k, v) in &muts {
-                        fb = fb.write(*k, *v);
-                    }
-                    let fused_root = fb.merkleize(&db, None).await.unwrap().root();
-                    assert_eq!(
-                        normal_root, fused_root,
-                        "root mismatch at salt={salt} depth={depth}"
-                    );
-                }
             }
         });
     }
@@ -738,7 +563,7 @@ pub(crate) mod test {
             }
 
             // Make sure size-constrained batches of operations are provable from the oldest
-            // cached op to tip.
+            // retained op to tip.
             let max_ops = NZU64!(4);
             let end_loc = db.bounds().await.end;
             let start_loc = db.log.merkle.bounds().start;

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -381,6 +381,180 @@ pub(crate) mod test {
         });
     }
 
+    /// A key deleted by a pending ancestor and re-written by the child must merkleize
+    /// identically whether or not its committed bucket siblings were read first. Its committed
+    /// location only surfaces through a sibling's bucket walk (gather skips ancestor-deleted
+    /// keys), so if retention suppressed the walk for read-then-updated siblings, the key would
+    /// be emitted as a create instead of an update and the root would diverge.
+    #[test_traced("WARN")]
+    fn test_ordered_fixed_retained_sibling_bucket_parity() {
+        fn dkey(bucket: u16, tail: u64) -> Digest {
+            let mut b = [0u8; 32];
+            b[..2].copy_from_slice(&bucket.to_be_bytes());
+            b[2..10].copy_from_slice(&tail.to_be_bytes());
+            Digest(b)
+        }
+        fn val(i: u64) -> Digest {
+            Sha256::hash(&i.to_le_bytes())
+        }
+
+        deterministic::Runner::default().start(|ctx| async move {
+            // Filler keys occupy the lowest committed locations so the ancestor's floor raise
+            // moves them, not the dense bucket. The sibling reads then resolve through the
+            // committed snapshot (and are retained) rather than through an ancestor diff.
+            let mut db = create_test_db(ctx.child("db")).await;
+            let mut seed = db.new_batch();
+            for i in 0..10u64 {
+                seed = seed.write(dkey(0, i), Some(val(i)));
+            }
+            for i in 0..4u64 {
+                seed = seed.write(dkey(1, i), Some(val(100 + i)));
+            }
+            let seed = seed.merkleize(&db, None).await.unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            // A pending ancestor deletes one key in the dense bucket.
+            let ancestor = db
+                .new_batch()
+                .write(dkey(1, 0), None)
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // The child re-writes the deleted key and updates every committed sibling in its
+            // bucket.
+            let muts: Vec<(Digest, Option<Digest>)> = (0..4u64)
+                .map(|i| (dkey(1, i), Some(val(200 + i))))
+                .collect();
+
+            let mut nb = ancestor.new_batch::<Sha256>();
+            for (k, v) in &muts {
+                nb = nb.write(*k, *v);
+            }
+            let normal_root = nb.merkleize(&db, None).await.unwrap().root();
+
+            // Read all committed siblings first (retaining their resolutions), then write.
+            let mut fb = ancestor.new_batch::<Sha256>();
+            let siblings: Vec<Digest> = (1..4u64).map(|i| dkey(1, i)).collect();
+            let sibling_refs: Vec<&Digest> = siblings.iter().collect();
+            fb.get_many(&sibling_refs, &db).await.unwrap();
+            for (k, v) in &muts {
+                fb = fb.write(*k, *v);
+            }
+            let fused_root = fb.merkleize(&db, None).await.unwrap().root();
+            assert_eq!(normal_root, fused_root, "root mismatch");
+        });
+    }
+
+    /// Randomized dense-bucket parity sweep: prefix-controlled keys force every translated
+    /// bucket to be dense, so retained reads, ancestor deletes, rewrites of ancestor-deleted
+    /// keys, and collision siblings constantly interact. The read-then-write root must match
+    /// the write-only root for every seed and ancestor depth.
+    #[test_traced("WARN")]
+    fn test_ordered_fixed_dense_bucket_retention_parity_sweep() {
+        type Merkleized = std::sync::Arc<
+            crate::qmdb::any::batch::MerkleizedBatch<
+                mmr::Family,
+                Digest,
+                crate::qmdb::any::operation::update::Ordered<Digest, FixedEncoding<Digest>>,
+                Sequential,
+            >,
+        >;
+
+        const BUCKETS: u16 = 4;
+        const KEYS_PER_BUCKET: u64 = 6;
+
+        fn dkey(bucket: u16, tail: u64) -> Digest {
+            let mut b = [0u8; 32];
+            b[..2].copy_from_slice(&bucket.to_be_bytes());
+            b[2..10].copy_from_slice(&tail.to_be_bytes());
+            Digest(b)
+        }
+        fn val(i: u64) -> Digest {
+            Sha256::hash(&i.to_le_bytes())
+        }
+
+        deterministic::Runner::default().start(|ctx| async move {
+            // Fillers occupy the lowest committed locations so pending ancestors' floor raises
+            // consume them first, leaving most dense-bucket keys committed-resolved (and thus
+            // retained when read).
+            let mut db = create_test_db(ctx.child("db")).await;
+            let mut seed = db.new_batch();
+            for i in 0..16u64 {
+                seed = seed.write(dkey(u16::MAX, i), Some(val(i)));
+            }
+            for bucket in 0..BUCKETS {
+                for tail in 0..KEYS_PER_BUCKET {
+                    seed = seed.write(dkey(bucket, tail), Some(val(1000 + tail)));
+                }
+            }
+            let seed = seed.merkleize(&db, None).await.unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            // Random mutations over the dense space: updates, deletes, and creates of fresh
+            // tails. Rewrites of ancestor-deleted keys arise by chance at high density.
+            let make = |salt: u64| -> Vec<(Digest, Option<Digest>)> {
+                let mut rng = test_rng_seeded(salt);
+                let mut m: BTreeMap<Digest, Option<Digest>> = BTreeMap::new();
+                for _ in 0..12 {
+                    let bucket = (rng.next_u32() as u16) % BUCKETS;
+                    let r = rng.next_u32() % 100;
+                    if r < 55 {
+                        let k = dkey(bucket, rng.next_u64() % KEYS_PER_BUCKET);
+                        m.insert(k, Some(val(rng.next_u64())));
+                    } else if r < 80 {
+                        let k = dkey(bucket, rng.next_u64() % KEYS_PER_BUCKET);
+                        m.insert(k, None);
+                    } else {
+                        let k = dkey(bucket, KEYS_PER_BUCKET + rng.next_u64() % KEYS_PER_BUCKET);
+                        m.insert(k, Some(val(rng.next_u64())));
+                    }
+                }
+                m.into_iter().collect()
+            };
+
+            for salt in 0..40u64 {
+                for depth in [1u64, 2] {
+                    // Hold every ancestor: a merkleized batch only weakly references its
+                    // parent, so dropping an uncommitted ancestor truncates the chain.
+                    let mut chain: Vec<Merkleized> = Vec::new();
+                    for d in 0..depth {
+                        let mut b = chain
+                            .last()
+                            .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>());
+                        for (k, v) in make(salt * 10 + d) {
+                            b = b.write(k, v);
+                        }
+                        chain.push(b.merkleize(&db, None).await.unwrap());
+                    }
+                    let parent = chain.last().unwrap();
+
+                    let muts = make(salt * 10 + 7);
+
+                    let mut nb = parent.new_batch::<Sha256>();
+                    for (k, v) in &muts {
+                        nb = nb.write(*k, *v);
+                    }
+                    let normal_root = nb.merkleize(&db, None).await.unwrap().root();
+
+                    let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
+                    let mut fb = parent.new_batch::<Sha256>();
+                    fb.get_many(&keys, &db).await.unwrap();
+                    for (k, v) in &muts {
+                        fb = fb.write(*k, *v);
+                    }
+                    let fused_root = fb.merkleize(&db, None).await.unwrap().root();
+                    assert_eq!(
+                        normal_root, fused_root,
+                        "root mismatch at salt={salt} depth={depth}"
+                    );
+                }
+            }
+        });
+    }
+
     #[test_traced("WARN")]
     // Test the edge case that arises where we're inserting the second key and it precedes the first
     // key, but shares the same translated key.

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -300,9 +300,9 @@ pub(crate) mod test {
         });
     }
 
-    /// Reads on a batch retain resolved locations that `merkleize` consumes to skip re-reading
+    /// Reads on a batch cache resolved locations that `merkleize` consumes to skip re-reading
     /// those keys. The root must be byte-identical to a write-only batch's `merkleize` (no
-    /// retained reads), across updates/deletes/creates, both with the batch rooted directly at
+    /// cached reads), across updates/deletes/creates, both with the batch rooted directly at
     /// the DB (D=0) and through pending ancestors (D=1, D=2).
     #[test_traced("WARN")]
     fn test_unordered_fixed_resolved_merkleize_parity() {
@@ -380,14 +380,14 @@ pub(crate) mod test {
                 }
                 let normal_root = nb.merkleize(&db, None).await.unwrap().root();
 
-                // Read-then-write on one batch: the read retains locations that merkleize
+                // Read-then-write on one batch: the read caches locations that merkleize
                 // consumes. Values and root must match the write-only path.
                 let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
                 let mut fb = new_batch();
-                // Duplicate keys in one read resolve identically per slot and retain once.
+                // Duplicate keys in one read resolve identically per slot and cache once.
                 let dup_values = fb.get_many(&[keys[0], keys[0]], &db).await.unwrap();
                 assert_eq!(dup_values[0], dup_values[1]);
-                // Keys read but never written (existing and absent) retain entries that
+                // Keys read but never written (existing and absent) cache entries that
                 // merkleize must drop without affecting the root.
                 let unwritten: Vec<Digest> = (0..40u64)
                     .map(|i| key(i * 50))
@@ -405,7 +405,7 @@ pub(crate) mod test {
                 assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
 
                 // Reads after writes: written keys are answered by the pending mutations and
-                // retain nothing; the root must still match.
+                // cache nothing; the root must still match.
                 let half = muts.len() / 2;
                 let mut mb = new_batch();
                 for (k, v) in muts.iter().take(half) {
@@ -429,7 +429,7 @@ pub(crate) mod test {
                     "mixed root mismatch at depth={depth}"
                 );
 
-                // Multiple disjoint reads accumulate, and single-key gets retain too.
+                // Multiple disjoint reads accumulate, and single-key gets populate the cache too.
                 let mut gb = new_batch();
                 gb.get_many(&keys[..half], &db).await.unwrap();
                 for key in &keys[half..] {
@@ -447,14 +447,14 @@ pub(crate) mod test {
         });
     }
 
-    /// A batch's retained read locations must stay valid when an ancestor is committed and
+    /// A batch's cached read locations must stay valid when an ancestor is committed and
     /// dropped between the read and merkleize. Keys resolved through an uncommitted ancestor's
-    /// diff retain nothing, so the merkleize-time re-resolution picks up the post-commit
+    /// diff cache nothing, so the merkleize-time re-resolution picks up the post-commit
     /// location and the final state matches a batch that never read. Keys resolved through the
-    /// committed snapshot retain their location, which the intervening commit cannot move
+    /// committed snapshot cache their location, which the intervening commit cannot move
     /// (applying an ancestor only relocates keys present in that ancestor's diff).
     #[test_traced("WARN")]
-    fn test_unordered_fixed_retention_survives_ancestor_commit() {
+    fn test_unordered_fixed_caching_survives_ancestor_commit() {
         deterministic::Runner::default().start(|ctx| async move {
             let mut roots = Vec::new();
             for read_first in [false, true] {
@@ -483,7 +483,7 @@ pub(crate) mod test {
                 let p = p.merkleize(&db, None).await.unwrap();
 
                 // Child reads the grandparent-touched keys (resolving through its diff,
-                // retaining nothing) and keys 20..30 (committed-resolved, retained).
+                // caching nothing) and keys 20..30 (committed-resolved, cached).
                 let b = p.new_batch::<Sha256>();
                 if read_first {
                     let keys: Vec<Digest> = (0..10u64).chain(20..30u64).map(key).collect();

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -387,6 +387,14 @@ pub(crate) mod test {
                 // Duplicate keys in one read resolve identically per slot and retain once.
                 let dup_values = fb.get_many(&[keys[0], keys[0]], &db).await.unwrap();
                 assert_eq!(dup_values[0], dup_values[1]);
+                // Keys read but never written (existing and absent) retain entries that
+                // merkleize must drop without affecting the root.
+                let unwritten: Vec<Digest> = (0..40u64)
+                    .map(|i| key(i * 50))
+                    .chain((0..5).map(|i| key(8000 + i)))
+                    .collect();
+                let unwritten_refs: Vec<&Digest> = unwritten.iter().collect();
+                fb.get_many(&unwritten_refs, &db).await.unwrap();
                 let values = fb.get_many(&keys, &db).await.unwrap();
                 let plain = new_batch().get_many(&keys, &db).await.unwrap();
                 assert_eq!(values, plain, "value mismatch at depth={depth}");

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -299,6 +299,214 @@ pub(crate) mod test {
         });
     }
 
+    /// Reads on a batch retain resolved locations that `merkleize` consumes to skip re-reading
+    /// those keys. The root must be byte-identical to a write-only batch's `merkleize` (no
+    /// retained reads), across updates/deletes/creates, both with the batch rooted directly at
+    /// the DB (D=0) and through one pending ancestor (D=1).
+    #[test_traced("WARN")]
+    fn test_unordered_fixed_resolved_merkleize_parity() {
+        use std::collections::HashMap;
+
+        type ParentChain = Vec<
+            std::sync::Arc<
+                crate::qmdb::any::batch::MerkleizedBatch<
+                    mmr::Family,
+                    Digest,
+                    crate::qmdb::any::operation::update::Unordered<Digest, FixedEncoding<Digest>>,
+                    Sequential,
+                >,
+            >,
+        >;
+
+        deterministic::Runner::default().start(|ctx| async move {
+            let mut db = create_test_db(ctx.child("db")).await;
+
+            // Seed 2000 keys and commit so they live in the committed snapshot.
+            let mut seed = db.new_batch();
+            for i in 0..2000u64 {
+                seed = seed.write(key(i), Some(val(i)));
+            }
+            let seed = seed.merkleize(&db, None).await.unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            // Build a mixed mutation set: updates of existing keys, deletes of existing keys,
+            // and creates of fresh keys. `make` re-derives the set from a seed so both paths and
+            // both depths see identical mutations.
+            let make = |salt: u64| -> Vec<(Digest, Option<Digest>)> {
+                let mut rng = test_rng_seeded(salt);
+                let mut out = Vec::new();
+                for _ in 0..600 {
+                    let r = rng.next_u32() % 100;
+                    if r < 60 {
+                        out.push((key(rng.next_u64() % 2000), Some(val(rng.next_u64()))));
+                    } else if r < 80 {
+                        out.push((key(rng.next_u64() % 2000), None));
+                    } else {
+                        out.push((key(2000 + rng.next_u64() % 2000), Some(val(rng.next_u64()))));
+                    }
+                }
+                // Dedup last-write-wins.
+                let mut m: HashMap<Digest, Option<Digest>> = HashMap::new();
+                for (k, v) in out {
+                    m.insert(k, v);
+                }
+                m.into_iter().collect()
+            };
+
+            // D=0: batch rooted directly at the DB. D=N: through N pending ancestors.
+            for depth in [0u64, 1, 2] {
+                let mut chain: ParentChain = Vec::new();
+                for d in 0..depth {
+                    let mut p = chain
+                        .last()
+                        .map_or_else(|| db.new_batch(), |l| l.new_batch::<Sha256>());
+                    for (k, v) in make(900 + d) {
+                        p = p.write(k, v);
+                    }
+                    chain.push(p.merkleize(&db, None).await.unwrap());
+                }
+
+                let muts = make(depth + 1);
+                let new_batch = || {
+                    chain
+                        .last()
+                        .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
+                };
+
+                // Normal path.
+                let mut nb = new_batch();
+                for (k, v) in &muts {
+                    nb = nb.write(*k, *v);
+                }
+                let normal_root = nb.merkleize(&db, None).await.unwrap().root();
+
+                // Read-then-write on one batch: the read retains locations that merkleize
+                // consumes. Values and root must match the write-only path.
+                let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
+                let mut fb = new_batch();
+                let values = fb.get_many(&keys, &db).await.unwrap();
+                let plain = new_batch().get_many(&keys, &db).await.unwrap();
+                assert_eq!(values, plain, "value mismatch at depth={depth}");
+                for (k, v) in &muts {
+                    fb = fb.write(*k, *v);
+                }
+                let fused_root = fb.merkleize(&db, None).await.unwrap().root();
+                assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
+
+                // Reads after writes: written keys are answered by the pending mutations and
+                // retain nothing; the root must still match.
+                let half = muts.len() / 2;
+                let mut mb = new_batch();
+                for (k, v) in muts.iter().take(half) {
+                    mb = mb.write(*k, *v);
+                }
+                let values = mb.get_many(&keys, &db).await.unwrap();
+                for (i, (_, v)) in muts.iter().enumerate().take(half) {
+                    assert_eq!(values[i], *v, "pending write not visible at depth={depth}");
+                }
+                assert_eq!(
+                    values[half..],
+                    plain[half..],
+                    "unwritten value mismatch at depth={depth}"
+                );
+                for (k, v) in muts.iter().skip(half) {
+                    mb = mb.write(*k, *v);
+                }
+                let mixed_root = mb.merkleize(&db, None).await.unwrap().root();
+                assert_eq!(
+                    normal_root, mixed_root,
+                    "mixed root mismatch at depth={depth}"
+                );
+
+                // Multiple disjoint reads accumulate, and single-key gets retain too.
+                let mut gb = new_batch();
+                gb.get_many(&keys[..half], &db).await.unwrap();
+                for key in &keys[half..] {
+                    gb.get(key, &db).await.unwrap();
+                }
+                for (k, v) in &muts {
+                    gb = gb.write(*k, *v);
+                }
+                let merged_root = gb.merkleize(&db, None).await.unwrap().root();
+                assert_eq!(
+                    normal_root, merged_root,
+                    "merged root mismatch at depth={depth}"
+                );
+            }
+        });
+    }
+
+    /// A batch's retained read locations must stay valid when an ancestor is committed and
+    /// dropped between the read and merkleize. Keys resolved through an uncommitted ancestor's
+    /// diff retain nothing, so the merkleize-time re-resolution picks up the post-commit
+    /// location and the final state matches a batch that never read.
+    #[test_traced("WARN")]
+    fn test_unordered_fixed_retention_survives_ancestor_commit() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let mut roots = Vec::new();
+            for read_first in [false, true] {
+                let label = if read_first { "db_read" } else { "db_write" };
+                let mut db = create_test_db(ctx.child(label)).await;
+
+                // Seed and commit keys 0..100.
+                let mut seed = db.new_batch();
+                for i in 0..100u64 {
+                    seed = seed.write(key(i), Some(val(i)));
+                }
+                let seed = seed.merkleize(&db, None).await.unwrap();
+                db.apply_batch(seed).await.unwrap();
+                db.commit().await.unwrap();
+
+                // Grandparent overwrites keys 0..10 (pending), parent touches disjoint keys.
+                let mut gp = db.new_batch();
+                for i in 0..10u64 {
+                    gp = gp.write(key(i), Some(val(i + 1000)));
+                }
+                let gp = gp.merkleize(&db, None).await.unwrap();
+                let mut p = gp.new_batch::<Sha256>();
+                for i in 50..60u64 {
+                    p = p.write(key(i), Some(val(i + 2000)));
+                }
+                let p = p.merkleize(&db, None).await.unwrap();
+
+                // Child reads the grandparent-touched keys (resolving through its diff).
+                let b = p.new_batch::<Sha256>();
+                if read_first {
+                    let keys: Vec<Digest> = (0..10u64).map(key).collect();
+                    let key_refs: Vec<&Digest> = keys.iter().collect();
+                    let values = b.get_many(&key_refs, &db).await.unwrap();
+                    for (i, v) in values.into_iter().enumerate() {
+                        assert_eq!(v, Some(val(i as u64 + 1000)));
+                    }
+                }
+
+                // Commit the grandparent and drop it before the child merkleizes.
+                db.apply_batch(gp).await.unwrap();
+                db.commit().await.unwrap();
+
+                let mut b = b;
+                for i in 0..10u64 {
+                    b = b.write(key(i), Some(val(i + 3000)));
+                }
+                let b = b.merkleize(&db, None).await.unwrap();
+                db.apply_batch(p).await.unwrap();
+                db.apply_batch(b).await.unwrap();
+                db.commit().await.unwrap();
+
+                for i in 0..10u64 {
+                    assert_eq!(db.get(&key(i)).await.unwrap(), Some(val(i + 3000)));
+                }
+                roots.push(db.root());
+                db.destroy().await.unwrap();
+            }
+            assert_eq!(
+                roots[0], roots[1],
+                "read-then-write diverged from write-only"
+            );
+        });
+    }
+
     // -- Generic inner functions for parameterized batch tests --
 
     async fn batch_empty_inner<F: Family>(context: deterministic::Context) {
@@ -813,6 +1021,8 @@ pub(crate) mod test {
 
     #[allow(dead_code)]
     fn assert_non_trait_futures_are_send(db: &AnyTest, key: Digest, value: Digest) {
+        let reader = db.new_batch();
+        is_send(reader.get_many(&[&key], db));
         let batch = db.new_batch().write(key, Some(value));
         is_send(batch.merkleize(db, None));
         is_send(db.get_with_loc(&key));

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -144,6 +144,7 @@ pub(crate) mod test {
     };
     use commonware_utils::{test_rng_seeded, NZU64};
     use rand::RngCore;
+    use std::collections::HashMap;
 
     /// A generic type alias for an Any database parameterized by merkle family.
     type AnyTestGeneric<F> = crate::qmdb::any::db::Db<
@@ -302,11 +303,9 @@ pub(crate) mod test {
     /// Reads on a batch retain resolved locations that `merkleize` consumes to skip re-reading
     /// those keys. The root must be byte-identical to a write-only batch's `merkleize` (no
     /// retained reads), across updates/deletes/creates, both with the batch rooted directly at
-    /// the DB (D=0) and through one pending ancestor (D=1).
+    /// the DB (D=0) and through pending ancestors (D=1, D=2).
     #[test_traced("WARN")]
     fn test_unordered_fixed_resolved_merkleize_parity() {
-        use std::collections::HashMap;
-
         type ParentChain = Vec<
             std::sync::Arc<
                 crate::qmdb::any::batch::MerkleizedBatch<
@@ -385,6 +384,9 @@ pub(crate) mod test {
                 // consumes. Values and root must match the write-only path.
                 let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
                 let mut fb = new_batch();
+                // Duplicate keys in one read resolve identically per slot and retain once.
+                let dup_values = fb.get_many(&[keys[0], keys[0]], &db).await.unwrap();
+                assert_eq!(dup_values[0], dup_values[1]);
                 let values = fb.get_many(&keys, &db).await.unwrap();
                 let plain = new_batch().get_many(&keys, &db).await.unwrap();
                 assert_eq!(values, plain, "value mismatch at depth={depth}");
@@ -440,7 +442,9 @@ pub(crate) mod test {
     /// A batch's retained read locations must stay valid when an ancestor is committed and
     /// dropped between the read and merkleize. Keys resolved through an uncommitted ancestor's
     /// diff retain nothing, so the merkleize-time re-resolution picks up the post-commit
-    /// location and the final state matches a batch that never read.
+    /// location and the final state matches a batch that never read. Keys resolved through the
+    /// committed snapshot retain their location, which the intervening commit cannot move
+    /// (applying an ancestor only relocates keys present in that ancestor's diff).
     #[test_traced("WARN")]
     fn test_unordered_fixed_retention_survives_ancestor_commit() {
         deterministic::Runner::default().start(|ctx| async move {
@@ -470,14 +474,20 @@ pub(crate) mod test {
                 }
                 let p = p.merkleize(&db, None).await.unwrap();
 
-                // Child reads the grandparent-touched keys (resolving through its diff).
+                // Child reads the grandparent-touched keys (resolving through its diff,
+                // retaining nothing) and keys 20..30 (committed-resolved, retained).
                 let b = p.new_batch::<Sha256>();
                 if read_first {
-                    let keys: Vec<Digest> = (0..10u64).map(key).collect();
+                    let keys: Vec<Digest> = (0..10u64).chain(20..30u64).map(key).collect();
                     let key_refs: Vec<&Digest> = keys.iter().collect();
                     let values = b.get_many(&key_refs, &db).await.unwrap();
                     for (i, v) in values.into_iter().enumerate() {
-                        assert_eq!(v, Some(val(i as u64 + 1000)));
+                        let expected = if i < 10 {
+                            val(i as u64 + 1000)
+                        } else {
+                            val(i as u64 + 10)
+                        };
+                        assert_eq!(v, Some(expected));
                     }
                 }
 
@@ -489,6 +499,9 @@ pub(crate) mod test {
                 for i in 0..10u64 {
                     b = b.write(key(i), Some(val(i + 3000)));
                 }
+                for i in 20..30u64 {
+                    b = b.write(key(i), Some(val(i + 4000)));
+                }
                 let b = b.merkleize(&db, None).await.unwrap();
                 db.apply_batch(p).await.unwrap();
                 db.apply_batch(b).await.unwrap();
@@ -496,6 +509,9 @@ pub(crate) mod test {
 
                 for i in 0..10u64 {
                     assert_eq!(db.get(&key(i)).await.unwrap(), Some(val(i + 3000)));
+                }
+                for i in 20..30u64 {
+                    assert_eq!(db.get(&key(i)).await.unwrap(), Some(val(i + 4000)));
                 }
                 roots.push(db.root());
                 db.destroy().await.unwrap();

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -10,7 +10,7 @@
 //!   cargo bench -p commonware-storage --bench constantinople -- [db] [depth] [iters] [keys] [updates]
 //!
 //! - db: "any" or "current" (default any)
-//! - depth: number of pending ancestor batches under the timed batch (0 or 1)
+//! - depth: number of pending ancestor batches under the timed batch
 //! - iters: timed iterations (default 15)
 //! - keys: total seeded keys (default 1,000,000)
 //! - updates: keys written per batch (default 32,768)

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -1,16 +1,16 @@
 //! Constantinople-shape harness: load+write+merkleize at 32k updates / 1M keys.
 //!
 //! Times the full per-block state pipeline (get_many load, batch writes, merkleize, root) on the
-//! tokio runtime with EightCap, matching the production validator shape. Runs against either
-//! `any::unordered::fixed::Db<mmr>` or `current::unordered::fixed::Db<mmr>`. Prints per-iteration
-//! latency with a load/write/merkleize phase split and the speculative root (a cross-binary
-//! parity check: any optimization must reproduce identical roots).
+//! tokio runtime with EightCap, matching the production validator shape. Runs against the
+//! unordered or ordered fixed `any`/`current` DBs over `mmr`. Prints per-iteration latency with
+//! a load/write/merkleize phase split and the speculative root (a cross-binary parity check:
+//! any optimization must reproduce identical roots).
 //!
 //! Usage:
 //!   cargo bench -p commonware-storage --bench constantinople -- <db> [depth] [iters] [keys] [updates]
 //!
-//! - db: "any" or "current" (required; without it the harness no-ops so blanket
-//!   `cargo bench --benches` invocations skip it)
+//! - db: "any", "current", "any-ordered", or "current-ordered" (required; without it the
+//!   harness no-ops so blanket `cargo bench --benches` invocations skip it)
 //! - depth: number of pending ancestor batches under the timed batch
 //! - iters: timed iterations (default 15)
 //! - keys: total seeded keys (default 1,000,000)
@@ -71,6 +71,42 @@ type CurrentMerkleized = std::sync::Arc<
         mmr::Family,
         Digest,
         commonware_storage::qmdb::any::unordered::fixed::Update<Digest, Digest>,
+        CHUNK_SIZE,
+        Rayon,
+    >,
+>;
+type AnyOrderedDb = commonware_storage::qmdb::any::ordered::fixed::Db<
+    mmr::Family,
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    Rayon,
+>;
+type AnyOrderedMerkleized = std::sync::Arc<
+    commonware_storage::qmdb::any::batch::MerkleizedBatch<
+        mmr::Family,
+        Digest,
+        commonware_storage::qmdb::any::ordered::fixed::Update<Digest, Digest>,
+        Rayon,
+    >,
+>;
+type CurrentOrderedDb = commonware_storage::qmdb::current::ordered::fixed::Db<
+    mmr::Family,
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    CHUNK_SIZE,
+    Rayon,
+>;
+type CurrentOrderedMerkleized = std::sync::Arc<
+    commonware_storage::qmdb::current::batch::MerkleizedBatch<
+        mmr::Family,
+        Digest,
+        commonware_storage::qmdb::any::ordered::fixed::Update<Digest, Digest>,
         CHUNK_SIZE,
         Rayon,
     >,
@@ -219,7 +255,13 @@ fn main() {
         num_keys: raw.get(4).and_then(|s| s.parse().ok()).unwrap_or(1_000_000),
         num_updates: raw.get(5).and_then(|s| s.parse().ok()).unwrap_or(32_768),
     };
-    assert!(db_kind == "any" || db_kind == "current", "db: any|current");
+    assert!(
+        matches!(
+            db_kind.as_str(),
+            "any" | "current" | "any-ordered" | "current-ordered"
+        ),
+        "db: any|current|any-ordered|current-ordered"
+    );
 
     eprintln!(
         "constantinople db={db_kind} depth={} iters={} keys={} updates={}",
@@ -242,23 +284,45 @@ fn main() {
             page_cache: pc,
             write_buffer: WRITE_BUFFER,
         };
-        if db_kind == "current" {
-            let cfg = CurrentFixedConfig {
-                merkle_config,
-                journal_config,
-                grafted_metadata_partition: "constantinople-grafted-metadata".into(),
-                translator: EightCap,
-            };
-            let db = CurrentDb::init(ctx.child("db"), cfg).await.unwrap();
-            run_pipeline!(db, args, "current", CurrentMerkleized)
-        } else {
-            let cfg = FixedConfig {
-                merkle_config,
-                journal_config,
-                translator: EightCap,
-            };
-            let db = AnyDb::init(ctx.child("db"), cfg).await.unwrap();
-            run_pipeline!(db, args, "any", AnyMerkleized)
+        match db_kind.as_str() {
+            "current" => {
+                let cfg = CurrentFixedConfig {
+                    merkle_config,
+                    journal_config,
+                    grafted_metadata_partition: "constantinople-grafted-metadata".into(),
+                    translator: EightCap,
+                };
+                let db = CurrentDb::init(ctx.child("db"), cfg).await.unwrap();
+                run_pipeline!(db, args, "current", CurrentMerkleized)
+            }
+            "current-ordered" => {
+                let cfg = CurrentFixedConfig {
+                    merkle_config,
+                    journal_config,
+                    grafted_metadata_partition: "constantinople-grafted-metadata".into(),
+                    translator: EightCap,
+                };
+                let db = CurrentOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
+                run_pipeline!(db, args, "current-ordered", CurrentOrderedMerkleized)
+            }
+            "any-ordered" => {
+                let cfg = FixedConfig {
+                    merkle_config,
+                    journal_config,
+                    translator: EightCap,
+                };
+                let db = AnyOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
+                run_pipeline!(db, args, "any-ordered", AnyOrderedMerkleized)
+            }
+            _ => {
+                let cfg = FixedConfig {
+                    merkle_config,
+                    journal_config,
+                    translator: EightCap,
+                };
+                let db = AnyDb::init(ctx.child("db"), cfg).await.unwrap();
+                run_pipeline!(db, args, "any", AnyMerkleized)
+            }
         }
     });
 }

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -1,15 +1,15 @@
 //! Constantinople-shape harness: load+write+merkleize at 32k updates / 1M keys.
 //!
 //! Times the full per-block state pipeline (get_many load, batch writes, merkleize, root) on the
-//! tokio runtime against `any::unordered::fixed::Db<mmr>` with EightCap, matching the production
-//! validator shape. Prints per-iteration latency and the speculative root (a cross-binary parity
-//! check: any optimization must reproduce identical roots).
+//! tokio runtime with EightCap, matching the production validator shape. Runs against either
+//! `any::unordered::fixed::Db<mmr>` or `current::unordered::fixed::Db<mmr>`. Prints per-iteration
+//! latency with a load/write/merkleize phase split and the speculative root (a cross-binary
+//! parity check: any optimization must reproduce identical roots).
 //!
 //! Usage:
-//!   cargo bench -p commonware-storage --bench constantinople -- [mode] [depth] [iters] [keys] [updates]
+//!   cargo bench -p commonware-storage --bench constantinople -- [db] [depth] [iters] [keys] [updates]
 //!
-//! - mode: "plain" or "fused" (identical since reads always retain resolved locations; both
-//!   accepted for output compatibility with older binaries)
+//! - db: "any" or "current" (default any)
 //! - depth: number of pending ancestor batches under the timed batch (0 or 1)
 //! - iters: timed iterations (default 15)
 //! - keys: total seeded keys (default 1,000,000)
@@ -25,7 +25,7 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{full, mmr},
-    qmdb::any::FixedConfig,
+    qmdb::{any::FixedConfig, current::FixedConfig as CurrentFixedConfig},
     translator::EightCap,
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -37,7 +37,7 @@ use std::{
 };
 
 type Digest = <Sha256 as Hasher>::Digest;
-type Db = commonware_storage::qmdb::any::unordered::fixed::Db<
+type AnyDb = commonware_storage::qmdb::any::unordered::fixed::Db<
     mmr::Family,
     Context,
     Digest,
@@ -46,11 +46,31 @@ type Db = commonware_storage::qmdb::any::unordered::fixed::Db<
     EightCap,
     Rayon,
 >;
-type Merkleized = std::sync::Arc<
+type AnyMerkleized = std::sync::Arc<
     commonware_storage::qmdb::any::batch::MerkleizedBatch<
         mmr::Family,
         Digest,
         commonware_storage::qmdb::any::unordered::fixed::Update<Digest, Digest>,
+        Rayon,
+    >,
+>;
+const CHUNK_SIZE: usize = 32;
+type CurrentDb = commonware_storage::qmdb::current::unordered::fixed::Db<
+    mmr::Family,
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    CHUNK_SIZE,
+    Rayon,
+>;
+type CurrentMerkleized = std::sync::Arc<
+    commonware_storage::qmdb::current::batch::MerkleizedBatch<
+        mmr::Family,
+        Digest,
+        commonware_storage::qmdb::any::unordered::fixed::Update<Digest, Digest>,
+        CHUNK_SIZE,
         Rayon,
     >,
 >;
@@ -62,6 +82,13 @@ const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(10_000_000);
 const WRITE_BUFFER: NonZeroUsize = NZUsize!(2 * 1024 * 1024);
 const THREADS: NonZeroUsize = NZUsize!(8);
 const CHURN_BATCHES: u64 = 4;
+
+struct Args {
+    depth: u8,
+    iters: usize,
+    num_keys: u64,
+    num_updates: u64,
+}
 
 fn key(i: u64) -> Digest {
     Sha256::hash(&i.to_be_bytes())
@@ -76,48 +103,31 @@ fn gen_muts(rng: &mut StdRng, num_updates: u64, num_keys: u64) -> Vec<(Digest, D
         .collect()
 }
 
-fn main() {
-    let args: Vec<String> = std::env::args().filter(|a| a != "--bench").collect();
-    let mode = args.get(1).cloned().unwrap_or_else(|| "fused".into());
-    let depth: u8 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
-    let iters: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(15);
-    let num_keys: u64 = args
-        .get(4)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(1_000_000);
-    let num_updates: u64 = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(32_768);
-    assert!(mode == "plain" || mode == "fused", "mode: plain|fused");
-
-    eprintln!(
-        "constantinople mode={mode} depth={depth} iters={iters} keys={num_keys} updates={num_updates}"
+fn report(db: &str, depth: u8, mut times_ms: Vec<f64>) {
+    times_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let p = |q: f64| times_ms[((times_ms.len() - 1) as f64 * q) as usize];
+    let mean: f64 = times_ms.iter().sum::<f64>() / times_ms.len() as f64;
+    println!(
+        "RESULT db={db} depth={depth} p10={:.2} p50={:.2} mean={:.2} max={:.2}",
+        p(0.1),
+        p(0.5),
+        mean,
+        times_ms[times_ms.len() - 1]
     );
+}
 
-    Runner::new(RConfig::default()).start(|ctx| async move {
-        let pc = CacheRef::from_pooler(&ctx, PAGE_SIZE, PAGE_CACHE_PAGES);
-        let cfg = FixedConfig {
-            merkle_config: full::Config {
-                journal_partition: "constantinople-merkle-journal".into(),
-                metadata_partition: "constantinople-merkle-metadata".into(),
-                items_per_blob: ITEMS_PER_BLOB,
-                write_buffer: WRITE_BUFFER,
-                strategy: ctx.create_strategy(THREADS).unwrap(),
-                page_cache: pc.clone(),
-            },
-            journal_config: FConfig {
-                partition: "constantinople-log".into(),
-                items_per_blob: ITEMS_PER_BLOB,
-                page_cache: pc,
-                write_buffer: WRITE_BUFFER,
-            },
-            translator: EightCap,
-        };
-        let mut db = Db::init(ctx.child("db"), cfg).await.unwrap();
+// One macro body for both db types: their batch APIs match but share no trait, and a bench does
+// not warrant inventing one.
+macro_rules! run_pipeline {
+    ($db:ident, $args:ident, $label:literal, $merkleized:ty) => {{
+        let args = $args;
+        let mut db = $db;
 
         // Seed all keys in one committed batch.
         let seed_start = Instant::now();
         let mut rng = StdRng::seed_from_u64(42);
         let mut batch = db.new_batch();
-        for i in 0..num_keys {
+        for i in 0..args.num_keys {
             batch = batch.write(key(i), Some(Sha256::hash(&rng.next_u32().to_be_bytes())));
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
@@ -127,7 +137,7 @@ fn main() {
         // Churn: overwrite batches so inactive ops accumulate above the floor.
         for _ in 0..CHURN_BATCHES {
             let mut batch = db.new_batch();
-            for (k, v) in gen_muts(&mut rng, num_updates, num_keys) {
+            for (k, v) in gen_muts(&mut rng, args.num_updates, args.num_keys) {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
@@ -138,21 +148,21 @@ fn main() {
         eprintln!("seed+churn done in {:?}", seed_start.elapsed());
 
         let mut rng = StdRng::seed_from_u64(99);
-        let mut times_ms: Vec<f64> = Vec::with_capacity(iters);
-        for iter in 0..iters {
+        let mut times_ms: Vec<f64> = Vec::with_capacity(args.iters);
+        for iter in 0..args.iters {
             // Pending ancestors are rebuilt per iteration and never applied (untimed).
-            let mut parent: Option<Merkleized> = None;
-            for _ in 0..depth {
+            let mut parent: Option<$merkleized> = None;
+            for _ in 0..args.depth {
                 let mut b = parent
                     .as_ref()
                     .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>());
-                for (k, v) in gen_muts(&mut rng, num_updates, num_keys) {
+                for (k, v) in gen_muts(&mut rng, args.num_updates, args.num_keys) {
                     b = b.write(k, Some(v));
                 }
                 parent = Some(b.merkleize(&db, None).await.unwrap());
             }
 
-            let muts = gen_muts(&mut rng, num_updates, num_keys);
+            let muts = gen_muts(&mut rng, args.num_updates, args.num_keys);
             let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
             let new_batch = || {
                 parent
@@ -167,28 +177,79 @@ fn main() {
             let mut b = new_batch();
             let values = b.get_many(&keys, &db).await.unwrap();
             black_box(&values);
+            let t_load = start.elapsed();
             for (k, v) in &muts {
                 b = b.write(*k, Some(*v));
             }
+            let t_write = start.elapsed();
             let merkleized = b.merkleize(&db, None).await.unwrap();
             let root = merkleized.root();
             let elapsed = start.elapsed();
 
             times_ms.push(elapsed.as_secs_f64() * 1000.0);
-            println!("iter={iter} ms={:.2} root={root}", times_ms[iter]);
+            println!(
+                "iter={iter} ms={:.2} load={:.2} write={:.2} merk={:.2} root={root}",
+                times_ms[iter],
+                t_load.as_secs_f64() * 1000.0,
+                (t_write - t_load).as_secs_f64() * 1000.0,
+                (elapsed - t_write).as_secs_f64() * 1000.0
+            );
         }
 
-        times_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        let p = |q: f64| times_ms[((times_ms.len() - 1) as f64 * q) as usize];
-        let mean: f64 = times_ms.iter().sum::<f64>() / times_ms.len() as f64;
-        println!(
-            "RESULT mode={mode} depth={depth} p10={:.2} p50={:.2} mean={:.2} max={:.2}",
-            p(0.1),
-            p(0.5),
-            mean,
-            times_ms[times_ms.len() - 1]
-        );
-
+        report($label, args.depth, times_ms);
         db.destroy().await.unwrap();
+    }};
+}
+
+fn main() {
+    let raw: Vec<String> = std::env::args().filter(|a| a != "--bench").collect();
+    let db_kind = raw.get(1).cloned().unwrap_or_else(|| "any".into());
+    let args = Args {
+        depth: raw.get(2).and_then(|s| s.parse().ok()).unwrap_or(0),
+        iters: raw.get(3).and_then(|s| s.parse().ok()).unwrap_or(15),
+        num_keys: raw.get(4).and_then(|s| s.parse().ok()).unwrap_or(1_000_000),
+        num_updates: raw.get(5).and_then(|s| s.parse().ok()).unwrap_or(32_768),
+    };
+    assert!(db_kind == "any" || db_kind == "current", "db: any|current");
+
+    eprintln!(
+        "constantinople db={db_kind} depth={} iters={} keys={} updates={}",
+        args.depth, args.iters, args.num_keys, args.num_updates
+    );
+
+    Runner::new(RConfig::default()).start(|ctx| async move {
+        let pc = CacheRef::from_pooler(&ctx, PAGE_SIZE, PAGE_CACHE_PAGES);
+        let merkle_config = full::Config {
+            journal_partition: "constantinople-merkle-journal".into(),
+            metadata_partition: "constantinople-merkle-metadata".into(),
+            items_per_blob: ITEMS_PER_BLOB,
+            write_buffer: WRITE_BUFFER,
+            strategy: ctx.create_strategy(THREADS).unwrap(),
+            page_cache: pc.clone(),
+        };
+        let journal_config = FConfig {
+            partition: "constantinople-log".into(),
+            items_per_blob: ITEMS_PER_BLOB,
+            page_cache: pc,
+            write_buffer: WRITE_BUFFER,
+        };
+        if db_kind == "current" {
+            let cfg = CurrentFixedConfig {
+                merkle_config,
+                journal_config,
+                grafted_metadata_partition: "constantinople-grafted-metadata".into(),
+                translator: EightCap,
+            };
+            let db = CurrentDb::init(ctx.child("db"), cfg).await.unwrap();
+            run_pipeline!(db, args, "current", CurrentMerkleized)
+        } else {
+            let cfg = FixedConfig {
+                merkle_config,
+                journal_config,
+                translator: EightCap,
+            };
+            let db = AnyDb::init(ctx.child("db"), cfg).await.unwrap();
+            run_pipeline!(db, args, "any", AnyMerkleized)
+        }
     });
 }

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -228,9 +228,9 @@ macro_rules! run_pipeline {
                     .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
             };
 
-            // Timed: load all touched keys, write them, merkleize, read root. Reads retain
+            // Timed: load all touched keys, write them, merkleize, read root. Reads cache
             // resolved locations on the batch, so merkleize skips re-reading those keys. Load
-            // and writes must share one batch for that retention to apply.
+            // and writes must share one batch for that caching to apply.
             let start = Instant::now();
             let mut b = new_batch();
             let values = b.get_many(&keys, &db).await.unwrap();
@@ -286,6 +286,10 @@ fn main() {
                 | "current::ordered::fixed::mmr"
         ),
         "db: any::unordered::fixed::mmr|any::ordered::fixed::mmr|any::unordered::variable::mmr|current::unordered::fixed::mmr|current::ordered::fixed::mmr"
+    );
+    assert!(
+        args.iters > 0 && args.num_keys > 0 && args.num_updates > 0,
+        "iters, keys, and updates must be non-zero"
     );
 
     eprintln!(

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -41,6 +41,7 @@ use std::{
 };
 
 type Digest = <Sha256 as Hasher>::Digest;
+const CHUNK_SIZE: usize = 32;
 type AnyDb = commonware_storage::qmdb::any::unordered::fixed::Db<
     mmb::Family,
     Context,
@@ -58,7 +59,6 @@ type AnyMerkleized = std::sync::Arc<
         Rayon,
     >,
 >;
-const CHUNK_SIZE: usize = 32;
 type CurrentDb = commonware_storage::qmdb::current::unordered::fixed::Db<
     mmb::Family,
     Context,
@@ -134,7 +134,6 @@ type AnyVarMerkleized = std::sync::Arc<
 >;
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(4096);
-// 512MB page cache, the production validator config (active window fully warm).
 const PAGE_CACHE_PAGES: NonZeroUsize = NZUsize!(131_072);
 const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(10_000_000);
 const WRITE_BUFFER: NonZeroUsize = NZUsize!(2 * 1024 * 1024);

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -7,9 +7,10 @@
 //! parity check: any optimization must reproduce identical roots).
 //!
 //! Usage:
-//!   cargo bench -p commonware-storage --bench constantinople -- [db] [depth] [iters] [keys] [updates]
+//!   cargo bench -p commonware-storage --bench constantinople -- <db> [depth] [iters] [keys] [updates]
 //!
-//! - db: "any" or "current" (default any)
+//! - db: "any" or "current" (required; without it the harness no-ops so blanket
+//!   `cargo bench --benches` invocations skip it)
 //! - depth: number of pending ancestor batches under the timed batch
 //! - iters: timed iterations (default 15)
 //! - keys: total seeded keys (default 1,000,000)
@@ -203,7 +204,15 @@ macro_rules! run_pipeline {
 
 fn main() {
     let raw: Vec<String> = std::env::args().filter(|a| a != "--bench").collect();
-    let db_kind = raw.get(1).cloned().unwrap_or_else(|| "any".into());
+    // Run only when explicitly given a db argument. Blanket harness invocations (no positional
+    // args, or libtest flags like `--list` or `--output-format bencher` from the benchmark CI)
+    // must no-op so `cargo bench --benches` does not seed a million keys or panic on the flags.
+    let Some(db_kind) = raw.get(1).cloned() else {
+        return;
+    };
+    if db_kind.starts_with("--") {
+        return;
+    }
     let args = Args {
         depth: raw.get(2).and_then(|s| s.parse().ok()).unwrap_or(0),
         iters: raw.get(3).and_then(|s| s.parse().ok()).unwrap_or(15),

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -1,0 +1,194 @@
+//! Constantinople-shape harness: load+write+merkleize at 32k updates / 1M keys.
+//!
+//! Times the full per-block state pipeline (get_many load, batch writes, merkleize, root) on the
+//! tokio runtime against `any::unordered::fixed::Db<mmr>` with EightCap, matching the production
+//! validator shape. Prints per-iteration latency and the speculative root (a cross-binary parity
+//! check: any optimization must reproduce identical roots).
+//!
+//! Usage:
+//!   cargo bench -p commonware-storage --bench constantinople -- [mode] [depth] [iters] [keys] [updates]
+//!
+//! - mode: "plain" or "fused" (identical since reads always retain resolved locations; both
+//!   accepted for output compatibility with older binaries)
+//! - depth: number of pending ancestor batches under the timed batch (0 or 1)
+//! - iters: timed iterations (default 15)
+//! - keys: total seeded keys (default 1,000,000)
+//! - updates: keys written per batch (default 32,768)
+
+use commonware_cryptography::{Hasher, Sha256};
+use commonware_parallel::Rayon;
+use commonware_runtime::{
+    buffer::paged::CacheRef,
+    tokio::{Config as RConfig, Context, Runner},
+    Runner as _, Supervisor as _, ThreadPooler as _,
+};
+use commonware_storage::{
+    journal::contiguous::fixed::Config as FConfig,
+    merkle::{full, mmr},
+    qmdb::any::FixedConfig,
+    translator::EightCap,
+};
+use commonware_utils::{NZUsize, NZU16, NZU64};
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use std::{
+    hint::black_box,
+    num::{NonZeroU16, NonZeroU64, NonZeroUsize},
+    time::Instant,
+};
+
+type Digest = <Sha256 as Hasher>::Digest;
+type Db = commonware_storage::qmdb::any::unordered::fixed::Db<
+    mmr::Family,
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    Rayon,
+>;
+type Merkleized = std::sync::Arc<
+    commonware_storage::qmdb::any::batch::MerkleizedBatch<
+        mmr::Family,
+        Digest,
+        commonware_storage::qmdb::any::unordered::fixed::Update<Digest, Digest>,
+        Rayon,
+    >,
+>;
+
+const PAGE_SIZE: NonZeroU16 = NZU16!(4096);
+// 512MB page cache, the production validator config (active window fully warm).
+const PAGE_CACHE_PAGES: NonZeroUsize = NZUsize!(131_072);
+const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(10_000_000);
+const WRITE_BUFFER: NonZeroUsize = NZUsize!(2 * 1024 * 1024);
+const THREADS: NonZeroUsize = NZUsize!(8);
+const CHURN_BATCHES: u64 = 4;
+
+fn key(i: u64) -> Digest {
+    Sha256::hash(&i.to_be_bytes())
+}
+
+fn gen_muts(rng: &mut StdRng, num_updates: u64, num_keys: u64) -> Vec<(Digest, Digest)> {
+    (0..num_updates)
+        .map(|_| {
+            let idx = rng.next_u64() % num_keys;
+            (key(idx), Sha256::hash(&rng.next_u32().to_be_bytes()))
+        })
+        .collect()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().filter(|a| a != "--bench").collect();
+    let mode = args.get(1).cloned().unwrap_or_else(|| "fused".into());
+    let depth: u8 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let iters: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(15);
+    let num_keys: u64 = args
+        .get(4)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1_000_000);
+    let num_updates: u64 = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(32_768);
+    assert!(mode == "plain" || mode == "fused", "mode: plain|fused");
+
+    eprintln!(
+        "constantinople mode={mode} depth={depth} iters={iters} keys={num_keys} updates={num_updates}"
+    );
+
+    Runner::new(RConfig::default()).start(|ctx| async move {
+        let pc = CacheRef::from_pooler(&ctx, PAGE_SIZE, PAGE_CACHE_PAGES);
+        let cfg = FixedConfig {
+            merkle_config: full::Config {
+                journal_partition: "constantinople-merkle-journal".into(),
+                metadata_partition: "constantinople-merkle-metadata".into(),
+                items_per_blob: ITEMS_PER_BLOB,
+                write_buffer: WRITE_BUFFER,
+                strategy: ctx.create_strategy(THREADS).unwrap(),
+                page_cache: pc.clone(),
+            },
+            journal_config: FConfig {
+                partition: "constantinople-log".into(),
+                items_per_blob: ITEMS_PER_BLOB,
+                page_cache: pc,
+                write_buffer: WRITE_BUFFER,
+            },
+            translator: EightCap,
+        };
+        let mut db = Db::init(ctx.child("db"), cfg).await.unwrap();
+
+        // Seed all keys in one committed batch.
+        let seed_start = Instant::now();
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut batch = db.new_batch();
+        for i in 0..num_keys {
+            batch = batch.write(key(i), Some(Sha256::hash(&rng.next_u32().to_be_bytes())));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+
+        // Churn: overwrite batches so inactive ops accumulate above the floor.
+        for _ in 0..CHURN_BATCHES {
+            let mut batch = db.new_batch();
+            for (k, v) in gen_muts(&mut rng, num_updates, num_keys) {
+                batch = batch.write(k, Some(v));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+        }
+        db.commit().await.unwrap();
+        db.sync().await.unwrap();
+        eprintln!("seed+churn done in {:?}", seed_start.elapsed());
+
+        let mut rng = StdRng::seed_from_u64(99);
+        let mut times_ms: Vec<f64> = Vec::with_capacity(iters);
+        for iter in 0..iters {
+            // Pending ancestors are rebuilt per iteration and never applied (untimed).
+            let mut parent: Option<Merkleized> = None;
+            for _ in 0..depth {
+                let mut b = parent
+                    .as_ref()
+                    .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>());
+                for (k, v) in gen_muts(&mut rng, num_updates, num_keys) {
+                    b = b.write(k, Some(v));
+                }
+                parent = Some(b.merkleize(&db, None).await.unwrap());
+            }
+
+            let muts = gen_muts(&mut rng, num_updates, num_keys);
+            let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
+            let new_batch = || {
+                parent
+                    .as_ref()
+                    .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
+            };
+
+            // Timed: load all touched keys, write them, merkleize, read root. Reads retain
+            // resolved locations on the batch, so merkleize skips re-reading those keys. Load
+            // and writes must share one batch for that retention to apply.
+            let start = Instant::now();
+            let mut b = new_batch();
+            let values = b.get_many(&keys, &db).await.unwrap();
+            black_box(&values);
+            for (k, v) in &muts {
+                b = b.write(*k, Some(*v));
+            }
+            let merkleized = b.merkleize(&db, None).await.unwrap();
+            let root = merkleized.root();
+            let elapsed = start.elapsed();
+
+            times_ms.push(elapsed.as_secs_f64() * 1000.0);
+            println!("iter={iter} ms={:.2} root={root}", times_ms[iter]);
+        }
+
+        times_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let p = |q: f64| times_ms[((times_ms.len() - 1) as f64 * q) as usize];
+        let mean: f64 = times_ms.iter().sum::<f64>() / times_ms.len() as f64;
+        println!(
+            "RESULT mode={mode} depth={depth} p10={:.2} p50={:.2} mean={:.2} max={:.2}",
+            p(0.1),
+            p(0.5),
+            mean,
+            times_ms[times_ms.len() - 1]
+        );
+
+        db.destroy().await.unwrap();
+    });
+}

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -2,16 +2,16 @@
 //!
 //! Times the full per-block state pipeline (get_many load, batch writes, merkleize, root) on the
 //! tokio runtime with EightCap, matching the production validator shape. Runs against the
-//! unordered or ordered fixed `any`/`current` DBs over `mmr`. Prints per-iteration latency with
+//! unordered or ordered fixed `any`/`current` DBs over `mmb`. Prints per-iteration latency with
 //! a load/write/merkleize phase split and the speculative root (a cross-binary parity check:
 //! any optimization must reproduce identical roots).
 //!
 //! Usage:
 //!   cargo bench -p commonware-storage --bench constantinople -- <db> [depth] [iters] [keys] [updates]
 //!
-//! - db: one of "any::unordered::fixed::mmr", "any::ordered::fixed::mmr",
-//!   "any::unordered::variable::mmr", "current::unordered::fixed::mmr", or
-//!   "current::ordered::fixed::mmr", matching the qmdb criterion bench variant names
+//! - db: one of "any::unordered::fixed::mmb", "any::ordered::fixed::mmb",
+//!   "any::unordered::variable::mmb", "current::unordered::fixed::mmb", or
+//!   "current::ordered::fixed::mmb", matching the qmdb criterion bench variant names
 //!   (required; without it the harness no-ops so blanket `cargo bench --benches`
 //!   invocations skip it)
 //! - depth: number of pending ancestor batches under the timed batch
@@ -28,7 +28,7 @@ use commonware_runtime::{
 };
 use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
-    merkle::{full, mmr},
+    merkle::{full, mmb},
     qmdb::{any::FixedConfig, current::FixedConfig as CurrentFixedConfig},
     translator::EightCap,
 };
@@ -42,7 +42,7 @@ use std::{
 
 type Digest = <Sha256 as Hasher>::Digest;
 type AnyDb = commonware_storage::qmdb::any::unordered::fixed::Db<
-    mmr::Family,
+    mmb::Family,
     Context,
     Digest,
     Digest,
@@ -52,7 +52,7 @@ type AnyDb = commonware_storage::qmdb::any::unordered::fixed::Db<
 >;
 type AnyMerkleized = std::sync::Arc<
     commonware_storage::qmdb::any::batch::MerkleizedBatch<
-        mmr::Family,
+        mmb::Family,
         Digest,
         commonware_storage::qmdb::any::unordered::fixed::Update<Digest, Digest>,
         Rayon,
@@ -60,7 +60,7 @@ type AnyMerkleized = std::sync::Arc<
 >;
 const CHUNK_SIZE: usize = 32;
 type CurrentDb = commonware_storage::qmdb::current::unordered::fixed::Db<
-    mmr::Family,
+    mmb::Family,
     Context,
     Digest,
     Digest,
@@ -71,7 +71,7 @@ type CurrentDb = commonware_storage::qmdb::current::unordered::fixed::Db<
 >;
 type CurrentMerkleized = std::sync::Arc<
     commonware_storage::qmdb::current::batch::MerkleizedBatch<
-        mmr::Family,
+        mmb::Family,
         Digest,
         commonware_storage::qmdb::any::unordered::fixed::Update<Digest, Digest>,
         CHUNK_SIZE,
@@ -79,7 +79,7 @@ type CurrentMerkleized = std::sync::Arc<
     >,
 >;
 type AnyOrderedDb = commonware_storage::qmdb::any::ordered::fixed::Db<
-    mmr::Family,
+    mmb::Family,
     Context,
     Digest,
     Digest,
@@ -89,14 +89,14 @@ type AnyOrderedDb = commonware_storage::qmdb::any::ordered::fixed::Db<
 >;
 type AnyOrderedMerkleized = std::sync::Arc<
     commonware_storage::qmdb::any::batch::MerkleizedBatch<
-        mmr::Family,
+        mmb::Family,
         Digest,
         commonware_storage::qmdb::any::ordered::fixed::Update<Digest, Digest>,
         Rayon,
     >,
 >;
 type CurrentOrderedDb = commonware_storage::qmdb::current::ordered::fixed::Db<
-    mmr::Family,
+    mmb::Family,
     Context,
     Digest,
     Digest,
@@ -107,7 +107,7 @@ type CurrentOrderedDb = commonware_storage::qmdb::current::ordered::fixed::Db<
 >;
 type CurrentOrderedMerkleized = std::sync::Arc<
     commonware_storage::qmdb::current::batch::MerkleizedBatch<
-        mmr::Family,
+        mmb::Family,
         Digest,
         commonware_storage::qmdb::any::ordered::fixed::Update<Digest, Digest>,
         CHUNK_SIZE,
@@ -116,7 +116,7 @@ type CurrentOrderedMerkleized = std::sync::Arc<
 >;
 
 type AnyVarDb = commonware_storage::qmdb::any::unordered::variable::Db<
-    mmr::Family,
+    mmb::Family,
     Context,
     Digest,
     Digest,
@@ -126,7 +126,7 @@ type AnyVarDb = commonware_storage::qmdb::any::unordered::variable::Db<
 >;
 type AnyVarMerkleized = std::sync::Arc<
     commonware_storage::qmdb::any::batch::MerkleizedBatch<
-        mmr::Family,
+        mmb::Family,
         Digest,
         commonware_storage::qmdb::any::unordered::variable::Update<Digest, Digest>,
         Rayon,
@@ -279,13 +279,13 @@ fn main() {
     assert!(
         matches!(
             db_kind.as_str(),
-            "any::unordered::fixed::mmr"
-                | "any::ordered::fixed::mmr"
-                | "any::unordered::variable::mmr"
-                | "current::unordered::fixed::mmr"
-                | "current::ordered::fixed::mmr"
+            "any::unordered::fixed::mmb"
+                | "any::ordered::fixed::mmb"
+                | "any::unordered::variable::mmb"
+                | "current::unordered::fixed::mmb"
+                | "current::ordered::fixed::mmb"
         ),
-        "db: any::unordered::fixed::mmr|any::ordered::fixed::mmr|any::unordered::variable::mmr|current::unordered::fixed::mmr|current::ordered::fixed::mmr"
+        "db: any::unordered::fixed::mmb|any::ordered::fixed::mmb|any::unordered::variable::mmb|current::unordered::fixed::mmb|current::ordered::fixed::mmb"
     );
     assert!(
         args.iters > 0 && args.num_keys > 0 && args.num_updates > 0,
@@ -315,7 +315,7 @@ fn main() {
             write_buffer: WRITE_BUFFER,
         };
         match db_kind.as_str() {
-            "current::unordered::fixed::mmr" => {
+            "current::unordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
                     merkle_config,
                     journal_config,
@@ -326,11 +326,11 @@ fn main() {
                 run_pipeline!(
                     db,
                     args,
-                    "current::unordered::fixed::mmr",
+                    "current::unordered::fixed::mmb",
                     CurrentMerkleized
                 )
             }
-            "current::ordered::fixed::mmr" => {
+            "current::ordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
                     merkle_config,
                     journal_config,
@@ -341,20 +341,20 @@ fn main() {
                 run_pipeline!(
                     db,
                     args,
-                    "current::ordered::fixed::mmr",
+                    "current::ordered::fixed::mmb",
                     CurrentOrderedMerkleized
                 )
             }
-            "any::ordered::fixed::mmr" => {
+            "any::ordered::fixed::mmb" => {
                 let cfg = FixedConfig {
                     merkle_config,
                     journal_config,
                     translator: EightCap,
                 };
                 let db = AnyOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
-                run_pipeline!(db, args, "any::ordered::fixed::mmr", AnyOrderedMerkleized)
+                run_pipeline!(db, args, "any::ordered::fixed::mmb", AnyOrderedMerkleized)
             }
-            "any::unordered::variable::mmr" => {
+            "any::unordered::variable::mmb" => {
                 let cfg = commonware_storage::qmdb::any::VariableConfig {
                     merkle_config,
                     journal_config: VConfig {
@@ -368,7 +368,7 @@ fn main() {
                     translator: EightCap,
                 };
                 let db = AnyVarDb::init(ctx.child("db"), cfg).await.unwrap();
-                run_pipeline!(db, args, "any::unordered::variable::mmr", AnyVarMerkleized)
+                run_pipeline!(db, args, "any::unordered::variable::mmb", AnyVarMerkleized)
             }
             _ => {
                 let cfg = FixedConfig {
@@ -377,7 +377,7 @@ fn main() {
                     translator: EightCap,
                 };
                 let db = AnyDb::init(ctx.child("db"), cfg).await.unwrap();
-                run_pipeline!(db, args, "any::unordered::fixed::mmr", AnyMerkleized)
+                run_pipeline!(db, args, "any::unordered::fixed::mmb", AnyMerkleized)
             }
         }
     });

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -9,8 +9,11 @@
 //! Usage:
 //!   cargo bench -p commonware-storage --bench constantinople -- <db> [depth] [iters] [keys] [updates]
 //!
-//! - db: "any", "current", "any-ordered", or "current-ordered" (required; without it the
-//!   harness no-ops so blanket `cargo bench --benches` invocations skip it)
+//! - db: one of "any::unordered::fixed::mmr", "any::ordered::fixed::mmr",
+//!   "any::unordered::variable::mmr", "current::unordered::fixed::mmr", or
+//!   "current::ordered::fixed::mmr", matching the qmdb criterion bench variant names
+//!   (required; without it the harness no-ops so blanket `cargo bench --benches`
+//!   invocations skip it)
 //! - depth: number of pending ancestor batches under the timed batch
 //! - iters: timed iterations (default 15)
 //! - keys: total seeded keys (default 1,000,000)
@@ -24,7 +27,7 @@ use commonware_runtime::{
     Runner as _, Supervisor as _, ThreadPooler as _,
 };
 use commonware_storage::{
-    journal::contiguous::fixed::Config as FConfig,
+    journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{full, mmr},
     qmdb::{any::FixedConfig, current::FixedConfig as CurrentFixedConfig},
     translator::EightCap,
@@ -108,6 +111,24 @@ type CurrentOrderedMerkleized = std::sync::Arc<
         Digest,
         commonware_storage::qmdb::any::ordered::fixed::Update<Digest, Digest>,
         CHUNK_SIZE,
+        Rayon,
+    >,
+>;
+
+type AnyVarDb = commonware_storage::qmdb::any::unordered::variable::Db<
+    mmr::Family,
+    Context,
+    Digest,
+    Digest,
+    Sha256,
+    EightCap,
+    Rayon,
+>;
+type AnyVarMerkleized = std::sync::Arc<
+    commonware_storage::qmdb::any::batch::MerkleizedBatch<
+        mmr::Family,
+        Digest,
+        commonware_storage::qmdb::any::unordered::variable::Update<Digest, Digest>,
         Rayon,
     >,
 >;
@@ -258,9 +279,13 @@ fn main() {
     assert!(
         matches!(
             db_kind.as_str(),
-            "any" | "current" | "any-ordered" | "current-ordered"
+            "any::unordered::fixed::mmr"
+                | "any::ordered::fixed::mmr"
+                | "any::unordered::variable::mmr"
+                | "current::unordered::fixed::mmr"
+                | "current::ordered::fixed::mmr"
         ),
-        "db: any|current|any-ordered|current-ordered"
+        "db: any::unordered::fixed::mmr|any::ordered::fixed::mmr|any::unordered::variable::mmr|current::unordered::fixed::mmr|current::ordered::fixed::mmr"
     );
 
     eprintln!(
@@ -270,6 +295,7 @@ fn main() {
 
     Runner::new(RConfig::default()).start(|ctx| async move {
         let pc = CacheRef::from_pooler(&ctx, PAGE_SIZE, PAGE_CACHE_PAGES);
+        let pc_var = pc.clone();
         let merkle_config = full::Config {
             journal_partition: "constantinople-merkle-journal".into(),
             metadata_partition: "constantinople-merkle-metadata".into(),
@@ -285,7 +311,7 @@ fn main() {
             write_buffer: WRITE_BUFFER,
         };
         match db_kind.as_str() {
-            "current" => {
+            "current::unordered::fixed::mmr" => {
                 let cfg = CurrentFixedConfig {
                     merkle_config,
                     journal_config,
@@ -293,9 +319,14 @@ fn main() {
                     translator: EightCap,
                 };
                 let db = CurrentDb::init(ctx.child("db"), cfg).await.unwrap();
-                run_pipeline!(db, args, "current", CurrentMerkleized)
+                run_pipeline!(
+                    db,
+                    args,
+                    "current::unordered::fixed::mmr",
+                    CurrentMerkleized
+                )
             }
-            "current-ordered" => {
+            "current::ordered::fixed::mmr" => {
                 let cfg = CurrentFixedConfig {
                     merkle_config,
                     journal_config,
@@ -303,16 +334,37 @@ fn main() {
                     translator: EightCap,
                 };
                 let db = CurrentOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
-                run_pipeline!(db, args, "current-ordered", CurrentOrderedMerkleized)
+                run_pipeline!(
+                    db,
+                    args,
+                    "current::ordered::fixed::mmr",
+                    CurrentOrderedMerkleized
+                )
             }
-            "any-ordered" => {
+            "any::ordered::fixed::mmr" => {
                 let cfg = FixedConfig {
                     merkle_config,
                     journal_config,
                     translator: EightCap,
                 };
                 let db = AnyOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
-                run_pipeline!(db, args, "any-ordered", AnyOrderedMerkleized)
+                run_pipeline!(db, args, "any::ordered::fixed::mmr", AnyOrderedMerkleized)
+            }
+            "any::unordered::variable::mmr" => {
+                let cfg = commonware_storage::qmdb::any::VariableConfig {
+                    merkle_config,
+                    journal_config: VConfig {
+                        partition: "constantinople-var-log".into(),
+                        items_per_section: ITEMS_PER_BLOB,
+                        compression: None,
+                        codec_config: ((), ()),
+                        page_cache: pc_var,
+                        write_buffer: WRITE_BUFFER,
+                    },
+                    translator: EightCap,
+                };
+                let db = AnyVarDb::init(ctx.child("db"), cfg).await.unwrap();
+                run_pipeline!(db, args, "any::unordered::variable::mmr", AnyVarMerkleized)
             }
             _ => {
                 let cfg = FixedConfig {
@@ -321,7 +373,7 @@ fn main() {
                     translator: EightCap,
                 };
                 let db = AnyDb::init(ctx.child("db"), cfg).await.unwrap();
-                run_pipeline!(db, args, "any", AnyMerkleized)
+                run_pipeline!(db, args, "any::unordered::fixed::mmr", AnyMerkleized)
             }
         }
     });

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -229,8 +229,8 @@ macro_rules! run_pipeline {
             };
 
             // Timed: load all touched keys, write them, merkleize, read root. Reads cache
-            // resolved locations on the batch, so merkleize skips re-reading those keys. Load
-            // and writes must share one batch for that caching to apply.
+            // resolved locations on the batch (consumed by unordered merkleize); load and
+            // writes must share one batch for that caching to apply.
             let start = Instant::now();
             let mut b = new_batch();
             let values = b.get_many(&keys, &db).await.unwrap();

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -37,8 +37,52 @@ impl<const N: usize> Shared<N> {
     }
 
     /// Single-lock alternative to `bitmap::Readable::ones_iter_from(from).next()`.
+    #[cfg(test)]
     pub(crate) fn next_one_from(&self, from: u64) -> Option<u64> {
         self.read().ones_iter_from(from).next()
+    }
+
+    /// Fill `out` with up to `limit` floor-raise candidates in `[scan_from, tip)`, holding a single
+    /// read guard for the whole batch. Returns the next `scan_from`.
+    ///
+    /// The candidate sequence is identical to repeatedly calling `any::batch::next_candidate`
+    /// (the test oracle): set bits in the committed prefix are returned in order via one
+    /// `ones_iter_from`, then locations at or beyond the committed boundary are returned
+    /// sequentially.
+    pub(crate) fn fill_candidates(
+        &self,
+        scan_from: u64,
+        tip: u64,
+        limit: usize,
+        out: &mut Vec<u64>,
+    ) -> u64 {
+        let guard = self.read();
+        let bitmap_len = bitmap::Readable::<N>::len(&*guard);
+        let committed_end = bitmap_len.min(tip);
+
+        let mut scan = scan_from;
+        if scan < committed_end {
+            let mut ones = guard.ones_iter_from(scan);
+            while out.len() < limit {
+                match ones.next() {
+                    Some(idx) if idx < committed_end => {
+                        out.push(idx);
+                        scan = idx + 1;
+                    }
+                    _ => break,
+                }
+            }
+        }
+        while out.len() < limit {
+            let candidate = scan.max(bitmap_len);
+            if candidate >= tip {
+                scan = candidate;
+                break;
+            }
+            out.push(candidate);
+            scan = candidate + 1;
+        }
+        scan
     }
 
     /// Return the number of pruned bits. Acquires the read lock briefly.

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -117,11 +117,10 @@ impl<const N: usize> ChunkOverlay<N> {
 /// Bitmap-accelerated floor scan over a layered `BitmapBatch` chain. Skips locations where the
 /// bitmap bit is unset, avoiding I/O reads for inactive operations.
 ///
-/// Mirrors the contract on `any::batch::next_candidate`: may return only locations that are
-/// *possibly* active in `[floor, tip)`, may skip locations only when known inactive.
-/// The floor-raise loop revalidates each candidate, so false positives are tolerated; false
-/// negatives
-/// are forbidden.
+/// Mirrors the contract on `any::batch::fill_candidates`: may return only locations that are
+/// *possibly* active in `[floor, tip)`, may skip locations only when known inactive. The
+/// floor-raise loop revalidates each candidate, so false positives are tolerated; false
+/// negatives are forbidden.
 ///
 /// False positives can arise two ways:
 /// - In the committed prefix, an uncommitted ancestor batch in the chain may have superseded
@@ -388,7 +387,7 @@ where
     /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys. Committed-DB operations resolved by
-    /// the read are retained on the batch and consumed by [`merkleize`](Self::merkleize), which
+    /// the read are cached on the batch and consumed by [`merkleize`](Self::merkleize), which
     /// skips re-reading those keys.
     pub async fn get_many<E, C, I>(
         &self,
@@ -455,7 +454,7 @@ where
     /// Batch read multiple keys.
     ///
     /// Returns results in the same order as the input keys. Committed-DB operations resolved by
-    /// the read are retained on the batch and consumed by [`merkleize`](Self::merkleize), which
+    /// the read are cached on the batch and consumed by [`merkleize`](Self::merkleize), which
     /// skips re-reading those keys.
     pub async fn get_many<E, C, I>(
         &self,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -386,7 +386,7 @@ where
 
     /// Batch read multiple keys.
     ///
-    /// Returns results in the same order as the input keys. Committed-DB operations resolved by
+    /// Returns results in the same order as the input keys. Committed-DB locations resolved by
     /// the read are cached on the batch and consumed by [`merkleize`](Self::merkleize), which
     /// skips re-reading those keys.
     pub async fn get_many<E, C, I>(
@@ -453,9 +453,7 @@ where
 
     /// Batch read multiple keys.
     ///
-    /// Returns results in the same order as the input keys. Committed-DB operations resolved by
-    /// the read are cached on the batch and consumed by [`merkleize`](Self::merkleize), which
-    /// skips re-reading those keys.
+    /// Returns results in the same order as the input keys.
     pub async fn get_many<E, C, I>(
         &self,
         keys: &[&K],

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -119,7 +119,8 @@ impl<const N: usize> ChunkOverlay<N> {
 ///
 /// Mirrors the contract on `any::batch::next_candidate`: may return only locations that are
 /// *possibly* active in `[floor, tip)`, may skip locations only when known inactive.
-/// `is_active_at` revalidates each candidate, so false positives are tolerated; false negatives
+/// The floor-raise loop revalidates each candidate, so false positives are tolerated; false
+/// negatives
 /// are forbidden.
 ///
 /// False positives can arise two ways:

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -146,6 +146,27 @@ pub(crate) fn next_candidate<F: Graftable, B: bitmap::Readable<N>, const N: usiz
     (candidate < tip).then(|| Location::<F>::new(candidate))
 }
 
+/// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` over the layered
+/// `BitmapBatch` chain, returning the next `floor`. Produces the same sequence as repeatedly
+/// calling [`next_candidate`].
+pub(crate) fn fill_candidates<F: Graftable, B: bitmap::Readable<N>, const N: usize>(
+    bitmap: &B,
+    floor: Location<F>,
+    tip: u64,
+    limit: usize,
+    out: &mut Vec<Location<F>>,
+) -> Location<F> {
+    let mut scan = floor;
+    while out.len() < limit {
+        let Some(candidate) = next_candidate(bitmap, scan, tip) else {
+            break;
+        };
+        out.push(candidate);
+        scan = Location::<F>::new(*candidate + 1);
+    }
+    scan
+}
+
 /// Adapter that resolves ops MMR nodes for a batch's `compute_current_layer`.
 ///
 /// Tries the batch chain's sync [`Readable`] first (which covers nodes appended or overwritten
@@ -365,7 +386,9 @@ where
 
     /// Batch read multiple keys.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Committed-DB operations resolved by
+    /// the read are retained on the batch and consumed by [`merkleize`](Self::merkleize), which
+    /// skips re-reading those keys.
     pub async fn get_many<E, C, I>(
         &self,
         keys: &[&K],
@@ -397,8 +420,8 @@ where
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip| {
-                next_candidate(&bitmap_parent, floor, tip)
+            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip, limit, out| {
+                fill_candidates(&bitmap_parent, floor, tip, limit, out)
             })
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
@@ -430,7 +453,9 @@ where
 
     /// Batch read multiple keys.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Committed-DB operations resolved by
+    /// the read are retained on the batch and consumed by [`merkleize`](Self::merkleize), which
+    /// skips re-reading those keys.
     pub async fn get_many<E, C, I>(
         &self,
         keys: &[&K],
@@ -462,8 +487,8 @@ where
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip| {
-                next_candidate(&bitmap_parent, floor, tip)
+            .merkleize_with_floor_scan(&db.any, metadata, |floor, tip, limit, out| {
+                fill_candidates(&bitmap_parent, floor, tip, limit, out)
             })
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -171,7 +171,7 @@ pub mod test {
         });
     }
 
-    /// Reads on a batch retain resolved locations that `merkleize` consumes to skip re-reading
+    /// Reads on a batch cache resolved locations that `merkleize` consumes to skip re-reading
     /// those keys. The root must match a write-only batch's `merkleize`, both rooted at the DB
     /// (D=0) and through one pending ancestor (D=1).
     #[test_traced("WARN")]

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -168,6 +168,92 @@ pub mod test {
         });
     }
 
+    /// Reads on a batch retain resolved locations that `merkleize` consumes to skip re-reading
+    /// those keys. The root must match a write-only batch's `merkleize`, both rooted at the DB
+    /// (D=0) and through one pending ancestor (D=1).
+    #[test_traced("WARN")]
+    pub fn test_current_unordered_fixed_resolved_merkleize_parity() {
+        use commonware_cryptography::Hasher as _;
+        use commonware_utils::test_rng_seeded;
+        use rand::RngCore as _;
+        use std::collections::HashMap;
+
+        fn key(i: u64) -> Digest {
+            Sha256::hash(&i.to_be_bytes())
+        }
+        fn val(i: u64) -> Digest {
+            Sha256::hash(&(i + 10000).to_be_bytes())
+        }
+
+        deterministic::Runner::default().start(|ctx| async move {
+            let mut db = open_db(ctx.child("current"), "fused-parity".to_string()).await;
+
+            let mut seed = db.new_batch();
+            for i in 0..2000u64 {
+                seed = seed.write(key(i), Some(val(i)));
+            }
+            let seed = seed.merkleize(&db, None).await.unwrap();
+            db.apply_batch(seed).await.unwrap();
+            db.commit().await.unwrap();
+
+            let make = |salt: u64| -> Vec<(Digest, Option<Digest>)> {
+                let mut rng = test_rng_seeded(salt);
+                let mut out = Vec::new();
+                for _ in 0..600 {
+                    let r = rng.next_u32() % 100;
+                    if r < 60 {
+                        out.push((key(rng.next_u64() % 2000), Some(val(rng.next_u64()))));
+                    } else if r < 80 {
+                        out.push((key(rng.next_u64() % 2000), None));
+                    } else {
+                        out.push((key(2000 + rng.next_u64() % 2000), Some(val(rng.next_u64()))));
+                    }
+                }
+                let mut m: HashMap<Digest, Option<Digest>> = HashMap::new();
+                for (k, v) in out {
+                    m.insert(k, v);
+                }
+                m.into_iter().collect()
+            };
+
+            for depth in [0u8, 1u8] {
+                let parent = if depth == 1 {
+                    let mut p = db.new_batch();
+                    for (k, v) in make(900) {
+                        p = p.write(k, v);
+                    }
+                    Some(p.merkleize(&db, None).await.unwrap())
+                } else {
+                    None
+                };
+
+                let muts = make(depth as u64 + 1);
+                let new_batch = || {
+                    parent
+                        .as_ref()
+                        .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
+                };
+
+                let mut nb = new_batch();
+                for (k, v) in &muts {
+                    nb = nb.write(*k, *v);
+                }
+                let normal_root = nb.merkleize(&db, None).await.unwrap().root();
+
+                let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
+                let mut fb = new_batch();
+                let values = fb.get_many(&keys, &db).await.unwrap();
+                let plain = new_batch().get_many(&keys, &db).await.unwrap();
+                assert_eq!(values, plain, "value mismatch at depth={depth}");
+                for (k, v) in &muts {
+                    fb = fb.write(*k, *v);
+                }
+                let fused_root = fb.merkleize(&db, None).await.unwrap().root();
+                assert_eq!(normal_root, fused_root, "root mismatch at depth={depth}");
+            }
+        });
+    }
+
     #[test_traced("DEBUG")]
     pub fn test_current_db_verify_proof_over_bits_in_uncommitted_chunk() {
         shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db);

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -113,6 +113,9 @@ pub mod test {
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Metrics, Runner as _, Supervisor as _};
+    use commonware_utils::test_rng_seeded;
+    use rand::RngCore as _;
+    use std::collections::HashMap;
 
     /// A type alias for the concrete [Db] type used in these unit tests.
     type CurrentTest = Db<
@@ -173,11 +176,6 @@ pub mod test {
     /// (D=0) and through one pending ancestor (D=1).
     #[test_traced("WARN")]
     pub fn test_current_unordered_fixed_resolved_merkleize_parity() {
-        use commonware_cryptography::Hasher as _;
-        use commonware_utils::test_rng_seeded;
-        use rand::RngCore as _;
-        use std::collections::HashMap;
-
         fn key(i: u64) -> Digest {
             Sha256::hash(&i.to_be_bytes())
         }


### PR DESCRIPTION
Replaces: #3993

Speeds up the QMDB per-block pipeline (load keys, write batch, merkleize, root) at the production validator shape: 32k updates over 1M keys, EightCap. All numbers are p50 from interleaved pinned-binary A/B runs on tokio (Apple Silicon) against the merge-base (13b4a18f), and the speculative root is byte-identical to main on every iteration of every variant.

### constantinople (load + write + merkleize + root)

| variant | depth | main | this PR | delta |
|---|---|---|---|---|
| any::unordered::fixed::mmb | 0 | 41.5ms | 29.9ms | -28% |
| any::unordered::fixed::mmb | 1 | 49.7ms | 37.4ms | -25% |
| any::ordered::fixed::mmb | 0 | 49.1ms | 43.2ms | -12% |
| any::ordered::fixed::mmb | 1 | 64.7ms | 57.4ms | -11% |
| current::unordered::fixed::mmb | 0 | 44.2ms | 34.8ms | -21% |
| current::unordered::fixed::mmb | 1 | 60.8ms | 50.6ms | -17% |
| current::ordered::fixed::mmb | 0 | 53.6ms | 47.6ms | -11% |
| current::ordered::fixed::mmb | 1 | 70.8ms | 67.1ms | -5% |

### criterion `qmdb::merkleize` (write-only merkleize, keys=1M, 100k updates/iter)

| variant | main | this PR | delta |
|---|---|---|---|
| any::unordered::fixed::mmr | 188.5ms | 172.5ms | -8.5% |
| any::ordered::fixed::mmr | 270.7ms | 265.0ms | -2.1% |

The criterion bench is write-only (no reads before writes), so it isolates the non-caching optimizations; constantinople exercises the full read-then-write pipeline where the read cache applies. (Criterion numbers were measured before the ordered-cache removal and the windowed cache probe; both are no-ops at this write-only shape.)

## Optimizations

**1. Batch reads are fused into unordered merkleize (default-on).** `get`/`get_many` on an `UnmerkleizedBatch` cache committed-DB locations on the batch (`Mutex<AHashMap<Key, Location>>`, never held across an await). Unordered `merkleize` consumes them: keys loaded and then written skip the merkleize-time journal re-read, which existed solely to re-resolve what the read already resolved. Any read-then-write flow on one batch object (the standard block-execution pattern, including through `current` and glue) fuses automatically; no API change.

- Only committed-snapshot resolutions are cached. Keys answered by pending mutations or ancestor diffs cache nothing: ancestor-diff caching is unsound if that ancestor is committed and dropped before merkleize.
- Ordered batches cache nothing (`CACHES_READS = false`): op generation needs each read operation's value and next key for linkage, and caching those payloads measured as a net loss (see "explored but not included").

**2. Sorted index probes for batch reads.** `index::Unordered` gains a defaulted `get_many(keys, visit)` whose probe order is implementation-defined. The tree-backed indexes (`index::ordered`, `index::partitioned::ordered`) override it to probe in translated-key order, so consecutive BTreeMap descents share upper node paths that stay cache-resident across the batch. Hash-backed indexes keep the plain loop (probe order is irrelevant there and the sort would be pure overhead). This took the ordered load phase from 12.5ms to 9.0ms at the bench shape; profiling attributed 6.5ms of the ordered load to random-order BTreeMap descents (vs 0.7ms for unordered's HashMap probes).

**3. Floor-raise scan batches bitmap locks and resolution.** `Shared::fill_candidates` fills each floor-raise candidate batch under a single bitmap read guard (previously two lock acquisitions per candidate, ~33k per merkleize at this shape). The per-candidate activity check and previous-committed-location lookup now share one diff binary-search and ancestor resolution (replaces `is_active_at`, which duplicated both). The per-round candidate cap (`MAX_CONCURRENT_READS = 64`) is removed: a round never requests more than the steps still needed, so the cap only throttled cold-path read concurrency (warm delta measured zero). `next_candidate` is kept as a test-module oracle and `bitmap_fill_candidates_matches_oracle` proves sequence equality across pruned/truncated/tail shapes, tips, and limits.

**4. One-lock batched journal reads.** Contiguous fixed `Reader::read_many` now routes every position through the segmented journal's `get_many` -> `Append::read_many_into`, which serves page-cache and tip-buffer hits under amortized lock acquisitions and reads only true misses from the blob, concurrently. This replaces the per-item synchronous probe (one lock acquisition per item): ~40-48% faster `db.get_many` over 32k warm keys. `read_many_into` returns the count of items served without a blob read, so `cache_hits`/`cache_misses` carry exact blob-read semantics.

## Bench

`constantinople`: full per-block pipeline harness (`get_many` load -> writes -> merkleize -> root) on tokio with EightCap, with configurable pending-ancestor depth, a per-iteration load/write/merkleize phase split, and the speculative root printed as a cross-binary parity check. Runs over `mmb` (the production-default merkle structure). Supports the qmdb criterion bench variant names: `any::unordered::fixed::mmb`, `any::ordered::fixed::mmb`, `any::unordered::variable::mmb`, `current::unordered::fixed::mmb`, `current::ordered::fixed::mmb`. It no-ops under blanket harness invocations (`cargo bench --benches`, `--output-format bencher`) so benchmark CI is unaffected.

```
cargo bench -p commonware-storage --bench constantinople -- <db> [depth] [iters] [keys] [updates]
```

## Optimizations explored but not included

- **Ordered payload caching** (cache `(old_value, next_key)` at read time so ordered merkleize can skip the cached keys' own re-reads): measured a net loss at the bench shape and removed. Load gained ~1.4-1.6ms/block from the per-read payload clones and fatter cache entries, while merkleize was unchanged at both depths (the skipped re-reads are warm page-cache hits served under one batched lock acquisition); roots byte-identical with and without. Could only pay off when the page cache cannot hold the touched ops between load and merkleize. A correctness wrinkle it carried for free: a deleted key's own-bucket read doubles as same-bucket predecessor discovery, so deletes could never be skipped.
- **Parallel index probes** (fan keys across `Strategy` workers): measured ordered load 9.0 -> 6.2ms (-7.5% total at depth 0, Rayon=8), but it needs an index-kind gate (rayon dispatch exceeds the entire hash-probe phase, so it must apply only to tree-backed indexes) and the validator default of 2 rayon threads halves the win. Deferred to a "parallel load" follow-up together with the other profiled load targets: parallel decode in the journal read, a pooled uninit staging buffer (`read_many` zeroes 3.3MB per 32k-key call, ~0.65ms), page-run copy reuse in `read_cached_many` (~0.8ms), and a linear-merge match-back (~0.3ms).
- **Variable journal `read_many` batching** (mirror of optimization 4): attempted and measured a wash (33.6 vs 34.1ms p50) -- the offsets journal is small and dense, so its per-item probes were never the cost. Variable's load cost is the per-item data probes, and items carry varint length prefixes, so batching them needs a two-pass ranged read (batched prefix reads, then one ranged payload read). Deferred; the `any::unordered::variable::mmb` harness mode is included to measure that follow-up.
- **Hash side-index for ordered point reads**: would erase the BTreeMap probe cost but doubles index memory; superseded by sorted probes (optimization 2) at zero memory cost.
- **Stable probe sort**: microbenched stable vs unstable on the probe-order pairs; unstable wins ~28% on random caller key order. Stable only wins on append-to-sorted input shapes, which these call sites never see.

## Testing

Root-parity tests assert read-then-write merkleize is byte-identical to write-only merkleize across updates/deletes/creates and pending-ancestor depths 0-2: unordered, ordered (TwoCap collision-heavy; ordered ignores the read cache, so this pins that reads cannot perturb its root), and `current`. Location caching across an intervening ancestor commit+drop is covered differentially (`test_unordered_fixed_caching_survives_ancestor_commit`). Journal batched reads are byte-compared against per-item reads with exact hit/miss accounting, including tip-straddling items whose prefix misses the cache.
