### PR TITLE
[storage/qmdb] Rename misleading sync_boundary `pruned_chunks` param

### DIFF
--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -704,19 +704,22 @@ where
     }
 }
 
-/// Compute the safe sync boundary from a pruning boundary and the current ops-tree size.
+/// Compute the safe sync boundary from the chunk-aligned inactivity floor and the current
+/// ops-tree size.
 ///
-/// Shared by the live DB and speculative batch wrappers so they both derive the same range start.
+/// `floor_chunks` is the inactivity floor expressed in bitmap chunks (`floor / CHUNK_SIZE_BITS`),
+/// not the number of physically pruned chunks. Shared by the live DB and speculative batch
+/// wrappers, which both derive it from the inactivity floor so they report the same range start.
 pub(crate) fn sync_boundary<F: Graftable, const N: usize>(
-    mut pruned_chunks: u64,
+    mut floor_chunks: u64,
     ops_leaves: u64,
 ) -> Location<F> {
     let chunk_bits = bitmap::Prunable::<N>::CHUNK_SIZE_BITS;
     let grafting_height = grafting::height::<N>();
 
-    while pruned_chunks > 0 {
-        let required_ops = pair_absorption_threshold::<F, N>(pruned_chunks).unwrap_or_else(|| {
-            let youngest_start = (pruned_chunks - 1) * chunk_bits;
+    while floor_chunks > 0 {
+        let required_ops = pair_absorption_threshold::<F, N>(floor_chunks).unwrap_or_else(|| {
+            let youngest_start = (floor_chunks - 1) * chunk_bits;
             let pos = F::subtree_root_position(Location::<F>::new(youngest_start), grafting_height);
             F::peak_birth_size(pos, grafting_height)
         });
@@ -724,22 +727,22 @@ pub(crate) fn sync_boundary<F: Graftable, const N: usize>(
         if ops_leaves >= required_ops {
             break;
         }
-        pruned_chunks -= 1;
+        floor_chunks -= 1;
     }
 
-    Location::new(pruned_chunks * chunk_bits)
+    Location::new(floor_chunks * chunk_bits)
 }
 
-/// For the youngest of `pruned_chunks` chunks, return the `peak_birth_size` of its
+/// For the youngest of `chunk_count` chunks, return the `peak_birth_size` of its
 /// chunk-pair parent at height `gh+1`. Returns `None` for families without delayed merges
 /// (where `peak_birth_size` at height `gh` equals the chunk boundary).
-fn pair_absorption_threshold<F: Graftable, const N: usize>(pruned_chunks: u64) -> Option<u64> {
-    if pruned_chunks == 0 {
+fn pair_absorption_threshold<F: Graftable, const N: usize>(chunk_count: u64) -> Option<u64> {
+    if chunk_count == 0 {
         return None;
     }
 
     let grafting_height = grafting::height::<N>();
-    let youngest = pruned_chunks - 1;
+    let youngest = chunk_count - 1;
     let youngest_start = youngest << grafting_height;
     let youngest_end = (youngest + 1) << grafting_height;
     let youngest_pos =


### PR DESCRIPTION
## Summary

- rename `current::db::sync_boundary`'s first parameter `pruned_chunks` -> `floor_chunks`
- rename the shared `pair_absorption_threshold` parameter `pruned_chunks` -> `chunk_count`
- clarify the `sync_boundary` doc to say it takes the chunk-aligned inactivity floor

## Motivation

`current::db::sync_boundary` named its first parameter `pruned_chunks`, but both call sites (`Db::sync_boundary` and `MerkleizedBatch::sync_boundary`) pass the chunk-aligned inactivity floor (`floor / CHUNK_SIZE_BITS`), not the physical pruned-chunk count. That naming is what invited #4064 / #4065, where the batch wrapper had wired up `bitmap.pruned_chunks()` and diverged from the DB. Renaming removes the footgun so the two accessors can't silently drift again.

`pair_absorption_threshold` becomes the neutral `chunk_count` because it is called both with the floor candidate (from `sync_boundary`) and with the physical pruned count (from `delayed_merge_rewind_floor`).

## Notes

Pure rename + doc; no behavior change.

## Testing

- `cargo check -p commonware-storage`
- commit-time `just fix-fmt --check` (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)