### PR TITLE
[qmdb/any] Cache batch reads for ordered merkleize

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -42,8 +42,10 @@ type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 /// of a given key during ordered merkleization.
 type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
 
-/// Committed-DB locations cached by a batch's reads, keyed by the resolved key.
-type ResolvedReads<F, U> = AHashMap<<U as update::Update>::Key, Location<F>>;
+/// Committed-DB locations (plus the update kind's cached payload) cached by a batch's reads,
+/// keyed by the resolved key.
+type ResolvedReads<F, U> =
+    AHashMap<<U as update::Update>::Key, (Location<F>, <U as update::Update>::Cached)>;
 
 /// What happened to a key in this batch.
 #[derive(Clone)]
@@ -182,11 +184,11 @@ where
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
 
-    /// Committed-DB locations cached by this batch's reads (`get`/`get_many`), keyed by the
-    /// key they matched. Populated only when `U::CACHES_READS` and consumed by `merkleize`:
-    /// when a mutation key is present here, `merkleize` reuses the location and skips the
-    /// redundant journal read. Ordered batches cache nothing: their op generation needs each
-    /// read operation's value and next key, so merkleize re-reads ops regardless.
+    /// Committed-DB locations (plus the update kind's cached payload) cached by this batch's
+    /// reads (`get`/`get_many`), keyed by the key they matched. Populated only when
+    /// `U::CACHES_READS` and consumed by `merkleize`: when a mutation key is present here,
+    /// `merkleize` reuses the location (and, for ordered, the old value and next key) and
+    /// skips the redundant index probe and journal read.
     ///
     /// Only committed-snapshot resolutions are cached. A cached location doubles as the
     /// key's previous committed location (`base_old_loc`), which holds because a
