### PR TITLE
[runtime] add jemalloc feature

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -120,6 +120,9 @@ jobs:
         include:
           - os: ubuntu-latest
             package: commonware-runtime
+            flags: "--features commonware-runtime/jemalloc"
+          - os: ubuntu-latest
+            package: commonware-runtime
             flags: "--features commonware-runtime/external"
           - os: windows-latest
             package: commonware-runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,6 +1930,7 @@ dependencies = [
  "sha2 0.10.9",
  "sysinfo",
  "thiserror 2.0.17",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -5484,6 +5485,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,7 @@ sha2 = { version = "0.10.8", default-features = false }
 syn = "2.0.0"
 sysinfo = "0.37.2"
 thiserror = { version = "2.0.12", default-features = false }
+tikv-jemallocator = "0.7.0"
 tokio = "1.50.0"
 toml = "0.9.8"
 tracing = "0.1.41"

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -37,7 +37,6 @@ struct ToolUrls {
     tempo: String,
     node_exporter: String,
     promtail: String,
-    libjemalloc: String,
     logrotate: String,
     fonts_dejavu_mono: String,
     fonts_dejavu_core: String,
@@ -307,7 +306,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
     let mut tool_urls_by_arch: HashMap<Architecture, ToolUrls> = HashMap::new();
     for arch in &architectures_needed {
         let [prometheus_url, grafana_url, loki_url, pyroscope_url, tempo_url, node_exporter_url, promtail_url,
-             libjemalloc_url, logrotate_url, fontconfig_config_url, libfontconfig_url, unzip_url, musl_url]: [String; 13] =
+             logrotate_url, fontconfig_config_url, libfontconfig_url, unzip_url, musl_url]: [String; 12] =
             try_join_all([
                 cache_tool(prometheus_bin_s3_key(PROMETHEUS_VERSION, *arch), prometheus_download_url(PROMETHEUS_VERSION, *arch)),
                 cache_tool(grafana_bin_s3_key(GRAFANA_VERSION, *arch), grafana_download_url(GRAFANA_VERSION, *arch)),
@@ -316,7 +315,6 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                 cache_tool(tempo_bin_s3_key(TEMPO_VERSION, *arch), tempo_download_url(TEMPO_VERSION, *arch)),
                 cache_tool(node_exporter_bin_s3_key(NODE_EXPORTER_VERSION, *arch), node_exporter_download_url(NODE_EXPORTER_VERSION, *arch)),
                 cache_tool(promtail_bin_s3_key(PROMTAIL_VERSION, *arch), promtail_download_url(PROMTAIL_VERSION, *arch)),
-                cache_tool(libjemalloc_bin_s3_key(LIBJEMALLOC2_VERSION, *arch), libjemalloc_download_url(LIBJEMALLOC2_VERSION, *arch)),
                 cache_tool(logrotate_bin_s3_key(LOGROTATE_VERSION, *arch), logrotate_download_url(LOGROTATE_VERSION, *arch)),
                 cache_tool(fontconfig_config_bin_s3_key(FONTCONFIG_CONFIG_VERSION, *arch), fontconfig_config_download_url(FONTCONFIG_CONFIG_VERSION, *arch)),
                 cache_tool(libfontconfig_bin_s3_key(LIBFONTCONFIG1_VERSION, *arch), libfontconfig_download_url(LIBFONTCONFIG1_VERSION, *arch)),
@@ -336,7 +334,6 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                 tempo: tempo_url,
                 node_exporter: node_exporter_url,
                 promtail: promtail_url,
-                libjemalloc: libjemalloc_url,
                 logrotate: logrotate_url,
                 fonts_dejavu_mono: fonts_dejavu_mono_url.clone(),
                 fonts_dejavu_core: fonts_dejavu_core_url.clone(),
@@ -865,7 +862,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
     // Cache binary_service per architecture
     let mut binary_service_urls_by_arch: HashMap<Architecture, String> = HashMap::new();
     for arch in &architectures_needed {
-        let binary_service_content = binary_service(*arch);
+        let binary_service_content = binary_service();
         let temp_path = tag_directory.join(format!("binary-{}.service", arch.as_str()));
         std::fs::write(&temp_path, &binary_service_content)?;
         let binary_service_url = cache_and_presign(
@@ -1072,7 +1069,6 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                     pyroscope_script: pyroscope_digest_to_url[pyroscope_digest].clone(),
                     pyroscope_service: pyroscope_agent_service_url.clone(),
                     pyroscope_timer: pyroscope_agent_timer_url.clone(),
-                    libjemalloc_deb: tool_urls.libjemalloc.clone(),
                     logrotate_deb: tool_urls.logrotate.clone(),
                     unzip_deb: tool_urls.unzip.clone(),
                 },

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -316,14 +316,6 @@ cfg_if::cfg_if! {
                     Self::X86_64 => "amd64",
                 }
             }
-
-            /// Returns the Linux library path component for jemalloc
-            pub const fn linux_lib(&self) -> &'static str {
-                match self {
-                    Self::Arm64 => "aarch64-linux-gnu",
-                    Self::X86_64 => "x86_64-linux-gnu",
-                }
-            }
         }
 
         impl std::fmt::Display for Architecture {

--- a/deployer/src/aws/services.rs
+++ b/deployer/src/aws/services.rs
@@ -42,9 +42,6 @@ pub const GRAFANA_VERSION: &str = "11.5.2";
 /// Version of Samply to download and install
 pub const SAMPLY_VERSION: &str = "0.13.1";
 
-/// Version of libjemalloc2 package for Ubuntu 24.04
-pub const LIBJEMALLOC2_VERSION: &str = "5.3.0-2build1";
-
 /// Version of logrotate package for Ubuntu 24.04
 pub const LOGROTATE_VERSION: &str = "3.21.0-2build1";
 
@@ -140,13 +137,6 @@ pub(crate) fn samply_bin_s3_key(version: &str, architecture: Architecture) -> St
         Architecture::X86_64 => "x86_64",
     };
     format!("{TOOLS_BINARIES_PREFIX}/samply/{version}/linux-{arch}/samply-{arch}-unknown-linux-gnu.tar.xz")
-}
-
-pub(crate) fn libjemalloc_bin_s3_key(version: &str, architecture: Architecture) -> String {
-    format!(
-        "{TOOLS_BINARIES_PREFIX}/libjemalloc2/{version}/linux-{arch}/libjemalloc2_{version}_{arch}.deb",
-        arch = architecture.as_str()
-    )
 }
 
 pub(crate) fn logrotate_bin_s3_key(version: &str, architecture: Architecture) -> String {
@@ -383,18 +373,6 @@ pub(crate) fn samply_download_url(version: &str, architecture: Architecture) -> 
     };
     format!(
         "https://github.com/mstange/samply/releases/download/samply-v{version}/samply-{arch}-unknown-linux-gnu.tar.xz"
-    )
-}
-
-/// Returns the download URL for libjemalloc2 from Ubuntu archive
-pub(crate) fn libjemalloc_download_url(version: &str, architecture: Architecture) -> String {
-    let base = match architecture {
-        Architecture::Arm64 => UBUNTU_ARCHIVE_ARM64,
-        Architecture::X86_64 => UBUNTU_ARCHIVE_X86_64,
-    };
-    format!(
-        "{base}/universe/j/jemalloc/libjemalloc2_{version}_{arch}.deb",
-        arch = architecture.as_str()
     )
 }
 
