### PR TITLE
[storage/qmdb/any] Use parallel index probe in `get_many_map`

### DIFF
--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -250,8 +250,6 @@ where
         self.metrics.reads.get_many_calls.inc();
         self.metrics.reads.keys_requested.inc_by(keys.len() as u64);
 
-        let mut results: Vec<Option<T>> = (0..keys.len()).map(|_| None).collect();
-
         // Phase 1: Collect candidate locations from the in-memory index. Each key may map to
         // multiple locations due to hash collisions. The index is read-only and Send+Sync, so
         // for large batches the probe is sharded across the strategy pool; each candidate carries
@@ -283,6 +281,7 @@ where
                 .collect()
         };
 
+        let mut results: Vec<Option<T>> = (0..keys.len()).map(|_| None).collect();
         if candidates.is_empty() {
             return Ok(results);
         }

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -28,8 +28,8 @@ use commonware_utils::bitmap;
 use core::num::NonZeroU64;
 use std::{collections::HashMap, sync::Arc};
 
-/// Minimum keys per shard for [`Db::get_many_map`] to parallelize the index probe rather than
-/// probe serially, ensuring each shard carries enough work to amortize the thread-pool handoff.
+/// Estimate of the number of keys per shard at which parallelizing [`Db::get_many_map`]'s
+/// index probe is faster than probing serially.
 const MIN_PROBES_PER_SHARD: usize = 8;
 
 /// Metrics for Any QMDBs.

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -256,7 +256,9 @@ where
         // its global key index, so partition order does not matter.
         let strategy = self.strategy();
         let parallelism = strategy.parallelism_hint().max(1);
