### PR TITLE
[cryptography/lthash] batch hash updates

### DIFF
--- a/cryptography/src/lthash/mod.rs
+++ b/cryptography/src/lthash/mod.rs
@@ -138,13 +138,12 @@ impl LtHash {
 
     /// Return the [Digest] of the current state.
     pub fn checksum(&self) -> Digest {
-        let mut hasher = Blake3::new();
-
-        // Convert u16 array to bytes in little-endian order
-        for &val in &self.state {
-            hasher.update(&val.to_le_bytes());
+        let mut bytes = [0u8; LTHASH_SIZE];
+        for (chunk, val) in bytes.chunks_exact_mut(2).zip(&self.state) {
+            chunk.copy_from_slice(&val.to_le_bytes());
         }
-
+        let mut hasher = Blake3::new();
+        hasher.update(&bytes);
         hasher.finalize()
     }
 


### PR DESCRIPTION
Here is the result on my MacBook Pro M1 Max.

```
Benchmarking lthash::checksum: Collecting 100 samples in estimated 5.0060 s (1.lthash::checksum        time:   [2.5671 µs 2.5961 µs 2.6436 µs]
                        change: [−84.322% −83.533% −82.986%] (p = 0.00 < 0.05)
                        Performance has improved.
```

I decided that the comment didn't carry much sense but lmk if you want it back.