### PR TITLE
[runtime] Add `Blob::start_sync`

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -469,7 +469,7 @@ impl Handle {
         self.start_sync(file)
             .await
             .await
-            .map_err(|_| Error::SyncFailed(std::io::Error::other("failed to read result")))?
+            .map_err(|_| Error::Io(std::io::Error::other("failed to read result")))?
     }
 
     /// Begin a logical fsync request, returning the completion receiver without waiting.
@@ -490,9 +490,7 @@ impl Handle {
             };
             let _ = request
                 .sender
-                .send(Err(Error::SyncFailed(std::io::Error::other(
-                    "failed to send work",
-                ))));
+                .send(Err(Error::Io(std::io::Error::other("failed to send work"))));
         }
         rx
     }

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -465,17 +465,36 @@ impl Handle {
 
     /// Submit a logical fsync request and wait for its completion.
     #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
-    pub async fn sync(&self, file: Arc<File>) -> std::io::Result<()> {
+    pub async fn sync(&self, file: Arc<File>) -> Result<(), Error> {
+        self.start_sync(file)
+            .await
+            .await
+            .map_err(|_| Error::SyncFailed(std::io::Error::other("failed to read result")))?
+    }
+
+    /// Begin a logical fsync request, returning the completion receiver without waiting.
+    ///
+    /// Enqueuing applies the same backpressure as every other request (it waits when the
+    /// submission channel is full). The returned receiver resolves once the fsync completes.
+    #[cfg_attr(not(feature = "iouring-storage"), allow(dead_code))]
+    pub async fn start_sync(&self, file: Arc<File>) -> oneshot::Receiver<Result<(), Error>> {
         let (tx, rx) = oneshot::channel();
-        self.enqueue(Request::Sync(SyncRequest {
+        let request = Request::Sync(SyncRequest {
             file,
             result: None,
             sender: tx,
-        }))
-        .await
-        .map_err(|_| std::io::Error::other("failed to send work"))?;
-        rx.await
-            .map_err(|_| std::io::Error::other("failed to read result"))?
+        });
+        if let Err(err) = self.enqueue(request).await {
+            let Request::Sync(request) = err.0 else {
+                unreachable!("sync enqueue returned wrong request variant");
+            };
+            let _ = request
+                .sender
+                .send(Err(Error::SyncFailed(std::io::Error::other(
+                    "failed to send work",
+                ))));
+        }
+        rx
     }
 }
 

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -623,15 +623,13 @@ impl SyncRequest {
         match CqeResult::from_raw(result, state) {
             CqeResult::Retry => false,
             CqeResult::Cancelled => {
-                self.result = Some(Err(Error::SyncFailed(std::io::Error::from_raw_os_error(
+                self.result = Some(Err(Error::Io(std::io::Error::from_raw_os_error(
                     libc::ECANCELED,
                 ))));
                 true
             }
             CqeResult::Error(code) => {
-                self.result = Some(Err(Error::SyncFailed(std::io::Error::from_raw_os_error(
-                    -code,
-                ))));
+                self.result = Some(Err(Error::Io(std::io::Error::from_raw_os_error(-code))));
                 true
             }
             CqeResult::Zero | CqeResult::Positive(_) => {
@@ -1336,8 +1334,8 @@ mod tests {
             .expect("missing timeout cancel result")
             .expect_err("expected timeout cancel error");
         match err {
-            Error::SyncFailed(err) => assert_eq!(err.raw_os_error(), Some(libc::ECANCELED)),
-            other => panic!("expected SyncFailed, got {other:?}"),
+            Error::Io(err) => assert_eq!(err.raw_os_error(), Some(libc::ECANCELED)),
+            other => panic!("expected io error, got {other:?}"),
         }
 
         // Hard errors should round-trip as std::io::Error values.
@@ -1353,8 +1351,8 @@ mod tests {
             .expect("missing hard error result")
             .expect_err("expected hard error");
         match err {
-            Error::SyncFailed(err) => assert_eq!(err.raw_os_error(), Some(libc::EIO)),
-            other => panic!("expected SyncFailed, got {other:?}"),
+            Error::Io(err) => assert_eq!(err.raw_os_error(), Some(libc::EIO)),
+            other => panic!("expected io error, got {other:?}"),
         }
 
         // Both zero and positive CQE results should count as sync success.
@@ -1557,9 +1555,9 @@ mod tests {
             sender: tx,
         });
         request.timeout();
-        assert!(matches!(
-            block_on(rx).expect("missing sync timeout"),
-            Err(Error::Timeout)
-        ));
+        let err = block_on(rx)
+            .expect("missing sync timeout")
+            .expect_err("sync timeout should be an error");
+        assert!(matches!(err, Error::Timeout));
     }
 }

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -211,12 +211,7 @@ impl Request {
                 let _ = w.sender.send(Err(Error::Timeout));
             }
             Self::Sync(s) => {
-                // Sync requests currently do not carry deadlines, but keep the
-                // timeout path consistent with storage's std::io::Result API.
-                let _ = s.sender.send(Err(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "request timed out",
-                )));
+                let _ = s.sender.send(Err(Error::Timeout));
             }
         }
     }
@@ -610,9 +605,9 @@ pub(super) struct SyncRequest {
     /// File descriptor to sync.
     pub(super) file: Arc<File>,
     /// Terminal result captured by `on_cqe` and delivered by `finish`.
-    pub(super) result: Option<std::io::Result<()>>,
+    pub(super) result: Option<Result<(), Error>>,
     /// Completion channel for the top-level caller.
-    pub(super) sender: oneshot::Sender<std::io::Result<()>>,
+    pub(super) sender: oneshot::Sender<Result<(), Error>>,
 }
 
 impl SyncRequest {
@@ -628,11 +623,15 @@ impl SyncRequest {
         match CqeResult::from_raw(result, state) {
             CqeResult::Retry => false,
             CqeResult::Cancelled => {
-                self.result = Some(Err(std::io::Error::from_raw_os_error(libc::ECANCELED)));
+                self.result = Some(Err(Error::SyncFailed(std::io::Error::from_raw_os_error(
+                    libc::ECANCELED,
+                ))));
                 true
             }
             CqeResult::Error(code) => {
-                self.result = Some(Err(std::io::Error::from_raw_os_error(-code)));
+                self.result = Some(Err(Error::SyncFailed(std::io::Error::from_raw_os_error(
+                    -code,
+                ))));
                 true
             }
             CqeResult::Zero | CqeResult::Positive(_) => {
@@ -1336,7 +1335,10 @@ mod tests {
         let err = block_on(rx)
             .expect("missing timeout cancel result")
             .expect_err("expected timeout cancel error");
-        assert_eq!(err.raw_os_error(), Some(libc::ECANCELED));
+        match err {
+            Error::SyncFailed(err) => assert_eq!(err.raw_os_error(), Some(libc::ECANCELED)),
+            other => panic!("expected SyncFailed, got {other:?}"),
+        }
 
         // Hard errors should round-trip as std::io::Error values.
         let (tx, rx) = oneshot::channel();
@@ -1350,7 +1352,10 @@ mod tests {
         let err = block_on(rx)
             .expect("missing hard error result")
             .expect_err("expected hard error");
-        assert_eq!(err.raw_os_error(), Some(libc::EIO));
+        match err {
+            Error::SyncFailed(err) => assert_eq!(err.raw_os_error(), Some(libc::EIO)),
+            other => panic!("expected SyncFailed, got {other:?}"),
+        }
 
         // Both zero and positive CQE results should count as sync success.
         let (tx, rx) = oneshot::channel();
@@ -1377,7 +1382,6 @@ mod tests {
             .expect("missing positive-result completion")
             .expect("sync should succeed on positive");
 
-        // Local timeout delivery should use TimedOut for the storage-facing API.
         let (tx, rx) = oneshot::channel();
         let request = Request::Sync(SyncRequest {
             file: make_file_fd(),
@@ -1388,7 +1392,7 @@ mod tests {
         let err = block_on(rx)
             .expect("missing timeout result")
             .expect_err("expected timeout error");
-        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert!(matches!(err, Error::Timeout));
     }
 
     #[test]
@@ -1546,7 +1550,6 @@ mod tests {
             Err(Error::Timeout)
         ));
 
-        // Sync uses `std::io::ErrorKind::TimedOut` to match its storage-facing API.
         let (tx, rx) = oneshot::channel();
         let request = Request::Sync(SyncRequest {
             file: make_file_fd(),
@@ -1554,9 +1557,9 @@ mod tests {
             sender: tx,
         });
         request.timeout();
-        let err = block_on(rx)
-            .expect("missing sync timeout")
-            .expect_err("sync timeout should be an error");
-        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert!(matches!(
+            block_on(rx).expect("missing sync timeout"),
+            Err(Error::Timeout)
+        ));
     }
 }

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -399,7 +399,7 @@ mod tests {
 
     /// Build a `Sync` request backed by a socket fd so waiter tests can
     /// exercise slot lifecycle without touching the filesystem.
-    fn make_sync_request() -> (Request, oneshot::Receiver<std::io::Result<()>>) {
+    fn make_sync_request() -> (Request, oneshot::Receiver<Result<(), crate::Error>>) {
         let (sock_left, _sock_right) =
             std::os::unix::net::UnixStream::pair().expect("failed to create unix socket pair");
         // SAFETY: sock_left is a valid fd that we own.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -116,8 +116,6 @@ stability_scope!(BETA {
         BlobResizeFailed(String, String, IoError),
         #[error("blob sync failed: {0}/{1} error: {2}")]
         BlobSyncFailed(String, String, IoError),
-        #[error("sync failed: {0}")]
-        SyncFailed(IoError),
         #[error("blob insufficient length")]
         BlobInsufficientLength,
         #[error("blob corrupt: {0}/{1} reason: {2}")]
@@ -763,8 +761,8 @@ stability_scope!(BETA {
 
         /// Begin syncing all pending data durably.
         ///
-        /// Awaiting this future waits until the backend has accepted or launched the sync work.
-        /// Awaiting the returned [oneshot::Receiver] waits for durability.
+        /// Awaiting this future waits until the backend has accepted or launched the sync work;
+        /// awaiting the returned [oneshot::Receiver] waits for durability.
         fn start_sync(
             &self,
         ) -> impl Future<Output = oneshot::Receiver<Result<(), Error>>> + Send;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -759,10 +759,10 @@ stability_scope!(BETA {
         /// Ensure all pending data is durably persisted.
         fn sync(&self) -> impl Future<Output = Result<(), Error>> + Send;
 
-        /// Begin syncing all pending data durably.
+        /// Request that all pending data is durably persisted.
         ///
-        /// Awaiting this future waits until the backend has accepted or launched the sync work;
-        /// awaiting the returned [oneshot::Receiver] waits for durability.
+        /// Awaiting this future waits until the sync has started. Awaiting the returned
+        /// [oneshot::Receiver] waits for the same durability guarantee as [`Blob::sync`].
         fn start_sync(
             &self,
         ) -> impl Future<Output = oneshot::Receiver<Result<(), Error>>> + Send;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -48,6 +48,7 @@ stability_scope!(BETA {
     pub use bytes::{Buf, BufMut};
     use commonware_macros::select;
     use commonware_parallel::{Rayon, ThreadPool};
+    use commonware_utils::channel::oneshot;
     /// Re-export of [governor::Quota] for rate limiting configuration.
     pub use governor::Quota;
     use iobuf::PoolError;
@@ -115,6 +116,8 @@ stability_scope!(BETA {
         BlobResizeFailed(String, String, IoError),
         #[error("blob sync failed: {0}/{1} error: {2}")]
         BlobSyncFailed(String, String, IoError),
+        #[error("sync failed: {0}")]
+        SyncFailed(IoError),
         #[error("blob insufficient length")]
         BlobInsufficientLength,
         #[error("blob corrupt: {0}/{1} reason: {2}")]
@@ -757,6 +760,14 @@ stability_scope!(BETA {
 
         /// Ensure all pending data is durably persisted.
         fn sync(&self) -> impl Future<Output = Result<(), Error>> + Send;
+
+        /// Begin syncing all pending data durably.
+        ///
+        /// Awaiting this future waits until the backend has accepted or launched the sync work.
+        /// Awaiting the returned [oneshot::Receiver] waits for durability.
+        fn start_sync(
+            &self,
+        ) -> impl Future<Output = oneshot::Receiver<Result<(), Error>>> + Send;
     }
 
     /// Interface that any runtime must implement to provide buffer pools.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -48,7 +48,6 @@ stability_scope!(BETA {
     pub use bytes::{Buf, BufMut};
     use commonware_macros::select;
     use commonware_parallel::{Rayon, ThreadPool};
-    use commonware_utils::channel::oneshot;
     /// Re-export of [governor::Quota] for rate limiting configuration.
     pub use governor::Quota;
     use iobuf::PoolError;
@@ -84,6 +83,8 @@ stability_scope!(BETA {
         Exited,
         #[error("closed")]
         Closed,
+        #[error("aborted")]
+        Aborted,
         #[error("timeout")]
         Timeout,
         #[error("bind failed")]
@@ -762,10 +763,8 @@ stability_scope!(BETA {
         /// Request that all pending data is durably persisted.
         ///
         /// Awaiting this future waits until the sync has started. Awaiting the returned
-        /// [oneshot::Receiver] waits for the same durability guarantee as [`Blob::sync`].
-        fn start_sync(
-            &self,
-        ) -> impl Future<Output = oneshot::Receiver<Result<(), Error>>> + Send;
+        /// [`Handle`] waits for the same durability guarantee as [`Blob::sync`].
+        fn start_sync(&self) -> impl Future<Output = Handle<()>> + Send;
     }
 
     /// Interface that any runtime must implement to provide buffer pools.
@@ -845,6 +844,7 @@ mod tests {
     use commonware_macros::select;
     use commonware_utils::{
         channel::{mpsc, oneshot},
+        futures::Pool as FuturesPool,
         sync::Mutex,
         NZUsize, SystemTimeExt, NZU32,
     };
@@ -874,6 +874,15 @@ mod tests {
         }
         let result = runner.start(|_| error_future());
         assert_eq!(result, Err("An error occurred"));
+    }
+
+    #[test]
+    fn test_handle_can_use_futures_pool() {
+        deterministic::Runner::default().start(|_| async move {
+            let mut pool = FuturesPool::<Result<(), Error>>::default();
+            pool.push(Handle::ready(Ok(())));
+            assert!(pool.next_completed().await.is_ok());
+        });
     }
 
     fn test_clock_sleep<R: Runner>(runner: R)

--- a/runtime/src/network/mod.rs
+++ b/runtime/src/network/mod.rs
@@ -452,7 +452,7 @@ mod tests {
 
             // Sink should be poisoned after cancellation.
             assert!(matches!(
-                sink.send(b"after".as_slice()).await,
+                sink.send(IoBuf::from(b"after")).await,
                 Err(crate::Error::Closed)
             ));
             canceled_sender
@@ -521,7 +521,7 @@ mod tests {
                 .await
                 .expect("Failed to dial server");
 
-            sink.send([1; 50].as_slice())
+            sink.send(vec![1u8; 50])
                 .await
                 .expect("Failed to send partial payload");
             drop(sink);
@@ -592,7 +592,7 @@ mod tests {
             for _ in 0..10 {
                 // A peer close is not guaranteed to make the next send fail
                 // immediately, so retry briefly until the error becomes visible.
-                match sink.send([9u8].as_slice()).await {
+                match sink.send(vec![9u8]).await {
                     Ok(()) => tokio::time::sleep(Duration::from_millis(5)).await,
                     Err(send_err) => {
                         err = Some(send_err);
@@ -603,7 +603,7 @@ mod tests {
             let err = err.expect("send should fail after the peer closes");
             assert!(matches!(err, crate::Error::SendFailed));
             assert!(matches!(
-                sink.send([9u8].as_slice()).await,
+                sink.send(vec![9u8]).await,
                 Err(crate::Error::Closed)
             ));
 

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -1,4 +1,4 @@
-use crate::{deterministic::Auditor, Error, IoBufs, IoBufsMut, Handle};
+use crate::{deterministic::Auditor, Error, Handle, IoBufs, IoBufsMut};
 use sha2::digest::Update;
 use std::sync::Arc;
 
@@ -165,8 +165,8 @@ mod tests {
             tests::run_storage_tests,
         },
         telemetry::metrics::Registry,
-        Blob as _, BufferPool, BufferPoolConfig, Error, IoBuf, IoBufs, IoBufsMut, Storage as _,
-        Handle,
+        Blob as _, BufferPool, BufferPoolConfig, Error, Handle, IoBuf, IoBufs, IoBufsMut,
+        Storage as _,
     };
     use commonware_utils::sync::Mutex;
     use std::sync::Arc;

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -1,5 +1,4 @@
-use crate::{deterministic::Auditor, Error, IoBufs, IoBufsMut};
-use commonware_utils::channel::oneshot;
+use crate::{deterministic::Auditor, Error, IoBufs, IoBufsMut, Handle};
 use sha2::digest::Update;
 use std::sync::Arc;
 
@@ -148,7 +147,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         self.inner.sync().await
     }
 
-    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+    async fn start_sync(&self) -> Handle<()> {
         self.auditor.event(b"start_sync", |hasher| {
             hasher.update(self.partition.as_bytes());
             hasher.update(&self.name);
@@ -167,8 +166,9 @@ mod tests {
         },
         telemetry::metrics::Registry,
         Blob as _, BufferPool, BufferPoolConfig, Error, IoBuf, IoBufs, IoBufsMut, Storage as _,
+        Handle,
     };
-    use commonware_utils::{channel::oneshot, sync::Mutex};
+    use commonware_utils::sync::Mutex;
     use std::sync::Arc;
 
     fn test_pool() -> BufferPool {
@@ -200,12 +200,7 @@ mod tests {
 
         // `start_sync` must record an auditor event, so the state advances.
         let before = auditor1.state();
-        blob1
-            .start_sync()
-            .await
-            .await
-            .expect("sync sender dropped")
-            .unwrap();
+        blob1.start_sync().await.await.unwrap();
         assert_ne!(
             auditor1.state(),
             before,
@@ -213,12 +208,7 @@ mod tests {
         );
 
         // The recorded event must be deterministic across independent runs.
-        blob2
-            .start_sync()
-            .await
-            .await
-            .expect("sync sender dropped")
-            .unwrap();
+        blob2.start_sync().await.await.unwrap();
         assert_eq!(
             auditor1.state(),
             auditor2.state(),
@@ -381,10 +371,8 @@ mod tests {
             Ok(())
         }
 
-        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
-            let (tx, rx) = oneshot::channel();
-            let _ = tx.send(self.sync().await);
-            rx
+        async fn start_sync(&self) -> Handle<()> {
+            Handle::ready(self.sync().await)
         }
     }
 

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -1,4 +1,5 @@
 use crate::{deterministic::Auditor, Error, IoBufs, IoBufsMut};
+use commonware_utils::channel::oneshot;
 use sha2::digest::Update;
 use std::sync::Arc;
 
@@ -146,11 +147,20 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         });
         self.inner.sync().await
     }
+
+    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+        self.auditor.event(b"start_sync", |hasher| {
+            hasher.update(self.partition.as_bytes());
+            hasher.update(&self.name);
+        });
+        self.inner.start_sync().await
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
+        deterministic::Auditor,
         storage::{
             audited::Storage as AuditedStorage, memory::Storage as MemStorage,
             tests::run_storage_tests,
@@ -158,7 +168,7 @@ mod tests {
         telemetry::metrics::Registry,
         Blob as _, BufferPool, BufferPoolConfig, Error, IoBuf, IoBufs, IoBufsMut, Storage as _,
     };
-    use commonware_utils::sync::Mutex;
+    use commonware_utils::{channel::oneshot, sync::Mutex};
     use std::sync::Arc;
 
     fn test_pool() -> BufferPool {
@@ -176,9 +186,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_audited_storage_combined() {
-        use crate::deterministic::Auditor;
+    async fn test_audited_start_sync() {
+        // Two independent storages run the same sequence of operations.
+        let auditor1 = Arc::new(Auditor::default());
+        let storage1 = AuditedStorage::new(MemStorage::new(test_pool()), auditor1.clone());
+        let auditor2 = Arc::new(Auditor::default());
+        let storage2 = AuditedStorage::new(MemStorage::new(test_pool()), auditor2.clone());
 
+        let (blob1, _) = storage1.open("partition", b"test_blob").await.unwrap();
+        let (blob2, _) = storage2.open("partition", b"test_blob").await.unwrap();
+        blob1.write_at(0, b"hello world").await.unwrap();
+        blob2.write_at(0, b"hello world").await.unwrap();
+
+        // `start_sync` must record an auditor event, so the state advances.
+        let before = auditor1.state();
+        blob1
+            .start_sync()
+            .await
+            .await
+            .expect("sync sender dropped")
+            .unwrap();
+        assert_ne!(
+            auditor1.state(),
+            before,
+            "start_sync must record an auditor event"
+        );
+
+        // The recorded event must be deterministic across independent runs.
+        blob2
+            .start_sync()
+            .await
+            .await
+            .expect("sync sender dropped")
+            .unwrap();
+        assert_eq!(
+            auditor1.state(),
+            auditor2.state(),
+            "Hashes do not match after start_sync"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_audited_storage_combined() {
         // Initialize the first storage and auditor
         let inner1 = MemStorage::new(test_pool());
         let auditor1 = Arc::new(Auditor::default());
@@ -330,6 +379,12 @@ mod tests {
 
         async fn sync(&self) -> Result<(), Error> {
             Ok(())
+        }
+
+        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+            let (tx, rx) = oneshot::channel();
+            let _ = tx.send(Ok(()));
+            rx
         }
     }
 

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -383,7 +383,7 @@ mod tests {
 
         async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
             let (tx, rx) = oneshot::channel();
-            let _ = tx.send(Ok(()));
+            let _ = tx.send(self.sync().await);
             rx
         }
     }

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -1,11 +1,8 @@
 //! A storage wrapper that injects deterministic faults for testing crash recovery.
 
-use crate::{deterministic::BoxDynRng, Error, IoBufs, IoBufsMut};
+use crate::{deterministic::BoxDynRng, Error, IoBufs, IoBufsMut, Handle};
 use bytes::Buf;
-use commonware_utils::{
-    channel::oneshot,
-    sync::{Mutex, RwLock},
-};
+use commonware_utils::sync::{Mutex, RwLock};
 use rand::Rng;
 use std::{
     io::Error as IoError,
@@ -395,11 +392,9 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         self.inner.sync().await
     }
 
-    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+    async fn start_sync(&self) -> Handle<()> {
         if self.ctx.should_fail(Op::Sync) {
-            let (tx, rx) = oneshot::channel();
-            let _ = tx.send(Err(Error::Io(injected_io_error())));
-            return rx;
+            return Handle::ready(Err(Error::Io(injected_io_error())));
         }
         self.inner.start_sync().await
     }
@@ -470,7 +465,7 @@ mod tests {
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec()).await.unwrap();
 
-        let result = blob.start_sync().await.await.expect("sync sender dropped");
+        let result = blob.start_sync().await.await;
         assert!(matches!(result, Err(Error::Io(_))));
     }
 

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -2,7 +2,10 @@
 
 use crate::{deterministic::BoxDynRng, Error, IoBufs, IoBufsMut};
 use bytes::Buf;
-use commonware_utils::sync::{Mutex, RwLock};
+use commonware_utils::{
+    channel::oneshot,
+    sync::{Mutex, RwLock},
+};
 use rand::Rng;
 use std::{
     io::Error as IoError,
@@ -391,6 +394,15 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         }
         self.inner.sync().await
     }
+
+    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+        if self.ctx.should_fail(Op::Sync) {
+            let (tx, rx) = oneshot::channel();
+            let _ = tx.send(Err(Error::Io(injected_io_error())));
+            return rx;
+        }
+        self.inner.start_sync().await
+    }
 }
 
 #[cfg(test)]
@@ -449,6 +461,17 @@ mod tests {
         blob.write_at(0, b"data".to_vec()).await.unwrap();
 
         assert!(matches!(blob.sync().await, Err(Error::Io(_))));
+    }
+
+    #[tokio::test]
+    async fn test_faulty_storage_start_sync_always_fails() {
+        let h = Harness::new(Config::default().sync(1.0));
+
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"data".to_vec()).await.unwrap();
+
+        let result = blob.start_sync().await.await.expect("sync sender dropped");
+        assert!(matches!(result, Err(Error::Io(_))));
     }
 
     #[tokio::test]

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -1,6 +1,6 @@
 //! A storage wrapper that injects deterministic faults for testing crash recovery.
 
-use crate::{deterministic::BoxDynRng, Error, IoBufs, IoBufsMut, Handle};
+use crate::{deterministic::BoxDynRng, Error, Handle, IoBufs, IoBufsMut};
 use bytes::Buf;
 use commonware_utils::sync::{Mutex, RwLock};
 use rand::Rng;

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use commonware_codec::Encode;
 use commonware_formatting::{from_hex, hex};
-use commonware_utils::sync::Mutex;
+use commonware_utils::{channel::oneshot, sync::Mutex};
 use std::{
     fs::{self, File},
     io::{Error as IoError, Read, Seek, SeekFrom, Write},

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -24,7 +24,7 @@ use super::Header;
 use crate::{
     iouring::{self},
     telemetry::metrics::Register,
-    utils, Buf, BufferPool, Error, IoBufs, IoBufsMut,
+    utils, Buf, BufferPool, Error, IoBufs, IoBufsMut, Handle,
 };
 use commonware_codec::Encode;
 use commonware_formatting::{from_hex, hex};
@@ -393,8 +393,8 @@ impl crate::Blob for Blob {
             })
     }
 
-    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
-        self.io_handle.start_sync(self.file.clone()).await
+    async fn start_sync(&self) -> Handle<()> {
+        Handle::from_receiver(self.io_handle.start_sync(self.file.clone()).await)
     }
 }
 

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -388,9 +388,7 @@ impl crate::Blob for Blob {
             .sync(self.file.clone())
             .await
             .map_err(|err| match err {
-                Error::SyncFailed(e) => {
-                    Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e)
-                }
+                Error::Io(e) => Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e),
                 err => err,
             })
     }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use commonware_codec::Encode;
 use commonware_formatting::{from_hex, hex};
-use commonware_utils::{channel::oneshot, sync::Mutex};
+use commonware_utils::sync::Mutex;
 use std::{
     fs::{self, File},
     io::{Error as IoError, Read, Seek, SeekFrom, Write},
@@ -394,7 +394,17 @@ impl crate::Blob for Blob {
     }
 
     async fn start_sync(&self) -> Handle<()> {
-        Handle::from_receiver(self.io_handle.start_sync(self.file.clone()).await)
+        let partition = self.partition.clone();
+        let name = self.name.clone();
+        let receiver = self.io_handle.start_sync(self.file.clone()).await;
+        Handle::from_future(async move {
+            match receiver.await {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(Error::Io(e))) => Err(Error::BlobSyncFailed(partition, hex(&name), e)),
+                Ok(Err(err)) => Err(err),
+                Err(_) => Err(Error::Closed),
+            }
+        })
     }
 }
 
@@ -947,6 +957,38 @@ mod tests {
             .sync()
             .await
             .expect_err("sync should fail without a loop");
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "blob sync failed: partition/{} error: failed to send work",
+                hex(b"blob")
+            )
+        );
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_blob_start_sync_reports_handle_disconnect() {
+        // Verify start_sync completion errors use the same blob-specific wrapper as sync.
+        let storage_directory = create_test_directory();
+        let path = storage_directory.join("disconnected_start_sync");
+        let file = File::create(&path).unwrap();
+
+        let mut registry = Registry::default();
+        let pool = test_pool(&mut registry.sub_registry("pool"));
+        let (submitter, io_loop) = iouring::IoUringLoop::new(
+            iouring::Config::default(),
+            &mut registry.sub_registry("iouring"),
+        );
+        drop(io_loop);
+
+        let blob = Blob::new("partition".into(), b"blob", file, submitter, pool);
+        let err = blob
+            .start_sync()
+            .await
+            .await
+            .expect_err("start_sync should fail without a loop");
         assert_eq!(
             err.to_string(),
             format!(

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -24,7 +24,7 @@ use super::Header;
 use crate::{
     iouring::{self},
     telemetry::metrics::Register,
-    utils, Buf, BufferPool, Error, IoBufs, IoBufsMut, Handle,
+    utils, Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut,
 };
 use commonware_codec::Encode;
 use commonware_formatting::{from_hex, hex};

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -387,7 +387,16 @@ impl crate::Blob for Blob {
         self.io_handle
             .sync(self.file.clone())
             .await
-            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
+            .map_err(|err| match err {
+                Error::SyncFailed(e) => {
+                    Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e)
+                }
+                err => err,
+            })
+    }
+
+    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+        self.io_handle.start_sync(self.file.clone()).await
     }
 }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -2,7 +2,10 @@ use super::Header;
 use crate::{Buf, BufferPool, IoBufs, IoBufsMut};
 use commonware_codec::Encode;
 use commonware_formatting::hex;
-use commonware_utils::sync::{Mutex, RwLock};
+use commonware_utils::{
+    channel::oneshot,
+    sync::{Mutex, RwLock},
+};
 use sha2::{Digest, Sha256};
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 
@@ -147,6 +150,25 @@ impl Blob {
             pool,
         }
     }
+
+    fn sync_inner(&self) -> Result<(), crate::Error> {
+        // Create new content for partition
+        let new_content = self.content.read().clone();
+
+        // Update partition content
+        let mut partitions = self.partitions.lock();
+        let partition = partitions
+            .get_mut(&self.partition)
+            .ok_or(crate::Error::PartitionMissing(self.partition.clone()))?;
+        let content = partition
+            .get_mut(&self.name)
+            .ok_or(crate::Error::BlobMissing(
+                self.partition.clone(),
+                hex(&self.name),
+            ))?;
+        *content = new_content;
+        Ok(())
+    }
 }
 
 impl crate::Blob for Blob {
@@ -224,22 +246,14 @@ impl crate::Blob for Blob {
     }
 
     async fn sync(&self) -> Result<(), crate::Error> {
-        // Create new content for partition
-        let new_content = self.content.read().clone();
+        self.sync_inner()
+    }
 
-        // Update partition content
-        let mut partitions = self.partitions.lock();
-        let partition = partitions
-            .get_mut(&self.partition)
-            .ok_or(crate::Error::PartitionMissing(self.partition.clone()))?;
-        let content = partition
-            .get_mut(&self.name)
-            .ok_or(crate::Error::BlobMissing(
-                self.partition.clone(),
-                hex(&self.name),
-            ))?;
-        *content = new_content;
-        Ok(())
+    async fn start_sync(&self) -> oneshot::Receiver<Result<(), crate::Error>> {
+        // The deterministic backend syncs synchronously, so resolve immediately.
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(self.sync_inner());
+        rx
     }
 }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,5 +1,5 @@
 use super::Header;
-use crate::{Buf, BufferPool, IoBufs, IoBufsMut, Handle};
+use crate::{Buf, BufferPool, Handle, IoBufs, IoBufsMut};
 use commonware_codec::Encode;
 use commonware_formatting::hex;
 use commonware_utils::sync::{Mutex, RwLock};

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,11 +1,8 @@
 use super::Header;
-use crate::{Buf, BufferPool, IoBufs, IoBufsMut};
+use crate::{Buf, BufferPool, IoBufs, IoBufsMut, Handle};
 use commonware_codec::Encode;
 use commonware_formatting::hex;
-use commonware_utils::{
-    channel::oneshot,
-    sync::{Mutex, RwLock},
-};
+use commonware_utils::sync::{Mutex, RwLock};
 use sha2::{Digest, Sha256};
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 
@@ -249,10 +246,8 @@ impl crate::Blob for Blob {
         self.sync_inner()
     }
 
-    async fn start_sync(&self) -> oneshot::Receiver<Result<(), crate::Error>> {
-        let (tx, rx) = oneshot::channel();
-        let _ = tx.send(self.sync().await);
-        rx
+    async fn start_sync(&self) -> Handle<()> {
+        Handle::ready(self.sync().await)
     }
 }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -250,7 +250,6 @@ impl crate::Blob for Blob {
     }
 
     async fn start_sync(&self) -> oneshot::Receiver<Result<(), crate::Error>> {
-        // The deterministic backend syncs synchronously, so resolve immediately.
         let (tx, rx) = oneshot::channel();
         let _ = tx.send(self.sync_inner());
         rx

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -251,7 +251,7 @@ impl crate::Blob for Blob {
 
     async fn start_sync(&self) -> oneshot::Receiver<Result<(), crate::Error>> {
         let (tx, rx) = oneshot::channel();
-        let _ = tx.send(self.sync_inner());
+        let _ = tx.send(self.sync().await);
         rx
     }
 }

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -2,6 +2,7 @@ use crate::{
     telemetry::metrics::{raw, Counter, Gauge, Register},
     Buf, Error, IoBufs, IoBufsMut,
 };
+use commonware_utils::channel::oneshot;
 use std::{
     ops::{Deref, RangeInclusive},
     sync::Arc,
@@ -223,6 +224,11 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         self.metrics.storage_syncs.inc();
         self.inner.sync().await
     }
+
+    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+        self.metrics.storage_syncs.inc();
+        self.inner.start_sync().await
+    }
 }
 
 #[cfg(test)]
@@ -353,6 +359,28 @@ mod tests {
         assert_eq!(
             open_blobs_after_drop, 0,
             "open_blobs metric was not decremented after dropping the blob"
+        );
+    }
+
+    /// Test that `start_sync` increments the sync metric, matching `sync`.
+    #[tokio::test]
+    async fn test_metered_start_sync_increments_metric() {
+        let mut registry = Registry::default();
+        let inner = MemoryStorage::new(test_pool(&mut registry.sub_registry("pool")));
+        let storage = Storage::new(inner, &mut registry.sub_registry("storage"));
+
+        let (blob, _) = storage.open("partition", b"test_blob").await.unwrap();
+        blob.write_at(0, b"hello world").await.unwrap();
+
+        blob.start_sync()
+            .await
+            .await
+            .expect("sync sender dropped")
+            .unwrap();
+        assert_eq!(
+            storage.metrics.storage_syncs.get(),
+            1,
+            "storage_syncs metric was not incremented after start_sync"
         );
     }
 

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -1,8 +1,7 @@
 use crate::{
     telemetry::metrics::{raw, Counter, Gauge, Register},
-    Buf, Error, IoBufs, IoBufsMut,
+    Buf, Error, IoBufs, IoBufsMut, Handle,
 };
-use commonware_utils::channel::oneshot;
 use std::{
     ops::{Deref, RangeInclusive},
     sync::Arc,
@@ -231,9 +230,12 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         skip_all,
         fields(partition = %self.partition)
     )]
-    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+    async fn start_sync(&self) -> Handle<()> {
         self.metrics.storage_syncs.inc();
-        self.inner.start_sync().await
+        self.inner.start_sync().await.with_span(tracing::info_span!(
+            "runtime.storage.blob.sync",
+            partition = %self.partition,
+        ))
     }
 }
 
@@ -378,11 +380,7 @@ mod tests {
         let (blob, _) = storage.open("partition", b"test_blob").await.unwrap();
         blob.write_at(0, b"hello world").await.unwrap();
 
-        blob.start_sync()
-            .await
-            .await
-            .expect("sync sender dropped")
-            .unwrap();
+        blob.start_sync().await.await.unwrap();
         assert_eq!(
             storage.metrics.storage_syncs.get(),
             1,

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -6,7 +6,7 @@ use std::{
     ops::{Deref, RangeInclusive},
     sync::Arc,
 };
-use tracing::{field::Empty, Span};
+use tracing::{field::Empty, Instrument as _, Span};
 
 pub struct Metrics {
     pub open_blobs: Gauge,
@@ -233,10 +233,11 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
     #[allow(clippy::async_yields_async)]
     async fn start_sync(&self) -> Handle<()> {
         self.metrics.storage_syncs.inc();
-        self.inner.start_sync().await.with_span(tracing::info_span!(
+        let handle = self.inner.start_sync().await;
+        Handle::from_future(handle.instrument(tracing::info_span!(
             "runtime.storage.blob.sync",
             partition = %self.partition,
-        ))
+        )))
     }
 }
 

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -1,6 +1,6 @@
 use crate::{
     telemetry::metrics::{raw, Counter, Gauge, Register},
-    Buf, Error, IoBufs, IoBufsMut, Handle,
+    Buf, Error, Handle, IoBufs, IoBufsMut,
 };
 use std::{
     ops::{Deref, RangeInclusive},

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -230,6 +230,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         skip_all,
         fields(partition = %self.partition)
     )]
+    #[allow(clippy::async_yields_async)]
     async fn start_sync(&self) -> Handle<()> {
         self.metrics.storage_syncs.inc();
         self.inner.start_sync().await.with_span(tracing::info_span!(

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -225,6 +225,12 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         self.inner.sync().await
     }
 
+    #[tracing::instrument(
+        name = "runtime.storage.blob.start_sync",
+        level = "info",
+        skip_all,
+        fields(partition = %self.partition)
+    )]
     async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
         self.metrics.storage_syncs.inc();
         self.inner.start_sync().await

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -388,6 +388,7 @@ pub(crate) mod tests {
         test_read_beyond_bound(&storage).await;
         test_write_at_large_offset(&storage).await;
         test_write_at_sync(&storage).await;
+        test_start_sync(&storage).await;
         test_append_data(&storage).await;
         test_vectored_write_at(&storage).await;
         test_vectored_write_at_large_offset(&storage).await;
@@ -881,6 +882,30 @@ pub(crate) mod tests {
             .open("test_write_at_sync", b"test_blob")
             .await
             .unwrap();
+        assert_eq!(len, 11);
+        let read = blob.read_at(0, 11).await.unwrap().coalesce();
+        assert_eq!(read.as_ref(), b"hello world");
+    }
+
+    /// Test that `start_sync` durably persists data, matching `sync`.
+    async fn test_start_sync<S>(storage: &S)
+    where
+        S: Storage + Send + Sync,
+        S::Blob: Send + Sync,
+    {
+        let (blob, len) = storage.open("test_start_sync", b"test_blob").await.unwrap();
+        assert_eq!(len, 0);
+
+        blob.write_at(0, b"hello world").await.unwrap();
+        blob.start_sync()
+            .await
+            .await
+            .expect("sync sender dropped")
+            .unwrap();
+        drop(blob);
+
+        // The bytes must survive a reopen, just as they would after `sync`.
+        let (blob, len) = storage.open("test_start_sync", b"test_blob").await.unwrap();
         assert_eq!(len, 11);
         let read = blob.read_at(0, 11).await.unwrap().coalesce();
         assert_eq!(read.as_ref(), b"hello world");

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -897,11 +897,7 @@ pub(crate) mod tests {
         assert_eq!(len, 0);
 
         blob.write_at(0, b"hello world").await.unwrap();
-        blob.start_sync()
-            .await
-            .await
-            .expect("sync sender dropped")
-            .unwrap();
+        blob.start_sync().await.await.unwrap();
         drop(blob);
 
         // The bytes must survive a reopen, just as they would after `sync`.

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -1,5 +1,5 @@
 use super::Header;
-use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut};
+use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut, Handle};
 use commonware_formatting::hex;
 use commonware_utils::channel::oneshot;
 use std::{io::SeekFrom, sync::Arc};
@@ -137,7 +137,7 @@ impl crate::Blob for Blob {
         Self::sync_inner(&file, &self.partition, &self.name).await
     }
 
-    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+    async fn start_sync(&self) -> Handle<()> {
         let (tx, rx) = oneshot::channel();
         let file = self.file.clone();
         let partition = self.partition.clone();
@@ -147,6 +147,6 @@ impl crate::Blob for Blob {
             let result = Self::sync_inner(&file, &partition, &name).await;
             let _ = tx.send(result);
         });
-        rx
+        Handle::from_receiver(rx)
     }
 }

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -6,7 +6,6 @@ use std::{io::SeekFrom, sync::Arc};
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
-    runtime::Handle,
     sync::Mutex,
 };
 
@@ -19,23 +18,15 @@ pub struct Blob {
     // we could remove this lock.
     file: Arc<Mutex<fs::File>>,
     pool: BufferPool,
-    handle: Handle,
 }
 
 impl Blob {
-    pub fn new(
-        partition: String,
-        name: &[u8],
-        file: fs::File,
-        pool: BufferPool,
-        handle: Handle,
-    ) -> Self {
+    pub fn new(partition: String, name: &[u8], file: fs::File, pool: BufferPool) -> Self {
         Self {
             partition,
             name: name.into(),
             file: Arc::new(Mutex::new(file)),
             pool,
-            handle,
         }
     }
 
@@ -62,10 +53,10 @@ impl Blob {
         }
     }
 
-    async fn sync_inner(&self, file: &fs::File) -> Result<(), Error> {
+    async fn sync_inner(file: &fs::File, partition: &str, name: &[u8]) -> Result<(), Error> {
         file.sync_all()
             .await
-            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))
+            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e))
     }
 }
 
@@ -127,7 +118,7 @@ impl crate::Blob for Blob {
 
         let mut file = self.file.lock().await;
         Self::write_at_inner(&mut file, offset, &mut bufs).await?;
-        self.sync_inner(&file).await
+        Self::sync_inner(&file, &self.partition, &self.name).await
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {
@@ -143,14 +134,18 @@ impl crate::Blob for Blob {
 
     async fn sync(&self) -> Result<(), Error> {
         let file = self.file.lock().await;
-        self.sync_inner(&file).await
+        Self::sync_inner(&file, &self.partition, &self.name).await
     }
 
     async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
         let (tx, rx) = oneshot::channel();
-        let this = self.clone();
-        self.handle.spawn(async move {
-            let _ = tx.send(this.sync().await);
+        let file = self.file.clone();
+        let partition = self.partition.clone();
+        let name = self.name.clone();
+        tokio::spawn(async move {
+            let file = file.lock().await;
+            let result = Self::sync_inner(&file, &partition, &name).await;
+            let _ = tx.send(result);
         });
         rx
     }

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -1,5 +1,5 @@
 use super::Header;
-use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut, Handle};
+use crate::{Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut};
 use commonware_formatting::hex;
 use commonware_utils::channel::oneshot;
 use std::{io::SeekFrom, sync::Arc};

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -1,10 +1,12 @@
 use super::Header;
 use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut};
 use commonware_formatting::hex;
+use commonware_utils::channel::oneshot;
 use std::{io::SeekFrom, sync::Arc};
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
+    runtime::Handle,
     sync::Mutex,
 };
 
@@ -17,15 +19,23 @@ pub struct Blob {
     // we could remove this lock.
     file: Arc<Mutex<fs::File>>,
     pool: BufferPool,
+    handle: Handle,
 }
 
 impl Blob {
-    pub fn new(partition: String, name: &[u8], file: fs::File, pool: BufferPool) -> Self {
+    pub fn new(
+        partition: String,
+        name: &[u8],
+        file: fs::File,
+        pool: BufferPool,
+        handle: Handle,
+    ) -> Self {
         Self {
             partition,
             name: name.into(),
             file: Arc::new(Mutex::new(file)),
             pool,
+            handle,
         }
     }
 
@@ -134,5 +144,14 @@ impl crate::Blob for Blob {
     async fn sync(&self) -> Result<(), Error> {
         let file = self.file.lock().await;
         self.sync_inner(&file).await
+    }
+
+    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+        let (tx, rx) = oneshot::channel();
+        let this = self.clone();
+        self.handle.spawn(async move {
+            let _ = tx.send(this.sync().await);
+        });
+        rx
     }
 }

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -294,11 +294,7 @@ mod tests {
         drop(blob.start_sync().await);
 
         // The blob remains usable, and a subsequent sync persists the data.
-        blob.start_sync()
-            .await
-            .await
-            .expect("sync sender dropped")
-            .unwrap();
+        blob.start_sync().await.await.unwrap();
         drop(blob);
 
         let (blob, len) = storage.open("partition", b"test_blob").await.unwrap();

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -277,10 +277,10 @@ mod tests {
         run_storage_tests(storage).await;
     }
 
-    /// Dropping the `start_sync` receiver before the background sync completes must not
-    /// break the blob: the handle stays usable and a later sync still persists data.
+    /// Dropping the `start_sync` receiver must not break the blob: the handle stays
+    /// usable and a later sync still persists data.
     #[tokio::test]
-    async fn test_start_sync_dropped_handle() {
+    async fn test_start_sync_dropped_receiver() {
         let mut rng = rand::rngs::StdRng::from_entropy();
         let storage_directory =
             env::temp_dir().join(format!("storage_tokio_start_sync_{}", rng.gen::<u64>()));

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -8,7 +8,6 @@ use std::{ops::RangeInclusive, path::PathBuf, sync::Arc};
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncWriteExt},
-    runtime::Handle,
     sync::Mutex,
 };
 
@@ -58,16 +57,14 @@ pub struct Storage {
     lock: Arc<Mutex<()>>,
     cfg: Config,
     pool: BufferPool,
-    handle: Handle,
 }
 
 impl Storage {
-    pub fn new(cfg: Config, pool: BufferPool, handle: Handle) -> Self {
+    pub fn new(cfg: Config, pool: BufferPool) -> Self {
         Self {
             lock: Arc::new(Mutex::new(())),
             cfg,
             pool,
-            handle,
         }
     }
 }
@@ -174,13 +171,7 @@ impl crate::Storage for Storage {
 
             // Construct the blob
             Ok((
-                Self::Blob::new(
-                    partition.into(),
-                    name,
-                    file,
-                    self.pool.clone(),
-                    self.handle.clone(),
-                ),
+                Self::Blob::new(partition.into(), name, file, self.pool.clone()),
                 logical_size,
                 blob_version,
             ))
@@ -189,13 +180,7 @@ impl crate::Storage for Storage {
         {
             // Construct the blob
             Ok((
-                Self::Blob::new(
-                    partition.into(),
-                    name,
-                    file,
-                    self.pool.clone(),
-                    self.handle.clone(),
-                ),
+                Self::Blob::new(partition.into(), name, file, self.pool.clone()),
                 logical_size,
                 blob_version,
             ))
@@ -288,28 +273,27 @@ mod tests {
         let mut rng = rand::rngs::StdRng::from_entropy();
         let storage_directory = env::temp_dir().join(format!("storage_tokio_{}", rng.gen::<u64>()));
         let config = Config::new(storage_directory, 2 * 1024 * 1024);
-        let storage = Storage::new(config, test_pool(), Handle::current());
+        let storage = Storage::new(config, test_pool());
         run_storage_tests(storage).await;
     }
 
     /// Dropping the `start_sync` receiver before the background sync completes must not
-    /// break the blob: the data still persists and the handle stays usable.
+    /// break the blob: the handle stays usable and a later sync still persists data.
     #[tokio::test]
-    async fn test_start_sync_dropped_receiver() {
+    async fn test_start_sync_dropped_handle() {
         let mut rng = rand::rngs::StdRng::from_entropy();
         let storage_directory =
             env::temp_dir().join(format!("storage_tokio_start_sync_{}", rng.gen::<u64>()));
         let config = Config::new(storage_directory, 2 * 1024 * 1024);
-        let storage = Storage::new(config, test_pool(), Handle::current());
+        let storage = Storage::new(config, test_pool());
 
         let (blob, _) = storage.open("partition", b"test_blob").await.unwrap();
         blob.write_at(0, b"hello world").await.unwrap();
 
-        // Drop the receiver immediately; the spawned sync task must tolerate the
-        // closed channel without panicking.
+        // Drop the completion receiver immediately.
         drop(blob.start_sync().await);
 
-        // The handle is still usable, and a subsequent sync persists the data.
+        // The blob remains usable, and a subsequent sync persists the data.
         blob.start_sync()
             .await
             .await
@@ -329,7 +313,7 @@ mod tests {
         let storage_directory =
             env::temp_dir().join(format!("storage_tokio_header_{}", rng.gen::<u64>()));
         let config = Config::new(storage_directory.clone(), 2 * 1024 * 1024);
-        let storage = Storage::new(config, test_pool(), Handle::current());
+        let storage = Storage::new(config, test_pool());
 
         // Test 1: New blob returns logical size 0 and correct app version
         let (blob, size) = storage.open("partition", b"test").await.unwrap();
@@ -431,7 +415,6 @@ mod tests {
                 maximum_buffer_size: 1024 * 1024,
             },
             test_pool(),
-            Handle::current(),
         );
 
         // Create the partition directory and a file with invalid magic bytes
@@ -468,7 +451,6 @@ mod tests {
                     maximum_buffer_size: 1024 * 1024,
                 },
                 test_pool(),
-                Handle::current(),
             );
 
             let partition_path = storage_directory.join("partition");

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -8,6 +8,7 @@ use std::{ops::RangeInclusive, path::PathBuf, sync::Arc};
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncWriteExt},
+    runtime::Handle,
     sync::Mutex,
 };
 
@@ -57,14 +58,16 @@ pub struct Storage {
     lock: Arc<Mutex<()>>,
     cfg: Config,
     pool: BufferPool,
+    handle: Handle,
 }
 
 impl Storage {
-    pub fn new(cfg: Config, pool: BufferPool) -> Self {
+    pub fn new(cfg: Config, pool: BufferPool, handle: Handle) -> Self {
         Self {
             lock: Arc::new(Mutex::new(())),
             cfg,
             pool,
+            handle,
         }
     }
 }
@@ -171,7 +174,13 @@ impl crate::Storage for Storage {
 
             // Construct the blob
             Ok((
-                Self::Blob::new(partition.into(), name, file, self.pool.clone()),
+                Self::Blob::new(
+                    partition.into(),
+                    name,
+                    file,
+                    self.pool.clone(),
+                    self.handle.clone(),
+                ),
                 logical_size,
                 blob_version,
             ))
@@ -180,7 +189,13 @@ impl crate::Storage for Storage {
         {
             // Construct the blob
             Ok((
-                Self::Blob::new(partition.into(), name, file, self.pool.clone()),
+                Self::Blob::new(
+                    partition.into(),
+                    name,
+                    file,
+                    self.pool.clone(),
+                    self.handle.clone(),
+                ),
                 logical_size,
                 blob_version,
             ))
@@ -273,8 +288,39 @@ mod tests {
         let mut rng = rand::rngs::StdRng::from_entropy();
         let storage_directory = env::temp_dir().join(format!("storage_tokio_{}", rng.gen::<u64>()));
         let config = Config::new(storage_directory, 2 * 1024 * 1024);
-        let storage = Storage::new(config, test_pool());
+        let storage = Storage::new(config, test_pool(), Handle::current());
         run_storage_tests(storage).await;
+    }
+
+    /// Dropping the `start_sync` receiver before the background sync completes must not
+    /// break the blob: the data still persists and the handle stays usable.
+    #[tokio::test]
+    async fn test_start_sync_dropped_receiver() {
+        let mut rng = rand::rngs::StdRng::from_entropy();
+        let storage_directory =
+            env::temp_dir().join(format!("storage_tokio_start_sync_{}", rng.gen::<u64>()));
+        let config = Config::new(storage_directory, 2 * 1024 * 1024);
+        let storage = Storage::new(config, test_pool(), Handle::current());
+
+        let (blob, _) = storage.open("partition", b"test_blob").await.unwrap();
+        blob.write_at(0, b"hello world").await.unwrap();
+
+        // Drop the receiver immediately; the spawned sync task must tolerate the
+        // closed channel without panicking.
+        drop(blob.start_sync().await);
+
+        // The handle is still usable, and a subsequent sync persists the data.
+        blob.start_sync()
+            .await
+            .await
+            .expect("sync sender dropped")
+            .unwrap();
+        drop(blob);
+
+        let (blob, len) = storage.open("partition", b"test_blob").await.unwrap();
+        assert_eq!(len, 11);
+        let read = blob.read_at(0, 11).await.unwrap().coalesce();
+        assert_eq!(read.as_ref(), b"hello world");
     }
 
     #[tokio::test]
@@ -283,7 +329,7 @@ mod tests {
         let storage_directory =
             env::temp_dir().join(format!("storage_tokio_header_{}", rng.gen::<u64>()));
         let config = Config::new(storage_directory.clone(), 2 * 1024 * 1024);
-        let storage = Storage::new(config, test_pool());
+        let storage = Storage::new(config, test_pool(), Handle::current());
 
         // Test 1: New blob returns logical size 0 and correct app version
         let (blob, size) = storage.open("partition", b"test").await.unwrap();
@@ -385,6 +431,7 @@ mod tests {
                 maximum_buffer_size: 1024 * 1024,
             },
             test_pool(),
+            Handle::current(),
         );
 
         // Create the partition directory and a file with invalid magic bytes
@@ -421,6 +468,7 @@ mod tests {
                     maximum_buffer_size: 1024 * 1024,
                 },
                 test_pool(),
+                Handle::current(),
             );
 
             let partition_path = storage_directory.join("partition");

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -2,13 +2,14 @@ use super::Header;
 use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut};
 use cfg_if::cfg_if;
 use commonware_formatting::hex;
+use commonware_utils::channel::oneshot;
 use std::{
     fs::File,
     io::IoSlice,
     os::{fd::AsRawFd, unix::fs::FileExt},
     sync::Arc,
 };
-use tokio::task;
+use tokio::{runtime::Handle, task};
 
 // Cap iovec batch size: larger iovecs reduce syscall count but increase
 // per-write kernel setup overhead.
@@ -20,15 +21,23 @@ pub struct Blob {
     name: Vec<u8>,
     file: Arc<File>,
     pool: BufferPool,
+    handle: Handle,
 }
 
 impl Blob {
-    pub fn new(partition: String, name: &[u8], file: File, pool: BufferPool) -> Self {
+    pub fn new(
+        partition: String,
+        name: &[u8],
+        file: File,
+        pool: BufferPool,
+        handle: Handle,
+    ) -> Self {
         Self {
             partition,
             name: name.into(),
             file: Arc::new(file),
             pool,
+            handle,
         }
     }
 
@@ -209,5 +218,14 @@ impl crate::Blob for Blob {
             .and_then(|r| r)
             .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))?;
         Ok(())
+    }
+
+    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+        let (tx, rx) = oneshot::channel();
+        let this = self.clone();
+        self.handle.spawn(async move {
+            let _ = tx.send(this.sync().await);
+        });
+        rx
     }
 }

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -1,5 +1,5 @@
 use super::Header;
-use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut, Handle};
+use crate::{Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut};
 use cfg_if::cfg_if;
 use commonware_formatting::hex;
 use commonware_utils::channel::oneshot;

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -1,5 +1,5 @@
 use super::Header;
-use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut};
+use crate::{Buf, BufferPool, Error, IoBufs, IoBufsMut, Handle};
 use cfg_if::cfg_if;
 use commonware_formatting::hex;
 use commonware_utils::channel::oneshot;
@@ -215,7 +215,7 @@ impl crate::Blob for Blob {
             .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e.into()))?
     }
 
-    async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+    async fn start_sync(&self) -> Handle<()> {
         let (tx, rx) = oneshot::channel();
         let file = self.file.clone();
         let partition = self.partition.clone();
@@ -224,6 +224,6 @@ impl crate::Blob for Blob {
             let result = Self::sync_inner(&file, &partition, &name);
             let _ = tx.send(result);
         });
-        rx
+        Handle::from_receiver(rx)
     }
 }

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -9,7 +9,7 @@ use std::{
     os::{fd::AsRawFd, unix::fs::FileExt},
     sync::Arc,
 };
-use tokio::{runtime::Handle, task};
+use tokio::task;
 
 // Cap iovec batch size: larger iovecs reduce syscall count but increase
 // per-write kernel setup overhead.
@@ -21,24 +21,21 @@ pub struct Blob {
     name: Vec<u8>,
     file: Arc<File>,
     pool: BufferPool,
-    handle: Handle,
 }
 
 impl Blob {
-    pub fn new(
-        partition: String,
-        name: &[u8],
-        file: File,
-        pool: BufferPool,
-        handle: Handle,
-    ) -> Self {
+    pub fn new(partition: String, name: &[u8], file: File, pool: BufferPool) -> Self {
         Self {
             partition,
             name: name.into(),
             file: Arc::new(file),
             pool,
-            handle,
         }
+    }
+
+    fn sync_inner(file: &File, partition: &str, name: &[u8]) -> Result<(), Error> {
+        file.sync_all()
+            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e))
     }
 
     fn write_single_at(file: &File, offset: u64, buf: &[u8]) -> Result<(), Error> {
@@ -188,8 +185,7 @@ impl crate::Blob for Blob {
                 let name = self.name.clone();
                 task::spawn_blocking(move || {
                     Self::write_vectored_at(&file, offset, bufs, None)?;
-                    file.sync_all()
-                        .map_err(|e| Error::BlobSyncFailed(partition, hex(&name), e))
+                    Self::sync_inner(&file, &partition, &name)
                 })
                 .await
                 .map_err(|_| Error::WriteFailed)?
@@ -212,19 +208,21 @@ impl crate::Blob for Blob {
 
     async fn sync(&self) -> Result<(), Error> {
         let file = self.file.clone();
-        task::spawn_blocking(move || file.sync_all())
+        let partition = self.partition.clone();
+        let name = self.name.clone();
+        task::spawn_blocking(move || Self::sync_inner(&file, &partition, &name))
             .await
-            .map_err(|e| e.into())
-            .and_then(|r| r)
-            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e))?;
-        Ok(())
+            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e.into()))?
     }
 
     async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
         let (tx, rx) = oneshot::channel();
-        let this = self.clone();
-        self.handle.spawn(async move {
-            let _ = tx.send(this.sync().await);
+        let file = self.file.clone();
+        let partition = self.partition.clone();
+        let name = self.name.clone();
+        task::spawn_blocking(move || {
+            let result = Self::sync_inner(&file, &partition, &name);
+            let _ = tx.send(result);
         });
         rx
     }

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -423,6 +423,7 @@ impl crate::Runner for Runner {
                             self.cfg.maximum_buffer_size,
                         ),
                         storage_buffer_pool.clone(),
+                        runtime.handle().clone(),
                     ),
                     &mut runtime_registry,
                 );

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -423,7 +423,6 @@ impl crate::Runner for Runner {
                             self.cfg.maximum_buffer_size,
                         ),
                         storage_buffer_pool.clone(),
-                        runtime.handle().clone(),
                     ),
                     &mut runtime_registry,
                 );

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -12,8 +12,8 @@ pub use write::Write;
 mod tests {
     use super::*;
     use crate::{
-        deterministic, Blob as _, Buf, BufMut, Clock, Error, IoBufMut, IoBufs, IoBufsMut, Runner,
-        Spawner, Storage, Supervisor as _, Handle,
+        deterministic, Blob as _, Buf, BufMut, Clock, Error, Handle, IoBufMut, IoBufs, IoBufsMut,
+        Runner, Spawner, Storage, Supervisor as _,
     };
     use commonware_macros::test_traced;
     use commonware_utils::{channel::oneshot, sync::Mutex, NZUsize};

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -129,7 +129,7 @@ mod tests {
 
         async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
             let (tx, rx) = oneshot::channel();
-            let _ = tx.send(Ok(()));
+            let _ = tx.send(self.sync().await);
             rx
         }
     }
@@ -258,12 +258,7 @@ mod tests {
 
         async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
             let (tx, rx) = oneshot::channel();
-            {
-                let mut state = self.state.lock();
-                state.durable = state.data.clone();
-                state.full_syncs += 1;
-            }
-            let _ = tx.send(Ok(()));
+            let _ = tx.send(self.sync().await);
             rx
         }
     }

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -126,6 +126,12 @@ mod tests {
         async fn sync(&self) -> Result<(), Error> {
             Ok(())
         }
+
+        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+            let (tx, rx) = oneshot::channel();
+            let _ = tx.send(Ok(()));
+            rx
+        }
     }
 
     #[derive(Default)]
@@ -248,6 +254,17 @@ mod tests {
             state.durable = state.data.clone();
             state.full_syncs += 1;
             Ok(())
+        }
+
+        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+            let (tx, rx) = oneshot::channel();
+            {
+                let mut state = self.state.lock();
+                state.durable = state.data.clone();
+                state.full_syncs += 1;
+            }
+            let _ = tx.send(Ok(()));
+            rx
         }
     }
 

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -13,7 +13,7 @@ mod tests {
     use super::*;
     use crate::{
         deterministic, Blob as _, Buf, BufMut, Clock, Error, IoBufMut, IoBufs, IoBufsMut, Runner,
-        Spawner, Storage, Supervisor as _,
+        Spawner, Storage, Supervisor as _, Handle,
     };
     use commonware_macros::test_traced;
     use commonware_utils::{channel::oneshot, sync::Mutex, NZUsize};
@@ -127,10 +127,8 @@ mod tests {
             Ok(())
         }
 
-        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
-            let (tx, rx) = oneshot::channel();
-            let _ = tx.send(self.sync().await);
-            rx
+        async fn start_sync(&self) -> Handle<()> {
+            Handle::ready(self.sync().await)
         }
     }
 
@@ -256,10 +254,8 @@ mod tests {
             Ok(())
         }
 
-        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
-            let (tx, rx) = oneshot::channel();
-            let _ = tx.send(self.sync().await);
-            rx
+        async fn start_sync(&self) -> Handle<()> {
+            Handle::ready(self.sync().await)
         }
     }
 

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -1389,11 +1389,11 @@ mod tests {
     use super::*;
     use crate::{
         buffer::tests::SyncTrackingBlob, deterministic, telemetry::metrics::Registry, Buf,
-        BufferPool, BufferPoolConfig, IoBufsMut, Runner as _, Storage as _,
+        BufferPool, BufferPoolConfig, IoBufsMut, Runner as _, Storage as _, Handle,
     };
     use commonware_codec::ReadExt;
     use commonware_macros::test_traced;
-    use commonware_utils::{channel::oneshot, NZUsize, NZU16, NZU32};
+    use commonware_utils::{NZUsize, NZU16, NZU32};
     use std::{
         num::NonZeroU16,
         sync::{
@@ -2662,7 +2662,7 @@ mod tests {
             self.inner.sync().await
         }
 
-        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+        async fn start_sync(&self) -> Handle<()> {
             self.inner.start_sync().await
         }
     }

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -1389,7 +1389,7 @@ mod tests {
     use super::*;
     use crate::{
         buffer::tests::SyncTrackingBlob, deterministic, telemetry::metrics::Registry, Buf,
-        BufferPool, BufferPoolConfig, IoBufsMut, Runner as _, Storage as _, Handle,
+        BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Storage as _,
     };
     use commonware_codec::ReadExt;
     use commonware_macros::test_traced;

--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -1393,7 +1393,7 @@ mod tests {
     };
     use commonware_codec::ReadExt;
     use commonware_macros::test_traced;
-    use commonware_utils::{NZUsize, NZU16, NZU32};
+    use commonware_utils::{channel::oneshot, NZUsize, NZU16, NZU32};
     use std::{
         num::NonZeroU16,
         sync::{
@@ -2660,6 +2660,10 @@ mod tests {
 
         async fn sync(&self) -> Result<(), Error> {
             self.inner.sync().await
+        }
+
+        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+            self.inner.start_sync().await
         }
     }
 

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -576,6 +576,12 @@ mod tests {
         async fn sync(&self) -> Result<(), Error> {
             Ok(())
         }
+
+        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+            let (tx, rx) = oneshot::channel();
+            let _ = tx.send(Ok(()));
+            rx
+        }
     }
 
     #[derive(Clone)]
@@ -654,6 +660,12 @@ mod tests {
 
         async fn sync(&self) -> Result<(), Error> {
             Ok(())
+        }
+
+        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+            let (tx, rx) = oneshot::channel();
+            let _ = tx.send(Ok(()));
+            rx
         }
     }
 

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -496,7 +496,7 @@ mod tests {
     use crate::{
         buffer::paged::CHECKSUM_SIZE, deterministic, telemetry::metrics::Registry, Buf, BufferPool,
         BufferPoolConfig, Clock as _, IoBufsMut, Runner as _, Spawner as _, Storage as _,
-        Supervisor as _,
+        Supervisor as _, Handle,
     };
     use commonware_cryptography::Crc32;
     use commonware_macros::test_traced;
@@ -577,10 +577,8 @@ mod tests {
             Ok(())
         }
 
-        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
-            let (tx, rx) = oneshot::channel();
-            let _ = tx.send(self.sync().await);
-            rx
+        async fn start_sync(&self) -> Handle<()> {
+            Handle::ready(self.sync().await)
         }
     }
 
@@ -662,10 +660,8 @@ mod tests {
             Ok(())
         }
 
-        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
-            let (tx, rx) = oneshot::channel();
-            let _ = tx.send(self.sync().await);
-            rx
+        async fn start_sync(&self) -> Handle<()> {
+            Handle::ready(self.sync().await)
         }
     }
 

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -495,8 +495,8 @@ mod tests {
     use super::{super::Checksum, *};
     use crate::{
         buffer::paged::CHECKSUM_SIZE, deterministic, telemetry::metrics::Registry, Buf, BufferPool,
-        BufferPoolConfig, Clock as _, IoBufsMut, Runner as _, Spawner as _, Storage as _,
-        Supervisor as _, Handle,
+        BufferPoolConfig, Clock as _, Handle, IoBufsMut, Runner as _, Spawner as _, Storage as _,
+        Supervisor as _,
     };
     use commonware_cryptography::Crc32;
     use commonware_macros::test_traced;

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -579,7 +579,7 @@ mod tests {
 
         async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
             let (tx, rx) = oneshot::channel();
-            let _ = tx.send(Ok(()));
+            let _ = tx.send(self.sync().await);
             rx
         }
     }
@@ -664,7 +664,7 @@ mod tests {
 
         async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
             let (tx, rx) = oneshot::channel();
-            let _ = tx.send(Ok(()));
+            let _ = tx.send(self.sync().await);
             rx
         }
     }

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -45,10 +45,36 @@ where
         metric: MetricHandle,
     },
     Completion {
-        receiver: Abortable<oneshot::Receiver<Result<T, Error>>>,
+        future: Abortable<Completion<T>>,
         abort_handle: AbortHandle,
         span: Option<Span>,
     },
+}
+
+enum Completion<T>
+where
+    T: Send + 'static,
+{
+    Receiver(oneshot::Receiver<Result<T, Error>>),
+    Future(Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'static>>),
+}
+
+impl<T> Unpin for Completion<T> where T: Send + 'static {}
+
+impl<T> Future for Completion<T>
+where
+    T: Send + 'static,
+{
+    type Output = Result<T, Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match &mut *self {
+            Self::Receiver(receiver) => Pin::new(receiver)
+                .poll(cx)
+                .map(|result| result.unwrap_or(Err(Error::Closed))),
+            Self::Future(future) => future.as_mut().poll(cx),
+        }
+    }
 }
 
 impl<T> Handle<T>
@@ -116,7 +142,22 @@ where
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
         Self {
             state: HandleState::Completion {
-                receiver: Abortable::new(receiver, abort_registration),
+                future: Abortable::new(Completion::Receiver(receiver), abort_registration),
+                abort_handle,
+                span: None,
+            },
+        }
+    }
+
+    /// Returns a handle backed by a completion future.
+    pub fn from_future<F>(future: F) -> Self
+    where
+        F: Future<Output = Result<T, Error>> + Send + 'static,
+    {
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        Self {
+            state: HandleState::Completion {
+                future: Abortable::new(Completion::Future(Box::pin(future)), abort_registration),
                 abort_handle,
                 span: None,
             },
@@ -196,13 +237,15 @@ where
             HandleState::Task { receiver, .. } => Pin::new(receiver)
                 .poll(cx)
                 .map(|result| result.unwrap_or_else(|_| Err(Error::Closed))),
-            HandleState::Completion { receiver, span, .. } => {
+            HandleState::Completion {
+                future,
+                span,
+                ..
+            } => {
                 let _guard = span.clone().map(Span::entered);
-                Pin::new(receiver).poll(cx).map(|result| match result {
-                    Ok(Ok(result)) => result,
-                    Ok(Err(_)) => Err(Error::Closed),
-                    Err(_) => Err(Error::Aborted),
-                })
+                Pin::new(future)
+                    .poll(cx)
+                    .map(|result| result.unwrap_or(Err(Error::Aborted)))
             }
         }
     }

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -21,16 +21,34 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use tracing::error;
+use tracing::{error, Span};
 
-/// Handle to a spawned task.
+/// Handle to an asynchronous result.
+///
+/// Handles returned by [`crate::Spawner::spawn`] abort the spawned task. Handles created from
+/// completion receivers only stop waiting when aborted, resolving to [`Error::Aborted`]; they do
+/// not cancel the underlying work.
 pub struct Handle<T>
 where
     T: Send + 'static,
 {
-    abort_handle: Option<AbortHandle>,
-    receiver: oneshot::Receiver<Result<T, Error>>,
-    metric: MetricHandle,
+    state: HandleState<T>,
+}
+
+enum HandleState<T>
+where
+    T: Send + 'static,
+{
+    Task {
+        receiver: oneshot::Receiver<Result<T, Error>>,
+        abort_handle: AbortHandle,
+        metric: MetricHandle,
+    },
+    Completion {
+        receiver: Abortable<oneshot::Receiver<Result<T, Error>>>,
+        abort_handle: AbortHandle,
+        span: Option<Span>,
+    },
 }
 
 impl<T> Handle<T>
@@ -84,11 +102,32 @@ where
         (
             task,
             Self {
-                abort_handle: Some(abort_handle),
-                receiver,
-                metric,
+                state: HandleState::Task {
+                    receiver,
+                    abort_handle,
+                    metric,
+                },
             },
         )
+    }
+
+    /// Returns a handle backed by a completion receiver.
+    pub fn from_receiver(receiver: oneshot::Receiver<Result<T, Error>>) -> Self {
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        Self {
+            state: HandleState::Completion {
+                receiver: Abortable::new(receiver, abort_registration),
+                abort_handle,
+                span: None,
+            },
+        }
+    }
+
+    /// Returns a handle that is already complete.
+    pub fn ready(result: Result<T, Error>) -> Self {
+        let (sender, receiver) = oneshot::channel();
+        let _ = sender.send(result);
+        Self::from_receiver(receiver)
     }
 
     /// Returns a handle that resolves to [`Error::Closed`] without spawning work.
@@ -100,31 +139,50 @@ where
         let (sender, receiver) = oneshot::channel();
         drop(sender);
 
-        Self {
-            abort_handle: None,
-            receiver,
-            metric,
-        }
+        Self::from_receiver(receiver)
     }
 
-    /// Abort the task (if not blocking).
-    pub fn abort(&self) {
-        // Get abort handle and abort the task
-        let Some(abort_handle) = &self.abort_handle else {
-            return;
-        };
-        abort_handle.abort();
+    pub(crate) fn with_span(mut self, span: Span) -> Self {
+        if let HandleState::Completion {
+            span: handle_span,
+            ..
+        } = &mut self.state
+        {
+            *handle_span = Some(span);
+        }
+        self
+    }
 
-        // We might never poll the future again after aborting it, so run the
-        // metric cleanup right away
-        self.metric.finish();
+    /// Abort the spawned task or stop waiting for a completion receiver.
+    pub fn abort(&self) {
+        match &self.state {
+            HandleState::Task {
+                abort_handle,
+                metric,
+                ..
+            } => {
+                abort_handle.abort();
+
+                // We might never poll the future again after aborting it, so run the
+                // metric cleanup right away.
+                metric.finish();
+            }
+            HandleState::Completion { abort_handle, .. } => {
+                abort_handle.abort();
+            }
+        }
     }
 
     /// Returns a helper that aborts the task and updates metrics consistently.
     pub(crate) fn aborter(&self) -> Option<Aborter> {
-        self.abort_handle
-            .clone()
-            .map(|inner| Aborter::new(inner, self.metric.clone()))
+        match &self.state {
+            HandleState::Task {
+                abort_handle,
+                metric,
+                ..
+            } => Some(Aborter::new(abort_handle.clone(), metric.clone())),
+            HandleState::Completion { .. } => None,
+        }
     }
 }
 
@@ -135,9 +193,19 @@ where
     type Output = Result<T, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.receiver)
-            .poll(cx)
-            .map(|result| result.unwrap_or_else(|_| Err(Error::Closed)))
+        match &mut self.state {
+            HandleState::Task { receiver, .. } => Pin::new(receiver)
+                .poll(cx)
+                .map(|result| result.unwrap_or_else(|_| Err(Error::Closed))),
+            HandleState::Completion { receiver, span, .. } => {
+                let _guard = span.clone().map(Span::entered);
+                Pin::new(receiver).poll(cx).map(|result| match result {
+                    Ok(Ok(result)) => result,
+                    Ok(Err(_)) => Err(Error::Closed),
+                    Err(_) => Err(Error::Aborted),
+                })
+            }
+        }
     }
 }
 
@@ -279,7 +347,9 @@ impl Aborter {
 
 #[cfg(test)]
 mod tests {
-    use crate::{deterministic, Metrics as _, Runner, Spawner, Supervisor as _};
+    use super::Handle;
+    use crate::{deterministic, Error, Metrics as _, Runner, Spawner, Supervisor as _};
+    use commonware_utils::channel::oneshot;
     use futures::future;
 
     const METRIC_PREFIX: &str = "runtime_tasks_running{";
@@ -376,6 +446,19 @@ mod tests {
                 Some(0),
                 "expected tasks_running gauge to return to 0 after abort: {metrics}",
             );
+        });
+    }
+
+    #[test]
+    fn completion_handle_abort_stops_waiting() {
+        deterministic::Runner::default().start(|_| async move {
+            let (sender, receiver) = oneshot::channel();
+            let handle = Handle::from_receiver(receiver);
+
+            handle.abort();
+
+            assert!(sender.send(Ok(())).is_ok());
+            assert!(matches!(handle.await, Err(Error::Aborted)));
         });
     }
 

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -21,7 +21,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use tracing::{error, Span};
+use tracing::error;
 
 /// Handle to an asynchronous result.
 ///
@@ -47,7 +47,6 @@ where
     Completion {
         future: Abortable<Completion<T>>,
         abort_handle: AbortHandle,
-        span: Option<Span>,
     },
 }
 