-        let mut candidates: Vec<(usize, u64)> = if keys.len() < MIN_PROBES_PER_SHARD * parallelism {
+        let mut candidates: Vec<(usize, u64)> = if parallelism == 1
+            || keys.len() < MIN_PROBES_PER_SHARD.saturating_mul(parallelism)
+        {
             let mut candidates = Vec::with_capacity(keys.len());
             self.snapshot
                 .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -256,32 +256,31 @@ where
         // its global key index, so partition order does not matter.
         let strategy = self.strategy();
         let parallelism = strategy.parallelism_hint().max(1);
-        let mut candidates: Vec<(usize, u64)> = if parallelism == 1
-            || keys.len() < MIN_PROBES_PER_SHARD.saturating_mul(parallelism)
-        {
-            let mut candidates = Vec::with_capacity(keys.len());
-            self.snapshot
-                .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
-            candidates
-        } else {
-            let chunk = keys.len().div_ceil(parallelism);
-            let snapshot = &self.snapshot;
-            strategy
-                .map_collect_vec(
-                    keys.chunks(chunk).enumerate().collect::<Vec<_>>(),
-                    |(ci, chunk_keys)| {
-                        let base = ci * chunk;
-                        let mut local: Vec<(usize, u64)> = Vec::with_capacity(chunk_keys.len());
-                        snapshot.get_many(chunk_keys, |key_idx, &loc| {
-                            local.push((base + key_idx, *loc))
-                        });
-                        local
-                    },
-                )
-                .into_iter()
-                .flatten()
-                .collect()
-        };
+        let mut candidates: Vec<(usize, u64)> =
+            if parallelism == 1 || keys.len() < MIN_PROBES_PER_SHARD.saturating_mul(parallelism) {
+                let mut candidates = Vec::with_capacity(keys.len());
+                self.snapshot
+                    .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
+                candidates
+            } else {
+                let chunk = keys.len().div_ceil(parallelism);
+                let snapshot = &self.snapshot;
+                strategy
+                    .map_collect_vec(
+                        keys.chunks(chunk).enumerate().collect::<Vec<_>>(),
+                        |(ci, chunk_keys)| {
+                            let base = ci * chunk;
+                            let mut local: Vec<(usize, u64)> = Vec::with_capacity(chunk_keys.len());
+                            snapshot.get_many(chunk_keys, |key_idx, &loc| {
+                                local.push((base + key_idx, *loc))
+                            });
+                            local
+                        },
+                    )
+                    .into_iter()
+                    .flatten()
+                    .collect()
+            };
 
         let mut results: Vec<Option<T>> = (0..keys.len()).map(|_| None).collect();
         if candidates.is_empty() {

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -28,6 +28,10 @@ use commonware_utils::bitmap;
 use core::num::NonZeroU64;
 use std::{collections::HashMap, sync::Arc};
 
+/// Minimum keys per shard for [`Db::get_many_map`] to parallelize the index probe rather than
+/// probe serially, ensuring each shard carries enough work to amortize the thread-pool handoff.
+const MIN_PROBES_PER_SHARD: usize = 8;
+
 /// Metrics for Any QMDBs.
 pub(crate) struct Metrics<E: Context> {
     /// State gauges.
@@ -254,7 +258,7 @@ where
         // its global key index, so partition order does not matter.
         let strategy = self.strategy();
         let parallelism = strategy.parallelism_hint().max(1);
-        let mut candidates: Vec<(usize, u64)> = if keys.len() < parallelism {
+        let mut candidates: Vec<(usize, u64)> = if keys.len() < MIN_PROBES_PER_SHARD * parallelism {
             let mut candidates = Vec::with_capacity(keys.len());
             self.snapshot
                 .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -246,13 +246,38 @@ where
         self.metrics.reads.get_many_calls.inc();
         self.metrics.reads.keys_requested.inc_by(keys.len() as u64);
 
-        // Phase 1: Collect candidate locations from the in-memory index.
-        // Each key may map to multiple locations due to hash collisions.
-        let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
         let mut results: Vec<Option<T>> = (0..keys.len()).map(|_| None).collect();
 
-        self.snapshot
-            .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
+        // Phase 1: Collect candidate locations from the in-memory index. Each key may map to
+        // multiple locations due to hash collisions. The index is read-only and Send+Sync, so
+        // for large batches the probe is sharded across the strategy pool; each candidate carries
+        // its global key index, so partition order does not matter.
+        let strategy = self.strategy();
+        let parallelism = strategy.parallelism_hint().max(1);
+        let mut candidates: Vec<(usize, u64)> = if keys.len() < parallelism {
+            let mut candidates = Vec::with_capacity(keys.len());
+            self.snapshot
+                .get_many(keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
+            candidates
+        } else {
+            let chunk = keys.len().div_ceil(parallelism);
+            let snapshot = &self.snapshot;
+            strategy
+                .map_collect_vec(
+                    keys.chunks(chunk).enumerate().collect::<Vec<_>>(),
+                    |(ci, chunk_keys)| {
+                        let base = ci * chunk;
+                        let mut local: Vec<(usize, u64)> = Vec::with_capacity(chunk_keys.len());
+                        snapshot.get_many(chunk_keys, |key_idx, &loc| {
+                            local.push((base + key_idx, *loc))
+                        });
+                        local
+                    },
+                )
+                .into_iter()
+                .flatten()
+                .collect()
+        };
 
         if candidates.is_empty() {
             return Ok(results);


### PR DESCRIPTION
## Change
The snapshot-index probe — one location lookup per requested key — was a serial loop on the calling thread. It now shards the keys across the `Strategy` pool: each worker probes its slice into a local `Vec<(global_key_index, location)>`, and the results are concatenated.

## Why
The index is read-only and `Send + Sync`, so concurrent probes need no locking. Each probe is a `BTreeMap` descent (random-memory, cache-miss bound); running them in parallel overlaps those misses across cores.

## Result
Constantinople benchmark, `depth=0`, 1,000,000 keys, 32,768 updates/block.

| Variant                        | main     | with change | Δ      |
|--------------------------------|----------|-------------|--------|
| `any::ordered::fixed::mmb`     | 22.6 ms  | 20.1 ms     | −11%   |
| `current::ordered::fixed::mmb` | 27.1 ms  | 24.6 ms     | −9%    |