### PR TITLE
[qmdb] Stream sorted-key lookups and batch ancestor reads in merkleize

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -11,7 +11,7 @@ use crate::{
         any::{
             db::Db,
             operation::{update, Operation},
-            ordered::{find_next_key, find_prev_key},
+            ordered::{find_next_key, find_next_key_ascending, find_prev_key},
             ValueEncoding,
         },
         batch_chain::{self, Bounds},
@@ -290,6 +290,37 @@ where
         }
     }
     None
+}
+
+/// Streaming equivalent of [`resolve_in_ancestors`] for an ascending sequence of queries:
+/// one cursor per key-sorted diff advances in a linear merge instead of binary-searching
+/// each diff per key. Diffs must be ordered closest-first (the first hit wins).
+pub(crate) struct DiffCursors<'a, K, F: Family, V> {
+    diffs: Vec<(&'a DiffSlice<K, F, V>, usize)>,
+}
+
+impl<'a, K: Ord, F: Family, V> DiffCursors<'a, K, F, V> {
+    pub(crate) fn new(diffs: impl IntoIterator<Item = &'a DiffSlice<K, F, V>>) -> Self {
+        Self {
+            diffs: diffs.into_iter().map(|diff| (diff, 0)).collect(),
+        }
+    }
+
+    /// Resolve `key` against the diffs (closest-first). Queries must be non-decreasing:
+    /// cursors only advance, so an out-of-order query may miss entries.
+    pub(crate) fn resolve(&mut self, key: &K) -> Option<&'a DiffEntry<F, V>> {
+        for (diff, cursor) in &mut self.diffs {
+            while *cursor < diff.len() && diff[*cursor].0 < *key {
+                *cursor += 1;
+            }
+            if let Some((k, entry)) = diff.get(*cursor) {
+                if k == key {
+                    return Some(entry);
+                }
+            }
+        }
+        None
+    }
 }
 
 /// Apply a single diff entry to the snapshot index and activity bitmap in lockstep:
@@ -628,8 +659,10 @@ where
                 locations.extend(db.snapshot.get(key).copied());
             }
         } else {
+            // `mutations.keys()` ascends, so ancestor resolution streams.
+            let mut ancestors = self.diff_cursors();
             for key in mutations.keys() {
-                match resolve_in_ancestors(&self.ancestors, key) {
+                match ancestors.resolve(key) {
                     Some(DiffEntry::Deleted { .. }) => {
                         // Stale; handled via extract_parent_deleted_creates.
                     }
@@ -657,6 +690,12 @@ where
         locations
     }
 
+    /// Build a [`DiffCursors`] over the ancestor diffs (closest-first) for streaming
+    /// resolution of an ascending key sequence.
+    fn diff_cursors(&self) -> DiffCursors<'_, U::Key, F, U::Value> {
+        DiffCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()))
+    }
+
     /// Extract keys that were deleted by a parent batch but are being
     /// re-created by this child batch. Removes those keys from `mutations`
     /// and returns `(key, value, base_old_loc)` entries.
@@ -668,11 +707,11 @@ where
         if self.ancestors.is_empty() {
             return Vec::new();
         }