@@ -144,7 +143,6 @@ where
             state: HandleState::Completion {
                 future: Abortable::new(Completion::Receiver(receiver), abort_registration),
                 abort_handle,
-                span: None,
             },
         }
     }
@@ -159,7 +157,6 @@ where
             state: HandleState::Completion {
                 future: Abortable::new(Completion::Future(Box::pin(future)), abort_registration),
                 abort_handle,
-                span: None,
             },
         }
     }
@@ -183,17 +180,7 @@ where
         Self::from_receiver(receiver)
     }
 
-    pub(crate) fn with_span(mut self, span: Span) -> Self {
-        if let HandleState::Completion {
-            span: handle_span, ..
-        } = &mut self.state
-        {
-            *handle_span = Some(span);
-        }
-        self
-    }
-
-    /// Abort the spawned task or stop waiting for a completion receiver.
+    /// Abort the spawned task or stop waiting for a completion.
     pub fn abort(&self) {
         match &self.state {
             HandleState::Task {
@@ -237,16 +224,9 @@ where
             HandleState::Task { receiver, .. } => Pin::new(receiver)
                 .poll(cx)
                 .map(|result| result.unwrap_or_else(|_| Err(Error::Closed))),
-            HandleState::Completion {
-                future,
-                span,
-                ..
-            } => {
-                let _guard = span.clone().map(Span::entered);
-                Pin::new(future)
-                    .poll(cx)
-                    .map(|result| result.unwrap_or(Err(Error::Aborted)))
-            }
+            HandleState::Completion { future, .. } => Pin::new(future)
+                .poll(cx)
+                .map(|result| result.unwrap_or(Err(Error::Aborted))),
         }
     }
 }

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -144,8 +144,7 @@ where
 
     pub(crate) fn with_span(mut self, span: Span) -> Self {
         if let HandleState::Completion {
-            span: handle_span,
-            ..
+            span: handle_span, ..
         } = &mut self.state
         {
             *handle_span = Some(span);

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -25,9 +25,9 @@ use tracing::{error, Span};
 
 /// Handle to an asynchronous result.
 ///
-/// Handles returned by [`crate::Spawner::spawn`] abort the spawned task. Handles created from
-/// completion receivers only stop waiting when aborted, resolving to [`Error::Aborted`]; they do
-/// not cancel the underlying work.
+/// Handles returned by [`crate::Spawner::spawn`] abort the spawned task. Completion handles only
+/// stop waiting when aborted, resolving to [`Error::Aborted`]; they do not cancel the underlying
+/// work.
 pub struct Handle<T>
 where
     T: Send + 'static,

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -35,6 +35,7 @@ where
     state: HandleState<T>,
 }
 
+/// Distinguishes handles that own spawned work from handles that only wait on completion.
 enum HandleState<T>
 where
     T: Send + 'static,
@@ -50,6 +51,7 @@ where
     },
 }
 
