### PR TITLE
[qmdb/compact] Add commit() for durability without full sync

### DIFF
--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -8,10 +8,10 @@
 //! mismatch fails with [`Error::DataCorrupted`].
 //!
 //! Entries are strictly increasing in committed leaf count (`proof.leaves`), so a leaf count
-//! uniquely identifies a rewind or prune target. The journal `sync` after an append is the
-//! commit point: a crash before it drops the unsynced tail on reopen, recovering the previous
-//! commit. [`Store::prune`] bounds how far back [`Store::rewind`] can reach; the tip entry is
-//! never pruned.
+//! uniquely identifies a rewind or prune target. The journal `commit` or `sync` after an append
+//! is the commit point: a crash before it drops the unsynced tail on reopen, recovering the
+//! previous commit. [`Store::prune`] bounds how far back [`Store::rewind`] can reach; the tip
+//! entry is never pruned.
 
 use crate::{
     journal::contiguous::{variable, Reader as _},
@@ -112,6 +112,16 @@ impl<F: Family, D: Digest> VerifiedWitness<F, D> {
 /// The contiguous variable journal that backs a witness [`Store`].
 pub(crate) type Journal<E, F, D> = variable::Journal<E, Witness<F, D>>;
 
+/// How a persisted witness entry is made durable.
+#[derive(Clone, Copy)]
+enum Durability {
+    /// Commit the journal: appended entries survive a crash, but journal recovery may be
+    /// required on reopen.
+    Commit,
+    /// Sync the journal and all of its metadata, minimizing recovery work on reopen.
+    Sync,
+}
+
 /// A contiguous journal plus an in-memory cache of the tip witness.
 pub(crate) struct Store<E: Context, F: Family, D: Digest> {
     journal: Journal<E, F, D>,
@@ -162,12 +172,13 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         *self.tip_witness.write() = witness;
     }
 
-    /// Persist the current compact state as a new witness journal entry.
+    /// Persist the current compact state as a new witness journal entry, committing the journal
+    /// so the entry survives a crash. Journal recovery may be required on reopen.
     ///
     /// No-op if the cached witness already matches the Merkle (the witness is already durable).
     /// Otherwise appends a witness built from the unpruned Merkle, prunes the Merkle to its
     /// frontier, and refreshes the cache.
-    pub(crate) async fn persist<H, S>(
+    pub(crate) async fn commit<H, S>(
         &self,
         merkle: &compact::Merkle<F, D, S>,
         inactivity_floor_loc: Location<F>,
@@ -177,34 +188,108 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         H: Hasher<Digest = D>,
         S: Strategy,
     {
-        let _guard = self.sync_lock.lock().await;
+        self.persist::<H, S>(
+            merkle,
+            inactivity_floor_loc,
+            last_commit_op_bytes,
+            Durability::Commit,
+        )
+        .await
+    }
 
+    /// Persist the current compact state as a new witness journal entry, syncing the journal and
+    /// all of its metadata to minimize recovery work on reopen.
+    ///
+    /// No-op if the cached witness already matches the Merkle (the witness is already durable).
+    /// Otherwise appends a witness built from the unpruned Merkle, prunes the Merkle to its
+    /// frontier, and refreshes the cache.
+    pub(crate) async fn sync<H, S>(
+        &self,
+        merkle: &compact::Merkle<F, D, S>,
+        inactivity_floor_loc: Location<F>,
+        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
+    ) -> Result<(), Error<F>>
+    where
+        H: Hasher<Digest = D>,
+        S: Strategy,
+    {
+        self.persist::<H, S>(
+            merkle,
+            inactivity_floor_loc,
+            last_commit_op_bytes,
+            Durability::Sync,
+        )
+        .await
+    }
+
+    /// Shared body of [`Self::commit`] and [`Self::sync`]: stage what must be persisted, append
+    /// it, make it durable per `durability`, and install it as the cached tip.
+    ///
+    /// A pending import is cleared only after the entry is durable, so an interrupted journal
+    /// replacement is retried by the next persist.
+    async fn persist<H, S>(
+        &self,
+        merkle: &compact::Merkle<F, D, S>,
+        inactivity_floor_loc: Location<F>,
+        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
+        durability: Durability,
+    ) -> Result<(), Error<F>>
+    where
+        H: Hasher<Digest = D>,
+        S: Strategy,
+    {
+        let _guard = self.sync_lock.lock().await;
+        let Some(verified) = self
+            .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
+            .await?
+        else {
+            return Ok(());
+        };
+        self.journal.append(&verified.witness).await?;
+        match durability {
+            Durability::Commit => self.journal.commit().await?,
+            Durability::Sync => self.journal.sync().await?,
+        }
+        self.import_pending.store(false, Ordering::Relaxed);
+        merkle.prune_to_frontier();
+        self.replace(verified);
+        Ok(())
+    }
+
+    /// Decide what a persist must write, clearing the journal first when an import is pending.
+    /// Callers must hold `sync_lock`.
+    ///
+    /// Returns `None` if the durable tip already matches the in-memory Merkle and no import is
+    /// pending, otherwise the witness to append and install in the cache.
+    async fn stage<H, S>(
+        &self,
+        merkle: &compact::Merkle<F, D, S>,
+        inactivity_floor_loc: Location<F>,
+        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
+    ) -> Result<Option<VerifiedWitness<F, D>>, Error<F>>
+    where
+        H: Hasher<Digest = D>,
+        S: Strategy,
+    {
         // An equal leaf count means no commit has been applied since the cache was set.
         // Normally the cache mirrors the journal tip, so the state is already durable and there
         // is nothing to do. During a pending import the cached witness is not in the journal
         // yet, so it is exactly what must be persisted: replace the journal's contents with it.
         let cached_leaves = self.with(|w| w.leaf_count());
-        if cached_leaves == merkle.leaves() {
-            if self.import_pending.load(Ordering::Relaxed) {
-                self.clear_for_import().await?;
-                let witness = self.with(|w| w.witness.clone());
-                self.append_and_sync(&witness).await?;
+        let verified = if cached_leaves == merkle.leaves() {
+            if !self.import_pending.load(Ordering::Relaxed) {
+                return Ok(None);
             }
-            return Ok(());
-        }
-        if cached_leaves > merkle.leaves() {
+            self.with(|w| w.clone())
+        } else if cached_leaves > merkle.leaves() {
             return Err(Error::DataCorrupted("witness ahead of in-memory state"));
-        }
-
-        let verified =
-            build_witness::<F, H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes())?;
+        } else {
+            build_witness::<F, H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes())?
+        };
         if self.import_pending.load(Ordering::Relaxed) {
             self.clear_for_import().await?;
         }
-        self.append_and_sync(&verified.witness).await?;
-        merkle.prune_to_frontier();
-        self.replace(verified);
-        Ok(())
+        Ok(Some(verified))
     }
 
     /// Rewind the journal so the entry committing exactly `target` leaves becomes the tip, then
@@ -326,17 +411,6 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     async fn clear_for_import(&self) -> Result<(), Error<F>> {
         let size = self.journal.size().await;
         self.journal.clear_to_size(size.max(1)).await?;
-        Ok(())
-    }
-
-    /// Append `entry` and sync it, making it the durable tip.
-    ///
-    /// A pending import is cleared only after the sync completes, so an interrupted journal
-    /// replacement is retried by the next persist.
-    async fn append_and_sync(&self, entry: &Witness<F, D>) -> Result<(), Error<F>> {
-        self.journal.append(entry).await?;
-        self.journal.sync().await?;
-        self.import_pending.store(false, Ordering::Relaxed);
         Ok(())
     }
 

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -544,8 +544,7 @@ where
     /// # Errors
     ///
     /// Returns [`crate::merkle::Error::RewindBeyondHistory`] (wrapped as [`Error::Merkle`]) if
-    /// no retained commit has exactly `target` operations (never synced, or pruned). Any error
-    /// is fatal for this handle: drop it and reopen from storage.
+    /// no retained commit has exactly `target` operations (never synced, or pruned).
     #[tracing::instrument(name = "qmdb.immutable.compact.db.rewind", level = "info", skip_all)]
     pub async fn rewind(&mut self, target: Location<F>) -> Result<(), Error<F>>
     where
@@ -586,7 +585,7 @@ where
     /// # Errors
     ///
     /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`] or
-    /// [`Self::sync`]. Any error is fatal for this handle: drop it and reopen from storage.
+    /// [`Self::sync`].
     pub async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
     }
@@ -974,6 +973,72 @@ mod tests {
             assert_eq!(db.root(), root_after_second);
             assert_eq!(db.get_metadata(), Some(meta2));
             assert_eq!(db.inactivity_floor_loc(), Location::new(1));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_to_committed_entry_after_reopen() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "immutable-commit-rewind-reopen";
+            let meta1 = Sha256::fill(0xaa);
+            let meta2 = Sha256::fill(0xbb);
+
+            let (root_a, size_a) = {
+                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                db.apply_batch(
+                    db.new_batch()
+                        .set(Sha256::hash(&[1]), Sha256::fill(11u8))
+                        .merkleize(&db, Some(meta1), Location::new(0)),
+                )
+                .unwrap();
+                db.commit().await.unwrap();
+                let root_a = db.root();
+                let size_a = db.size();
+
+                db.apply_batch(
+                    db.new_batch()
+                        .set(Sha256::hash(&[2]), Sha256::fill(22u8))
+                        .merkleize(&db, Some(meta2), Location::new(1)),
+                )
+                .unwrap();
+                db.commit().await.unwrap();
+                (root_a, size_a)
+            };
+
+            // Both committed witnesses survive the crash: reopen recovers the tip, and the
+            // earlier commit remains a valid rewind target.
+            let mut db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            db.rewind(size_a).await.unwrap();
+            assert_eq!(db.root(), root_a);
+            assert_eq!(db.get_metadata(), Some(meta1));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_sync_after_commit() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "immutable-sync-after-commit";
+            let meta = Sha256::fill(0xaa);
+
+            let root = {
+                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                db.apply_batch(
+                    db.new_batch()
+                        .set(Sha256::hash(&[1]), Sha256::fill(11u8))
+                        .merkleize(&db, Some(meta), Location::new(0)),
+                )
+                .unwrap();
+                db.commit().await.unwrap();
+                // The commit already made the state durable, so this is a no-op.
+                db.sync().await.unwrap();
+                db.root()
+            };
+
+            let db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get_metadata(), Some(meta));
             db.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -274,8 +274,8 @@ where
     /// Build a compact db handle from already-validated compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
-    /// supplied witness/root pair. The import lives only in memory until the first
-    /// [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
+    /// supplied witness/root pair. The import lives only in memory until the first [`Self::commit`]
+    /// or [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
     /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
     pub(crate) fn init_from_validated_state(
         strategy: S,
@@ -411,7 +411,7 @@ where
     /// Return the compact-sync target described by the current witness.
     ///
     /// This reflects the last durably persisted commit, which may lag behind live in-memory
-    /// mutations until [`Self::sync`] is called.
+    /// mutations until [`Self::commit`] or [`Self::sync`] is called.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
         self.witness.with(VerifiedWitness::target)
     }
@@ -484,7 +484,7 @@ where
     /// Apply a merkleized batch to the database.
     ///
     /// Returns the range of locations written. The state is updated in memory only; call
-    /// [`Self::sync`] to persist.
+    /// [`Self::commit`] or [`Self::sync`] to persist.
     ///
     /// # Errors
     ///
@@ -515,11 +515,23 @@ where
         Ok(start_loc..Location::new(batch.bounds.total_size))
     }
 
-    /// Durably persist the current db state to disk.
+    /// Durably persist the current db state to disk. This is faster than [`Self::sync`] but
+    /// reopen may need to replay the witness journal's tail to recover.
+    #[tracing::instrument(name = "qmdb.immutable.compact.db.commit", level = "info", skip_all)]
+    pub async fn commit(&self) -> Result<(), Error<F>> {
+        self.witness
+            .commit::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
+                Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
+            })
+            .await
+    }
+
+    /// Durably persist the current db state to disk, also persisting journal metadata to
+    /// minimize recovery work on reopen.
     #[tracing::instrument(name = "qmdb.immutable.compact.db.sync", level = "info", skip_all)]
     pub async fn sync(&self) -> Result<(), Error<F>> {
         self.witness
-            .persist::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
+            .sync::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
                 Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
             })
             .await
@@ -565,16 +577,16 @@ where
         Ok(())
     }
 
-    /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Some witness
-    /// below the boundary may survive.
+    /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Some witness below
+    /// the boundary may survive.
     ///
-    /// Pruning bounds how far back [`Self::rewind`] can reach; the current commit's witness
-    /// always survives. The prune is made durable before this method returns.
+    /// Pruning bounds how far back [`Self::rewind`] can reach; the current commit's witness always
+    /// survives. The prune is made durable before this method returns.
     ///
     /// # Errors
     ///
-    /// Fails if a compact-sync import has not yet been persisted by [`Self::sync`]. Any error
-    /// is fatal for this handle: drop it and reopen from storage.
+    /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`] or
+    /// [`Self::sync`]. Any error is fatal for this handle: drop it and reopen from storage.
     pub async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
     }
@@ -926,6 +938,42 @@ mod tests {
             assert_eq!(db.get_metadata(), Some(meta1));
             assert_eq!(db.inactivity_floor_loc(), floor1);
 
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_commit_persists_across_reopen() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "immutable-commit-reopen";
+            let meta1 = Sha256::fill(0xaa);
+            let meta2 = Sha256::fill(0xbb);
+
+            let root_after_second = {
+                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                db.apply_batch(
+                    db.new_batch()
+                        .set(Sha256::hash(&[1]), Sha256::fill(11u8))
+                        .merkleize(&db, Some(meta1), Location::new(0)),
+                )
+                .unwrap();
+                db.commit().await.unwrap();
+
+                db.apply_batch(
+                    db.new_batch()
+                        .set(Sha256::hash(&[2]), Sha256::fill(22u8))
+                        .merkleize(&db, Some(meta2), Location::new(1)),
+                )
+                .unwrap();
+                db.commit().await.unwrap();
+                db.root()
+            };
+
+            // Reopen recovers the committed tip even though the journal was never synced.
+            let db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            assert_eq!(db.root(), root_after_second);
+            assert_eq!(db.get_metadata(), Some(meta2));
+            assert_eq!(db.inactivity_floor_loc(), Location::new(1));
             db.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -525,8 +525,7 @@ where
     /// # Errors
     ///
     /// Returns [`crate::merkle::Error::RewindBeyondHistory`] (wrapped as [`Error::Merkle`]) if
-    /// no retained commit has exactly `target` operations (never synced, or pruned). Any error
-    /// is fatal for this handle: drop it and reopen from storage.
+    /// no retained commit has exactly `target` operations (never synced, or pruned).
     #[tracing::instrument(name = "qmdb.keyless.compact.db.rewind", level = "info", skip_all)]
     pub async fn rewind(&mut self, target: Location<F>) -> Result<(), Error<F>>
     where
@@ -567,8 +566,7 @@ where
     /// # Errors
     ///
     /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`] or
-    /// [`Self::sync`]. Any error
-    /// is fatal for this handle: drop it and reopen from storage.
+    /// [`Self::sync`].
     pub async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
     }
@@ -1020,6 +1018,79 @@ mod tests {
             let db = open_db::<mmr::Family>(context.child("second"), partition).await;
             assert_eq!(db.root(), root);
             assert_eq!(db.get_metadata(), Some(meta));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_import_persists_with_commit() {
+        deterministic::Runner::default().start(|context| async move {
+            let dst = "keyless-import-commit-dst";
+            let src = "keyless-import-commit-src";
+            let meta_a = U64::new(11);
+            let meta_b = U64::new(22);
+
+            // Build state B in a separate source partition and capture its validated state.
+            let target_b = {
+                let mut source = open_db::<mmr::Family>(context.child("src"), src).await;
+                source
+                    .apply_batch(source.new_batch().append(U64::new(2)).merkleize(
+                        &source,
+                        Some(meta_b.clone()),
+                        Location::new(0),
+                    ))
+                    .unwrap();
+                source.sync().await.unwrap();
+                source.target()
+            };
+            let (_, proof_b, pinned_b) = {
+                let journal = open_witness_journal(context.child("src_tip"), src).await;
+                witness::tests::tip(&journal).await
+            };
+            let validated = compact_sync::ValidatedState {
+                state: compact_sync::State {
+                    leaf_count: target_b.leaf_count,
+                    pinned_nodes: pinned_b,
+                    last_commit_op: Operation::Commit(Some(meta_b.clone()), Location::new(0)),
+                    last_commit_proof: proof_b,
+                },
+                root: target_b.root,
+            };
+
+            // Seed the destination partition with a different committed state A.
+            {
+                let mut seeded = open_db::<mmr::Family>(context.child("seed"), dst).await;
+                seeded
+                    .apply_batch(seeded.new_batch().append(U64::new(1)).merkleize(
+                        &seeded,
+                        Some(meta_a),
+                        Location::new(0),
+                    ))
+                    .unwrap();
+                seeded.sync().await.unwrap();
+                assert_ne!(seeded.target(), target_b);
+            }
+
+            // Import state B over the destination and make it durable with commit (not sync).
+            {
+                let journal = open_witness_journal(context.child("import"), dst).await;
+                let imported = TestDb::<mmr::Family>::init_from_validated_state(
+                    Sequential,
+                    journal,
+                    (),
+                    validated,
+                )
+                .unwrap();
+                assert_eq!(imported.target(), target_b);
+                imported.commit().await.unwrap();
+            }
+
+            // Reopen recovers the committed import, replacing state A even though the journal was
+            // never synced.
+            let db = open_db::<mmr::Family>(context.child("reopen"), dst).await;
+            assert_eq!(db.target(), target_b);
+            assert_eq!(db.root(), target_b.root);
+            assert_eq!(db.get_metadata(), Some(meta_b));
             db.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -262,8 +262,8 @@ where
     /// Build a compact db handle from already-validated compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
-    /// supplied witness/root pair. The import lives only in memory until the first
-    /// [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
+    /// supplied witness/root pair. The import lives only in memory until the first [`Self::commit`]
+    /// or [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
     /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
     pub(crate) fn init_from_validated_state(
         strategy: S,
@@ -397,7 +397,7 @@ where
     /// Return the compact-sync target described by the current witness.
     ///
     /// This reflects the last durably persisted commit, which may lag behind live in-memory
-    /// mutations until [`Self::sync`] is called.
+    /// mutations until [`Self::commit`] or [`Self::sync`] is called.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
         self.witness.with(VerifiedWitness::target)
     }
@@ -469,7 +469,7 @@ where
     /// Apply a merkleized batch to the database.
     ///
     /// Returns the range of locations written. The state is updated in memory only; call
-    /// [`Self::sync`] to persist.
+    /// [`Self::commit`] or [`Self::sync`] to persist.
     ///
     /// # Errors
     ///
@@ -496,11 +496,23 @@ where
         Ok(start_loc..Location::new(batch.bounds.total_size))
     }
 
-    /// Durably persist the current db state to disk.
+    /// Durably persist the current db state to disk. This is faster than [`Self::sync`] but
+    /// reopen may need to replay the witness journal's tail to recover.
+    #[tracing::instrument(name = "qmdb.keyless.compact.db.commit", level = "info", skip_all)]
+    pub async fn commit(&self) -> Result<(), Error<F>> {
+        self.witness
+            .commit::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
+                Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
+            })
+            .await
+    }
+
+    /// Durably persist the current db state to disk, also persisting journal metadata to
+    /// minimize recovery work on reopen.
     #[tracing::instrument(name = "qmdb.keyless.compact.db.sync", level = "info", skip_all)]
     pub async fn sync(&self) -> Result<(), Error<F>> {
         self.witness
-            .persist::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
+            .sync::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
                 Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
             })
             .await
@@ -554,7 +566,8 @@ where
     ///
     /// # Errors
     ///
-    /// Fails if a compact-sync import has not yet been persisted by [`Self::sync`]. Any error
+    /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`] or
+    /// [`Self::sync`]. Any error
     /// is fatal for this handle: drop it and reopen from storage.
     pub async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.witness.prune(pruning_boundary).await
@@ -905,6 +918,108 @@ mod tests {
             assert_eq!(db.get_metadata(), Some(meta1));
             assert_eq!(db.inactivity_floor_loc(), floor1);
 
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_commit_persists_across_reopen() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "keyless-commit-reopen";
+            let meta1 = U64::new(11);
+            let meta2 = U64::new(22);
+
+            let root_after_second = {
+                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                db.apply_batch(db.new_batch().append(U64::new(1)).merkleize(
+                    &db,
+                    Some(meta1),
+                    Location::new(0),
+                ))
+                .unwrap();
+                db.commit().await.unwrap();
+
+                db.apply_batch(db.new_batch().append(U64::new(2)).merkleize(
+                    &db,
+                    Some(meta2.clone()),
+                    Location::new(1),
+                ))
+                .unwrap();
+                db.commit().await.unwrap();
+                db.root()
+            };
+
+            // Reopen recovers the committed tip even though the journal was never synced.
+            let db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            assert_eq!(db.root(), root_after_second);
+            assert_eq!(db.get_metadata(), Some(meta2));
+            assert_eq!(db.inactivity_floor_loc(), Location::new(1));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_rewind_to_committed_entry_after_reopen() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "keyless-commit-rewind-reopen";
+            let meta1 = U64::new(11);
+            let meta2 = U64::new(22);
+
+            let (root_a, size_a) = {
+                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                db.apply_batch(db.new_batch().append(U64::new(1)).merkleize(
+                    &db,
+                    Some(meta1.clone()),
+                    Location::new(0),
+                ))
+                .unwrap();
+                db.commit().await.unwrap();
+                let root_a = db.root();
+                let size_a = db.size();
+
+                db.apply_batch(db.new_batch().append(U64::new(2)).merkleize(
+                    &db,
+                    Some(meta2),
+                    Location::new(1),
+                ))
+                .unwrap();
+                db.commit().await.unwrap();
+                (root_a, size_a)
+            };
+
+            // Both committed witnesses survive the crash: reopen recovers the tip, and the
+            // earlier commit remains a valid rewind target.
+            let mut db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            db.rewind(size_a).await.unwrap();
+            assert_eq!(db.root(), root_a);
+            assert_eq!(db.get_metadata(), Some(meta1));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_sync_after_commit() {
+        deterministic::Runner::default().start(|context| async move {
+            let partition = "keyless-sync-after-commit";
+            let meta = U64::new(11);
+
+            let root = {
+                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                db.apply_batch(db.new_batch().append(U64::new(1)).merkleize(
+                    &db,
+                    Some(meta.clone()),
+                    Location::new(0),
+                ))
+                .unwrap();
+                db.commit().await.unwrap();
+                // The commit already made the state durable, so this is a no-op.
+                db.sync().await.unwrap();
+                db.root()
+            };
+
+            let db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get_metadata(), Some(meta));
             db.destroy().await.unwrap();
         });
     }


### PR DESCRIPTION
## Summary

Compact dbs (`keyless::CompactDb`, `immutable::CompactDb`) previously only exposed `sync()`, which persists the witness journal's data and all of its metadata. This adds `commit()`, mirroring the `commit()`/`sync()` split on the non-compact dbs: it makes the appended witness durable via the contiguous journal's cheaper commit point (data + offsets sections fsynced, offsets metadata sync skipped). Committed state always survives a crash; the tradeoff is that reopen may replay the witness journal's tail during recovery.

No new durability bookkeeping is needed: the contiguous journal's recovery already treats the data journal as the source of truth and rebuilds the offsets suffix on reopen, so a lagging recovery watermark only adds (negligible, since the witness journal is small and regularly pruned) replay work — it never changes the recovered state.

## Changes

- `qmdb/compact/witness.rs`: the witness store exposes matching `commit()`/`sync()` entry points that delegate to one shared private `persist()` body — stage what must be persisted (no-op detection, corruption check, import clearing, witness building), append it, make it durable via `journal.commit()` or `journal.sync()` (a private `Durability` selector), and install it as the cached tip.
- Both compact dbs: public `commit()` alongside `sync()`, delegating to the corresponding witness store method; doc references to "persisted by sync" updated to mention both. `sync()` is documented as minimizing recovery work on reopen.

The compact-sync import path (`persist_compact_state`) still uses `sync()`.

## Testing

- `test_compact_commit_persists_across_reopen` (both dbs): two commits, drop without ever syncing, reopen recovers the tip. This exercises journal recovery since the deterministic runtime drops unsynced writes.
- `test_compact_rewind_to_committed_entry_after_reopen` (keyless): two commits, crash, reopen, rewind to the first — every committed witness is durable, not just the tip.
- `test_compact_sync_after_commit` (keyless): redundant `sync()` after `commit()` is a no-op and state still recovers on reopen.
- All 1539 `qmdb::` tests pass; storage clippy/fmt clean.

Note: `just lint` currently fails on main in `cryptography/src/bls12381/dkg/feldman_desmedt.rs` (`useless_borrows_in_formatting`, presumably from a newer clippy); unrelated to this change and not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)