### PR TITLE
[storage] Write large appends directly to blob

### DIFF
--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -17,9 +17,10 @@
 //! # Blob Semantics
 //!
 //! [Append] owns the physical page layout, read cache, and durability bookkeeping for the wrapped
-//! [Blob]. Cloned [Append] handles share that state and are safe to use concurrently. Raw [Blob]
-//! handles cloned before wrapping operate on physical bytes, including checksum records, rather
-//! than [Append]'s logical view, and they do not observe buffered data until it is flushed.
+//! [Blob]. Cloned [Append] handles share that state; reads may run concurrently with anything,
+//! but mutable operations (append, resize) must be serialized by the caller. Raw [Blob] handles
+//! cloned before wrapping operate on physical bytes, including checksum records, rather than
+//! [Append]'s logical view, and they do not observe buffered data until it is flushed.
 //!
 //! Raw [Blob] handles must not be used to write, resize, or otherwise mutate the blob while an
 //! [Append] exists. Those mutations bypass the buffer and page cache, can invalidate checksum
@@ -325,11 +326,6 @@ impl<B: Blob> Append<B> {
     /// flush would), and the remaining sub-page suffix is buffered.
     ///
     /// Like [Self::append], the write is not durable until [Self::sync] is called.
-    ///
-    /// # Warning
-    ///
-    /// Concurrent mutable operations (other appends, resize) are not supported while a `buf`
-    /// too large to buffer is being written and may panic.
     pub async fn append_owned(&self, buf: IoBuf) -> Result<(), Error> {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let mut buf_guard = self.buffer.write().await;

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -147,18 +147,25 @@ pub struct Append<B: Blob> {
     buffer: Arc<AsyncRwLock<Buffer>>,
 }
 
-/// Returns the capacity with a floor applied to ensure it can hold at least one full page of new
-/// data even when caching a nearly-full page of already written data.
-fn capacity_with_floor(capacity: usize, page_size: u64) -> usize {
-    let floor = page_size as usize * 2;
-    if capacity < floor {
+/// Adjusts a requested write-buffer `capacity` upward to the value the buffer actually uses,
+/// applying two upward adjustments:
+///
+/// - Rounds up to a whole multiple of `page_size`, so the buffer always holds an exact number of
+///   pages. Callers can then drain and bulk-cache full pages without re-rounding the capacity.
+/// - Raises the result to a floor of two pages, so the buffer can hold at least one full page of
+///   new data even while caching a nearly-full page of already written data.
+fn adjusted_capacity(capacity: usize, page_size: u64) -> usize {
+    let page_size = page_size as usize;
+    let rounded = capacity.div_ceil(page_size) * page_size;
+    let floor = page_size * 2;
+    if rounded < floor {
         warn!(
             floor,
             "requested buffer capacity is too low, increasing it to floor"
         );
         floor
     } else {
-        capacity
+        rounded
     }
 }
 
@@ -186,7 +193,7 @@ impl<B: Blob> Append<B> {
             blob.sync().await?;
         }
 
-        let capacity = capacity_with_floor(capacity, cache_ref.page_size());
+        let capacity = adjusted_capacity(capacity, cache_ref.page_size());
         let needs_sync = !invalid_data_found; // ensure pending writes on the wrapped blob are synced
 
         let (blob_state, partial_data) = match partial_page_state {
@@ -297,43 +304,43 @@ impl<B: Blob> Append<B> {
     /// the first byte was written.
     pub async fn append(&self, buf: &[u8]) -> Result<u64, Error> {
         let logical_page_size = self.cache_ref.page_size() as usize;
-        let mut buffer = self.buffer.write().await;
+        let mut buf_guard = self.buffer.write().await;
 
-        // Take the buffered path unless `buf` would push the buffer over capacity and at least
-        // one full page could be written directly from it.
-        let fill = (logical_page_size - (buffer.len() % logical_page_size)) % logical_page_size;
-        if buffer.len() + buf.len() <= buffer.capacity || buf.len() < fill + logical_page_size {
-            let offset = buffer.size();
-            if buffer.append(buf) {
-                self.flush_internal(buffer, false, false).await?;
-            }
-            return Ok(offset);
+        // Bytes needed to fill current page to a page boundary (0 if already aligned).
+        let fill = (logical_page_size - (buf_guard.len() % logical_page_size)) % logical_page_size;
+
+        // Bypass the append buffer if appending `buf` would overflow capacity, and at least one
+        // whole page remains to be written after filling the current page to a page boundary.
+        let overflows_capacity = buf_guard.len() + buf.len() > buf_guard.capacity;
+        let has_full_page_after_fill = buf.len() >= fill + logical_page_size;
+        if overflows_capacity && has_full_page_after_fill {
+            drop(buf_guard);
+            return self.append_owned(IoBuf::copy_from_slice(buf)).await;
         }
-        drop(buffer);
 
-        self.append_owned(IoBuf::copy_from_slice(buf)).await
+        let offset = buf_guard.size();
+        if buf_guard.append(buf) {
+            self.flush_internal(buf_guard, false, false).await?;
+        }
+        Ok(offset)
     }
 
     /// Append all bytes in `buf` to the tip of the blob, writing whole pages directly to the
     /// underlying blob instead of staging them in the write buffer when `buf` is large.
-    ///
-    /// Behaves like [Self::append], but an owned `buf` too large to buffer additionally avoids
-    /// the copy into the write buffer: bytes needed to complete the current partial page are
-    /// buffered and flushed through the regular path, the whole pages that follow are written to
-    /// the blob as zero-copy slices of `buf` (populating the page cache, exactly as a buffered
-    /// flush would), and the remaining sub-page suffix is buffered.
-    ///
-    /// Like [Self::append], the write is not durable until [Self::sync] is called.
     pub async fn append_owned(&self, buf: IoBuf) -> Result<u64, Error> {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let mut buf_guard = self.buffer.write().await;
         let offset = buf_guard.size();
 
-        // Take the buffered path unless `buf` would push the buffer over capacity and at least
-        // one full page can be written directly from it.
+        // Bytes needed to fill current page to a page boundary (0 if already aligned).
         let fill = (logical_page_size - (buf_guard.len() % logical_page_size)) % logical_page_size;
-        if buf_guard.len() + buf.len() <= buf_guard.capacity || buf.len() < fill + logical_page_size
-        {
+
+        // Buffer the bytes within the append buffer if the append fits within its capacity, or if
+        // no whole page remains to write directly after filling the current page to a page
+        // boundary.
+        let overflows_capacity = buf_guard.len() + buf.len() > buf_guard.capacity;
+        let has_full_page_after_fill = buf.len() >= fill + logical_page_size;
+        if !overflows_capacity || !has_full_page_after_fill {
             if buf_guard.append(buf.as_ref()) {
                 self.flush_internal(buf_guard, false, false).await?;
             }
@@ -375,11 +382,12 @@ impl<B: Blob> Append<B> {
             "an empty tip implies no partial page state"
         );
 
-        // Cache the bulk pages before `replace` publishes the new size and the tip lock is
-        // released, so reads of the bulk range are served from the cache while the blob write
-        // is still in flight. Insert in write-buffer-sized chunks so the cache lock is not held
-        // across the entire copy.
-        let chunk_len = buf_guard.capacity / logical_page_size * logical_page_size;
+        // Cache the pages before `replace` publishes the new size and the tip lock is released, so
+        // reads of the bulk range are served from the cache while the blob write is still in
+        // flight. Insert in write-buffer-sized chunks so the cache lock is not held across the
+        // entire copy. The capacity is a whole number of pages (see [adjusted_capacity]), so each
+        // chunk is page-aligned.
+        let chunk_len = buf_guard.capacity;
         let mut cache_offset = boundary;
         for chunk in bulk.as_ref().chunks(chunk_len) {
             let remaining = self.cache_ref.cache(self.id, chunk, cache_offset);

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -170,6 +170,10 @@ fn adjusted_capacity(capacity: usize, page_size: u64) -> usize {
 /// Returns whether appending `append_len` bytes should bypass the write buffer and write whole
 /// pages directly: the append would overflow capacity, and at least one whole page remains to
 /// write after filling the current page up to a boundary.
+///
+/// Larger appends bypass the buffer, so a buffered append exceeds `capacity` by less than one
+/// page (given `capacity` is a whole number of pages; see [adjusted_capacity]). The write
+/// buffer's peak size therefore stays under `capacity + logical_page_size`.
 const fn too_big_for_buffer(
     buffer_len: usize,
     buffer_capacity: usize,

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -293,29 +293,37 @@ impl<B: Blob> Append<B> {
     }
 
     /// Append all bytes in `buf` to the tip of the blob.
+    ///
+    /// A `buf` too large to fit in the write buffer is copied once into an owned buffer and
+    /// written through [Self::append_owned]'s direct path, so the write buffer never grows
+    /// meaningfully beyond its capacity no matter how large the append.
     pub async fn append(&self, buf: &[u8]) -> Result<(), Error> {
+        let logical_page_size = self.cache_ref.page_size() as usize;
         let mut buffer = self.buffer.write().await;
 
-        if !buffer.append(buf) {
+        // Take the buffered path unless `buf` would push the buffer over capacity and at least
+        // one full page could be written directly from it.
+        let fill = (logical_page_size - (buffer.len() % logical_page_size)) % logical_page_size;
+        if buffer.len() + buf.len() <= buffer.capacity || buf.len() < fill + logical_page_size {
+            if buffer.append(buf) {
+                self.flush_internal(buffer, false, false).await?;
+            }
             return Ok(());
         }
+        drop(buffer);
 
-        // Buffer is over capacity, so we need to write data to the blob.
-        self.flush_internal(buffer, false, false).await?;
-        Ok(())
+        self.append_owned(IoBuf::copy_from_slice(buf)).await
     }
 
     /// Append all bytes in `buf` to the tip of the blob, writing whole pages directly to the
     /// underlying blob instead of staging them in the write buffer when `buf` is large.
     ///
-    /// Behaves like [Self::append], but a `buf` too large to buffer avoids the copy into the
-    /// write buffer (and the over-capacity allocation that copy requires): bytes needed to
-    /// complete the current partial page are buffered and flushed through the regular path, the
-    /// whole pages that follow are written to the blob as zero-copy slices of `buf`, and any
-    /// remaining partial-page suffix seeds the write buffer without copying.
-    ///
-    /// Unlike a buffered flush, the directly written pages do not populate the page cache (a
-    /// large write would evict most of it); they are cached on demand when read.
+    /// Behaves like [Self::append], but an owned `buf` too large to buffer additionally avoids
+    /// the copy into the write buffer: bytes needed to complete the current partial page are
+    /// buffered and flushed through the regular path, the whole pages that follow are written to
+    /// the blob as zero-copy slices of `buf` (populating the page cache, exactly as a buffered
+    /// flush would), and any remaining partial-page suffix seeds the write buffer without
+    /// copying.
     ///
     /// Like [Self::append], the write is not durable until [Self::sync] is called.
     pub async fn append_owned(&self, buf: IoBuf) -> Result<(), Error> {
@@ -354,14 +362,15 @@ impl<B: Blob> Append<B> {
         }
 
         // Prepare physical pages for the whole pages remaining in `buf` without copying them.
-        // These pages are not inserted into the page cache: a write this large would evict most
-        // of the cache for data that may never be read, and any page of it that is read gets
-        // cached on demand by the page-fault path. Readers of this region are correct in the
-        // meantime because they block on the blob lock held below until the write completes.
         let bulk_len = (buf.len() - fill) / logical_page_size * logical_page_size;
         let bulk = buf.slice(fill..fill + bulk_len);
         let mut physical_pages = IoBufs::default();
         self.physical_full_pages(&bulk, None, &mut physical_pages);
+
+        // Cache the bulk pages before releasing the tip lock so reads don't observe stale
+        // persisted bytes during the handoff from tip to cache.
+        let remaining = self.cache_ref.cache(self.id, bulk.as_ref(), boundary);
+        assert_eq!(remaining, 0, "cached bulk pages must be page-aligned");
 
         // Acquire a write lock on the blob state so nobody tries to read or modify the blob
         // while we're writing to it.
@@ -1206,7 +1215,7 @@ impl<B: Blob> Append<B> {
             let zeros_needed = (size - current_size) as usize;
             let mut zeros = self.cache_ref.pool().alloc(zeros_needed);
             zeros.put_bytes(0, zeros_needed);
-            self.append(zeros.as_ref()).await?;
+            self.append_owned(zeros.freeze()).await?;
             return Ok(());
         }
 
@@ -1881,19 +1890,18 @@ mod tests {
                 .unwrap();
             assert_eq!(append.size().await, 500);
 
-            // The directly written pages do not populate the page cache.
+            // The directly written pages populate the page cache, exactly as a buffered flush
+            // would.
             let mut probe = vec![0u8; PAGE_SIZE.get() as usize];
-            assert_eq!(append.cache_ref.read_cached(append.id, &mut probe, 0), 0);
-
-            // All bytes are readable before any sync (bulk from the blob, suffix from tip).
-            let read_buf = append.read_at(0, 500).await.unwrap().coalesce();
-            assert_eq!(read_buf, &data[..]);
-
-            // Pages of the bulk region are cached on demand by reads.
             assert_eq!(
                 append.cache_ref.read_cached(append.id, &mut probe, 0),
                 PAGE_SIZE.get() as usize
             );
+            assert_eq!(probe, &data[..PAGE_SIZE.get() as usize]);
+
+            // All bytes are readable before any sync (bulk from the cache, suffix from tip).
+            let read_buf = append.read_at(0, 500).await.unwrap().coalesce();
+            assert_eq!(read_buf, &data[..]);
 
             // Everything becomes durable with a single sync.
             append.sync().await.unwrap();
@@ -2065,6 +2073,51 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(append.size().await, 422);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_append_borrowed_large_takes_direct_path() {
+        // A plain `append` larger than the write buffer is routed through the direct path, so the
+        // write buffer holds only the partial-page suffix afterwards instead of the whole input.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"borrowed_large")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Start misaligned with a small buffered prefix.
+            let all: Vec<u8> = (0..530).map(|i| (i % 241) as u8).collect();
+            append.append(&all[..30]).await.unwrap();
+
+            // 500 more bytes exceed the 206-byte write buffer and take the direct path.
+            append.append(&all[30..]).await.unwrap();
+            assert_eq!(append.size().await, 530);
+
+            // Only the partial-page suffix remains buffered (530 = 5 full pages + 15 bytes).
+            assert_eq!(append.buffer.read().await.len(), 15);
+
+            let read_buf = append.read_at(0, 530).await.unwrap().coalesce();
+            assert_eq!(read_buf, &all[..]);
+
+            append.sync().await.unwrap();
+            drop(append);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"borrowed_large")
+                .await
+                .unwrap();
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 530);
+            let read_buf = append.read_at(0, 530).await.unwrap().coalesce();
+            assert_eq!(read_buf, &all[..]);
         });
     }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -322,10 +322,14 @@ impl<B: Blob> Append<B> {
     /// the copy into the write buffer: bytes needed to complete the current partial page are
     /// buffered and flushed through the regular path, the whole pages that follow are written to
     /// the blob as zero-copy slices of `buf` (populating the page cache, exactly as a buffered
-    /// flush would), and any remaining partial-page suffix seeds the write buffer without
-    /// copying.
+    /// flush would), and the remaining sub-page suffix is buffered.
     ///
     /// Like [Self::append], the write is not durable until [Self::sync] is called.
+    ///
+    /// # Warning
+    ///
+    /// Concurrent mutable operations (other appends, resize) are not supported while a `buf`
+    /// too large to buffer is being written and may panic.
     pub async fn append_owned(&self, buf: IoBuf) -> Result<(), Error> {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let mut buf_guard = self.buffer.write().await;
@@ -350,15 +354,14 @@ impl<B: Blob> Append<B> {
         if !buf_guard.is_empty() {
             self.flush_internal(buf_guard, false, false).await?;
 
-            // The flush releases the buffer lock during blob I/O; if a concurrent append claimed
-            // the boundary in the meantime, finish with the buffered path.
+            // The flush releases the buffer lock during blob I/O. Concurrent mutable operations
+            // (other appends, resize) are not supported while the direct path is in flight, so
+            // nothing may claim the boundary in the meantime.
             buf_guard = self.buffer.write().await;
-            if buf_guard.size() != boundary || !buf_guard.is_empty() {
-                if buf_guard.append(&buf.as_ref()[fill..]) {
-                    self.flush_internal(buf_guard, false, false).await?;
-                }
-                return Ok(());
-            }
+            assert!(
+                buf_guard.size() == boundary && buf_guard.is_empty(),
+                "concurrent mutable operation raced a direct-path append"
+            );
         }
 
         // Prepare physical pages for the whole pages remaining in `buf` without copying them.
@@ -367,25 +370,42 @@ impl<B: Blob> Append<B> {
         let mut physical_pages = IoBufs::default();
         self.physical_full_pages(&bulk, None, &mut physical_pages);
 
-        // Cache the bulk pages before releasing the tip lock so reads don't observe stale
-        // persisted bytes during the handoff from tip to cache.
-        let remaining = self.cache_ref.cache(self.id, bulk.as_ref(), boundary);
-        assert_eq!(remaining, 0, "cached bulk pages must be page-aligned");
-
         // Acquire a write lock on the blob state so nobody tries to read or modify the blob
-        // while we're writing to it.
+        // while we're writing to it. Everything below up to the write mutates shared state
+        // without an intervening await, so a future dropped before the write leaves no trace;
+        // one dropped during the write is covered by the fatal-failure convention.
         let mut blob_state = self.blob_state.write().await;
         debug_assert!(
             blob_state.partial_page_state.is_none(),
             "an empty tip implies no partial page state"
         );
 
+        // Cache the bulk pages before `replace` publishes the new size and the tip lock is
+        // released, so reads of the bulk range are served from the cache while the blob write
+        // is still in flight. Insert in write-buffer-sized chunks so the cache lock is not held
+        // across the entire copy.
+        let chunk_len = buf_guard.capacity / logical_page_size * logical_page_size;
+        let mut cache_offset = boundary;
+        for chunk in bulk.as_ref().chunks(chunk_len) {
+            let remaining = self.cache_ref.cache(self.id, chunk, cache_offset);
+            assert_eq!(remaining, 0, "cached bulk pages must be page-aligned");
+            cache_offset += chunk.len() as u64;
+        }
+
         // Update state before writing, seeding the tip with the partial-page suffix of `buf`.
-        // This may appear to risk data loss if writes fail, but write failures are fatal per
-        // this codebase's design - callers must not use the blob after any mutable method
-        // returns an error.
+        // The suffix (less than one page) is copied: a sub-page tip is never drained by flush,
+        // so seeding it with a view of `buf` would pin the entire backing allocation until the
+        // next append to this blob (or forever, if there is none).
         blob_state.current_page += (bulk_len / logical_page_size) as u64;
-        buf_guard.replace(boundary + bulk_len as u64, buf.slice(fill + bulk_len..));
+        let suffix = buf.slice(fill + bulk_len..);
+        let suffix = if suffix.is_empty() {
+            suffix
+        } else {
+            let mut copied = self.cache_ref.pool().alloc(suffix.len());
+            copied.put_slice(suffix.as_ref());
+            copied.freeze()
+        };
+        buf_guard.replace(boundary + bulk_len as u64, suffix);
 
         // Make sure the buffer offset and underlying blob agree on the state of the tip.
         assert_eq!(
@@ -1884,11 +1904,15 @@ mod tests {
 
             // 500 bytes = 4 full pages (412 bytes) + 88-byte remainder.
             let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            append
-                .append_owned(IoBuf::from(data.clone()))
-                .await
-                .unwrap();
+            let src = IoBuf::from(data.clone());
+            let src_start = src.as_ptr() as usize;
+            let src_range = src_start..src_start + src.len();
+            append.append_owned(src.clone()).await.unwrap();
             assert_eq!(append.size().await, 500);
+
+            // The buffered suffix is a copy, not a view that would pin the input allocation.
+            let tip_ptr = append.buffer.read().await.as_ref().as_ptr() as usize;
+            assert!(!src_range.contains(&tip_ptr));
 
             // The directly written pages populate the page cache, exactly as a buffered flush
             // would.
@@ -2073,6 +2097,58 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(append.size().await, 422);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_append_owned_physical_bytes_match_buffered() {
+        // The direct path must produce byte-identical physical output (page layout, CRC slot
+        // placement, zero padding) to the buffered path for the same logical content.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+
+            let (blob, size) = context
+                .open("test_partition", b"phys_direct")
+                .await
+                .unwrap();
+            let direct = Append::new(blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            direct
+                .append_owned(IoBuf::from(data.clone()))
+                .await
+                .unwrap();
+            direct.sync().await.unwrap();
+            drop(direct);
+
+            // Small appends always stay on the buffered path and force intermediate flushes.
+            let (blob, size) = context
+                .open("test_partition", b"phys_buffered")
+                .await
+                .unwrap();
+            let buffered = Append::new(blob, size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            for chunk in data.chunks(10) {
+                buffered.append(chunk).await.unwrap();
+            }
+            buffered.sync().await.unwrap();
+            drop(buffered);
+
+            let (blob_a, size_a) = context
+                .open("test_partition", b"phys_direct")
+                .await
+                .unwrap();
+            let (blob_b, size_b) = context
+                .open("test_partition", b"phys_buffered")
+                .await
+                .unwrap();
+            assert_eq!(size_a, size_b);
+            let bytes_a = blob_a.read_at(0, size_a as usize).await.unwrap().coalesce();
+            let bytes_b = blob_b.read_at(0, size_b as usize).await.unwrap().coalesce();
+            assert_eq!(bytes_a.as_ref(), bytes_b.as_ref());
         });
     }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -384,7 +384,7 @@ impl<B: Blob> Append<B> {
         let bulk_len = (buf.len() - fill) / logical_page_size * logical_page_size;
         let bulk = buf.slice(fill..fill + bulk_len);
         let mut physical_pages = IoBufs::default();
-        self.physical_full_pages(&bulk, None, &mut physical_pages);
+        self.append_full_pages(&bulk, None, &mut physical_pages);
 
         // Acquire a write lock on the blob state so nobody tries to read or modify the blob
         // while we're writing to it. Everything below up to the write mutates shared state
@@ -943,7 +943,7 @@ impl<B: Blob> Append<B> {
         let buffer_data = buffer.as_ref();
 
         if pages_to_write > 0 {
-            self.physical_full_pages(
+            self.append_full_pages(
                 &buffer.slice(..pages_to_write * logical_page_size),
                 old_crc_record,
                 &mut write_buffer,
@@ -997,12 +997,12 @@ impl<B: Blob> Append<B> {
         (write_buffer, Some(crc_record))
     }
 
-    /// Append the physical-page representation of `data` to `write_buffer`: payload bytes as
-    /// zero-copy slices of `data`, interleaved with newly built CRC records.
+    /// Appends each page of `data` to `write_buffer` in on-disk format: its payload (a zero-copy
+    /// slice of `data`) followed by a CRC record.
     ///
-    /// `data` must contain a non-zero whole number of logical pages. If `old_crc_record` is
-    /// present, the first page's CRC record preserves the old CRC in its original slot.
-    fn physical_full_pages(
+    /// `data.len()` must be a non-zero multiple of the page size. When `old_crc_record` is present,
+    /// the first page's record preserves the old CRC in its original slot.
+    fn append_full_pages(
         &self,
         data: &IoBuf,
         old_crc_record: Option<&Checksum>,

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -156,17 +156,31 @@ pub struct Append<B: Blob> {
 ///   new data even while caching a nearly-full page of already written data.
 fn adjusted_capacity(capacity: usize, page_size: u64) -> usize {
     let page_size = page_size as usize;
-    let rounded = capacity.div_ceil(page_size) * page_size;
+    let rounded = capacity.next_multiple_of(page_size);
     let floor = page_size * 2;
     if rounded < floor {
         warn!(
             floor,
             "requested buffer capacity is too low, increasing it to floor"
         );
-        floor
-    } else {
-        rounded
     }
+    rounded.max(floor)
+}
+
+/// Returns whether appending `append_len` bytes should bypass the write buffer and write whole
+/// pages directly: the append would overflow capacity, and at least one whole page remains to
+/// write after filling the current page up to a boundary.
+const fn too_big_for_buffer(
+    buffer_len: usize,
+    buffer_capacity: usize,
+    append_len: usize,
+    logical_page_size: usize,
+) -> bool {
+    let fill = buffer_len.next_multiple_of(logical_page_size) - buffer_len;
+    let overflows_capacity = buffer_len + append_len > buffer_capacity;
+    let has_full_page_after_fill = append_len >= fill + logical_page_size;
+
+    overflows_capacity && has_full_page_after_fill
 }
 
 impl<B: Blob> Append<B> {
@@ -306,14 +320,13 @@ impl<B: Blob> Append<B> {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let mut buf_guard = self.buffer.write().await;
 
-        // Bytes needed to fill current page to a page boundary (0 if already aligned).
-        let fill = (logical_page_size - (buf_guard.len() % logical_page_size)) % logical_page_size;
-
-        // Bypass the append buffer if appending `buf` would overflow capacity, and at least one
-        // whole page remains to be written after filling the current page to a page boundary.
-        let overflows_capacity = buf_guard.len() + buf.len() > buf_guard.capacity;
-        let has_full_page_after_fill = buf.len() >= fill + logical_page_size;
-        if overflows_capacity && has_full_page_after_fill {
+        // Bypass the append buffer and write whole pages directly when `buf` is large.
+        if too_big_for_buffer(
+            buf_guard.len(),
+            buf_guard.capacity,
+            buf.len(),
+            logical_page_size,
+        ) {
             drop(buf_guard);
             return self.append_owned(IoBuf::copy_from_slice(buf)).await;
         }
@@ -332,20 +345,21 @@ impl<B: Blob> Append<B> {
         let mut buf_guard = self.buffer.write().await;
         let offset = buf_guard.size();
 
-        // Bytes needed to fill current page to a page boundary (0 if already aligned).
-        let fill = (logical_page_size - (buf_guard.len() % logical_page_size)) % logical_page_size;
-
-        // Buffer the bytes within the append buffer if the append fits within its capacity, or if
-        // no whole page remains to write directly after filling the current page to a page
-        // boundary.
-        let overflows_capacity = buf_guard.len() + buf.len() > buf_guard.capacity;
-        let has_full_page_after_fill = buf.len() >= fill + logical_page_size;
-        if !overflows_capacity || !has_full_page_after_fill {
+        // Buffer the append unless `buf` is too big for the buffer.
+        if !too_big_for_buffer(
+            buf_guard.len(),
+            buf_guard.capacity,
+            buf.len(),
+            logical_page_size,
+        ) {
             if buf_guard.append(buf.as_ref()) {
                 self.flush_internal(buf_guard, false, false).await?;
             }
             return Ok(offset);
         }
+
+        // Bytes needed to fill current page to a page boundary (0 if already aligned).
+        let fill = buf_guard.len().next_multiple_of(logical_page_size) - buf_guard.len();
 
         // Top up the tip to a page boundary so its contents flush as full pages, leaving any
         // partial-page CRC handling to the regular flush path.

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -305,6 +305,96 @@ impl<B: Blob> Append<B> {
         Ok(())
     }
 
+    /// Append all bytes in `buf` to the tip of the blob, writing whole pages directly to the
+    /// underlying blob instead of staging them in the write buffer when `buf` is large.
+    ///
+    /// Behaves like [Self::append], but a `buf` too large to buffer avoids the copy into the
+    /// write buffer (and the over-capacity allocation that copy requires): bytes needed to
+    /// complete the current partial page are buffered and flushed through the regular path, the
+    /// whole pages that follow are written to the blob as zero-copy slices of `buf`, and any
+    /// remaining partial-page suffix seeds the write buffer without copying.
+    ///
+    /// Unlike a buffered flush, the directly written pages do not populate the page cache (a
+    /// large write would evict most of it); they are cached on demand when read.
+    ///
+    /// Like [Self::append], the write is not durable until [Self::sync] is called.
+    pub async fn append_owned(&self, buf: IoBuf) -> Result<(), Error> {
+        let logical_page_size = self.cache_ref.page_size() as usize;
+        let mut buf_guard = self.buffer.write().await;
+
+        // Take the buffered path unless `buf` would push the buffer over capacity and at least
+        // one full page can be written directly from it.
+        let fill = (logical_page_size - (buf_guard.len() % logical_page_size)) % logical_page_size;
+        if buf_guard.len() + buf.len() <= buf_guard.capacity || buf.len() < fill + logical_page_size
+        {
+            if buf_guard.append(buf.as_ref()) {
+                self.flush_internal(buf_guard, false, false).await?;
+            }
+            return Ok(());
+        }
+
+        // Top up the tip to a page boundary so its contents flush as full pages, leaving any
+        // partial-page CRC handling to the regular flush path.
+        if fill > 0 {
+            buf_guard.append(&buf.as_ref()[..fill]);
+        }
+        let boundary = buf_guard.size();
+        if !buf_guard.is_empty() {
+            self.flush_internal(buf_guard, false, false).await?;
+
+            // The flush releases the buffer lock during blob I/O; if a concurrent append claimed
+            // the boundary in the meantime, finish with the buffered path.
+            buf_guard = self.buffer.write().await;
+            if buf_guard.size() != boundary || !buf_guard.is_empty() {
+                if buf_guard.append(&buf.as_ref()[fill..]) {
+                    self.flush_internal(buf_guard, false, false).await?;
+                }
+                return Ok(());
+            }
+        }
+
+        // Prepare physical pages for the whole pages remaining in `buf` without copying them.
+        // These pages are not inserted into the page cache: a write this large would evict most
+        // of the cache for data that may never be read, and any page of it that is read gets
+        // cached on demand by the page-fault path. Readers of this region are correct in the
+        // meantime because they block on the blob lock held below until the write completes.
+        let bulk_len = (buf.len() - fill) / logical_page_size * logical_page_size;
+        let bulk = buf.slice(fill..fill + bulk_len);
+        let mut physical_pages = IoBufs::default();
+        self.physical_full_pages(&bulk, None, &mut physical_pages);
+
+        // Acquire a write lock on the blob state so nobody tries to read or modify the blob
+        // while we're writing to it.
+        let mut blob_state = self.blob_state.write().await;
+        debug_assert!(
+            blob_state.partial_page_state.is_none(),
+            "an empty tip implies no partial page state"
+        );
+
+        // Update state before writing, seeding the tip with the partial-page suffix of `buf`.
+        // This may appear to risk data loss if writes fail, but write failures are fatal per
+        // this codebase's design - callers must not use the blob after any mutable method
+        // returns an error.
+        blob_state.current_page += (bulk_len / logical_page_size) as u64;
+        buf_guard.replace(boundary + bulk_len as u64, buf.slice(fill + bulk_len..));
+
+        // Make sure the buffer offset and underlying blob agree on the state of the tip.
+        assert_eq!(
+            blob_state.current_page * self.cache_ref.page_size(),
+            buf_guard.offset
+        );
+
+        // Release the buffer lock to allow for concurrent reads & buffered writes while we
+        // write the physical pages.
+        drop(buf_guard);
+
+        let physical_page_size = logical_page_size as u64 + CHECKSUM_SIZE;
+        let write_at_offset = boundary / logical_page_size as u64 * physical_page_size;
+        blob_state.write_at(write_at_offset, physical_pages).await?;
+
+        Ok(())
+    }
+
     /// Flush all full pages from the buffer to disk, resetting the buffer to contain only the bytes
     /// in any final partial page.
     ///
@@ -807,41 +897,11 @@ impl<B: Blob> Append<B> {
         let buffer_data = buffer.as_ref();
 
         if pages_to_write > 0 {
-            let logical_page_size_u16 =
-                u16::try_from(logical_page_size).expect("page size must fit in u16 for CRC record");
-
-            // Build CRC bytes for full pages once. Full-page payload bytes are appended below as
-            // slices from tip, so we avoid copying logical payload here.
-            let mut crcs = self
-                .cache_ref
-                .pool()
-                .alloc(CHECKSUM_SIZE as usize * pages_to_write);
-            for page in 0..pages_to_write {
-                let start_read_idx = page * logical_page_size;
-                let end_read_idx = start_read_idx + logical_page_size;
-                let logical_page = &buffer_data[start_read_idx..end_read_idx];
-                let crc = Crc32::checksum(logical_page);
-
-                // For the first page, if there's an old partial page CRC, construct the record
-                // to preserve the old CRC in its original slot.
-                let crc_record = if let (0, Some(old_crc)) = (page, old_crc_record) {
-                    Self::build_crc_record_preserving_old(logical_page_size_u16, crc, old_crc)
-                } else {
-                    Checksum::new(logical_page_size_u16, crc)
-                };
-                crcs.put_slice(&crc_record.to_bytes());
-            }
-            let crc_blob = crcs.freeze();
-
-            // Physical full-page layout is [logical_page_bytes, crc_record_bytes].
-            for page in 0..pages_to_write {
-                let start_read_idx = page * logical_page_size;
-                let end_read_idx = start_read_idx + logical_page_size;
-                write_buffer.append(buffer.slice(start_read_idx..end_read_idx));
-
-                let crc_start = page * CHECKSUM_SIZE as usize;
-                write_buffer.append(crc_blob.slice(crc_start..crc_start + CHECKSUM_SIZE as usize));
-            }
+            self.physical_full_pages(
+                &buffer.slice(..pages_to_write * logical_page_size),
+                old_crc_record,
+                &mut write_buffer,
+            );
         }
 
         if !include_partial_page {
@@ -889,6 +949,56 @@ impl<B: Blob> Append<B> {
         // Return the CRC record that matches what we wrote to disk, so that future flushes
         // correctly identify which slot is protected.
         (write_buffer, Some(crc_record))
+    }
+
+    /// Append the physical-page representation of `data` to `write_buffer`: payload bytes as
+    /// zero-copy slices of `data`, interleaved with newly built CRC records.
+    ///
+    /// `data` must contain a non-zero whole number of logical pages. If `old_crc_record` is
+    /// present, the first page's CRC record preserves the old CRC in its original slot.
+    fn physical_full_pages(
+        &self,
+        data: &IoBuf,
+        old_crc_record: Option<&Checksum>,
+        write_buffer: &mut IoBufs,
+    ) {
+        let logical_page_size = self.cache_ref.page_size() as usize;
+        let pages = data.len() / logical_page_size;
+        debug_assert!(pages > 0);
+        debug_assert_eq!(data.len() % logical_page_size, 0);
+        let logical_page_size_u16 =
+            u16::try_from(logical_page_size).expect("page size must fit in u16 for CRC record");
+
+        // Build CRC bytes for full pages once. Full-page payload bytes are appended below as
+        // slices from `data`, so we avoid copying logical payload here.
+        let mut crcs = self.cache_ref.pool().alloc(CHECKSUM_SIZE as usize * pages);
+        let data_bytes = data.as_ref();
+        for page in 0..pages {
+            let start_read_idx = page * logical_page_size;
+            let end_read_idx = start_read_idx + logical_page_size;
+            let logical_page = &data_bytes[start_read_idx..end_read_idx];
+            let crc = Crc32::checksum(logical_page);
+
+            // For the first page, if there's an old partial page CRC, construct the record
+            // to preserve the old CRC in its original slot.
+            let crc_record = if let (0, Some(old_crc)) = (page, old_crc_record) {
+                Self::build_crc_record_preserving_old(logical_page_size_u16, crc, old_crc)
+            } else {
+                Checksum::new(logical_page_size_u16, crc)
+            };
+            crcs.put_slice(&crc_record.to_bytes());
+        }
+        let crc_blob = crcs.freeze();
+
+        // Physical full-page layout is [logical_page_bytes, crc_record_bytes].
+        for page in 0..pages {
+            let start_read_idx = page * logical_page_size;
+            let end_read_idx = start_read_idx + logical_page_size;
+            write_buffer.append(data.slice(start_read_idx..end_read_idx));
+
+            let crc_start = page * CHECKSUM_SIZE as usize;
+            write_buffer.append(crc_blob.slice(crc_start..crc_start + CHECKSUM_SIZE as usize));
+        }
     }
 
     /// Encode one checksum slot as `[len: u16][crc: u32]`, matching `Checksum::write`.
@@ -1745,6 +1855,216 @@ mod tests {
             // Verify data is still readable after reopen.
             let read_buf = append.read_at(0, 206).await.unwrap().coalesce();
             assert_eq!(read_buf, &expected[..]);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_append_owned_bypass_from_empty_tip() {
+        // A large owned append from an empty, page-aligned tip writes whole pages directly to the
+        // blob and leaves the partial-page suffix buffered.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"owned_empty")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // 500 bytes = 4 full pages (412 bytes) + 88-byte remainder.
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            append
+                .append_owned(IoBuf::from(data.clone()))
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 500);
+
+            // The directly written pages do not populate the page cache.
+            let mut probe = vec![0u8; PAGE_SIZE.get() as usize];
+            assert_eq!(append.cache_ref.read_cached(append.id, &mut probe, 0), 0);
+
+            // All bytes are readable before any sync (bulk from the blob, suffix from tip).
+            let read_buf = append.read_at(0, 500).await.unwrap().coalesce();
+            assert_eq!(read_buf, &data[..]);
+
+            // Pages of the bulk region are cached on demand by reads.
+            assert_eq!(
+                append.cache_ref.read_cached(append.id, &mut probe, 0),
+                PAGE_SIZE.get() as usize
+            );
+
+            // Everything becomes durable with a single sync.
+            append.sync().await.unwrap();
+            drop(append);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"owned_empty")
+                .await
+                .unwrap();
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 500);
+            let read_buf = append.read_at(0, 500).await.unwrap().coalesce();
+            assert_eq!(read_buf, &data[..]);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_append_owned_bypass_with_synced_partial_page() {
+        // A large owned append on top of a synced partial page must run the protected-CRC
+        // handling for the first page before writing the bulk directly.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"owned_partial")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Durably write a 50-byte partial page.
+            let all: Vec<u8> = (0..500).map(|i| (i % 247) as u8).collect();
+            append.append(&all[..50]).await.unwrap();
+            append.sync().await.unwrap();
+
+            // 450 more bytes: 53 fill the first page (protected CRC), 3 whole pages (309 bytes)
+            // bypass the buffer, 88 remain in the tip.
+            append
+                .append_owned(IoBuf::from(all[50..].to_vec()))
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 500);
+            let read_buf = append.read_at(0, 500).await.unwrap().coalesce();
+            assert_eq!(read_buf, &all[..]);
+
+            // The direct write is not durable until sync: dropping without one preserves only the
+            // synced 50-byte prefix.
+            drop(append);
+            let (blob, blob_size) = context
+                .open("test_partition", b"owned_partial")
+                .await
+                .unwrap();
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 50);
+            let read_buf = append.read_at(0, 50).await.unwrap().coalesce();
+            assert_eq!(read_buf, &all[..50]);
+
+            // Repeating the owned append after recovery and syncing makes everything durable,
+            // exercising the protected-CRC handling for the recovered partial page.
+            append
+                .append_owned(IoBuf::from(all[50..].to_vec()))
+                .await
+                .unwrap();
+            append.sync().await.unwrap();
+            drop(append);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"owned_partial")
+                .await
+                .unwrap();
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 500);
+            let read_buf = append.read_at(0, 500).await.unwrap().coalesce();
+            assert_eq!(read_buf, &all[..]);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_append_owned_bypass_with_buffered_tip() {
+        // A large owned append merges with unsynced buffered bytes: the fill completes the
+        // current page, the bulk bypasses the buffer, and everything is readable.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"owned_buffered")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let all: Vec<u8> = (0..430).map(|i| (i % 239) as u8).collect();
+            append.append(&all[..30]).await.unwrap();
+            append
+                .append_owned(IoBuf::from(all[30..].to_vec()))
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 430);
+            let read_buf = append.read_at(0, 430).await.unwrap().coalesce();
+            assert_eq!(read_buf, &all[..]);
+
+            append.sync().await.unwrap();
+            drop(append);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"owned_buffered")
+                .await
+                .unwrap();
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 430);
+            let read_buf = append.read_at(0, 430).await.unwrap().coalesce();
+            assert_eq!(read_buf, &all[..]);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_append_owned_exact_page_multiple_and_small() {
+        // An owned append of an exact page multiple leaves an empty tip that later buffered and
+        // small owned appends continue from; small owned appends use the buffered path.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"owned_exact")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Exactly 4 pages: no remainder.
+            let bulk: Vec<u8> = (0..412).map(|i| (i % 233) as u8).collect();
+            append
+                .append_owned(IoBuf::from(bulk.clone()))
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 412);
+
+            // A small owned append takes the buffered path.
+            let small: Vec<u8> = (0..10).map(|i| (i % 229) as u8).collect();
+            append
+                .append_owned(IoBuf::from(small.clone()))
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 422);
+
+            let read_buf = append.read_at(0, 422).await.unwrap().coalesce();
+            assert_eq!(&read_buf.as_ref()[..412], &bulk[..]);
+            assert_eq!(&read_buf.as_ref()[412..], &small[..]);
+
+            append.sync().await.unwrap();
+            drop(append);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"owned_exact")
+                .await
+                .unwrap();
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(append.size().await, 422);
         });
     }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -294,10 +294,6 @@ impl<B: Blob> Append<B> {
     }
 
     /// Append all bytes in `buf` to the tip of the blob.
-    ///
-    /// A `buf` too large to fit in the write buffer is copied once into an owned buffer and
-    /// written through [Self::append_owned]'s direct path, so the write buffer never grows
-    /// meaningfully beyond its capacity no matter how large the append.
     pub async fn append(&self, buf: &[u8]) -> Result<(), Error> {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let mut buffer = self.buffer.write().await;

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -293,8 +293,9 @@ impl<B: Blob> Append<B> {
         Ok((None, 0, invalid_data_found))
     }
 
-    /// Append all bytes in `buf` to the tip of the blob.
-    pub async fn append(&self, buf: &[u8]) -> Result<(), Error> {
+    /// Append all bytes in `buf` to the tip of the blob, returning the logical offset at which
+    /// the first byte was written.
+    pub async fn append(&self, buf: &[u8]) -> Result<u64, Error> {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let mut buffer = self.buffer.write().await;
 
@@ -302,10 +303,11 @@ impl<B: Blob> Append<B> {
         // one full page could be written directly from it.
         let fill = (logical_page_size - (buffer.len() % logical_page_size)) % logical_page_size;
         if buffer.len() + buf.len() <= buffer.capacity || buf.len() < fill + logical_page_size {
+            let offset = buffer.size();
             if buffer.append(buf) {
                 self.flush_internal(buffer, false, false).await?;
             }
-            return Ok(());
+            return Ok(offset);
         }
         drop(buffer);
 
@@ -322,9 +324,10 @@ impl<B: Blob> Append<B> {
     /// flush would), and the remaining sub-page suffix is buffered.
     ///
     /// Like [Self::append], the write is not durable until [Self::sync] is called.
-    pub async fn append_owned(&self, buf: IoBuf) -> Result<(), Error> {
+    pub async fn append_owned(&self, buf: IoBuf) -> Result<u64, Error> {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let mut buf_guard = self.buffer.write().await;
+        let offset = buf_guard.size();
 
         // Take the buffered path unless `buf` would push the buffer over capacity and at least
         // one full page can be written directly from it.
@@ -334,7 +337,7 @@ impl<B: Blob> Append<B> {
             if buf_guard.append(buf.as_ref()) {
                 self.flush_internal(buf_guard, false, false).await?;
             }
-            return Ok(());
+            return Ok(offset);
         }
 
         // Top up the tip to a page boundary so its contents flush as full pages, leaving any
@@ -413,7 +416,7 @@ impl<B: Blob> Append<B> {
         let write_at_offset = boundary / logical_page_size as u64 * physical_page_size;
         blob_state.write_at(write_at_offset, physical_pages).await?;
 
-        Ok(())
+        Ok(offset)
     }
 
     /// Flush all full pages from the buffer to disk, resetting the buffer to contain only the bytes

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -212,6 +212,15 @@ impl Buffer {
         true
     }
 
+    /// Replaces the buffered contents with `data` positioned at blob offset `offset`, without
+    /// copying. The capacity and pool are preserved; a later mutation recovers or reallocates
+    /// backing via [Self::writable].
+    pub(super) fn replace(&mut self, offset: u64, data: IoBuf) {
+        self.len = data.len();
+        self.data = data;
+        self.offset = offset;
+    }
+
     /// Appends the provided `data` to the buffer, and returns `true` if the buffer is over capacity
     /// after the append.
     ///

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -97,7 +97,7 @@ use crate::{
     Context,
 };
 use commonware_codec::CodecFixedShared;
-use commonware_runtime::buffer::paged::CacheRef;
+use commonware_runtime::{buffer::paged::CacheRef, IoBuf};
 use commonware_utils::{
     sequence::VecU64,
     sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard},
@@ -1159,6 +1159,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         if items_count == 0 {
             return Err(Error::EmptyAppend);
         }
+        let items_buf = IoBuf::from(items_buf);
 
         let _op_guard = self.op_lock.lock().await;
         let mut inner = self.inner.write().await;
@@ -1182,7 +1183,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
             inner
                 .journal
-                .append_raw(section, &items_buf[start..end])
+                .append_raw(section, items_buf.slice(start..end))
                 .await?;
             inner.size += batch_count as u64;
             written += batch_count;
@@ -2615,7 +2616,7 @@ mod tests {
                 let mut inner = journal.inner.write().await;
                 inner
                     .journal
-                    .append_raw(0, extra.as_ref())
+                    .append_raw(0, IoBuf::copy_from_slice(extra.as_ref()))
                     .await
                     .expect("failed to append extra item");
                 inner
@@ -3543,6 +3544,54 @@ mod tests {
                     journal.read(position).await.unwrap(),
                     items[index],
                     "item at position {position} did not match after reopen"
+                );
+            }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_append_many_exceeding_write_buffer() {
+        // A batch much larger than the write buffer (2048 bytes = 64 digests) takes the direct
+        // blob-write path and spans multiple sections.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(100));
+            let journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Start mid-page with a couple of single appends so the batch begins unaligned.
+            journal.append(&test_digest(0)).await.unwrap();
+            journal.append(&test_digest(1)).await.unwrap();
+
+            let items: Vec<_> = (2..252u64).map(test_digest).collect();
+            let last = journal.append_many(Many::Flat(&items)).await.unwrap();
+            assert_eq!(last, 251);
+            assert_eq!(journal.bounds().await, 0..252);
+
+            // Every item is readable before any sync.
+            for pos in 0..252u64 {
+                assert_eq!(
+                    journal.read(pos).await.unwrap(),
+                    test_digest(pos),
+                    "item at position {pos} did not match"
+                );
+            }
+
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..252);
+            for pos in 0..252u64 {
+                assert_eq!(
+                    journal.read(pos).await.unwrap(),
+                    test_digest(pos),
+                    "item at position {pos} did not match after reopen"
                 );
             }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use commonware_codec::{Codec, CodecShared};
 use commonware_macros::boxed;
-use commonware_runtime::buffer::paged::CacheRef;
+use commonware_runtime::{buffer::paged::CacheRef, IoBuf};
 use commonware_utils::{
     sync::{AsyncMutex, AsyncRwLock, AsyncRwLockReadGuard},
     NZUsize,
@@ -822,6 +822,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             return Err(Error::EmptyAppend);
         }
 
+        let encoded = IoBuf::from(encoded);
+
         let _op_guard = self.op_lock.lock().await;
 
         // Mutating operations are serialized by taking the write guard.
@@ -850,7 +852,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             // into absolute offsets.
             let base_offset = inner
                 .data
-                .append_raw(section, &encoded[batch_start..batch_end])
+                .append_raw(section, encoded.slice(batch_start..batch_end))
                 .await?;
 
             let absolute_offsets = item_starts[written..written + batch_count]

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1596,6 +1596,60 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_variable_append_many_exceeding_write_buffer() {
+        // A batch much larger than the write buffer takes the direct blob-write path, spanning
+        // multiple sections so append_raw receives interior slices of the encoded batch buffer.
+        // The returned base offsets feed the offsets journal, so every position must remain
+        // readable by random access after the direct writes.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "append-many-direct".into(),
+                items_per_section: NZU64!(25),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(1024),
+            };
+            let journal = Journal::<_, FixedBytes<64>>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Start mid-page with single appends so the batch begins unaligned.
+            let item = |i: usize| {
+                let mut bytes = [0u8; 64];
+                bytes[..8].copy_from_slice(&(i as u64).to_be_bytes());
+                FixedBytes::new(bytes)
+            };
+            journal.append(&item(0)).await.unwrap();
+            journal.append(&item(1)).await.unwrap();
+
+            // ~6.5KB encoded, far above the 1KB write buffer, crossing section boundaries.
+            let items: Vec<_> = (2..102).map(item).collect();
+            let last = journal.append_many(Many::Flat(&items)).await.unwrap();
+            assert_eq!(last, 101);
+
+            // Every item is readable before any sync.
+            for pos in 0..102u64 {
+                assert_eq!(journal.read(pos).await.unwrap(), item(pos as usize));
+            }
+
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, FixedBytes<64>>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..102);
+            for pos in 0..102u64 {
+                assert_eq!(journal.read(pos).await.unwrap(), item(pos as usize));
+            }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_variable_init_at_max_size_rejected() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -140,8 +140,6 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     /// Append pre-encoded bytes to the given section.
     ///
     /// The buffer must contain one or more encoded items with size [Self::CHUNK_SIZE] each.
-    /// Buffers too large for the write buffer are written directly to the blob without an
-    /// intermediate copy.
     ///
     /// # Panics
     ///

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -25,7 +25,7 @@ use crate::journal::Error;
 use commonware_codec::{CodecFixed, CodecFixedShared, DecodeExt as _, ReadExt as _};
 use commonware_runtime::{
     buffer::paged::{CacheRef, Replay},
-    Blob, Buf, Metrics, Storage,
+    Blob, Buf, IoBuf, Metrics, Storage,
 };
 use futures::{
     stream::{self, Stream},
@@ -140,20 +140,19 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     /// Append pre-encoded bytes to the given section.
     ///
     /// The buffer must contain one or more encoded items with size [Self::CHUNK_SIZE] each.
+    /// Buffers too large for the write buffer are written directly to the blob without an
+    /// intermediate copy.
     ///
     /// # Panics
     ///
     /// Panics if `buf` is empty or not a multiple of [Self::CHUNK_SIZE].
-    pub(crate) async fn append_raw(&mut self, section: u64, buf: &[u8]) -> Result<(), Error> {
+    pub(crate) async fn append_raw(&mut self, section: u64, buf: IoBuf) -> Result<(), Error> {
         assert!(!buf.is_empty());
         assert!(buf.len().is_multiple_of(Self::CHUNK_SIZE));
+        let count = buf.len() / Self::CHUNK_SIZE;
         let blob = self.manager.get_or_create(section).await?;
-        blob.append(buf).await?;
-        trace!(
-            section,
-            count = buf.len() / Self::CHUNK_SIZE,
-            "appended items"
-        );
+        blob.append_owned(buf).await?;
+        trace!(section, count, "appended items");
         Ok(())
     }
 

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -123,15 +123,13 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     pub async fn append(&mut self, section: u64, item: &A) -> Result<u64, Error> {
         let blob = self.manager.get_or_create(section).await?;
 
-        let size = blob.size().await;
-        if !size.is_multiple_of(Self::CHUNK_SIZE_U64) {
-            return Err(Error::InvalidBlobSize(section, size));
-        }
-        let position = size / Self::CHUNK_SIZE_U64;
-
         // Encode the item
         let buf = item.encode_mut();
-        blob.append(&buf).await?;
+        let offset = blob.append(&buf).await?;
+        if !offset.is_multiple_of(Self::CHUNK_SIZE_U64) {
+            return Err(Error::InvalidBlobSize(section, offset));
+        }
+        let position = offset / Self::CHUNK_SIZE_U64;
         trace!(section, position, "appended item");
 
         Ok(position)
@@ -170,14 +168,16 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         let offset = position
             .checked_mul(Self::CHUNK_SIZE_U64)
             .ok_or(Error::ItemOutOfRange(position))?;
-        let end = offset
-            .checked_add(Self::CHUNK_SIZE_U64)
-            .ok_or(Error::ItemOutOfRange(position))?;
-        if end > blob.size().await {
-            return Err(Error::ItemOutOfRange(position));
-        }
 
-        let buf = blob.read_at(offset, Self::CHUNK_SIZE).await?;
+        // The read validates bounds against the blob's logical size.
+        let buf = blob
+            .read_at(offset, Self::CHUNK_SIZE)
+            .await
+            .map_err(|err| match err {
+                commonware_runtime::Error::BlobInsufficientLength
+                | commonware_runtime::Error::OffsetOverflow => Error::ItemOutOfRange(position),
+                err => Error::Runtime(err),
+            })?;
         A::decode(buf.coalesce()).map_err(Error::Codec)
     }
 

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -588,8 +588,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// Append pre-encoded bytes to the given section, returning the byte offset
     /// where the data was written.
     ///
-    /// The buffer must be in the on-disk format produced by [Self::encode_item]. Buffers too
-    /// large for the write buffer are written directly to the blob without an intermediate copy.
+    /// The buffer must be in the on-disk format produced by [Self::encode_item].
     pub(crate) async fn append_raw(&mut self, section: u64, buf: IoBuf) -> Result<u64, Error> {
         let blob = self.manager.get_or_create(section).await?;
         let offset = blob.size().await;

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -591,8 +591,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// The buffer must be in the on-disk format produced by [Self::encode_item].
     pub(crate) async fn append_raw(&mut self, section: u64, buf: IoBuf) -> Result<u64, Error> {
         let blob = self.manager.get_or_create(section).await?;
-        let offset = blob.size().await;
-        blob.append_owned(buf).await?;
+        let offset = blob.append_owned(buf).await?;
         trace!(blob = section, offset, "appended item");
         Ok(offset)
     }

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -580,7 +580,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// from the raw encoded size if compression is enabled).
     pub async fn append(&mut self, section: u64, item: &V) -> Result<(u64, u32), Error> {
         let (buf, item_len) = Self::encode_item(self.compression, item)?;
-        self.append_raw(section, &buf)
+        self.append_raw(section, IoBuf::from(buf))
             .await
             .map(|offset| (offset, item_len))
     }
@@ -588,11 +588,12 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// Append pre-encoded bytes to the given section, returning the byte offset
     /// where the data was written.
     ///
-    /// The buffer must be in the on-disk format produced by [Self::encode_item].
-    pub(crate) async fn append_raw(&mut self, section: u64, buf: &[u8]) -> Result<u64, Error> {
+    /// The buffer must be in the on-disk format produced by [Self::encode_item]. Buffers too
+    /// large for the write buffer are written directly to the blob without an intermediate copy.
+    pub(crate) async fn append_raw(&mut self, section: u64, buf: IoBuf) -> Result<u64, Error> {
         let blob = self.manager.get_or_create(section).await?;
         let offset = blob.size().await;
-        blob.append(buf).await?;
+        blob.append_owned(buf).await?;
         trace!(blob = section, offset, "appended item");
         Ok(offset)
     }
@@ -1393,7 +1394,7 @@ mod tests {
                 .await
                 .expect("Failed to append item");
             journal
-                .append_raw(section, &[0xFF, 0xFF])
+                .append_raw(section, IoBuf::copy_from_slice(&[0xFF, 0xFF]))
                 .await
                 .expect("Failed to append trailing bytes");
             journal.sync(section).await.expect("Failed to sync journal");

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -2447,6 +2447,85 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_journal_large_item_direct_path() {
+        // Items larger than the write buffer are written directly to the blob. The first append
+        // takes the direct path from an empty tip; the second takes it with a non-empty tip
+        // (holding the first item's sub-page remainder), covering both top-up branches. The
+        // returned offsets must remain correct since callers persist them for random access.
+        const LARGE_SIZE: usize = 2048;
+        type LargeItem = [u8; LARGE_SIZE];
+
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-partition".into(),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::init(context.child("first"), cfg.clone())
+                .await
+                .expect("Failed to initialize journal");
+
+            let mut first: LargeItem = [0u8; LARGE_SIZE];
+            for (i, byte) in first.iter_mut().enumerate() {
+                *byte = (i % 256) as u8;
+            }
+            let mut second: LargeItem = [0u8; LARGE_SIZE];
+            for (i, byte) in second.iter_mut().enumerate() {
+                *byte = ((i + 7) % 251) as u8;
+            }
+
+            let (first_offset, _) = journal
+                .append(1, &first)
+                .await
+                .expect("Failed to append first item");
+            let (second_offset, _) = journal
+                .append(1, &second)
+                .await
+                .expect("Failed to append second item");
+
+            // Both items are readable at their returned offsets before any sync.
+            let retrieved: LargeItem = journal.get(1, first_offset).await.unwrap();
+            assert_eq!(retrieved, first);
+            let retrieved: LargeItem = journal.get(1, second_offset).await.unwrap();
+            assert_eq!(retrieved, second);
+
+            // Everything survives a sync and reopen.
+            journal.sync(1).await.expect("Failed to sync");
+            drop(journal);
+            let journal = Journal::<_, LargeItem>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("Failed to re-initialize journal");
+
+            let retrieved: LargeItem = journal.get(1, first_offset).await.unwrap();
+            assert_eq!(retrieved, first);
+            let retrieved: LargeItem = journal.get(1, second_offset).await.unwrap();
+            assert_eq!(retrieved, second);
+
+            {
+                let stream = journal
+                    .replay(0, 0, NZUsize!(1024))
+                    .await
+                    .expect("Failed to setup replay");
+                pin_mut!(stream);
+
+                let mut items = Vec::new();
+                while let Some(result) = stream.next().await {
+                    let (section, off, _, item) = result.expect("Failed to replay item");
+                    items.push((section, off, item));
+                }
+                assert_eq!(items.len(), 2);
+                assert_eq!(items[0], (1, first_offset, first));
+                assert_eq!(items[1], (1, second_offset, second));
+            }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_journal_non_contiguous_sections() {
         // Test that sections with gaps in numbering work correctly.
         // Sections 1, 5, 10 should all be independent and accessible.

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -599,18 +599,24 @@ pub mod tests {
     }
 
     /// Commit a set of writes as a single batch.
-    async fn commit_writes<F: merkle::Graftable, C: DbAny<F>>(
-        db: &mut C,
-        writes: impl IntoIterator<Item = (C::Key, Option<<C as DbAny<F>>::Value>)>,
-    ) -> Result<(), Error<F>> {
-        let mut batch = db.new_batch();
-        for (k, v) in writes {
-            batch = batch.write(k, v);
-        }
-        let merkleized = batch.merkleize(db, None).await?;
-        db.apply_batch(merkleized).await?;
-        db.commit().await?;
-        Ok(())
+    ///
+    /// Returns a boxed future so the merkleize/apply/commit chain does not inflate the futures
+    /// (and poll frames) of every test composing commits, which overflow the stack on platforms
+    /// with small defaults.
+    fn commit_writes<'a, F: merkle::Graftable, C: DbAny<F>>(
+        db: &'a mut C,
+        writes: impl IntoIterator<Item = (C::Key, Option<<C as DbAny<F>>::Value>)> + 'a,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), Error<F>>> + 'a>> {
+        Box::pin(async move {
+            let mut batch = db.new_batch();
+            for (k, v) in writes {
+                batch = batch.write(k, v);
+            }
+            let merkleized = batch.merkleize(db, None).await?;
+            db.apply_batch(merkleized).await?;
+            db.commit().await?;
+            Ok(())
+        })
     }
 
     /// Apply random operations to the given db, committing them (randomly and at the end) only if
@@ -740,7 +746,7 @@ pub mod tests {
     {
         let mut open_db_clone = open_db.clone();
         let partition = "commit-after-sync".to_string();
-        let mut db: C = open_db_clone(context.child("first"), partition.clone()).await;
+        let mut db: C = Box::pin(open_db_clone(context.child("first"), partition.clone())).await;
         let key0 = <<C as DbAny<M>>::Key as TestKey>::from_seed(0);
         let key1 = <<C as DbAny<M>>::Key as TestKey>::from_seed(1);
         let value0 = <C as DbAny<M>>::Value::from_seed(100);
@@ -760,7 +766,7 @@ pub mod tests {
         let committed_size = db.size().await;
         drop(db);
 
-        let db: C = open_db(context.child("second"), partition).await;
+        let db: C = Box::pin(open_db(context.child("second"), partition)).await;
         assert_eq!(db.root(), committed_root);
         assert_eq!(db.size().await, committed_size);
         assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
@@ -786,7 +792,7 @@ pub mod tests {
 
         let partition = "build-random-fail-commit".to_string();
         let rng_seed = context.next_u64();
-        let mut db: C = open_db(context.child("first"), partition.clone()).await;
+        let mut db: C = Box::pin(open_db(context.child("first"), partition.clone())).await;
         db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
             .await
             .unwrap();
@@ -803,10 +809,10 @@ pub mod tests {
         // SCENARIO #1: Simulate a crash that happens before any writes. Upon reopening, the
         // state of the DB should be as of the last commit.
         drop(db);
-        let db: C = open_db(
+        let db: C = Box::pin(open_db(
             context.child("scenario").with_attribute("index", 1),
             partition.clone(),
-        )
+        ))
         .await;
         assert_eq!(db.root(), committed_root);
         assert_eq!(db.bounds().await.end, committed_op_count);
@@ -824,17 +830,17 @@ pub mod tests {
 
         // We should be able to recover, so the root should differ from the previous commit, and
         // the op count should be greater than before.
-        let db: C = open_db(
+        let db: C = Box::pin(open_db(
             context.child("scenario").with_attribute("index", 2),
             partition.clone(),
-        )
+        ))
         .await;
         let scenario_2_root = db.root();
 
         // To confirm the second committed hash is correct we'll re-build the DB in a new
         // partition, but without any failures. They should have the exact same state.
         let fresh_partition = "build-random-fail-commit-fresh".to_string();
-        let mut db: C = open_db(context.child("fresh"), fresh_partition.clone()).await;
+        let mut db: C = Box::pin(open_db(context.child("fresh"), fresh_partition.clone())).await;
         db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
             .await
             .unwrap();
@@ -869,9 +875,13 @@ pub mod tests {
 
         let mut open_db_clone = open_db.clone();
         // Create two databases that are identical other than how they are pruned.
-        let mut db_no_pruning: C =
-            open_db_clone(context.child("no_pruning"), "no-pruning-test".into()).await;
-        let mut db_pruning: C = open_db(context.child("pruning"), "pruning-test".into()).await;
+        let mut db_no_pruning: C = Box::pin(open_db_clone(
+            context.child("no_pruning"),
+            "no-pruning-test".into(),
+        ))
+        .await;
+        let mut db_pruning: C =
+            Box::pin(open_db(context.child("pruning"), "pruning-test".into())).await;
 
         // Apply identical operations to both databases, but only prune one.
         // Accumulate writes between commits.
@@ -943,7 +953,7 @@ pub mod tests {
         let mut open_db_clone = open_db.clone();
         let partition = "sync-bitmap-pruning".to_string();
         let rng_seed = context.next_u64();
-        let mut db: C = open_db_clone(context.child("first"), partition.clone()).await;
+        let mut db: C = Box::pin(open_db_clone(context.child("first"), partition.clone())).await;
 
         // Apply random operations with commits to advance the inactivity floor.
         db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
@@ -977,7 +987,7 @@ pub mod tests {
         drop(db);
 
         // Reopen the database.
-        let db: C = open_db(context.child("second"), partition).await;
+        let db: C = Box::pin(open_db(context.child("second"), partition)).await;
 
         // The pruned bits count should match. If sync() didn't persist the bitmap pruned
         // state, this would be 0.
@@ -1012,7 +1022,7 @@ pub mod tests {
         const ELEMENTS: u64 = 1000;
 
         let mut open_db_clone = open_db.clone();
-        let mut db: C = open_db_clone(context.child("first"), "build-big".into()).await;
+        let mut db: C = Box::pin(open_db_clone(context.child("first"), "build-big".into())).await;
 
         let mut map = std::collections::HashMap::<C::Key, <C as DbAny<M>>::Value>::default();
 
@@ -1061,7 +1071,7 @@ pub mod tests {
         drop(db);
 
         // Reopen the db and verify it has exactly the same state.
-        let db: C = open_db(context.child("second"), "build-big".into()).await;
+        let db: C = Box::pin(open_db(context.child("second"), "build-big".into())).await;
         assert_eq!(root, db.root());
 
         // Confirm the db's state matches that of the separate map we computed independently.
@@ -1090,7 +1100,11 @@ pub mod tests {
         F: FnMut(Context, String) -> Fut,
         Fut: Future<Output = C>,
     {
-        let mut db: C = open_db(context.child("db"), "stale-side-effect-free".into()).await;
+        let mut db: C = Box::pin(open_db(
+            context.child("db"),
+            "stale-side-effect-free".into(),
+        ))
+        .await;
 
         let key1 = <C::Key as TestKey>::from_seed(1);
         let key2 = <C::Key as TestKey>::from_seed(2);
@@ -2651,7 +2665,7 @@ pub mod tests {
         // 260 writes + 1 CommitFloor = 261 operations, completing one chunk with 5 ops in the
         // next partial chunk. This ensures the grafted root computation must handle the
         // newly completed chunk.
-        let mut db: C = open_db_clone(context.child("init"), partition.clone()).await;
+        let mut db: C = Box::pin(open_db_clone(context.child("init"), partition.clone())).await;
         let mut batch = db.new_batch();
         for i in 0..260 {
             batch = batch.write(TestKey::from_seed(i), Some(TestValue::from_seed(i + 1000)));
@@ -2664,7 +2678,7 @@ pub mod tests {
         db.sync().await.unwrap();
         drop(db);
 
-        let db: C = open_db(context.child("reopen"), partition).await;
+        let db: C = Box::pin(open_db(context.child("reopen"), partition)).await;
         assert_eq!(db.root(), speculative_root);
 
         db.destroy().await.unwrap();


### PR DESCRIPTION
  ## Write large appends directly to the blob

  An append larger than the write buffer previously ballooned the buffer to the append's full size: the bytes were copied into the buffer, flushed, and copied again into the page cache. Now `Append::append_owned` writes whole pages of an owned buffer directly to the blob as zero-copy slices (the current partial page is topped up and flushed through the regular protected-CRC path first, and the sub-page tail stays buffered), so the write buffer never grows meaningfully beyond capacity for any caller. The fixed and variable journals pass owned `IoBuf`s down, making batched appends (e.g. qmdb commits) zero-copy end to end. Page-cache population, on-disk format, and durability semantics are unchanged and pinned by tests (including byte-identical physical output vs the buffered path).

No shared state is mutated before the last suspension point (a dropped future leaves no trace), concurrent mutable operations fail loudly instead of silently interleaving (mirroring `resize`), the buffered tail is copied so it cannot pin the caller's batch allocation, and the page cache is populated in write-buffer-sized chunks so readers are never stalled behind a multi-MB copy.

 Benchmarks vs main: merkle::flush −5–8% at n=100k (n=10k control flat: the path only engages above the write buffer); qmdb::apply_batch −6 to −12% on the journal-I/O-heavy ancestor cases (uncomm_ancestor, comm_uncomm_chain, multi_uncomm), with the in-memory direct and comm_ancestor cases flat; prove/read/small-append/variable-journal benches all flat.
