### PR TITLE
[ci] Disable cargo HTTP/2 multiplexing

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -31,9 +31,13 @@ inputs:
 runs:
   using: composite
   steps:
+    # Disabling HTTP/2 multiplexing avoids spurious connection resets fetching the sparse
+    # registry index, at the cost of slower index fetches when the cache is cold.
     - name: Configure Cargo network
       shell: bash
-      run: echo "CARGO_NET_RETRY=30" >> "$GITHUB_ENV"
+      run: |
+        echo "CARGO_NET_RETRY=30" >> "$GITHUB_ENV"
+        echo "CARGO_HTTP_MULTIPLEXING=false" >> "$GITHUB_ENV"
 
     # Use /mnt for Cargo builds on Linux (has ~70GB vs ~14GB on /)
     - name: Relocate Cargo directories to /mnt on Linux


### PR DESCRIPTION
## Summary

CI jobs intermittently die fetching the sparse registry index with curl error 56 ("Recv failure: Connection was reset"), most often on Windows runners, e.g.:

```
error: failed to get `serde_derive` as a dependency of package `serde v1.0.228`
Caused by: ... download of se/rd/serde_derive failed
Caused by: [56] Failure when receiving data from the peer (Recv failure: Connection was reset)
```

The setup action already sets `CARGO_NET_RETRY=30`, but it doesn't help here: cargo's retries re-establish the same HTTP/2 multiplexed connection pattern that keeps getting reset. Setting `CARGO_HTTP_MULTIPLEXING=false` makes cargo fetch index entries over separate connections — the standard mitigation for this failure signature. The cost is slower index fetches when the rust-cache is cold; with a warm cache, no difference.

Applied unconditionally in the shared setup action (the flake has been observed beyond Windows, and the cost is small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)