+/// Normalizes receiver-backed and future-backed completions behind one abortable future.
 enum Completion<T>
 where
     T: Send + 'static,

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -10,9 +10,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 pub(super) mod partition_sync_fault {
     use commonware_runtime::{
         deterministic, telemetry::metrics, Blob, Clock, Error, IoBufs, IoBufsMut, Metrics, Name,
-        Storage, Supervisor,
+        Storage, Supervisor, Handle,
     };
-    use commonware_utils::channel::oneshot;
     use governor::clock::{Clock as GovernorClock, ReasonablyRealtime};
     use std::{
         future::Future,
@@ -170,11 +169,9 @@ pub(super) mod partition_sync_fault {
             self.inner.sync().await
         }
 
-        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+        async fn start_sync(&self) -> Handle<()> {
             if self.partition == self.fail_partition {
-                let (tx, rx) = oneshot::channel();
-                let _ = tx.send(self.sync().await);
-                return rx;
+                return Handle::ready(self.sync().await);
             }
             self.inner.start_sync().await
         }

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -12,6 +12,7 @@ pub(super) mod partition_sync_fault {
         deterministic, telemetry::metrics, Blob, Clock, Error, IoBufs, IoBufsMut, Metrics, Name,
         Storage, Supervisor,
     };
+    use commonware_utils::channel::oneshot;
     use governor::clock::{Clock as GovernorClock, ReasonablyRealtime};
     use std::{
         future::Future,
@@ -167,6 +168,17 @@ pub(super) mod partition_sync_fault {
                 return Err(Error::Io(IoError::other("injected partition sync fault")));
             }
             self.inner.sync().await
+        }
+
+        async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
+            if self.partition == self.fail_partition {
+                let (tx, rx) = oneshot::channel();
+                let _ = tx.send(Err(Error::Io(IoError::other(
+                    "injected partition sync fault",
+                ))));
+                return rx;
+            }
+            self.inner.start_sync().await
         }
     }
 }

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -9,8 +9,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub(super) mod partition_sync_fault {
     use commonware_runtime::{
-        deterministic, telemetry::metrics, Blob, Clock, Error, IoBufs, IoBufsMut, Metrics, Name,
-        Storage, Supervisor, Handle,
+        deterministic, telemetry::metrics, Blob, Clock, Error, Handle, IoBufs, IoBufsMut, Metrics,
+        Name, Storage, Supervisor,
     };
     use governor::clock::{Clock as GovernorClock, ReasonablyRealtime};
     use std::{

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -173,9 +173,7 @@ pub(super) mod partition_sync_fault {
         async fn start_sync(&self) -> oneshot::Receiver<Result<(), Error>> {
             if self.partition == self.fail_partition {
                 let (tx, rx) = oneshot::channel();
-                let _ = tx.send(Err(Error::Io(IoError::other(
-                    "injected partition sync fault",
-                ))));
+                let _ = tx.send(self.sync().await);
                 return rx;
             }
             self.inner.start_sync().await

--- a/storage/src/qmdb/benches/apply_batch.rs
+++ b/storage/src/qmdb/benches/apply_batch.rs
@@ -4,6 +4,7 @@ use crate::common::{
     any_fix_cfg_with, imm_fix_cfg_with, make_fixed_value, seed_db, AnyUFixDb, ImmFixDb, CHUNK_SIZE,
 };
 use commonware_cryptography::{Hasher as _, Sha256};
+use commonware_macros::boxed;
 use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::{Config, Context},
@@ -44,6 +45,7 @@ async fn open_db(ctx: &Context) -> Db {
         .unwrap()
 }
 
+#[boxed]
 async fn bench_direct_apply(ctx: &Context, updates: u64) -> Duration {
     let mut db = open_db(ctx).await;
     seed_db(&mut db, NUM_KEYS).await;
@@ -60,6 +62,7 @@ async fn bench_direct_apply(ctx: &Context, updates: u64) -> Duration {
     elapsed
 }
 
+#[boxed]
 async fn bench_apply_with_uncommitted_ancestor(ctx: &Context, updates: u64) -> Duration {
     let mut db = open_db(ctx).await;
     seed_db(&mut db, NUM_KEYS).await;
@@ -79,6 +82,7 @@ async fn bench_apply_with_uncommitted_ancestor(ctx: &Context, updates: u64) -> D
     elapsed
 }
 
+#[boxed]
 async fn bench_apply_with_committed_ancestor(ctx: &Context, updates: u64) -> Duration {
     let mut db = open_db(ctx).await;
     seed_db(&mut db, NUM_KEYS).await;
@@ -101,6 +105,7 @@ async fn bench_apply_with_committed_ancestor(ctx: &Context, updates: u64) -> Dur
 }
 
 // 1 committed + 1 uncommitted ancestor: apply A, then apply C (whose chain is [B, A]).
+#[boxed]
 async fn bench_apply_committed_uncommitted_chain(ctx: &Context, updates: u64) -> Duration {
     let mut db = open_db(ctx).await;
     seed_db(&mut db, NUM_KEYS).await;
@@ -126,6 +131,7 @@ async fn bench_apply_committed_uncommitted_chain(ctx: &Context, updates: u64) ->
 }
 
 // 2 uncommitted ancestors: apply C directly without applying A or B.
+#[boxed]
 async fn bench_apply_multi_uncommitted(ctx: &Context, updates: u64) -> Duration {
     let mut db = open_db(ctx).await;
     seed_db(&mut db, NUM_KEYS).await;
@@ -171,6 +177,7 @@ async fn open_imm_db(ctx: &Context) -> ImmDb {
         .unwrap()
 }
 
+#[boxed]
 async fn bench_imm_direct_apply(ctx: &Context, updates: u64) -> Duration {
     let mut db = open_imm_db(ctx).await;
     let mut rng = StdRng::seed_from_u64(7);
@@ -194,6 +201,7 @@ async fn bench_imm_direct_apply(ctx: &Context, updates: u64) -> Duration {
     elapsed
 }
 
+#[boxed]
 async fn bench_imm_apply_with_uncommitted_ancestor(ctx: &Context, updates: u64) -> Duration {
     let mut db = open_imm_db(ctx).await;
     let mut rng = StdRng::seed_from_u64(7);
@@ -239,7 +247,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += Box::pin(bench_direct_apply(&ctx, updates)).await;
+                        total += bench_direct_apply(&ctx, updates).await;
                     }
                     total
                 });
@@ -256,8 +264,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total +=
-                            Box::pin(bench_apply_with_uncommitted_ancestor(&ctx, updates)).await;
+                        total += bench_apply_with_uncommitted_ancestor(&ctx, updates).await;
                     }
                     total
                 });
@@ -274,8 +281,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total +=
-                            Box::pin(bench_apply_with_committed_ancestor(&ctx, updates)).await;
+                        total += bench_apply_with_committed_ancestor(&ctx, updates).await;
                     }
                     total
                 });
