### PR TITLE
[storage/journal/contiguous] Skip offsets.commit() in variable commit()

### DIFF
--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -352,4 +352,4 @@ hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
 
 ["commonware_storage::queue::conformance::QueueConformance"]
 n_cases = 512
-hash = "8ad72ade337ff26e83094f8d65ece4c8b6fd07814a5e8db14d1b0b4df17c13dc"
+hash = "72de7b1d620649a954afc24944b8474dd1d7556fc5859a46dd212ce02aba197d"

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -956,13 +956,15 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok(())
     }
 
-    /// Persist dirty data and offsets sections so committed data survives a crash.
+    /// Persist dirty data sections so committed data survives a crash.
+    ///
+    /// Does not advance the recovery watermark, so reopen may need to replay entries beyond
+    /// the previous `sync()`.
     pub async fn commit(&self) -> Result<(), Error> {
         let _timer = self.metrics.commit_timer();
         self.metrics.record_commit();
         let _op_guard = self.op_lock.lock().await;
         self.flush_dirty_data().await?;
-        self.offsets.commit().await?;
         let mut inner = self.inner.write().await;
         inner.dirty_from_section = None;
         Ok(())
@@ -3623,6 +3625,42 @@ mod tests {
             // Data should be intact and offsets rebuilt
             assert_eq!(journal.size().await, 15);
             for i in 0..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_commit_only_durability_across_sections() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "commit-only-durability".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            // Append items one commit at a time, never syncing, spanning several sections.
+            let journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..23u64 {
+                journal.append(&(i * 100)).await.unwrap();
+                journal.commit().await.unwrap();
+            }
+            drop(journal);
+
+            // Reopen recovers every committed item by rebuilding offsets from the data journal.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds().await, 0..23);
+            for i in 0..23u64 {
                 assert_eq!(journal.read(i).await.unwrap(), i * 100);
             }
 


### PR DESCRIPTION
## Summary

`variable::Journal::commit()` previously called `offsets.commit()` after flushing the dirty data sections. That call only flushes the dirty offsets sections, and it never contributed to recovery: on reopen, `align_journals` rewinds the offsets journal to the recovery watermark (advanced only by `sync()`) and rebuilds everything beyond it by replaying the data journal, so offsets sections flushed by `commit()` are discarded regardless. Dropping the call halves the fsyncs per commit (the data-section fsync is the durability point) with bit-for-bit identical reopen behavior.

This benefits every `commit()` caller: the non-compact qmdb dbs via the authenticated journal today, and the compact dbs once #4032 lands (the branches touch disjoint files).

## Conformance

The `QueueConformance` fixture is regenerated (the only one of 89 storage fixtures affected). It hashes the deterministic storage *operation trace*, which now contains fewer offsets sync events because `Queue::enqueue` commits per item. The persisted format and the recovered state are unchanged; queue unit and recovery tests pass unmodified.

## Testing

- New `test_variable_commit_only_durability_across_sections`: 23 append+commit cycles across 5-item sections with no `sync()` ever, drop, reopen recovers every item (the deterministic runtime drops unsynced writes, so this exercises real recovery).
- Pre-existing commit-crash tests (`test_variable_rewind_commit_reopen`, `test_variable_recovery_boundary_data_rewind_rebuilds_offsets`) already pin the commit-then-reopen recovery path and still pass.
- All 329 `journal::`, 1535 `qmdb::`, 33 `queue::`, and 89 conformance tests pass; storage clippy/fmt clean.

Note: `just lint` currently fails on main in `cryptography/src/bls12381/dkg/feldman_desmedt.rs` (`useless_borrows_in_formatting`, presumably from a newer clippy); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)