@@ -976,15 +978,20 @@ where
         }
 
         if !db_keys.is_empty() {
-            let db_results = db.get_many_with_locations(&db_keys).await?;
+            let db_results = if U::CACHES_READS {
+                db.get_many_with_locations::<true>(&db_keys).await?
+            } else {
+                db.get_many_with_locations::<false>(&db_keys).await?
+            };
             let mut resolved = U::CACHES_READS.then(|| self.resolved.lock());
             if let Some(resolved) = resolved.as_deref_mut() {
                 resolved.reserve(db_keys.len());
             }
             for (slot, result) in db_indices.into_iter().zip(db_results) {
-                results[slot] = result.map(|(value, loc)| {
+                results[slot] = result.map(|(value, loc, cached)| {
                     if let Some(resolved) = resolved.as_deref_mut() {
-                        resolved.insert((*keys[slot]).clone(), loc);
+                        let cached = cached.expect("cached payload requested for caching reads");
+                        resolved.insert((*keys[slot]).clone(), (loc, cached));
                     }
                     value
                 });
@@ -1058,7 +1065,7 @@ where
         // below, exactly where the read path would have emitted them.
         let mut cached: Vec<(K, Location<F>, Option<V::Value>)> =
             Vec::with_capacity(resolved.len());
-        for (key, loc) in resolved {
+        for (key, (loc, ())) in resolved {
             if let Some(mutation) = mutations.remove(&key) {
                 cached.push((key, loc, mutation));
             }
@@ -1207,9 +1214,11 @@ where
 {
     /// Resolve mutations into operations, merkleize, and return an `Arc<MerkleizedBatch>`.
     ///
-    /// Reads on ordered batches cache nothing (`CACHES_READS` is false): op generation needs
-    /// each read operation's value and next key for linkage, and re-reading them through the
-    /// journal's page cache is cheaper than caching the payloads at read time.
+    /// Consumes the payloads cached by this batch's reads: keys loaded via `get`/`get_many`
+    /// before being updated skip the index probe and journal re-read their resolution would
+    /// otherwise require (the cached old value and next key feed op generation directly).
+    /// Deletes never consume the cache: a deleted key's own-bucket scan doubles as same-bucket
+    /// predecessor discovery.
     #[allow(clippy::type_complexity)]
     #[tracing::instrument(
         name = "qmdb::any::batch::merkleize",
@@ -1253,7 +1262,24 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
+        let resolved = core::mem::take(&mut *self.resolved.lock());
         let (mut mutations, m) = self.into_parts();
+
+        // Pull update mutations whose committed op this batch's reads already resolved: they
+        // skip the index probe and journal re-read, and their old op's payload feeds the
+        // candidate sets directly. Deletes never consume the cache because a deleted key's
+        // own-bucket scan doubles as same-bucket predecessor discovery.
+        let mut cached: Vec<(K, V::Value, Location<F>, V::Value, K)> =
+            Vec::with_capacity(resolved.len());
+        for (key, (loc, (old_value, old_next))) in resolved {
+            if matches!(mutations.get(&key), Some(Some(_))) {
+                let value = mutations
+                    .remove(&key)
+                    .flatten()
+                    .expect("mutation presence checked above");
+                cached.push((key, value, loc, old_value, old_next));
+            }
+        }
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);
@@ -1298,6 +1324,14 @@ where
             } else {
                 deleted.push((key, old_loc));
             }
+        }
+
+        // Merge cache-resolved updates: their old op's next_key and (key, value, loc) feed the
+        // candidate sets exactly as the skipped journal read would have.
+        for (key, value, loc, old_value, old_next) in cached {
+            next_candidates.push(old_next);
+            prev_candidates.push((key.clone(), (old_value, loc)));
+            updated.push((key, value, loc));
         }
 
         deleted.sort_by(|a, b| a.0.cmp(&b.0));

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1266,18 +1266,17 @@ where
         let (mut mutations, m) = self.into_parts();
 
         // Pull update mutations whose committed op this batch's reads already resolved: they
-        // skip the index probe and journal re-read, and their old op's payload feeds the
+        // skip the index probe and journal re-read, and their old op's next key feeds the
         // candidate sets directly. Deletes never consume the cache because a deleted key's
         // own-bucket scan doubles as same-bucket predecessor discovery.
-        let mut cached: Vec<(K, V::Value, Location<F>, V::Value, K)> =
-            Vec::with_capacity(resolved.len());
-        for (key, (loc, (old_value, old_next))) in resolved {
+        let mut cached: Vec<(K, V::Value, Location<F>, K)> = Vec::with_capacity(resolved.len());
+        for (key, (loc, old_next)) in resolved {
             if matches!(mutations.get(&key), Some(Some(_))) {
                 let value = mutations
                     .remove(&key)
                     .flatten()
                     .expect("mutation presence checked above");
-                cached.push((key, value, loc, old_value, old_next));
+                cached.push((key, value, loc, old_next));
             }
         }
 
@@ -1327,10 +1326,13 @@ where
         }
 
         // Merge cache-resolved updates: their old op's next_key and (key, value, loc) feed the
-        // candidate sets exactly as the skipped journal read would have.
-        for (key, value, loc, old_value, old_next) in cached {
+        // candidate sets exactly as the skipped journal read would have. The prev-candidate
+        // value uses the NEW value rather than the old one: a prev candidate's value is only
+        // consumed when the predecessor-rewrite loop emits an op for it, and that loop skips
+        // every key present in `updated`, so a cached key's prev-candidate value is never read.
+        for (key, value, loc, old_next) in cached {
             next_candidates.push(old_next);
-            prev_candidates.push((key.clone(), (old_value, loc)));
+            prev_candidates.push((key.clone(), (value.clone(), loc)));
             updated.push((key, value, loc));
         }
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -42,8 +42,7 @@ type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 /// of a given key during ordered merkleization.
 type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
 
-/// Committed-DB locations (plus the update kind's cached payload) cached by a batch's reads,
-/// keyed by the resolved key.
+/// Committed-DB locations cached by a batch's reads, keyed by the resolved key.
 type ResolvedReads<F, U> =
     AHashMap<<U as update::Update>::Key, (Location<F>, <U as update::Update>::Cached)>;
 
@@ -184,10 +183,10 @@ where
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
 
-    /// Committed-DB locations (plus the update kind's cached payload) cached by this batch's
-    /// reads (`get`/`get_many`), keyed by the key they matched. Consumed by `merkleize`: when
-    /// a mutation key is present here, `merkleize` reuses the location (and, for ordered, the
-    /// old next key) and skips the redundant index probe and journal read.
+    /// Committed-DB locations cached by this batch's reads (`get`/`get_many`), keyed by the
+    /// key they matched. Consumed by `merkleize`: when a mutation key is present here,
+    /// `merkleize` reuses the location (and, for ordered, the old next key) and skips the
+    /// redundant index probe and journal read.
     ///
     /// Only committed-snapshot resolutions are cached. A cached location doubles as the
     /// key's previous committed location (`base_old_loc`), which holds because a
@@ -307,9 +306,18 @@ impl<'a, K: Ord, F: Family, V> DiffCursors<'a, K, F, V> {
     }
 
     /// Resolve `key` against the diffs (closest-first). Queries must be non-decreasing:
-    /// cursors only advance, so an out-of-order query may miss entries.
+    /// cursors only advance, so an out-of-order query could miss entries.
+    ///
+    /// # Panics
+    ///
+    /// Panics on any out-of-order query that would return a wrong result (the cursor has
+    /// already advanced past an entry at or above the query).
     pub(crate) fn resolve(&mut self, key: &K) -> Option<&'a DiffEntry<F, V>> {
         for (diff, cursor) in &mut self.diffs {
+            assert!(
+                *cursor == 0 || diff[*cursor - 1].0 < *key,
+                "queries must be non-decreasing"
+            );
             while *cursor < diff.len() && diff[*cursor].0 < *key {
                 *cursor += 1;
             }
@@ -568,21 +576,6 @@ where
             .or_else(|| reader.try_read_sync(*loc))
     }
 
-    /// Read a single operation by location (test oracle; production paths batch via
-    /// [`Self::read_ops`]).
-    #[cfg(test)]
-    async fn read_op<R: Reader<Item = Operation<F, U>>>(
-        &self,
-        loc: Location<F>,
-        batch_ops: &[Operation<F, U>],
-        reader: &R,
-    ) -> Result<Operation<F, U>, crate::qmdb::Error<F>> {
-        match self.try_read_op_sync(loc, batch_ops, reader) {
-            Some(op) => Ok(op),
-            None => Ok(reader.read(*loc).await?),
-        }
-    }
-
     /// Read multiple operations by location.
     async fn read_ops<R: Reader<Item = Operation<F, U>>>(
         &self,
@@ -659,8 +652,7 @@ where
                 locations.extend(db.snapshot.get(key).copied());
             }
         } else {
-            // `mutations.keys()` ascends, so ancestor resolution streams.
-            let mut ancestors = self.diff_cursors();
+            let mut ancestors = DiffCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()));
             for key in mutations.keys() {
                 match ancestors.resolve(key) {
                     Some(DiffEntry::Deleted { .. }) => {
@@ -690,12 +682,6 @@ where
         locations
     }
 
-    /// Build a [`DiffCursors`] over the ancestor diffs (closest-first) for streaming
-    /// resolution of an ascending key sequence.
-    fn diff_cursors(&self) -> DiffCursors<'_, U::Key, F, U::Value> {
-        DiffCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()))
-    }
-
     /// Extract keys that were deleted by a parent batch but are being
     /// re-created by this child batch. Removes those keys from `mutations`
     /// and returns `(key, value, base_old_loc)` entries.
@@ -707,8 +693,7 @@ where
         if self.ancestors.is_empty() {
             return Vec::new();
         }
-        // `retain` visits keys in ascending order, so ancestor resolution streams.
-        let mut ancestors = self.diff_cursors();
+        let mut ancestors = DiffCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()));
         let mut creates = Vec::new();
         mutations.retain(|key, value| {
             if let Some(DiffEntry::Deleted { base_old_loc }) = ancestors.resolve(key) {
@@ -1018,7 +1003,11 @@ where
         }
 
         if !db_keys.is_empty() {
-            let db_results = db.get_many_with_locations(&db_keys).await?;
+            let db_results = db
+                .get_many_map(&db_keys, |data, loc| {
+                    (data.value().clone(), loc, data.cached())
+                })
+                .await?;
             let mut resolved = self.resolved.lock();
             resolved.reserve(db_keys.len());
             for (slot, result) in db_indices.into_iter().zip(db_results) {
@@ -1257,8 +1246,9 @@ where
     /// Consumes the payloads cached by this batch's reads: keys loaded via `get`/`get_many`
     /// before being updated skip the index probe and journal re-read their resolution would
     /// otherwise require (the cached old value and next key feed op generation directly).
-    /// Deletes never consume the cache: a deleted key's own-bucket scan doubles as same-bucket
-    /// predecessor discovery.
+    /// Deletes never consume the cache. Deleting a key requires rewriting its predecessor,
+    /// which may be a colliding key in the deleted key's snapshot bucket, so that bucket
+    /// must be scanned regardless and the cached location saves nothing.
     #[allow(clippy::type_complexity)]
     #[tracing::instrument(
         name = "qmdb::any::batch::merkleize",
@@ -1307,8 +1297,9 @@ where
 
         // Pull update mutations whose committed op this batch's reads already resolved: they
         // skip the index probe and journal re-read, and their old op's next key feeds the
-        // candidate sets directly. Deletes never consume the cache because a deleted key's
-        // own-bucket scan doubles as same-bucket predecessor discovery.
+        // candidate sets directly. Deletes never consume the cache: a deleted key's
+        // predecessor may be a colliding key in its snapshot bucket, so that bucket must be
+        // scanned regardless.
         //
         // The join drains `mutations` (sorted streaming) and probes `resolved` per key: a
         // hash probe is much cheaper than the tree descent the inverse join would pay, and
@@ -1549,11 +1540,9 @@ where
             Vec::with_capacity(deleted.len() + updated.len() + created.len());
         let mut active_keys_delta: isize = 0;
         let mut user_steps: u64 = 0;
-        // Each emit loop below iterates a key-sorted vec, so ancestor resolution and
-        // next-key selection advance cursors in a sorted merge (one `DiffCursors` /
-        // `find_next_key_ascending` index per loop) instead of binary-searching per key.
+
         // Process deletes.
-        let mut ancestors = m.diff_cursors();
+        let mut ancestors = DiffCursors::new(m.ancestors.iter().map(|a| a.diff.as_slice()));
         for (key, old_loc) in &deleted {
             ops.push(Operation::Delete(key.clone()));
 
@@ -1567,7 +1556,7 @@ where
         }
 
         // Process updates of existing keys.
-        let mut ancestors = m.diff_cursors();
+        let mut ancestors = DiffCursors::new(m.ancestors.iter().map(|a| a.diff.as_slice()));
         let mut next_idx = 0;
         for (key, value, old_loc) in &updated {
             let new_loc = Location::new(m.base_size + ops.len() as u64);
@@ -2186,6 +2175,8 @@ mod tests {
     use commonware_cryptography::{sha256, Sha256};
     use commonware_parallel::Sequential;
     use commonware_runtime::{deterministic, Runner as _};
+    use commonware_utils::test_rng;
+    use rand::Rng;
 
     const BITMAP_CHUNK_BITS: u64 = bitmap::Prunable::<BITMAP_CHUNK_BYTES>::CHUNK_SIZE_BITS;
 
@@ -2207,9 +2198,6 @@ mod tests {
     /// diff and diffs with disjoint or overlapping key ranges.
     #[test]
     fn diff_cursors_matches_lookup_sorted() {
-        use commonware_utils::test_rng;
-        use rand::Rng;
-
         let mut rng = test_rng();
         for _ in 0..50 {
             // Build 1-4 sorted diffs over a small key universe so overlaps are common.
@@ -2253,6 +2241,28 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// An out-of-order query that would return a wrong result must panic instead.
+    #[test]
+    #[should_panic(expected = "queries must be non-decreasing")]
+    fn diff_cursors_rejects_out_of_order_query() {
+        let diff: DiffVec<u64, mmr::Family, u64> = vec![1, 5]
+            .into_iter()
+            .map(|k| {
+                (
+                    k,
+                    DiffEntry::Active {
+                        value: k,
+                        loc: loc(k),
+                        base_old_loc: None,
+                    },
+                )
+            })
+            .collect();
+        let mut cursors = DiffCursors::new([diff.as_slice()]);
+        assert!(cursors.resolve(&5).is_some());
+        cursors.resolve(&1);
     }
 
     /// Single-step oracle for [`fill_candidates`]: return the next floor-raise candidate in
@@ -2802,36 +2812,6 @@ mod tests {
                     Operation::Update(update::Unordered(key_db, value_db)),
                 ]
             );
-
-            // read_op: single-location reads across all three sources.
-            let reader = db.log.reader().await;
-            let disk_op = merkleizer
-                .read_op(committed_loc, &batch_ops, &reader)
-                .await
-                .unwrap();
-            assert_eq!(
-                disk_op,
-                Operation::Update(update::Unordered(key_db, value_db))
-            );
-
-            let ancestor_op = merkleizer
-                .read_op(parent_loc, &batch_ops, &reader)
-                .await
-                .unwrap();
-            assert_eq!(
-                ancestor_op,
-                Operation::Update(update::Unordered(key_parent, value_parent))
-            );
-
-            let current_op = merkleizer
-                .read_op(current_loc, &batch_ops, &reader)
-                .await
-                .unwrap();
-            assert_eq!(
-                current_op,
-                Operation::Update(update::Unordered(key_current, value_current))
-            );
-            drop(reader);
 
             db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -39,8 +39,10 @@ type DiffVec<K, F, V> = Vec<(K, DiffEntry<F, V>)>;
 type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 
 /// Sorted `(key, (value, loc))` vec consulted by `find_prev_key` to find the predecessor
-/// of a given key during ordered merkleization.
-type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
+/// of a given key during ordered merkleization. The value is `None` for cache-resolved
+/// keys: the predecessor-rewrite loop only reads a value for keys outside this batch's
+/// mutations, and cache-resolved keys are always in `updated`.
+type PrevCandidates<K, F, V> = Vec<(K, (Option<V>, Location<F>))>;
 
 /// Committed-DB locations cached by a batch's reads, keyed by the resolved key.
 type ResolvedReads<F, U> =
@@ -1323,7 +1325,7 @@ where
             next_candidates.push(next_key);
 
             let mutation = mutations.remove(&key);
-            prev_candidates.push((key.clone(), (value, old_loc)));
+            prev_candidates.push((key.clone(), (Some(value), old_loc)));
 
             let Some(mutation) = mutation else {
                 // Snapshot index collision: this operation's key does not match
@@ -1339,14 +1341,13 @@ where
             }
         }
 
-        // Merge cache-resolved updates: their old op's next_key and (key, value, loc) feed the
-        // candidate sets exactly as the skipped journal read would have. The prev-candidate
-        // value uses the NEW value rather than the old one: a prev candidate's value is only
-        // consumed when the predecessor-rewrite loop emits an op for it, and that loop skips
-        // every key present in `updated`, so a cached key's prev-candidate value is never read.
+        // Merge cache-resolved updates: their old op's next_key and (key, loc) feed the
+        // candidate sets exactly as the skipped journal read would have. No prev-candidate
+        // value is stored: it is only consumed when the predecessor-rewrite loop emits an op
+        // for the key, and that loop skips every key present in `updated`.
         for (key, value, loc, old_next) in cached {
             next_candidates.push(old_next);
-            prev_candidates.push((key.clone(), (value.clone(), loc)));
+            prev_candidates.push((key.clone(), (None, loc)));
             updated.push((key, value, loc));
         }
 
@@ -1398,7 +1399,7 @@ where
                 _ => unreachable!("expected update operation"),
             };
             next_candidates.push(data.next_key);
-            prev_candidates.push((data.key, (data.value, old_loc)));
+            prev_candidates.push((data.key, (Some(data.value), old_loc)));
         }
 
         // Add ancestor-diff keys that may be predecessors or successors of this batch's mutations
@@ -1476,7 +1477,7 @@ where
             };
             next_candidates.push(key.clone());
             next_candidates.push(data.next_key);
-            prev_candidates.push((key.clone(), (value.clone(), loc)));
+            prev_candidates.push((key.clone(), (Some(value.clone()), loc)));
         }
 
         // Sort + dedup candidate sets now so find_next_key/find_prev_key can binary-search.
@@ -1604,6 +1605,9 @@ where
                     continue;
                 }
 
+                let prev_value = prev_value
+                    .as_ref()
+                    .expect("cache-resolved keys are skipped as updated");
                 let prev_new_loc = Location::new(m.base_size + ops.len() as u64);
                 let prev_next_key = find_next_key(prev_key, &next_candidates);
                 ops.push(Operation::Update(update::Ordered {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -185,10 +185,9 @@ where
     base: Base<F, H::Digest, U, S>,
 
     /// Committed-DB locations (plus the update kind's cached payload) cached by this batch's
-    /// reads (`get`/`get_many`), keyed by the key they matched. Populated only when
-    /// `U::CACHES_READS` and consumed by `merkleize`: when a mutation key is present here,
-    /// `merkleize` reuses the location (and, for ordered, the old value and next key) and
-    /// skips the redundant index probe and journal read.
+    /// reads (`get`/`get_many`), keyed by the key they matched. Consumed by `merkleize`: when
+    /// a mutation key is present here, `merkleize` reuses the location (and, for ordered, the
+    /// old next key) and skips the redundant index probe and journal read.
     ///
     /// Only committed-snapshot resolutions are cached. A cached location doubles as the
     /// key's previous committed location (`base_old_loc`), which holds because a
@@ -978,21 +977,13 @@ where
         }
 
         if !db_keys.is_empty() {
-            let db_results = if U::CACHES_READS {
-                db.get_many_with_locations::<true>(&db_keys).await?
-            } else {
-                db.get_many_with_locations::<false>(&db_keys).await?
-            };
-            let mut resolved = U::CACHES_READS.then(|| self.resolved.lock());
-            if let Some(resolved) = resolved.as_deref_mut() {
-                resolved.reserve(db_keys.len());
-            }
+            let db_results = db.get_many_with_locations::<true>(&db_keys).await?;
+            let mut resolved = self.resolved.lock();
+            resolved.reserve(db_keys.len());
             for (slot, result) in db_indices.into_iter().zip(db_results) {
                 results[slot] = result.map(|(value, loc, cached)| {
-                    if let Some(resolved) = resolved.as_deref_mut() {
-                        let cached = cached.expect("cached payload requested for caching reads");
-                        resolved.insert((*keys[slot]).clone(), (loc, cached));
-                    }
+                    let cached = cached.expect("cached payload requested for caching reads");
+                    resolved.insert((*keys[slot]).clone(), (loc, cached));
                     value
                 });
             }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -42,10 +42,12 @@ type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 /// of a given key during ordered merkleization.
 type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
 
-/// Committed-DB locations (plus the update kind's cached payload) cached by a batch's reads,
-/// keyed by the resolved key.
-type ResolvedReads<F, U> =
-    AHashMap<<U as update::Update>::Key, (Location<F>, <U as update::Update>::Cached)>;
+/// Committed-DB locations (plus the old op's next key, when the update kind has one) cached
+/// by a batch's reads, keyed by the resolved key.
+type ResolvedReads<F, U> = AHashMap<
+    <U as update::Update>::Key,
+    (Location<F>, Option<<U as update::Update>::Key>),
+>;
 
 /// What happened to a key in this batch.
 #[derive(Clone)]
@@ -184,10 +186,11 @@ where
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
 
-    /// Committed-DB locations (plus the update kind's cached payload) cached by this batch's
-    /// reads (`get`/`get_many`), keyed by the key they matched. Consumed by `merkleize`: when
-    /// a mutation key is present here, `merkleize` reuses the location (and, for ordered, the
-    /// old next key) and skips the redundant index probe and journal read.
+    /// Committed-DB locations (plus the old op's next key, when the update kind has one)
+    /// cached by this batch's reads (`get`/`get_many`), keyed by the key they matched.
+    /// Consumed by `merkleize`: when a mutation key is present here, `merkleize` reuses the
+    /// location (and, for ordered, the old next key) and skips the redundant index probe and
+    /// journal read.
     ///
     /// Only committed-snapshot resolutions are cached. A cached location doubles as the
     /// key's previous committed location (`base_old_loc`), which holds because a
@@ -981,9 +984,8 @@ where
             let mut resolved = self.resolved.lock();
             resolved.reserve(db_keys.len());
             for (slot, result) in db_indices.into_iter().zip(db_results) {
-                results[slot] = result.map(|(value, loc, cached)| {
-                    let cached = cached.expect("cached payload requested for caching reads");
-                    resolved.insert((*keys[slot]).clone(), (loc, cached));
+                results[slot] = result.map(|(value, loc, next_key)| {
+                    resolved.insert((*keys[slot]).clone(), (loc, next_key));
                     value
                 });
             }
@@ -1056,7 +1058,7 @@ where
         // below, exactly where the read path would have emitted them.
         let mut cached: Vec<(K, Location<F>, Option<V::Value>)> =
             Vec::with_capacity(resolved.len());
-        for (key, (loc, ())) in resolved {
+        for (key, (loc, _)) in resolved {
             if let Some(mutation) = mutations.remove(&key) {
                 cached.push((key, loc, mutation));
             }
@@ -1263,6 +1265,7 @@ where
         // (one lookup per key on the hot path instead of a get-then-remove pair).
         let mut cached: Vec<(K, V::Value, Location<F>, K)> = Vec::with_capacity(resolved.len());
         for (key, (loc, old_next)) in resolved {
+            let old_next = old_next.expect("ordered updates always carry a next key");
             match mutations.remove(&key) {
                 Some(Some(value)) => cached.push((key, value, loc, old_next)),
                 Some(None) => {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -11,7 +11,7 @@ use crate::{
         any::{
             db::Db,
             operation::{update, Operation},
-            ordered::{find_next_key, find_prev_key},
+            ordered::{find_next_key, find_next_key_ascending, find_prev_key},
             ValueEncoding,
         },
         batch_chain::{self, Bounds},
@@ -292,6 +292,37 @@ where
     None
 }
 
+/// Streaming equivalent of [`resolve_in_ancestors`] for an ascending sequence of queries:
+/// one cursor per key-sorted diff advances in a linear merge instead of binary-searching
+/// each diff per key. Diffs must be ordered closest-first (the first hit wins).
+pub(crate) struct DiffCursors<'a, K, F: Family, V> {
+    diffs: Vec<(&'a DiffSlice<K, F, V>, usize)>,
+}
+
+impl<'a, K: Ord, F: Family, V> DiffCursors<'a, K, F, V> {
+    pub(crate) fn new(diffs: impl IntoIterator<Item = &'a DiffSlice<K, F, V>>) -> Self {
+        Self {
+            diffs: diffs.into_iter().map(|diff| (diff, 0)).collect(),
+        }
+    }
+
+    /// Resolve `key` against the diffs (closest-first). Queries must be non-decreasing:
+    /// cursors only advance, so an out-of-order query may miss entries.
+    pub(crate) fn resolve(&mut self, key: &K) -> Option<&'a DiffEntry<F, V>> {
+        for (diff, cursor) in &mut self.diffs {
+            while *cursor < diff.len() && diff[*cursor].0 < *key {
+                *cursor += 1;
+            }
+            if let Some((k, entry)) = diff.get(*cursor) {
+                if k == key {
+                    return Some(entry);
+                }
+            }
+        }
+        None
+    }
+}
+
 /// Apply a single diff entry to the snapshot index and activity bitmap in lockstep:
 /// install the winning `Active` location and clear the prior committed location.
 fn apply_diff<F: Family, V, I: UnorderedIndex<Value = Location<F>>, const N: usize>(
@@ -537,7 +568,9 @@ where
             .or_else(|| reader.try_read_sync(*loc))
     }
 
-    /// Read a single operation by location.
+    /// Read a single operation by location (test oracle; production paths batch via
+    /// [`Self::read_ops`]).
+    #[cfg(test)]
     async fn read_op<R: Reader<Item = Operation<F, U>>>(
         &self,
         loc: Location<F>,
@@ -626,8 +659,10 @@ where
                 locations.extend(db.snapshot.get(key).copied());
             }
         } else {
+            // `mutations.keys()` ascends, so ancestor resolution streams.
+            let mut ancestors = self.diff_cursors();
             for key in mutations.keys() {
-                match resolve_in_ancestors(&self.ancestors, key) {
+                match ancestors.resolve(key) {
                     Some(DiffEntry::Deleted { .. }) => {
                         // Stale; handled via extract_parent_deleted_creates.
                     }
@@ -655,6 +690,12 @@ where
         locations
     }
 
+    /// Build a [`DiffCursors`] over the ancestor diffs (closest-first) for streaming
+    /// resolution of an ascending key sequence.
+    fn diff_cursors(&self) -> DiffCursors<'_, U::Key, F, U::Value> {
+        DiffCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()))
+    }
+
     /// Extract keys that were deleted by a parent batch but are being
     /// re-created by this child batch. Removes those keys from `mutations`
     /// and returns `(key, value, base_old_loc)` entries.
@@ -666,11 +707,11 @@ where
         if self.ancestors.is_empty() {
             return Vec::new();
         }
+        // `retain` visits keys in ascending order, so ancestor resolution streams.
+        let mut ancestors = self.diff_cursors();
         let mut creates = Vec::new();
         mutations.retain(|key, value| {
-            if let Some(DiffEntry::Deleted { base_old_loc }) =
-                resolve_in_ancestors(&self.ancestors, key)
-            {
+            if let Some(DiffEntry::Deleted { base_old_loc }) = ancestors.resolve(key) {
                 if let Some(v) = value.take() {
                     creates.push((key.clone(), v, *base_old_loc));
                     return false;
@@ -1405,6 +1446,11 @@ where
         //
         // Depth-1 chains skip the set entirely — a single ancestor can't shadow itself,
         // and each diff's keys are unique by construction.
+        //
+        // Each diff is key-sorted, as are `updated`/`created`/`deleted`, so the handled check
+        // advances three cursors in a sorted merge instead of three binary searches per key.
+        // Active entries are collected and read in one batch below instead of one awaited
+        // read per key.
         let track_shadow = m.ancestors.len() > 1;
         let seen_cap = if track_shadow {
             m.ancestors.iter().map(|a| a.diff.len()).sum()
@@ -1413,28 +1459,32 @@ where
         };
         let mut seen: AHashSet<&K> = AHashSet::with_capacity(seen_cap);
         let mut ancestor_deleted: Vec<K> = Vec::new();
+        let mut ancestor_active: Vec<(&K, &V::Value, Location<F>)> = Vec::new();
         for batch in m.ancestors.iter() {
+            let (mut ui, mut ci, mut di) = (0, 0, 0);
             for (key, entry) in batch.diff.iter() {
                 if track_shadow && !seen.insert(key) {
                     continue;
                 }
                 // Skip keys already handled by this batch's mutations.
-                if updated.binary_search_by(|(k, _, _)| k.cmp(key)).is_ok()
-                    || created.binary_search_by(|(k, _, _)| k.cmp(key)).is_ok()
-                    || deleted.binary_search_by(|(k, _)| k.cmp(key)).is_ok()
+                while ui < updated.len() && updated[ui].0 < *key {
+                    ui += 1;
+                }
+                while ci < created.len() && created[ci].0 < *key {
+                    ci += 1;
+                }
+                while di < deleted.len() && deleted[di].0 < *key {
+                    di += 1;
+                }
+                if updated.get(ui).is_some_and(|(k, ..)| k == key)
+                    || created.get(ci).is_some_and(|(k, ..)| k == key)
+                    || deleted.get(di).is_some_and(|(k, _)| k == key)
                 {
                     continue;
                 }
                 match entry {
                     DiffEntry::Active { value, loc, .. } => {
-                        let op = m.read_op(*loc, &[], &reader).await?;
-                        let data = match op {
-                            Operation::Update(data) => data,
-                            _ => unreachable!("ancestor diff Active should reference Update op"),
-                        };
-                        next_candidates.push(key.clone());
-                        next_candidates.push(data.next_key);
-                        prev_candidates.push((key.clone(), (value.clone(), *loc)));
+                        ancestor_active.push((key, value, *loc));
                     }
                     DiffEntry::Deleted { .. } => {
                         ancestor_deleted.push(key.clone());
@@ -1444,6 +1494,24 @@ where
         }
         ancestor_deleted.sort();
         ancestor_deleted.dedup();
+
+        // Batch-read the collected active entries' ops and emit their candidates.
+        let ancestor_locs: Vec<Location<F>> =
+            ancestor_active.iter().map(|&(_, _, loc)| loc).collect();
+        for (op, (key, value, loc)) in m
+            .read_ops(&ancestor_locs, &[], &reader)
+            .await?
+            .into_iter()
+            .zip(ancestor_active)
+        {
+            let data = match op {
+                Operation::Update(data) => data,
+                _ => unreachable!("ancestor diff Active should reference Update op"),
+            };
+            next_candidates.push(key.clone());
+            next_candidates.push(data.next_key);
+            prev_candidates.push((key.clone(), (value.clone(), loc)));
+        }
 
         // Sort + dedup candidate sets now so find_next_key/find_prev_key can binary-search.
         next_candidates.sort();
@@ -1481,11 +1549,16 @@ where
             Vec::with_capacity(deleted.len() + updated.len() + created.len());
         let mut active_keys_delta: isize = 0;
         let mut user_steps: u64 = 0;
+        // Each emit loop below iterates a key-sorted vec, so ancestor resolution and
+        // next-key selection advance cursors in a sorted merge (one `DiffCursors` /
+        // `find_next_key_ascending` index per loop) instead of binary-searching per key.
         // Process deletes.
+        let mut ancestors = m.diff_cursors();
         for (key, old_loc) in &deleted {
             ops.push(Operation::Delete(key.clone()));
 
-            let base_old_loc = resolve_in_ancestors(&m.ancestors, key)
+            let base_old_loc = ancestors
+                .resolve(key)
                 .map_or(Some(*old_loc), DiffEntry::base_old_loc);
 
             diff.push((key.clone(), DiffEntry::Deleted { base_old_loc }));
@@ -1494,16 +1567,19 @@ where
         }
 
         // Process updates of existing keys.
+        let mut ancestors = m.diff_cursors();
+        let mut next_idx = 0;
         for (key, value, old_loc) in &updated {
             let new_loc = Location::new(m.base_size + ops.len() as u64);
-            let next_key = find_next_key(key, &next_candidates);
+            let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
                 value: value.clone(),
                 next_key,
             }));
 
-            let base_old_loc = resolve_in_ancestors(&m.ancestors, key)
+            let base_old_loc = ancestors
+                .resolve(key)
                 .map_or(Some(*old_loc), DiffEntry::base_old_loc);
 
             diff.push((
@@ -1518,9 +1594,10 @@ where
         }
 
         // Process creates.
+        let mut next_idx = 0;
         for (key, value, base_old_loc) in &created {
             let new_loc = Location::new(m.base_size + ops.len() as u64);
-            let next_key = find_next_key(key, &next_candidates);
+            let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
                 value: value.clone(),
@@ -2123,6 +2200,59 @@ mod tests {
         let mut bm = bitmap::Prunable::<BITMAP_CHUNK_BYTES>::new();
         build(&mut bm);
         Shared::new(bm)
+    }
+
+    /// [`DiffCursors`] must resolve exactly like per-key `lookup_sorted` over the same diffs
+    /// (closest-first) for any ascending query sequence, including queries absent from every
+    /// diff and diffs with disjoint or overlapping key ranges.
+    #[test]
+    fn diff_cursors_matches_lookup_sorted() {
+        use commonware_utils::test_rng;
+        use rand::Rng;
+
+        let mut rng = test_rng();
+        for _ in 0..50 {
+            // Build 1-4 sorted diffs over a small key universe so overlaps are common.
+            let num_diffs = rng.gen_range(1..=4);
+            let diffs: Vec<DiffVec<u64, mmr::Family, u64>> = (0..num_diffs)
+                .map(|d| {
+                    let mut keys: Vec<u64> = (0..rng.gen_range(0..30))
+                        .map(|_| rng.gen_range(0..50u64))
+                        .collect();
+                    keys.sort_unstable();
+                    keys.dedup();
+                    keys.into_iter()
+                        .map(|k| {
+                            (
+                                k,
+                                DiffEntry::Active {
+                                    value: k * 1000 + d,
+                                    loc: loc(k * 1000 + d),
+                                    base_old_loc: None,
+                                },
+                            )
+                        })
+                        .collect()
+                })
+                .collect();
+
+            // Ascending queries spanning the universe (with gaps and duplicates).
+            let mut queries: Vec<u64> = (0..rng.gen_range(1..60))
+                .map(|_| rng.gen_range(0..55u64))
+                .collect();
+            queries.sort_unstable();
+
+            let mut cursors = DiffCursors::new(diffs.iter().map(|d| d.as_slice()));
+            for q in queries {
+                let expected = diffs.iter().find_map(|d| lookup_sorted(d.as_slice(), &q));
+                let actual = cursors.resolve(&q);
+                assert_eq!(
+                    expected.map(DiffEntry::loc),
+                    actual.map(DiffEntry::loc),
+                    "query {q} diverged"
+                );
+            }
+        }
     }
 
     /// Single-step oracle for [`fill_candidates`]: return the next floor-raise candidate in

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -441,35 +441,6 @@ impl<'a, K: Ord, F: Family, V> Iterator for DiffMerge<'a, K, F, V> {
     }
 }
 
-/// Resolves a key's `base_old_loc` by walking parallel cursors over already-applied
-/// ancestor diffs (parent-first). Lookups must be issued in ascending key order because
-/// cursors only advance forward. Returns `Some(Some(loc))` for an active entry,
-/// `Some(None)` for a deletion, and `None` when no already-applied ancestor touched the
-/// key.
-struct AppliedAncestorResolver<'a, K, F: Family, V> {
-    cursors: Vec<(&'a DiffSlice<K, F, V>, usize)>,
-}
-
-impl<'a, K: Ord, F: Family, V> AppliedAncestorResolver<'a, K, F, V> {
-    fn new(applied: impl IntoIterator<Item = &'a DiffSlice<K, F, V>>) -> Self {
-        Self {
-            cursors: applied.into_iter().map(|s| (s, 0)).collect(),
-        }
-    }
-
-    fn lookup(&mut self, key: &K) -> Option<Option<Location<F>>> {
-        for (slice, idx) in self.cursors.iter_mut() {
-            while *idx < slice.len() && slice[*idx].0 < *key {
-                *idx += 1;
-            }
-            if *idx < slice.len() && slice[*idx].0 == *key {
-                return Some(slice[*idx].1.loc());
-            }
-        }
-        None
-    }
-}
-
 /// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` under a single bitmap
 /// read guard, returning the next `floor`.
 fn fill_candidates<F: Family, const N: usize>(
@@ -947,8 +918,8 @@ where
     /// Batch read multiple keys (mutations -> ancestor diffs -> committed DB).
     ///
     /// Returns results in the same order as the input keys, with `None` for absent or deleted
-    /// keys. When the update kind caches reads, each unique read resolved from the committed
-    /// DB is cached on the batch for reuse at merkleize.
+    /// keys. Each unique read resolved from the committed DB is cached on the batch for reuse
+    /// at merkleize.
     pub async fn get_many<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
@@ -1078,7 +1049,7 @@ where
         I: UnorderedIndex<Value = Location<F>>,
     {
         let mut resolved = core::mem::take(&mut *self.resolved.lock());
-        let (mutations, m) = self.into_parts();
+        let (mut mutations, m) = self.into_parts();
 
         // Pull mutations whose committed location this batch's reads already resolved. They
         // skip the journal re-read and are emitted at their cached location by the merge
@@ -1089,17 +1060,19 @@ where
         // rebuilding the unconsumed remainder from a sorted stream is a linear bulk build.
         let mut cached: Vec<(K, Location<F>, Option<V::Value>)> =
             Vec::with_capacity(resolved.len().min(mutations.len()));
-        let mut mutations: BTreeMap<K, Option<V::Value>> = mutations
-            .into_iter()
-            .filter_map(|(key, mutation)| match resolved.remove(&key) {
-                Some((loc, ())) => {
-                    cached.push((key, loc, mutation));
-                    None
-                }
-                None => Some((key, mutation)),
-            })
-            .collect();
-        cached.sort_unstable_by_key(|&(_, loc, _)| loc);
+        if !resolved.is_empty() {
+            mutations = mutations
+                .into_iter()
+                .filter_map(|(key, mutation)| match resolved.remove(&key) {
+                    Some((loc, ())) => {
+                        cached.push((key, loc, mutation));
+                        None
+                    }
+                    None => Some((key, mutation)),
+                })
+                .collect();
+            cached.sort_unstable_by_key(|&(_, loc, _)| loc);
+        }
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, false);
@@ -1293,7 +1266,7 @@ where
         I: OrderedIndex<Value = Location<F>>,
     {
         let mut resolved = core::mem::take(&mut *self.resolved.lock());
-        let (mutations, m) = self.into_parts();
+        let (mut mutations, m) = self.into_parts();
 
         // Pull update mutations whose committed op this batch's reads already resolved: they
         // skip the index probe and journal re-read, and their old op's next key feeds the
@@ -1308,16 +1281,18 @@ where
         // mostly-sorted input.
         let mut cached: Vec<(K, V::Value, Location<F>, K)> =
             Vec::with_capacity(resolved.len().min(mutations.len()));
-        let mut mutations: BTreeMap<K, Option<V::Value>> = mutations
-            .into_iter()
-            .filter_map(|(key, mutation)| match (resolved.remove(&key), mutation) {
-                (Some((loc, old_next)), Some(value)) => {
-                    cached.push((key, value, loc, old_next));
-                    None
-                }
-                (_, mutation) => Some((key, mutation)),
-            })
-            .collect();
+        if !resolved.is_empty() {
+            mutations = mutations
+                .into_iter()
+                .filter_map(|(key, mutation)| match (resolved.remove(&key), mutation) {
+                    (Some((loc, old_next)), Some(value)) => {
+                        cached.push((key, value, loc, old_next));
+                        None
+                    }
+                    (_, mutation) => Some((key, mutation)),
+                })
+                .collect();
+        }
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);
@@ -1920,12 +1895,15 @@ where
                         pending.push(ancestor_diff.as_slice());
                     }
                 }
-                let mut resolver = AppliedAncestorResolver::new(applied);
+                let mut resolver = DiffCursors::new(applied);
                 let merge = DiffMerge::new(
                     iter::once(batch.diff.as_slice()).chain(pending.iter().copied()),
                 );
                 for (key, entry) in merge {
-                    let old = resolver.lookup(key).unwrap_or_else(|| entry.base_old_loc());
+                    let old = resolver
+                        .resolve(key)
+                        .map(DiffEntry::loc)
+                        .unwrap_or_else(|| entry.base_old_loc());
                     apply_diff(&mut self.snapshot, &mut bitmap, key, entry, old);
                 }
             }
@@ -2380,22 +2358,21 @@ mod tests {
     }
 
     #[test]
-    fn applied_ancestor_resolver_uses_nearest_touch() {
+    fn diff_cursors_use_nearest_touch() {
         let parent = vec![(2, active(20, 20)), (5, deleted(Some(5)))];
         let grandparent = vec![
             (2, active(200, 200)),
             (4, active(40, 40)),
             (5, active(50, 50)),
         ];
-        let mut resolver =
-            AppliedAncestorResolver::new([parent.as_slice(), grandparent.as_slice()]);
+        let mut cursors = DiffCursors::new([parent.as_slice(), grandparent.as_slice()]);
 
         // Lookups are issued in ascending order, as they are from DiffMerge in apply_batch.
-        assert_eq!(resolver.lookup(&1), None);
-        assert_eq!(resolver.lookup(&2), Some(Some(loc(20))));
-        assert_eq!(resolver.lookup(&4), Some(Some(loc(40))));
-        assert_eq!(resolver.lookup(&5), Some(None));
-        assert_eq!(resolver.lookup(&9), None);
+        assert_eq!(cursors.resolve(&1).map(DiffEntry::loc), None);
+        assert_eq!(cursors.resolve(&2).map(DiffEntry::loc), Some(Some(loc(20))));
+        assert_eq!(cursors.resolve(&4).map(DiffEntry::loc), Some(Some(loc(40))));
+        assert_eq!(cursors.resolve(&5).map(DiffEntry::loc), Some(None));
+        assert_eq!(cursors.resolve(&9).map(DiffEntry::loc), None);
     }
 
     #[test]

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1047,19 +1047,28 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        let resolved = core::mem::take(&mut *self.resolved.lock());
-        let (mut mutations, m) = self.into_parts();
+        let mut resolved = core::mem::take(&mut *self.resolved.lock());
+        let (mutations, m) = self.into_parts();
 
         // Pull mutations whose committed location this batch's reads already resolved. They
         // skip the journal re-read and are emitted at their cached location by the merge
         // below, exactly where the read path would have emitted them.
+        //
+        // The join drains `mutations` (sorted streaming) and probes `resolved` per key: a
+        // hash probe is much cheaper than the tree descent the inverse join would pay, and
+        // rebuilding the unconsumed remainder from a sorted stream is a linear bulk build.
         let mut cached: Vec<(K, Location<F>, Option<V::Value>)> =
-            Vec::with_capacity(resolved.len());
-        for (key, (loc, ())) in resolved {
-            if let Some(mutation) = mutations.remove(&key) {
-                cached.push((key, loc, mutation));
-            }
-        }
+            Vec::with_capacity(resolved.len().min(mutations.len()));
+        let mut mutations: BTreeMap<K, Option<V::Value>> = mutations
+            .into_iter()
+            .filter_map(|(key, mutation)| match resolved.remove(&key) {
+                Some((loc, ())) => {
+                    cached.push((key, loc, mutation));
+                    None
+                }
+                None => Some((key, mutation)),
+            })
+            .collect();
         cached.sort_unstable_by_key(|&(_, loc, _)| loc);
 
         // Resolve existing keys.
@@ -1252,24 +1261,31 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
-        let resolved = core::mem::take(&mut *self.resolved.lock());
-        let (mut mutations, m) = self.into_parts();
+        let mut resolved = core::mem::take(&mut *self.resolved.lock());
+        let (mutations, m) = self.into_parts();
 
         // Pull update mutations whose committed op this batch's reads already resolved: they
         // skip the index probe and journal re-read, and their old op's next key feeds the
         // candidate sets directly. Deletes never consume the cache because a deleted key's
-        // own-bucket scan doubles as same-bucket predecessor discovery; they are reinserted
-        // (one lookup per key on the hot path instead of a get-then-remove pair).
-        let mut cached: Vec<(K, V::Value, Location<F>, K)> = Vec::with_capacity(resolved.len());
-        for (key, (loc, old_next)) in resolved {
-            match mutations.remove(&key) {
-                Some(Some(value)) => cached.push((key, value, loc, old_next)),
-                Some(None) => {
-                    mutations.insert(key, None);
+        // own-bucket scan doubles as same-bucket predecessor discovery.
+        //
+        // The join drains `mutations` (sorted streaming) and probes `resolved` per key: a
+        // hash probe is much cheaper than the tree descent the inverse join would pay, and
+        // rebuilding the unconsumed remainder from a sorted stream is a linear bulk build.
+        // As a bonus, `cached` comes out key-sorted, so the candidate sorts below see
+        // mostly-sorted input.
+        let mut cached: Vec<(K, V::Value, Location<F>, K)> =
+            Vec::with_capacity(resolved.len().min(mutations.len()));
+        let mut mutations: BTreeMap<K, Option<V::Value>> = mutations
+            .into_iter()
+            .filter_map(|(key, mutation)| match (resolved.remove(&key), mutation) {
+                (Some((loc, old_next)), Some(value)) => {
+                    cached.push((key, value, loc, old_next));
+                    None
                 }
-                None => {}
-            }
-        }
+                (_, mutation) => Some((key, mutation)),
+            })
+            .collect();
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -42,12 +42,10 @@ type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 /// of a given key during ordered merkleization.
 type PrevCandidates<K, F, V> = Vec<(K, (V, Location<F>))>;
 
-/// Committed-DB locations (plus the old op's next key, when the update kind has one) cached
-/// by a batch's reads, keyed by the resolved key.
-type ResolvedReads<F, U> = AHashMap<
-    <U as update::Update>::Key,
-    (Location<F>, Option<<U as update::Update>::Key>),
->;
+/// Committed-DB locations (plus the update kind's cached payload) cached by a batch's reads,
+/// keyed by the resolved key.
+type ResolvedReads<F, U> =
+    AHashMap<<U as update::Update>::Key, (Location<F>, <U as update::Update>::Cached)>;
 
 /// What happened to a key in this batch.
 #[derive(Clone)]
@@ -186,11 +184,10 @@ where
     /// The committed DB or parent batch this batch was created from.
     base: Base<F, H::Digest, U, S>,
 
-    /// Committed-DB locations (plus the old op's next key, when the update kind has one)
-    /// cached by this batch's reads (`get`/`get_many`), keyed by the key they matched.
-    /// Consumed by `merkleize`: when a mutation key is present here, `merkleize` reuses the
-    /// location (and, for ordered, the old next key) and skips the redundant index probe and
-    /// journal read.
+    /// Committed-DB locations (plus the update kind's cached payload) cached by this batch's
+    /// reads (`get`/`get_many`), keyed by the key they matched. Consumed by `merkleize`: when
+    /// a mutation key is present here, `merkleize` reuses the location (and, for ordered, the
+    /// old next key) and skips the redundant index probe and journal read.
     ///
     /// Only committed-snapshot resolutions are cached. A cached location doubles as the
     /// key's previous committed location (`base_old_loc`), which holds because a
@@ -980,12 +977,12 @@ where
         }
 
         if !db_keys.is_empty() {
-            let db_results = db.get_many_with_locations::<true>(&db_keys).await?;
+            let db_results = db.get_many_with_locations(&db_keys).await?;
             let mut resolved = self.resolved.lock();
             resolved.reserve(db_keys.len());
             for (slot, result) in db_indices.into_iter().zip(db_results) {
-                results[slot] = result.map(|(value, loc, next_key)| {
-                    resolved.insert((*keys[slot]).clone(), (loc, next_key));
+                results[slot] = result.map(|(value, loc, cached)| {
+                    resolved.insert((*keys[slot]).clone(), (loc, cached));
                     value
                 });
             }
@@ -1058,7 +1055,7 @@ where
         // below, exactly where the read path would have emitted them.
         let mut cached: Vec<(K, Location<F>, Option<V::Value>)> =
             Vec::with_capacity(resolved.len());
-        for (key, (loc, _)) in resolved {
+        for (key, (loc, ())) in resolved {
             if let Some(mutation) = mutations.remove(&key) {
                 cached.push((key, loc, mutation));
             }
@@ -1265,7 +1262,6 @@ where
         // (one lookup per key on the hot path instead of a get-then-remove pair).
         let mut cached: Vec<(K, V::Value, Location<F>, K)> = Vec::with_capacity(resolved.len());
         for (key, (loc, old_next)) in resolved {
-            let old_next = old_next.expect("ordered updates always carry a next key");
             match mutations.remove(&key) {
                 Some(Some(value)) => cached.push((key, value, loc, old_next)),
                 Some(None) => {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1259,15 +1259,16 @@ where
         // Pull update mutations whose committed op this batch's reads already resolved: they
         // skip the index probe and journal re-read, and their old op's next key feeds the
         // candidate sets directly. Deletes never consume the cache because a deleted key's
-        // own-bucket scan doubles as same-bucket predecessor discovery.
+        // own-bucket scan doubles as same-bucket predecessor discovery; they are reinserted
+        // (one lookup per key on the hot path instead of a get-then-remove pair).
         let mut cached: Vec<(K, V::Value, Location<F>, K)> = Vec::with_capacity(resolved.len());
         for (key, (loc, old_next)) in resolved {
-            if matches!(mutations.get(&key), Some(Some(_))) {
-                let value = mutations
-                    .remove(&key)
-                    .flatten()
-                    .expect("mutation presence checked above");
-                cached.push((key, value, loc, old_next));
+            match mutations.remove(&key) {
+                Some(Some(value)) => cached.push((key, value, loc, old_next)),
+                Some(None) => {
+                    mutations.insert(key, None);
+                }
+                None => {}
             }
         }
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -226,20 +226,22 @@ where
         &self,
         keys: &[&U::Key],
     ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>> {
-        let results = self.get_many_with_locations(keys).await?;
+        let results = self.get_many_with_locations::<false>(keys).await?;
         Ok(results
             .into_iter()
-            .map(|result| result.map(|(value, _)| value))
+            .map(|result| result.map(|(value, ..)| value))
             .collect())
     }
 
     /// Like [`Self::get_many`] but additionally returns the committed location each value was
-    /// read from.
+    /// read from. When `CACHE` is set, each result also carries the update's cached payload
+    /// (for batch reads to stash for merkleize); plain reads pass `false` and pay nothing.
     #[allow(clippy::type_complexity)]
-    pub(crate) async fn get_many_with_locations(
+    pub(crate) async fn get_many_with_locations<const CACHE: bool>(
         &self,
         keys: &[&U::Key],
-    ) -> Result<Vec<Option<(U::Value, Location<F>)>>, crate::qmdb::Error<F>> {
+    ) -> Result<Vec<Option<(U::Value, Location<F>, Option<U::Cached>)>>, crate::qmdb::Error<F>>
+    {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -251,7 +253,8 @@ where
         // Phase 1: Collect candidate locations from the in-memory index.
         // Each key may map to multiple locations due to hash collisions.
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
-        let mut results: Vec<Option<(U::Value, Location<F>)>> = vec![None; keys.len()];
+        let mut results: Vec<Option<(U::Value, Location<F>, Option<U::Cached>)>> =
+            (0..keys.len()).map(|_| None).collect();
 
         self.snapshot
             .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
@@ -286,7 +289,8 @@ where
                 panic!("location does not reference update operation. loc={pos}");
             };
             if data.key() == keys[key_idx] {
-                results[key_idx] = Some((data.value().clone(), Location::new(pos)));
+                let cached = CACHE.then(|| data.cached());
+                results[key_idx] = Some((data.value().clone(), Location::new(pos), cached));
             }
         }
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -226,20 +226,17 @@ where
         &self,
         keys: &[&U::Key],
     ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>> {
-        let results = self.get_many_with_locations(keys).await?;
-        Ok(results
-            .into_iter()
-            .map(|result| result.map(|(value, ..)| value))
-            .collect())
+        self.get_many_map(keys, |data, _| data.value().clone())
+            .await
     }
 
-    /// Like [`Self::get_many`] but additionally returns the committed location each value was
-    /// read from, plus the update's cached payload (stashed by batch reads for merkleize).
-    #[allow(clippy::type_complexity)]
-    pub(crate) async fn get_many_with_locations(
+    /// Like [`Self::get_many`] but maps each matched update through `map`, which also
+    /// receives the committed location the update was read from.
+    pub(crate) async fn get_many_map<T>(
         &self,
         keys: &[&U::Key],
-    ) -> Result<Vec<Option<(U::Value, Location<F>, U::Cached)>>, crate::qmdb::Error<F>> {
+        map: impl Fn(&U, Location<F>) -> T,
+    ) -> Result<Vec<Option<T>>, crate::qmdb::Error<F>> {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -251,8 +248,7 @@ where
         // Phase 1: Collect candidate locations from the in-memory index.
         // Each key may map to multiple locations due to hash collisions.
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
-        let mut results: Vec<Option<(U::Value, Location<F>, U::Cached)>> =
-            (0..keys.len()).map(|_| None).collect();
+        let mut results: Vec<Option<T>> = (0..keys.len()).map(|_| None).collect();
 
         self.snapshot
             .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
@@ -287,7 +283,7 @@ where
                 panic!("location does not reference update operation. loc={pos}");
             };
             if data.key() == keys[key_idx] {
-                results[key_idx] = Some((data.value().clone(), Location::new(pos), data.cached()));
+                results[key_idx] = Some(map(data, Location::new(pos)));
             }
         }
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -226,7 +226,7 @@ where
         &self,
         keys: &[&U::Key],
     ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>> {
-        let results = self.get_many_with_locations::<false>(keys).await?;
+        let results = self.get_many_with_locations(keys).await?;
         Ok(results
             .into_iter()
             .map(|result| result.map(|(value, ..)| value))
@@ -234,14 +234,12 @@ where
     }
 
     /// Like [`Self::get_many`] but additionally returns the committed location each value was
-    /// read from. When `CACHE` is set, each result also carries the update's next key (for
-    /// batch reads to stash for merkleize); plain reads pass `false` and pay nothing.
+    /// read from, plus the update's cached payload (stashed by batch reads for merkleize).
     #[allow(clippy::type_complexity)]
-    pub(crate) async fn get_many_with_locations<const CACHE: bool>(
+    pub(crate) async fn get_many_with_locations(
         &self,
         keys: &[&U::Key],
-    ) -> Result<Vec<Option<(U::Value, Location<F>, Option<U::Key>)>>, crate::qmdb::Error<F>>
-    {
+    ) -> Result<Vec<Option<(U::Value, Location<F>, U::Cached)>>, crate::qmdb::Error<F>> {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -253,8 +251,8 @@ where
         // Phase 1: Collect candidate locations from the in-memory index.
         // Each key may map to multiple locations due to hash collisions.
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
-        let mut results: Vec<Option<(U::Value, Location<F>, Option<U::Key>)>> =
-            vec![None; keys.len()];
+        let mut results: Vec<Option<(U::Value, Location<F>, U::Cached)>> =
+            (0..keys.len()).map(|_| None).collect();
 
         self.snapshot
             .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
@@ -289,8 +287,7 @@ where
                 panic!("location does not reference update operation. loc={pos}");
             };
             if data.key() == keys[key_idx] {
-                let next_key = if CACHE { data.next_key().cloned() } else { None };
-                results[key_idx] = Some((data.value().clone(), Location::new(pos), next_key));
+                results[key_idx] = Some((data.value().clone(), Location::new(pos), data.cached()));
             }
         }
 

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -234,13 +234,13 @@ where
     }
 
     /// Like [`Self::get_many`] but additionally returns the committed location each value was
-    /// read from. When `CACHE` is set, each result also carries the update's cached payload
-    /// (for batch reads to stash for merkleize); plain reads pass `false` and pay nothing.
+    /// read from. When `CACHE` is set, each result also carries the update's next key (for
+    /// batch reads to stash for merkleize); plain reads pass `false` and pay nothing.
     #[allow(clippy::type_complexity)]
     pub(crate) async fn get_many_with_locations<const CACHE: bool>(
         &self,
         keys: &[&U::Key],
-    ) -> Result<Vec<Option<(U::Value, Location<F>, Option<U::Cached>)>>, crate::qmdb::Error<F>>
+    ) -> Result<Vec<Option<(U::Value, Location<F>, Option<U::Key>)>>, crate::qmdb::Error<F>>
     {
         if keys.is_empty() {
             return Ok(Vec::new());
@@ -253,8 +253,8 @@ where
         // Phase 1: Collect candidate locations from the in-memory index.
         // Each key may map to multiple locations due to hash collisions.
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
-        let mut results: Vec<Option<(U::Value, Location<F>, Option<U::Cached>)>> =
-            (0..keys.len()).map(|_| None).collect();
+        let mut results: Vec<Option<(U::Value, Location<F>, Option<U::Key>)>> =
+            vec![None; keys.len()];
 
         self.snapshot
             .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
@@ -289,8 +289,8 @@ where
                 panic!("location does not reference update operation. loc={pos}");
             };
             if data.key() == keys[key_idx] {
-                let cached = CACHE.then(|| data.cached());
-                results[key_idx] = Some((data.value().clone(), Location::new(pos), cached));
+                let next_key = if CACHE { data.next_key().cloned() } else { None };
+                results[key_idx] = Some((data.value().clone(), Location::new(pos), next_key));
             }
         }
 

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -26,6 +26,12 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     /// Whether batch reads cache resolved committed locations for merkleize to consume.
     const CACHES_READS: bool;
 
+    /// Payload cached alongside the resolved location of a batch read, consumed by merkleize.
+    type Cached: Send + Sync;
+
+    /// Build the cached payload from a resolved update.
+    fn cached(&self) -> Self::Cached;
+
     /// The updated key.
     fn key(&self) -> &Self::Key;
 

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -23,11 +23,9 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     /// The value encoding (fixed or variable).
     type ValueEncoding: ValueEncoding<Value = Self::Value>;
 
-    /// Payload cached alongside the resolved location of a batch read, consumed by merkleize.
-    type Cached: Send + Sync;
-
-    /// Build the cached payload from a resolved update.
-    fn cached(&self) -> Self::Cached;
+    /// The key after this one in the keyspace, or `None` when the update kind tracks no
+    /// linkage. Batch reads cache it alongside the resolved location for merkleize to consume.
+    fn next_key(&self) -> Option<&Self::Key>;
 
     /// The updated key.
     fn key(&self) -> &Self::Key;

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -26,14 +26,14 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     /// Payload cached alongside the resolved location of a batch read, consumed by merkleize.
     type Cached: Send + Sync;
 
-    /// Build the cached payload from a resolved update.
-    fn cached(&self) -> Self::Cached;
-
     /// The updated key.
     fn key(&self) -> &Self::Key;
 
     /// The updated value.
     fn value(&self) -> &Self::Value;
+
+    /// Build the cached payload from a resolved update.
+    fn cached(&self) -> Self::Cached;
 
     /// Format the update for display.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -23,9 +23,6 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     /// The value encoding (fixed or variable).
     type ValueEncoding: ValueEncoding<Value = Self::Value>;
 
-    /// Whether batch reads cache resolved committed locations for merkleize to consume.
-    const CACHES_READS: bool;
-
     /// Payload cached alongside the resolved location of a batch read, consumed by merkleize.
     type Cached: Send + Sync;
 

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -23,9 +23,11 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     /// The value encoding (fixed or variable).
     type ValueEncoding: ValueEncoding<Value = Self::Value>;
 
-    /// The key after this one in the keyspace, or `None` when the update kind tracks no
-    /// linkage. Batch reads cache it alongside the resolved location for merkleize to consume.
-    fn next_key(&self) -> Option<&Self::Key>;
+    /// Payload cached alongside the resolved location of a batch read, consumed by merkleize.
+    type Cached: Send + Sync;
+
+    /// Build the cached payload from a resolved update.
+    fn cached(&self) -> Self::Cached;
 
     /// The updated key.
     fn key(&self) -> &Self::Key;

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -44,10 +44,10 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type ValueEncoding = V;
     const CACHES_READS: bool = true;
 
-    type Cached = (V::Value, K);
+    type Cached = K;
 
-    fn cached(&self) -> (V::Value, K) {
-        (self.value.clone(), self.next_key.clone())
+    fn cached(&self) -> K {
+        self.next_key.clone()
     }
 
     fn key(&self) -> &K {

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -42,8 +42,6 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    const CACHES_READS: bool = true;
-
     type Cached = K;
 
     fn cached(&self) -> K {

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -42,8 +42,10 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    fn next_key(&self) -> Option<&K> {
-        Some(&self.next_key)
+    type Cached = K;
+
+    fn cached(&self) -> K {
+        self.next_key.clone()
     }
 
     fn key(&self) -> &K {

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -44,16 +44,16 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type ValueEncoding = V;
     type Cached = K;
 
-    fn cached(&self) -> K {
-        self.next_key.clone()
-    }
-
     fn key(&self) -> &K {
         &self.key
     }
 
     fn value(&self) -> &V::Value {
         &self.value
+    }
+
+    fn cached(&self) -> K {
+        self.next_key.clone()
     }
 
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -42,7 +42,13 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    const CACHES_READS: bool = false;
+    const CACHES_READS: bool = true;
+
+    type Cached = (V::Value, K);
+
+    fn cached(&self) -> (V::Value, K) {
+        (self.value.clone(), self.next_key.clone())
+    }
 
     fn key(&self) -> &K {
         &self.key

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -42,10 +42,8 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    type Cached = K;
-
-    fn cached(&self) -> K {
-        self.next_key.clone()
+    fn next_key(&self) -> Option<&K> {
+        Some(&self.next_key)
     }
 
     fn key(&self) -> &K {

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -34,8 +34,6 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    const CACHES_READS: bool = true;
-
     type Cached = ();
 
     fn cached(&self) {}

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -36,6 +36,10 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type ValueEncoding = V;
     const CACHES_READS: bool = true;
 
+    type Cached = ();
+
+    fn cached(&self) {}
+
     fn key(&self) -> &K {
         &self.0
     }

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -34,9 +34,9 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    fn next_key(&self) -> Option<&K> {
-        None
-    }
+    type Cached = ();
+
+    fn cached(&self) {}
 
     fn key(&self) -> &K {
         &self.0

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -36,8 +36,6 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type ValueEncoding = V;
     type Cached = ();
 
-    fn cached(&self) {}
-
     fn key(&self) -> &K {
         &self.0
     }
@@ -45,6 +43,8 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     fn value(&self) -> &V::Value {
         &self.1
     }
+
+    fn cached(&self) {}
 
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[key:{} value:{}]", hex(&self.0), hex(&self.1.encode()))

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -34,9 +34,9 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type Key = K;
     type Value = V::Value;
     type ValueEncoding = V;
-    type Cached = ();
-
-    fn cached(&self) {}
+    fn next_key(&self) -> Option<&K> {
+        None
+    }
 
     fn key(&self) -> &K {
         &self.0

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -380,6 +380,97 @@ pub(crate) mod test {
         });
     }
 
+    /// A batch's cached read resolutions (location plus old next key) must stay valid when an
+    /// ancestor is committed and dropped between the read and merkleize. Keys resolved through
+    /// an uncommitted ancestor's diff cache nothing, so the merkleize-time re-resolution picks
+    /// up the post-commit location and linkage. Keys resolved through the committed snapshot
+    /// cache their location and next key, which the intervening commit cannot change (applying
+    /// an ancestor only relocates or relinks keys present in that ancestor's diff).
+    #[test_traced("WARN")]
+    fn test_ordered_fixed_caching_survives_ancestor_commit() {
+        fn key(i: u64) -> Digest {
+            Sha256::hash(&i.to_be_bytes())
+        }
+        fn val(i: u64) -> Digest {
+            Sha256::hash(&i.to_le_bytes())
+        }
+
+        deterministic::Runner::default().start(|ctx| async move {
+            let mut roots = Vec::new();
+            for read_first in [false, true] {
+                let label = if read_first { "db_read" } else { "db_write" };
+                let mut db = create_test_db(ctx.child(label)).await;
+
+                // Seed and commit keys 0..100.
+                let mut seed = db.new_batch();
+                for i in 0..100u64 {
+                    seed = seed.write(key(i), Some(val(i)));
+                }
+                let seed = seed.merkleize(&db, None).await.unwrap();
+                db.apply_batch(seed).await.unwrap();
+                db.commit().await.unwrap();
+
+                // Grandparent overwrites keys 0..10 (pending), parent touches disjoint keys.
+                let mut gp = db.new_batch();
+                for i in 0..10u64 {
+                    gp = gp.write(key(i), Some(val(i + 1000)));
+                }
+                let gp = gp.merkleize(&db, None).await.unwrap();
+                let mut p = gp.new_batch::<Sha256>();
+                for i in 50..60u64 {
+                    p = p.write(key(i), Some(val(i + 2000)));
+                }
+                let p = p.merkleize(&db, None).await.unwrap();
+
+                // Child reads the grandparent-touched keys (resolving through its diff,
+                // caching nothing) and keys 20..30 (committed-resolved, cached).
+                let b = p.new_batch::<Sha256>();
+                if read_first {
+                    let keys: Vec<Digest> = (0..10u64).chain(20..30u64).map(key).collect();
+                    let key_refs: Vec<&Digest> = keys.iter().collect();
+                    let values = b.get_many(&key_refs, &db).await.unwrap();
+                    for (i, v) in values.into_iter().enumerate() {
+                        let expected = if i < 10 {
+                            val(i as u64 + 1000)
+                        } else {
+                            val(i as u64 + 10)
+                        };
+                        assert_eq!(v, Some(expected));
+                    }
+                }
+
+                // Commit the grandparent and drop it before the child merkleizes.
+                db.apply_batch(gp).await.unwrap();
+                db.commit().await.unwrap();
+
+                let mut b = b;
+                for i in 0..10u64 {
+                    b = b.write(key(i), Some(val(i + 3000)));
+                }
+                for i in 20..30u64 {
+                    b = b.write(key(i), Some(val(i + 4000)));
+                }
+                let b = b.merkleize(&db, None).await.unwrap();
+                db.apply_batch(p).await.unwrap();
+                db.apply_batch(b).await.unwrap();
+                db.commit().await.unwrap();
+
+                for i in 0..10u64 {
+                    assert_eq!(db.get(&key(i)).await.unwrap(), Some(val(i + 3000)));
+                }
+                for i in 20..30u64 {
+                    assert_eq!(db.get(&key(i)).await.unwrap(), Some(val(i + 4000)));
+                }
+                roots.push(db.root());
+                db.destroy().await.unwrap();
+            }
+            assert_eq!(
+                roots[0], roots[1],
+                "read-then-write diverged from write-only"
+            );
+        });
+    }
+
     #[test_traced("WARN")]
     // Test the edge case that arises where we're inserting the second key and it precedes the first
     // key, but shares the same translated key.

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -230,6 +230,30 @@ pub(crate) fn find_next_key<K: Ord + Clone>(key: &K, possible_next: &[K]) -> K {
         .clone()
 }
 
+/// Streaming equivalent of [`find_next_key`] for an ascending sequence of queries: `idx`
+/// advances in a linear merge instead of binary-searching per query. Queries must be
+/// non-decreasing; `idx` must start at 0 and be threaded through every call.
+///
+/// # Panics
+///
+/// Panics if `possible_next` is empty.
+pub(crate) fn find_next_key_ascending<K: Ord + Clone>(
+    key: &K,
+    possible_next: &[K],
+    idx: &mut usize,
+) -> K {
+    while *idx < possible_next.len() && possible_next[*idx] <= *key {
+        *idx += 1;
+    }
+    if *idx < possible_next.len() {
+        return possible_next[*idx].clone();
+    }
+    possible_next
+        .first()
+        .expect("possible_next should not be empty")
+        .clone()
+}
+
 /// Returns the previous key to `key` within `possible_previous` (sorted by `.0`, deduplicated).
 /// The result will "cycle around" to the last entry if `key` is the first key.
 ///
@@ -296,8 +320,37 @@ mod test {
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_runtime::{deterministic::Context, Supervisor as _};
-    use commonware_utils::sequence::FixedBytes;
+    use commonware_utils::{sequence::FixedBytes, test_rng};
     use core::{future::Future, pin::Pin};
+    use rand::Rng;
+
+    /// [`find_next_key_ascending`] must return exactly what [`find_next_key`] returns for any
+    /// ascending query sequence, including queries past the last candidate (cyclic wrap).
+    #[test]
+    fn find_next_key_ascending_matches_binary_search() {
+        let mut rng = test_rng();
+        for _ in 0..50 {
+            let mut candidates: Vec<u64> = (0..rng.gen_range(1..40))
+                .map(|_| rng.gen_range(0..60u64))
+                .collect();
+            candidates.sort_unstable();
+            candidates.dedup();
+
+            let mut queries: Vec<u64> = (0..rng.gen_range(1..80))
+                .map(|_| rng.gen_range(0..70u64))
+                .collect();
+            queries.sort_unstable();
+
+            let mut idx = 0;
+            for q in queries {
+                assert_eq!(
+                    find_next_key(&q, &candidates),
+                    find_next_key_ascending(&q, &candidates, &mut idx),
+                    "query {q} diverged"
+                );
+            }
+        }
+    }
 
     pub(crate) async fn test_ordered_any_db_empty<
         F: Family,

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -236,12 +236,17 @@ pub(crate) fn find_next_key<K: Ord + Clone>(key: &K, possible_next: &[K]) -> K {
 ///
 /// # Panics
 ///
-/// Panics if `possible_next` is empty.
+/// Panics if `possible_next` is empty, or on any out-of-order query that would return a
+/// wrong result (`idx` has already advanced past a candidate above the query).
 pub(crate) fn find_next_key_ascending<K: Ord + Clone>(
     key: &K,
     possible_next: &[K],
     idx: &mut usize,
 ) -> K {
+    assert!(
+        *idx == 0 || possible_next[*idx - 1] <= *key,
+        "queries must be non-decreasing"
+    );
     while *idx < possible_next.len() && possible_next[*idx] <= *key {
         *idx += 1;
     }
@@ -350,6 +355,16 @@ mod test {
                 );
             }
         }
+    }
+
+    /// An out-of-order query that would return a wrong result must panic instead.
+    #[test]
+    #[should_panic(expected = "queries must be non-decreasing")]
+    fn find_next_key_ascending_rejects_out_of_order_query() {
+        let candidates = vec![1u64, 5, 9];
+        let mut idx = 0;
+        assert_eq!(find_next_key_ascending(&5, &candidates, &mut idx), 9);
+        find_next_key_ascending(&1, &candidates, &mut idx);
     }
 
     pub(crate) async fn test_ordered_any_db_empty<

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -207,23 +207,25 @@ macro_rules! run_pipeline {
         let mut rng = StdRng::seed_from_u64(99);
         let mut times_ms: Vec<f64> = Vec::with_capacity(args.iters);
         for iter in 0..args.iters {
-            // Pending ancestors are rebuilt per iteration and never applied (untimed).
-            let mut parent: Option<$merkleized> = None;
+            // Pending ancestors are rebuilt per iteration and never applied (untimed). The
+            // whole chain is held alive: dropping an uncommitted ancestor before merkleize
+            // loses its diff (the parent link is a Weak ref).
+            let mut chain: Vec<$merkleized> = Vec::with_capacity(args.depth as usize);
             for _ in 0..args.depth {
-                let mut b = parent
-                    .as_ref()
+                let mut b = chain
+                    .last()
                     .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>());
                 for (k, v) in gen_muts(&mut rng, args.num_updates, args.num_keys) {
                     b = b.write(k, Some(v));
                 }
-                parent = Some(b.merkleize(&db, None).await.unwrap());
+                chain.push(b.merkleize(&db, None).await.unwrap());
             }
 
             let muts = gen_muts(&mut rng, args.num_updates, args.num_keys);
             let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
             let new_batch = || {
-                parent
-                    .as_ref()
+                chain
+                    .last()
                     .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
             };
 

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -13,7 +13,7 @@ use crate::{
         self,
         any::{
             self,
-            batch::{lookup_sorted, DiffEntry},
+            batch::{DiffCursors, DiffEntry},
             operation::{update, Operation},
             ValueEncoding,
         },
@@ -524,7 +524,9 @@ where
     // 2. Inactivate previous CommitFloor.
     overlay.clear_bit(base, pruned_chunks, batch_base - 1);
 
-    // 3. Set active bits + clear superseded locations from the diff.
+    // 3. Set active bits + clear superseded locations from the diff. The diff is key-sorted,
+    // so ancestor resolution streams (one cursor per ancestor diff).
+    let mut ancestors = DiffCursors::new(ancestor_diffs.iter().map(|d| d.as_slice()));
     for (key, entry) in diff {
         // Set the active bit for this key's final location.
         if let Some(loc) = entry.loc() {
@@ -536,11 +538,8 @@ where
         // Clear the most recent superseded location. Older locations were already cleared by the
         // ancestor batch that superseded them.
         let mut prev_loc = entry.base_old_loc();
-        for ancestor_diff in ancestor_diffs {
-            if let Some(ancestor_entry) = lookup_sorted(ancestor_diff.as_slice(), key) {
-                prev_loc = ancestor_entry.loc();
-                break;
-            }
+        if let Some(ancestor_entry) = ancestors.resolve(key) {
+            prev_loc = ancestor_entry.loc();
         }
         if let Some(old) = prev_loc {
             overlay.clear_bit(base, pruned_chunks, *old);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Speeds up Any/Current batch merkleization end to end: extends #4007's read caching to the ordered path, inverts how both paths consume the cache at merkleize, replaces per-key binary searches with sorted merges everywhere merkleize issues lookups from key-sorted loops, and batches the ancestor walk's journal reads. #4021 was stacked on this branch and merged into it, so this description covers the combined change (plus review follow-ups).

Measured at the Constantinople shape (1M keys, 32k updates/batch, EightCap, tokio, Linux x86_64, 4 cores), interleaved single-session A/B vs main (`bf0c21955`), 6 reps x 30 iters, pooled p50:

| variant | depth | main | this PR | delta |
|---|---|---|---|---|
| any::ordered::fixed::mmb | 0 | 60.4 | 43.3 | -28.3% |
| any::ordered::fixed::mmb | 1 | 89.0 | 61.3 | -31.2% |
| current::ordered::fixed::mmb | 1 | 100.0 | 67.8 | -32.2% |
| current::unordered::fixed::mmb | 1 | 64.6 | 55.2 | -14.5% |

The walk-related gains scale with pending-ancestor depth: an earlier session measured any::ordered depth 2 at 139.4 -> 110.4 (-20.9%) before the streamed-lookup work landed on top. The read-cache half alone (measured before #4021 merged in) also improved any::unordered (-11.8% / -8.1% at depths 0/1) via the consumption-join inversion. The speculative root was byte-identical to main on every iteration of every run (150+ runs across sessions).

Benchmarks were taken at the pre-review-feedback head; the follow-up commits only remove work on the measured paths (the mutations rebuild is skipped for read-free batches, a dead value clone and a duplicate resolver are gone) and add two O(1) ordering asserts.

Note: #4007 explored ordered payload caching and measured it as a net loss; this PR's history reproduced that result before finding the implementation details that flip it (see "History" below). The win comes from the same redundancy the unordered cache removes; the earlier loss was overhead in how the cache was carried and consumed, not in the idea.

## What it does

### Ordered read cache + consumption join

- `update::Update` gains `type Cached` + `fn cached()`: the payload a batch read stashes alongside the resolved committed location. Unordered caches `()` (zero cost); ordered caches the old op's `next_key` (required for linkage, so a location-only cache could not skip the re-read). Every update kind caches unconditionally (no `CACHES_READS` const).
- Batch `get`/`get_many` cache each committed-snapshot resolution; `merkleize` consumes the cache so keys loaded and then updated skip the merkleize-time index probe and journal re-read. Deletes never consume it: a deleted key's predecessor may be a colliding key in its own snapshot bucket, so that bucket scan is needed regardless.
- The consumption join drains `mutations` in key order and probes the cache (O(1) hash probes instead of per-key BTreeMap descents), rebuilds the unconsumed remainder as a linear bulk build, and is skipped entirely when the batch did no reads. `cached` comes out key-sorted, so ordered's candidate sorts see mostly-sorted input. This inversion alone roughly tripled the win and also speeds up the pre-existing unordered cache.
- `Db::get_many_map(keys, map)` generalizes the committed read path: plain `db.get_many` maps hits straight to values and never builds a cached payload; the batch path passes a closure building `(value, location, cached)`.
- `PrevCandidates` holds `Option<value>`: cache-resolved keys store `None` (their prev-candidate value is provably never read, because the predecessor-rewrite loop skips every key in `updated`) and the rewrite loop panics if that invariant is ever violated, instead of silently emitting an op with the wrong value.

### Streamed lookups + batched reads (merged from #4021)

1. **Sorted merge in the ancestor walk.** The per-entry "already handled by this batch?" check (three binary searches over `updated`/`created`/`deleted`, each ~16 cache-missy 32-byte compares over MB-sized arrays) now advances three cursors in a linear merge. Cursors reset per ancestor; shadow-set (`seen`) semantics are unchanged.
2. **Batched ancestor walk reads.** Active entries are collected during the walk and resolved with one `read_ops` call instead of one awaited read per key (up to ~65k sequential awaits per merkleize at the Constantinople shape, depth 1). Every location resolves synchronously through the same layers as before; only the call pattern changes.
3. **Streamed sorted-key lookups** everywhere merkleize queries from a key-sorted loop (`DiffCursors` + `find_next_key_ascending`): the ordered emit loops, `gather_existing_locations`, `extract_parent_deleted_creates`, and `build_chunk_overlay` (current). Both primitives `assert!` queries are non-decreasing against the last consumed entry, panicking precisely when an out-of-order query would return a wrong result. `DiffCursors` also replaces `apply_batch`'s hand-rolled `AppliedAncestorResolver` (an identical cursor merge). The predecessor-rewrite loop keeps per-key binary searches: its query keys are unsorted and its counts are small.
4. **Harness fix (pre-existing bug).** `constantinople` only kept the latest pending ancestor alive, but the merkle batch parent link is a `Weak` ref and the API requires the whole uncommitted chain to stay alive, so depth >= 2 panicked with "peak missing" on main too. The harness now holds the full chain, which is what made depth-2 measurement possible.

## Soundness

Mirrors the unordered argument: only committed-snapshot resolutions are cached, so the cached location doubles as `base_old_loc`, and an intervening commit of this batch's own ancestors cannot move or relink a committed-resolved key (any location or linkage change puts the key in an ancestor diff, which would have answered the read instead of the snapshot). Required candidates are preserved: an updated key's successor comes from its own cached `next_key`; predecessor discovery for deletes/creates goes through `prev_translated_key` bucket reads (plus the delete's own-bucket scan), never through an update key's bucket scan. Skipping a cached key's bucket scan only drops collision-sibling candidates that are all live keys and cannot fall strictly between a key and its successor, so `find_next_key`/`find_prev_key` results are unchanged.

## History (why ordered caching initially measured as a loss)

The first attempts measured roughly neutral, apparently confirming #4007's "explored but not included" result. Three details accounted for the entire gap; each was found by drift-controlled interleaved A/B against pinned binaries:

1. **Caching the old value**: the per-read value clone plus fatter cache entries cost ~0.5-1ms/block of load for a payload that is provably never read (the predecessor-rewrite loop skips keys in `updated`). Fixed by caching only `next_key`.
2. **Double map lookup at consumption**: `mutations.get` followed by `mutations.remove` per cached key doubled the BTreeMap descents, costing ~2-4ms of merkleize. Fixed by a single `remove`.
3. **Join direction**: draining the cache and probing `mutations` paid a random-order tree descent per key and produced randomly-ordered output for the candidate sorts. Draining `mutations` and probing the cache eliminates both costs (tripled the win and sped up unordered as well).

A `next_key()`-accessor variant of the trait (no associated type) was tried and reverted: `type Cached` keeps unordered's cache entry payload-free instead of carrying a dead `Option<K>`.

## Testing

- Full `commonware-storage` suite passes (2571 default-profile tests, 356 slow-profile qmdb tests), including `test_ordered_fixed_resolved_merkleize_parity` (TwoCap collision-heavy, depths 0-2 with multi-ancestor shadow tracking, mixed updates/deletes/creates) and `test_ordered_fixed_caching_survives_ancestor_commit` (differential read-then-write vs write-only across an ancestor commit and drop between read and merkleize).
- Equivalence tests: `diff_cursors_matches_lookup_sorted` (random overlapping diffs, ascending queries vs per-key `lookup_sorted` closest-first) and `find_next_key_ascending_matches_binary_search` (random candidate sets, ascending queries vs `find_next_key`, including cyclic wrap), plus `should_panic` tests proving both non-decreasing asserts fire on out-of-order queries that would return wrong results.
- Benchmark root parity vs main on every iteration of every run, including collision-heavy and depth 1-2 chains.
- `cargo clippy -p commonware-storage --tests`, `rustfmt`, `just check-stability -p commonware-storage`, and `just unstable-public -p commonware-storage` all clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c4e9e62-510e-4929-a6a0-7edb74702f40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4e9e62-510e-4929-a6a0-7edb74702f40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>