@@ -292,8 +298,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total +=
-                            Box::pin(bench_apply_committed_uncommitted_chain(&ctx, updates)).await;
+                        total += bench_apply_committed_uncommitted_chain(&ctx, updates).await;
                     }
                     total
                 });
@@ -310,7 +315,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += Box::pin(bench_apply_multi_uncommitted(&ctx, updates)).await;
+                        total += bench_apply_multi_uncommitted(&ctx, updates).await;
                     }
                     total
                 });
@@ -327,7 +332,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += Box::pin(bench_imm_direct_apply(&ctx, updates)).await;
+                        total += bench_imm_direct_apply(&ctx, updates).await;
                     }
                     total
                 });
@@ -344,9 +349,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total +=
-                            Box::pin(bench_imm_apply_with_uncommitted_ancestor(&ctx, updates))
-                                .await;
+                        total += bench_imm_apply_with_uncommitted_ancestor(&ctx, updates).await;
                     }
                     total
                 });

--- a/storage/src/qmdb/benches/apply_batch.rs
+++ b/storage/src/qmdb/benches/apply_batch.rs
@@ -239,7 +239,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += bench_direct_apply(&ctx, updates).await;
+                        total += Box::pin(bench_direct_apply(&ctx, updates)).await;
                     }
                     total
                 });
