### PR TITLE
[storage/journal/contiguous] Don't time cache hits

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -325,7 +325,7 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
 
         // Only misses are timed: hits complete below the histogram's resolution and the clock
         // reads would dominate their cost.
-        let _timer = self.metrics.read_miss_timer();
+        let _timer = self.metrics.read_timer();
         let item = self.guard.read(pos, self.items_per_blob).await?;
         self.metrics.items_read.inc();
         Ok(item)
@@ -4493,7 +4493,7 @@ mod tests {
                 "fixed_metrics_sync_calls_total 1",
                 "fixed_metrics_append_duration_count 1",
                 "fixed_metrics_append_many_duration_count 1",
-                "fixed_metrics_read_miss_duration_count 0",
+                "fixed_metrics_read_duration_count 0",
                 "fixed_metrics_read_many_duration_count 1",
                 "fixed_metrics_commit_duration_count 1",
                 "fixed_metrics_sync_duration_count 1",
@@ -4510,7 +4510,7 @@ mod tests {
 
     #[test_traced]
     fn test_fixed_journal_read_miss_timed() {
-        // Reads served from storage record a read_miss_duration sample; cache hits do not.
+        // Reads served from storage record a read_duration sample; cache hits do not.
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let journal =
@@ -4531,10 +4531,7 @@ mod tests {
             drop(reader);
 
             let buffer = context.encode();
-            assert!(
-                buffer.contains("miss_read_miss_duration_count 1"),
-                "{buffer}"
-            );
+            assert!(buffer.contains("miss_read_duration_count 1"), "{buffer}");
 
             journal.destroy().await.unwrap();
         });

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -323,8 +323,6 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         }
         self.metrics.record_cache_misses(1);
 
-        // Only misses are timed: hits complete below the histogram's resolution and the clock
-        // reads would dominate their cost.
         let _timer = self.metrics.read_timer();
         let item = self.guard.read(pos, self.items_per_blob).await?;
         self.metrics.items_read.inc();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -313,7 +313,6 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
     }
 
     async fn read(&self, pos: u64) -> Result<A, Error> {
-        let _timer = self.metrics.read_timer();
         self.metrics.read_calls.inc();
 
         // Serve from the page cache synchronously when possible, avoiding the async storage path.
@@ -324,6 +323,9 @@ impl<E: Context, A: CodecFixedShared> super::Reader for Reader<'_, E, A> {
         }
         self.metrics.record_cache_misses(1);
 
+        // Only misses are timed: hits complete below the histogram's resolution and the clock
+        // reads would dominate their cost.
+        let _timer = self.metrics.read_miss_timer();
         let item = self.guard.read(pos, self.items_per_blob).await?;
         self.metrics.items_read.inc();
         Ok(item)
@@ -4491,7 +4493,7 @@ mod tests {
                 "fixed_metrics_sync_calls_total 1",
                 "fixed_metrics_append_duration_count 1",
                 "fixed_metrics_append_many_duration_count 1",
-                "fixed_metrics_read_duration_count 1",
+                "fixed_metrics_read_miss_duration_count 0",
                 "fixed_metrics_read_many_duration_count 1",
                 "fixed_metrics_commit_duration_count 1",
                 "fixed_metrics_sync_duration_count 1",
@@ -4501,6 +4503,38 @@ mod tests {
             ] {
                 assert!(buffer.contains(expected), "{expected}\n{buffer}");
             }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_read_miss_timed() {
+        // Reads served from storage record a read_miss_duration sample; cache hits do not.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let journal =
+                Journal::<_, Digest>::init(context.child("miss"), test_cfg(&context, NZU64!(2)))
+                    .await
+                    .unwrap();
+            for i in 0..20 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+
+            // The page cache cannot hold every page, so some position must be cold.
+            let reader = journal.reader().await;
+            let pos = (0..20)
+                .find(|&pos| reader.try_read_sync(pos).is_none())
+                .expect("some position should be cold");
+            assert_eq!(reader.read(pos).await.unwrap(), test_digest(pos));
+            drop(reader);
+
+            let buffer = context.encode();
+            assert!(
+                buffer.contains("miss_read_miss_duration_count 1"),
+                "{buffer}"
+            );
 
             journal.destroy().await.unwrap();
         });

