### PR TITLE
[storage] Make `bmt` no_std

### DIFF
--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -42,10 +42,15 @@
 //! assert!(proof.verify_element_inclusion(&mut hasher, &digests[1], 1, &root).is_ok());
 //! ```
 
-use alloc::collections::btree_set::BTreeSet;
+use alloc::{
+    collections::btree_set::BTreeSet,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
+use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Read, ReadExt, ReadRangeExt, Write};
 use commonware_cryptography::{Digest, Hasher};
-use commonware_runtime::{Buf, BufMut};
 use commonware_utils::{non_empty_vec, vec::NonEmptyVec};
 use thiserror::Error;
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -13,6 +13,7 @@
 commonware_macros::stability_scope!(ALPHA {
     extern crate alloc;
 
+    pub mod bmt;
     pub mod merkle;
     pub use merkle::{mmb, mmr};
 });
@@ -20,7 +21,6 @@ commonware_macros::stability_scope!(ALPHA, cfg(feature = "std") {
     mod bitmap;
     pub mod qmdb;
     pub use crate::bitmap::{BitMap as AuthenticatedBitMap, MerkleizedBitMap, UnmerkleizedBitMap};
-    pub mod bmt;
     pub mod cache;
     pub mod queue;
     #[cfg(any(test, feature = "test-utils"))]


### PR DESCRIPTION
## Summary

`storage::bmt` is a pure Binary Merkle Tree over `Digest`/`Hasher` — no runtime or I/O dependency — yet it sits in the `cfg(feature = "std")` stability scope alongside the I/O-bound modules (`qmdb`, `cache`, `queue`). Its sibling Merkle primitives (`merkle`, `mmr`, `mmb`) already live in the no_std `ALPHA` scope. This moves `bmt` there too.

## What tied `bmt` to std

A single import: `use commonware_runtime::{Buf, BufMut}`. `commonware-runtime` re-exports both verbatim from `bytes` (`pub use bytes::{Buf, BufMut}`), and `bytes` is already a `default-features = false` dependency of `commonware-storage`. Importing them from `bytes` directly uses identical types and adds no new dependency, while dropping the `commonware-runtime` (hence std/I/O) coupling.

## Changes

- `storage/src/bmt/mod.rs`: import `Buf`/`BufMut` from `bytes`; add the standard `alloc` prelude imports (`String`, `ToString`, `vec`, `Vec`) the module already relies on.
- `storage/src/lib.rs`: move `pub mod bmt;` from the `cfg(feature = "std")` scope into the no_std `ALPHA` scope next to `merkle`/`mmr`/`mmb`.

No public API or behavior change; the std build is unaffected.

## Verification

- `cargo build -p commonware-storage --no-default-features` — compiles under `#![no_std]`.
- `cargo test -p commonware-storage --lib bmt::` — 69 tests pass.
- `cargo build -p commonware-storage` + `cargo clippy -p commonware-storage --all-targets` — std build and lints clean (warnings as errors).
- `cargo fmt -p commonware-storage -- --check` — clean.

Closes #4089