### PR TITLE
[storage/qmdb] Align current batch sync boundary

### DIFF
--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -861,11 +861,11 @@ where
 
     /// Return the batch's safe sync boundary.
     ///
-    /// This derives from the chunk-aligned inactivity floor declared by this batch's commit, the
-    /// same quantity [`super::db::Db::sync_boundary`] derives from after the database is reopened.
-    /// It deliberately does not derive from the physical bitmap pruning boundary, which can lag the
-    /// inactivity floor when pruning has not run.
+    /// This equals the boundary [`super::db::Db::sync_boundary`] reports once this batch is applied.
     pub fn sync_boundary(&self) -> Location<F> {
+        // Derive from the commit's chunk-aligned inactivity floor, the same quantity the DB uses
+        // after apply. Deliberately not the physical bitmap pruning boundary, which can lag the
+        // inactivity floor when pruning has not run.
         super::db::sync_boundary::<F, N>(
             *self.inner.bounds().inactivity_floor / bitmap::Prunable::<N>::CHUNK_SIZE_BITS,
             self.inner.bounds().total_size,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -860,9 +860,14 @@ where
     }
 
     /// Return the batch's safe sync boundary.
+    ///
+    /// This derives from the chunk-aligned inactivity floor declared by this batch's commit, the
+    /// same quantity [`super::db::Db::sync_boundary`] derives from after the database is reopened.
+    /// It deliberately does not derive from the physical bitmap pruning boundary, which can lag the
+    /// inactivity floor when pruning has not run.
     pub fn sync_boundary(&self) -> Location<F> {
         super::db::sync_boundary::<F, N>(
-            self.bitmap.pruned_chunks() as u64,
+            *self.inner.bounds().inactivity_floor / bitmap::Prunable::<N>::CHUNK_SIZE_BITS,
             self.inner.bounds().total_size,
         )
     }

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -252,6 +252,53 @@ pub mod test {
         });
     }
 
+    /// The sync boundary recorded from a merkleized batch must match the boundary recovered by the
+    /// database after reopening. This can diverge if the batch boundary is derived from physical
+    /// bitmap pruning rather than the batch's declared inactivity floor, because the floor can
+    /// advance past a chunk even when pruning has not run.
+    #[test_traced("INFO")]
+    pub fn test_merkleized_batch_sync_boundary_survives_reopen() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let partition = "batch-boundary-reopen".to_string();
+            let mut db = open_db(ctx.child("current"), partition.clone()).await;
+
+            let key = Sha256::fill(1u8);
+            let mut last_batch_boundary = mmr::Location::new(0);
+            for i in 0..300u64 {
+                let value = Sha256::hash(&i.to_be_bytes());
+                let batch = db
+                    .new_batch()
+                    .write(key, Some(value))
+                    .merkleize(&db, None)
+                    .await
+                    .unwrap();
+                last_batch_boundary = batch.sync_boundary();
+                db.apply_batch(batch).await.unwrap();
+            }
+            db.sync().await.unwrap();
+
+            let db_boundary = db.sync_boundary();
+            assert!(
+                *db_boundary > 0,
+                "inactivity floor never crossed a chunk; add more commits"
+            );
+            assert_eq!(
+                last_batch_boundary,
+                db_boundary,
+                "batch boundary diverged from db boundary"
+            );
+
+            drop(db);
+            let reopened = open_db(ctx.child("reopen"), partition).await;
+            assert_eq!(
+                reopened.sync_boundary(),
+                last_batch_boundary,
+                "reopened db boundary disagrees with the boundary recorded from the last merkleized batch"
+            );
+            reopened.destroy().await.unwrap();
+        });
+    }
+
     #[test_traced("DEBUG")]
     pub fn test_current_db_verify_proof_over_bits_in_uncommitted_chunk() {
         shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db);

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -252,14 +252,15 @@ pub mod test {
         });
     }
 
-    /// The sync boundary recorded from a merkleized batch must match the boundary recovered by the
-    /// database after reopening. This can diverge if the batch boundary is derived from physical
-    /// bitmap pruning rather than the batch's declared inactivity floor, because the floor can
-    /// advance past a chunk even when pruning has not run.
+    /// The sync boundary recorded from a merkleized batch must match the boundary the database
+    /// reports once that batch is applied. These can diverge if the batch boundary is derived from
+    /// physical bitmap pruning rather than the batch's declared inactivity floor, because the floor
+    /// can advance past a chunk even when pruning has not run. Reopening is exercised afterward as a
+    /// persistence sanity check; it must not move the boundary.
     #[test_traced("INFO")]
-    pub fn test_merkleized_batch_sync_boundary_survives_reopen() {
+    pub fn test_merkleized_batch_sync_boundary_matches_db() {
         deterministic::Runner::default().start(|ctx| async move {
-            let partition = "batch-boundary-reopen".to_string();
+            let partition = "batch-boundary-match".to_string();
             let mut db = open_db(ctx.child("current"), partition.clone()).await;
 
             let key = Sha256::fill(1u8);
@@ -277,17 +278,22 @@ pub mod test {
             }
             db.sync().await.unwrap();
 
+            // The boundary must have advanced, otherwise the inactivity floor never crossed a chunk
+            // and the equality below would hold trivially.
             let db_boundary = db.sync_boundary();
             assert!(
                 *db_boundary > 0,
                 "inactivity floor never crossed a chunk; add more commits"
             );
+
+            // The headline invariant: the boundary the batch advertised equals the boundary the DB
+            // reports after applying that batch.
             assert_eq!(
-                last_batch_boundary,
-                db_boundary,
-                "batch boundary diverged from db boundary"
+                last_batch_boundary, db_boundary,
+                "batch boundary diverged from applied db boundary"
             );
 
+            // Reopening must not move the boundary.
             drop(db);
             let reopened = open_db(ctx.child("reopen"), partition).await;
             assert_eq!(


### PR DESCRIPTION
## Summary

- derive `qmdb::current::MerkleizedBatch::sync_boundary()` from the batch commit's chunk-aligned inactivity floor
- match the boundary `qmdb::current::Db::sync_boundary()` reports once the batch is applied
- add a regression test covering the no-pruning case where the inactivity floor crosses a bitmap chunk

Closes #4064

## Motivation

`current::MerkleizedBatch::sync_boundary()` previously derived its lower bound from `bitmap.pruned_chunks()`. `current::Db::sync_boundary()` derives from the chunk-aligned inactivity floor. These can diverge when the inactivity floor advances past a chunk before physical pruning catches up, or when pruning has not run.

That makes the same committed state report different target lower bounds depending on whether the target is read from the merkleized batch or from the DB after the batch is applied. The target lower bound is load-bearing for strict sync target equality, so the two accessors should share the same source of truth rather than relaxing comparison.

## Notes

The regression test lives in `current::unordered::fixed`, but the fixed method is `current::MerkleizedBatch::sync_boundary()`, which is shared by all current variants (ordered/unordered, fixed/variable). One variant is sufficient to cover the shared path.

## Testing

- `cargo test -p commonware-storage test_merkleized_batch_sync_boundary_matches_db`
- `cargo fmt --check`
- `git diff --check`