--- a/storage/src/journal/contiguous/metrics.rs
+++ b/storage/src/journal/contiguous/metrics.rs
@@ -53,7 +53,7 @@ pub(super) struct CommonMetrics<E: Clock> {
     /// Single-item read calls.
     pub read_calls: Counter,
     /// Duration of single-item read calls that miss the page cache.
-    read_miss_duration: Timed,
+    read_duration: Timed,
     /// Non-empty batch async read calls.
     pub read_many_calls: Counter,
     /// Duration of non-empty batch read calls.
@@ -111,9 +111,9 @@ impl<E: RuntimeMetrics + Clock> CommonMetrics<E> {
         let read_calls = context
             .as_ref()
             .counter("read_calls", "Number of single-item read calls");
-        let read_miss_duration = duration_histogram(
+        let read_duration = duration_histogram(
             context.as_ref(),
-            "read_miss_duration",
+            "read_duration",
             "Duration of single-item read calls that miss the page cache",
         );
         let read_many_calls = context
@@ -153,7 +153,7 @@ impl<E: RuntimeMetrics + Clock> CommonMetrics<E> {
             append_prepared_calls,
             append_prepared_duration: Timed::new(append_prepared_duration),
             read_calls,
-            read_miss_duration: Timed::new(read_miss_duration),
+            read_duration: Timed::new(read_duration),
             read_many_calls,
             read_many_duration: Timed::new(read_many_duration),
             try_read_sync_hits,
@@ -177,8 +177,8 @@ impl<E: Clock> CommonMetrics<E> {
         self.append_prepared_duration.scoped(&self.clock)
     }
 
-    pub(super) fn read_miss_timer(&self) -> ScopedTimer<E> {
-        self.read_miss_duration.scoped(&self.clock)
+    pub(super) fn read_timer(&self) -> ScopedTimer<E> {
+        self.read_duration.scoped(&self.clock)
     }
 
     pub(super) fn read_many_timer(&self) -> ScopedTimer<E> {

--- a/storage/src/journal/contiguous/metrics.rs
+++ b/storage/src/journal/contiguous/metrics.rs
@@ -52,8 +52,8 @@ pub(super) struct CommonMetrics<E: Clock> {
     append_prepared_duration: Timed,
     /// Single-item read calls.
     pub read_calls: Counter,
-    /// Duration of single-item read calls.
-    read_duration: Timed,
+    /// Duration of single-item read calls that miss the page cache.
+    read_miss_duration: Timed,
     /// Non-empty batch async read calls.
     pub read_many_calls: Counter,
     /// Duration of non-empty batch read calls.
@@ -111,10 +111,10 @@ impl<E: RuntimeMetrics + Clock> CommonMetrics<E> {
         let read_calls = context
             .as_ref()
             .counter("read_calls", "Number of single-item read calls");
-        let read_duration = duration_histogram(
+        let read_miss_duration = duration_histogram(
             context.as_ref(),
-            "read_duration",
-            "Duration of single-item read calls",
+            "read_miss_duration",
+            "Duration of single-item read calls that miss the page cache",
         );
         let read_many_calls = context
             .as_ref()
@@ -153,7 +153,7 @@ impl<E: RuntimeMetrics + Clock> CommonMetrics<E> {
             append_prepared_calls,
             append_prepared_duration: Timed::new(append_prepared_duration),
             read_calls,
-            read_duration: Timed::new(read_duration),
+            read_miss_duration: Timed::new(read_miss_duration),
             read_many_calls,
             read_many_duration: Timed::new(read_many_duration),
             try_read_sync_hits,
@@ -177,8 +177,8 @@ impl<E: Clock> CommonMetrics<E> {
         self.append_prepared_duration.scoped(&self.clock)
     }
 
-    pub(super) fn read_timer(&self) -> ScopedTimer<E> {
-        self.read_duration.scoped(&self.clock)
+    pub(super) fn read_miss_timer(&self) -> ScopedTimer<E> {
+        self.read_miss_duration.scoped(&self.clock)
     }
 
     pub(super) fn read_many_timer(&self) -> ScopedTimer<E> {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -277,7 +277,6 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<'_, E, V> {
     }
 
     async fn read(&self, position: u64) -> Result<V, Error> {
-        let _timer = self.metrics.read_timer();
         self.metrics.read_calls.inc();
 
         // Serve from the page cache synchronously when possible, collapsing the offsets and data
@@ -290,6 +289,9 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<'_, E, V> {
             return Ok(item);
         }
 
+        // Only misses are timed: hits complete below the histogram's resolution and the clock
+        // reads would dominate their cost.
+        let _timer = self.metrics.read_miss_timer();
         let item = self
             .guard
             .read(position, self.items_per_section, &self.offsets)
@@ -5495,7 +5497,7 @@ mod tests {
                 "variable_metrics_sync_calls_total 1",
                 "variable_metrics_append_duration_count 1",
                 "variable_metrics_append_many_duration_count 1",
-                "variable_metrics_read_duration_count 1",
+                "variable_metrics_read_miss_duration_count 0",
                 "variable_metrics_read_many_duration_count 1",
                 "variable_metrics_commit_duration_count 1",
                 "variable_metrics_sync_duration_count 1",
@@ -5511,6 +5513,47 @@ mod tests {
             ] {
                 assert!(!buffer.contains(unexpected), "{unexpected}\n{buffer}");
             }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_journal_read_miss_timed() {
+        // Reads served from storage record a read_miss_duration sample; cache hits do not.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Sections span multiple full pages so their data must go through the (evictable)
+            // page cache rather than staying resident in each blob's partial tail page.
+            let cfg = Config {
+                partition: "miss".into(),
+                items_per_section: NZU64!(50),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let journal = Journal::<_, u64>::init(context.child("miss"), cfg)
+                .await
+                .unwrap();
+            for i in 0..200u64 {
+                journal.append(&i).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+
+            // The page cache cannot hold every page, so some position must be cold.
+            let reader = journal.reader().await;
+            let pos = (0..200)
+                .find(|&pos| reader.try_read_sync(pos).is_none())
+                .expect("some position should be cold");
+            assert_eq!(reader.read(pos).await.unwrap(), pos);
+            drop(reader);
+
+            let buffer = context.encode();
+            assert!(
+                buffer.contains("miss_read_miss_duration_count 1"),
+                "{buffer}"
+            );
 
             journal.destroy().await.unwrap();
         });

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -289,8 +289,6 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<'_, E, V> {
             return Ok(item);
         }
 
-        // Only misses are timed: hits complete below the histogram's resolution and the clock
-        // reads would dominate their cost.
         let _timer = self.metrics.read_timer();
         let item = self
             .guard

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -291,7 +291,7 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<'_, E, V> {
 
         // Only misses are timed: hits complete below the histogram's resolution and the clock
         // reads would dominate their cost.
-        let _timer = self.metrics.read_miss_timer();
+        let _timer = self.metrics.read_timer();
         let item = self
             .guard
             .read(position, self.items_per_section, &self.offsets)
@@ -5497,7 +5497,7 @@ mod tests {
                 "variable_metrics_sync_calls_total 1",
                 "variable_metrics_append_duration_count 1",
                 "variable_metrics_append_many_duration_count 1",
-                "variable_metrics_read_miss_duration_count 0",
+                "variable_metrics_read_duration_count 0",
                 "variable_metrics_read_many_duration_count 1",
                 "variable_metrics_commit_duration_count 1",
                 "variable_metrics_sync_duration_count 1",
@@ -5520,7 +5520,7 @@ mod tests {
 
     #[test_traced]
     fn test_variable_journal_read_miss_timed() {
-        // Reads served from storage record a read_miss_duration sample; cache hits do not.
+        // Reads served from storage record a read_duration sample; cache hits do not.
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Sections span multiple full pages so their data must go through the (evictable)
@@ -5550,10 +5550,7 @@ mod tests {
             drop(reader);
 
             let buffer = context.encode();
-            assert!(
-                buffer.contains("miss_read_miss_duration_count 1"),
-                "{buffer}"
-            );
+            assert!(buffer.contains("miss_read_duration_count 1"), "{buffer}");
 
             journal.destroy().await.unwrap();
         });


### PR DESCRIPTION
Cache hits are very fast so the amount of time it takes to measure them is comparable to the thing being measured.