@@ -912,7 +890,6 @@ pub struct InstanceUrls {
     pub pyroscope_script: String,
     pub pyroscope_service: String,
     pub pyroscope_timer: String,
-    pub libjemalloc_deb: String,
     pub logrotate_deb: String,
     pub unzip_deb: String,
 }
@@ -950,7 +927,7 @@ pub(crate) fn install_binary_download_cmd(urls: &InstanceUrls) -> String {
         r#"
 # Clean up any previous download artifacts (allows retries to re-download fresh copies)
 rm -f /home/ubuntu/promtail.zip /home/ubuntu/node_exporter.tar.gz \
-      /home/ubuntu/libjemalloc2.deb /home/ubuntu/logrotate.deb /home/ubuntu/unzip.deb
+      /home/ubuntu/logrotate.deb /home/ubuntu/unzip.deb
 rm -rf /home/ubuntu/promtail-linux-* /home/ubuntu/node_exporter-*
 
 # Unmask services in case previous attempt left them masked
@@ -970,7 +947,6 @@ sudo systemctl unmask promtail node_exporter binary 2>/dev/null || true
 {WGET} -O /home/ubuntu/pyroscope-agent.sh '{}' &
 {WGET} -O /home/ubuntu/pyroscope-agent.service '{}' &
 {WGET} -O /home/ubuntu/pyroscope-agent.timer '{}' &
-{WGET} -O /home/ubuntu/libjemalloc2.deb '{}' &
 {WGET} -O /home/ubuntu/logrotate.deb '{}' &
 {WGET} -O /home/ubuntu/unzip.deb '{}' &
 wait
@@ -979,7 +955,7 @@ wait
 for f in binary config.conf hosts.yaml promtail.zip promtail.yml promtail.service \
          node_exporter.tar.gz node_exporter.service binary.service logrotate.conf \
          pyroscope-agent.sh pyroscope-agent.service pyroscope-agent.timer \
-         libjemalloc2.deb logrotate.deb unzip.deb; do
+         logrotate.deb unzip.deb; do
     if [ ! -f "/home/ubuntu/$f" ]; then
         echo "ERROR: Failed to download $f" >&2
         exit 1
@@ -999,7 +975,6 @@ done
         urls.pyroscope_script,
         urls.pyroscope_service,
         urls.pyroscope_timer,
-        urls.libjemalloc_deb,
         urls.logrotate_deb,
         urls.unzip_deb,
     )
