### PR TITLE
[storage/index] store collision chains in a side table

### DIFF
--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -237,10 +237,6 @@ jobs:
       uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2.60.0
       with:
         tool: just@1.43.0,cargo-nextest@0.9.133
-    - name: Run miri tests for storage::index
-      run: |
-        cd storage
-        just miri index::tests --partition hash:${{matrix.partition}}/12
     - name: Run miri tests for runtime::iobuf
       run: |
         cd runtime

--- a/storage/src/index/benches/hashmap_insert.rs
+++ b/storage/src/index/benches/hashmap_insert.rs
@@ -11,7 +11,6 @@ struct MockIndex {
     _section: u64,
     _offset: u32,
     _len: u32,
-    _next: Option<Box<Self>>,
 }
 
 fn bench_hashmap_insert(c: &mut Criterion) {
@@ -44,7 +43,6 @@ fn bench_hashmap_insert(c: &mut Criterion) {
                                 _section: section,
                                 _offset: offset,
                                 _len: len,
-                                _next: None,
                             };
                             map.insert(key, value);
                         }

--- a/storage/src/index/benches/hashmap_insert_fixed.rs
+++ b/storage/src/index/benches/hashmap_insert_fixed.rs
@@ -11,7 +11,6 @@ struct MockIndex {
     _section: u64,
     _offset: u32,
     _len: u32,
-    _next: Option<Box<Self>>,
 }
 
 fn bench_hashmap_insert_fixed(c: &mut Criterion) {
@@ -42,7 +41,6 @@ fn bench_hashmap_insert_fixed(c: &mut Criterion) {
                             _section: section,
                             _offset: offset,
                             _len: len,
-                            _next: None,
                         };
                         map.insert(key, value);
                     }

--- a/storage/src/index/benches/hashmap_iteration.rs
+++ b/storage/src/index/benches/hashmap_iteration.rs
@@ -11,7 +11,6 @@ struct MockIndex {
     section: u64,
     _offset: u32,
     _len: u32,
-    _next: Option<Box<Self>>,
 }
 
 fn bench_hashmap_iteration(c: &mut Criterion) {
@@ -31,7 +30,6 @@ fn bench_hashmap_iteration(c: &mut Criterion) {
                                 section: rng.gen(),
                                 _offset: rng.gen(),
                                 _len: rng.gen(),
-                                _next: None,
                             };
                             map.insert(key.clone(), value);
                         }

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -2425,15 +2425,7 @@ mod tests {
     /// Exercises a single translated key holding a very large overflow chain, ensuring inserts and
     /// the resulting `Vec` overflow stay correct at scale.
     fn run_index_large_collision_chain<I: Unordered<Value = u64>>(index: &mut I) {
-        cfg_if::cfg_if! {
-            if #[cfg(miri)] {
-                // miri uses a smaller chain to keep runtime reasonable while exercising the same
-                // insert and overflow paths.
-                const ITEMS: usize = 5_000;
-            } else {
-                const ITEMS: usize = 50_000;
-            }
-        }
+        const ITEMS: usize = 50_000;
         for i in 0..ITEMS {
             index.insert(b"", i as u64);
         }

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -33,7 +33,7 @@ pub mod unordered;
 /// - Insertion via `insert()` to add new values.
 /// - Deletion via `delete()` to remove values.
 ///
-/// # Safety
+/// # Usage
 ///
 /// - Must call `next()` before `update()`, `insert()`, or `delete()` to establish a valid position.
 /// - Once `next()` returns `None`, only `insert()` can be called.
@@ -1355,6 +1355,62 @@ mod tests {
             {
                 let mut index = new_partitioned_ordered(context.child("ordered"));
                 run_index_insert_and_retain_dead_insert(&mut index);
+            }
+        });
+    }
+
+    /// Exercises `insert_and_retain` on single-value (collision-free) keys, covering each
+    /// combination of retaining the existing and new values.
+    fn run_index_insert_and_retain_single_value<I: Unordered<Value = u64>>(index: &mut I) {
+        // Retain both: the new value joins the chain after the existing one.
+        index.insert(b"both", 1u64);
+        index.insert_and_retain(b"both", 2u64, |_| true);
+        assert_eq!(index.get(b"both").copied().collect::<Vec<_>>(), vec![1, 2]);
+
+        // Retain the existing value, drop the new one: a no-op.
+        index.insert(b"keep", 1u64);
+        index.insert_and_retain(b"keep", 2u64, |v| *v == 1);
+        assert_eq!(index.get(b"keep").copied().collect::<Vec<_>>(), vec![1]);
+
+        // Drop both: the key is removed.
+        index.insert(b"drop", 1u64);
+        index.insert_and_retain(b"drop", 2u64, |_| false);
+        assert!(index.get(b"drop").next().is_none());
+
+        assert_eq!(index.keys(), 2); // "both" and "keep" remain
+        assert_eq!(index.items(), 3); // both -> [1, 2], keep -> [1]
+        assert_eq!(index.pruned(), 1); // the dropped "drop" value
+    }
+
+    #[test_traced]
+    fn test_hash_index_insert_and_retain_single_value() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let mut index = new_unordered(context);
+            run_index_insert_and_retain_single_value(&mut index);
+        });
+    }
+
+    #[test_traced]
+    fn test_ordered_index_insert_and_retain_single_value() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let mut index = new_ordered(context);
+            run_index_insert_and_retain_single_value(&mut index);
+        });
+    }
+
+    #[test_traced]
+    fn test_partitioned_index_insert_and_retain_single_value() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            {
+                let mut index = new_partitioned_unordered(context.child("unordered"));
+                run_index_insert_and_retain_single_value(&mut index);
+            }
+            {
+                let mut index = new_partitioned_ordered(context.child("ordered"));
+                run_index_insert_and_retain_single_value(&mut index);
             }
         });
     }

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -25,7 +25,7 @@ pub mod unordered;
 /// A mutable iterator over the values associated with a translated key, allowing in-place
 /// modifications.
 ///
-/// The [Cursor] provides a way to traverse and modify the linked list of values associated with a
+/// The [Cursor] provides a way to traverse and modify the chain of values associated with a
 /// translated key by an index while maintaining its structure. It supports:
 ///
 /// - Iteration via `next()` to access values.
@@ -37,7 +37,7 @@ pub mod unordered;
 ///
 /// - Must call `next()` before `update()`, `insert()`, or `delete()` to establish a valid position.
 /// - Once `next()` returns `None`, only `insert()` can be called.
-/// - The cursor mutates the linked list in place. If the sole element is deleted, dropping the
+/// - The cursor mutates the chain of values in place. If the sole element is deleted, dropping the
 ///   cursor removes the map entry.
 ///
 /// _If you don't need advanced functionality, just use `insert()`, `insert_and_retain()`, or
@@ -53,7 +53,7 @@ pub trait Cursor: Send + Sync {
     /// If after `insert()`, the next active item is the item after the inserted item. If after
     /// `delete()`, the next active item is the item after the deleted item.
     ///
-    /// Advances through cursor states and adjusts for deletions. Returns `None` when the list is
+    /// Advances through cursor states and adjusts for deletions. Returns `None` when the chain is
     /// exhausted. It is safe to call `next()` even after it returns `None`.
     #[allow(clippy::should_implement_trait)]
     fn next(&mut self) -> Option<&Self::Value>;
@@ -61,7 +61,7 @@ pub trait Cursor: Send + Sync {
     /// Inserts a new value at the current position.
     fn insert(&mut self, value: Self::Value);
 
-    /// Deletes the current value, adjusting the list structure.
+    /// Deletes the current value, adjusting the chain structure.
     fn delete(&mut self);
 
     /// Updates the value at the current position in the iteration.

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -2422,11 +2422,13 @@ mod tests {
         });
     }
 
