### PR TITLE
Remove unneeded async from conformance tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,6 @@ dependencies = [
  "commonware-conformance-macros",
  "commonware-formatting",
  "commonware-macros",
- "futures",
  "serde",
  "sha2 0.10.9",
  "toml",

--- a/codec/src/conformance.rs
+++ b/codec/src/conformance.rs
@@ -85,7 +85,7 @@ impl<T> Conformance for CodecConformance<T>
 where
     T: Encode + for<'a> Arbitrary<'a> + Send + Sync,
 {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let value: T = generate_value(seed);
         value.encode().to_vec()
     }

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 commonware-conformance-macros.workspace = true
 commonware-formatting.workspace = true
 commonware-macros.workspace = true
-futures.workspace = true
 serde = { workspace = true, features = ["derive"] }
 sha2.workspace = true
 toml.workspace = true

--- a/conformance/macros/src/lib.rs
+++ b/conformance/macros/src/lib.rs
@@ -133,12 +133,10 @@ pub fn conformance_tests(input: TokenStream) -> TokenStream {
             #[::commonware_conformance::commonware_macros::test_group("conformance")]
             #[test]
             fn #fn_name() {
-                ::commonware_conformance::futures::executor::block_on(
-                    ::commonware_conformance::run_conformance_test::<#ty>(
-                        concat!(module_path!(), "::", #type_name_str),
-                        #n_cases,
-                        ::std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/conformance.toml")),
-                    )
+                ::commonware_conformance::run_conformance_test::<#ty>(
+                    concat!(module_path!(), "::", #type_name_str),
+                    #n_cases,
+                    ::std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/conformance.toml")),
                 );
             }
         }

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -49,9 +49,6 @@
 pub use commonware_conformance_macros::conformance_tests;
 #[doc(hidden)]
 pub use commonware_macros;
-use core::future::Future;
-#[doc(hidden)]
-pub use futures;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{collections::BTreeMap, fs, path::Path};
@@ -72,7 +69,7 @@ pub const DEFAULT_CASES: usize = 65536;
 /// struct MyConformance;
 ///
 /// impl Conformance for MyConformance {
-///     async fn commit(seed: u64) -> Vec<u8> {
+///     fn commit(seed: u64) -> Vec<u8> {
 ///         // Generate deterministic bytes from the seed
 ///         seed.to_le_bytes().to_vec()
 ///     }
@@ -83,7 +80,7 @@ pub trait Conformance: Send + Sync {
     ///
     /// The implementation should use the seed to generate deterministic
     /// test data and return a byte vector representing the commitment.
-    fn commit(seed: u64) -> impl Future<Output = Vec<u8>> + Send;
+    fn commit(seed: u64) -> Vec<u8>;
 }
 
 /// A conformance test file containing test data for multiple types.
@@ -166,11 +163,11 @@ fn acquire_lock(path: &Path) -> fs::File {
 ///
 /// Generates `n_cases` commitments (using seeds 0..n_cases), and hashes
 /// all the bytes together using SHA-256.
-pub async fn compute_conformance_hash<C: Conformance>(n_cases: usize) -> String {
+pub fn compute_conformance_hash<C: Conformance>(n_cases: usize) -> String {
     let mut hasher = Sha256::new();
 
     for seed in 0..n_cases as u64 {
-        let committed = C::commit(seed).await;
+        let committed = C::commit(seed);
 
         // Write length prefix to avoid ambiguity between concatenated values
         hasher.update((committed.len() as u64).to_le_bytes());
@@ -200,33 +197,29 @@ pub async fn compute_conformance_hash<C: Conformance>(n_cases: usize) -> String 
 /// # Panics
 ///
 /// Panics if the hash doesn't match (format changed).
-pub async fn run_conformance_test<C: Conformance>(
+pub fn run_conformance_test<C: Conformance>(
     type_name: &str,
     n_cases: usize,
     conformance_path: &Path,
 ) {
     #[cfg(generate_conformance_tests)]
     {
-        regenerate_conformance::<C>(type_name, n_cases, conformance_path).await;
+        regenerate_conformance::<C>(type_name, n_cases, conformance_path);
     }
 
     #[cfg(not(generate_conformance_tests))]
     {
-        verify_and_update_conformance::<C>(type_name, n_cases, conformance_path).await;
+        verify_and_update_conformance::<C>(type_name, n_cases, conformance_path);
     }
 }
 
 #[cfg(not(generate_conformance_tests))]
-async fn verify_and_update_conformance<C: Conformance>(
-    type_name: &str,
-    n_cases: usize,
-    path: &Path,
-) {
+fn verify_and_update_conformance<C: Conformance>(type_name: &str, n_cases: usize, path: &Path) {
     use std::io::{Read, Seek, Write};
 
     // Compute the hash first WITHOUT holding the lock - this is the expensive part
     // and can run in parallel across all conformance tests
-    let actual_hash = compute_conformance_hash::<C>(n_cases).await;
+    let actual_hash = compute_conformance_hash::<C>(n_cases);
 
     // Now acquire the lock only for file I/O
     let mut lock = acquire_lock(path);
@@ -291,12 +284,12 @@ async fn verify_and_update_conformance<C: Conformance>(
 }
 
 #[cfg(generate_conformance_tests)]
-async fn regenerate_conformance<C: Conformance>(type_name: &str, n_cases: usize, path: &Path) {
+fn regenerate_conformance<C: Conformance>(type_name: &str, n_cases: usize, path: &Path) {
     use std::io::{Read, Seek, Write};
 
     // Compute the hash first WITHOUT holding the lock - this is the expensive part
     // and can run in parallel across all conformance tests
-    let hash = compute_conformance_hash::<C>(n_cases).await;
+    let hash = compute_conformance_hash::<C>(n_cases);
 
     // Now acquire the lock only for file I/O
     let mut lock = acquire_lock(path);
@@ -334,24 +327,22 @@ mod tests {
     struct SimpleConformance;
 
     impl Conformance for SimpleConformance {
-        async fn commit(seed: u64) -> Vec<u8> {
+        fn commit(seed: u64) -> Vec<u8> {
             seed.to_le_bytes().to_vec()
         }
     }
 
     #[test]
     fn test_compute_conformance_hash_deterministic() {
-        let hash_1 = futures::executor::block_on(compute_conformance_hash::<SimpleConformance>(1));
-        let hash_2 = futures::executor::block_on(compute_conformance_hash::<SimpleConformance>(1));
+        let hash_1 = compute_conformance_hash::<SimpleConformance>(1);
+        let hash_2 = compute_conformance_hash::<SimpleConformance>(1);
         assert_eq!(hash_1, hash_2);
     }
 
     #[test]
     fn test_compute_conformance_hash_different_n_cases() {
-        let hash_10 =
-            futures::executor::block_on(compute_conformance_hash::<SimpleConformance>(10));
-        let hash_20 =
-            futures::executor::block_on(compute_conformance_hash::<SimpleConformance>(20));
+        let hash_10 = compute_conformance_hash::<SimpleConformance>(10);
+        let hash_20 = compute_conformance_hash::<SimpleConformance>(20);
         assert_ne!(hash_10, hash_20);
     }
 

--- a/consensus/src/marshal/conformance.rs
+++ b/consensus/src/marshal/conformance.rs
@@ -24,13 +24,13 @@ struct StandardStorageConformance;
 struct CodingStorageConformance;
 
 impl Conformance for StandardStorageConformance {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         marshal_commit::<StandardHarness>(seed)
     }
 }
 
 impl Conformance for CodingStorageConformance {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         marshal_commit::<CodingHarness>(seed)
     }
 }

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -507,7 +507,7 @@ mod tests {
         struct RoundRobinShuffleConformance;
 
         impl Conformance for RoundRobinShuffleConformance {
-            async fn commit(seed: u64) -> Vec<u8> {
+            fn commit(seed: u64) -> Vec<u8> {
                 let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
                 // Generate deterministic participants (using ed25519 fixture)
@@ -535,7 +535,7 @@ mod tests {
         struct RandomSelectLeaderConformance;
 
         impl Conformance for RandomSelectLeaderConformance {
-            async fn commit(seed: u64) -> Vec<u8> {
+            fn commit(seed: u64) -> Vec<u8> {
                 let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
                 // Generate deterministic BLS threshold fixture (4-10 participants)

--- a/cryptography/src/bloomfilter/conformance.rs
+++ b/cryptography/src/bloomfilter/conformance.rs
@@ -18,7 +18,7 @@ commonware_conformance::conformance_tests! {
 struct RationalOptimalBits;
 
 impl Conformance for RationalOptimalBits {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let mut log = Vec::new();
 
         // Use seed to vary expected_items (1 to 1M range)

--- a/cryptography/src/handshake/conformance.rs
+++ b/cryptography/src/handshake/conformance.rs
@@ -17,7 +17,7 @@ const NAMESPACE: &[u8] = b"_COMMONWARE_HANDSHAKE_CONFORMANCE_TESTS";
 struct Handshake;
 
 impl Conformance for Handshake {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let mut log = Vec::new();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
 

--- a/storage/src/archive/conformance.rs
+++ b/storage/src/archive/conformance.rs
@@ -19,7 +19,7 @@ const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 struct ArchivePrunable;
 
 impl Conformance for ArchivePrunable {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let config = prunable::Config {
@@ -60,7 +60,7 @@ impl Conformance for ArchivePrunable {
 struct ArchiveImmutable;
 
 impl Conformance for ArchiveImmutable {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let config = immutable::Config {

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -2563,7 +2563,7 @@ mod tests {
         struct RootConformance;
 
         impl Conformance for RootConformance {
-            async fn commit(seed: u64) -> Vec<u8> {
+            fn commit(seed: u64) -> Vec<u8> {
                 let root = test_merkle_tree(seed as usize);
                 root.to_vec()
             }

--- a/storage/src/freezer/conformance.rs
+++ b/storage/src/freezer/conformance.rs
@@ -14,7 +14,7 @@ const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 struct Freezer;
 
 impl Conformance for Freezer {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let config = Config {

--- a/storage/src/journal/conformance.rs
+++ b/storage/src/journal/conformance.rs
@@ -22,7 +22,7 @@ const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 struct ContiguousFixed;
 
 impl Conformance for ContiguousFixed {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let config = fixed::Config {
@@ -53,7 +53,7 @@ impl Conformance for ContiguousFixed {
 struct ContiguousVariable;
 
 impl Conformance for ContiguousVariable {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let config = variable::Config {
@@ -90,7 +90,7 @@ impl Conformance for ContiguousVariable {
 struct SegmentedFixed;
 
 impl Conformance for SegmentedFixed {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let config = segmented_fixed::Config {
@@ -128,7 +128,7 @@ impl Conformance for SegmentedFixed {
 struct SegmentedGlob;
 
 impl Conformance for SegmentedGlob {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let config = glob::Config {
@@ -170,7 +170,7 @@ impl Conformance for SegmentedGlob {
 struct SegmentedVariable;
 
 impl Conformance for SegmentedVariable {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let config = segmented_variable::Config {
@@ -261,7 +261,7 @@ impl Record for TestEntry {
 struct SegmentedOversized;
 
 impl Conformance for SegmentedOversized {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let config = oversized::Config {

--- a/storage/src/merkle/conformance.rs
+++ b/storage/src/merkle/conformance.rs
@@ -54,7 +54,7 @@ type Standard = crate::merkle::hasher::Standard<Sha256>;
 struct MmrRootStability;
 
 impl Conformance for MmrRootStability {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let hasher = Standard::new(ForwardFold);
         let mmr = crate::mmr::mem::Mmr::new();
         build_test_mem(&hasher, mmr, seed)
@@ -71,7 +71,7 @@ impl Conformance for MmrRootStability {
 struct MmbRootStability;
 
 impl Conformance for MmbRootStability {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let hasher = Standard::new(ForwardFold);
         let mmb = crate::mmb::mem::Mmb::new();
         build_test_mem(&hasher, mmb, seed)

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -605,7 +605,7 @@ macro_rules! db_conformance {
     ($name:ident, $db:ty, $cfg_fn:expr, |$d:ident, $s:ident| $body:expr) => {
         struct $name;
         impl Conformance for $name {
-            async fn commit($s: u64) -> Vec<u8> {
+            fn commit($s: u64) -> Vec<u8> {
                 deterministic::Runner::seeded($s).start(|ctx| async move {
                     let mut $d = <$db>::init(ctx.child("db"), ($cfg_fn)("cf", &ctx))
                         .await

--- a/storage/src/queue/conformance.rs
+++ b/storage/src/queue/conformance.rs
@@ -29,7 +29,7 @@ fn config(seed: u64, pooler: &impl BufferPooler) -> Config<(RangeCfg<usize>, ())
 struct QueueConformance;
 
 impl Conformance for QueueConformance {
-    async fn commit(seed: u64) -> Vec<u8> {
+    fn commit(seed: u64) -> Vec<u8> {
         let runner = deterministic::Runner::seeded(seed);
         runner.start(|mut context| async move {
             let mut queue = Queue::<_, Vec<u8>>::init(

--- a/utils/src/bitmap/roaring/container/mod.rs
+++ b/utils/src/bitmap/roaring/container/mod.rs
@@ -1154,7 +1154,7 @@ mod tests {
         }
 
         impl Conformance for ContainerTransitionsConformance {
-            async fn commit(seed: u64) -> Vec<u8> {
+            fn commit(seed: u64) -> Vec<u8> {
                 let mut out = Vec::new();
 
                 // Start from a dense contiguous range so in-memory normalization picks Run.

--- a/utils/src/rng.rs
+++ b/utils/src/rng.rs
@@ -383,7 +383,7 @@ mod tests {
         struct FuzzRngConformance;
 
         impl Conformance for FuzzRngConformance {
-            async fn commit(seed: u64) -> Vec<u8> {
+            fn commit(seed: u64) -> Vec<u8> {
                 let mut seed_rng = test_rng_seeded(seed);
                 let len = seed_rng.gen_range(1..=64);
                 let mut input = vec![0u8; len];


### PR DESCRIPTION
No `commit` impls are `async` so the trait method doesn't need `async`