@@ -1105,7 +1080,6 @@ echo -e "net.core.default_qdisc=fq\nnet.ipv4.tcp_congestion_control=bbr" | sudo 
 
 # Install deb packages
 sudo dpkg -i /home/ubuntu/unzip.deb
-sudo dpkg -i /home/ubuntu/libjemalloc2.deb
 sudo dpkg -i /home/ubuntu/logrotate.deb
 
 # Install Promtail
@@ -1243,15 +1217,13 @@ pub const LOGROTATE_CONF: &str = r#"
 "#;
 
 /// Generates systemd service file content for the deployed binary
-pub(crate) fn binary_service(architecture: Architecture) -> String {
-    let lib_arch = architecture.linux_lib();
-    format!(
+pub(crate) fn binary_service() -> String {
+    String::from(
         r#"[Unit]
 Description=Deployed Binary Service
 After=network.target
 
 [Service]
-Environment="LD_PRELOAD=/usr/lib/{lib_arch}/libjemalloc.so.2"
 ExecStart=/home/ubuntu/binary --hosts=/home/ubuntu/hosts.yaml --config=/home/ubuntu/config.conf
 TimeoutStopSec=60
 Restart=always
@@ -1262,7 +1234,7 @@ StandardError=append:/var/log/binary.log
 
 [Install]
 WantedBy=multi-user.target
-"#
+"#,
     )
 }
 
@@ -1398,10 +1370,6 @@ mod tests {
             "tools/binaries/promtail/3.4.2/linux-arm64/promtail-linux-arm64.zip"
         );
         assert_eq!(
-            libjemalloc_bin_s3_key("5.3.0-2build1", arch),
-            "tools/binaries/libjemalloc2/5.3.0-2build1/linux-arm64/libjemalloc2_5.3.0-2build1_arm64.deb"
-        );
-        assert_eq!(
             logrotate_bin_s3_key("3.21.0-2build1", arch),
             "tools/binaries/logrotate/3.21.0-2build1/linux-arm64/logrotate_3.21.0-2build1_arm64.deb"
         );
@@ -1445,10 +1413,6 @@ mod tests {
         assert_eq!(
             promtail_bin_s3_key("3.4.2", arch),
             "tools/binaries/promtail/3.4.2/linux-amd64/promtail-linux-amd64.zip"
-        );
-        assert_eq!(
-            libjemalloc_bin_s3_key("5.3.0-2build1", arch),
-            "tools/binaries/libjemalloc2/5.3.0-2build1/linux-amd64/libjemalloc2_5.3.0-2build1_amd64.deb"
         );
         assert_eq!(
             logrotate_bin_s3_key("3.21.0-2build1", arch),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -59,6 +59,9 @@ opentelemetry-otlp = { workspace = true, features = ["http-proto"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
 tokio = { workspace = true, features = ["full"] }
 
+[target.'cfg(all(not(target_arch = "wasm32"), not(target_env = "msvc")))'.dependencies]
+tikv-jemallocator = { workspace = true, features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
+
 [dev-dependencies]
 clap = { workspace = true, features = ["derive"] }
 rand = { workspace = true, features = ["small_rng"] }
@@ -75,6 +78,7 @@ arbitrary = [
 ]
 bench = [ "dep:crossbeam-queue" ]
 external = [ "pin-project" ]
+jemalloc = [ "dep:tikv-jemallocator" ]
 loom = [ "dep:loom" ]
 test-utils = []
 iouring = [ "iouring-network", "iouring-storage" ]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,6 +23,14 @@
 
 use commonware_macros::stability_scope;
 
+#[cfg(all(
+    feature = "jemalloc",
+    not(target_arch = "wasm32"),
+    not(target_env = "msvc")
+))]
+#[global_allocator]
+static ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[macro_use]
 mod macros;
 


### PR DESCRIPTION
This PR adds an optional `jemalloc` feature to `commonware-runtime`. When enabled on supported targets, the runtime sets `tikv_jemallocator::Jemalloc` as the global allocator. This also removes the deployer's `LD_PRELOAD`-based jemalloc setup.

Using jemalloc through `LD_PRELOAD` swaps the process `malloc`/`free` symbols, which means that Rust still goes through the platform `System` allocator path. That loses some of the allocation layout information Rust already has, especially on deallocation.

## Rationale

The main distinction is where allocation layout information is preserved. The C allocator API does not carry Rust's `Layout` through the full allocation lifecycle. In particular, `free(ptr)` only receives a pointer, so size and alignment information have to be recovered by the allocator. Rust's allocator API does preserve this information: `alloc`, `dealloc`, and `realloc` are all called with a `Layout`, and callers are expected to pass the same layout back when freeing or resizing an allocation.

Using jemalloc as the Rust global allocator lets us exploit that. `tikv-jemallocator` can translate Rust's `Layout` into jemalloc's extended APIs, preserving size and alignment information that would otherwise be lost through the C std allocator interface.

This matters for `commonware-runtime` because it exposes buffer APIs where alignment and zeroing are part of the allocation contract.

The current Rust `System` path on Unix is roughly:

```text
alloc        -> malloc(...) or posix_memalign(...)
alloc_zeroed -> calloc(...) or alloc + memset for higher/special alignment
dealloc      -> free(ptr)
realloc      -> realloc(...) or fallback alloc/copy/free
```

With tikv-jemallocator:

```
alloc        -> malloc(size) or mallocx(size, MALLOCX_ALIGN(...))
alloc_zeroed -> calloc(1, size) or mallocx(size, flags | MALLOCX_ZERO)
dealloc      -> sdallocx(ptr, size, flags)
realloc      -> realloc(ptr, new_size) or rallocx(ptr, new_size, flags)
```

We enable `unprefixed_malloc_on_supported_platforms` so linked C/C++ libraries that call `malloc`, `calloc`, `realloc`, or `free` also use jemalloc on supported targets. This preserves the process-wide allocator behavior we previously got from LD_PRELOAD.