-    fn run_index_large_collision_chain_stack_overflow<I: Unordered<Value = u64>>(index: &mut I) {
+    /// Exercises a single translated key holding a very large overflow chain, ensuring inserts and
+    /// the resulting `Vec` overflow stay correct at scale.
+    fn run_index_large_collision_chain<I: Unordered<Value = u64>>(index: &mut I) {
         cfg_if::cfg_if! {
             if #[cfg(miri)] {
-                // The full native test stresses stack depth, while miri is mainly checking the
-                // same iterative drop path for memory safety.
+                // miri uses a smaller chain to keep runtime reasonable while exercising the same
+                // insert and overflow paths.
                 const ITEMS: usize = 5_000;
             } else {
                 const ITEMS: usize = 50_000;
@@ -2438,34 +2440,34 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_hash_index_large_collision_chain_stack_overflow() {
+    fn test_hash_index_large_collision_chain() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_unordered(context);
-            run_index_large_collision_chain_stack_overflow(&mut index);
+            run_index_large_collision_chain(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_ordered_index_large_collision_chain_stack_overflow() {
+    fn test_ordered_index_large_collision_chain() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_ordered(context);
-            run_index_large_collision_chain_stack_overflow(&mut index);
+            run_index_large_collision_chain(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_partitioned_index_large_collision_chain_stack_overflow() {
+    fn test_partitioned_index_large_collision_chain() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             {
                 let mut index = new_partitioned_unordered(context.child("unordered"));
-                run_index_large_collision_chain_stack_overflow(&mut index);
+                run_index_large_collision_chain(&mut index);
             }
             {
                 let mut index = new_partitioned_ordered(context.child("ordered"));
-                run_index_large_collision_chain_stack_overflow(&mut index);
+                run_index_large_collision_chain(&mut index);
             }
         });
     }

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -29,12 +29,15 @@ use std::{
 /// Implementation of [IndexEntry] for [BTreeOccupiedEntry].
 impl<K: Ord + Send + Sync, V: Send + Sync> IndexEntry<V> for BTreeOccupiedEntry<'_, K, V> {
     type Key = K;
+
     fn key(&self) -> &K {
         BTreeOccupiedEntry::key(self)
     }
+
     fn get_mut(&mut self) -> &mut V {
         self.get_mut()
     }
+
     fn remove(self) {
         self.remove_entry();
     }

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -268,16 +268,14 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             BTreeEntry::Occupied(mut entry) => {
-                // Fast path: a key with no overflow chain holds exactly one value, so retaining
-                // it and inserting the new value reduces to a few direct cases. This avoids
-                // building a cursor for the common (collision-free) case. The cases below match
-                // the cursor's value ordering and metric accounting exactly.
+                // Optimized fast path for the common case of no overflow chain. The cases below
+                // match the cursor's value ordering and metric accounting exactly.
+                #[allow(clippy::map_entry)] // suppress lint false positive
                 if !self.overflow.contains_key(&k) {
                     match (should_retain(entry.get()), should_retain(&value)) {
-                        // Keep both: the new value joins the chain as the oldest (the position a
-                        // cursor insert after retain would place it).
+                        // Keep both, with the new value placed at the end of the overflow chain.
                         (true, true) => {
-                            self.overflow.entry(k).or_default().push(value);
+                            self.overflow.insert(k, vec![value]);
                             self.items.inc();
                         }
                         // Drop the existing value, keep the new one: replace in place.
@@ -333,9 +331,9 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
             self.items.dec();
             self.pruned.inc();
             if !self.overflow.is_empty() {
-                for _ in self.overflow.remove(&k).into_iter().flatten() {
-                    self.items.dec();
-                    self.pruned.inc();
+                if let Some(chain) = self.overflow.remove(&k) {
+                    self.items.dec_by(chain.len() as i64);
+                    self.pruned.inc_by(chain.len() as u64);
                 }
             }
         }

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -42,9 +42,9 @@ pub type Cursor<'a, K, V> = CursorImpl<'a, K, V, BTreeOccupiedEntry<'a, K, V>>;
 /// A memory-efficient index that uses an ordered map internally to map translated keys to arbitrary
 /// values.
 ///
-/// Each translated key maps directly to its most recently inserted value; conflicting values (from
-/// key collisions or repeated insertions) are stored in a separate overflow map so the common
-/// (collision-free) case stays as compact as possible.
+/// Each translated key maps directly to its most recently inserted value. Conflicting values (from
+/// key collisions or repeated insertions) live in a separate overflow map, keeping the common
+/// (collision-free) case compact.
 pub struct Index<T: Translator, V: Send + Sync> {
     translator: T,
     map: BTreeMap<T::Key, V>,
@@ -268,9 +268,8 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             BTreeEntry::Occupied(mut entry) => {
-                // Optimized fast path for the common case of no overflow chain. The cases below
-                // match the cursor's value ordering and metric accounting exactly.
-                #[allow(clippy::map_entry)] // suppress lint false positive
+                // Optimized fast path for the common case of no overflow chain.
+                #[allow(clippy::map_entry)]
                 if !self.overflow.contains_key(&k) {
                     match (should_retain(entry.get()), should_retain(&value)) {
                         // Keep both, with the new value placed at the end of the overflow chain.

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -28,6 +28,10 @@ use std::{
 
 /// Implementation of [IndexEntry] for [BTreeOccupiedEntry].
 impl<K: Ord + Send + Sync, V: Send + Sync> IndexEntry<V> for BTreeOccupiedEntry<'_, K, V> {
+    type Key = K;
+    fn key(&self) -> &K {
+        BTreeOccupiedEntry::key(self)
+    }
     fn get_mut(&mut self) -> &mut V {
         self.get_mut()
     }
@@ -220,7 +224,6 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         match self.map.entry(k) {
             BTreeEntry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
                 entry,
-                k,
                 &mut self.overflow,
                 &self.keys,
                 &self.items,
@@ -235,7 +238,6 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         match self.map.entry(k) {
             BTreeEntry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
                 entry,
-                k,
                 &mut self.overflow,
                 &self.keys,
                 &self.items,
@@ -298,7 +300,6 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
                 // Slow path: the key has conflicting values; walk them with a cursor.
                 let mut cursor = Cursor::<'_, T::Key, V>::new(
                     entry,
-                    k,
                     &mut self.overflow,
                     &self.keys,
                     &self.items,

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -267,7 +267,38 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     fn insert_and_retain(&mut self, key: &[u8], value: V, should_retain: impl Fn(&V) -> bool) {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
-            BTreeEntry::Occupied(entry) => {
+            BTreeEntry::Occupied(mut entry) => {
+                // Fast path: a key with no overflow chain holds exactly one value, so retaining
+                // it and inserting the new value reduces to a few direct cases. This avoids
+                // building a cursor for the common (collision-free) case. The cases below match
+                // the cursor's value ordering and metric accounting exactly.
+                if !self.overflow.contains_key(&k) {
+                    match (should_retain(entry.get()), should_retain(&value)) {
+                        // Keep both: the new value joins the chain as the oldest (the position a
+                        // cursor insert after retain would place it).
+                        (true, true) => {
+                            self.overflow.entry(k).or_default().push(value);
+                            self.items.inc();
+                        }
+                        // Drop the existing value, keep the new one: replace in place.
+                        (false, true) => {
+                            *entry.get_mut() = value;
+                            self.pruned.inc();
+                        }
+                        // Drop both: remove the key entirely.
+                        (false, false) => {
+                            entry.remove();
+                            self.keys.dec();
+                            self.items.dec();
+                            self.pruned.inc();
+                        }
+                        // Keep the existing value, drop the new one: nothing to do.
+                        (true, false) => {}
+                    }
+                    return;
+                }
+
+                // Slow path: the key has conflicting values; walk them with a cursor.
                 let mut cursor = Cursor::<'_, T::Key, V>::new(
                     entry,
                     k,

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -21,7 +21,7 @@ use std::{
             Entry as BTreeEntry, OccupiedEntry as BTreeOccupiedEntry,
             VacantEntry as BTreeVacantEntry,
         },
-        BTreeMap,
+        BTreeMap, HashMap,
     },
     ops::Bound::{Excluded, Unbounded},
 };
@@ -41,7 +41,7 @@ impl<K: Ord + Send + Sync, V: Send + Sync> IndexEntry<V> for BTreeOccupiedEntry<
 }
 
 /// A [crate::index::Cursor] over the values associated with a translated key.
-pub type Cursor<'a, K, V> = CursorImpl<'a, K, V, BTreeOccupiedEntry<'a, K, V>>;
+pub type Cursor<'a, K, V, S> = CursorImpl<'a, K, V, BTreeOccupiedEntry<'a, K, V>, S>;
 
 /// A memory-efficient index that uses an ordered map internally to map translated keys to arbitrary
 /// values.
@@ -52,7 +52,7 @@ pub type Cursor<'a, K, V> = CursorImpl<'a, K, V, BTreeOccupiedEntry<'a, K, V>>;
 pub struct Index<T: Translator, V: Send + Sync> {
     translator: T,
     map: BTreeMap<T::Key, V>,
-    overflow: Overflow<T::Key, V>,
+    overflow: Overflow<T::Key, V, T>,
 
     keys: Gauge,
     items: Gauge,
@@ -70,9 +70,9 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
     /// Create a new [Index] with the given translator and metrics registry.
     pub fn new(ctx: impl Metrics, translator: T) -> Self {
         Self {
+            overflow: HashMap::with_hasher(translator.clone()),
             translator,
             map: BTreeMap::new(),
-            overflow: Overflow::new(),
             keys: ctx.gauge("keys", "Number of translated keys in the index"),
             items: ctx.gauge("items", "Number of items in the index"),
             pruned: ctx.counter("pruned", "Number of items pruned"),
@@ -81,7 +81,7 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
 
     /// Returns an iterator over the values associated with the translated key `k`, given that
     /// key's inline (head) value.
-    fn values<'a>(&'a self, k: &T::Key, head: &'a V) -> Values<'a, T::Key, V> {
+    fn values<'a>(&'a self, k: &T::Key, head: &'a V) -> Values<'a, T::Key, V, T> {
         Values::new(Some(head), &self.overflow, *k)
     }
 
@@ -91,7 +91,7 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
     }
 
     /// Returns an iterator over all values associated with an already-translated key.
-    pub(super) fn get_translated(&self, key: T::Key) -> Values<'_, T::Key, V> {
+    pub(super) fn get_translated(&self, key: T::Key) -> Values<'_, T::Key, V, T> {
         Values::new(self.map.get(&key), &self.overflow, key)
     }
 
@@ -100,7 +100,7 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
     pub(super) fn next_translated_values_no_cycle(
         &self,
         key: &[u8],
-    ) -> Option<Values<'_, T::Key, V>> {
+    ) -> Option<Values<'_, T::Key, V, T>> {
         let k = self.translator.transform(key);
         self.map
             .range((Excluded(k), Unbounded))
@@ -113,7 +113,7 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
     pub(super) fn prev_translated_values_no_cycle(
         &self,
         key: &[u8],
-    ) -> Option<Values<'_, T::Key, V>> {
+    ) -> Option<Values<'_, T::Key, V, T>> {
         let k = self.translator.transform(key);
         self.map
             .range(..k)
@@ -123,7 +123,7 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
 
     /// Returns an iterator over the values of the lexicographically first translated key, or
     /// None if the index is empty.
-    pub(super) fn first_translated_values(&self) -> Option<Values<'_, T::Key, V>> {
+    pub(super) fn first_translated_values(&self) -> Option<Values<'_, T::Key, V, T>> {
         self.map
             .first_key_value()
             .map(|(k, head)| self.values(k, head))
@@ -131,7 +131,7 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
 
     /// Returns an iterator over the values of the lexicographically last translated key, or
     /// None if the index is empty.
-    pub(super) fn last_translated_values(&self) -> Option<Values<'_, T::Key, V>> {
+    pub(super) fn last_translated_values(&self) -> Option<Values<'_, T::Key, V, T>> {
         self.map
             .last_key_value()
             .map(|(k, head)| self.values(k, head))
@@ -208,7 +208,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         }
     }
     type Cursor<'a>
-        = Cursor<'a, T::Key, V>
+        = Cursor<'a, T::Key, V, T>
     where
         Self: 'a;
 
@@ -222,7 +222,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     fn get_mut<'a>(&'a mut self, key: &[u8]) -> Option<Self::Cursor<'a>> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
-            BTreeEntry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
+            BTreeEntry::Occupied(entry) => Some(Cursor::<'_, T::Key, V, T>::new(
                 entry,
                 &mut self.overflow,
                 &self.keys,
@@ -236,7 +236,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     fn get_mut_or_insert<'a>(&'a mut self, key: &[u8], value: V) -> Option<Self::Cursor<'a>> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
-            BTreeEntry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
+            BTreeEntry::Occupied(entry) => Some(Cursor::<'_, T::Key, V, T>::new(
                 entry,
                 &mut self.overflow,
                 &self.keys,
@@ -298,7 +298,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
                 }
 
                 // Slow path: the key has conflicting values; walk them with a cursor.
-                let mut cursor = Cursor::<'_, T::Key, V>::new(
+                let mut cursor = Cursor::<'_, T::Key, V, T>::new(
                     entry,
                     &mut self.overflow,
                     &self.keys,

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     index::{
-        storage::{insert_front, iter_chain, Cursor as CursorImpl, IndexEntry, Record},
+        storage::{push_displaced, Cursor as CursorImpl, IndexEntry, Overflow, Values},
         Cursor as CursorTrait, Ordered, Unordered,
     },
     translator::Translator,
@@ -27,8 +27,8 @@ use std::{
 };
 
 /// Implementation of [IndexEntry] for [BTreeOccupiedEntry].
-impl<K: Ord + Send + Sync, V: Send + Sync> IndexEntry<V> for BTreeOccupiedEntry<'_, K, Record<V>> {
-    fn get_mut(&mut self) -> &mut Record<V> {
+impl<K: Ord + Send + Sync, V: Send + Sync> IndexEntry<V> for BTreeOccupiedEntry<'_, K, V> {
+    fn get_mut(&mut self) -> &mut V {
         self.get_mut()
     }
     fn remove(self) {
@@ -37,13 +37,18 @@ impl<K: Ord + Send + Sync, V: Send + Sync> IndexEntry<V> for BTreeOccupiedEntry<
 }
 
 /// A [crate::index::Cursor] over the values associated with a translated key.
-pub type Cursor<'a, K, V> = CursorImpl<'a, V, BTreeOccupiedEntry<'a, K, Record<V>>>;
+pub type Cursor<'a, K, V> = CursorImpl<'a, K, V, BTreeOccupiedEntry<'a, K, V>>;
 
 /// A memory-efficient index that uses an ordered map internally to map translated keys to arbitrary
 /// values.
+///
+/// Each translated key maps directly to its most recently inserted value; conflicting values (from
+/// key collisions or repeated insertions) are stored in a separate overflow map so the common
+/// (collision-free) case stays as compact as possible.
 pub struct Index<T: Translator, V: Send + Sync> {
     translator: T,
-    map: BTreeMap<T::Key, Record<V>>,
+    map: BTreeMap<T::Key, V>,
+    overflow: Overflow<T::Key, V>,
 
     keys: Gauge,
     items: Gauge,
@@ -51,27 +56,11 @@ pub struct Index<T: Translator, V: Send + Sync> {
 }
 
 impl<T: Translator, V: Send + Sync> Index<T, V> {
-    /// Translate a key without probing.
-    pub(super) fn translate(&self, key: &[u8]) -> T::Key {
-        self.translator.transform(key)
-    }
-
-    /// Returns an iterator over all values associated with an already-translated key.
-    pub(super) fn get_translated<'a>(&'a self, key: T::Key) -> impl Iterator<Item = &'a V> + 'a
-    where
-        V: 'a,
-    {
-        self.map.get(&key).into_iter().flat_map(iter_chain)
-    }
-
     /// Create a new entry in the index.
-    fn create(keys: &Gauge, items: &Gauge, vacant: BTreeVacantEntry<'_, T::Key, Record<V>>, v: V) {
+    fn create(keys: &Gauge, items: &Gauge, vacant: BTreeVacantEntry<'_, T::Key, V>, v: V) {
         keys.inc();
         items.inc();
-        vacant.insert(Record {
-            value: v,
-            next: None,
-        });
+        vacant.insert(v);
     }
 
     /// Create a new [Index] with the given translator and metrics registry.
@@ -79,39 +68,69 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
         Self {
             translator,
             map: BTreeMap::new(),
+            overflow: Overflow::new(),
             keys: ctx.gauge("keys", "Number of translated keys in the index"),
             items: ctx.gauge("items", "Number of items in the index"),
             pruned: ctx.counter("pruned", "Number of items pruned"),
         }
     }
 
-    /// Returns the head record of the chain for the translated key that lexicographically follows
+    /// Returns an iterator over the values associated with the translated key `k`, given that
+    /// key's inline (head) value.
+    fn values<'a>(&'a self, k: &T::Key, head: &'a V) -> Values<'a, T::Key, V> {
+        Values::new(Some(head), &self.overflow, *k)
+    }
+
+    /// Translate a key without probing.
+    pub(super) fn translate(&self, key: &[u8]) -> T::Key {
+        self.translator.transform(key)
+    }
+
+    /// Returns an iterator over all values associated with an already-translated key.
+    pub(super) fn get_translated(&self, key: T::Key) -> Values<'_, T::Key, V> {
+        Values::new(self.map.get(&key), &self.overflow, key)
+    }
+
+    /// Returns an iterator over the values of the translated key that lexicographically follows
     /// `key`, or None if no such key exists (no cycling).
-    pub(super) fn next_translated_record_no_cycle(&self, key: &[u8]) -> Option<&Record<V>> {
+    pub(super) fn next_translated_values_no_cycle(
+        &self,
+        key: &[u8],
+    ) -> Option<Values<'_, T::Key, V>> {
         let k = self.translator.transform(key);
         self.map
             .range((Excluded(k), Unbounded))
             .next()
-            .map(|(_, r)| r)
+            .map(|(k, head)| self.values(k, head))
     }
 
-    /// Returns the head record of the chain for the translated key that lexicographically precedes
+    /// Returns an iterator over the values of the translated key that lexicographically precedes
     /// `key`, or None if no such key exists (no cycling).
-    pub(super) fn prev_translated_record_no_cycle(&self, key: &[u8]) -> Option<&Record<V>> {
+    pub(super) fn prev_translated_values_no_cycle(
+        &self,
+        key: &[u8],
+    ) -> Option<Values<'_, T::Key, V>> {
         let k = self.translator.transform(key);
-        self.map.range(..k).next_back().map(|(_, r)| r)
+        self.map
+            .range(..k)
+            .next_back()
+            .map(|(k, head)| self.values(k, head))
     }
 
-    /// Returns the head record of the chain for the lexicographically first translated key, or
+    /// Returns an iterator over the values of the lexicographically first translated key, or
     /// None if the index is empty.
-    pub(super) fn first_translated_record(&self) -> Option<&Record<V>> {
-        self.map.first_key_value().map(|(_, r)| r)
+    pub(super) fn first_translated_values(&self) -> Option<Values<'_, T::Key, V>> {
+        self.map
+            .first_key_value()
+            .map(|(k, head)| self.values(k, head))
     }
 
-    /// Returns the head record of the chain for the lexicographically last translated key, or
+    /// Returns an iterator over the values of the lexicographically last translated key, or
     /// None if the index is empty.
-    pub(super) fn last_translated_record(&self) -> Option<&Record<V>> {
-        self.map.last_key_value().map(|(_, r)| r)
+    pub(super) fn last_translated_values(&self) -> Option<Values<'_, T::Key, V>> {
+        self.map
+            .last_key_value()
+            .map(|(k, head)| self.values(k, head))
     }
 }
 
@@ -123,10 +142,10 @@ impl<T: Translator, V: Send + Sync> Ordered for Index<T, V> {
     where
         V: 'a,
     {
-        if let Some(r) = self.prev_translated_record_no_cycle(key) {
-            return Some((iter_chain(r), false));
+        if let Some(values) = self.prev_translated_values_no_cycle(key) {
+            return Some((values, false));
         }
-        self.last_translated_record().map(|r| (iter_chain(r), true))
+        self.last_translated_values().map(|values| (values, true))
     }
 
     fn next_translated_key<'a>(
@@ -136,25 +155,24 @@ impl<T: Translator, V: Send + Sync> Ordered for Index<T, V> {
     where
         V: 'a,
     {
-        if let Some(r) = self.next_translated_record_no_cycle(key) {
-            return Some((iter_chain(r), false));
+        if let Some(values) = self.next_translated_values_no_cycle(key) {
+            return Some((values, false));
         }
-        self.first_translated_record()
-            .map(|r| (iter_chain(r), true))
+        self.first_translated_values().map(|values| (values, true))
     }
 
     fn first_translated_key<'a>(&'a self) -> Option<impl Iterator<Item = &'a V> + Send + 'a>
     where
         V: 'a,
     {
-        self.first_translated_record().map(iter_chain)
+        self.first_translated_values()
     }
 
     fn last_translated_key<'a>(&'a self) -> Option<impl Iterator<Item = &'a V> + Send + 'a>
     where
         V: 'a,
     {
-        self.last_translated_record().map(iter_chain)
+        self.last_translated_values()
     }
 }
 
@@ -202,6 +220,8 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         match self.map.entry(k) {
             BTreeEntry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
                 entry,
+                k,
+                &mut self.overflow,
                 &self.keys,
                 &self.items,
                 &self.pruned,
@@ -215,6 +235,8 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         match self.map.entry(k) {
             BTreeEntry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
                 entry,
+                k,
+                &mut self.overflow,
                 &self.keys,
                 &self.items,
                 &self.pruned,
@@ -230,7 +252,10 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             BTreeEntry::Occupied(mut entry) => {
-                insert_front(entry.get_mut(), value);
+                // The newest value is stored inline; the displaced value joins the end of the
+                // overflow chain.
+                let old = std::mem::replace(entry.get_mut(), value);
+                push_displaced(&mut self.overflow, k, old);
                 self.items.inc();
             }
             BTreeEntry::Vacant(entry) => {
@@ -243,8 +268,14 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             BTreeEntry::Occupied(entry) => {
-                let mut cursor =
-                    Cursor::<'_, T::Key, V>::new(entry, &self.keys, &self.items, &self.pruned);
+                let mut cursor = Cursor::<'_, T::Key, V>::new(
+                    entry,
+                    k,
+                    &mut self.overflow,
+                    &self.keys,
+                    &self.items,
+                    &self.pruned,
+                );
 
                 // Drop anything that should not be retained.
                 cursor.retain(&should_retain);
@@ -265,15 +296,16 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
 
     fn remove(&mut self, key: &[u8]) {
         let k = self.translator.transform(key);
-        if let Some(mut record) = self.map.remove(&k) {
+        if self.map.remove(&k).is_some() {
             // To ensure metrics are accurate, account for all conflicting values in the chain.
             self.keys.dec();
             self.items.dec();
             self.pruned.inc();
-            while let Some(next) = record.next.take() {
-                self.items.dec();
-                self.pruned.inc();
-                record = *next;
+            if !self.overflow.is_empty() {
+                for _ in self.overflow.remove(&k).into_iter().flatten() {
+                    self.items.dec();
+                    self.pruned.inc();
+                }
             }
         }
     }
@@ -291,19 +323,6 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     #[cfg(test)]
     fn pruned(&self) -> usize {
         self.pruned.get() as usize
-    }
-}
-
-impl<T: Translator, V: Send + Sync> Drop for Index<T, V> {
-    /// To avoid stack overflow on keys with many collisions, we implement an iterative drop (in
-    /// lieu of Rust's default recursive drop).
-    fn drop(&mut self) {
-        for record in self.map.values_mut() {
-            let mut next = record.next.take();
-            while let Some(mut record) = next {
-                next = record.next.take();
-            }
-        }
     }
 }
 

--- a/storage/src/index/partitioned/ordered.rs
+++ b/storage/src/index/partitioned/ordered.rs
@@ -2,9 +2,7 @@
 
 use crate::{
     index::{
-        ordered::Index as OrderedIndex,
-        partitioned::partition_index_and_sub_key,
-        storage::{iter_chain, Record},
+        ordered::Index as OrderedIndex, partitioned::partition_index_and_sub_key, storage::Values,
         Ordered as OrderedTrait, Unordered as UnorderedTrait,
     },
     translator::Translator,
@@ -49,21 +47,21 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         (&mut self.partitions[i], sub_key)
     }
 
-    /// Returns the head record of the chain for the lexicographically first translated key across
+    /// Returns an iterator over the values of the lexicographically first translated key across
     /// all partitions, or None if every partition is empty.
-    fn first_translated_record(&self) -> Option<&Record<V>> {
+    fn first_translated_values(&self) -> Option<Values<'_, T::Key, V>> {
         self.partitions
             .iter()
-            .find_map(|p| p.first_translated_record())
+            .find_map(|p| p.first_translated_values())
     }
 
-    /// Returns the head record of the chain for the lexicographically last translated key across
+    /// Returns an iterator over the values of the lexicographically last translated key across
     /// all partitions, or None if every partition is empty.
-    fn last_translated_record(&self) -> Option<&Record<V>> {
+    fn last_translated_values(&self) -> Option<Values<'_, T::Key, V>> {
         self.partitions
             .iter()
             .rev()
-            .find_map(|p| p.last_translated_record())
+            .find_map(|p| p.last_translated_values())
     }
 }
 
@@ -198,15 +196,17 @@ impl<T: Translator, V: Send + Sync, const P: usize> OrderedTrait for Index<T, V,
     {
         let (partition_index, sub_key) = partition_index_and_sub_key::<P>(key);
 
-        if let Some(r) = self.partitions[partition_index].prev_translated_record_no_cycle(sub_key) {
-            return Some((iter_chain(r), false));
+        if let Some(values) =
+            self.partitions[partition_index].prev_translated_values_no_cycle(sub_key)
+        {
+            return Some((values, false));
         }
         for partition in self.partitions[..partition_index].iter().rev() {
-            if let Some(r) = partition.last_translated_record() {
-                return Some((iter_chain(r), false));
+            if let Some(values) = partition.last_translated_values() {
+                return Some((values, false));
             }
         }
-        self.last_translated_record().map(|r| (iter_chain(r), true))
+        self.last_translated_values().map(|values| (values, true))
     }
 
     fn next_translated_key<'a>(
@@ -218,30 +218,31 @@ impl<T: Translator, V: Send + Sync, const P: usize> OrderedTrait for Index<T, V,
     {
         let (partition_index, sub_key) = partition_index_and_sub_key::<P>(key);
 
-        if let Some(r) = self.partitions[partition_index].next_translated_record_no_cycle(sub_key) {
-            return Some((iter_chain(r), false));
+        if let Some(values) =
+            self.partitions[partition_index].next_translated_values_no_cycle(sub_key)
+        {
+            return Some((values, false));
         }
         for partition in self.partitions[partition_index + 1..].iter() {
-            if let Some(r) = partition.first_translated_record() {
-                return Some((iter_chain(r), false));
+            if let Some(values) = partition.first_translated_values() {
+                return Some((values, false));
             }
         }
-        self.first_translated_record()
-            .map(|r| (iter_chain(r), true))
+        self.first_translated_values().map(|values| (values, true))
     }
 
     fn first_translated_key<'a>(&'a self) -> Option<impl Iterator<Item = &'a V> + Send + 'a>
     where
         V: 'a,
     {
-        self.first_translated_record().map(iter_chain)
+        self.first_translated_values()
     }
 
     fn last_translated_key<'a>(&'a self) -> Option<impl Iterator<Item = &'a V> + Send + 'a>
     where
         V: 'a,
     {
-        self.last_translated_record().map(iter_chain)
+        self.last_translated_values()
     }
 }
 

--- a/storage/src/index/partitioned/ordered.rs
+++ b/storage/src/index/partitioned/ordered.rs
@@ -49,7 +49,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
 
     /// Returns an iterator over the values of the lexicographically first translated key across
     /// all partitions, or None if every partition is empty.
-    fn first_translated_values(&self) -> Option<Values<'_, T::Key, V>> {
+    fn first_translated_values(&self) -> Option<Values<'_, T::Key, V, T>> {
         self.partitions
             .iter()
             .find_map(|p| p.first_translated_values())
@@ -57,7 +57,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
 
     /// Returns an iterator over the values of the lexicographically last translated key across
     /// all partitions, or None if every partition is empty.
-    fn last_translated_values(&self) -> Option<Values<'_, T::Key, V>> {
+    fn last_translated_values(&self) -> Option<Values<'_, T::Key, V, T>> {
         self.partitions
             .iter()
             .rev()

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -43,10 +43,19 @@ enum Position {
     Overflow(usize),
 }
 
+/// An occupied entry in an index's map, abstracting over the hash- and tree-map entry types so
+/// the shared [Cursor] can operate on either.
 pub trait IndexEntry<V: Send + Sync>: Send + Sync {
+    /// The translated key type of the entry.
     type Key;
+
+    /// Returns the entry's translated key.
     fn key(&self) -> &Self::Key;
+
+    /// Returns a mutable reference to the entry's inline value.
     fn get_mut(&mut self) -> &mut V;
+
+    /// Removes the entry from the map.
     fn remove(self);
 }
 
@@ -87,8 +96,13 @@ enum State {
 ///   may hold the index of a just-deleted slot, which is only ever stepped down from, never
 ///   read).
 /// - [`State::EntryRemoved`] implies the chain was taken and is empty.
-pub struct Cursor<'a, K: Hash + Eq + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>, S: BuildHasher>
-{
+pub struct Cursor<
+    'a,
+    K: Hash + Eq + Copy,
+    V: Send + Sync,
+    E: IndexEntry<V, Key = K>,
+    S: BuildHasher,
+> {
     // The occupied index entry holding the inline value (and its key) while the cursor exists.
     entry: Option<E>,
     // The overflow values for all keys in the index, used to take and reinstall `chain`.
@@ -134,13 +148,13 @@ impl<'a, K: Hash + Eq + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>, S: Buil
 
     /// Returns the key's overflow chain, taking it from the overflow map on first use.
     fn chain_mut(&mut self) -> &mut Vec<V> {
-        let key = *self.entry.as_ref().unwrap().key();
+        let key = self.entry.as_ref().unwrap().key();
         let overflow = &mut self.overflow;
         self.chain.get_or_insert_with(|| {
             if overflow.is_empty() {
                 Vec::new()
             } else {
-                overflow.remove(&key).unwrap_or_default()
+                overflow.remove(key).unwrap_or_default()
             }
         })
     }

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -2,31 +2,42 @@
 
 use crate::index::Cursor as CursorTrait;
 use commonware_runtime::telemetry::metrics::{Counter, Gauge};
-use std::ptr::NonNull;
+use std::collections::BTreeMap;
 
-/// Each key is mapped to a [Record] that contains a linked list of potential values for that key.
+/// Maps a translated key to the values that conflict with the value stored inline in the index's
+/// map, stored oldest first.
 ///
-/// We avoid using a [Vec] to store values because the common case (where there are no collisions)
-/// would require an additional 24 bytes of memory for each value (the `len`, `capacity`, and `ptr`
-/// fields).
+/// In the common case (no collisions), a translated key maps to exactly one value, which is stored
+/// directly in the index's map. Storing conflicting values out-of-line keeps map entries as small
+/// as possible: a per-entry chain pointer or [Vec] would add 8+ bytes to every entry to support
+/// collisions that are rare for well-distributed translated keys.
 ///
-/// Again optimizing for the common case, we store the first value directly in the [Record] to avoid
-/// indirection (heap jumping).
-pub struct Record<V: Send + Sync> {
-    pub(super) value: V,
-    pub(super) next: Option<Box<Self>>,
+/// The logical chain of values for a key is the inline map value followed by the overflow values
+/// in reverse order (newest first).
+pub type Overflow<K, V> = BTreeMap<K, Vec<V>>;
+
+/// Adds a value displaced from a key's inline slot to that key's overflow chain.
+///
+/// Collisions are rare for well-distributed translated keys, so this is kept out of line to
+/// keep the hot (vacant or collision-free) insert path small.
+#[cold]
+#[inline(never)]
+pub(super) fn push_displaced<K: Ord + Copy, V>(overflow: &mut Overflow<K, V>, key: K, old: V) {
+    overflow.entry(key).or_default().push(old);
 }
 
-pub(super) fn insert_front<V: Send + Sync>(record: &mut Record<V>, value: V) {
-    let old = std::mem::replace(&mut record.value, value);
-    record.next = Some(Box::new(Record {
-        value: old,
-        next: record.next.take(),
-    }));
+/// Identifies one value in the chain of values associated with a translated key.
+#[derive(Clone, Copy)]
+enum Position {
+    /// The value stored inline in the index's map.
+    Head,
+    /// The value at this index of the key's overflow vector. Iteration visits overflow values
+    /// from the highest index down to 0.
+    Overflow(usize),
 }
 
 pub trait IndexEntry<V: Send + Sync>: Send + Sync {
-    fn get_mut(&mut self) -> &mut Record<V>;
+    fn get_mut(&mut self) -> &mut V;
     fn remove(self);
 }
 
@@ -37,50 +48,47 @@ const MUST_CALL_NEXT: &str = "must call Cursor::next()";
 /// Panic message shown when `update()` or `delete()` is called after [Cursor] has returned `None`.
 const NO_ACTIVE_ITEM: &str = "no active item in Cursor";
 
-/// Position of the [Cursor] within the linked list owned by its entry.
-enum State<V: Send + Sync> {
+/// Position of the [Cursor] within the chain of values owned by its entry.
+#[derive(Clone, Copy)]
+enum State {
     /// Before first `next()` call, or immediately after `insert()`/`delete()`.
     ///
-    /// `from` is the node the next `next()` will step from; `None` means start at the entry head.
-    NeedNext { from: Option<NonNull<Record<V>>> },
-    /// `next()` returned `current`; `update()`/`delete()`/`insert()` are valid.
-    ///
-    /// `prev` is the predecessor live node, `None` when `current` is the entry head.
-    Active {
-        current: NonNull<Record<V>>,
-        prev: Option<NonNull<Record<V>>>,
-    },
+    /// `from` is the position the next `next()` will step from; `None` means start at the head.
+    NeedNext { from: Option<Position> },
+    /// `next()` returned the value at `pos`; `update()`/`delete()`/`insert()` are valid.
+    Active { pos: Position },
     /// `next()` returned `None`; only `insert()` (which appends) is valid.
-    ///
-    /// `tail` is the final node of the chain, used by `insert` to append.
-    Done { tail: NonNull<Record<V>> },
+    Done,
     /// The sole element was deleted; the entry will be removed on Drop.
     EntryRemoved,
 }
 
-// Manual `Copy`/`Clone` to avoid deriving an unnecessary `V: Copy` bound: the enum only contains
-// `NonNull<Record<V>>` (always `Copy`) and `Option<NonNull<...>>` (also `Copy`).
-impl<V: Send + Sync> Clone for State<V> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<V: Send + Sync> Copy for State<V> {}
-
-/// A cursor that traverses and mutates a linked list of [Record]s in place using raw pointers.
+/// A cursor that traverses and mutates the chain of values associated with a translated key: the
+/// entry's inline value followed by the key's overflow values in reverse order.
+///
+/// The first cursor operation that needs the key's overflow values removes them from the overflow
+/// map and operates on them directly, avoiding a map probe per operation. Any remaining values
+/// are reinstalled when the cursor is dropped. Operations that never advance past the inline
+/// value (e.g. find-then-update) never touch the overflow map.
 ///
 /// Invariants:
-/// - `entry` owns the linked list and keeps it exclusively borrowed for the cursor's lifetime.
-/// - All pointers stored inside `state` were created from exclusive references via `NonNull::from`
-///   and refer to nodes owned by `entry`.
-/// - In [`State::Active`], when `prev` is `Some`, `prev.next` owns the node at `current`.
-/// - After a non-head delete, the [`State::NeedNext`] `from` is the surviving predecessor;
-///   after a head delete, it is `None` so the next `next()` re-reads the entry head.
-pub struct Cursor<'a, V: Send + Sync, E: IndexEntry<V>> {
-    // The occupied index entry that owns the linked list while the cursor exists.
+/// - `entry` holds the inline value and keeps it exclusively borrowed for the cursor's lifetime.
+/// - Any [`Position::Overflow`] index stored in `state` is within bounds of the taken `chain`
+///   (a position past the head is only reachable after the chain is taken; [`State::NeedNext`]
+///   may hold the index of a just-deleted slot, which is only ever stepped down from, never
+///   read).
+/// - [`State::EntryRemoved`] implies the chain was taken and is empty.
+pub struct Cursor<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> {
+    // The occupied index entry holding the inline value while the cursor exists.
     entry: Option<E>,
-    // The current position/state of the cursor, including any live pointers into the chain.
-    state: State<V>,
+    // The translated key whose values the cursor traverses.
+    key: K,
+    // The overflow values for all keys in the index, used to take and reinstall `chain`.
+    overflow: &'a mut Overflow<K, V>,
+    // The key's overflow values; `None` until first needed.
+    chain: Option<Vec<V>>,
+    // The current position/state of the cursor.
+    state: State,
 
     // Metrics.
     keys: &'a Gauge,
@@ -88,16 +96,22 @@ pub struct Cursor<'a, V: Send + Sync, E: IndexEntry<V>> {
     pruned: &'a Counter,
 }
 
-impl<'a, V: Send + Sync, E: IndexEntry<V>> Cursor<'a, V, E> {
+impl<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> Cursor<'a, K, V, E> {
     /// Creates a new [Cursor] from an occupied index entry.
+    #[inline]
     pub(super) const fn new(
         entry: E,
+        key: K,
+        overflow: &'a mut Overflow<K, V>,
         keys: &'a Gauge,
         items: &'a Gauge,
         pruned: &'a Counter,
     ) -> Self {
         Self {
             entry: Some(entry),
+            key,
+            overflow,
+            chain: None,
             state: State::NeedNext { from: None },
             keys,
             items,
@@ -105,148 +119,210 @@ impl<'a, V: Send + Sync, E: IndexEntry<V>> Cursor<'a, V, E> {
         }
     }
 
-    const fn record_mut(&mut self, mut ptr: NonNull<Record<V>>) -> &mut Record<V> {
-        // SAFETY: `ptr` was created by `NonNull::from` from a record owned by `entry`, which is
-        // exclusively borrowed through this cursor. Cursor state clears or rewinds pointers before
-        // an owner is dropped.
-        unsafe { ptr.as_mut() }
+    #[inline]
+    fn head_mut(&mut self) -> &mut V {
+        self.entry.as_mut().unwrap().get_mut()
+    }
+
+    /// Returns the key's overflow chain, taking it from the overflow map on first use.
+    fn chain_mut(&mut self) -> &mut Vec<V> {
+        let Self {
+            key,
+            overflow,
+            chain,
+            ..
+        } = self;
+        chain.get_or_insert_with(|| {
+            if overflow.is_empty() {
+                Vec::new()
+            } else {
+                overflow.remove(key).unwrap_or_default()
+            }
+        })
     }
 }
 
-impl<V: Send + Sync, E: IndexEntry<V>> CursorTrait for Cursor<'_, V, E> {
+impl<K: Ord + Copy + Send + Sync, V: Send + Sync, E: IndexEntry<V>> CursorTrait
+    for Cursor<'_, K, V, E>
+{
     type Value = V;
 
+    #[inline]
     fn next(&mut self) -> Option<&V> {
         let from = match self.state {
-            State::Done { .. } | State::EntryRemoved => return None,
+            State::Done | State::EntryRemoved => return None,
             State::NeedNext { from } => from,
-            State::Active { current, .. } => Some(current),
+            State::Active { pos } => Some(pos),
         };
 
-        // Derive the next pointer from `from.next`, or the entry head when `from` is `None`.
-        let next_ptr = if let Some(from) = from {
-            match self.record_mut(from).next.as_deref_mut() {
-                Some(next) => NonNull::from(next),
-                None => {
-                    self.state = State::Done { tail: from };
+        // Derive the next position from `from`, or start at the head when `from` is `None`.
+        let next = match from {
+            None => Position::Head,
+            Some(Position::Head) => match self.chain_mut().len() {
+                0 => {
+                    self.state = State::Done;
                     return None;
                 }
+                len => Position::Overflow(len - 1),
+            },
+            Some(Position::Overflow(0)) => {
+                self.state = State::Done;
+                return None;
             }
-        } else {
-            NonNull::from(self.entry.as_mut().unwrap().get_mut())
+            Some(Position::Overflow(i)) => Position::Overflow(i - 1),
         };
 
-        self.state = State::Active {
-            current: next_ptr,
-            prev: from,
-        };
-        Some(&self.record_mut(next_ptr).value)
+        self.state = State::Active { pos: next };
+        Some(match next {
+            Position::Head => self.head_mut(),
+            Position::Overflow(i) => &self.chain.as_ref().unwrap()[i],
+        })
     }
 
+    #[inline]
     fn update(&mut self, v: V) {
         match self.state {
             State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
-            State::Done { .. } | State::EntryRemoved => panic!("{NO_ACTIVE_ITEM}"),
-            State::Active { current, .. } => {
-                self.record_mut(current).value = v;
-            }
+            State::Done | State::EntryRemoved => panic!("{NO_ACTIVE_ITEM}"),
+            State::Active {
+                pos: Position::Head,
+            } => *self.head_mut() = v,
+            State::Active {
+                pos: Position::Overflow(i),
+            } => self.chain.as_mut().unwrap()[i] = v,
         }
     }
 
     fn insert(&mut self, v: V) {
         match self.state {
             State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
-            State::Active { current, .. } => {
+            State::Active { pos } => {
                 self.items.inc();
-                let inserted = {
-                    let current_record = self.record_mut(current);
-                    let new = Box::new(Record {
-                        value: v,
-                        next: current_record.next.take(),
-                    });
-                    current_record.next = Some(new);
-                    NonNull::from(current_record.next.as_deref_mut().unwrap())
+                // Insert immediately after the current position in iteration order. Iteration
+                // visits overflow values from the highest index down, so the slot after the head
+                // is the end of the vector, and the slot after `Overflow(i)` is index `i` (which
+                // shifts the current value up by one).
+                let chain = self.chain_mut();
+                let at = match pos {
+                    Position::Head => chain.len(),
+                    Position::Overflow(i) => i,
                 };
-                // Advance past the inserted node so next() returns the element after it.
+                chain.insert(at, v);
+                // Step from the inserted value so next() returns the element after it.
                 self.state = State::NeedNext {
-                    from: Some(inserted),
+                    from: Some(Position::Overflow(at)),
                 };
             }
             State::EntryRemoved => {
                 // Re-populate the entry that was emptied by delete.
                 self.items.inc();
-                let entry_record = self.entry.as_mut().unwrap().get_mut();
-                entry_record.value = v;
-                entry_record.next = None;
-                self.state = State::Done {
-                    tail: NonNull::from(entry_record),
-                };
+                *self.head_mut() = v;
+                self.state = State::Done;
             }
-            State::Done { tail } => {
+            State::Done => {
+                // Append to the end of the iteration order (index 0 of the overflow vector).
                 self.items.inc();
-                let inserted = {
-                    let tail_record = self.record_mut(tail);
-                    tail_record.next = Some(Box::new(Record {
-                        value: v,
-                        next: None,
-                    }));
-                    NonNull::from(tail_record.next.as_deref_mut().unwrap())
-                };
-                self.state = State::Done { tail: inserted };
+                self.chain_mut().insert(0, v);
             }
         }
     }
 
     fn delete(&mut self) {
-        let (current, prev) = match self.state {
+        let pos = match self.state {
             State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
-            State::Done { .. } | State::EntryRemoved => panic!("{NO_ACTIVE_ITEM}"),
-            State::Active { current, prev } => (current, prev),
+            State::Done | State::EntryRemoved => panic!("{NO_ACTIVE_ITEM}"),
+            State::Active { pos } => pos,
         };
         self.pruned.inc();
         self.items.dec();
 
-        if let Some(prev) = prev {
-            // Deleting a non-head node: relink prev.next to current.next.
-            let next = self.record_mut(current).next.take();
-            self.record_mut(prev).next = next;
-            self.state = State::NeedNext { from: Some(prev) };
-        } else {
-            // Deleting the head node (the entry record itself).
-            let head = self.record_mut(current);
-            if let Some(next) = head.next.take() {
-                // Promote the next record into the head position.
-                head.value = next.value;
-                head.next = next.next;
-                self.state = State::NeedNext { from: None };
-            } else {
-                // Sole element deleted.
-                self.state = State::EntryRemoved;
+        match pos {
+            Position::Head => {
+                if let Some(promoted) = self.chain_mut().pop() {
+                    // Promote the newest overflow value (the next value in iteration order) into
+                    // the head position, so the following next() revisits the head.
+                    *self.head_mut() = promoted;
+                    self.state = State::NeedNext { from: None };
+                } else {
+                    // Sole element deleted.
+                    self.state = State::EntryRemoved;
+                }
+            }
+            Position::Overflow(i) => {
+                self.chain.as_mut().unwrap().remove(i);
+                // Step from the deleted slot so next() returns the element after it.
+                self.state = State::NeedNext {
+                    from: Some(Position::Overflow(i)),
+                };
             }
         }
     }
 }
 
-// SAFETY: `NonNull` is not `Send`, so this cannot be derived automatically. The pointers stored
-// inside `state` are only bookkeeping pointers into the linked list owned by `entry`. Moving the
-// cursor to another thread also moves `entry`, keeping the list alive and exclusively borrowed by
-// the cursor.
-unsafe impl<V: Send + Sync, E: IndexEntry<V>> Send for Cursor<'_, V, E> {}
-// SAFETY: `NonNull` is not `Sync`, so this cannot be derived automatically. Sharing a cursor does
-// not grant access to the records without `&mut self`, and `entry` keeps the list alive and
-// exclusively borrowed for the cursor's lifetime.
-unsafe impl<V: Send + Sync, E: IndexEntry<V>> Sync for Cursor<'_, V, E> {}
-
-impl<V: Send + Sync, E: IndexEntry<V>> Drop for Cursor<'_, V, E> {
+impl<K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> Drop for Cursor<'_, K, V, E> {
+    #[inline]
     fn drop(&mut self) {
         if matches!(self.state, State::EntryRemoved) {
             self.keys.dec();
             self.entry.take().unwrap().remove();
+        } else if let Some(chain) = self.chain.take() {
+            // Reinstall the key's remaining overflow values.
+            if !chain.is_empty() {
+                self.overflow.insert(self.key, chain);
+            }
         }
     }
 }
 
-/// Walks the linked list of values starting at `head` and yields each value.
-pub(super) fn iter_chain<V: Send + Sync>(head: &Record<V>) -> impl Iterator<Item = &V> + Send {
-    std::iter::successors(Some(head), |r| r.next.as_deref()).map(|r| &r.value)
+/// Iterates over all values associated with a translated key, newest first: the inline head
+/// value, then any overflow values in reverse insertion order.
+///
+/// The overflow map is probed lazily, only when iteration advances past the head value. Callers
+/// that consume just the first value (e.g. existence checks) never touch the overflow map.
+pub struct Values<'a, K: Ord, V> {
+    head: Option<&'a V>,
+    overflow: OverflowValues<'a, K, V>,
+}
+
+/// The overflow portion of a [Values] iterator.
+enum OverflowValues<'a, K: Ord, V> {
+    /// The overflow map has not been probed yet.
+    Pending {
+        overflow: &'a Overflow<K, V>,
+        key: K,
+    },
+    /// Iterating the key's overflow values (an empty iterator when the key has none).
+    Iter(std::iter::Rev<std::slice::Iter<'a, V>>),
+}
+
+impl<'a, K: Ord, V> Values<'a, K, V> {
+    /// Creates a [Values] iterator from a key's optional inline value and the index's overflow
+    /// map. If `head` is `None` (the key is absent), the iterator is empty and the overflow map
+    /// is never probed.
+    pub(super) fn new(head: Option<&'a V>, overflow: &'a Overflow<K, V>, key: K) -> Self {
+        let overflow = match head {
+            Some(_) => OverflowValues::Pending { overflow, key },
+            None => OverflowValues::Iter([].iter().rev()),
+        };
+        Self { head, overflow }
+    }
+}
+
+impl<'a, K: Ord, V> Iterator for Values<'a, K, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<&'a V> {
+        if let Some(head) = self.head.take() {
+            return Some(head);
+        }
+        loop {
+            match &mut self.overflow {
+                OverflowValues::Pending { overflow, key } => {
+                    let values = overflow.get(key).map_or(&[][..], Vec::as_slice);
+                    self.overflow = OverflowValues::Iter(values.iter().rev());
+                }
+                OverflowValues::Iter(values) => return values.next(),
+            }
+        }
+    }
 }

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -2,7 +2,10 @@
 
 use crate::index::Cursor as CursorTrait;
 use commonware_runtime::telemetry::metrics::{Counter, Gauge};
-use std::collections::BTreeMap;
+use std::{
+    collections::HashMap,
+    hash::{BuildHasher, Hash},
+};
 
 /// Maps a translated key to the values that conflict with the value stored inline in the index's
 /// map, stored oldest first.
@@ -14,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// The logical chain of values for a key is the inline map value followed by the overflow values
 /// in reverse order (newest first).
-pub type Overflow<K, V> = BTreeMap<K, Vec<V>>;
+pub type Overflow<K, V, S> = HashMap<K, Vec<V>, S>;
 
 /// Adds a value displaced from a key's inline slot to that key's overflow chain.
 ///
@@ -22,7 +25,11 @@ pub type Overflow<K, V> = BTreeMap<K, Vec<V>>;
 /// keep the hot (vacant or collision-free) insert path small.
 #[cold]
 #[inline(never)]
-pub(super) fn push_displaced<K: Ord + Copy, V>(overflow: &mut Overflow<K, V>, key: K, old: V) {
+pub(super) fn push_displaced<K: Hash + Eq + Copy, V, S: BuildHasher>(
+    overflow: &mut Overflow<K, V, S>,
+    key: K,
+    old: V,
+) {
     overflow.entry(key).or_default().push(old);
 }
 
@@ -80,11 +87,12 @@ enum State {
 ///   may hold the index of a just-deleted slot, which is only ever stepped down from, never
 ///   read).
 /// - [`State::EntryRemoved`] implies the chain was taken and is empty.
-pub struct Cursor<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>> {
+pub struct Cursor<'a, K: Hash + Eq + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>, S: BuildHasher>
+{
     // The occupied index entry holding the inline value (and its key) while the cursor exists.
     entry: Option<E>,
     // The overflow values for all keys in the index, used to take and reinstall `chain`.
-    overflow: &'a mut Overflow<K, V>,
+    overflow: &'a mut Overflow<K, V, S>,
     // The key's overflow values; `None` until first needed.
     chain: Option<Vec<V>>,
     // The current position/state of the cursor.
@@ -96,12 +104,14 @@ pub struct Cursor<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>> 
     pruned: &'a Counter,
 }
 
-impl<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>> Cursor<'a, K, V, E> {
+impl<'a, K: Hash + Eq + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>, S: BuildHasher>
+    Cursor<'a, K, V, E, S>
+{
     /// Creates a new [Cursor] from an occupied index entry.
     #[inline]
     pub(super) const fn new(
         entry: E,
-        overflow: &'a mut Overflow<K, V>,
+        overflow: &'a mut Overflow<K, V, S>,
         keys: &'a Gauge,
         items: &'a Gauge,
         pruned: &'a Counter,
@@ -136,8 +146,12 @@ impl<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>> Cursor<'a, K,
     }
 }
 
-impl<K: Ord + Copy + Send + Sync, V: Send + Sync, E: IndexEntry<V, Key = K>> CursorTrait
-    for Cursor<'_, K, V, E>
+impl<
+        K: Hash + Eq + Copy + Send + Sync,
+        V: Send + Sync,
+        E: IndexEntry<V, Key = K>,
+        S: BuildHasher + Send + Sync,
+    > CursorTrait for Cursor<'_, K, V, E, S>
 {
     type Value = V;
 
@@ -253,7 +267,9 @@ impl<K: Ord + Copy + Send + Sync, V: Send + Sync, E: IndexEntry<V, Key = K>> Cur
     }
 }
 
-impl<K: Ord + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>> Drop for Cursor<'_, K, V, E> {
+impl<K: Hash + Eq + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>, S: BuildHasher> Drop
+    for Cursor<'_, K, V, E, S>
+{
     #[inline]
     fn drop(&mut self) {
         if matches!(self.state, State::EntryRemoved) {
@@ -274,27 +290,27 @@ impl<K: Ord + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>> Drop for Cursor<'
 ///
 /// The overflow map is probed lazily, only when iteration advances past the head value. Callers
 /// that consume just the first value (e.g. existence checks) never touch the overflow map.
-pub struct Values<'a, K: Ord, V> {
+pub struct Values<'a, K: Hash + Eq, V, S: BuildHasher> {
     head: Option<&'a V>,
-    overflow: OverflowValues<'a, K, V>,
+    overflow: OverflowValues<'a, K, V, S>,
 }
 
 /// The overflow portion of a [Values] iterator.
-enum OverflowValues<'a, K: Ord, V> {
+enum OverflowValues<'a, K: Hash + Eq, V, S: BuildHasher> {
     /// The overflow map has not been probed yet.
     Pending {
-        overflow: &'a Overflow<K, V>,
+        overflow: &'a Overflow<K, V, S>,
         key: K,
     },
     /// Iterating the key's overflow values (an empty iterator when the key has none).
     Iter(std::iter::Rev<std::slice::Iter<'a, V>>),
 }
 
-impl<'a, K: Ord, V> Values<'a, K, V> {
+impl<'a, K: Hash + Eq, V, S: BuildHasher> Values<'a, K, V, S> {
     /// Creates a [Values] iterator from a key's optional inline value and the index's overflow
     /// map. If `head` is `None` (the key is absent), the iterator is empty and the overflow map
     /// is never probed.
-    pub(super) fn new(head: Option<&'a V>, overflow: &'a Overflow<K, V>, key: K) -> Self {
+    pub(super) fn new(head: Option<&'a V>, overflow: &'a Overflow<K, V, S>, key: K) -> Self {
         let overflow = match head {
             Some(_) => OverflowValues::Pending { overflow, key },
             None => OverflowValues::Iter([].iter().rev()),
@@ -303,7 +319,7 @@ impl<'a, K: Ord, V> Values<'a, K, V> {
     }
 }
 
-impl<'a, K: Ord, V> Iterator for Values<'a, K, V> {
+impl<'a, K: Hash + Eq, V, S: BuildHasher> Iterator for Values<'a, K, V, S> {
     type Item = &'a V;
 
     fn next(&mut self) -> Option<&'a V> {

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -37,6 +37,8 @@ enum Position {
 }
 
 pub trait IndexEntry<V: Send + Sync>: Send + Sync {
+    type Key;
+    fn key(&self) -> &Self::Key;
     fn get_mut(&mut self) -> &mut V;
     fn remove(self);
 }
@@ -78,11 +80,9 @@ enum State {
 ///   may hold the index of a just-deleted slot, which is only ever stepped down from, never
 ///   read).
 /// - [`State::EntryRemoved`] implies the chain was taken and is empty.
-pub struct Cursor<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> {
-    // The occupied index entry holding the inline value while the cursor exists.
+pub struct Cursor<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>> {
+    // The occupied index entry holding the inline value (and its key) while the cursor exists.
     entry: Option<E>,
-    // The translated key whose values the cursor traverses.
-    key: K,
     // The overflow values for all keys in the index, used to take and reinstall `chain`.
     overflow: &'a mut Overflow<K, V>,
     // The key's overflow values; `None` until first needed.
@@ -96,12 +96,11 @@ pub struct Cursor<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> {
     pruned: &'a Counter,
 }
 
-impl<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> Cursor<'a, K, V, E> {
+impl<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>> Cursor<'a, K, V, E> {
     /// Creates a new [Cursor] from an occupied index entry.
     #[inline]
     pub(super) const fn new(
         entry: E,
-        key: K,
         overflow: &'a mut Overflow<K, V>,
         keys: &'a Gauge,
         items: &'a Gauge,
@@ -109,7 +108,6 @@ impl<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> Cursor<'a, K, V, E> {
     ) -> Self {
         Self {
             entry: Some(entry),
-            key,
             overflow,
             chain: None,
             state: State::NeedNext { from: None },
@@ -126,7 +124,7 @@ impl<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> Cursor<'a, K, V, E> {
 
     /// Returns the key's overflow chain, taking it from the overflow map on first use.
     fn chain_mut(&mut self) -> &mut Vec<V> {
-        let key = self.key;
+        let key = *self.entry.as_ref().unwrap().key();
         let overflow = &mut self.overflow;
         self.chain.get_or_insert_with(|| {
             if overflow.is_empty() {
@@ -138,7 +136,7 @@ impl<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> Cursor<'a, K, V, E> {
     }
 }
 
-impl<K: Ord + Copy + Send + Sync, V: Send + Sync, E: IndexEntry<V>> CursorTrait
+impl<K: Ord + Copy + Send + Sync, V: Send + Sync, E: IndexEntry<V, Key = K>> CursorTrait
     for Cursor<'_, K, V, E>
 {
     type Value = V;
@@ -255,7 +253,7 @@ impl<K: Ord + Copy + Send + Sync, V: Send + Sync, E: IndexEntry<V>> CursorTrait
     }
 }
 
-impl<K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> Drop for Cursor<'_, K, V, E> {
+impl<K: Ord + Copy, V: Send + Sync, E: IndexEntry<V, Key = K>> Drop for Cursor<'_, K, V, E> {
     #[inline]
     fn drop(&mut self) {
         if matches!(self.state, State::EntryRemoved) {
@@ -264,7 +262,8 @@ impl<K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> Drop for Cursor<'_, K, V, 
         } else if let Some(chain) = self.chain.take() {
             // Reinstall the key's remaining overflow values.
             if !chain.is_empty() {
-                self.overflow.insert(self.key, chain);
+                let key = *self.entry.as_ref().unwrap().key();
+                self.overflow.insert(key, chain);
             }
         }
     }

--- a/storage/src/index/storage.rs
+++ b/storage/src/index/storage.rs
@@ -126,17 +126,13 @@ impl<'a, K: Ord + Copy, V: Send + Sync, E: IndexEntry<V>> Cursor<'a, K, V, E> {
 
     /// Returns the key's overflow chain, taking it from the overflow map on first use.
     fn chain_mut(&mut self) -> &mut Vec<V> {
-        let Self {
-            key,
-            overflow,
-            chain,
-            ..
-        } = self;
-        chain.get_or_insert_with(|| {
+        let key = self.key;
+        let overflow = &mut self.overflow;
+        self.chain.get_or_insert_with(|| {
             if overflow.is_empty() {
                 Vec::new()
             } else {
-                overflow.remove(key).unwrap_or_default()
+                overflow.remove(&key).unwrap_or_default()
             }
         })
     }

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -39,9 +39,9 @@ pub type Cursor<'a, K, V> = CursorImpl<'a, K, V, OccupiedEntry<'a, K, V>>;
 /// A memory-efficient index that uses an unordered map internally to map translated keys to
 /// arbitrary values.
 ///
-/// Each translated key maps directly to its most recently inserted value; conflicting values (from
-/// key collisions or repeated insertions) are stored in a separate overflow map so the common
-/// (collision-free) case stays as compact as possible.
+/// Each translated key maps directly to its most recently inserted value. Conflicting values (from
+/// key collisions or repeated insertions) live in a separate overflow map, keeping the common
+/// (collision-free) case compact.
 pub struct Index<T: Translator, V: Send + Sync> {
     translator: T,
     map: HashMap<T::Key, V, T>,
@@ -147,9 +147,8 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             Entry::Occupied(mut entry) => {
-                // Optimized fast path for the common case of no overflow chain. The cases below
-                // match the cursor's value ordering and metric accounting exactly.
-                #[allow(clippy::map_entry)] // suppress lint false positive
+                // Optimized fast path for the common case of no overflow chain.
+                #[allow(clippy::map_entry)]
                 if !self.overflow.contains_key(&k) {
                     match (should_retain(entry.get()), should_retain(&value)) {
                         // Keep both, with the new value placed at the end of the overflow chain.

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -147,16 +147,14 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             Entry::Occupied(mut entry) => {
-                // Fast path: a key with no overflow chain holds exactly one value, so retaining
-                // it and inserting the new value reduces to a few direct cases. This avoids
-                // building a cursor for the common (collision-free) case. The cases below match
-                // the cursor's value ordering and metric accounting exactly.
+                // Optimized fast path for the common case of no overflow chain. The cases below
+                // match the cursor's value ordering and metric accounting exactly.
+                #[allow(clippy::map_entry)] // suppress lint false positive
                 if !self.overflow.contains_key(&k) {
                     match (should_retain(entry.get()), should_retain(&value)) {
-                        // Keep both: the new value joins the chain as the oldest (the position a
-                        // cursor insert after retain would place it).
+                        // Keep both, with the new value placed at the end of the overflow chain.
                         (true, true) => {
-                            self.overflow.entry(k).or_default().push(value);
+                            self.overflow.insert(k, vec![value]);
                             self.items.inc();
                         }
                         // Drop the existing value, keep the new one: replace in place.
@@ -212,9 +210,9 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
             self.items.dec();
             self.pruned.inc();
             if !self.overflow.is_empty() {
-                for _ in self.overflow.remove(&k).into_iter().flatten() {
-                    self.items.dec();
-                    self.pruned.inc();
+                if let Some(chain) = self.overflow.remove(&k) {
+                    self.items.dec_by(chain.len() as i64);
+                    self.pruned.inc_by(chain.len() as u64);
                 }
             }
         }

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -25,6 +25,10 @@ const INITIAL_CAPACITY: usize = 256;
 
 /// Implementation of [IndexEntry] for [OccupiedEntry].
 impl<K: Send + Sync, V: Send + Sync> IndexEntry<V> for OccupiedEntry<'_, K, V> {
+    type Key = K;
+    fn key(&self) -> &K {
+        OccupiedEntry::key(self)
+    }
     fn get_mut(&mut self) -> &mut V {
         self.get_mut()
     }
@@ -99,7 +103,6 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         match self.map.entry(k) {
             Entry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
                 entry,
-                k,
                 &mut self.overflow,
                 &self.keys,
                 &self.items,
@@ -114,7 +117,6 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         match self.map.entry(k) {
             Entry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
                 entry,
-                k,
                 &mut self.overflow,
                 &self.keys,
                 &self.items,
@@ -177,7 +179,6 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
                 // Slow path: the key has conflicting values; walk them with a cursor.
                 let mut cursor = Cursor::<'_, T::Key, V>::new(
                     entry,
-                    k,
                     &mut self.overflow,
                     &self.keys,
                     &self.items,

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     index::{
-        storage::{insert_front, iter_chain, Cursor as CursorImpl, IndexEntry, Record},
+        storage::{push_displaced, Cursor as CursorImpl, IndexEntry, Overflow, Values},
         Cursor as CursorTrait, Unordered,
     },
     translator::Translator,
@@ -24,8 +24,8 @@ use std::collections::{
 const INITIAL_CAPACITY: usize = 256;
 
 /// Implementation of [IndexEntry] for [OccupiedEntry].
-impl<K: Send + Sync, V: Send + Sync> IndexEntry<V> for OccupiedEntry<'_, K, Record<V>> {
-    fn get_mut(&mut self) -> &mut Record<V> {
+impl<K: Send + Sync, V: Send + Sync> IndexEntry<V> for OccupiedEntry<'_, K, V> {
+    fn get_mut(&mut self) -> &mut V {
         self.get_mut()
     }
     fn remove(self) {
@@ -34,13 +34,18 @@ impl<K: Send + Sync, V: Send + Sync> IndexEntry<V> for OccupiedEntry<'_, K, Reco
 }
 
 /// A [crate::index::Cursor] over the values associated with a translated key.
-pub type Cursor<'a, K, V> = CursorImpl<'a, V, OccupiedEntry<'a, K, Record<V>>>;
+pub type Cursor<'a, K, V> = CursorImpl<'a, K, V, OccupiedEntry<'a, K, V>>;
 
 /// A memory-efficient index that uses an unordered map internally to map translated keys to
 /// arbitrary values.
+///
+/// Each translated key maps directly to its most recently inserted value; conflicting values (from
+/// key collisions or repeated insertions) are stored in a separate overflow map so the common
+/// (collision-free) case stays as compact as possible.
 pub struct Index<T: Translator, V: Send + Sync> {
     translator: T,
-    map: HashMap<T::Key, Record<V>, T>,
+    map: HashMap<T::Key, V, T>,
+    overflow: Overflow<T::Key, V>,
 
     keys: Gauge,
     items: Gauge,
@@ -49,13 +54,10 @@ pub struct Index<T: Translator, V: Send + Sync> {
 
 impl<T: Translator, V: Send + Sync> Index<T, V> {
     /// Create a new entry in the index.
-    fn create(keys: &Gauge, items: &Gauge, vacant: VacantEntry<'_, T::Key, Record<V>>, v: V) {
+    fn create(keys: &Gauge, items: &Gauge, vacant: VacantEntry<'_, T::Key, V>, v: V) {
         keys.inc();
         items.inc();
-        vacant.insert(Record {
-            value: v,
-            next: None,
-        });
+        vacant.insert(v);
     }
 
     /// Create a new index with the given translator and metrics registry.
@@ -63,6 +65,7 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
         Self {
             translator: translator.clone(),
             map: HashMap::with_capacity_and_hasher(INITIAL_CAPACITY, translator),
+            overflow: Overflow::new(),
             keys: ctx.gauge("keys", "Number of translated keys in the index"),
             items: ctx.gauge("items", "Number of items in the index"),
             pruned: ctx.counter("pruned", "Number of items pruned"),
@@ -88,7 +91,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         V: 'a,
     {
         let k = self.translator.transform(key);
-        self.map.get(&k).into_iter().flat_map(iter_chain)
+        Values::new(self.map.get(&k), &self.overflow, k)
     }
 
     fn get_mut<'a>(&'a mut self, key: &[u8]) -> Option<Self::Cursor<'a>> {
@@ -96,6 +99,8 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         match self.map.entry(k) {
             Entry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
                 entry,
+                k,
+                &mut self.overflow,
                 &self.keys,
                 &self.items,
                 &self.pruned,
@@ -109,6 +114,8 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         match self.map.entry(k) {
             Entry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
                 entry,
+                k,
+                &mut self.overflow,
                 &self.keys,
                 &self.items,
                 &self.pruned,
@@ -124,7 +131,10 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             Entry::Occupied(mut entry) => {
-                insert_front(entry.get_mut(), v);
+                // The newest value is stored inline; the displaced value joins the end of the
+                // overflow chain.
+                let old = std::mem::replace(entry.get_mut(), v);
+                push_displaced(&mut self.overflow, k, old);
                 self.items.inc();
             }
             Entry::Vacant(entry) => {
@@ -137,8 +147,14 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
             Entry::Occupied(entry) => {
-                let mut cursor =
-                    Cursor::<'_, T::Key, V>::new(entry, &self.keys, &self.items, &self.pruned);
+                let mut cursor = Cursor::<'_, T::Key, V>::new(
+                    entry,
+                    k,
+                    &mut self.overflow,
+                    &self.keys,
+                    &self.items,
+                    &self.pruned,
+                );
 
                 // Drop anything that should not be retained.
                 cursor.retain(&should_retain);
@@ -159,15 +175,16 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
 
     fn remove(&mut self, key: &[u8]) {
         let k = self.translator.transform(key);
-        if let Some(mut record) = self.map.remove(&k) {
+        if self.map.remove(&k).is_some() {
             // To ensure metrics are accurate, account for all conflicting values in the chain.
             self.keys.dec();
             self.items.dec();
             self.pruned.inc();
-            while let Some(next) = record.next.take() {
-                self.items.dec();
-                self.pruned.inc();
-                record = *next;
+            if !self.overflow.is_empty() {
+                for _ in self.overflow.remove(&k).into_iter().flatten() {
+                    self.items.dec();
+                    self.pruned.inc();
+                }
             }
         }
     }
@@ -185,18 +202,5 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     #[cfg(test)]
     fn pruned(&self) -> usize {
         self.pruned.get() as usize
-    }
-}
-
-impl<T: Translator, V: Send + Sync> Drop for Index<T, V> {
-    /// To avoid stack overflow on keys with many collisions, we implement an iterative drop (in
-    /// lieu of Rust's default recursive drop).
-    fn drop(&mut self) {
-        for (_, mut record) in self.map.drain() {
-            let mut next = record.next.take();
-            while let Some(mut record) = next {
-                next = record.next.take();
-            }
-        }
     }
 }

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -146,7 +146,38 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     fn insert_and_retain(&mut self, key: &[u8], value: V, should_retain: impl Fn(&V) -> bool) {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
-            Entry::Occupied(entry) => {
+            Entry::Occupied(mut entry) => {
+                // Fast path: a key with no overflow chain holds exactly one value, so retaining
+                // it and inserting the new value reduces to a few direct cases. This avoids
+                // building a cursor for the common (collision-free) case. The cases below match
+                // the cursor's value ordering and metric accounting exactly.
+                if !self.overflow.contains_key(&k) {
+                    match (should_retain(entry.get()), should_retain(&value)) {
+                        // Keep both: the new value joins the chain as the oldest (the position a
+                        // cursor insert after retain would place it).
+                        (true, true) => {
+                            self.overflow.entry(k).or_default().push(value);
+                            self.items.inc();
+                        }
+                        // Drop the existing value, keep the new one: replace in place.
+                        (false, true) => {
+                            *entry.get_mut() = value;
+                            self.pruned.inc();
+                        }
+                        // Drop both: remove the key entirely.
+                        (false, false) => {
+                            entry.remove();
+                            self.keys.dec();
+                            self.items.dec();
+                            self.pruned.inc();
+                        }
+                        // Keep the existing value, drop the new one: nothing to do.
+                        (true, false) => {}
+                    }
+                    return;
+                }
+
+                // Slow path: the key has conflicting values; walk them with a cursor.
                 let mut cursor = Cursor::<'_, T::Key, V>::new(
                     entry,
                     k,

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -26,12 +26,15 @@ const INITIAL_CAPACITY: usize = 256;
 /// Implementation of [IndexEntry] for [OccupiedEntry].
 impl<K: Send + Sync, V: Send + Sync> IndexEntry<V> for OccupiedEntry<'_, K, V> {
     type Key = K;
+
     fn key(&self) -> &K {
         OccupiedEntry::key(self)
     }
+
     fn get_mut(&mut self) -> &mut V {
         self.get_mut()
     }
+
     fn remove(self) {
         OccupiedEntry::remove(self);
     }

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -38,7 +38,7 @@ impl<K: Send + Sync, V: Send + Sync> IndexEntry<V> for OccupiedEntry<'_, K, V> {
 }
 
 /// A [crate::index::Cursor] over the values associated with a translated key.
-pub type Cursor<'a, K, V> = CursorImpl<'a, K, V, OccupiedEntry<'a, K, V>>;
+pub type Cursor<'a, K, V, S> = CursorImpl<'a, K, V, OccupiedEntry<'a, K, V>, S>;
 
 /// A memory-efficient index that uses an unordered map internally to map translated keys to
 /// arbitrary values.
@@ -49,7 +49,7 @@ pub type Cursor<'a, K, V> = CursorImpl<'a, K, V, OccupiedEntry<'a, K, V>>;
 pub struct Index<T: Translator, V: Send + Sync> {
     translator: T,
     map: HashMap<T::Key, V, T>,
-    overflow: Overflow<T::Key, V>,
+    overflow: Overflow<T::Key, V, T>,
 
     keys: Gauge,
     items: Gauge,
@@ -68,8 +68,8 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
     pub fn new(ctx: impl Metrics, translator: T) -> Self {
         Self {
             translator: translator.clone(),
+            overflow: HashMap::with_hasher(translator.clone()),
             map: HashMap::with_capacity_and_hasher(INITIAL_CAPACITY, translator),
-            overflow: Overflow::new(),
             keys: ctx.gauge("keys", "Number of translated keys in the index"),
             items: ctx.gauge("items", "Number of items in the index"),
             pruned: ctx.counter("pruned", "Number of items pruned"),
@@ -86,7 +86,7 @@ impl<T: Translator, V: Send + Sync> super::Factory<T> for Index<T, V> {
 impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     type Value = V;
     type Cursor<'a>
-        = Cursor<'a, T::Key, V>
+        = Cursor<'a, T::Key, V, T>
     where
         Self: 'a;
 
@@ -101,7 +101,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     fn get_mut<'a>(&'a mut self, key: &[u8]) -> Option<Self::Cursor<'a>> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
-            Entry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
+            Entry::Occupied(entry) => Some(Cursor::<'_, T::Key, V, T>::new(
                 entry,
                 &mut self.overflow,
                 &self.keys,
@@ -115,7 +115,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
     fn get_mut_or_insert<'a>(&'a mut self, key: &[u8], value: V) -> Option<Self::Cursor<'a>> {
         let k = self.translator.transform(key);
         match self.map.entry(k) {
-            Entry::Occupied(entry) => Some(Cursor::<'_, T::Key, V>::new(
+            Entry::Occupied(entry) => Some(Cursor::<'_, T::Key, V, T>::new(
                 entry,
                 &mut self.overflow,
                 &self.keys,
@@ -177,7 +177,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
                 }
 
                 // Slow path: the key has conflicting values; walk them with a cursor.
-                let mut cursor = Cursor::<'_, T::Key, V>::new(
+                let mut cursor = Cursor::<'_, T::Key, V, T>::new(
                     entry,
                     &mut self.overflow,
                     &self.keys,


### PR DESCRIPTION
Replace the per-entry Record linked list (an inline value plus a boxed `next` pointer on every entry) with an inline value plus a separate Overflow side table (BTreeMap) holding only the rare conflicting values. The common collision-free entry loses its 8-byte chain pointer: ~32% less memory for the unordered (HashMap) index and ~30% for the ordered (BTreeMap) index.

The Cursor is rewritten to walk the inline value then the key's overflow chain, and is now entirely safe code (the previous NonNull raw-pointer chain-walking and its iterative Drop are gone). It takes the key's overflow values lazily, so find-then-update never probes the overflow map. Collision-free get/insert behavior is unchanged.

This covers the two flat indexes (unordered + ordered) plus the ordered partitioned wrapper, which share the cursor machinery in storage.rs.

## Memory (measured)

Resident heap **bytes per key** via a counting global allocator, collision-free distinct 8-byte keys inserted in **random order** (realistic for translated/hashed keys), `V = u64`, this branch vs `origin/main` (`e68fede11`). Each map entry's value shrinks from `Record<u64>` (the `u64` plus an 8-byte `Option<Box>` chain pointer = 16 B) to a bare inline `u64` (8 B), so the stored key+value pair drops from 24 to 16 bytes.

| index | main | branch | delta |
|---|---|---|---|
| unordered (`HashMap`), ~86% load | 29.13 | 19.81 | **−32.0%** |
| unordered (`HashMap`), ~48% load | 52.43 | 35.65 | **−32.0%** |
| ordered (`BTreeMap`) | 38.87 | 27.13 | **−30.2%** |

- The **−32% / −30% delta is the figure to trust**: main and branch use the same map with the same slot count at a given N, so only the per-entry size differs (24 vs 16 bytes) and the ratio is the same regardless of how full the table is.
- Absolute `HashMap` B/key depends on how full the slot array happens to be — it allocates a power-of-two array of slots and pays for all of them, so bytes/key nearly doubles right after the array resizes (half-empty) and shrinks back as it fills. Both extremes are shown: ~86% full (N=0.9M, just under the `2^20` resize) and ~48% full (N=1M, just past it). `BTreeMap` has no such resize step; its absolute reflects ~70% node fill under random insertion and is stable across all N.


## Benchmark: `constantinople`

Production-shape pipeline (1M keys, 32,768 updates/batch, `depth=0`, 15 timed iterations) on Apple Silicon, this branch vs `origin/main` (`bce243dab`). Times in ms. `load` = the `get_many` phase (the only phase this PR touches); `merk` = merkleize, which is hashing and index-independent.

**Correctness:** per-iteration Merkle roots are byte-identical to `main` for both variants — the refactor preserves exact semantics.

| variant | load (main → branch) | total p50 (main → branch) |
|---|---|---|
| `any::unordered::fixed::mmb` | 3.78 → 3.83 ms (neutral) | 20.28 → 20.00 ms (−1.4%) |
| `any::ordered::fixed::mmb` | 7.17 → 6.27 ms (**−12.6%**) | 23.12 → 22.29 ms (−3.6%) |

- The pipeline is merkleize-dominated (~65% of total time), so the index memory reduction (this PR's primary goal) only partially surfaces as latency.
- **Unordered**: neutral, within run-to-run noise — at 1M keys the load phase is small and the smaller HashMap slot doesn't move it measurably.
- **Ordered**: the denser `BTreeMap` (inline `V` instead of `Record<V>`) makes `get_many`'s tree traversal touch fewer cache lines, cutting the load phase ~13% (per-iteration distributions are non-overlapping across the two runs) and total ~3.6%.
- Single 15-iteration run per variant on one machine; deltas under ~2% are within noise.


## Index microbenchmarks (criterion)

Flat indexes only (partitioned/hashed variants and the std-`HashMap` reference benches excluded), small cache-resident sizes (10k/50k items), this branch vs `origin/main` (`bce243dab`). Negative = faster.

| operation | change |
|---|---|
| `lookup` (all translators/sizes) | **−2% to −11%** (realistic `eight_cap`: −6% to −8%) |
| `insert_and_retain` | **−37% to −43%** |
| `insert` (unordered) | −5% |
| `insert` (ordered) | neutral (±6% run-to-run) |
| `lookup_miss` (`eight_cap`, realistic) | neutral |
| `lookup_miss` (`two_cap`/`four_cap`) | +5% to +10% (noisy) |

- `lookup` is consistently faster: the `get` path now probes the overflow side table lazily (only past the inline value), so collision-free hits do strictly less work.
- `insert_and_retain` was initially **+48%** (the side-table cursor is heavier than the old inline `Record`); the follow-up commit adds a fast path that handles a key with no overflow chain directly, without building a cursor, which more than recovers it. This is the path qmdb immutable snapshot building and archive pruning use.
- `lookup_miss` is neutral for the realistic collision-free translator (`eight_cap`); the small regressions are confined to the high-collision toy translators (`two_cap`/`four_cap`) and are within run-to-run noise.
- These are single runs at sizes where the index is cache-resident, so the memory reduction does not surface as latency; deltas under ~5% are within noise.