+        // `retain` visits keys in ascending order, so ancestor resolution streams.
+        let mut ancestors = self.diff_cursors();
         let mut creates = Vec::new();
         mutations.retain(|key, value| {
-            if let Some(DiffEntry::Deleted { base_old_loc }) =
-                resolve_in_ancestors(&self.ancestors, key)
-            {
+            if let Some(DiffEntry::Deleted { base_old_loc }) = ancestors.resolve(key) {
                 if let Some(v) = value.take() {
                     creates.push((key.clone(), v, *base_old_loc));
                     return false;
@@ -1510,11 +1549,16 @@ where
             Vec::with_capacity(deleted.len() + updated.len() + created.len());
         let mut active_keys_delta: isize = 0;
         let mut user_steps: u64 = 0;
+        // Each emit loop below iterates a key-sorted vec, so ancestor resolution and
+        // next-key selection advance cursors in a sorted merge (one `DiffCursors` /
+        // `find_next_key_ascending` index per loop) instead of binary-searching per key.
         // Process deletes.
+        let mut ancestors = m.diff_cursors();
         for (key, old_loc) in &deleted {
             ops.push(Operation::Delete(key.clone()));
 
-            let base_old_loc = resolve_in_ancestors(&m.ancestors, key)
+            let base_old_loc = ancestors
+                .resolve(key)
                 .map_or(Some(*old_loc), DiffEntry::base_old_loc);
 
             diff.push((key.clone(), DiffEntry::Deleted { base_old_loc }));
@@ -1523,16 +1567,19 @@ where
         }
 
         // Process updates of existing keys.
+        let mut ancestors = m.diff_cursors();
+        let mut next_idx = 0;
         for (key, value, old_loc) in &updated {
             let new_loc = Location::new(m.base_size + ops.len() as u64);
-            let next_key = find_next_key(key, &next_candidates);
+            let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
                 value: value.clone(),
                 next_key,
             }));
 
-            let base_old_loc = resolve_in_ancestors(&m.ancestors, key)
+            let base_old_loc = ancestors
+                .resolve(key)
                 .map_or(Some(*old_loc), DiffEntry::base_old_loc);
 
             diff.push((
@@ -1547,9 +1594,10 @@ where
         }
 
         // Process creates.
+        let mut next_idx = 0;
         for (key, value, base_old_loc) in &created {
             let new_loc = Location::new(m.base_size + ops.len() as u64);
-            let next_key = find_next_key(key, &next_candidates);
+            let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
                 value: value.clone(),
@@ -2152,6 +2200,59 @@ mod tests {
         let mut bm = bitmap::Prunable::<BITMAP_CHUNK_BYTES>::new();
         build(&mut bm);
         Shared::new(bm)
+    }
+
+    /// [`DiffCursors`] must resolve exactly like per-key `lookup_sorted` over the same diffs
+    /// (closest-first) for any ascending query sequence, including queries absent from every
+    /// diff and diffs with disjoint or overlapping key ranges.
+    #[test]
+    fn diff_cursors_matches_lookup_sorted() {
+        use commonware_utils::test_rng;
+        use rand::Rng;
+
+        let mut rng = test_rng();
+        for _ in 0..50 {
+            // Build 1-4 sorted diffs over a small key universe so overlaps are common.
+            let num_diffs = rng.gen_range(1..=4);
+            let diffs: Vec<DiffVec<u64, mmr::Family, u64>> = (0..num_diffs)
+                .map(|d| {
+                    let mut keys: Vec<u64> = (0..rng.gen_range(0..30))
+                        .map(|_| rng.gen_range(0..50u64))
+                        .collect();
+                    keys.sort_unstable();
+                    keys.dedup();
+                    keys.into_iter()
+                        .map(|k| {
+                            (
+                                k,
+                                DiffEntry::Active {
+                                    value: k * 1000 + d,
+                                    loc: loc(k * 1000 + d),
+                                    base_old_loc: None,
+                                },
+                            )
+                        })
+                        .collect()
+                })
+                .collect();
+
+            // Ascending queries spanning the universe (with gaps and duplicates).
+            let mut queries: Vec<u64> = (0..rng.gen_range(1..60))
+                .map(|_| rng.gen_range(0..55u64))
+                .collect();
+            queries.sort_unstable();
+
+            let mut cursors = DiffCursors::new(diffs.iter().map(|d| d.as_slice()));
+            for q in queries {
+                let expected = diffs.iter().find_map(|d| lookup_sorted(d.as_slice(), &q));
+                let actual = cursors.resolve(&q);
+                assert_eq!(
+                    expected.map(DiffEntry::loc),
+                    actual.map(DiffEntry::loc),
+                    "query {q} diverged"
+                );
+            }
+        }
     }
 
     /// Single-step oracle for [`fill_candidates`]: return the next floor-raise candidate in

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -537,7 +537,9 @@ where
             .or_else(|| reader.try_read_sync(*loc))
     }
 
-    /// Read a single operation by location.
+    /// Read a single operation by location (test oracle; production paths batch via
+    /// [`Self::read_ops`]).
+    #[cfg(test)]
     async fn read_op<R: Reader<Item = Operation<F, U>>>(
         &self,
         loc: Location<F>,
@@ -1405,6 +1407,11 @@ where
         //
         // Depth-1 chains skip the set entirely — a single ancestor can't shadow itself,
         // and each diff's keys are unique by construction.
+        //
+        // Each diff is key-sorted, as are `updated`/`created`/`deleted`, so the handled check
+        // advances three cursors in a sorted merge instead of three binary searches per key.
+        // Active entries are collected and read in one batch below instead of one awaited
+        // read per key.
         let track_shadow = m.ancestors.len() > 1;
         let seen_cap = if track_shadow {
             m.ancestors.iter().map(|a| a.diff.len()).sum()
@@ -1413,28 +1420,32 @@ where
         };
         let mut seen: AHashSet<&K> = AHashSet::with_capacity(seen_cap);
         let mut ancestor_deleted: Vec<K> = Vec::new();
+        let mut ancestor_active: Vec<(&K, &V::Value, Location<F>)> = Vec::new();
         for batch in m.ancestors.iter() {
+            let (mut ui, mut ci, mut di) = (0, 0, 0);
             for (key, entry) in batch.diff.iter() {
                 if track_shadow && !seen.insert(key) {
                     continue;
                 }
                 // Skip keys already handled by this batch's mutations.
-                if updated.binary_search_by(|(k, _, _)| k.cmp(key)).is_ok()
-                    || created.binary_search_by(|(k, _, _)| k.cmp(key)).is_ok()
-                    || deleted.binary_search_by(|(k, _)| k.cmp(key)).is_ok()
+                while ui < updated.len() && updated[ui].0 < *key {
+                    ui += 1;
+                }
+                while ci < created.len() && created[ci].0 < *key {
+                    ci += 1;
+                }
+                while di < deleted.len() && deleted[di].0 < *key {
+                    di += 1;
+                }
+                if updated.get(ui).is_some_and(|(k, ..)| k == key)
+                    || created.get(ci).is_some_and(|(k, ..)| k == key)
+                    || deleted.get(di).is_some_and(|(k, _)| k == key)
                 {
                     continue;
                 }
                 match entry {
                     DiffEntry::Active { value, loc, .. } => {
-                        let op = m.read_op(*loc, &[], &reader).await?;
-                        let data = match op {
-                            Operation::Update(data) => data,
-                            _ => unreachable!("ancestor diff Active should reference Update op"),
-                        };
-                        next_candidates.push(key.clone());
-                        next_candidates.push(data.next_key);
-                        prev_candidates.push((key.clone(), (value.clone(), *loc)));
+                        ancestor_active.push((key, value, *loc));
                     }
                     DiffEntry::Deleted { .. } => {
                         ancestor_deleted.push(key.clone());
@@ -1444,6 +1455,24 @@ where
         }
         ancestor_deleted.sort();
         ancestor_deleted.dedup();
+
+        // Batch-read the collected active entries' ops and emit their candidates.
+        let ancestor_locs: Vec<Location<F>> =
+            ancestor_active.iter().map(|&(_, _, loc)| loc).collect();
+        for (op, (key, value, loc)) in m
+            .read_ops(&ancestor_locs, &[], &reader)
+            .await?
+            .into_iter()
+            .zip(ancestor_active)
+        {
+            let data = match op {
+                Operation::Update(data) => data,
+                _ => unreachable!("ancestor diff Active should reference Update op"),
+            };
+            next_candidates.push(key.clone());
+            next_candidates.push(data.next_key);
+            prev_candidates.push((key.clone(), (value.clone(), loc)));
+        }
 
         // Sort + dedup candidate sets now so find_next_key/find_prev_key can binary-search.
         next_candidates.sort();

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -230,6 +230,30 @@ pub(crate) fn find_next_key<K: Ord + Clone>(key: &K, possible_next: &[K]) -> K {
         .clone()
 }
 
+/// Streaming equivalent of [`find_next_key`] for an ascending sequence of queries: `idx`
+/// advances in a linear merge instead of binary-searching per query. Queries must be
+/// non-decreasing; `idx` must start at 0 and be threaded through every call.
+///
+/// # Panics
+///
+/// Panics if `possible_next` is empty.
+pub(crate) fn find_next_key_ascending<K: Ord + Clone>(
+    key: &K,
+    possible_next: &[K],
+    idx: &mut usize,
+) -> K {
+    while *idx < possible_next.len() && possible_next[*idx] <= *key {
+        *idx += 1;
+    }
+    if *idx < possible_next.len() {
+        return possible_next[*idx].clone();
+    }
+    possible_next
+        .first()
+        .expect("possible_next should not be empty")
+        .clone()
+}
+
 /// Returns the previous key to `key` within `possible_previous` (sorted by `.0`, deduplicated).
 /// The result will "cycle around" to the last entry if `key` is the first key.
 ///
@@ -296,8 +320,37 @@ mod test {
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_runtime::{deterministic::Context, Supervisor as _};
-    use commonware_utils::sequence::FixedBytes;
+    use commonware_utils::{sequence::FixedBytes, test_rng};
     use core::{future::Future, pin::Pin};
+    use rand::Rng;
+
+    /// [`find_next_key_ascending`] must return exactly what [`find_next_key`] returns for any
+    /// ascending query sequence, including queries past the last candidate (cyclic wrap).
+    #[test]
+    fn find_next_key_ascending_matches_binary_search() {
+        let mut rng = test_rng();
+        for _ in 0..50 {
+            let mut candidates: Vec<u64> = (0..rng.gen_range(1..40))
+                .map(|_| rng.gen_range(0..60u64))
+                .collect();
+            candidates.sort_unstable();
+            candidates.dedup();
+
+            let mut queries: Vec<u64> = (0..rng.gen_range(1..80))
+                .map(|_| rng.gen_range(0..70u64))
+                .collect();
+            queries.sort_unstable();
+
+            let mut idx = 0;
+            for q in queries {
+                assert_eq!(
+                    find_next_key(&q, &candidates),
+                    find_next_key_ascending(&q, &candidates, &mut idx),
+                    "query {q} diverged"
+                );
+            }
+        }
+    }
 
     pub(crate) async fn test_ordered_any_db_empty<
         F: Family,

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -207,23 +207,25 @@ macro_rules! run_pipeline {
         let mut rng = StdRng::seed_from_u64(99);
         let mut times_ms: Vec<f64> = Vec::with_capacity(args.iters);
         for iter in 0..args.iters {
-            // Pending ancestors are rebuilt per iteration and never applied (untimed).
-            let mut parent: Option<$merkleized> = None;
+            // Pending ancestors are rebuilt per iteration and never applied (untimed). The
+            // whole chain is held alive: dropping an uncommitted ancestor before merkleize
+            // loses its diff (the parent link is a Weak ref).
+            let mut chain: Vec<$merkleized> = Vec::with_capacity(args.depth as usize);
             for _ in 0..args.depth {
-                let mut b = parent
-                    .as_ref()
+                let mut b = chain
+                    .last()
                     .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>());
                 for (k, v) in gen_muts(&mut rng, args.num_updates, args.num_keys) {
                     b = b.write(k, Some(v));
                 }
-                parent = Some(b.merkleize(&db, None).await.unwrap());
+                chain.push(b.merkleize(&db, None).await.unwrap());
             }
 
             let muts = gen_muts(&mut rng, args.num_updates, args.num_keys);
             let keys: Vec<&Digest> = muts.iter().map(|(k, _)| k).collect();
             let new_batch = || {
-                parent
-                    .as_ref()
+                chain
+                    .last()
                     .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
             };
 

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -13,7 +13,7 @@ use crate::{
         self,
         any::{
             self,
-            batch::{lookup_sorted, DiffEntry},
+            batch::{DiffCursors, DiffEntry},
             operation::{update, Operation},
             ValueEncoding,
         },
@@ -524,7 +524,9 @@ where
     // 2. Inactivate previous CommitFloor.
     overlay.clear_bit(base, pruned_chunks, batch_base - 1);
 
-    // 3. Set active bits + clear superseded locations from the diff.
+    // 3. Set active bits + clear superseded locations from the diff. The diff is key-sorted,
+    // so ancestor resolution streams (one cursor per ancestor diff).
+    let mut ancestors = DiffCursors::new(ancestor_diffs.iter().map(|d| d.as_slice()));
     for (key, entry) in diff {
         // Set the active bit for this key's final location.
         if let Some(loc) = entry.loc() {
@@ -536,11 +538,8 @@ where
         // Clear the most recent superseded location. Older locations were already cleared by the
         // ancestor batch that superseded them.
         let mut prev_loc = entry.base_old_loc();
-        for ancestor_diff in ancestor_diffs {
-            if let Some(ancestor_entry) = lookup_sorted(ancestor_diff.as_slice(), key) {
-                prev_loc = ancestor_entry.loc();
-                break;
-            }
+        if let Some(ancestor_entry) = ancestors.resolve(key) {
+            prev_loc = ancestor_entry.loc();
         }
         if let Some(old) = prev_loc {
             overlay.clear_bit(base, pruned_chunks, *old);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stacked on #4020. Replaces per-key binary searches with sorted merges everywhere merkleize issues lookups from a key-sorted loop, and batches the ancestor walk's per-key reads. All changes are general (no batch-composition assumptions) and behavior-identical (byte-identical roots, see Results).

## What it does

1. **Sorted merge in the ancestor walk.** For every ancestor-diff entry, the walk checked "is this key already handled by this batch?" with three binary searches (over `updated`, `created`, and `deleted`, each ~16 cache-missy 32-byte compares per probe over MB-sized arrays). Each ancestor diff is key-sorted, as are all three vecs, so the check now advances three cursors in a linear merge. Cursors reset per ancestor; shadow-set (`seen`) semantics are unchanged.
2. **Batched ancestor walk reads.** The walk awaited `read_op` once per ancestor-diff Active key (up to ~65k sequential awaits per merkleize at the Constantinople shape, depth 1). Active entries are now collected during the walk and resolved with one `read_ops` call (the same batching #4007 applied to the other read paths). Every ancestor-diff location resolves synchronously through the same layers as before, so this changes only the call pattern, not the resolution source.
3. **Streamed sorted-key lookups everywhere else** (`DiffCursors` + `find_next_key_ascending`):
   - Ordered emit loops: `resolve_in_ancestors` per updated/deleted key and `find_next_key` per updated/created key now stream (the emit loops iterate key-sorted vecs, so one cursor per ancestor diff and one index into `next_candidates` replace per-key binary searches). The `find_next_key` change pays off at every depth, including 0.
   - `gather_existing_locations` and `extract_parent_deleted_creates`: ancestor resolution streams over the ascending `mutations` iteration.
   - `build_chunk_overlay` (current): the superseded-location lookup per diff entry streams over the key-sorted diff, benefiting both ordered and unordered `current` variants at depth >= 1.
   - The predecessor-rewrite loop keeps per-key searches: its query keys are not sorted and its counts are small.
4. **Harness fix (pre-existing bug).** The `constantinople` harness only kept the latest pending ancestor alive, but the merkle batch parent link is a `Weak` ref and the API requires the whole uncommitted chain to stay alive, so `depth >= 2` panicked with "peak missing" (`merkle::batch::MerkleizedBatch::root` fails fast when a dropped ancestor's appended peaks become unreachable) - on main too. The harness now holds the full chain (the same pattern the parity tests use), which is what made depth-2 measurement possible.

`Merkleizer::read_op` becomes test-only (`#[cfg(test)]`, used as an oracle by the batch tests).

## Results

Constantinople shape (1M keys, 32k updates/batch, EightCap, tokio, Linux x86_64, 4 cores), 3-way interleaved single session (main vs this PR after items 1-2 vs final), 6 reps x 30 iters, pooled p50:

| variant | depth | main | walk batching (1-2) | final (3) | final vs main | paired reps faster (3 vs 1-2) |
|---|---|---|---|---|---|---|
| any::ordered::fixed::mmb | 0 | 60.4 | 45.1 | 43.3 | -28.3% | 5/6 |
| any::ordered::fixed::mmb | 1 | 89.0 | 66.4 | 61.3 | -31.2% | 6/6 |
| current::ordered::fixed::mmb | 1 | 100.0 | 80.4 | 67.8 | -32.2% | 6/6 |
| current::unordered::fixed::mmb | 1 | 64.6 | 60.2 | 55.2 | -14.5% | 6/6 |

An earlier session additionally measured depth 2 for items 1-2 (any::ordered: main 139.4 -> 110.4, -20.9%); the walk-related gains scale with pending-ancestor depth. The speculative root was byte-identical across all binaries on every iteration of every run (72 runs per session). The deltas vs main include #4020 (this PR is stacked on it); the "vs (1-2)" pairing isolates this PR's item 3.

## Testing

- Full `commonware-storage` lib suite passes (2968+ tests), including `test_ordered_fixed_resolved_merkleize_parity` (TwoCap collision-heavy, depths 0-2 with multi-ancestor shadow tracking, mixed updates/deletes/creates) and `test_ordered_fixed_caching_survives_ancestor_commit`.
- New equivalence tests: `diff_cursors_matches_lookup_sorted` (random overlapping diffs, ascending queries vs per-key `lookup_sorted` closest-first) and `find_next_key_ascending_matches_binary_search` (random candidate sets, ascending queries vs `find_next_key`, including cyclic wrap).
- Benchmark root parity vs main and vs the intermediate head on every iteration of every run, including depth 2.
- Nightly `rustfmt --check` (CI-equivalent invocation) and `cargo clippy -p commonware-storage --lib --tests` clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c4e9e62-510e-4929-a6a0-7edb74702f40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4e9e62-510e-4929-a6a0-7edb74702f40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