@@ -256,7 +256,8 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += bench_apply_with_uncommitted_ancestor(&ctx, updates).await;
+                        total +=
+                            Box::pin(bench_apply_with_uncommitted_ancestor(&ctx, updates)).await;
                     }
                     total
                 });
@@ -273,7 +274,8 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += bench_apply_with_committed_ancestor(&ctx, updates).await;
+                        total +=
+                            Box::pin(bench_apply_with_committed_ancestor(&ctx, updates)).await;
                     }
                     total
                 });
@@ -290,7 +292,8 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += bench_apply_committed_uncommitted_chain(&ctx, updates).await;
+                        total +=
+                            Box::pin(bench_apply_committed_uncommitted_chain(&ctx, updates)).await;
                     }
                     total
                 });
@@ -307,7 +310,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += bench_apply_multi_uncommitted(&ctx, updates).await;
+                        total += Box::pin(bench_apply_multi_uncommitted(&ctx, updates)).await;
                     }
                     total
                 });
@@ -324,7 +327,7 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += bench_imm_direct_apply(&ctx, updates).await;
+                        total += Box::pin(bench_imm_direct_apply(&ctx, updates)).await;
                     }
                     total
                 });
@@ -341,7 +344,9 @@ fn bench_apply_batch(c: &mut Criterion) {
                     let ctx = context::get::<Context>();
                     let mut total = Duration::ZERO;
                     for _ in 0..iters {
-                        total += bench_imm_apply_with_uncommitted_ancestor(&ctx, updates).await;
+                        total +=
+                            Box::pin(bench_imm_apply_with_uncommitted_ancestor(&ctx, updates))
+                                .await;
                     }
                     total
                 });


### PR DESCRIPTION
Blocks: #4013 

Adds new fn that starts an `fsync` but doesn't await completion