### PR TITLE
[cryptography] Vendor `reed-solomon-simd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,7 +1387,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
- "reed-solomon-simd",
  "thiserror 2.0.17",
 ]
 
@@ -1547,15 +1546,18 @@ dependencies = [
  "commonware-math",
  "commonware-parallel",
  "commonware-utils",
+ "cpufeatures 0.2.17",
  "crc",
  "crc-fast",
  "criterion",
  "ctutils 0.3.1",
  "curve25519-dalek",
  "ecdsa",
+ "fixedbitset",
  "getrandom 0.2.16",
  "num-rational",
  "num-traits",
+ "once_cell",
  "p256",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -4597,30 +4599,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "readme-rustdocifier"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "reed-solomon-simd"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffef0520d30fbd4151fb20e262947ae47fb0ab276a744a19b6398438105a072"
-dependencies = [
- "cpufeatures 0.2.17",
- "fixedbitset",
- "once_cell",
- "readme-rustdocifier",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ commonware-stream = { version = "2026.5.0", path = "stream" }
 commonware-utils = { version = "2026.5.0", path = "utils", default-features = false }
 console-subscriber = "0.5.0"
 const-hex = { version = "1.18.1", default-features = false }
+cpufeatures = "0.2.17"
 crc = "3.4.0"
 crc-fast = { version = "1.10.0", default-features = false }
 criterion = "0.7.0"
@@ -156,6 +157,7 @@ ecdsa = { version = "0.16.9", default-features = false }
 ed25519-consensus = "2.1.0"
 ed25519-zebra = "4.1.0"
 either = "1.13.0"
+fixedbitset = { version = "0.5.7", default-features = false }
 futures = "0.3.31"
 futures-timer = "3.0.3"
 futures-util = { version = "0.3.31", default-features = false, features = ["std"] }
@@ -169,6 +171,7 @@ num-bigint = { version = "0.4.6", default-features = false }
 num-integer = "0.1.46"
 num-rational = { version = "0.4.2", features = ["num-bigint"] }
 num-traits = { version = "0.2.19", default-features = false }
+once_cell = { version = "1.21.3", default-features = false }
 opentelemetry = "0.31.0"
 opentelemetry-otlp = "0.31.0"
 opentelemetry_sdk = "0.31.0"
@@ -189,7 +192,6 @@ rand_core = "0.6.4"
 rand_distr = "0.4.3"
 ratatui = "0.29.0"
 rayon = { version = "1.10.0", default-features = false }
-reed-solomon-simd = "3.1.0"
 reqwest = "0.12.12"
 rstest = "0.26.1"
 serde = "1.0.218"
@@ -295,9 +297,6 @@ opt-level = 3
 opt-level = 3
 
 [profile.test.package.rand_chacha]
-opt-level = 3
-
-[profile.test.package.reed-solomon-simd]
 opt-level = 3
 
 [profile.test.package.sha2]

--- a/coding/Cargo.toml
+++ b/coding/Cargo.toml
@@ -27,7 +27,6 @@ num-rational.workspace = true
 rand.workspace = true
 rand_core.workspace = true
 rayon.workspace = true
-reed-solomon-simd.workspace = true
 thiserror.workspace = true
 
 [lib]

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -2,7 +2,7 @@ use crate::{Config, Scheme};
 use bytes::{Buf, BufMut, Bytes};
 use commonware_codec::{BufsMut, EncodeSize, FixedSize, RangeCfg, Read, ReadExt, Write};
 use commonware_cryptography::{
-    reed_solomon::{Error as RsError, ReedSolomonDecoder, ReedSolomonEncoder},
+    reed_solomon::{Decoder, Encoder, Error as RsError},
     Digest, Hasher,
 };
 use commonware_parallel::Strategy;
@@ -11,12 +11,12 @@ use commonware_utils::Cached;
 use std::marker::PhantomData;
 use thiserror::Error;
 
-// Thread-local caches for reusing `ReedSolomonEncoder` and `ReedSolomonDecoder`
+// Thread-local caches for reusing `Encoder` and `Decoder`
 // instances across calls. Constructing these objects is expensive because
 // the underlying engine initializes GF lookup tables. The `reset()` method
 // reconfigures the work buffers without rebuilding those tables.
-commonware_utils::thread_local_cache!(static CACHED_ENCODER: ReedSolomonEncoder);
-commonware_utils::thread_local_cache!(static CACHED_DECODER: ReedSolomonDecoder);
+commonware_utils::thread_local_cache!(static CACHED_ENCODER: Encoder);
+commonware_utils::thread_local_cache!(static CACHED_DECODER: Decoder);
 
 /// Errors that can occur when interacting with the Reed-Solomon coder.
 #[derive(Error, Debug)]
@@ -333,7 +333,7 @@ fn encode<H: Hasher, S: Strategy>(
     let recovery_buf = {
         let mut encoder = Cached::take(
             &CACHED_ENCODER,
-            || ReedSolomonEncoder::new(k, m, shard_len),
+            || Encoder::new(k, m, shard_len),
             |enc| enc.reset(k, m, shard_len),
         )
         .map_err(Error::ReedSolomon)?;
@@ -452,7 +452,7 @@ fn decode<'a, H: Hasher, S: Strategy>(
     // Decode original data
     let mut decoder = Cached::take(
         &CACHED_DECODER,
-        || ReedSolomonDecoder::new(k, m, shard_len),
+        || Decoder::new(k, m, shard_len),
         |dec| dec.reset(k, m, shard_len),
     )
     .map_err(Error::ReedSolomon)?;
@@ -481,7 +481,7 @@ fn decode<'a, H: Hasher, S: Strategy>(
     // Re-encode recovered data to get recovery shards
     let mut encoder = Cached::take(
         &CACHED_ENCODER,
-        || ReedSolomonEncoder::new(k, m, shard_len),
+        || Encoder::new(k, m, shard_len),
         |enc| enc.reset(k, m, shard_len),
     )
     .map_err(Error::ReedSolomon)?;
@@ -795,7 +795,7 @@ mod tests {
             padded[offset] ^= u.arbitrary::<u8>()? | 1;
         }
 
-        let mut encoder = ReedSolomonEncoder::new(k, m, shard_len).unwrap();
+        let mut encoder = Encoder::new(k, m, shard_len).unwrap();
         for shard in padded.chunks(shard_len) {
             encoder.add_original_shard(shard).unwrap();
         }
@@ -1064,7 +1064,7 @@ mod tests {
         let (padded, shard_size) = prepare_data(data.as_slice(), min as usize);
 
         // Re-encode the data
-        let mut encoder = ReedSolomonEncoder::new(min as usize, m as usize, shard_size).unwrap();
+        let mut encoder = Encoder::new(min as usize, m as usize, shard_size).unwrap();
         for shard in padded.chunks(shard_size) {
             encoder.add_original_shard(shard).unwrap();
         }
@@ -1134,7 +1134,7 @@ mod tests {
         let pad_offset = payload_end % shard_len;
         padded[pad_shard * shard_len + pad_offset] = 0xAA;
 
-        let mut encoder = ReedSolomonEncoder::new(k, m, shard_len).unwrap();
+        let mut encoder = Encoder::new(k, m, shard_len).unwrap();
         for shard in padded.chunks(shard_len) {
             encoder.add_original_shard(shard).unwrap();
         }
@@ -1188,7 +1188,7 @@ mod tests {
         padded[..u32::SIZE].copy_from_slice(&(data.len() as u32).to_be_bytes());
         padded[u32::SIZE..u32::SIZE + data.len()].copy_from_slice(data);
 
-        let mut encoder = ReedSolomonEncoder::new(k, m, oversized_shard_len).unwrap();
+        let mut encoder = Encoder::new(k, m, oversized_shard_len).unwrap();
         for shard in padded.chunks(oversized_shard_len) {
             encoder.add_original_shard(shard).unwrap();
         }

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -205,14 +205,14 @@ fn prepare_data(mut data: impl Buf, k: usize) -> (Vec<u8>, usize) {
 /// Return the canonical shard width for a payload and shard count.
 ///
 /// Encoding prefixes the payload with its length, splits the result across
-/// `k` original shards, and rounds up to an even width required by
-/// `reed-solomon-simd`. Decode uses the same calculation to reject commitments
-/// that decode to the same payload with a non-canonical shard width.
+/// `k` original shards, and rounds up to an even width required by the
+/// Reed-Solomon implementation. Decode uses the same calculation to reject
+/// commitments that decode to the same payload with a non-canonical shard width.
 const fn canonical_shard_len(data_len: usize, k: usize) -> usize {
     let prefixed_len = u32::SIZE + data_len;
     let mut shard_len = prefixed_len.div_ceil(k);
 
-    // Ensure shard length is even (required for optimizations in `reed-solomon-simd`)
+    // Ensure shard length is even, as required by the Reed-Solomon implementation.
     if !shard_len.is_multiple_of(2) {
         shard_len += 1;
     }
@@ -923,7 +923,7 @@ mod tests {
     fn test_invalid_total() {
         let data = b"Test parameter validation";
 
-        // total <= min should panic
+        // The total shard count must exceed the recovery threshold.
         encode::<Sha256, _>(3, 3, data.as_slice(), &STRATEGY).unwrap();
     }
 
@@ -932,7 +932,7 @@ mod tests {
     fn test_invalid_min() {
         let data = b"Test parameter validation";
 
-        // min = 0 should panic
+        // The recovery threshold must be non-zero.
         encode::<Sha256, _>(5, 0, data.as_slice(), &STRATEGY).unwrap();
     }
 
@@ -1025,8 +1025,8 @@ mod tests {
         let data = b"leaf_count mismatch proof";
         let (commitment, shards) = RS::encode(&config_actual, data.as_slice(), &STRATEGY).unwrap();
 
-        // Previously this passed because check() ignored config and only verified
-        // against commitment root. It must now fail immediately.
+        // A proof generated under a different shard configuration is invalid
+        // for this commitment.
         let check_result = RS::check(&config_expected, &commitment, 0, &shards[0]);
         assert!(matches!(check_result, Err(Error::InvalidProof)));
     }

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -1,11 +1,13 @@
 use crate::{Config, Scheme};
 use bytes::{Buf, BufMut, Bytes};
 use commonware_codec::{BufsMut, EncodeSize, FixedSize, RangeCfg, Read, ReadExt, Write};
-use commonware_cryptography::{Digest, Hasher};
+use commonware_cryptography::{
+    reed_solomon::{Error as RsError, ReedSolomonDecoder, ReedSolomonEncoder},
+    Digest, Hasher,
+};
 use commonware_parallel::Strategy;
 use commonware_storage::bmt::{self, Builder};
 use commonware_utils::Cached;
-use reed_solomon_simd::{Error as RsError, ReedSolomonDecoder, ReedSolomonEncoder};
 use std::marker::PhantomData;
 use thiserror::Error;
 
@@ -1351,12 +1353,10 @@ mod tests {
         let result = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY);
         assert!(matches!(
             result,
-            Err(Error::ReedSolomon(
-                reed_solomon_simd::Error::UnsupportedShardCount {
-                    original_count: _,
-                    recovery_count: _,
-                }
-            ))
+            Err(Error::ReedSolomon(RsError::UnsupportedShardCount {
+                original_count: _,
+                recovery_count: _,
+            }))
         ));
     }
 

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -120,6 +120,7 @@ std = [
 	"num-rational",
 	"num-traits",
 	"num-traits?/std",
+	"once_cell/std",
 	"p256/std",
 	"rand/std",
 	"rand/std_rng",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -36,8 +36,10 @@ crc-fast = { workspace = true, features = ["std"], optional = true }
 ctutils.workspace = true
 curve25519-dalek = { workspace = true, features = ["digest"] }
 ecdsa.workspace = true
+fixedbitset.workspace = true
 num-rational = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
+once_cell = { workspace = true, features = ["alloc", "race"] }
 p256 = { workspace = true, features = ["ecdsa"] }
 rand.workspace = true
 rand_chacha.workspace = true
@@ -50,6 +52,9 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # aws-lc-rs provides optimized P-256 verification and handshake cipher on x86_64 and aarch64.
 aws-lc-rs.workspace = true
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
+cpufeatures.workspace = true
 
 [target.'cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies.chacha20poly1305]
 workspace = true
@@ -110,6 +115,7 @@ std = [
 	"crc-fast",
 	"crc-fast?/std",
 	"ecdsa/std",
+	"fixedbitset/std",
 	"getrandom/std",
 	"num-rational",
 	"num-traits",
@@ -153,6 +159,11 @@ path = "src/blake3/benches/bench.rs"
 name = "lthash"
 harness = false
 path = "src/lthash/benches/bench.rs"
+
+[[bench]]
+name = "reed_solomon"
+harness = false
+path = "src/reed_solomon/benches/bench.rs"
 
 [[bench]]
 name = "handshake"

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -45,6 +45,8 @@ commonware_macros::stability_scope!(ALPHA {
     pub mod lthash;
     pub use crate::lthash::LtHash;
 
+    pub mod reed_solomon;
+
     pub mod zk;
 });
 commonware_macros::stability_scope!(BETA {

--- a/cryptography/src/reed_solomon/LICENSE
+++ b/cryptography/src/reed_solomon/LICENSE
@@ -1,0 +1,78 @@
+All code from Anders Trier Olesen is under the MIT License (1st license below).
+All code from Markus Laire is under MIT License (2nd license below).
+
+This crate is based on [1] which uses BSD-3-Clause License (3rd license below).
+
+[1] https://github.com/catid/leopard
+
+-----
+
+Copyright (c) 2023 Anders Trier Olesen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
+Copyright (c) 2022 Markus Laire
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
+Copyright (c) 2017 Christopher A. Taylor.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Leopard-RS nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/cryptography/src/reed_solomon/algorithm.md
+++ b/cryptography/src/reed_solomon/algorithm.md
@@ -1,0 +1,130 @@
+Algorithm documentation.
+
+As I don't understand algorithm fully myself,
+I'll just document some parts which I do understand.
+
+# Shard
+
+- Reed-Solomon `GF(2^16)` erasure coding works on 16-bit elements ([`GfElement`]).
+- A **shard** is a byte-array which is interpreted as an array of [`GfElement`]:s.
+
+A naive implementation could e.g. require shards to be a multiple of **2 bytes**
+and then interpret each byte-pair as low/high parts of a single [`GfElement`]:
+
+```text
+[ low_0, high_0, low_1, high_1, ...]
+```
+
+However that approach isn't good for SIMD optimizations.
+Instead shards are required to be a multiple of **64 bytes**.
+In each 64-byte block first 32 bytes are low parts of 32 [`GfElement`]:s
+and last 32 bytes are high parts of those 32 [`GfElement`]:s.
+
+```text
+[ low_0, low_1, ..., low_31, high_0, high_1, ..., high_31 ]
+```
+
+A shard then consists of one or more of these 64-byte blocks:
+
+```text
+// -------- first 64-byte block --------- | --------- second 64-byte block ---------- | ...
+[ low_0, ..., low_31, high_0, ..., high_31, low_32, ..., low_63, high_32, ..., high_63, ... ]
+```
+
+# Rate
+
+Encoding and decoding both have two variations:
+
+- **High rate** refers to having more original shards than recovery shards.
+    - High rate must be used when there are over 32768 original shards.
+    - High rate encoding uses **chunks** of `recovery_count.next_power_of_two()` shards.
+- **Low rate** refers to having more recovery shards than original shards.
+    - Low rate must be used when there are over 32768 recovery shards.
+    - Low rate encoding uses **chunks** of `original_count.next_power_of_two()` shards.
+- Because of padding either rate can be used when there are
+  at most 32768 original shards and at most 32768 recovery shards.
+    - High rate and low rate are not [^1] compatible with each other,
+      i.e. decoding must use same rate that encoding used.
+    - With multiple chunks "correct" rate is generally faster in encoding
+      and not-slower in decoding.
+    - With single chunk "wrong" rate is generally faster in decoding
+      if `original_count` and `recovery_count` differ a lot.
+
+[^1]: They seem to be compatible with single chunk. However I don't quite
+    understand why and I don't recommend relying on this.
+
+## Benchmarks
+
+- These benchmarks are from `cargo bench rate`
+  and use similar setup than [main benchmarks],
+  except with maximum possible shard loss.
+
+| original : recovery | Chunks  | `HighRateEncoder` | `LowRateEncoder` | `HighRateDecoder` | `LowRateDecoder` |
+| ------------------- | ------- | ----------------- | ---------------- | ----------------- | ---------------- |
+| 1024 : 1024         | 1x 1024 | 175 MiB/s         | 176 MiB/s        | 76 MiB/s          | 75 MiB/s         |
+| 1024 : 1025 (Low)   | 2x 1024 | 140               | **153**          | 47                | **59**           |
+| 1025 : 1024 (High)  | 2x 1024 | **152**           | 132              | **60**            | 46               |
+| 1024 : 2048 (Low)   | 2x 1024 | 157               | **169**          | 70                | 70               |
+| 2048 : 1024 (High)  | 2x 1024 | **167**           | 151              | 69                | 68               |
+| 1025 : 1025         | 1x 2048 | 125               | 126              | 44                | 43               |
+| 1025 : 2048 (Low)   | 1x 2048 | 144               | 144              | **65** **!!!**    | 53               |
+| 2048 : 1025 (High)  | 1x 2048 | 144               | 145              | 53                | **62** **!!!**   |
+| 2048 : 2048         | 1x 2048 | 156               | 157              | 70                | 69               |
+
+[main benchmarks]: crate::reed_solomon#benchmarks
+
+# Encoding
+
+Encoding takes original shards as input and generates recovery shards.
+
+## High rate encoding
+
+- Encoding is done in **chunks** of `recovery_count.next_power_of_two()` shards.
+- Original shards are split into chunks and last chunk
+  is padded with zero-filled shards if needed.
+    - In theory original shards are padded to [`GF_ORDER`]` - chunk_size` shards
+      but since `IFFT([0u8; x]) == [0u8; x]` and `xor` with `0` is no-op,
+      the chunks which contain only `0u8`:s can be ignored.
+- Recovery shards fit into a single chunk
+  which is padded with unused shards if needed.
+- Recovery chunk is generated with following algorithm
+
+```text
+recovery_chunk = FFT(
+    IFFT(original_chunk_0, skew_0) xor
+    IFFT(original_chunk_1, skew_1) xor
+    ...
+)
+```
+
+This is implemented in [`HighRateEncoder`].
+
+## Low rate encoding
+
+- Encoding is done in **chunks** of `original_count.next_power_of_two()` shards.
+- Original shards fit into a single chunk
+  which is padded with zero-filled shards if needed.
+- Recovery shards are generated in chunks and last chunk
+  is padded with unused shards if needed.
+    - In theory recovery shards are padded to [`GF_ORDER`]` - chunk_size` shards
+      but chunks which contain only unused shards can be ignored.
+- Recovery chunks are generated with following algorithm
+
+```text
+recovery_chunk_0 = FFT( IFFT(original_chunk), skew_0 )
+recovery_chunk_1 = FFT( IFFT(original_chunk), skew_1 )
+...
+```
+
+This is implemented in [`LowRateEncoder`].
+
+# Decoding
+
+**TODO**
+
+
+[`GfElement`]: crate::reed_solomon::engine::GfElement
+[`HighRateEncoder`]: crate::reed_solomon::rate::HighRateEncoder
+[`LowRateEncoder`]: crate::reed_solomon::rate::LowRateEncoder
+
+[`GF_ORDER`]: crate::reed_solomon::engine::GF_ORDER

--- a/cryptography/src/reed_solomon/algorithm.md
+++ b/cryptography/src/reed_solomon/algorithm.md
@@ -118,11 +118,6 @@ recovery_chunk_1 = FFT( IFFT(original_chunk), skew_1 )
 
 This is implemented in [`LowRateEncoder`].
 
-# Decoding
-
-**TODO**
-
-
 [`GfElement`]: crate::reed_solomon::engine::GfElement
 [`HighRateEncoder`]: crate::reed_solomon::rate::HighRateEncoder
 [`LowRateEncoder`]: crate::reed_solomon::rate::LowRateEncoder

--- a/cryptography/src/reed_solomon/benches/bench.rs
+++ b/cryptography/src/reed_solomon/benches/bench.rs
@@ -7,7 +7,7 @@ use commonware_cryptography::reed_solomon::{
     rate::{
         HighRateDecoder, HighRateEncoder, LowRateDecoder, LowRateEncoder, RateDecoder, RateEncoder,
     },
-    ReedSolomonDecoder, ReedSolomonEncoder,
+    Decoder, Encoder, SHARD_CHUNK_BYTES,
 };
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::{Rng, RngCore, SeedableRng};
@@ -22,9 +22,13 @@ const SHARD_BYTES: usize = 1024;
 // ======================================================================
 // UTIL
 
-fn generate_shards_64(shard_count: usize, chunk_count: usize, seed: u8) -> Vec<Vec<[u8; 64]>> {
+fn generate_shard_chunks(
+    shard_count: usize,
+    chunk_count: usize,
+    seed: u8,
+) -> Vec<Vec<[u8; SHARD_CHUNK_BYTES]>> {
     let mut rng = ChaCha8Rng::from_seed([seed; 32]);
-    let mut shards = vec![vec![[0u8; 64]; chunk_count]; shard_count];
+    let mut shards = vec![vec![[0u8; SHARD_CHUNK_BYTES]; chunk_count]; shard_count];
     for shard in &mut shards {
         rng.fill_bytes(shard.as_flattened_mut());
     }
@@ -32,8 +36,8 @@ fn generate_shards_64(shard_count: usize, chunk_count: usize, seed: u8) -> Vec<V
 }
 
 fn generate_shards(shard_count: usize, shard_bytes: usize, seed: u8) -> Vec<Vec<u8>> {
-    assert_eq!(shard_bytes % 64, 0);
-    generate_shards_64(shard_count, shard_bytes / 64, seed)
+    assert_eq!(shard_bytes % SHARD_CHUNK_BYTES, 0);
+    generate_shard_chunks(shard_count, shard_bytes / SHARD_CHUNK_BYTES, seed)
         .into_iter()
         .map(|s| s.into_flattened())
         .collect()
@@ -87,8 +91,7 @@ fn benchmarks_main(c: &mut Criterion) {
                 ((original_count + recovery_count) * SHARD_BYTES) as u64,
             ));
 
-            let mut encoder =
-                ReedSolomonEncoder::new(original_count, recovery_count, SHARD_BYTES).unwrap();
+            let mut encoder = Encoder::new(original_count, recovery_count, SHARD_BYTES).unwrap();
 
             let id = format!(
                 "original={original_count} recovery={recovery_count} shard_bytes={SHARD_BYTES}"
@@ -134,7 +137,7 @@ fn benchmarks_main(c: &mut Criterion) {
                 let recovery_provided_count = original_loss_count;
 
                 let mut decoder =
-                    ReedSolomonDecoder::new(original_count, recovery_count, SHARD_BYTES).unwrap();
+                    Decoder::new(original_count, recovery_count, SHARD_BYTES).unwrap();
 
                 let id = format!(
                     "original={original_count} recovery={recovery_count} shard_bytes={SHARD_BYTES} loss={loss_percent}"
@@ -381,7 +384,7 @@ fn benchmarks_engine(c: &mut Criterion) {
 }
 
 fn benchmarks_engine_one<E: Engine>(c: &mut Criterion, engine_name: &str, engine: E) {
-    let shard_len_64 = SHARD_BYTES / 64;
+    let shard_chunk_count = SHARD_BYTES / SHARD_CHUNK_BYTES;
 
     let mut rng = ChaCha8Rng::from_seed([0; 32]);
     let mut data = [(); GF_ORDER].map(|_| rng.gen());
@@ -399,15 +402,17 @@ fn benchmarks_engine_one<E: Engine>(c: &mut Criterion, engine_name: &str, engine
         |b| b.iter(|| E::eval_poly(black_box(&mut data), GF_ORDER / 8)),
     );
 
-    let mut x = generate_shards_64(1, shard_len_64, 0).pop().unwrap();
+    let mut x = generate_shard_chunks(1, shard_chunk_count, 0)
+        .pop()
+        .unwrap();
 
     c.bench_function(
         &format!("reed_solomon::engine_mul/engine={engine_name} shard_bytes={SHARD_BYTES}"),
         |b| b.iter(|| engine.mul(black_box(x.as_mut_slice()), black_box(12345))),
     );
 
-    let shards_128_data = &mut generate_shards_64(1, 128 * shard_len_64, 0)[0];
-    let mut shards_128 = ShardsRefMut::new(128, shard_len_64, shards_128_data.as_mut());
+    let shards_128_data = &mut generate_shard_chunks(1, 128 * shard_chunk_count, 0)[0];
+    let mut shards_128 = ShardsRefMut::new(128, shard_chunk_count, shards_128_data.as_mut());
 
     c.bench_function(
         &format!("reed_solomon::engine_fft/engine={engine_name} shards=128"),

--- a/cryptography/src/reed_solomon/benches/bench.rs
+++ b/cryptography/src/reed_solomon/benches/bench.rs
@@ -176,7 +176,6 @@ fn benchmarks_main(c: &mut Criterion) {
 // BENCHMARKS - RATE
 
 fn benchmarks_rate(c: &mut Criterion) {
-    // benchmarks_rate_one(c, "rate-Naive", Naive::new);
     benchmarks_rate_one(c, "rate", DefaultEngine::new);
 }
 

--- a/cryptography/src/reed_solomon/benches/bench.rs
+++ b/cryptography/src/reed_solomon/benches/bench.rs
@@ -43,6 +43,24 @@ fn generate_shards(shard_count: usize, shard_bytes: usize, seed: u8) -> Vec<Vec<
         .collect()
 }
 
+fn encode_recovery(
+    original_count: usize,
+    recovery_count: usize,
+    original: &[Vec<u8>],
+) -> Vec<Vec<u8>> {
+    let mut encoder = Encoder::new(original_count, recovery_count, SHARD_BYTES).unwrap();
+    for shard in original {
+        encoder.add_original_shard(shard).unwrap();
+    }
+    let recovery = encoder
+        .encode()
+        .unwrap()
+        .recovery_iter()
+        .map(<[u8]>::to_vec)
+        .collect();
+    recovery
+}
+
 // ======================================================================
 // BENCHMARKS - MAIN
 
@@ -122,12 +140,7 @@ fn benchmarks_main(c: &mut Criterion) {
             group.sample_size(sample_size);
 
             let original = generate_shards(original_count, SHARD_BYTES, 0);
-            let recovery = commonware_cryptography::reed_solomon::encode(
-                original_count,
-                recovery_count,
-                &original,
-            )
-            .unwrap();
+            let recovery = encode_recovery(original_count, recovery_count, &original);
             let max_original_loss_count = std::cmp::min(original_count, recovery_count);
 
             for loss_percent in [1, 100] {
@@ -266,12 +279,7 @@ fn benchmarks_rate_one<E: Engine>(c: &mut Criterion, name: &str, new_engine: fn(
 
         for (original_count, recovery_count) in cases {
             let original = generate_shards(original_count, SHARD_BYTES, 0);
-            let recovery = commonware_cryptography::reed_solomon::encode(
-                original_count,
-                recovery_count,
-                &original,
-            )
-            .unwrap();
+            let recovery = encode_recovery(original_count, recovery_count, &original);
             group.throughput(Throughput::Bytes(
                 ((original_count + recovery_count) * SHARD_BYTES) as u64,
             ));
@@ -314,12 +322,7 @@ fn benchmarks_rate_one<E: Engine>(c: &mut Criterion, name: &str, new_engine: fn(
 
         for (original_count, recovery_count) in cases {
             let original = generate_shards(original_count, SHARD_BYTES, 0);
-            let recovery = commonware_cryptography::reed_solomon::encode(
-                original_count,
-                recovery_count,
-                &original,
-            )
-            .unwrap();
+            let recovery = encode_recovery(original_count, recovery_count, &original);
             group.throughput(Throughput::Bytes(
                 ((original_count + recovery_count) * SHARD_BYTES) as u64,
             ));

--- a/cryptography/src/reed_solomon/benches/bench.rs
+++ b/cryptography/src/reed_solomon/benches/bench.rs
@@ -1,0 +1,449 @@
+#[cfg(target_arch = "aarch64")]
+use commonware_cryptography::reed_solomon::engine::Neon;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use commonware_cryptography::reed_solomon::engine::{Avx2, Ssse3};
+use commonware_cryptography::reed_solomon::{
+    engine::{DefaultEngine, Engine, Naive, NoSimd, ShardsRefMut, GF_ORDER},
+    rate::{
+        HighRateDecoder, HighRateEncoder, LowRateDecoder, LowRateEncoder, RateDecoder, RateEncoder,
+    },
+    ReedSolomonDecoder, ReedSolomonEncoder,
+};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rand::{Rng, RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use std::hint::black_box;
+
+// ======================================================================
+// CONST
+
+const SHARD_BYTES: usize = 1024;
+
+// ======================================================================
+// UTIL
+
+fn generate_shards_64(shard_count: usize, chunk_count: usize, seed: u8) -> Vec<Vec<[u8; 64]>> {
+    let mut rng = ChaCha8Rng::from_seed([seed; 32]);
+    let mut shards = vec![vec![[0u8; 64]; chunk_count]; shard_count];
+    for shard in &mut shards {
+        rng.fill_bytes(shard.as_flattened_mut());
+    }
+    shards
+}
+
+fn generate_shards(shard_count: usize, shard_bytes: usize, seed: u8) -> Vec<Vec<u8>> {
+    assert_eq!(shard_bytes % 64, 0);
+    generate_shards_64(shard_count, shard_bytes / 64, seed)
+        .into_iter()
+        .map(|s| s.into_flattened())
+        .collect()
+}
+
+// ======================================================================
+// BENCHMARKS - MAIN
+
+fn benchmarks_main(c: &mut Criterion) {
+    let cases = [
+        // 2^n. original_count == recovery_count
+        (32, 32),
+        (64, 64),
+        (128, 128),
+        (256, 256),
+        (512, 512),
+        (1024, 1024),
+        (2048, 2048),
+        (4096, 4096),
+        (8192, 8192),
+        (16384, 16384),
+        (32768, 32768),
+        // And some other combinations
+        (128, 1024),
+        (1000, 100),
+        (1000, 10000),
+        (1024, 128),
+        (1024, 8192),
+        (8192, 1024),
+        (8192, 16384),
+        (8192, 57344),
+        (10000, 1000),
+        (16384, 8192),
+        (16385, 16385), // 2^n + 1
+        (57344, 8192),
+    ];
+
+    {
+        let mut group = c.benchmark_group("reed_solomon::encoder");
+
+        for (original_count, recovery_count) in cases {
+            let sample_size = if original_count >= 1000 && recovery_count >= 1000 {
+                10
+            } else {
+                100
+            };
+            group.sample_size(sample_size);
+
+            let original = generate_shards(original_count, SHARD_BYTES, 0);
+            group.throughput(Throughput::Bytes(
+                ((original_count + recovery_count) * SHARD_BYTES) as u64,
+            ));
+
+            let mut encoder =
+                ReedSolomonEncoder::new(original_count, recovery_count, SHARD_BYTES).unwrap();
+
+            let id = format!(
+                "original={original_count} recovery={recovery_count} shard_bytes={SHARD_BYTES}"
+            );
+
+            group.bench_with_input(BenchmarkId::from_parameter(id), &original, |b, original| {
+                b.iter(|| {
+                    for original in original {
+                        encoder.add_original_shard(original).unwrap();
+                    }
+                    encoder.encode().unwrap();
+                });
+            });
+        }
+
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("reed_solomon::decoder");
+
+        for (original_count, recovery_count) in cases {
+            let sample_size = if original_count >= 1000 && recovery_count >= 1000 {
+                10
+            } else {
+                100
+            };
+            group.sample_size(sample_size);
+
+            let original = generate_shards(original_count, SHARD_BYTES, 0);
+            let recovery = commonware_cryptography::reed_solomon::encode(
+                original_count,
+                recovery_count,
+                &original,
+            )
+            .unwrap();
+            let max_original_loss_count = std::cmp::min(original_count, recovery_count);
+
+            for loss_percent in [1, 100] {
+                // We round up to make sure at least one shard is lost for low shard counts.
+                let original_loss_count = (max_original_loss_count * loss_percent).div_ceil(100);
+                let original_provided_count = original_count - original_loss_count;
+                let recovery_provided_count = original_loss_count;
+
+                let mut decoder =
+                    ReedSolomonDecoder::new(original_count, recovery_count, SHARD_BYTES).unwrap();
+
+                let id = format!(
+                    "original={original_count} recovery={recovery_count} shard_bytes={SHARD_BYTES} loss={loss_percent}"
+            );
+
+                group.throughput(Throughput::Bytes(
+                    ((original_count + recovery_count) * SHARD_BYTES) as u64,
+                ));
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(id),
+                    &recovery,
+                    |b, recovery| {
+                        b.iter(|| {
+                            for (index, shard) in
+                                original.iter().enumerate().take(original_provided_count)
+                            {
+                                decoder.add_original_shard(index, shard).unwrap();
+                            }
+                            for (index, shard) in
+                                recovery.iter().enumerate().take(recovery_provided_count)
+                            {
+                                decoder.add_recovery_shard(index, shard).unwrap();
+                            }
+                            decoder.decode().unwrap();
+                        });
+                    },
+                );
+            }
+        }
+
+        group.finish();
+    }
+}
+
+// ======================================================================
+// BENCHMARKS - RATE
+
+fn benchmarks_rate(c: &mut Criterion) {
+    // benchmarks_rate_one(c, "rate-Naive", Naive::new);
+    benchmarks_rate_one(c, "rate", DefaultEngine::new);
+}
+
+fn benchmarks_rate_one<E: Engine>(c: &mut Criterion, name: &str, new_engine: fn() -> E) {
+    let cases = [
+        (1024, 1024),
+        (1024, 1025),
+        (1025, 1024),
+        (1024, 2048),
+        (2048, 1024),
+        (1025, 1025),
+        (1025, 2048),
+        (2048, 1025),
+        (2048, 2048),
+    ];
+
+    {
+        let mut group = c.benchmark_group("reed_solomon::high_rate_encoder");
+        group.sample_size(10);
+
+        for (original_count, recovery_count) in cases {
+            let original = generate_shards(original_count, SHARD_BYTES, 0);
+            group.throughput(Throughput::Bytes(
+                ((original_count + recovery_count) * SHARD_BYTES) as u64,
+            ));
+            let id = format!(
+                "rate={name} original={original_count} recovery={recovery_count} shard_bytes={SHARD_BYTES}"
+            );
+            let mut encoder = HighRateEncoder::new(
+                original_count,
+                recovery_count,
+                SHARD_BYTES,
+                new_engine(),
+                None,
+            )
+            .unwrap();
+
+            group.bench_with_input(BenchmarkId::from_parameter(id), &original, |b, original| {
+                b.iter(|| {
+                    for original in original {
+                        encoder.add_original_shard(original).unwrap();
+                    }
+                    encoder.encode().unwrap();
+                });
+            });
+        }
+
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("reed_solomon::low_rate_encoder");
+        group.sample_size(10);
+
+        for (original_count, recovery_count) in cases {
+            let original = generate_shards(original_count, SHARD_BYTES, 0);
+            group.throughput(Throughput::Bytes(
+                ((original_count + recovery_count) * SHARD_BYTES) as u64,
+            ));
+            let id = format!(
+                "rate={name} original={original_count} recovery={recovery_count} shard_bytes={SHARD_BYTES}"
+            );
+            let mut encoder = LowRateEncoder::new(
+                original_count,
+                recovery_count,
+                SHARD_BYTES,
+                new_engine(),
+                None,
+            )
+            .unwrap();
+
+            group.bench_with_input(BenchmarkId::from_parameter(id), &original, |b, original| {
+                b.iter(|| {
+                    for original in original {
+                        encoder.add_original_shard(original).unwrap();
+                    }
+                    encoder.encode().unwrap();
+                });
+            });
+        }
+
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("reed_solomon::high_rate_decoder");
+        group.sample_size(10);
+
+        for (original_count, recovery_count) in cases {
+            let original = generate_shards(original_count, SHARD_BYTES, 0);
+            let recovery = commonware_cryptography::reed_solomon::encode(
+                original_count,
+                recovery_count,
+                &original,
+            )
+            .unwrap();
+            group.throughput(Throughput::Bytes(
+                ((original_count + recovery_count) * SHARD_BYTES) as u64,
+            ));
+            let id = format!(
+                "rate={name} original={original_count} recovery={recovery_count} shard_bytes={SHARD_BYTES}"
+            );
+            let original_loss_count = std::cmp::min(original_count, recovery_count);
+            let original_provided_count = original_count - original_loss_count;
+            let recovery_provided_count = original_loss_count;
+            let mut decoder = HighRateDecoder::new(
+                original_count,
+                recovery_count,
+                SHARD_BYTES,
+                new_engine(),
+                None,
+            )
+            .unwrap();
+
+            group.bench_with_input(BenchmarkId::from_parameter(id), &recovery, |b, recovery| {
+                b.iter(|| {
+                    for (index, shard) in original.iter().enumerate().take(original_provided_count)
+                    {
+                        decoder.add_original_shard(index, shard).unwrap();
+                    }
+                    for (index, shard) in recovery.iter().enumerate().take(recovery_provided_count)
+                    {
+                        decoder.add_recovery_shard(index, shard).unwrap();
+                    }
+                    decoder.decode().unwrap();
+                });
+            });
+        }
+
+        group.finish();
+    }
+
+    {
+        let mut group = c.benchmark_group("reed_solomon::low_rate_decoder");
+        group.sample_size(10);
+
+        for (original_count, recovery_count) in cases {
+            let original = generate_shards(original_count, SHARD_BYTES, 0);
+            let recovery = commonware_cryptography::reed_solomon::encode(
+                original_count,
+                recovery_count,
+                &original,
+            )
+            .unwrap();
+            group.throughput(Throughput::Bytes(
+                ((original_count + recovery_count) * SHARD_BYTES) as u64,
+            ));
+            let id = format!(
+                "rate={name} original={original_count} recovery={recovery_count} shard_bytes={SHARD_BYTES}"
+            );
+            let original_loss_count = std::cmp::min(original_count, recovery_count);
+            let original_provided_count = original_count - original_loss_count;
+            let recovery_provided_count = original_loss_count;
+            let mut decoder = LowRateDecoder::new(
+                original_count,
+                recovery_count,
+                SHARD_BYTES,
+                new_engine(),
+                None,
+            )
+            .unwrap();
+
+            group.bench_with_input(BenchmarkId::from_parameter(id), &recovery, |b, recovery| {
+                b.iter(|| {
+                    for (index, shard) in original.iter().enumerate().take(original_provided_count)
+                    {
+                        decoder.add_original_shard(index, shard).unwrap();
+                    }
+                    for (index, shard) in recovery.iter().enumerate().take(recovery_provided_count)
+                    {
+                        decoder.add_recovery_shard(index, shard).unwrap();
+                    }
+                    decoder.decode().unwrap();
+                });
+            });
+        }
+
+        group.finish();
+    }
+}
+
+// ======================================================================
+// BENCHMARKS - ENGINES
+
+fn benchmarks_engine(c: &mut Criterion) {
+    benchmarks_engine_one(c, "naive", Naive::new());
+    benchmarks_engine_one(c, "nosimd", NoSimd::new());
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if is_x86_feature_detected!("ssse3") {
+            benchmarks_engine_one(c, "ssse3", Ssse3::new());
+        }
+        if is_x86_feature_detected!("avx2") {
+            benchmarks_engine_one(c, "avx2", Avx2::new());
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            benchmarks_engine_one(c, "neon", Neon::new());
+        }
+    }
+}
+
+fn benchmarks_engine_one<E: Engine>(c: &mut Criterion, engine_name: &str, engine: E) {
+    let shard_len_64 = SHARD_BYTES / 64;
+
+    let mut rng = ChaCha8Rng::from_seed([0; 32]);
+    let mut data = [(); GF_ORDER].map(|_| rng.gen());
+
+    c.bench_function(
+        &format!("reed_solomon::engine_eval_poly/engine={engine_name} elems={GF_ORDER}"),
+        |b| b.iter(|| E::eval_poly(black_box(&mut data), GF_ORDER)),
+    );
+
+    c.bench_function(
+        &format!(
+            "reed_solomon::engine_eval_poly/engine={engine_name} elems={} mode=truncated",
+            GF_ORDER / 8
+        ),
+        |b| b.iter(|| E::eval_poly(black_box(&mut data), GF_ORDER / 8)),
+    );
+
+    let mut x = generate_shards_64(1, shard_len_64, 0).pop().unwrap();
+
+    c.bench_function(
+        &format!("reed_solomon::engine_mul/engine={engine_name} shard_bytes={SHARD_BYTES}"),
+        |b| b.iter(|| engine.mul(black_box(x.as_mut_slice()), black_box(12345))),
+    );
+
+    let shards_128_data = &mut generate_shards_64(1, 128 * shard_len_64, 0)[0];
+    let mut shards_128 = ShardsRefMut::new(128, shard_len_64, shards_128_data.as_mut());
+
+    c.bench_function(
+        &format!("reed_solomon::engine_fft/engine={engine_name} shards=128"),
+        |b| {
+            b.iter(|| {
+                engine.fft(
+                    black_box(&mut shards_128),
+                    black_box(0),
+                    black_box(128),
+                    black_box(128),
+                    black_box(128),
+                )
+            })
+        },
+    );
+
+    c.bench_function(
+        &format!("reed_solomon::engine_ifft/engine={engine_name} shards=128"),
+        |b| {
+            b.iter(|| {
+                engine.ifft(
+                    black_box(&mut shards_128),
+                    black_box(0),
+                    black_box(128),
+                    black_box(128),
+                    black_box(128),
+                )
+            })
+        },
+    );
+}
+
+// ======================================================================
+// MAIN
+
+criterion_group!(benches_main, benchmarks_main);
+criterion_group!(benches_rate, benchmarks_rate);
+criterion_group!(benches_engine, benchmarks_engine);
+criterion_main!(benches_main, benches_rate, benches_engine);

--- a/cryptography/src/reed_solomon/decoder_result.rs
+++ b/cryptography/src/reed_solomon/decoder_result.rs
@@ -1,0 +1,238 @@
+use crate::reed_solomon::rate::DecoderWork;
+
+// ======================================================================
+// DecoderResult - PUBLIC
+
+/// Result of decoding. Contains the restored original shards.
+///
+/// This struct is created by [`ReedSolomonDecoder::decode`]
+/// and [`RateDecoder::decode`].
+///
+/// [`RateDecoder::decode`]: crate::reed_solomon::rate::RateDecoder::decode
+/// [`ReedSolomonDecoder::decode`]: crate::reed_solomon::ReedSolomonDecoder::decode
+pub struct DecoderResult<'a> {
+    work: &'a mut DecoderWork,
+}
+
+impl DecoderResult<'_> {
+    /// Returns restored original shard with given `index`
+    /// or `None` if given `index` doesn't correspond to
+    /// a missing original shard.
+    pub fn restored_original(&self, index: usize) -> Option<&[u8]> {
+        self.work.restored_original(index)
+    }
+
+    /// Returns iterator over all restored original shards
+    /// and their indexes, ordered by indexes.
+    pub fn restored_original_iter(&self) -> RestoredOriginal<'_> {
+        RestoredOriginal::new(self.work)
+    }
+}
+
+// ======================================================================
+// DecoderResult - CRATE
+
+impl<'a> DecoderResult<'a> {
+    pub(crate) fn new(work: &'a mut DecoderWork) -> Self {
+        Self { work }
+    }
+}
+
+// ======================================================================
+// DecoderResult - IMPL DROP
+
+impl Drop for DecoderResult<'_> {
+    fn drop(&mut self) {
+        self.work.reset_received();
+    }
+}
+
+// ======================================================================
+// RestoredOriginal - PUBLIC
+
+/// Iterator over restored original shards and their indexes.
+///
+/// This struct is created by [`DecoderResult::restored_original_iter`].
+pub struct RestoredOriginal<'a> {
+    remaining: usize,
+    next_index: usize,
+    work: &'a DecoderWork,
+}
+
+// ======================================================================
+// RestoredOriginal - IMPL Iterator
+
+impl<'a> Iterator for RestoredOriginal<'a> {
+    type Item = (usize, &'a [u8]);
+    fn next(&mut self) -> Option<(usize, &'a [u8])> {
+        if self.remaining == 0 {
+            return None;
+        }
+
+        let mut index = self.next_index;
+        while index < self.work.original_count() {
+            if let Some(original) = self.work.restored_original(index) {
+                self.next_index = index + 1;
+                self.remaining -= 1;
+                return Some((index, original));
+            }
+            index += 1;
+        }
+
+        debug_assert!(
+            false,
+            "Inconsistency in internal data structures. Please report."
+        );
+
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+// ======================================================================
+// RestoredOriginal - IMPL ExactSizeIterator
+
+impl ExactSizeIterator for RestoredOriginal<'_> {}
+
+// ======================================================================
+// RestoredOriginal - CRATE
+
+impl<'a> RestoredOriginal<'a> {
+    pub(crate) fn new(work: &'a DecoderWork) -> Self {
+        Self {
+            remaining: work.missing_original_count(),
+            next_index: 0,
+            work,
+        }
+    }
+}
+
+// ======================================================================
+// TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reed_solomon::{test_util, ReedSolomonDecoder, ReedSolomonEncoder};
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
+    fn simple_roundtrip(shard_size: usize) {
+        let original = test_util::generate_original(3, shard_size, 0);
+
+        let mut encoder = ReedSolomonEncoder::new(3, 2, shard_size).unwrap();
+        let mut decoder = ReedSolomonDecoder::new(3, 2, shard_size).unwrap();
+
+        for original in &original {
+            encoder.add_original_shard(original).unwrap();
+        }
+
+        let result = encoder.encode().unwrap();
+        let recovery: Vec<_> = result.recovery_iter().collect();
+
+        assert!(recovery.iter().all(|slice| slice.len() == shard_size));
+
+        decoder.add_original_shard(1, &original[1]).unwrap();
+        decoder.add_recovery_shard(0, recovery[0]).unwrap();
+        decoder.add_recovery_shard(1, recovery[1]).unwrap();
+
+        let result: DecoderResult = decoder.decode().unwrap();
+
+        assert_eq!(result.restored_original(0).unwrap(), original[0]);
+        assert!(result.restored_original(1).is_none());
+        assert_eq!(result.restored_original(2).unwrap(), original[2]);
+        assert!(result.restored_original(3).is_none());
+
+        let mut iter: RestoredOriginal = result.restored_original_iter();
+        assert_eq!(iter.next(), Some((0, original[0].as_slice())));
+        assert_eq!(iter.next(), Some((2, original[2].as_slice())));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    // DecoderResult::restored_original
+    // DecoderResult::restored_original_iter
+    // RestoredOriginal
+    fn decoder_result() {
+        simple_roundtrip(1024);
+    }
+
+    #[test]
+    fn shard_size_not_divisible_by_64() {
+        for shard_size in [2, 4, 6, 30, 32, 34, 62, 64, 66, 126, 128, 130] {
+            simple_roundtrip(shard_size);
+        }
+    }
+
+    #[test]
+    fn decoder_result_size_hint() {
+        let shard_size = 64;
+        let original = test_util::generate_original(3, shard_size, 0);
+
+        let mut encoder = ReedSolomonEncoder::new(3, 2, shard_size).unwrap();
+        let mut decoder = ReedSolomonDecoder::new(3, 2, shard_size).unwrap();
+
+        for original in &original {
+            encoder.add_original_shard(original).unwrap();
+        }
+
+        let result = encoder.encode().unwrap();
+        let recovery: Vec<_> = result.recovery_iter().collect();
+
+        decoder.add_original_shard(1, &original[1]).unwrap();
+        decoder.add_recovery_shard(0, recovery[0]).unwrap();
+        decoder.add_recovery_shard(1, recovery[1]).unwrap();
+
+        let result: DecoderResult = decoder.decode().unwrap();
+
+        let mut iter: RestoredOriginal = result.restored_original_iter();
+
+        assert_eq!(iter.len(), 2);
+
+        assert!(iter.next().is_some());
+        assert_eq!(iter.len(), 1);
+
+        assert!(iter.next().is_some());
+        assert_eq!(iter.len(), 0);
+
+        assert!(iter.next().is_none());
+        assert_eq!(iter.len(), 0);
+    }
+
+    #[test]
+    fn decoder_result_size_hint_no_missing() {
+        let shard_size = 64;
+        let original = test_util::generate_original(3, shard_size, 0);
+
+        let mut encoder = ReedSolomonEncoder::new(3, 2, shard_size).unwrap();
+        let mut decoder = ReedSolomonDecoder::new(3, 2, shard_size).unwrap();
+
+        for original in &original {
+            encoder.add_original_shard(original).unwrap();
+        }
+
+        let result = encoder.encode().unwrap();
+        let _recovery: Vec<_> = result.recovery_iter().collect();
+
+        // Add all the original shards
+        decoder.add_original_shard(0, &original[0]).unwrap();
+        decoder.add_original_shard(1, &original[1]).unwrap();
+        decoder.add_original_shard(2, &original[2]).unwrap();
+
+        let result: DecoderResult = decoder.decode().unwrap();
+
+        let mut iter: RestoredOriginal = result.restored_original_iter();
+
+        assert_eq!(iter.len(), 0);
+
+        assert!(iter.next().is_none());
+        assert_eq!(iter.len(), 0);
+
+        assert!(iter.next().is_none());
+        assert_eq!(iter.len(), 0);
+    }
+}

--- a/cryptography/src/reed_solomon/decoder_result.rs
+++ b/cryptography/src/reed_solomon/decoder_result.rs
@@ -5,11 +5,11 @@ use crate::reed_solomon::rate::DecoderWork;
 
 /// Result of decoding. Contains the restored original shards.
 ///
-/// This struct is created by [`ReedSolomonDecoder::decode`]
+/// This struct is created by [`Decoder::decode`]
 /// and [`RateDecoder::decode`].
 ///
 /// [`RateDecoder::decode`]: crate::reed_solomon::rate::RateDecoder::decode
-/// [`ReedSolomonDecoder::decode`]: crate::reed_solomon::ReedSolomonDecoder::decode
+/// [`Decoder::decode`]: crate::reed_solomon::Decoder::decode
 pub struct DecoderResult<'a> {
     work: &'a mut DecoderWork,
 }
@@ -24,7 +24,7 @@ impl DecoderResult<'_> {
 
     /// Returns iterator over all restored original shards
     /// and their indexes, ordered by indexes.
-    pub fn restored_original_iter(&self) -> RestoredOriginal<'_> {
+    pub const fn restored_original_iter(&self) -> RestoredOriginal<'_> {
         RestoredOriginal::new(self.work)
     }
 }
@@ -33,7 +33,7 @@ impl DecoderResult<'_> {
 // DecoderResult - CRATE
 
 impl<'a> DecoderResult<'a> {
-    pub(crate) fn new(work: &'a mut DecoderWork) -> Self {
+    pub(crate) const fn new(work: &'a mut DecoderWork) -> Self {
         Self { work }
     }
 }
@@ -79,12 +79,7 @@ impl<'a> Iterator for RestoredOriginal<'a> {
             index += 1;
         }
 
-        debug_assert!(
-            false,
-            "Inconsistency in internal data structures. Please report."
-        );
-
-        None
+        unreachable!("Inconsistency in internal data structures. Please report.");
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -101,7 +96,7 @@ impl ExactSizeIterator for RestoredOriginal<'_> {}
 // RestoredOriginal - CRATE
 
 impl<'a> RestoredOriginal<'a> {
-    pub(crate) fn new(work: &'a DecoderWork) -> Self {
+    pub(crate) const fn new(work: &'a DecoderWork) -> Self {
         Self {
             remaining: work.missing_original_count(),
             next_index: 0,
@@ -116,15 +111,15 @@ impl<'a> RestoredOriginal<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reed_solomon::{test_util, ReedSolomonDecoder, ReedSolomonEncoder};
+    use crate::reed_solomon::{test_util, Decoder, Encoder, SHARD_CHUNK_BYTES};
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
 
     fn simple_roundtrip(shard_size: usize) {
         let original = test_util::generate_original(3, shard_size, 0);
 
-        let mut encoder = ReedSolomonEncoder::new(3, 2, shard_size).unwrap();
-        let mut decoder = ReedSolomonDecoder::new(3, 2, shard_size).unwrap();
+        let mut encoder = Encoder::new(3, 2, shard_size).unwrap();
+        let mut decoder = Decoder::new(3, 2, shard_size).unwrap();
 
         for original in &original {
             encoder.add_original_shard(original).unwrap();
@@ -139,14 +134,14 @@ mod tests {
         decoder.add_recovery_shard(0, recovery[0]).unwrap();
         decoder.add_recovery_shard(1, recovery[1]).unwrap();
 
-        let result: DecoderResult = decoder.decode().unwrap();
+        let result: DecoderResult<'_> = decoder.decode().unwrap();
 
         assert_eq!(result.restored_original(0).unwrap(), original[0]);
         assert!(result.restored_original(1).is_none());
         assert_eq!(result.restored_original(2).unwrap(), original[2]);
         assert!(result.restored_original(3).is_none());
 
-        let mut iter: RestoredOriginal = result.restored_original_iter();
+        let mut iter: RestoredOriginal<'_> = result.restored_original_iter();
         assert_eq!(iter.next(), Some((0, original[0].as_slice())));
         assert_eq!(iter.next(), Some((2, original[2].as_slice())));
         assert_eq!(iter.next(), None);
@@ -162,19 +157,32 @@ mod tests {
     }
 
     #[test]
-    fn shard_size_not_divisible_by_64() {
-        for shard_size in [2, 4, 6, 30, 32, 34, 62, 64, 66, 126, 128, 130] {
+    fn shard_size_not_divisible_by_chunk_size() {
+        for shard_size in [
+            2,
+            4,
+            6,
+            30,
+            32,
+            34,
+            62,
+            SHARD_CHUNK_BYTES,
+            66,
+            126,
+            128,
+            130,
+        ] {
             simple_roundtrip(shard_size);
         }
     }
 
     #[test]
     fn decoder_result_size_hint() {
-        let shard_size = 64;
+        let shard_size = SHARD_CHUNK_BYTES;
         let original = test_util::generate_original(3, shard_size, 0);
 
-        let mut encoder = ReedSolomonEncoder::new(3, 2, shard_size).unwrap();
-        let mut decoder = ReedSolomonDecoder::new(3, 2, shard_size).unwrap();
+        let mut encoder = Encoder::new(3, 2, shard_size).unwrap();
+        let mut decoder = Decoder::new(3, 2, shard_size).unwrap();
 
         for original in &original {
             encoder.add_original_shard(original).unwrap();
@@ -187,9 +195,9 @@ mod tests {
         decoder.add_recovery_shard(0, recovery[0]).unwrap();
         decoder.add_recovery_shard(1, recovery[1]).unwrap();
 
-        let result: DecoderResult = decoder.decode().unwrap();
+        let result: DecoderResult<'_> = decoder.decode().unwrap();
 
-        let mut iter: RestoredOriginal = result.restored_original_iter();
+        let mut iter: RestoredOriginal<'_> = result.restored_original_iter();
 
         assert_eq!(iter.len(), 2);
 
@@ -205,11 +213,11 @@ mod tests {
 
     #[test]
     fn decoder_result_size_hint_no_missing() {
-        let shard_size = 64;
+        let shard_size = SHARD_CHUNK_BYTES;
         let original = test_util::generate_original(3, shard_size, 0);
 
-        let mut encoder = ReedSolomonEncoder::new(3, 2, shard_size).unwrap();
-        let mut decoder = ReedSolomonDecoder::new(3, 2, shard_size).unwrap();
+        let mut encoder = Encoder::new(3, 2, shard_size).unwrap();
+        let mut decoder = Decoder::new(3, 2, shard_size).unwrap();
 
         for original in &original {
             encoder.add_original_shard(original).unwrap();
@@ -223,9 +231,9 @@ mod tests {
         decoder.add_original_shard(1, &original[1]).unwrap();
         decoder.add_original_shard(2, &original[2]).unwrap();
 
-        let result: DecoderResult = decoder.decode().unwrap();
+        let result: DecoderResult<'_> = decoder.decode().unwrap();
 
-        let mut iter: RestoredOriginal = result.restored_original_iter();
+        let mut iter: RestoredOriginal<'_> = result.restored_original_iter();
 
         assert_eq!(iter.len(), 0);
 

--- a/cryptography/src/reed_solomon/encoder_result.rs
+++ b/cryptography/src/reed_solomon/encoder_result.rs
@@ -1,0 +1,172 @@
+use crate::reed_solomon::rate::EncoderWork;
+
+// ======================================================================
+// EncoderResult - PUBLIC
+
+/// Result of encoding. Contains the generated recovery shards.
+///
+/// This struct is created by [`ReedSolomonEncoder::encode`]
+/// and [`RateEncoder::encode`].
+///
+/// [`RateEncoder::encode`]: crate::reed_solomon::rate::RateEncoder::encode
+/// [`ReedSolomonEncoder::encode`]: crate::reed_solomon::ReedSolomonEncoder::encode
+pub struct EncoderResult<'a> {
+    work: &'a mut EncoderWork,
+}
+
+impl EncoderResult<'_> {
+    /// Returns recovery shard with given `index`
+    /// or `None` if `index >= recovery_count`.
+    ///
+    /// Recovery shards have indexes `0..recovery_count`
+    /// and these same indexes must be used when decoding.
+    pub fn recovery(&self, index: usize) -> Option<&[u8]> {
+        self.work.recovery(index)
+    }
+
+    /// Returns iterator over all recovery shards ordered by their indexes.
+    ///
+    /// Recovery shards have indexes `0..recovery_count`
+    /// and these same indexes must be used when decoding.
+    pub fn recovery_iter(&self) -> Recovery<'_> {
+        Recovery::new(self.work)
+    }
+}
+
+// ======================================================================
+// EncoderResult - CRATE
+
+impl<'a> EncoderResult<'a> {
+    pub(crate) fn new(work: &'a mut EncoderWork) -> Self {
+        Self { work }
+    }
+}
+
+// ======================================================================
+// EncoderResult - IMPL DROP
+
+impl Drop for EncoderResult<'_> {
+    fn drop(&mut self) {
+        self.work.reset_received();
+    }
+}
+
+// ======================================================================
+// Recovery - PUBLIC
+
+/// Iterator over generated recovery shards.
+///
+/// This struct is created by [`EncoderResult::recovery_iter`].
+pub struct Recovery<'a> {
+    ended: bool,
+    next_index: usize,
+    work: &'a EncoderWork,
+}
+
+// ======================================================================
+// Recovery - IMPL Iterator
+
+impl<'a> Iterator for Recovery<'a> {
+    type Item = &'a [u8];
+    fn next(&mut self) -> Option<&'a [u8]> {
+        if self.ended {
+            None
+        } else if let Some(next) = self.work.recovery(self.next_index) {
+            self.next_index += 1;
+            Some(next)
+        } else {
+            self.ended = true;
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.work.recovery_count() - self.next_index;
+        (remaining, Some(remaining))
+    }
+}
+
+// ======================================================================
+// Recovery - IMPL ExactSizeIterator
+
+impl ExactSizeIterator for Recovery<'_> {}
+
+// ======================================================================
+// Recovery - CRATE
+
+impl<'a> Recovery<'a> {
+    pub(crate) fn new(work: &'a EncoderWork) -> Self {
+        Self {
+            ended: false,
+            next_index: 0,
+            work,
+        }
+    }
+}
+
+// ======================================================================
+// TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reed_solomon::{test_util, ReedSolomonEncoder};
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
+    #[test]
+    // EncoderResult::recovery
+    // EncoderResult::recovery_iter
+    // Recovery
+    fn encoder_result() {
+        let original = test_util::generate_original(2, 1024, 123);
+        let mut encoder = ReedSolomonEncoder::new(2, 3, 1024).unwrap();
+
+        for original in &original {
+            encoder.add_original_shard(original).unwrap();
+        }
+
+        let result: EncoderResult = encoder.encode().unwrap();
+
+        let mut all = Vec::new();
+        all.push(result.recovery(0).unwrap());
+        all.push(result.recovery(1).unwrap());
+        all.push(result.recovery(2).unwrap());
+        assert!(result.recovery(3).is_none());
+        test_util::assert_hash(all, test_util::LOW_2_3);
+
+        let mut iter: Recovery = result.recovery_iter();
+        let mut all = Vec::new();
+        all.push(iter.next().unwrap());
+        all.push(iter.next().unwrap());
+        all.push(iter.next().unwrap());
+        assert!(iter.next().is_none());
+        test_util::assert_hash(all, test_util::LOW_2_3);
+    }
+
+    #[test]
+    fn encoder_result_size_hint() {
+        let original = test_util::generate_original(2, 1024, 123);
+        let mut encoder = ReedSolomonEncoder::new(2, 3, 1024).unwrap();
+
+        for original in &original {
+            encoder.add_original_shard(original).unwrap();
+        }
+
+        let result: EncoderResult = encoder.encode().unwrap();
+
+        let mut iter: Recovery = result.recovery_iter();
+
+        assert_eq!(iter.len(), 3);
+
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_some());
+        assert_eq!(iter.len(), 1);
+
+        assert!(iter.next().is_some());
+        assert_eq!(iter.len(), 0);
+
+        assert!(iter.next().is_none());
+        assert_eq!(iter.len(), 0);
+    }
+}

--- a/cryptography/src/reed_solomon/encoder_result.rs
+++ b/cryptography/src/reed_solomon/encoder_result.rs
@@ -5,11 +5,11 @@ use crate::reed_solomon::rate::EncoderWork;
 
 /// Result of encoding. Contains the generated recovery shards.
 ///
-/// This struct is created by [`ReedSolomonEncoder::encode`]
+/// This struct is created by [`Encoder::encode`]
 /// and [`RateEncoder::encode`].
 ///
 /// [`RateEncoder::encode`]: crate::reed_solomon::rate::RateEncoder::encode
-/// [`ReedSolomonEncoder::encode`]: crate::reed_solomon::ReedSolomonEncoder::encode
+/// [`Encoder::encode`]: crate::reed_solomon::Encoder::encode
 pub struct EncoderResult<'a> {
     work: &'a mut EncoderWork,
 }
@@ -28,7 +28,7 @@ impl EncoderResult<'_> {
     ///
     /// Recovery shards have indexes `0..recovery_count`
     /// and these same indexes must be used when decoding.
-    pub fn recovery_iter(&self) -> Recovery<'_> {
+    pub const fn recovery_iter(&self) -> Recovery<'_> {
         Recovery::new(self.work)
     }
 }
@@ -37,7 +37,7 @@ impl EncoderResult<'_> {
 // EncoderResult - CRATE
 
 impl<'a> EncoderResult<'a> {
-    pub(crate) fn new(work: &'a mut EncoderWork) -> Self {
+    pub(crate) const fn new(work: &'a mut EncoderWork) -> Self {
         Self { work }
     }
 }
@@ -95,7 +95,7 @@ impl ExactSizeIterator for Recovery<'_> {}
 // Recovery - CRATE
 
 impl<'a> Recovery<'a> {
-    pub(crate) fn new(work: &'a EncoderWork) -> Self {
+    pub(crate) const fn new(work: &'a EncoderWork) -> Self {
         Self {
             ended: false,
             next_index: 0,
@@ -110,7 +110,7 @@ impl<'a> Recovery<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reed_solomon::{test_util, ReedSolomonEncoder};
+    use crate::reed_solomon::{test_util, Encoder};
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
 
@@ -120,26 +120,28 @@ mod tests {
     // Recovery
     fn encoder_result() {
         let original = test_util::generate_original(2, 1024, 123);
-        let mut encoder = ReedSolomonEncoder::new(2, 3, 1024).unwrap();
+        let mut encoder = Encoder::new(2, 3, 1024).unwrap();
 
         for original in &original {
             encoder.add_original_shard(original).unwrap();
         }
 
-        let result: EncoderResult = encoder.encode().unwrap();
+        let result: EncoderResult<'_> = encoder.encode().unwrap();
 
-        let mut all = Vec::new();
-        all.push(result.recovery(0).unwrap());
-        all.push(result.recovery(1).unwrap());
-        all.push(result.recovery(2).unwrap());
+        let all = vec![
+            result.recovery(0).unwrap(),
+            result.recovery(1).unwrap(),
+            result.recovery(2).unwrap(),
+        ];
         assert!(result.recovery(3).is_none());
         test_util::assert_hash(all, test_util::LOW_2_3);
 
-        let mut iter: Recovery = result.recovery_iter();
-        let mut all = Vec::new();
-        all.push(iter.next().unwrap());
-        all.push(iter.next().unwrap());
-        all.push(iter.next().unwrap());
+        let mut iter: Recovery<'_> = result.recovery_iter();
+        let all = vec![
+            iter.next().unwrap(),
+            iter.next().unwrap(),
+            iter.next().unwrap(),
+        ];
         assert!(iter.next().is_none());
         test_util::assert_hash(all, test_util::LOW_2_3);
     }
@@ -147,15 +149,15 @@ mod tests {
     #[test]
     fn encoder_result_size_hint() {
         let original = test_util::generate_original(2, 1024, 123);
-        let mut encoder = ReedSolomonEncoder::new(2, 3, 1024).unwrap();
+        let mut encoder = Encoder::new(2, 3, 1024).unwrap();
 
         for original in &original {
             encoder.add_original_shard(original).unwrap();
         }
 
-        let result: EncoderResult = encoder.encode().unwrap();
+        let result: EncoderResult<'_> = encoder.encode().unwrap();
 
-        let mut iter: Recovery = result.recovery_iter();
+        let mut iter: Recovery<'_> = result.recovery_iter();
 
         assert_eq!(iter.len(), 3);
 

--- a/cryptography/src/reed_solomon/engine.rs
+++ b/cryptography/src/reed_solomon/engine.rs
@@ -1,0 +1,163 @@
+//! Low-level building blocks for Reed-Solomon encoding/decoding.
+//!
+//! **This is an advanced module which is not needed for [simple usage] or [basic usage].**
+//!
+//! This module is relevant if you want to
+//! - use [`rate`] module and need an [`Engine`] to use with it.
+//! - create your own [`Engine`].
+//! - understand/benchmark/test at low level.
+//!
+//! # Engines
+//!
+//! An [`Engine`] is an implementation of basic low-level algorithms
+//! needed for Reed-Solomon encoding/decoding.
+//!
+//! - [`Naive`]
+//!     - Simple reference implementation.
+//! - [`NoSimd`]
+//!     - Basic optimized engine without SIMD so that it works on all CPUs.
+//! - `Avx2`
+//!     - Optimized engine that takes advantage of the x86(-64) AVX2 SIMD instructions.
+//! - `Ssse3`
+//!     - Optimized engine that takes advantage of the x86(-64) SSSE3 SIMD instructions.
+//! - `Neon`
+//!     - Optimized engine that takes advantage of the `AArch64` Neon SIMD instructions.
+//! - [`DefaultEngine`]
+//!     - Default engine which is used when no specific engine is given.
+//!     - Automatically selects best engine at runtime.
+//!
+//! [simple usage]: crate::reed_solomon#simple-usage
+//! [basic usage]: crate::reed_solomon#basic-usage
+//! [`ReedSolomonEncoder`]: crate::reed_solomon::ReedSolomonEncoder
+//! [`ReedSolomonDecoder`]: crate::reed_solomon::ReedSolomonDecoder
+//! [`rate`]: crate::reed_solomon::rate
+
+#[cfg(target_arch = "aarch64")]
+pub use self::engine_neon::Neon;
+pub(crate) use self::shards::Shards;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub use self::{engine_avx2::Avx2, engine_ssse3::Ssse3};
+pub use self::{
+    engine_default::DefaultEngine, engine_naive::Naive, engine_nosimd::NoSimd, shards::ShardsRefMut,
+};
+pub(crate) use utils::{fft_skew_end, formal_derivative, ifft_skew_end, xor_within};
+
+mod engine_default;
+mod engine_naive;
+mod engine_nosimd;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod engine_avx2;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod engine_ssse3;
+
+#[cfg(target_arch = "aarch64")]
+mod engine_neon;
+
+mod fwht;
+mod shards;
+
+pub mod tables;
+pub mod utils;
+
+// ======================================================================
+// CONST - PUBLIC
+
+/// Size of Galois field element [`GfElement`] in bits.
+pub const GF_BITS: usize = 16;
+
+/// Galois field order, i.e. number of elements.
+pub const GF_ORDER: usize = 65536;
+
+/// `GF_ORDER - 1`
+pub const GF_MODULUS: GfElement = 65535;
+
+/// Galois field polynomial.
+pub const GF_POLYNOMIAL: usize = 0x1002D;
+
+/// TODO
+pub const CANTOR_BASIS: [GfElement; GF_BITS] = [
+    0x0001, 0xACCA, 0x3C0E, 0x163E, 0xC582, 0xED2E, 0x914C, 0x4012, 0x6C98, 0x10D8, 0x6A72, 0xB900,
+    0xFDB8, 0xFB34, 0xFF38, 0x991E,
+];
+
+// ======================================================================
+// TYPE ALIASES - PUBLIC
+
+/// Galois field element.
+pub type GfElement = u16;
+
+// ======================================================================
+// Engine - PUBLIC
+
+/// Trait for compute-intensive low-level algorithms needed
+/// for Reed-Solomon encoding/decoding.
+///
+/// This is the trait you would implement to provide SIMD support
+/// for a CPU architecture not already provided.
+///
+/// [`Naive`] engine is provided for those who want to
+/// study the source code to understand [`Engine`].
+pub trait Engine {
+    // ============================================================
+    // REQUIRED
+
+    /// In-place decimation-in-time FFT (fast Fourier transform).
+    ///
+    /// - FFT is done on chunk `data[pos .. pos + size]`
+    /// - `size` must be `2^n`
+    /// - Before function call `data[pos .. pos + size]` must be valid.
+    /// - After function call
+    ///     - `data[pos .. pos + truncated_size]`
+    ///       contains valid FFT result.
+    ///     - `data[pos + truncated_size .. pos + size]`
+    ///       contains valid FFT result if this contained
+    ///       only `0u8`:s and garbage otherwise.
+    fn fft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    );
+
+    /// In-place decimation-in-time IFFT (inverse fast Fourier transform).
+    ///
+    /// - IFFT is done on chunk `data[pos .. pos + size]`
+    /// - `size` must be `2^n`
+    /// - Before function call `data[pos .. pos + size]` must be valid.
+    /// - After function call
+    ///     - `data[pos .. pos + truncated_size]`
+    ///       contains valid IFFT result.
+    ///     - `data[pos + truncated_size .. pos + size]`
+    ///       contains valid IFFT result if this contained
+    ///       only `0u8`:s and garbage otherwise.
+    fn ifft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    );
+
+    /// `x[] *= log_m`
+    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement);
+
+    // ============================================================
+    // PROVIDED
+
+    /// Evaluate polynomial.
+    fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize)
+    where
+        Self: Sized,
+    {
+        utils::eval_poly(erasures, truncated_size);
+    }
+}
+
+// ======================================================================
+// TESTS
+
+// Engines are tested indirectly via roundtrip tests of HighRate and LowRate.

--- a/cryptography/src/reed_solomon/engine.rs
+++ b/cryptography/src/reed_solomon/engine.rs
@@ -82,7 +82,7 @@ pub const GF_POLYNOMIAL: usize = 0x1002D;
 /// during processing and returned at the original shard length.
 pub const SHARD_CHUNK_BYTES: usize = 64;
 
-/// TODO
+/// Cantor basis used by the additive FFT over GF(2^16).
 pub const CANTOR_BASIS: [GfElement; GF_BITS] = [
     0x0001, 0xACCA, 0x3C0E, 0x163E, 0xC582, 0xED2E, 0x914C, 0x4012, 0x6C98, 0x10D8, 0x6A72, 0xB900,
     0xFDB8, 0xFB34, 0xFF38, 0x991E,

--- a/cryptography/src/reed_solomon/engine.rs
+++ b/cryptography/src/reed_solomon/engine.rs
@@ -28,8 +28,8 @@
 //!
 //! [simple usage]: crate::reed_solomon#simple-usage
 //! [basic usage]: crate::reed_solomon#basic-usage
-//! [`ReedSolomonEncoder`]: crate::reed_solomon::ReedSolomonEncoder
-//! [`ReedSolomonDecoder`]: crate::reed_solomon::ReedSolomonDecoder
+//! [`Encoder`]: crate::reed_solomon::Encoder
+//! [`Decoder`]: crate::reed_solomon::Decoder
 //! [`rate`]: crate::reed_solomon::rate
 
 #[cfg(target_arch = "aarch64")]
@@ -75,6 +75,13 @@ pub const GF_MODULUS: GfElement = 65535;
 /// Galois field polynomial.
 pub const GF_POLYNOMIAL: usize = 0x1002D;
 
+/// Byte width of a shard chunk.
+///
+/// [`Engine`] methods process shard buffers as arrays of this size.
+/// Input shards may span multiple chunks; any partial final chunk is padded
+/// during processing and returned at the original shard length.
+pub const SHARD_CHUNK_BYTES: usize = 64;
+
 /// TODO
 pub const CANTOR_BASIS: [GfElement; GF_BITS] = [
     0x0001, 0xACCA, 0x3C0E, 0x163E, 0xC582, 0xED2E, 0x914C, 0x4012, 0x6C98, 0x10D8, 0x6A72, 0xB900,
@@ -115,7 +122,7 @@ pub trait Engine {
     ///       only `0u8`:s and garbage otherwise.
     fn fft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -135,7 +142,7 @@ pub trait Engine {
     ///       only `0u8`:s and garbage otherwise.
     fn ifft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -143,7 +150,7 @@ pub trait Engine {
     );
 
     /// `x[] *= log_m`
-    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement);
+    fn mul(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement);
 
     // ============================================================
     // PROVIDED

--- a/cryptography/src/reed_solomon/engine/engine_avx2.rs
+++ b/cryptography/src/reed_solomon/engine/engine_avx2.rs
@@ -95,8 +95,6 @@ impl Default for Avx2 {
 
 // ======================================================================
 // Avx2 - PRIVATE
-//
-//
 
 #[derive(Copy, Clone)]
 struct LutAvx2 {
@@ -164,7 +162,7 @@ impl Avx2 {
         }
     }
 
-    // Impelemntation of LEO_MUL_256
+    // Implementation of LEO_MUL_256
     #[inline(always)]
     fn mul_256(value_lo: __m256i, value_hi: __m256i, lut_avx2: LutAvx2) -> (__m256i, __m256i) {
         let mut prod_lo: __m256i;
@@ -194,7 +192,7 @@ impl Avx2 {
         (prod_lo, prod_hi)
     }
 
-    //// {x_lo, x_hi} ^= {y_lo, y_hi} * log_m
+    // {x_lo, x_hi} ^= {y_lo, y_hi} * log_m.
     // Implementation of LEO_MULADD_256
     #[inline(always)]
     fn muladd_256(
@@ -311,7 +309,6 @@ impl Avx2 {
         truncated_size: usize,
         skew_delta: usize,
     ) {
-        // Drop unsafe privileges
         self.fft_private(data, pos, size, truncated_size, skew_delta);
     }
 
@@ -464,7 +461,6 @@ impl Avx2 {
         truncated_size: usize,
         skew_delta: usize,
     ) {
-        // Drop unsafe privileges
         self.ifft_private(data, pos, size, truncated_size, skew_delta);
     }
 

--- a/cryptography/src/reed_solomon/engine/engine_avx2.rs
+++ b/cryptography/src/reed_solomon/engine/engine_avx2.rs
@@ -1,6 +1,6 @@
 use crate::reed_solomon::engine::{
     tables::{self, Mul128, Multiply128lutT, Skew},
-    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER,
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER, SHARD_CHUNK_BYTES,
 };
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
@@ -32,6 +32,9 @@ impl Avx2 {
     ///
     /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
     pub fn new() -> Self {
+        cpufeatures::new!(has_avx2_for_engine, "avx2");
+        assert!(has_avx2_for_engine::get());
+
         let mul128 = tables::get_mul128();
         let skew = tables::get_skew();
 
@@ -42,12 +45,13 @@ impl Avx2 {
 impl Engine for Avx2 {
     fn fft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
         skew_delta: usize,
     ) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             self.fft_private_avx2(data, pos, size, truncated_size, skew_delta);
         }
@@ -55,24 +59,27 @@ impl Engine for Avx2 {
 
     fn ifft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
         skew_delta: usize,
     ) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             self.ifft_private_avx2(data, pos, size, truncated_size, skew_delta);
         }
     }
 
-    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+    fn mul(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             self.mul_avx2(x, log_m);
         }
     }
 
     fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe { Self::eval_poly_avx2(erasures, truncated_size) }
     }
 }
@@ -106,6 +113,7 @@ struct LutAvx2 {
 impl From<&Multiply128lutT> for LutAvx2 {
     #[inline(always)]
     fn from(lut: &Multiply128lutT) -> Self {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             Self {
                 t0_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
@@ -139,12 +147,13 @@ impl From<&Multiply128lutT> for LutAvx2 {
 
 impl Avx2 {
     #[target_feature(enable = "avx2")]
-    unsafe fn mul_avx2(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+    unsafe fn mul_avx2(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement) {
         let lut = &self.mul128[log_m as usize];
         let lut_avx2 = LutAvx2::from(lut);
 
         for chunk in x.iter_mut() {
             let x_ptr = chunk.as_mut_ptr().cast::<__m256i>();
+            // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
             unsafe {
                 let x_lo = _mm256_loadu_si256(x_ptr);
                 let x_hi = _mm256_loadu_si256(x_ptr.add(1));
@@ -161,6 +170,7 @@ impl Avx2 {
         let mut prod_lo: __m256i;
         let mut prod_hi: __m256i;
 
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             let clr_mask = _mm256_set1_epi8(0x0f);
 
@@ -195,6 +205,7 @@ impl Avx2 {
         lut_avx2: LutAvx2,
     ) -> (__m256i, __m256i) {
         let (prod_lo, prod_hi) = Self::mul_256(y_lo, y_hi, lut_avx2);
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             x_lo = _mm256_xor_si256(x_lo, prod_lo);
             x_hi = _mm256_xor_si256(x_hi, prod_hi);
@@ -209,10 +220,15 @@ impl Avx2 {
 impl Avx2 {
     // Implementation of LEO_FFTB_256
     #[inline(always)]
-    fn fftb_256(x: &mut [u8; 64], y: &mut [u8; 64], lut_avx2: LutAvx2) {
+    fn fftb_256(
+        x: &mut [u8; SHARD_CHUNK_BYTES],
+        y: &mut [u8; SHARD_CHUNK_BYTES],
+        lut_avx2: LutAvx2,
+    ) {
         let x_ptr = x.as_mut_ptr().cast::<__m256i>();
         let y_ptr = y.as_mut_ptr().cast::<__m256i>();
 
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             let mut x_lo = _mm256_loadu_si256(x_ptr);
             let mut x_hi = _mm256_loadu_si256(x_ptr.add(1));
@@ -235,7 +251,12 @@ impl Avx2 {
 
     // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
     #[inline(always)]
-    fn fft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+    fn fft_butterfly_partial(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &mut [[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
         let lut = &self.mul128[log_m as usize];
         let lut_avx2 = LutAvx2::from(lut);
 
@@ -247,7 +268,7 @@ impl Avx2 {
     #[inline(always)]
     fn fft_butterfly_two_layers(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         dist: usize,
         log_m01: GfElement,
@@ -284,7 +305,7 @@ impl Avx2 {
     #[target_feature(enable = "avx2")]
     unsafe fn fft_private_avx2(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -297,7 +318,7 @@ impl Avx2 {
     #[inline(always)]
     fn fft_private(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -353,10 +374,15 @@ impl Avx2 {
 impl Avx2 {
     // Implementation of LEO_IFFTB_256
     #[inline(always)]
-    fn ifftb_256(x: &mut [u8; 64], y: &mut [u8; 64], lut_avx2: LutAvx2) {
+    fn ifftb_256(
+        x: &mut [u8; SHARD_CHUNK_BYTES],
+        y: &mut [u8; SHARD_CHUNK_BYTES],
+        lut_avx2: LutAvx2,
+    ) {
         let x_ptr = x.as_mut_ptr().cast::<__m256i>();
         let y_ptr = y.as_mut_ptr().cast::<__m256i>();
 
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             let mut x_lo = _mm256_loadu_si256(x_ptr);
             let mut x_hi = _mm256_loadu_si256(x_ptr.add(1));
@@ -378,7 +404,12 @@ impl Avx2 {
     }
 
     #[inline(always)]
-    fn ifft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+    fn ifft_butterfly_partial(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &mut [[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
         let lut = &self.mul128[log_m as usize];
         let lut_avx2 = LutAvx2::from(lut);
 
@@ -390,7 +421,7 @@ impl Avx2 {
     #[inline(always)]
     fn ifft_butterfly_two_layers(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         dist: usize,
         log_m01: GfElement,
@@ -427,7 +458,7 @@ impl Avx2 {
     #[target_feature(enable = "avx2")]
     unsafe fn ifft_private_avx2(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -440,7 +471,7 @@ impl Avx2 {
     #[inline(always)]
     fn ifft_private(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,

--- a/cryptography/src/reed_solomon/engine/engine_avx2.rs
+++ b/cryptography/src/reed_solomon/engine/engine_avx2.rs
@@ -1,0 +1,505 @@
+use crate::reed_solomon::engine::{
+    tables::{self, Mul128, Multiply128lutT, Skew},
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER,
+};
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+use core::iter::zip;
+
+// ======================================================================
+// Avx2 - PUBLIC
+
+/// Optimized [`Engine`] using AVX2 instructions.
+///
+/// [`Avx2`] is an optimized engine that follows the same algorithm as
+/// [`NoSimd`] but takes advantage of the x86 AVX2 SIMD instructions.
+///
+/// [`NoSimd`]: crate::reed_solomon::engine::NoSimd
+#[derive(Clone, Copy)]
+pub struct Avx2 {
+    mul128: &'static Mul128,
+    skew: &'static Skew,
+}
+
+impl Avx2 {
+    /// Creates new [`Avx2`], initializing all [tables]
+    /// needed for encoding or decoding.
+    ///
+    /// Currently only difference between encoding/decoding is
+    /// [`LogWalsh`] (128 kiB) which is only needed for decoding.
+    ///
+    /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
+    pub fn new() -> Self {
+        let mul128 = tables::get_mul128();
+        let skew = tables::get_skew();
+
+        Self { mul128, skew }
+    }
+}
+
+impl Engine for Avx2 {
+    fn fft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        unsafe {
+            self.fft_private_avx2(data, pos, size, truncated_size, skew_delta);
+        }
+    }
+
+    fn ifft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        unsafe {
+            self.ifft_private_avx2(data, pos, size, truncated_size, skew_delta);
+        }
+    }
+
+    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+        unsafe {
+            self.mul_avx2(x, log_m);
+        }
+    }
+
+    fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        unsafe { Self::eval_poly_avx2(erasures, truncated_size) }
+    }
+}
+
+// ======================================================================
+// Avx2 - IMPL Default
+
+impl Default for Avx2 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ======================================================================
+// Avx2 - PRIVATE
+//
+//
+
+#[derive(Copy, Clone)]
+struct LutAvx2 {
+    t0_lo: __m256i,
+    t1_lo: __m256i,
+    t2_lo: __m256i,
+    t3_lo: __m256i,
+    t0_hi: __m256i,
+    t1_hi: __m256i,
+    t2_hi: __m256i,
+    t3_hi: __m256i,
+}
+
+impl From<&Multiply128lutT> for LutAvx2 {
+    #[inline(always)]
+    fn from(lut: &Multiply128lutT) -> Self {
+        unsafe {
+            Self {
+                t0_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                    core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>(),
+                )),
+                t1_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                    core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>(),
+                )),
+                t2_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                    core::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>(),
+                )),
+                t3_lo: _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                    core::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>(),
+                )),
+                t0_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                    core::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>(),
+                )),
+                t1_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                    core::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>(),
+                )),
+                t2_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                    core::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>(),
+                )),
+                t3_hi: _mm256_broadcastsi128_si256(_mm_loadu_si128(
+                    core::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>(),
+                )),
+            }
+        }
+    }
+}
+
+impl Avx2 {
+    #[target_feature(enable = "avx2")]
+    unsafe fn mul_avx2(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+        let lut = &self.mul128[log_m as usize];
+        let lut_avx2 = LutAvx2::from(lut);
+
+        for chunk in x.iter_mut() {
+            let x_ptr = chunk.as_mut_ptr().cast::<__m256i>();
+            unsafe {
+                let x_lo = _mm256_loadu_si256(x_ptr);
+                let x_hi = _mm256_loadu_si256(x_ptr.add(1));
+                let (prod_lo, prod_hi) = Self::mul_256(x_lo, x_hi, lut_avx2);
+                _mm256_storeu_si256(x_ptr, prod_lo);
+                _mm256_storeu_si256(x_ptr.add(1), prod_hi);
+            }
+        }
+    }
+
+    // Impelemntation of LEO_MUL_256
+    #[inline(always)]
+    fn mul_256(value_lo: __m256i, value_hi: __m256i, lut_avx2: LutAvx2) -> (__m256i, __m256i) {
+        let mut prod_lo: __m256i;
+        let mut prod_hi: __m256i;
+
+        unsafe {
+            let clr_mask = _mm256_set1_epi8(0x0f);
+
+            let data_0 = _mm256_and_si256(value_lo, clr_mask);
+            prod_lo = _mm256_shuffle_epi8(lut_avx2.t0_lo, data_0);
+            prod_hi = _mm256_shuffle_epi8(lut_avx2.t0_hi, data_0);
+
+            let data_1 = _mm256_and_si256(_mm256_srli_epi64(value_lo, 4), clr_mask);
+            prod_lo = _mm256_xor_si256(prod_lo, _mm256_shuffle_epi8(lut_avx2.t1_lo, data_1));
+            prod_hi = _mm256_xor_si256(prod_hi, _mm256_shuffle_epi8(lut_avx2.t1_hi, data_1));
+
+            let data_0 = _mm256_and_si256(value_hi, clr_mask);
+            prod_lo = _mm256_xor_si256(prod_lo, _mm256_shuffle_epi8(lut_avx2.t2_lo, data_0));
+            prod_hi = _mm256_xor_si256(prod_hi, _mm256_shuffle_epi8(lut_avx2.t2_hi, data_0));
+
+            let data_1 = _mm256_and_si256(_mm256_srli_epi64(value_hi, 4), clr_mask);
+            prod_lo = _mm256_xor_si256(prod_lo, _mm256_shuffle_epi8(lut_avx2.t3_lo, data_1));
+            prod_hi = _mm256_xor_si256(prod_hi, _mm256_shuffle_epi8(lut_avx2.t3_hi, data_1));
+        }
+
+        (prod_lo, prod_hi)
+    }
+
+    //// {x_lo, x_hi} ^= {y_lo, y_hi} * log_m
+    // Implementation of LEO_MULADD_256
+    #[inline(always)]
+    fn muladd_256(
+        mut x_lo: __m256i,
+        mut x_hi: __m256i,
+        y_lo: __m256i,
+        y_hi: __m256i,
+        lut_avx2: LutAvx2,
+    ) -> (__m256i, __m256i) {
+        let (prod_lo, prod_hi) = Self::mul_256(y_lo, y_hi, lut_avx2);
+        unsafe {
+            x_lo = _mm256_xor_si256(x_lo, prod_lo);
+            x_hi = _mm256_xor_si256(x_hi, prod_hi);
+        }
+        (x_lo, x_hi)
+    }
+}
+
+// ======================================================================
+// Avx2 - PRIVATE - FFT (fast Fourier transform)
+
+impl Avx2 {
+    // Implementation of LEO_FFTB_256
+    #[inline(always)]
+    fn fftb_256(x: &mut [u8; 64], y: &mut [u8; 64], lut_avx2: LutAvx2) {
+        let x_ptr = x.as_mut_ptr().cast::<__m256i>();
+        let y_ptr = y.as_mut_ptr().cast::<__m256i>();
+
+        unsafe {
+            let mut x_lo = _mm256_loadu_si256(x_ptr);
+            let mut x_hi = _mm256_loadu_si256(x_ptr.add(1));
+
+            let mut y_lo = _mm256_loadu_si256(y_ptr);
+            let mut y_hi = _mm256_loadu_si256(y_ptr.add(1));
+
+            (x_lo, x_hi) = Self::muladd_256(x_lo, x_hi, y_lo, y_hi, lut_avx2);
+
+            _mm256_storeu_si256(x_ptr, x_lo);
+            _mm256_storeu_si256(x_ptr.add(1), x_hi);
+
+            y_lo = _mm256_xor_si256(y_lo, x_lo);
+            y_hi = _mm256_xor_si256(y_hi, x_hi);
+
+            _mm256_storeu_si256(y_ptr, y_lo);
+            _mm256_storeu_si256(y_ptr.add(1), y_hi);
+        }
+    }
+
+    // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
+    #[inline(always)]
+    fn fft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+        let lut = &self.mul128[log_m as usize];
+        let lut_avx2 = LutAvx2::from(lut);
+
+        for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
+            Self::fftb_256(x_chunk, y_chunk, lut_avx2);
+        }
+    }
+
+    #[inline(always)]
+    fn fft_butterfly_two_layers(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        dist: usize,
+        log_m01: GfElement,
+        log_m23: GfElement,
+        log_m02: GfElement,
+    ) {
+        let (s0, s1, s2, s3) = data.dist4_mut(pos, dist);
+
+        // FIRST LAYER
+
+        if log_m02 == GF_MODULUS {
+            utils::xor(s2, s0);
+            utils::xor(s3, s1);
+        } else {
+            self.fft_butterfly_partial(s0, s2, log_m02);
+            self.fft_butterfly_partial(s1, s3, log_m02);
+        }
+
+        // SECOND LAYER
+
+        if log_m01 == GF_MODULUS {
+            utils::xor(s1, s0);
+        } else {
+            self.fft_butterfly_partial(s0, s1, log_m01);
+        }
+
+        if log_m23 == GF_MODULUS {
+            utils::xor(s3, s2);
+        } else {
+            self.fft_butterfly_partial(s2, s3, log_m23);
+        }
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn fft_private_avx2(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // Drop unsafe privileges
+        self.fft_private(data, pos, size, truncated_size, skew_delta);
+    }
+
+    #[inline(always)]
+    fn fft_private(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // TWO LAYERS AT TIME
+
+        let mut dist4 = size;
+        let mut dist = size >> 2;
+        while dist != 0 {
+            let mut r = 0;
+            while r < truncated_size {
+                let base = r + dist + skew_delta - 1;
+
+                let log_m01 = self.skew[base];
+                let log_m02 = self.skew[base + dist];
+                let log_m23 = self.skew[base + dist * 2];
+
+                for i in r..r + dist {
+                    self.fft_butterfly_two_layers(data, pos + i, dist, log_m01, log_m23, log_m02);
+                }
+
+                r += dist4;
+            }
+            dist4 = dist;
+            dist >>= 2;
+        }
+
+        // FINAL ODD LAYER
+
+        if dist4 == 2 {
+            let mut r = 0;
+            while r < truncated_size {
+                let log_m = self.skew[r + skew_delta];
+
+                let (x, y) = data.dist2_mut(pos + r, 1);
+
+                if log_m == GF_MODULUS {
+                    utils::xor(y, x);
+                } else {
+                    self.fft_butterfly_partial(x, y, log_m);
+                }
+
+                r += 2;
+            }
+        }
+    }
+}
+
+// ======================================================================
+// Avx2 - PRIVATE - IFFT (inverse fast Fourier transform)
+
+impl Avx2 {
+    // Implementation of LEO_IFFTB_256
+    #[inline(always)]
+    fn ifftb_256(x: &mut [u8; 64], y: &mut [u8; 64], lut_avx2: LutAvx2) {
+        let x_ptr = x.as_mut_ptr().cast::<__m256i>();
+        let y_ptr = y.as_mut_ptr().cast::<__m256i>();
+
+        unsafe {
+            let mut x_lo = _mm256_loadu_si256(x_ptr);
+            let mut x_hi = _mm256_loadu_si256(x_ptr.add(1));
+
+            let mut y_lo = _mm256_loadu_si256(y_ptr);
+            let mut y_hi = _mm256_loadu_si256(y_ptr.add(1));
+
+            y_lo = _mm256_xor_si256(y_lo, x_lo);
+            y_hi = _mm256_xor_si256(y_hi, x_hi);
+
+            _mm256_storeu_si256(y_ptr, y_lo);
+            _mm256_storeu_si256(y_ptr.add(1), y_hi);
+
+            (x_lo, x_hi) = Self::muladd_256(x_lo, x_hi, y_lo, y_hi, lut_avx2);
+
+            _mm256_storeu_si256(x_ptr, x_lo);
+            _mm256_storeu_si256(x_ptr.add(1), x_hi);
+        }
+    }
+
+    #[inline(always)]
+    fn ifft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+        let lut = &self.mul128[log_m as usize];
+        let lut_avx2 = LutAvx2::from(lut);
+
+        for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
+            Self::ifftb_256(x_chunk, y_chunk, lut_avx2);
+        }
+    }
+
+    #[inline(always)]
+    fn ifft_butterfly_two_layers(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        dist: usize,
+        log_m01: GfElement,
+        log_m23: GfElement,
+        log_m02: GfElement,
+    ) {
+        let (s0, s1, s2, s3) = data.dist4_mut(pos, dist);
+
+        // FIRST LAYER
+
+        if log_m01 == GF_MODULUS {
+            utils::xor(s1, s0);
+        } else {
+            self.ifft_butterfly_partial(s0, s1, log_m01);
+        }
+
+        if log_m23 == GF_MODULUS {
+            utils::xor(s3, s2);
+        } else {
+            self.ifft_butterfly_partial(s2, s3, log_m23);
+        }
+
+        // SECOND LAYER
+
+        if log_m02 == GF_MODULUS {
+            utils::xor(s2, s0);
+            utils::xor(s3, s1);
+        } else {
+            self.ifft_butterfly_partial(s0, s2, log_m02);
+            self.ifft_butterfly_partial(s1, s3, log_m02);
+        }
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn ifft_private_avx2(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // Drop unsafe privileges
+        self.ifft_private(data, pos, size, truncated_size, skew_delta);
+    }
+
+    #[inline(always)]
+    fn ifft_private(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // TWO LAYERS AT TIME
+
+        let mut dist = 1;
+        let mut dist4 = 4;
+        while dist4 <= size {
+            let mut r = 0;
+            while r < truncated_size {
+                let base = r + dist + skew_delta - 1;
+
+                let log_m01 = self.skew[base];
+                let log_m02 = self.skew[base + dist];
+                let log_m23 = self.skew[base + dist * 2];
+
+                for i in r..r + dist {
+                    self.ifft_butterfly_two_layers(data, pos + i, dist, log_m01, log_m23, log_m02);
+                }
+
+                r += dist4;
+            }
+            dist = dist4;
+            dist4 <<= 2;
+        }
+
+        // FINAL ODD LAYER
+
+        if dist < size {
+            let log_m = self.skew[dist + skew_delta - 1];
+            if log_m == GF_MODULUS {
+                utils::xor_within(data, pos + dist, pos, dist);
+            } else {
+                let (mut a, mut b) = data.split_at_mut(pos + dist);
+                for i in 0..dist {
+                    self.ifft_butterfly_partial(
+                        &mut a[pos + i], // data[pos + i]
+                        &mut b[i],       // data[pos + i + dist]
+                        log_m,
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ======================================================================
+// Avx2 - PRIVATE - Evaluate polynomial
+
+impl Avx2 {
+    #[target_feature(enable = "avx2")]
+    unsafe fn eval_poly_avx2(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        utils::eval_poly(erasures, truncated_size);
+    }
+}
+
+// ======================================================================
+// TESTS
+
+// Engines are tested indirectly via roundtrip tests of HighRate and LowRate.

--- a/cryptography/src/reed_solomon/engine/engine_default.rs
+++ b/cryptography/src/reed_solomon/engine/engine_default.rs
@@ -1,0 +1,115 @@
+#[cfg(target_arch = "aarch64")]
+use crate::reed_solomon::engine::Neon;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use crate::reed_solomon::engine::{Avx2, Ssse3};
+use crate::reed_solomon::engine::{Engine, GfElement, NoSimd, ShardsRefMut, GF_ORDER};
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
+// ======================================================================
+// DefaultEngine - PUBLIC
+
+/// [`Engine`] that at runtime selects the best Engine.
+pub struct DefaultEngine(Box<dyn Engine + Send + Sync>);
+
+impl DefaultEngine {
+    /// Creates new [`DefaultEngine`] by chosing and initializing the underlying engine.
+    ///
+    /// On x86(-64) the engine is chosen in the following order of preference:
+    /// 1. `Avx2`
+    /// 2. `Ssse3`
+    /// 3. [`NoSimd`]
+    ///
+    /// On `AArch64` the engine is chosen in the following order of preference:
+    /// 1. `Neon`
+    /// 2. [`NoSimd`]
+    pub fn new() -> Self {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            cpufeatures::new!(has_avx2, "avx2");
+            if has_avx2::get() {
+                return Self(Box::new(Avx2::new()));
+            }
+
+            cpufeatures::new!(has_ssse3, "ssse3");
+            if has_ssse3::get() {
+                return Self(Box::new(Ssse3::new()));
+            }
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            cpufeatures::new!(has_neon, "neon");
+            if has_neon::get() {
+                return Self(Box::new(Neon::new()));
+            }
+        }
+
+        Self(Box::new(NoSimd::new()))
+    }
+}
+
+// ======================================================================
+// DefaultEngine - IMPL Default
+
+impl Default for DefaultEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ======================================================================
+// DefaultEngine - IMPL Engine
+
+impl Engine for DefaultEngine {
+    fn fft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        self.0.fft(data, pos, size, truncated_size, skew_delta);
+    }
+
+    fn ifft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        self.0.ifft(data, pos, size, truncated_size, skew_delta);
+    }
+
+    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+        self.0.mul(x, log_m);
+    }
+
+    fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            cpufeatures::new!(has_avx2, "avx2");
+            if has_avx2::get() {
+                return Avx2::eval_poly(erasures, truncated_size);
+            }
+
+            cpufeatures::new!(has_ssse3, "ssse3");
+            if has_ssse3::get() {
+                return Ssse3::eval_poly(erasures, truncated_size);
+            }
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            cpufeatures::new!(has_neon, "neon");
+            if has_neon::get() {
+                return Neon::eval_poly(erasures, truncated_size);
+            }
+        }
+
+        NoSimd::eval_poly(erasures, truncated_size);
+    }
+}

--- a/cryptography/src/reed_solomon/engine/engine_default.rs
+++ b/cryptography/src/reed_solomon/engine/engine_default.rs
@@ -2,7 +2,9 @@
 use crate::reed_solomon::engine::Neon;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use crate::reed_solomon::engine::{Avx2, Ssse3};
-use crate::reed_solomon::engine::{Engine, GfElement, NoSimd, ShardsRefMut, GF_ORDER};
+use crate::reed_solomon::engine::{
+    Engine, GfElement, NoSimd, ShardsRefMut, GF_ORDER, SHARD_CHUNK_BYTES,
+};
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 
@@ -64,7 +66,7 @@ impl Default for DefaultEngine {
 impl Engine for DefaultEngine {
     fn fft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -75,7 +77,7 @@ impl Engine for DefaultEngine {
 
     fn ifft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -84,7 +86,7 @@ impl Engine for DefaultEngine {
         self.0.ifft(data, pos, size, truncated_size, skew_delta);
     }
 
-    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+    fn mul(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement) {
         self.0.mul(x, log_m);
     }
 

--- a/cryptography/src/reed_solomon/engine/engine_naive.rs
+++ b/cryptography/src/reed_solomon/engine/engine_naive.rs
@@ -1,0 +1,152 @@
+use crate::reed_solomon::engine::{
+    tables::{self, Exp, Log, Skew},
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS,
+};
+
+// ======================================================================
+// Naive - PUBLIC
+
+/// Simple reference implementation of [`Engine`].
+///
+/// - [`Naive`] is meant for those who want to study
+///   the source code to understand [`Engine`].
+/// - [`Naive`] also includes some debug assertions
+///   which are not present in other implementations.
+#[derive(Clone, Copy)]
+pub struct Naive {
+    exp: &'static Exp,
+    log: &'static Log,
+    skew: &'static Skew,
+}
+
+impl Naive {
+    /// Creates new [`Naive`], initializing all [tables]
+    /// needed for encoding or decoding.
+    ///
+    /// Currently only difference between encoding/decoding is
+    /// [`LogWalsh`] (128 kiB) which is only needed for decoding.
+    ///
+    /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
+    pub fn new() -> Self {
+        let exp_log = tables::get_exp_log();
+        let skew = tables::get_skew();
+
+        Self {
+            exp: &exp_log.exp,
+            log: &exp_log.log,
+            skew,
+        }
+    }
+}
+
+impl Engine for Naive {
+    fn fft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        debug_assert!(size.is_power_of_two());
+        debug_assert!(truncated_size <= size);
+
+        let mut dist = size / 2;
+        while dist > 0 {
+            let mut r = 0;
+            while r < truncated_size {
+                let log_m = self.skew[r + dist + skew_delta - 1];
+                for i in r..r + dist {
+                    let (a, b) = data.dist2_mut(pos + i, dist);
+
+                    // FFT BUTTERFLY
+
+                    if log_m != GF_MODULUS {
+                        self.mul_add(a, b, log_m);
+                    }
+                    utils::xor(b, a);
+                }
+                r += dist * 2;
+            }
+            dist /= 2;
+        }
+    }
+
+    fn ifft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        debug_assert!(size.is_power_of_two());
+        debug_assert!(truncated_size <= size);
+
+        let mut dist = 1;
+        while dist < size {
+            let mut r = 0;
+            while r < truncated_size {
+                let log_m = self.skew[r + dist + skew_delta - 1];
+                for i in r..r + dist {
+                    let (a, b) = data.dist2_mut(pos + i, dist);
+
+                    // IFFT BUTTERFLY
+
+                    utils::xor(b, a);
+                    if log_m != GF_MODULUS {
+                        self.mul_add(a, b, log_m);
+                    }
+                }
+                r += dist * 2;
+            }
+            dist *= 2;
+        }
+    }
+
+    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+        for chunk in x.iter_mut() {
+            for i in 0..32 {
+                let lo = GfElement::from(chunk[i]);
+                let hi = GfElement::from(chunk[i + 32]);
+                let prod = tables::mul(lo | (hi << 8), log_m, self.exp, self.log);
+                chunk[i] = prod as u8;
+                chunk[i + 32] = (prod >> 8) as u8;
+            }
+        }
+    }
+}
+
+// ======================================================================
+// Naive - IMPL Default
+
+impl Default for Naive {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ======================================================================
+// Naive - PRIVATE
+
+impl Naive {
+    /// `x[] ^= y[] * log_m`
+    fn mul_add(&self, x: &mut [[u8; 64]], y: &[[u8; 64]], log_m: GfElement) {
+        debug_assert_eq!(x.len(), y.len());
+
+        for (x_chunk, y_chunk) in core::iter::zip(x.iter_mut(), y.iter()) {
+            for i in 0..32 {
+                let lo = GfElement::from(y_chunk[i]);
+                let hi = GfElement::from(y_chunk[i + 32]);
+                let prod = tables::mul(lo | (hi << 8), log_m, self.exp, self.log);
+                x_chunk[i] ^= prod as u8;
+                x_chunk[i + 32] ^= (prod >> 8) as u8;
+            }
+        }
+    }
+}
+
+// ======================================================================
+// TESTS
+
+// Engines are tested indirectly via roundtrip tests of HighRate and LowRate.

--- a/cryptography/src/reed_solomon/engine/engine_naive.rs
+++ b/cryptography/src/reed_solomon/engine/engine_naive.rs
@@ -1,6 +1,6 @@
 use crate::reed_solomon::engine::{
     tables::{self, Exp, Log, Skew},
-    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS,
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, SHARD_CHUNK_BYTES,
 };
 
 // ======================================================================
@@ -10,7 +10,7 @@ use crate::reed_solomon::engine::{
 ///
 /// - [`Naive`] is meant for those who want to study
 ///   the source code to understand [`Engine`].
-/// - [`Naive`] also includes some debug assertions
+/// - [`Naive`] also includes some assertions
 ///   which are not present in other implementations.
 #[derive(Clone, Copy)]
 pub struct Naive {
@@ -42,14 +42,14 @@ impl Naive {
 impl Engine for Naive {
     fn fft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
         skew_delta: usize,
     ) {
-        debug_assert!(size.is_power_of_two());
-        debug_assert!(truncated_size <= size);
+        assert!(size.is_power_of_two());
+        assert!(truncated_size <= size);
 
         let mut dist = size / 2;
         while dist > 0 {
@@ -74,14 +74,14 @@ impl Engine for Naive {
 
     fn ifft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
         skew_delta: usize,
     ) {
-        debug_assert!(size.is_power_of_two());
-        debug_assert!(truncated_size <= size);
+        assert!(size.is_power_of_two());
+        assert!(truncated_size <= size);
 
         let mut dist = 1;
         while dist < size {
@@ -104,14 +104,14 @@ impl Engine for Naive {
         }
     }
 
-    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+    fn mul(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement) {
         for chunk in x.iter_mut() {
-            for i in 0..32 {
+            for i in 0..SHARD_CHUNK_BYTES / 2 {
                 let lo = GfElement::from(chunk[i]);
-                let hi = GfElement::from(chunk[i + 32]);
+                let hi = GfElement::from(chunk[i + SHARD_CHUNK_BYTES / 2]);
                 let prod = tables::mul(lo | (hi << 8), log_m, self.exp, self.log);
                 chunk[i] = prod as u8;
-                chunk[i + 32] = (prod >> 8) as u8;
+                chunk[i + SHARD_CHUNK_BYTES / 2] = (prod >> 8) as u8;
             }
         }
     }
@@ -131,16 +131,21 @@ impl Default for Naive {
 
 impl Naive {
     /// `x[] ^= y[] * log_m`
-    fn mul_add(&self, x: &mut [[u8; 64]], y: &[[u8; 64]], log_m: GfElement) {
-        debug_assert_eq!(x.len(), y.len());
+    fn mul_add(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &[[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
+        assert_eq!(x.len(), y.len());
 
         for (x_chunk, y_chunk) in core::iter::zip(x.iter_mut(), y.iter()) {
-            for i in 0..32 {
+            for i in 0..SHARD_CHUNK_BYTES / 2 {
                 let lo = GfElement::from(y_chunk[i]);
-                let hi = GfElement::from(y_chunk[i + 32]);
+                let hi = GfElement::from(y_chunk[i + SHARD_CHUNK_BYTES / 2]);
                 let prod = tables::mul(lo | (hi << 8), log_m, self.exp, self.log);
                 x_chunk[i] ^= prod as u8;
-                x_chunk[i + 32] ^= (prod >> 8) as u8;
+                x_chunk[i + SHARD_CHUNK_BYTES / 2] ^= (prod >> 8) as u8;
             }
         }
     }

--- a/cryptography/src/reed_solomon/engine/engine_neon.rs
+++ b/cryptography/src/reed_solomon/engine/engine_neon.rs
@@ -1,0 +1,492 @@
+use crate::reed_solomon::engine::{
+    tables::{self, Mul128, Multiply128lutT, Skew},
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER,
+};
+use core::{arch::aarch64::*, iter::zip};
+
+// ======================================================================
+// Neon - PUBLIC
+
+/// Optimized [`Engine`] using Arm Neon instructions.
+///
+/// [`Neon`] is an optimized engine that follows the same algorithm as
+/// [`NoSimd`] but takes advantage of the Arm Neon SIMD instructions.
+///
+/// [`NoSimd`]: crate::reed_solomon::engine::NoSimd
+#[derive(Clone, Copy)]
+pub struct Neon {
+    mul128: &'static Mul128,
+    skew: &'static Skew,
+}
+
+impl Neon {
+    /// Creates new [`Neon`], initializing all [tables]
+    /// needed for encoding or decoding.
+    ///
+    /// Currently only difference between encoding/decoding is
+    /// [`LogWalsh`] (128 kiB) which is only needed for decoding.
+    ///
+    /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
+    pub fn new() -> Self {
+        let mul128 = tables::get_mul128();
+        let skew = tables::get_skew();
+
+        Self { mul128, skew }
+    }
+}
+
+impl Engine for Neon {
+    fn fft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        unsafe {
+            self.fft_private_neon(data, pos, size, truncated_size, skew_delta);
+        }
+    }
+
+    fn ifft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        unsafe {
+            self.ifft_private_neon(data, pos, size, truncated_size, skew_delta);
+        }
+    }
+
+    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+        unsafe {
+            self.mul_neon(x, log_m);
+        }
+    }
+
+    fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        unsafe { Self::eval_poly_neon(erasures, truncated_size) }
+    }
+}
+
+// ======================================================================
+// Neon - IMPL Default
+
+impl Default for Neon {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ======================================================================
+// Neon - PRIVATE
+//
+//
+
+impl Neon {
+    #[target_feature(enable = "neon")]
+    unsafe fn mul_neon(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+        let lut = &self.mul128[log_m as usize];
+
+        for chunk in x.iter_mut() {
+            let x_ptr: *mut u8 = chunk.as_mut_ptr();
+            unsafe {
+                let x0_lo = vld1q_u8(x_ptr);
+                let x1_lo = vld1q_u8(x_ptr.add(16));
+                let x0_hi = vld1q_u8(x_ptr.add(16 * 2));
+                let x1_hi = vld1q_u8(x_ptr.add(16 * 3));
+
+                let (prod0_lo, prod0_hi) = Self::mul_128(x0_lo, x0_hi, lut);
+                let (prod1_lo, prod1_hi) = Self::mul_128(x1_lo, x1_hi, lut);
+
+                vst1q_u8(x_ptr, prod0_lo);
+                vst1q_u8(x_ptr.add(16), prod1_lo);
+                vst1q_u8(x_ptr.add(16 * 2), prod0_hi);
+                vst1q_u8(x_ptr.add(16 * 3), prod1_hi);
+            }
+        }
+    }
+
+    // Impelemntation of LEO_MUL_128
+    #[inline(always)]
+    fn mul_128(
+        value_lo: uint8x16_t,
+        value_hi: uint8x16_t,
+        lut: &Multiply128lutT,
+    ) -> (uint8x16_t, uint8x16_t) {
+        let mut prod_lo: uint8x16_t;
+        let mut prod_hi: uint8x16_t;
+
+        unsafe {
+            let t0_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<u8>());
+            let t1_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<u8>());
+            let t2_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[2]).cast::<u8>());
+            let t3_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[3]).cast::<u8>());
+
+            let t0_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[0]).cast::<u8>());
+            let t1_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[1]).cast::<u8>());
+            let t2_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[2]).cast::<u8>());
+            let t3_hi = vld1q_u8(core::ptr::from_ref::<u128>(&lut.hi[3]).cast::<u8>());
+
+            let clr_mask = vdupq_n_u8(0x0f);
+
+            let data_0 = vandq_u8(value_lo, clr_mask);
+            prod_lo = vqtbl1q_u8(t0_lo, data_0);
+            prod_hi = vqtbl1q_u8(t0_hi, data_0);
+
+            let data_1 = vshrq_n_u8(value_lo, 4);
+            prod_lo = veorq_u8(prod_lo, vqtbl1q_u8(t1_lo, data_1));
+            prod_hi = veorq_u8(prod_hi, vqtbl1q_u8(t1_hi, data_1));
+
+            let data_0 = vandq_u8(value_hi, clr_mask);
+            prod_lo = veorq_u8(prod_lo, vqtbl1q_u8(t2_lo, data_0));
+            prod_hi = veorq_u8(prod_hi, vqtbl1q_u8(t2_hi, data_0));
+
+            let data_1 = vshrq_n_u8(value_hi, 4);
+            prod_lo = veorq_u8(prod_lo, vqtbl1q_u8(t3_lo, data_1));
+            prod_hi = veorq_u8(prod_hi, vqtbl1q_u8(t3_hi, data_1));
+        }
+
+        (prod_lo, prod_hi)
+    }
+
+    //// {x_lo, x_hi} ^= {y_lo, y_hi} * log_m
+    // Implementation of LEO_MULADD_128
+    #[inline(always)]
+    fn muladd_128(
+        mut x_lo: uint8x16_t,
+        mut x_hi: uint8x16_t,
+        y_lo: uint8x16_t,
+        y_hi: uint8x16_t,
+        lut: &Multiply128lutT,
+    ) -> (uint8x16_t, uint8x16_t) {
+        let (prod_lo, prod_hi) = Self::mul_128(y_lo, y_hi, lut);
+        unsafe {
+            x_lo = veorq_u8(x_lo, prod_lo);
+            x_hi = veorq_u8(x_hi, prod_hi);
+        }
+        (x_lo, x_hi)
+    }
+}
+
+// ======================================================================
+// Neon - PRIVATE - FFT (fast Fourier transform)
+
+impl Neon {
+    // Implementation of LEO_FFTB_128
+    #[inline(always)]
+    fn fftb_128(&self, x: &mut [u8; 64], y: &mut [u8; 64], log_m: GfElement) {
+        let lut = &self.mul128[log_m as usize];
+        let x_ptr: *mut u8 = x.as_mut_ptr();
+        let y_ptr: *mut u8 = y.as_mut_ptr();
+        unsafe {
+            let mut x0_lo = vld1q_u8(x_ptr);
+            let mut x1_lo = vld1q_u8(x_ptr.add(16));
+            let mut x0_hi = vld1q_u8(x_ptr.add(16 * 2));
+            let mut x1_hi = vld1q_u8(x_ptr.add(16 * 3));
+
+            let mut y0_lo = vld1q_u8(y_ptr);
+            let mut y1_lo = vld1q_u8(y_ptr.add(16));
+            let mut y0_hi = vld1q_u8(y_ptr.add(16 * 2));
+            let mut y1_hi = vld1q_u8(y_ptr.add(16 * 3));
+
+            (x0_lo, x0_hi) = Self::muladd_128(x0_lo, x0_hi, y0_lo, y0_hi, lut);
+            (x1_lo, x1_hi) = Self::muladd_128(x1_lo, x1_hi, y1_lo, y1_hi, lut);
+
+            vst1q_u8(x_ptr, x0_lo);
+            vst1q_u8(x_ptr.add(16), x1_lo);
+            vst1q_u8(x_ptr.add(16 * 2), x0_hi);
+            vst1q_u8(x_ptr.add(16 * 3), x1_hi);
+
+            y0_lo = veorq_u8(y0_lo, x0_lo);
+            y1_lo = veorq_u8(y1_lo, x1_lo);
+            y0_hi = veorq_u8(y0_hi, x0_hi);
+            y1_hi = veorq_u8(y1_hi, x1_hi);
+
+            vst1q_u8(y_ptr, y0_lo);
+            vst1q_u8(y_ptr.add(16), y1_lo);
+            vst1q_u8(y_ptr.add(16 * 2), y0_hi);
+            vst1q_u8(y_ptr.add(16 * 3), y1_hi);
+        }
+    }
+
+    // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
+    #[inline(always)]
+    fn fft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+        for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
+            self.fftb_128(x_chunk, y_chunk, log_m);
+        }
+    }
+
+    #[inline(always)]
+    fn fft_butterfly_two_layers(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        dist: usize,
+        log_m01: GfElement,
+        log_m23: GfElement,
+        log_m02: GfElement,
+    ) {
+        let (s0, s1, s2, s3) = data.dist4_mut(pos, dist);
+
+        // FIRST LAYER
+
+        if log_m02 == GF_MODULUS {
+            utils::xor(s2, s0);
+            utils::xor(s3, s1);
+        } else {
+            self.fft_butterfly_partial(s0, s2, log_m02);
+            self.fft_butterfly_partial(s1, s3, log_m02);
+        }
+
+        // SECOND LAYER
+
+        if log_m01 == GF_MODULUS {
+            utils::xor(s1, s0);
+        } else {
+            self.fft_butterfly_partial(s0, s1, log_m01);
+        }
+
+        if log_m23 == GF_MODULUS {
+            utils::xor(s3, s2);
+        } else {
+            self.fft_butterfly_partial(s2, s3, log_m23);
+        }
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn fft_private_neon(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // Drop unsafe privileges
+        self.fft_private(data, pos, size, truncated_size, skew_delta);
+    }
+
+    #[inline(always)]
+    fn fft_private(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // TWO LAYERS AT TIME
+
+        let mut dist4 = size;
+        let mut dist = size >> 2;
+        while dist != 0 {
+            let mut r = 0;
+            while r < truncated_size {
+                let base = r + dist + skew_delta - 1;
+
+                let log_m01 = self.skew[base];
+                let log_m02 = self.skew[base + dist];
+                let log_m23 = self.skew[base + dist * 2];
+
+                for i in r..r + dist {
+                    self.fft_butterfly_two_layers(data, pos + i, dist, log_m01, log_m23, log_m02);
+                }
+
+                r += dist4;
+            }
+            dist4 = dist;
+            dist >>= 2;
+        }
+
+        // FINAL ODD LAYER
+
+        if dist4 == 2 {
+            let mut r = 0;
+            while r < truncated_size {
+                let log_m = self.skew[r + skew_delta];
+
+                let (x, y) = data.dist2_mut(pos + r, 1);
+
+                if log_m == GF_MODULUS {
+                    utils::xor(y, x);
+                } else {
+                    self.fft_butterfly_partial(x, y, log_m);
+                }
+
+                r += 2;
+            }
+        }
+    }
+}
+
+// ======================================================================
+// Neon - PRIVATE - IFFT (inverse fast Fourier transform)
+
+impl Neon {
+    // Implementation of LEO_IFFTB_128
+    #[inline(always)]
+    fn ifftb_128(&self, x: &mut [u8; 64], y: &mut [u8; 64], log_m: GfElement) {
+        let lut = &self.mul128[log_m as usize];
+        let x_ptr: *mut u8 = x.as_mut_ptr();
+        let y_ptr: *mut u8 = y.as_mut_ptr();
+
+        unsafe {
+            let mut x0_lo = vld1q_u8(x_ptr);
+            let mut x1_lo = vld1q_u8(x_ptr.add(16));
+            let mut x0_hi = vld1q_u8(x_ptr.add(16 * 2));
+            let mut x1_hi = vld1q_u8(x_ptr.add(16 * 3));
+
+            let mut y0_lo = vld1q_u8(y_ptr);
+            let mut y1_lo = vld1q_u8(y_ptr.add(16));
+            let mut y0_hi = vld1q_u8(y_ptr.add(16 * 2));
+            let mut y1_hi = vld1q_u8(y_ptr.add(16 * 3));
+
+            y0_lo = veorq_u8(y0_lo, x0_lo);
+            y1_lo = veorq_u8(y1_lo, x1_lo);
+            y0_hi = veorq_u8(y0_hi, x0_hi);
+            y1_hi = veorq_u8(y1_hi, x1_hi);
+
+            vst1q_u8(y_ptr, y0_lo);
+            vst1q_u8(y_ptr.add(16), y1_lo);
+            vst1q_u8(y_ptr.add(16 * 2), y0_hi);
+            vst1q_u8(y_ptr.add(16 * 3), y1_hi);
+
+            (x0_lo, x0_hi) = Self::muladd_128(x0_lo, x0_hi, y0_lo, y0_hi, lut);
+            (x1_lo, x1_hi) = Self::muladd_128(x1_lo, x1_hi, y1_lo, y1_hi, lut);
+
+            vst1q_u8(x_ptr, x0_lo);
+            vst1q_u8(x_ptr.add(16), x1_lo);
+            vst1q_u8(x_ptr.add(16 * 2), x0_hi);
+            vst1q_u8(x_ptr.add(16 * 3), x1_hi);
+        }
+    }
+
+    #[inline(always)]
+    fn ifft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+        for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
+            self.ifftb_128(x_chunk, y_chunk, log_m);
+        }
+    }
+
+    #[inline(always)]
+    fn ifft_butterfly_two_layers(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        dist: usize,
+        log_m01: GfElement,
+        log_m23: GfElement,
+        log_m02: GfElement,
+    ) {
+        let (s0, s1, s2, s3) = data.dist4_mut(pos, dist);
+
+        // FIRST LAYER
+
+        if log_m01 == GF_MODULUS {
+            utils::xor(s1, s0);
+        } else {
+            self.ifft_butterfly_partial(s0, s1, log_m01);
+        }
+
+        if log_m23 == GF_MODULUS {
+            utils::xor(s3, s2);
+        } else {
+            self.ifft_butterfly_partial(s2, s3, log_m23);
+        }
+
+        // SECOND LAYER
+
+        if log_m02 == GF_MODULUS {
+            utils::xor(s2, s0);
+            utils::xor(s3, s1);
+        } else {
+            self.ifft_butterfly_partial(s0, s2, log_m02);
+            self.ifft_butterfly_partial(s1, s3, log_m02);
+        }
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn ifft_private_neon(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // Drop unsafe privileges
+        self.ifft_private(data, pos, size, truncated_size, skew_delta);
+    }
+
+    #[inline(always)]
+    fn ifft_private(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // TWO LAYERS AT TIME
+
+        let mut dist = 1;
+        let mut dist4 = 4;
+        while dist4 <= size {
+            let mut r = 0;
+            while r < truncated_size {
+                let base = r + dist + skew_delta - 1;
+
+                let log_m01 = self.skew[base];
+                let log_m02 = self.skew[base + dist];
+                let log_m23 = self.skew[base + dist * 2];
+
+                for i in r..r + dist {
+                    self.ifft_butterfly_two_layers(data, pos + i, dist, log_m01, log_m23, log_m02);
+                }
+
+                r += dist4;
+            }
+            dist = dist4;
+            dist4 <<= 2;
+        }
+
+        // FINAL ODD LAYER
+
+        if dist < size {
+            let log_m = self.skew[dist + skew_delta - 1];
+            if log_m == GF_MODULUS {
+                utils::xor_within(data, pos + dist, pos, dist);
+            } else {
+                let (mut a, mut b) = data.split_at_mut(pos + dist);
+                for i in 0..dist {
+                    self.ifft_butterfly_partial(
+                        &mut a[pos + i], // data[pos + i]
+                        &mut b[i],       // data[pos + i + dist]
+                        log_m,
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ======================================================================
+// Neon - PRIVATE - Evaluate polynomial
+
+impl Neon {
+    #[target_feature(enable = "neon")]
+    unsafe fn eval_poly_neon(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        utils::eval_poly(erasures, truncated_size);
+    }
+}
+
+// ======================================================================
+// TESTS
+
+// Engines are tested indirectly via roundtrip tests of HighRate and LowRate.

--- a/cryptography/src/reed_solomon/engine/engine_neon.rs
+++ b/cryptography/src/reed_solomon/engine/engine_neon.rs
@@ -1,6 +1,6 @@
 use crate::reed_solomon::engine::{
     tables::{self, Mul128, Multiply128lutT, Skew},
-    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER,
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER, SHARD_CHUNK_BYTES,
 };
 use core::{arch::aarch64::*, iter::zip};
 
@@ -28,6 +28,9 @@ impl Neon {
     ///
     /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
     pub fn new() -> Self {
+        cpufeatures::new!(has_neon_for_engine, "neon");
+        assert!(has_neon_for_engine::get());
+
         let mul128 = tables::get_mul128();
         let skew = tables::get_skew();
 
@@ -38,12 +41,13 @@ impl Neon {
 impl Engine for Neon {
     fn fft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
         skew_delta: usize,
     ) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             self.fft_private_neon(data, pos, size, truncated_size, skew_delta);
         }
@@ -51,24 +55,27 @@ impl Engine for Neon {
 
     fn ifft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
         skew_delta: usize,
     ) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             self.ifft_private_neon(data, pos, size, truncated_size, skew_delta);
         }
     }
 
-    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+    fn mul(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             self.mul_neon(x, log_m);
         }
     }
 
     fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe { Self::eval_poly_neon(erasures, truncated_size) }
     }
 }
@@ -89,11 +96,12 @@ impl Default for Neon {
 
 impl Neon {
     #[target_feature(enable = "neon")]
-    unsafe fn mul_neon(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+    unsafe fn mul_neon(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement) {
         let lut = &self.mul128[log_m as usize];
 
         for chunk in x.iter_mut() {
             let x_ptr: *mut u8 = chunk.as_mut_ptr();
+            // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
             unsafe {
                 let x0_lo = vld1q_u8(x_ptr);
                 let x1_lo = vld1q_u8(x_ptr.add(16));
@@ -121,6 +129,7 @@ impl Neon {
         let mut prod_lo: uint8x16_t;
         let mut prod_hi: uint8x16_t;
 
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             let t0_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<u8>());
             let t1_lo = vld1q_u8(core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<u8>());
@@ -165,6 +174,7 @@ impl Neon {
         lut: &Multiply128lutT,
     ) -> (uint8x16_t, uint8x16_t) {
         let (prod_lo, prod_hi) = Self::mul_128(y_lo, y_hi, lut);
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             x_lo = veorq_u8(x_lo, prod_lo);
             x_hi = veorq_u8(x_hi, prod_hi);
@@ -179,10 +189,16 @@ impl Neon {
 impl Neon {
     // Implementation of LEO_FFTB_128
     #[inline(always)]
-    fn fftb_128(&self, x: &mut [u8; 64], y: &mut [u8; 64], log_m: GfElement) {
+    fn fftb_128(
+        &self,
+        x: &mut [u8; SHARD_CHUNK_BYTES],
+        y: &mut [u8; SHARD_CHUNK_BYTES],
+        log_m: GfElement,
+    ) {
         let lut = &self.mul128[log_m as usize];
         let x_ptr: *mut u8 = x.as_mut_ptr();
         let y_ptr: *mut u8 = y.as_mut_ptr();
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             let mut x0_lo = vld1q_u8(x_ptr);
             let mut x1_lo = vld1q_u8(x_ptr.add(16));
@@ -216,7 +232,12 @@ impl Neon {
 
     // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
     #[inline(always)]
-    fn fft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+    fn fft_butterfly_partial(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &mut [[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
         for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
             self.fftb_128(x_chunk, y_chunk, log_m);
         }
@@ -225,7 +246,7 @@ impl Neon {
     #[inline(always)]
     fn fft_butterfly_two_layers(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         dist: usize,
         log_m01: GfElement,
@@ -262,7 +283,7 @@ impl Neon {
     #[target_feature(enable = "neon")]
     unsafe fn fft_private_neon(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -275,7 +296,7 @@ impl Neon {
     #[inline(always)]
     fn fft_private(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -331,11 +352,17 @@ impl Neon {
 impl Neon {
     // Implementation of LEO_IFFTB_128
     #[inline(always)]
-    fn ifftb_128(&self, x: &mut [u8; 64], y: &mut [u8; 64], log_m: GfElement) {
+    fn ifftb_128(
+        &self,
+        x: &mut [u8; SHARD_CHUNK_BYTES],
+        y: &mut [u8; SHARD_CHUNK_BYTES],
+        log_m: GfElement,
+    ) {
         let lut = &self.mul128[log_m as usize];
         let x_ptr: *mut u8 = x.as_mut_ptr();
         let y_ptr: *mut u8 = y.as_mut_ptr();
 
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             let mut x0_lo = vld1q_u8(x_ptr);
             let mut x1_lo = vld1q_u8(x_ptr.add(16));
@@ -368,7 +395,12 @@ impl Neon {
     }
 
     #[inline(always)]
-    fn ifft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+    fn ifft_butterfly_partial(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &mut [[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
         for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
             self.ifftb_128(x_chunk, y_chunk, log_m);
         }
@@ -377,7 +409,7 @@ impl Neon {
     #[inline(always)]
     fn ifft_butterfly_two_layers(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         dist: usize,
         log_m01: GfElement,
@@ -414,7 +446,7 @@ impl Neon {
     #[target_feature(enable = "neon")]
     unsafe fn ifft_private_neon(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -427,7 +459,7 @@ impl Neon {
     #[inline(always)]
     fn ifft_private(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,

--- a/cryptography/src/reed_solomon/engine/engine_neon.rs
+++ b/cryptography/src/reed_solomon/engine/engine_neon.rs
@@ -91,8 +91,6 @@ impl Default for Neon {
 
 // ======================================================================
 // Neon - PRIVATE
-//
-//
 
 impl Neon {
     #[target_feature(enable = "neon")]
@@ -119,7 +117,7 @@ impl Neon {
         }
     }
 
-    // Impelemntation of LEO_MUL_128
+    // Implementation of LEO_MUL_128
     #[inline(always)]
     fn mul_128(
         value_lo: uint8x16_t,
@@ -163,7 +161,7 @@ impl Neon {
         (prod_lo, prod_hi)
     }
 
-    //// {x_lo, x_hi} ^= {y_lo, y_hi} * log_m
+    // {x_lo, x_hi} ^= {y_lo, y_hi} * log_m.
     // Implementation of LEO_MULADD_128
     #[inline(always)]
     fn muladd_128(
@@ -289,7 +287,6 @@ impl Neon {
         truncated_size: usize,
         skew_delta: usize,
     ) {
-        // Drop unsafe privileges
         self.fft_private(data, pos, size, truncated_size, skew_delta);
     }
 
@@ -452,7 +449,6 @@ impl Neon {
         truncated_size: usize,
         skew_delta: usize,
     ) {
-        // Drop unsafe privileges
         self.ifft_private(data, pos, size, truncated_size, skew_delta);
     }
 

--- a/cryptography/src/reed_solomon/engine/engine_nosimd.rs
+++ b/cryptography/src/reed_solomon/engine/engine_nosimd.rs
@@ -1,6 +1,6 @@
 use crate::reed_solomon::engine::{
     tables::{self, Mul16, Skew},
-    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS,
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, SHARD_CHUNK_BYTES,
 };
 use core::iter::zip;
 
@@ -35,7 +35,7 @@ impl NoSimd {
 impl Engine for NoSimd {
     fn fft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -46,7 +46,7 @@ impl Engine for NoSimd {
 
     fn ifft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -55,13 +55,13 @@ impl Engine for NoSimd {
         self.ifft_private(data, pos, size, truncated_size, skew_delta);
     }
 
-    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+    fn mul(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement) {
         let lut = &self.mul16[log_m as usize];
 
         for x_chunk in x.iter_mut() {
-            let (x_lo, x_hi) = x_chunk.split_at_mut(32);
+            let (x_lo, x_hi) = x_chunk.split_at_mut(SHARD_CHUNK_BYTES / 2);
 
-            for i in 0..32 {
+            for i in 0..SHARD_CHUNK_BYTES / 2 {
                 let lo = x_lo[i];
                 let hi = x_hi[i];
                 let prod = lut[0][usize::from(lo & 15)]
@@ -89,14 +89,19 @@ impl Default for NoSimd {
 
 impl NoSimd {
     /// `x[] ^= y[] * log_m`
-    fn mul_add(&self, x: &mut [[u8; 64]], y: &[[u8; 64]], log_m: GfElement) {
+    fn mul_add(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &[[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
         let lut = &self.mul16[log_m as usize];
 
         for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter()) {
-            let (x_lo, x_hi) = x_chunk.split_at_mut(32);
-            let (y_lo, y_hi) = y_chunk.split_at(32);
+            let (x_lo, x_hi) = x_chunk.split_at_mut(SHARD_CHUNK_BYTES / 2);
+            let (y_lo, y_hi) = y_chunk.split_at(SHARD_CHUNK_BYTES / 2);
 
-            for i in 0..32 {
+            for i in 0..SHARD_CHUNK_BYTES / 2 {
                 let lo = y_lo[i];
                 let hi = y_hi[i];
                 let prod = lut[0][usize::from(lo & 15)]
@@ -116,7 +121,12 @@ impl NoSimd {
 impl NoSimd {
     // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
     #[inline(always)]
-    fn fft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+    fn fft_butterfly_partial(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &mut [[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
         self.mul_add(x, y, log_m);
         utils::xor(y, x);
     }
@@ -124,7 +134,7 @@ impl NoSimd {
     #[inline(always)]
     fn fft_butterfly_two_layers(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         dist: usize,
         log_m01: GfElement,
@@ -161,7 +171,7 @@ impl NoSimd {
     #[inline(always)]
     fn fft_private(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -217,7 +227,12 @@ impl NoSimd {
 impl NoSimd {
     // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
     #[inline(always)]
-    fn ifft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+    fn ifft_butterfly_partial(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &mut [[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
         utils::xor(y, x);
         self.mul_add(x, y, log_m);
     }
@@ -225,7 +240,7 @@ impl NoSimd {
     #[inline(always)]
     fn ifft_butterfly_two_layers(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         dist: usize,
         log_m01: GfElement,
@@ -262,7 +277,7 @@ impl NoSimd {
     #[inline(always)]
     fn ifft_private(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -318,7 +333,7 @@ impl NoSimd {
 
 #[cfg(test)]
 mod tests {
-    use crate::reed_solomon::engine::{Engine, Naive, NoSimd};
+    use crate::reed_solomon::engine::{Engine, Naive, NoSimd, SHARD_CHUNK_BYTES};
     #[cfg(not(feature = "std"))]
     use alloc::vec;
     use rand::{Rng, RngCore, SeedableRng};
@@ -332,7 +347,7 @@ mod tests {
         let mut rng = ChaCha8Rng::from_seed([0; 32]);
 
         for shard_chunks in 0..6 {
-            let mut data_nosimd = vec![[0; 64]; shard_chunks];
+            let mut data_nosimd = vec![[0; SHARD_CHUNK_BYTES]; shard_chunks];
             rng.fill_bytes(data_nosimd.as_flattened_mut());
             let mut data_naive = data_nosimd.clone();
 

--- a/cryptography/src/reed_solomon/engine/engine_nosimd.rs
+++ b/cryptography/src/reed_solomon/engine/engine_nosimd.rs
@@ -1,0 +1,347 @@
+use crate::reed_solomon::engine::{
+    tables::{self, Mul16, Skew},
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS,
+};
+use core::iter::zip;
+
+// ======================================================================
+// NoSimd - PUBLIC
+
+/// Optimized [`Engine`] without SIMD.
+///
+/// [`NoSimd`] is a basic optimized engine which works on all CPUs.
+#[derive(Clone, Copy)]
+pub struct NoSimd {
+    mul16: &'static Mul16,
+    skew: &'static Skew,
+}
+
+impl NoSimd {
+    /// Creates new [`NoSimd`], initializing all [tables]
+    /// needed for encoding or decoding.
+    ///
+    /// Currently only difference between encoding/decoding is
+    /// [`LogWalsh`] (128 kiB) which is only needed for decoding.
+    ///
+    /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
+    pub fn new() -> Self {
+        let mul16 = tables::get_mul16();
+        let skew = tables::get_skew();
+
+        Self { mul16, skew }
+    }
+}
+
+impl Engine for NoSimd {
+    fn fft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        self.fft_private(data, pos, size, truncated_size, skew_delta);
+    }
+
+    fn ifft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        self.ifft_private(data, pos, size, truncated_size, skew_delta);
+    }
+
+    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+        let lut = &self.mul16[log_m as usize];
+
+        for x_chunk in x.iter_mut() {
+            let (x_lo, x_hi) = x_chunk.split_at_mut(32);
+
+            for i in 0..32 {
+                let lo = x_lo[i];
+                let hi = x_hi[i];
+                let prod = lut[0][usize::from(lo & 15)]
+                    ^ lut[1][usize::from(lo >> 4)]
+                    ^ lut[2][usize::from(hi & 15)]
+                    ^ lut[3][usize::from(hi >> 4)];
+                x_lo[i] = prod as u8;
+                x_hi[i] = (prod >> 8) as u8;
+            }
+        }
+    }
+}
+
+// ======================================================================
+// NoSimd - IMPL Default
+
+impl Default for NoSimd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ======================================================================
+// NoSimd - PRIVATE
+
+impl NoSimd {
+    /// `x[] ^= y[] * log_m`
+    fn mul_add(&self, x: &mut [[u8; 64]], y: &[[u8; 64]], log_m: GfElement) {
+        let lut = &self.mul16[log_m as usize];
+
+        for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter()) {
+            let (x_lo, x_hi) = x_chunk.split_at_mut(32);
+            let (y_lo, y_hi) = y_chunk.split_at(32);
+
+            for i in 0..32 {
+                let lo = y_lo[i];
+                let hi = y_hi[i];
+                let prod = lut[0][usize::from(lo & 15)]
+                    ^ lut[1][usize::from(lo >> 4)]
+                    ^ lut[2][usize::from(hi & 15)]
+                    ^ lut[3][usize::from(hi >> 4)];
+                x_lo[i] ^= prod as u8;
+                x_hi[i] ^= (prod >> 8) as u8;
+            }
+        }
+    }
+}
+
+// ======================================================================
+// NoSimd - PRIVATE - FFT (fast Fourier transform)
+
+impl NoSimd {
+    // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
+    #[inline(always)]
+    fn fft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+        self.mul_add(x, y, log_m);
+        utils::xor(y, x);
+    }
+
+    #[inline(always)]
+    fn fft_butterfly_two_layers(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        dist: usize,
+        log_m01: GfElement,
+        log_m23: GfElement,
+        log_m02: GfElement,
+    ) {
+        let (s0, s1, s2, s3) = data.dist4_mut(pos, dist);
+
+        // FIRST LAYER
+
+        if log_m02 == GF_MODULUS {
+            utils::xor(s2, s0);
+            utils::xor(s3, s1);
+        } else {
+            self.fft_butterfly_partial(s0, s2, log_m02);
+            self.fft_butterfly_partial(s1, s3, log_m02);
+        }
+
+        // SECOND LAYER
+
+        if log_m01 == GF_MODULUS {
+            utils::xor(s1, s0);
+        } else {
+            self.fft_butterfly_partial(s0, s1, log_m01);
+        }
+
+        if log_m23 == GF_MODULUS {
+            utils::xor(s3, s2);
+        } else {
+            self.fft_butterfly_partial(s2, s3, log_m23);
+        }
+    }
+
+    #[inline(always)]
+    fn fft_private(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // TWO LAYERS AT TIME
+
+        let mut dist4 = size;
+        let mut dist = size >> 2;
+        while dist != 0 {
+            let mut r = 0;
+            while r < truncated_size {
+                let base = r + dist + skew_delta - 1;
+
+                let log_m01 = self.skew[base];
+                let log_m02 = self.skew[base + dist];
+                let log_m23 = self.skew[base + dist * 2];
+
+                for i in r..r + dist {
+                    self.fft_butterfly_two_layers(data, pos + i, dist, log_m01, log_m23, log_m02);
+                }
+
+                r += dist4;
+            }
+            dist4 = dist;
+            dist >>= 2;
+        }
+
+        // FINAL ODD LAYER
+
+        if dist4 == 2 {
+            let mut r = 0;
+            while r < truncated_size {
+                let log_m = self.skew[r + skew_delta];
+
+                let (x, y) = data.dist2_mut(pos + r, 1);
+
+                if log_m == GF_MODULUS {
+                    utils::xor(y, x);
+                } else {
+                    self.fft_butterfly_partial(x, y, log_m);
+                }
+
+                r += 2;
+            }
+        }
+    }
+}
+
+// ======================================================================
+// NoSimd - PRIVATE - IFFT (inverse fast Fourier transform)
+
+impl NoSimd {
+    // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
+    #[inline(always)]
+    fn ifft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+        utils::xor(y, x);
+        self.mul_add(x, y, log_m);
+    }
+
+    #[inline(always)]
+    fn ifft_butterfly_two_layers(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        dist: usize,
+        log_m01: GfElement,
+        log_m23: GfElement,
+        log_m02: GfElement,
+    ) {
+        let (s0, s1, s2, s3) = data.dist4_mut(pos, dist);
+
+        // FIRST LAYER
+
+        if log_m01 == GF_MODULUS {
+            utils::xor(s1, s0);
+        } else {
+            self.ifft_butterfly_partial(s0, s1, log_m01);
+        }
+
+        if log_m23 == GF_MODULUS {
+            utils::xor(s3, s2);
+        } else {
+            self.ifft_butterfly_partial(s2, s3, log_m23);
+        }
+
+        // SECOND LAYER
+
+        if log_m02 == GF_MODULUS {
+            utils::xor(s2, s0);
+            utils::xor(s3, s1);
+        } else {
+            self.ifft_butterfly_partial(s0, s2, log_m02);
+            self.ifft_butterfly_partial(s1, s3, log_m02);
+        }
+    }
+
+    #[inline(always)]
+    fn ifft_private(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // TWO LAYERS AT TIME
+
+        let mut dist = 1;
+        let mut dist4 = 4;
+        while dist4 <= size {
+            let mut r = 0;
+            while r < truncated_size {
+                let base = r + dist + skew_delta - 1;
+
+                let log_m01 = self.skew[base];
+                let log_m02 = self.skew[base + dist];
+                let log_m23 = self.skew[base + dist * 2];
+
+                for i in r..r + dist {
+                    self.ifft_butterfly_two_layers(data, pos + i, dist, log_m01, log_m23, log_m02);
+                }
+
+                r += dist4;
+            }
+            dist = dist4;
+            dist4 <<= 2;
+        }
+
+        // FINAL ODD LAYER
+
+        if dist < size {
+            let log_m = self.skew[dist + skew_delta - 1];
+            if log_m == GF_MODULUS {
+                utils::xor_within(data, pos + dist, pos, dist);
+            } else {
+                let (mut a, mut b) = data.split_at_mut(pos + dist);
+                for i in 0..dist {
+                    self.ifft_butterfly_partial(
+                        &mut a[pos + i], // data[pos + i]
+                        &mut b[i],       // data[pos + i + dist]
+                        log_m,
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ======================================================================
+// TESTS
+
+// Engines are tested indirectly via roundtrip tests of HighRate and LowRate.
+
+#[cfg(test)]
+mod tests {
+    use crate::reed_solomon::engine::{Engine, Naive, NoSimd};
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+    use rand::{Rng, RngCore, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn mul() {
+        let naive = Naive::default();
+        let nosimd = NoSimd::default();
+
+        let mut rng = ChaCha8Rng::from_seed([0; 32]);
+
+        for shard_chunks in 0..6 {
+            let mut data_nosimd = vec![[0; 64]; shard_chunks];
+            rng.fill_bytes(data_nosimd.as_flattened_mut());
+            let mut data_naive = data_nosimd.clone();
+
+            let log_m = rng.gen();
+
+            nosimd.mul(&mut data_nosimd, log_m);
+            naive.mul(&mut data_naive, log_m);
+
+            assert_eq!(data_nosimd, data_naive);
+        }
+    }
+}

--- a/cryptography/src/reed_solomon/engine/engine_ssse3.rs
+++ b/cryptography/src/reed_solomon/engine/engine_ssse3.rs
@@ -95,8 +95,6 @@ impl Default for Ssse3 {
 
 // ======================================================================
 // Ssse3 - PRIVATE
-//
-//
 
 impl Ssse3 {
     #[target_feature(enable = "ssse3")]
@@ -121,7 +119,7 @@ impl Ssse3 {
         }
     }
 
-    // Impelemntation of LEO_MUL_128
+    // Implementation of LEO_MUL_128
     #[inline(always)]
     fn mul_128(value_lo: __m128i, value_hi: __m128i, lut: &Multiply128lutT) -> (__m128i, __m128i) {
         let mut prod_lo: __m128i;
@@ -161,7 +159,7 @@ impl Ssse3 {
         (prod_lo, prod_hi)
     }
 
-    //// {x_lo, x_hi} ^= {y_lo, y_hi} * log_m
+    // {x_lo, x_hi} ^= {y_lo, y_hi} * log_m.
     // Implementation of LEO_MULADD_128
     #[inline(always)]
     fn muladd_128(
@@ -287,7 +285,6 @@ impl Ssse3 {
         truncated_size: usize,
         skew_delta: usize,
     ) {
-        // Drop unsafe privileges
         self.fft_private(data, pos, size, truncated_size, skew_delta);
     }
 
@@ -450,7 +447,6 @@ impl Ssse3 {
         truncated_size: usize,
         skew_delta: usize,
     ) {
-        // Drop unsafe privileges
         self.ifft_private(data, pos, size, truncated_size, skew_delta);
     }
 

--- a/cryptography/src/reed_solomon/engine/engine_ssse3.rs
+++ b/cryptography/src/reed_solomon/engine/engine_ssse3.rs
@@ -1,0 +1,490 @@
+use crate::reed_solomon::engine::{
+    tables::{self, Mul128, Multiply128lutT, Skew},
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER,
+};
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+use core::iter::zip;
+
+// ======================================================================
+// Ssse3 - PUBLIC
+
+/// Optimized [`Engine`] using SSSE3 instructions.
+///
+/// [`Ssse3`] is an optimized engine that follows the same algorithm as
+/// [`NoSimd`] but takes advantage of the x86 SSSE3 SIMD instructions.
+///
+/// [`NoSimd`]: crate::reed_solomon::engine::NoSimd
+#[derive(Clone, Copy)]
+pub struct Ssse3 {
+    mul128: &'static Mul128,
+    skew: &'static Skew,
+}
+
+impl Ssse3 {
+    /// Creates new [`Ssse3`], initializing all [tables]
+    /// needed for encoding or decoding.
+    ///
+    /// Currently only difference between encoding/decoding is
+    /// [`LogWalsh`] (128 kiB) which is only needed for decoding.
+    ///
+    /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
+    pub fn new() -> Self {
+        let mul128 = tables::get_mul128();
+        let skew = tables::get_skew();
+
+        Self { mul128, skew }
+    }
+}
+
+impl Engine for Ssse3 {
+    fn fft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        unsafe {
+            self.fft_private_ssse3(data, pos, size, truncated_size, skew_delta);
+        }
+    }
+
+    fn ifft(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        unsafe {
+            self.ifft_private_ssse3(data, pos, size, truncated_size, skew_delta);
+        }
+    }
+
+    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+        unsafe {
+            self.mul_ssse3(x, log_m);
+        }
+    }
+
+    fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        unsafe { Self::eval_poly_ssse3(erasures, truncated_size) }
+    }
+}
+
+// ======================================================================
+// Ssse3 - IMPL Default
+
+impl Default for Ssse3 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ======================================================================
+// Ssse3 - PRIVATE
+//
+//
+
+impl Ssse3 {
+    #[target_feature(enable = "ssse3")]
+    unsafe fn mul_ssse3(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+        let lut = &self.mul128[log_m as usize];
+
+        for chunk in x.iter_mut() {
+            let x_ptr = chunk.as_mut_ptr().cast::<__m128i>();
+            unsafe {
+                let x0_lo = _mm_loadu_si128(x_ptr);
+                let x1_lo = _mm_loadu_si128(x_ptr.add(1));
+                let x0_hi = _mm_loadu_si128(x_ptr.add(2));
+                let x1_hi = _mm_loadu_si128(x_ptr.add(3));
+                let (prod0_lo, prod0_hi) = Self::mul_128(x0_lo, x0_hi, lut);
+                let (prod1_lo, prod1_hi) = Self::mul_128(x1_lo, x1_hi, lut);
+                _mm_storeu_si128(x_ptr, prod0_lo);
+                _mm_storeu_si128(x_ptr.add(1), prod1_lo);
+                _mm_storeu_si128(x_ptr.add(2), prod0_hi);
+                _mm_storeu_si128(x_ptr.add(3), prod1_hi);
+            }
+        }
+    }
+
+    // Impelemntation of LEO_MUL_128
+    #[inline(always)]
+    fn mul_128(value_lo: __m128i, value_hi: __m128i, lut: &Multiply128lutT) -> (__m128i, __m128i) {
+        let mut prod_lo: __m128i;
+        let mut prod_hi: __m128i;
+
+        unsafe {
+            let t0_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>());
+            let t1_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>());
+            let t2_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[2]).cast::<__m128i>());
+            let t3_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[3]).cast::<__m128i>());
+
+            let t0_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[0]).cast::<__m128i>());
+            let t1_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[1]).cast::<__m128i>());
+            let t2_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[2]).cast::<__m128i>());
+            let t3_hi = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.hi[3]).cast::<__m128i>());
+
+            let clr_mask = _mm_set1_epi8(0x0f);
+
+            let data_0 = _mm_and_si128(value_lo, clr_mask);
+            prod_lo = _mm_shuffle_epi8(t0_lo, data_0);
+            prod_hi = _mm_shuffle_epi8(t0_hi, data_0);
+
+            let data_1 = _mm_and_si128(_mm_srli_epi64(value_lo, 4), clr_mask);
+            prod_lo = _mm_xor_si128(prod_lo, _mm_shuffle_epi8(t1_lo, data_1));
+            prod_hi = _mm_xor_si128(prod_hi, _mm_shuffle_epi8(t1_hi, data_1));
+
+            let data_0 = _mm_and_si128(value_hi, clr_mask);
+            prod_lo = _mm_xor_si128(prod_lo, _mm_shuffle_epi8(t2_lo, data_0));
+            prod_hi = _mm_xor_si128(prod_hi, _mm_shuffle_epi8(t2_hi, data_0));
+
+            let data_1 = _mm_and_si128(_mm_srli_epi64(value_hi, 4), clr_mask);
+            prod_lo = _mm_xor_si128(prod_lo, _mm_shuffle_epi8(t3_lo, data_1));
+            prod_hi = _mm_xor_si128(prod_hi, _mm_shuffle_epi8(t3_hi, data_1));
+        }
+
+        (prod_lo, prod_hi)
+    }
+
+    //// {x_lo, x_hi} ^= {y_lo, y_hi} * log_m
+    // Implementation of LEO_MULADD_128
+    #[inline(always)]
+    fn muladd_128(
+        mut x_lo: __m128i,
+        mut x_hi: __m128i,
+        y_lo: __m128i,
+        y_hi: __m128i,
+        lut: &Multiply128lutT,
+    ) -> (__m128i, __m128i) {
+        let (prod_lo, prod_hi) = Self::mul_128(y_lo, y_hi, lut);
+        unsafe {
+            x_lo = _mm_xor_si128(x_lo, prod_lo);
+            x_hi = _mm_xor_si128(x_hi, prod_hi);
+        }
+        (x_lo, x_hi)
+    }
+}
+
+// ======================================================================
+// Ssse3 - PRIVATE - FFT (fast Fourier transform)
+
+impl Ssse3 {
+    // Implementation of LEO_FFTB_128
+    #[inline(always)]
+    fn fftb_128(&self, x: &mut [u8; 64], y: &mut [u8; 64], log_m: GfElement) {
+        let lut = &self.mul128[log_m as usize];
+        let x_ptr = x.as_mut_ptr().cast::<__m128i>();
+        let y_ptr = y.as_mut_ptr().cast::<__m128i>();
+        unsafe {
+            let mut x0_lo = _mm_loadu_si128(x_ptr);
+            let mut x1_lo = _mm_loadu_si128(x_ptr.add(1));
+            let mut x0_hi = _mm_loadu_si128(x_ptr.add(2));
+            let mut x1_hi = _mm_loadu_si128(x_ptr.add(3));
+
+            let mut y0_lo = _mm_loadu_si128(y_ptr);
+            let mut y1_lo = _mm_loadu_si128(y_ptr.add(1));
+            let mut y0_hi = _mm_loadu_si128(y_ptr.add(2));
+            let mut y1_hi = _mm_loadu_si128(y_ptr.add(3));
+
+            (x0_lo, x0_hi) = Self::muladd_128(x0_lo, x0_hi, y0_lo, y0_hi, lut);
+            (x1_lo, x1_hi) = Self::muladd_128(x1_lo, x1_hi, y1_lo, y1_hi, lut);
+
+            _mm_storeu_si128(x_ptr, x0_lo);
+            _mm_storeu_si128(x_ptr.add(1), x1_lo);
+            _mm_storeu_si128(x_ptr.add(2), x0_hi);
+            _mm_storeu_si128(x_ptr.add(3), x1_hi);
+
+            y0_lo = _mm_xor_si128(y0_lo, x0_lo);
+            y1_lo = _mm_xor_si128(y1_lo, x1_lo);
+            y0_hi = _mm_xor_si128(y0_hi, x0_hi);
+            y1_hi = _mm_xor_si128(y1_hi, x1_hi);
+
+            _mm_storeu_si128(y_ptr, y0_lo);
+            _mm_storeu_si128(y_ptr.add(1), y1_lo);
+            _mm_storeu_si128(y_ptr.add(2), y0_hi);
+            _mm_storeu_si128(y_ptr.add(3), y1_hi);
+        }
+    }
+
+    // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
+    #[inline(always)]
+    fn fft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+        for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
+            self.fftb_128(x_chunk, y_chunk, log_m);
+        }
+    }
+
+    #[inline(always)]
+    fn fft_butterfly_two_layers(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        dist: usize,
+        log_m01: GfElement,
+        log_m23: GfElement,
+        log_m02: GfElement,
+    ) {
+        let (s0, s1, s2, s3) = data.dist4_mut(pos, dist);
+
+        // FIRST LAYER
+
+        if log_m02 == GF_MODULUS {
+            utils::xor(s2, s0);
+            utils::xor(s3, s1);
+        } else {
+            self.fft_butterfly_partial(s0, s2, log_m02);
+            self.fft_butterfly_partial(s1, s3, log_m02);
+        }
+
+        // SECOND LAYER
+
+        if log_m01 == GF_MODULUS {
+            utils::xor(s1, s0);
+        } else {
+            self.fft_butterfly_partial(s0, s1, log_m01);
+        }
+
+        if log_m23 == GF_MODULUS {
+            utils::xor(s3, s2);
+        } else {
+            self.fft_butterfly_partial(s2, s3, log_m23);
+        }
+    }
+
+    #[target_feature(enable = "ssse3")]
+    unsafe fn fft_private_ssse3(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // Drop unsafe privileges
+        self.fft_private(data, pos, size, truncated_size, skew_delta);
+    }
+
+    #[inline(always)]
+    fn fft_private(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // TWO LAYERS AT TIME
+
+        let mut dist4 = size;
+        let mut dist = size >> 2;
+        while dist != 0 {
+            let mut r = 0;
+            while r < truncated_size {
+                let base = r + dist + skew_delta - 1;
+
+                let log_m01 = self.skew[base];
+                let log_m02 = self.skew[base + dist];
+                let log_m23 = self.skew[base + dist * 2];
+
+                for i in r..r + dist {
+                    self.fft_butterfly_two_layers(data, pos + i, dist, log_m01, log_m23, log_m02);
+                }
+
+                r += dist4;
+            }
+            dist4 = dist;
+            dist >>= 2;
+        }
+
+        // FINAL ODD LAYER
+
+        if dist4 == 2 {
+            let mut r = 0;
+            while r < truncated_size {
+                let log_m = self.skew[r + skew_delta];
+
+                let (x, y) = data.dist2_mut(pos + r, 1);
+
+                if log_m == GF_MODULUS {
+                    utils::xor(y, x);
+                } else {
+                    self.fft_butterfly_partial(x, y, log_m);
+                }
+
+                r += 2;
+            }
+        }
+    }
+}
+
+// ======================================================================
+// Ssse3 - PRIVATE - IFFT (inverse fast Fourier transform)
+
+impl Ssse3 {
+    // Implementation of LEO_IFFTB_128
+    #[inline(always)]
+    fn ifftb_128(&self, x: &mut [u8; 64], y: &mut [u8; 64], log_m: GfElement) {
+        let lut = &self.mul128[log_m as usize];
+        let x_ptr = x.as_mut_ptr().cast::<__m128i>();
+        let y_ptr = y.as_mut_ptr().cast::<__m128i>();
+
+        unsafe {
+            let mut x0_lo = _mm_loadu_si128(x_ptr);
+            let mut x1_lo = _mm_loadu_si128(x_ptr.add(1));
+            let mut x0_hi = _mm_loadu_si128(x_ptr.add(2));
+            let mut x1_hi = _mm_loadu_si128(x_ptr.add(3));
+
+            let mut y0_lo = _mm_loadu_si128(y_ptr);
+            let mut y1_lo = _mm_loadu_si128(y_ptr.add(1));
+            let mut y0_hi = _mm_loadu_si128(y_ptr.add(2));
+            let mut y1_hi = _mm_loadu_si128(y_ptr.add(3));
+
+            y0_lo = _mm_xor_si128(y0_lo, x0_lo);
+            y1_lo = _mm_xor_si128(y1_lo, x1_lo);
+            y0_hi = _mm_xor_si128(y0_hi, x0_hi);
+            y1_hi = _mm_xor_si128(y1_hi, x1_hi);
+
+            _mm_storeu_si128(y_ptr, y0_lo);
+            _mm_storeu_si128(y_ptr.add(1), y1_lo);
+            _mm_storeu_si128(y_ptr.add(2), y0_hi);
+            _mm_storeu_si128(y_ptr.add(3), y1_hi);
+
+            (x0_lo, x0_hi) = Self::muladd_128(x0_lo, x0_hi, y0_lo, y0_hi, lut);
+            (x1_lo, x1_hi) = Self::muladd_128(x1_lo, x1_hi, y1_lo, y1_hi, lut);
+
+            _mm_storeu_si128(x_ptr, x0_lo);
+            _mm_storeu_si128(x_ptr.add(1), x1_lo);
+            _mm_storeu_si128(x_ptr.add(2), x0_hi);
+            _mm_storeu_si128(x_ptr.add(3), x1_hi);
+        }
+    }
+
+    #[inline(always)]
+    fn ifft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+        for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
+            self.ifftb_128(x_chunk, y_chunk, log_m);
+        }
+    }
+
+    #[inline(always)]
+    fn ifft_butterfly_two_layers(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        dist: usize,
+        log_m01: GfElement,
+        log_m23: GfElement,
+        log_m02: GfElement,
+    ) {
+        let (s0, s1, s2, s3) = data.dist4_mut(pos, dist);
+
+        // FIRST LAYER
+
+        if log_m01 == GF_MODULUS {
+            utils::xor(s1, s0);
+        } else {
+            self.ifft_butterfly_partial(s0, s1, log_m01);
+        }
+
+        if log_m23 == GF_MODULUS {
+            utils::xor(s3, s2);
+        } else {
+            self.ifft_butterfly_partial(s2, s3, log_m23);
+        }
+
+        // SECOND LAYER
+
+        if log_m02 == GF_MODULUS {
+            utils::xor(s2, s0);
+            utils::xor(s3, s1);
+        } else {
+            self.ifft_butterfly_partial(s0, s2, log_m02);
+            self.ifft_butterfly_partial(s1, s3, log_m02);
+        }
+    }
+
+    #[target_feature(enable = "ssse3")]
+    unsafe fn ifft_private_ssse3(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // Drop unsafe privileges
+        self.ifft_private(data, pos, size, truncated_size, skew_delta);
+    }
+
+    #[inline(always)]
+    fn ifft_private(
+        &self,
+        data: &mut ShardsRefMut,
+        pos: usize,
+        size: usize,
+        truncated_size: usize,
+        skew_delta: usize,
+    ) {
+        // TWO LAYERS AT TIME
+
+        let mut dist = 1;
+        let mut dist4 = 4;
+        while dist4 <= size {
+            let mut r = 0;
+            while r < truncated_size {
+                let base = r + dist + skew_delta - 1;
+
+                let log_m01 = self.skew[base];
+                let log_m02 = self.skew[base + dist];
+                let log_m23 = self.skew[base + dist * 2];
+
+                for i in r..r + dist {
+                    self.ifft_butterfly_two_layers(data, pos + i, dist, log_m01, log_m23, log_m02);
+                }
+
+                r += dist4;
+            }
+            dist = dist4;
+            dist4 <<= 2;
+        }
+
+        // FINAL ODD LAYER
+
+        if dist < size {
+            let log_m = self.skew[dist + skew_delta - 1];
+            if log_m == GF_MODULUS {
+                utils::xor_within(data, pos + dist, pos, dist);
+            } else {
+                let (mut a, mut b) = data.split_at_mut(pos + dist);
+                for i in 0..dist {
+                    self.ifft_butterfly_partial(
+                        &mut a[pos + i], // data[pos + i]
+                        &mut b[i],       // data[pos + i + dist]
+                        log_m,
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ======================================================================
+// Ssse3 - PRIVATE - Evaluate polynomial
+
+impl Ssse3 {
+    #[target_feature(enable = "ssse3")]
+    unsafe fn eval_poly_ssse3(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        utils::eval_poly(erasures, truncated_size);
+    }
+}
+
+// ======================================================================
+// TESTS
+
+// Engines are tested indirectly via roundtrip tests of HighRate and LowRate.

--- a/cryptography/src/reed_solomon/engine/engine_ssse3.rs
+++ b/cryptography/src/reed_solomon/engine/engine_ssse3.rs
@@ -1,6 +1,6 @@
 use crate::reed_solomon::engine::{
     tables::{self, Mul128, Multiply128lutT, Skew},
-    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER,
+    utils, Engine, GfElement, ShardsRefMut, GF_MODULUS, GF_ORDER, SHARD_CHUNK_BYTES,
 };
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
@@ -32,6 +32,9 @@ impl Ssse3 {
     ///
     /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
     pub fn new() -> Self {
+        cpufeatures::new!(has_ssse3_for_engine, "ssse3");
+        assert!(has_ssse3_for_engine::get());
+
         let mul128 = tables::get_mul128();
         let skew = tables::get_skew();
 
@@ -42,12 +45,13 @@ impl Ssse3 {
 impl Engine for Ssse3 {
     fn fft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
         skew_delta: usize,
     ) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             self.fft_private_ssse3(data, pos, size, truncated_size, skew_delta);
         }
@@ -55,24 +59,27 @@ impl Engine for Ssse3 {
 
     fn ifft(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
         skew_delta: usize,
     ) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             self.ifft_private_ssse3(data, pos, size, truncated_size, skew_delta);
         }
     }
 
-    fn mul(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+    fn mul(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             self.mul_ssse3(x, log_m);
         }
     }
 
     fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe { Self::eval_poly_ssse3(erasures, truncated_size) }
     }
 }
@@ -93,11 +100,12 @@ impl Default for Ssse3 {
 
 impl Ssse3 {
     #[target_feature(enable = "ssse3")]
-    unsafe fn mul_ssse3(&self, x: &mut [[u8; 64]], log_m: GfElement) {
+    unsafe fn mul_ssse3(&self, x: &mut [[u8; SHARD_CHUNK_BYTES]], log_m: GfElement) {
         let lut = &self.mul128[log_m as usize];
 
         for chunk in x.iter_mut() {
             let x_ptr = chunk.as_mut_ptr().cast::<__m128i>();
+            // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
             unsafe {
                 let x0_lo = _mm_loadu_si128(x_ptr);
                 let x1_lo = _mm_loadu_si128(x_ptr.add(1));
@@ -119,6 +127,7 @@ impl Ssse3 {
         let mut prod_lo: __m128i;
         let mut prod_hi: __m128i;
 
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             let t0_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[0]).cast::<__m128i>());
             let t1_lo = _mm_loadu_si128(core::ptr::from_ref::<u128>(&lut.lo[1]).cast::<__m128i>());
@@ -163,6 +172,7 @@ impl Ssse3 {
         lut: &Multiply128lutT,
     ) -> (__m128i, __m128i) {
         let (prod_lo, prod_hi) = Self::mul_128(y_lo, y_hi, lut);
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             x_lo = _mm_xor_si128(x_lo, prod_lo);
             x_hi = _mm_xor_si128(x_hi, prod_hi);
@@ -177,10 +187,16 @@ impl Ssse3 {
 impl Ssse3 {
     // Implementation of LEO_FFTB_128
     #[inline(always)]
-    fn fftb_128(&self, x: &mut [u8; 64], y: &mut [u8; 64], log_m: GfElement) {
+    fn fftb_128(
+        &self,
+        x: &mut [u8; SHARD_CHUNK_BYTES],
+        y: &mut [u8; SHARD_CHUNK_BYTES],
+        log_m: GfElement,
+    ) {
         let lut = &self.mul128[log_m as usize];
         let x_ptr = x.as_mut_ptr().cast::<__m128i>();
         let y_ptr = y.as_mut_ptr().cast::<__m128i>();
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             let mut x0_lo = _mm_loadu_si128(x_ptr);
             let mut x1_lo = _mm_loadu_si128(x_ptr.add(1));
@@ -214,7 +230,12 @@ impl Ssse3 {
 
     // Partial butterfly, caller must do `GF_MODULUS` check with `xor`.
     #[inline(always)]
-    fn fft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+    fn fft_butterfly_partial(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &mut [[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
         for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
             self.fftb_128(x_chunk, y_chunk, log_m);
         }
@@ -223,7 +244,7 @@ impl Ssse3 {
     #[inline(always)]
     fn fft_butterfly_two_layers(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         dist: usize,
         log_m01: GfElement,
@@ -260,7 +281,7 @@ impl Ssse3 {
     #[target_feature(enable = "ssse3")]
     unsafe fn fft_private_ssse3(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -273,7 +294,7 @@ impl Ssse3 {
     #[inline(always)]
     fn fft_private(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -329,11 +350,17 @@ impl Ssse3 {
 impl Ssse3 {
     // Implementation of LEO_IFFTB_128
     #[inline(always)]
-    fn ifftb_128(&self, x: &mut [u8; 64], y: &mut [u8; 64], log_m: GfElement) {
+    fn ifftb_128(
+        &self,
+        x: &mut [u8; SHARD_CHUNK_BYTES],
+        y: &mut [u8; SHARD_CHUNK_BYTES],
+        log_m: GfElement,
+    ) {
         let lut = &self.mul128[log_m as usize];
         let x_ptr = x.as_mut_ptr().cast::<__m128i>();
         let y_ptr = y.as_mut_ptr().cast::<__m128i>();
 
+        // SAFETY: Constructors and runtime dispatch ensure the SIMD feature is available; offsets stay within fixed-size shard buffers.
         unsafe {
             let mut x0_lo = _mm_loadu_si128(x_ptr);
             let mut x1_lo = _mm_loadu_si128(x_ptr.add(1));
@@ -366,7 +393,12 @@ impl Ssse3 {
     }
 
     #[inline(always)]
-    fn ifft_butterfly_partial(&self, x: &mut [[u8; 64]], y: &mut [[u8; 64]], log_m: GfElement) {
+    fn ifft_butterfly_partial(
+        &self,
+        x: &mut [[u8; SHARD_CHUNK_BYTES]],
+        y: &mut [[u8; SHARD_CHUNK_BYTES]],
+        log_m: GfElement,
+    ) {
         for (x_chunk, y_chunk) in zip(x.iter_mut(), y.iter_mut()) {
             self.ifftb_128(x_chunk, y_chunk, log_m);
         }
@@ -375,7 +407,7 @@ impl Ssse3 {
     #[inline(always)]
     fn ifft_butterfly_two_layers(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         dist: usize,
         log_m01: GfElement,
@@ -412,7 +444,7 @@ impl Ssse3 {
     #[target_feature(enable = "ssse3")]
     unsafe fn ifft_private_ssse3(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,
@@ -425,7 +457,7 @@ impl Ssse3 {
     #[inline(always)]
     fn ifft_private(
         &self,
-        data: &mut ShardsRefMut,
+        data: &mut ShardsRefMut<'_>,
         pos: usize,
         size: usize,
         truncated_size: usize,

--- a/cryptography/src/reed_solomon/engine/fwht.rs
+++ b/cryptography/src/reed_solomon/engine/fwht.rs
@@ -1,0 +1,150 @@
+use crate::reed_solomon::engine::{utils, GfElement, GF_ORDER};
+
+// ======================================================================
+// FWHT (fast Walsh-Hadamard transform) - CRATE
+
+/// Decimation in time (DIT) Fast Walsh-Hadamard Transform.
+/// `m_truncated`: Number of non-zero elements in `data` (at the front).
+#[inline(always)]
+pub(crate) fn fwht(data: &mut [GfElement; GF_ORDER], m_truncated: usize) {
+    // Note to self: fwht_8 is slightly faster on x86 (AMD Ryzen 5 3600),
+    // but slower on ARM (Apple silicon M1).
+    // fwht_16 is always slower. See branch: AndersTrier/FWHT_8_and_16
+    let mut dist = 1;
+    let mut dist4 = 4;
+    while dist4 <= GF_ORDER {
+        for r in (0..m_truncated).step_by(dist4) {
+            for offset in r..r + dist {
+                fwht_4(data, offset as u16, dist as u16);
+            }
+        }
+
+        dist = dist4;
+        dist4 <<= 2;
+    }
+}
+
+// ======================================================================
+// FWHT - PRIVATE
+
+#[inline(always)]
+fn fwht_2(a: GfElement, b: GfElement) -> (GfElement, GfElement) {
+    let sum = utils::add_mod(a, b);
+    let dif = utils::sub_mod(a, b);
+    (sum, dif)
+}
+
+#[inline(always)]
+fn fwht_4(data: &mut [GfElement; GF_ORDER], offset: u16, dist: u16) {
+    // Indices. u16 additions and multiplication to avoid bounds checks
+    // on array access. (GF_ORDER == (u16::MAX+1))
+    let i0 = usize::from(offset);
+    let i1 = usize::from(offset + dist);
+    let i2 = usize::from(offset + dist * 2);
+    let i3 = usize::from(offset + dist * 3);
+
+    let (s0, d0) = fwht_2(data[i0], data[i1]);
+    let (s1, d1) = fwht_2(data[i2], data[i3]);
+    let (s2, d2) = fwht_2(s0, s1);
+    let (s3, d3) = fwht_2(d0, d1);
+
+    data[i0] = s2;
+    data[i1] = s3;
+    data[i2] = d2;
+    data[i3] = d3;
+}
+
+// ======================================================================
+// FWHT - TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    // Reference implementation
+    fn fwht_naive(data: &mut [GfElement; GF_ORDER]) {
+        let mut dist = 1;
+        let mut dist2 = 2;
+        while dist2 <= data.len() {
+            for r in (0..data.len()).step_by(dist2) {
+                for offset in r..r + dist {
+                    let (sum, dif) = fwht_2_naive(data[offset], data[offset + dist]);
+                    data[offset] = sum;
+                    data[offset + dist] = dif;
+                }
+            }
+
+            dist = dist2;
+            dist2 *= 2;
+        }
+    }
+
+    fn fwht_2_naive(a: GfElement, b: GfElement) -> (GfElement, GfElement) {
+        let (mut sum, sum_overflow) = a.overflowing_add(b);
+        if sum_overflow {
+            // `sum` got reduced mod 65536, but we want to
+            // reduce it mod GF_MODULUS (65535) instead.
+            sum += 1;
+        }
+
+        let (mut dif, dif_overflow) = a.overflowing_sub(b);
+        if dif_overflow {
+            dif -= 1;
+        }
+
+        (sum, dif)
+    }
+
+    #[test]
+    fn test_full() {
+        let mut rng = ChaCha8Rng::from_seed([0; 32]);
+
+        let mut data1 = [(); GF_ORDER].map(|_| rng.gen());
+        let mut data2 = data1;
+
+        fwht(&mut data1, GF_ORDER);
+        fwht_naive(&mut data2);
+
+        assert_eq!(data1, data2);
+    }
+
+    #[test]
+    fn test_truncated() {
+        let mut rng = ChaCha8Rng::from_seed([0; 32]);
+        let random: Vec<GfElement> = (0..GF_ORDER).map(|_| rng.gen()).collect();
+
+        for nonzero_count in [
+            0,
+            1,
+            2,
+            3,
+            4,
+            64,
+            127,
+            16384 - 1,
+            16384 + 1,
+            GF_ORDER / 2 - 1,
+            GF_ORDER / 2,
+            GF_ORDER / 2 + 1,
+            GF_ORDER - 4,
+            GF_ORDER - 3,
+            GF_ORDER - 2,
+            GF_ORDER - 1,
+            GF_ORDER,
+        ] {
+            let mut data1 = [0; GF_ORDER];
+
+            data1[..nonzero_count].copy_from_slice(&random[..nonzero_count]);
+            let mut data2 = data1;
+
+            fwht(&mut data1, nonzero_count);
+            fwht_naive(&mut data2);
+
+            assert_eq!(data1, data2);
+        }
+    }
+}

--- a/cryptography/src/reed_solomon/engine/shards.rs
+++ b/cryptography/src/reed_solomon/engine/shards.rs
@@ -262,9 +262,7 @@ impl ShardsRefMut<'_> {
     }
 
     // Returns mutable references to flat-arrays of shard-ranges
-    // `x .. x + count` and `y .. y + count`.
-    //
-    // Ranges must not overlap.
+    // `x .. x + count` and `y .. y + count`. Ranges must not overlap.
     pub(crate) fn flat2_mut(
         &mut self,
         mut x: usize,

--- a/cryptography/src/reed_solomon/engine/shards.rs
+++ b/cryptography/src/reed_solomon/engine/shards.rs
@@ -1,3 +1,4 @@
+use crate::reed_solomon::engine::SHARD_CHUNK_BYTES;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use core::ops::{Bound, Index, IndexMut, Range, RangeBounds};
@@ -7,39 +8,41 @@ use core::ops::{Bound, Index, IndexMut, Range, RangeBounds};
 
 pub(crate) struct Shards {
     shard_count: usize,
-    // Shard length in 64 byte chunks
-    shard_len_64: usize,
+    // Shard length in `SHARD_CHUNK_BYTES` chunks.
+    shard_chunk_count: usize,
 
-    // Flat Vec of `shard_count * shard_len_64 * 64` bytes.
-    data: Vec<[u8; 64]>,
+    // Flat Vec of `shard_count * shard_chunk_count * SHARD_CHUNK_BYTES` bytes.
+    data: Vec<[u8; SHARD_CHUNK_BYTES]>,
 }
 
 impl Shards {
     pub(crate) fn as_ref_mut(&mut self) -> ShardsRefMut<'_> {
-        ShardsRefMut::new(self.shard_count, self.shard_len_64, self.data.as_mut())
+        ShardsRefMut::new(self.shard_count, self.shard_chunk_count, self.data.as_mut())
     }
 
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             shard_count: 0,
-            shard_len_64: 0,
+            shard_chunk_count: 0,
             data: Vec::new(),
         }
     }
 
-    pub(crate) fn resize(&mut self, shard_count: usize, shard_len_64: usize) {
+    pub(crate) fn resize(&mut self, shard_count: usize, shard_chunk_count: usize) {
         self.shard_count = shard_count;
-        self.shard_len_64 = shard_len_64;
+        self.shard_chunk_count = shard_chunk_count;
 
-        self.data
-            .resize(self.shard_count * self.shard_len_64, [0; 64]);
+        self.data.resize(
+            self.shard_count * self.shard_chunk_count,
+            [0; SHARD_CHUNK_BYTES],
+        );
     }
 
     pub(crate) fn insert(&mut self, index: usize, shard: &[u8]) {
-        debug_assert_eq!(shard.len() % 2, 0);
+        assert_eq!(shard.len() % 2, 0);
 
-        let whole_chunk_count = shard.len() / 64;
-        let tail_len = shard.len() % 64;
+        let whole_chunk_count = shard.len() / SHARD_CHUNK_BYTES;
+        let tail_len = shard.len() % SHARD_CHUNK_BYTES;
 
         let (src_chunks, src_tail) = shard.split_at(shard.len() - tail_len);
 
@@ -48,11 +51,11 @@ impl Shards {
             .as_flattened_mut()
             .copy_from_slice(src_chunks);
 
-        // Last chunk is special if shard.len() % 64 != 0.
+        // Last chunk is special if shard.len() % SHARD_CHUNK_BYTES != 0.
         // See src/algorithm.md for an explanation.
         if tail_len > 0 {
             let (src_lo, src_hi) = src_tail.split_at(tail_len / 2);
-            let (dst_lo, dst_hi) = dst[whole_chunk_count].split_at_mut(32);
+            let (dst_lo, dst_hi) = dst[whole_chunk_count].split_at_mut(SHARD_CHUNK_BYTES / 2);
             dst_lo[..src_lo.len()].copy_from_slice(src_lo);
             dst_hi[..src_hi.len()].copy_from_slice(src_hi);
         }
@@ -60,8 +63,8 @@ impl Shards {
 
     // Undoes the encoding of the last chunk for the given range of shards
     pub(crate) fn undo_last_chunk_encoding(&mut self, shard_bytes: usize, range: Range<usize>) {
-        let whole_chunk_count = shard_bytes / 64;
-        let tail_len = shard_bytes % 64;
+        let whole_chunk_count = shard_bytes / SHARD_CHUNK_BYTES;
+        let tail_len = shard_bytes % SHARD_CHUNK_BYTES;
 
         if tail_len == 0 {
             return;
@@ -69,7 +72,10 @@ impl Shards {
 
         for idx in range {
             let last_chunk = &mut self[idx][whole_chunk_count];
-            last_chunk.copy_within(32..32 + tail_len / 2, tail_len / 2);
+            last_chunk.copy_within(
+                SHARD_CHUNK_BYTES / 2..SHARD_CHUNK_BYTES / 2 + tail_len / 2,
+                tail_len / 2,
+            );
         }
     }
 }
@@ -78,9 +84,9 @@ impl Shards {
 // Shards - IMPL Index
 
 impl Index<usize> for Shards {
-    type Output = [[u8; 64]];
+    type Output = [[u8; SHARD_CHUNK_BYTES]];
     fn index(&self, index: usize) -> &Self::Output {
-        &self.data[index * self.shard_len_64..(index + 1) * self.shard_len_64]
+        &self.data[index * self.shard_chunk_count..(index + 1) * self.shard_chunk_count]
     }
 }
 
@@ -89,7 +95,7 @@ impl Index<usize> for Shards {
 
 impl IndexMut<usize> for Shards {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.data[index * self.shard_len_64..(index + 1) * self.shard_len_64]
+        &mut self.data[index * self.shard_chunk_count..(index + 1) * self.shard_chunk_count]
     }
 }
 
@@ -99,10 +105,17 @@ impl IndexMut<usize> for Shards {
 /// Mutable reference to a shard array.
 pub struct ShardsRefMut<'a> {
     shard_count: usize,
-    shard_len_64: usize,
+    shard_chunk_count: usize,
 
-    data: &'a mut [[u8; 64]],
+    data: &'a mut [[u8; SHARD_CHUNK_BYTES]],
 }
+
+type FourShardsMut<'a> = (
+    &'a mut [[u8; SHARD_CHUNK_BYTES]],
+    &'a mut [[u8; SHARD_CHUNK_BYTES]],
+    &'a mut [[u8; SHARD_CHUNK_BYTES]],
+    &'a mut [[u8; SHARD_CHUNK_BYTES]],
+);
 
 impl<'a> ShardsRefMut<'a> {
     /// Returns mutable references to shards at `pos` and `pos + dist`.
@@ -118,12 +131,18 @@ impl<'a> ShardsRefMut<'a> {
         &mut self,
         mut pos: usize,
         mut dist: usize,
-    ) -> (&mut [[u8; 64]], &mut [[u8; 64]]) {
-        pos *= self.shard_len_64;
-        dist *= self.shard_len_64;
+    ) -> (
+        &mut [[u8; SHARD_CHUNK_BYTES]],
+        &mut [[u8; SHARD_CHUNK_BYTES]],
+    ) {
+        pos *= self.shard_chunk_count;
+        dist *= self.shard_chunk_count;
 
         let (a, b) = self.data[pos..].split_at_mut(dist);
-        (&mut a[..self.shard_len_64], &mut b[..self.shard_len_64])
+        (
+            &mut a[..self.shard_chunk_count],
+            &mut b[..self.shard_chunk_count],
+        )
     }
 
     /// Returns mutable references to shards at
@@ -137,39 +156,29 @@ impl<'a> ShardsRefMut<'a> {
     /// If `dist` is `0`.
     ///
     /// [`NoSimd::fft`]: crate::reed_solomon::engine::NoSimd#method.fft
-    #[allow(clippy::type_complexity)]
-    pub fn dist4_mut(
-        &mut self,
-        mut pos: usize,
-        mut dist: usize,
-    ) -> (
-        &mut [[u8; 64]],
-        &mut [[u8; 64]],
-        &mut [[u8; 64]],
-        &mut [[u8; 64]],
-    ) {
-        pos *= self.shard_len_64;
-        dist *= self.shard_len_64;
+    pub fn dist4_mut(&mut self, mut pos: usize, mut dist: usize) -> FourShardsMut<'_> {
+        pos *= self.shard_chunk_count;
+        dist *= self.shard_chunk_count;
 
         let (ab, cd) = self.data[pos..].split_at_mut(dist * 2);
         let (a, b) = ab.split_at_mut(dist);
         let (c, d) = cd.split_at_mut(dist);
 
         (
-            &mut a[..self.shard_len_64],
-            &mut b[..self.shard_len_64],
-            &mut c[..self.shard_len_64],
-            &mut d[..self.shard_len_64],
+            &mut a[..self.shard_chunk_count],
+            &mut b[..self.shard_chunk_count],
+            &mut c[..self.shard_chunk_count],
+            &mut d[..self.shard_chunk_count],
         )
     }
 
     /// Returns `true` if this contains no shards.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.shard_count == 0
     }
 
     /// Returns number of shards.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.shard_count
     }
 
@@ -177,43 +186,47 @@ impl<'a> ShardsRefMut<'a> {
     ///
     /// # Panics
     ///
-    /// If `data.len() < shard_count * shard_len_64`.
-    pub fn new(shard_count: usize, shard_len_64: usize, data: &'a mut [[u8; 64]]) -> Self {
-        assert!(data.len() >= shard_count * shard_len_64);
+    /// If `data.len() < shard_count * shard_chunk_count`.
+    pub fn new(
+        shard_count: usize,
+        shard_chunk_count: usize,
+        data: &'a mut [[u8; SHARD_CHUNK_BYTES]],
+    ) -> Self {
+        assert!(data.len() >= shard_count * shard_chunk_count);
 
         Self {
             shard_count,
-            shard_len_64,
-            data: &mut data[..shard_count * shard_len_64],
+            shard_chunk_count,
+            data: &mut data[..shard_count * shard_chunk_count],
         }
     }
 
     /// Splits this [`ShardsRefMut`] into two so that
     /// first includes shards `0..mid` and second includes shards `mid..`.
     pub fn split_at_mut(&mut self, mid: usize) -> (ShardsRefMut<'_>, ShardsRefMut<'_>) {
-        let (a, b) = self.data.split_at_mut(mid * self.shard_len_64);
+        let (a, b) = self.data.split_at_mut(mid * self.shard_chunk_count);
 
         (
-            ShardsRefMut::new(mid, self.shard_len_64, a),
-            ShardsRefMut::new(self.shard_count - mid, self.shard_len_64, b),
+            ShardsRefMut::new(mid, self.shard_chunk_count, a),
+            ShardsRefMut::new(self.shard_count - mid, self.shard_chunk_count, b),
         )
     }
 
     /// Fills the given shard-range with `0u8`:s.
     pub fn zero<R: RangeBounds<usize>>(&mut self, range: R) {
         let start = match range.start_bound() {
-            Bound::Included(start) => start * self.shard_len_64,
-            Bound::Excluded(start) => (start + 1) * self.shard_len_64,
+            Bound::Included(start) => start * self.shard_chunk_count,
+            Bound::Excluded(start) => (start + 1) * self.shard_chunk_count,
             Bound::Unbounded => 0,
         };
 
         let end = match range.end_bound() {
-            Bound::Included(end) => (end + 1) * self.shard_len_64,
-            Bound::Excluded(end) => end * self.shard_len_64,
-            Bound::Unbounded => self.shard_count * self.shard_len_64,
+            Bound::Included(end) => (end + 1) * self.shard_chunk_count,
+            Bound::Excluded(end) => end * self.shard_chunk_count,
+            Bound::Unbounded => self.shard_count * self.shard_chunk_count,
         };
 
-        self.data[start..end].fill([0; 64]);
+        self.data[start..end].fill([0; SHARD_CHUNK_BYTES]);
     }
 }
 
@@ -221,9 +234,9 @@ impl<'a> ShardsRefMut<'a> {
 // ShardsRefMut - IMPL Index
 
 impl Index<usize> for ShardsRefMut<'_> {
-    type Output = [[u8; 64]];
+    type Output = [[u8; SHARD_CHUNK_BYTES]];
     fn index(&self, index: usize) -> &Self::Output {
-        &self.data[index * self.shard_len_64..(index + 1) * self.shard_len_64]
+        &self.data[index * self.shard_chunk_count..(index + 1) * self.shard_chunk_count]
     }
 }
 
@@ -232,7 +245,7 @@ impl Index<usize> for ShardsRefMut<'_> {
 
 impl IndexMut<usize> for ShardsRefMut<'_> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.data[index * self.shard_len_64..(index + 1) * self.shard_len_64]
+        &mut self.data[index * self.shard_chunk_count..(index + 1) * self.shard_chunk_count]
     }
 }
 
@@ -241,9 +254,9 @@ impl IndexMut<usize> for ShardsRefMut<'_> {
 
 impl ShardsRefMut<'_> {
     pub(crate) fn copy_within(&mut self, mut src: usize, mut dest: usize, mut count: usize) {
-        src *= self.shard_len_64;
-        dest *= self.shard_len_64;
-        count *= self.shard_len_64;
+        src *= self.shard_chunk_count;
+        dest *= self.shard_chunk_count;
+        count *= self.shard_chunk_count;
 
         self.data.copy_within(src..src + count, dest);
     }
@@ -257,10 +270,13 @@ impl ShardsRefMut<'_> {
         mut x: usize,
         mut y: usize,
         mut count: usize,
-    ) -> (&mut [[u8; 64]], &mut [[u8; 64]]) {
-        x *= self.shard_len_64;
-        y *= self.shard_len_64;
-        count *= self.shard_len_64;
+    ) -> (
+        &mut [[u8; SHARD_CHUNK_BYTES]],
+        &mut [[u8; SHARD_CHUNK_BYTES]],
+    ) {
+        x *= self.shard_chunk_count;
+        y *= self.shard_chunk_count;
+        count *= self.shard_chunk_count;
 
         if x < y {
             let (head, tail) = self.data.split_at_mut(y);

--- a/cryptography/src/reed_solomon/engine/shards.rs
+++ b/cryptography/src/reed_solomon/engine/shards.rs
@@ -1,0 +1,273 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use core::ops::{Bound, Index, IndexMut, Range, RangeBounds};
+
+// ======================================================================
+// Shards - CRATE
+
+pub(crate) struct Shards {
+    shard_count: usize,
+    // Shard length in 64 byte chunks
+    shard_len_64: usize,
+
+    // Flat Vec of `shard_count * shard_len_64 * 64` bytes.
+    data: Vec<[u8; 64]>,
+}
+
+impl Shards {
+    pub(crate) fn as_ref_mut(&mut self) -> ShardsRefMut<'_> {
+        ShardsRefMut::new(self.shard_count, self.shard_len_64, self.data.as_mut())
+    }
+
+    pub(crate) fn new() -> Self {
+        Self {
+            shard_count: 0,
+            shard_len_64: 0,
+            data: Vec::new(),
+        }
+    }
+
+    pub(crate) fn resize(&mut self, shard_count: usize, shard_len_64: usize) {
+        self.shard_count = shard_count;
+        self.shard_len_64 = shard_len_64;
+
+        self.data
+            .resize(self.shard_count * self.shard_len_64, [0; 64]);
+    }
+
+    pub(crate) fn insert(&mut self, index: usize, shard: &[u8]) {
+        debug_assert_eq!(shard.len() % 2, 0);
+
+        let whole_chunk_count = shard.len() / 64;
+        let tail_len = shard.len() % 64;
+
+        let (src_chunks, src_tail) = shard.split_at(shard.len() - tail_len);
+
+        let dst = &mut self[index];
+        dst[..whole_chunk_count]
+            .as_flattened_mut()
+            .copy_from_slice(src_chunks);
+
+        // Last chunk is special if shard.len() % 64 != 0.
+        // See src/algorithm.md for an explanation.
+        if tail_len > 0 {
+            let (src_lo, src_hi) = src_tail.split_at(tail_len / 2);
+            let (dst_lo, dst_hi) = dst[whole_chunk_count].split_at_mut(32);
+            dst_lo[..src_lo.len()].copy_from_slice(src_lo);
+            dst_hi[..src_hi.len()].copy_from_slice(src_hi);
+        }
+    }
+
+    // Undoes the encoding of the last chunk for the given range of shards
+    pub(crate) fn undo_last_chunk_encoding(&mut self, shard_bytes: usize, range: Range<usize>) {
+        let whole_chunk_count = shard_bytes / 64;
+        let tail_len = shard_bytes % 64;
+
+        if tail_len == 0 {
+            return;
+        }
+
+        for idx in range {
+            let last_chunk = &mut self[idx][whole_chunk_count];
+            last_chunk.copy_within(32..32 + tail_len / 2, tail_len / 2);
+        }
+    }
+}
+
+// ======================================================================
+// Shards - IMPL Index
+
+impl Index<usize> for Shards {
+    type Output = [[u8; 64]];
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.data[index * self.shard_len_64..(index + 1) * self.shard_len_64]
+    }
+}
+
+// ======================================================================
+// Shards - IMPL IndexMut
+
+impl IndexMut<usize> for Shards {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.data[index * self.shard_len_64..(index + 1) * self.shard_len_64]
+    }
+}
+
+// ======================================================================
+// ShardsRefMut - PUBLIC
+
+/// Mutable reference to a shard array.
+pub struct ShardsRefMut<'a> {
+    shard_count: usize,
+    shard_len_64: usize,
+
+    data: &'a mut [[u8; 64]],
+}
+
+impl<'a> ShardsRefMut<'a> {
+    /// Returns mutable references to shards at `pos` and `pos + dist`.
+    ///
+    /// See source code of [`Naive::fft`] for an example.
+    ///
+    /// # Panics
+    ///
+    /// If `dist` is `0`.
+    ///
+    /// [`Naive::fft`]: crate::reed_solomon::engine::Naive#method.fft
+    pub fn dist2_mut(
+        &mut self,
+        mut pos: usize,
+        mut dist: usize,
+    ) -> (&mut [[u8; 64]], &mut [[u8; 64]]) {
+        pos *= self.shard_len_64;
+        dist *= self.shard_len_64;
+
+        let (a, b) = self.data[pos..].split_at_mut(dist);
+        (&mut a[..self.shard_len_64], &mut b[..self.shard_len_64])
+    }
+
+    /// Returns mutable references to shards at
+    /// `pos`, `pos + dist`, `pos + dist * 2` and `pos + dist * 3`.
+    ///
+    /// See source code of [`NoSimd::fft`] for an example
+    /// (specifically the private method `fft_butterfly_two_layers`).
+    ///
+    /// # Panics
+    ///
+    /// If `dist` is `0`.
+    ///
+    /// [`NoSimd::fft`]: crate::reed_solomon::engine::NoSimd#method.fft
+    #[allow(clippy::type_complexity)]
+    pub fn dist4_mut(
+        &mut self,
+        mut pos: usize,
+        mut dist: usize,
+    ) -> (
+        &mut [[u8; 64]],
+        &mut [[u8; 64]],
+        &mut [[u8; 64]],
+        &mut [[u8; 64]],
+    ) {
+        pos *= self.shard_len_64;
+        dist *= self.shard_len_64;
+
+        let (ab, cd) = self.data[pos..].split_at_mut(dist * 2);
+        let (a, b) = ab.split_at_mut(dist);
+        let (c, d) = cd.split_at_mut(dist);
+
+        (
+            &mut a[..self.shard_len_64],
+            &mut b[..self.shard_len_64],
+            &mut c[..self.shard_len_64],
+            &mut d[..self.shard_len_64],
+        )
+    }
+
+    /// Returns `true` if this contains no shards.
+    pub fn is_empty(&self) -> bool {
+        self.shard_count == 0
+    }
+
+    /// Returns number of shards.
+    pub fn len(&self) -> usize {
+        self.shard_count
+    }
+
+    /// Creates new [`ShardsRefMut`] that references given `data`.
+    ///
+    /// # Panics
+    ///
+    /// If `data.len() < shard_count * shard_len_64`.
+    pub fn new(shard_count: usize, shard_len_64: usize, data: &'a mut [[u8; 64]]) -> Self {
+        assert!(data.len() >= shard_count * shard_len_64);
+
+        Self {
+            shard_count,
+            shard_len_64,
+            data: &mut data[..shard_count * shard_len_64],
+        }
+    }
+
+    /// Splits this [`ShardsRefMut`] into two so that
+    /// first includes shards `0..mid` and second includes shards `mid..`.
+    pub fn split_at_mut(&mut self, mid: usize) -> (ShardsRefMut<'_>, ShardsRefMut<'_>) {
+        let (a, b) = self.data.split_at_mut(mid * self.shard_len_64);
+
+        (
+            ShardsRefMut::new(mid, self.shard_len_64, a),
+            ShardsRefMut::new(self.shard_count - mid, self.shard_len_64, b),
+        )
+    }
+
+    /// Fills the given shard-range with `0u8`:s.
+    pub fn zero<R: RangeBounds<usize>>(&mut self, range: R) {
+        let start = match range.start_bound() {
+            Bound::Included(start) => start * self.shard_len_64,
+            Bound::Excluded(start) => (start + 1) * self.shard_len_64,
+            Bound::Unbounded => 0,
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(end) => (end + 1) * self.shard_len_64,
+            Bound::Excluded(end) => end * self.shard_len_64,
+            Bound::Unbounded => self.shard_count * self.shard_len_64,
+        };
+
+        self.data[start..end].fill([0; 64]);
+    }
+}
+
+// ======================================================================
+// ShardsRefMut - IMPL Index
+
+impl Index<usize> for ShardsRefMut<'_> {
+    type Output = [[u8; 64]];
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.data[index * self.shard_len_64..(index + 1) * self.shard_len_64]
+    }
+}
+
+// ======================================================================
+// ShardsRefMut - IMPL IndexMut
+
+impl IndexMut<usize> for ShardsRefMut<'_> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.data[index * self.shard_len_64..(index + 1) * self.shard_len_64]
+    }
+}
+
+// ======================================================================
+// ShardsRefMut - CRATE
+
+impl ShardsRefMut<'_> {
+    pub(crate) fn copy_within(&mut self, mut src: usize, mut dest: usize, mut count: usize) {
+        src *= self.shard_len_64;
+        dest *= self.shard_len_64;
+        count *= self.shard_len_64;
+
+        self.data.copy_within(src..src + count, dest);
+    }
+
+    // Returns mutable references to flat-arrays of shard-ranges
+    // `x .. x + count` and `y .. y + count`.
+    //
+    // Ranges must not overlap.
+    pub(crate) fn flat2_mut(
+        &mut self,
+        mut x: usize,
+        mut y: usize,
+        mut count: usize,
+    ) -> (&mut [[u8; 64]], &mut [[u8; 64]]) {
+        x *= self.shard_len_64;
+        y *= self.shard_len_64;
+        count *= self.shard_len_64;
+
+        if x < y {
+            let (head, tail) = self.data.split_at_mut(y);
+            (&mut head[x..x + count], &mut tail[..count])
+        } else {
+            let (head, tail) = self.data.split_at_mut(x);
+            (&mut tail[..count], &mut head[y..y + count])
+        }
+    }
+}

--- a/cryptography/src/reed_solomon/engine/tables.rs
+++ b/cryptography/src/reed_solomon/engine/tables.rs
@@ -1,0 +1,318 @@
+//! Lookup-tables used by [`Engine`]:s.
+//!
+//! All tables are global and each is initialized at most once.
+//!
+//! # Tables
+//!
+//! | Table        | Size    | Used in encoding | Used in decoding | By engines         |
+//! | ------------ | ------- | ---------------- | ---------------- | ------------------ |
+//! | [`Exp`]      | 128 kiB | yes              | yes              | all                |
+//! | [`Log`]      | 128 kiB | yes              | yes              | all                |
+//! | [`LogWalsh`] | 128 kiB | -                | yes              | all                |
+//! | [`Mul16`]    | 8 MiB   | yes              | yes              | [`NoSimd`]         |
+//! | [`Mul128`]   | 8 MiB   | yes              | yes              | `Avx2` `Ssse3`     |
+//! | [`Skew`]     | 128 kiB | yes              | yes              | all                |
+//!
+//! [`NoSimd`]: crate::reed_solomon::engine::NoSimd
+//! [`Engine`]: crate::reed_solomon::engine
+//!
+
+use crate::reed_solomon::engine::{
+    fwht, utils, GfElement, CANTOR_BASIS, GF_BITS, GF_MODULUS, GF_ORDER, GF_POLYNOMIAL,
+};
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use once_cell::race::OnceBox;
+#[cfg(feature = "std")]
+use std::sync::LazyLock;
+
+// ======================================================================
+// TYPE ALIASES - PUBLIC
+
+/// Used by [`Naive`] engine for multiplications
+/// and by all [`Engine`]:s to initialize other tables.
+///
+/// [`Naive`]: crate::reed_solomon::engine::Naive
+/// [`Engine`]: crate::reed_solomon::engine
+pub type Exp = [GfElement; GF_ORDER];
+
+/// Used by [`Naive`] engine for multiplications
+/// and by all [`Engine`]:s to initialize other tables.
+///
+/// [`Naive`]: crate::reed_solomon::engine::Naive
+/// [`Engine`]: crate::reed_solomon::engine
+pub type Log = [GfElement; GF_ORDER];
+
+/// Used by `Avx2` and `Ssse3` engines for multiplications.
+pub type Mul128 = [Multiply128lutT; GF_ORDER];
+
+/// Elements of the Mul128 table
+#[derive(Clone, Debug)]
+pub struct Multiply128lutT {
+    /// Lower half of `GfElements`
+    pub lo: [u128; 4],
+    /// Upper half of `GfElements`
+    pub hi: [u128; 4],
+}
+
+/// Used by all [`Engine`]:s in [`Engine::eval_poly`].
+///
+/// [`Engine`]: crate::reed_solomon::engine
+/// [`Engine::eval_poly`]: crate::reed_solomon::engine::Engine::eval_poly
+pub type LogWalsh = [GfElement; GF_ORDER];
+
+/// Used by [`NoSimd`] engine for multiplications.
+///
+/// [`NoSimd`]: crate::reed_solomon::engine::NoSimd
+pub type Mul16 = [[[GfElement; 16]; 4]; GF_ORDER];
+
+/// Used by all [`Engine`]:s for FFT and IFFT.
+///
+/// [`Engine`]: crate::reed_solomon::engine
+pub type Skew = [GfElement; GF_MODULUS as usize];
+
+// ======================================================================
+// ExpLog - PUBLIC
+
+/// Struct holding the [`Exp`] and [`Log`] lookup tables.
+pub struct ExpLog {
+    /// Exponentiation table.
+    pub exp: Box<Exp>,
+    /// Logarithm table.
+    pub log: Box<Log>,
+}
+
+// ======================================================================
+// STATIC - PUBLIC
+
+/// Lazily initialized exponentiation and logarithm tables.
+pub fn get_exp_log() -> &'static ExpLog {
+    #[cfg(feature = "std")]
+    {
+        static EXP_LOG: LazyLock<ExpLog> = LazyLock::new(initialize_exp_log);
+        &EXP_LOG
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static EXP_LOG: OnceBox<ExpLog> = OnceBox::new();
+        EXP_LOG.get_or_init(|| Box::new(initialize_exp_log()))
+    }
+}
+
+/// Lazily initialized logarithmic Walsh transform table.
+pub fn get_log_walsh() -> &'static LogWalsh {
+    #[cfg(feature = "std")]
+    {
+        static LOG_WALSH: LazyLock<Box<LogWalsh>> = LazyLock::new(initialize_log_walsh);
+        &LOG_WALSH
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static LOG_WALSH: OnceBox<LogWalsh> = OnceBox::new();
+        LOG_WALSH.get_or_init(initialize_log_walsh)
+    }
+}
+
+/// Lazily initialized multiplication table for the `NoSimd` engine.
+pub fn get_mul16() -> &'static Mul16 {
+    #[cfg(feature = "std")]
+    {
+        static MUL16: LazyLock<Box<Mul16>> = LazyLock::new(initialize_mul16);
+        &MUL16
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static MUL16: OnceBox<Mul16> = OnceBox::new();
+        MUL16.get_or_init(initialize_mul16)
+    }
+}
+
+/// Lazily initialized multiplication table for SIMD engines.
+pub fn get_mul128() -> &'static Mul128 {
+    #[cfg(feature = "std")]
+    {
+        static MUL128: LazyLock<Box<Mul128>> = LazyLock::new(initialize_mul128);
+        &MUL128
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static MUL128: OnceBox<Mul128> = OnceBox::new();
+        MUL128.get_or_init(initialize_mul128)
+    }
+}
+
+/// Lazily initialized skew table used in FFT and IFFT operations.
+pub fn get_skew() -> &'static Skew {
+    #[cfg(feature = "std")]
+    {
+        static SKEW: LazyLock<Box<Skew>> = LazyLock::new(initialize_skew);
+        &SKEW
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        static SKEW: OnceBox<Skew> = OnceBox::new();
+        SKEW.get_or_init(initialize_skew)
+    }
+}
+
+// ======================================================================
+// FUNCTIONS - PUBLIC - math
+
+/// Calculates `x * log_m` using [`Exp`] and [`Log`] tables.
+#[inline(always)]
+pub fn mul(x: GfElement, log_m: GfElement, exp: &Exp, log: &Log) -> GfElement {
+    if x == 0 {
+        0
+    } else {
+        exp[utils::add_mod(log[x as usize], log_m) as usize]
+    }
+}
+
+// ======================================================================
+// FUNCTIONS - PRIVATE - initialize tables
+
+#[allow(clippy::needless_range_loop)]
+fn initialize_exp_log() -> ExpLog {
+    let mut exp = Box::new([0; GF_ORDER]);
+    let mut log = Box::new([0; GF_ORDER]);
+
+    // GENERATE LFSR TABLE
+
+    let mut state = 1;
+    for i in 0..GF_MODULUS {
+        exp[state] = i;
+        state <<= 1;
+        if state >= GF_ORDER {
+            state ^= GF_POLYNOMIAL;
+        }
+    }
+    exp[0] = GF_MODULUS;
+
+    // CONVERT TO CANTOR BASIS
+
+    log[0] = 0;
+    for i in 0..GF_BITS {
+        let width = 1usize << i;
+        for j in 0..width {
+            log[j + width] = log[j] ^ CANTOR_BASIS[i];
+        }
+    }
+
+    for i in 0..GF_ORDER {
+        log[i] = exp[log[i] as usize];
+    }
+
+    for i in 0..GF_ORDER {
+        exp[log[i] as usize] = i as GfElement;
+    }
+
+    exp[GF_MODULUS as usize] = exp[0];
+
+    ExpLog { exp, log }
+}
+
+fn initialize_log_walsh() -> Box<LogWalsh> {
+    let log = get_exp_log().log.as_slice();
+
+    let mut log_walsh: Box<LogWalsh> = Box::new([0; GF_ORDER]);
+
+    log_walsh.copy_from_slice(log);
+    log_walsh[0] = 0;
+    fwht::fwht(log_walsh.as_mut(), GF_ORDER);
+
+    log_walsh
+}
+
+fn initialize_mul16() -> Box<Mul16> {
+    let exp = &get_exp_log().exp;
+    let log = &get_exp_log().log;
+    let mut mul16 = vec![[[0; 16]; 4]; GF_ORDER];
+
+    for log_m in 0..=GF_MODULUS {
+        let lut = &mut mul16[log_m as usize];
+        for i in 0..16 {
+            lut[0][i] = mul(i as GfElement, log_m, exp, log);
+            lut[1][i] = mul((i << 4) as GfElement, log_m, exp, log);
+            lut[2][i] = mul((i << 8) as GfElement, log_m, exp, log);
+            lut[3][i] = mul((i << 12) as GfElement, log_m, exp, log);
+        }
+    }
+
+    mul16.into_boxed_slice().try_into().unwrap()
+}
+
+fn initialize_mul128() -> Box<Mul128> {
+    // Based on:
+    // https://github.com/catid/leopard/blob/22ddc7804998d31c8f1a2617ee720e063b1fa6cd/LeopardFF16.cpp#L375
+    let exp = &get_exp_log().exp;
+    let log = &get_exp_log().log;
+
+    let mut mul128 = vec![
+        Multiply128lutT {
+            lo: [0; 4],
+            hi: [0; 4],
+        };
+        GF_ORDER
+    ];
+
+    for log_m in 0..=GF_MODULUS {
+        for i in 0..=3 {
+            let mut prod_lo = [0u8; 16];
+            let mut prod_hi = [0u8; 16];
+            for x in 0..16 {
+                let prod = mul((x << (i * 4)) as GfElement, log_m, exp, log);
+                prod_lo[x] = prod as u8;
+                prod_hi[x] = (prod >> 8) as u8;
+            }
+            mul128[log_m as usize].lo[i] = u128::from_le_bytes(prod_lo);
+            mul128[log_m as usize].hi[i] = u128::from_le_bytes(prod_hi);
+        }
+    }
+
+    mul128.into_boxed_slice().try_into().unwrap()
+}
+
+#[allow(clippy::needless_range_loop)]
+fn initialize_skew() -> Box<Skew> {
+    let exp = &get_exp_log().exp;
+    let log = &get_exp_log().log;
+
+    let mut skew = Box::new([0; GF_MODULUS as usize]);
+
+    let mut temp = [0; GF_BITS - 1];
+
+    for i in 1..GF_BITS {
+        temp[i - 1] = 1 << i;
+    }
+
+    for m in 0..GF_BITS - 1 {
+        let step: usize = 1 << (m + 1);
+
+        skew[(1 << m) - 1] = 0;
+
+        for i in m..GF_BITS - 1 {
+            let s: usize = 1 << (i + 1);
+            let mut j = (1 << m) - 1;
+            while j < s {
+                skew[j + s] = skew[j] ^ temp[i];
+                j += step;
+            }
+        }
+
+        temp[m] = GF_MODULUS - log[mul(temp[m], log[(temp[m] ^ 1) as usize], exp, log) as usize];
+
+        for i in m + 1..GF_BITS - 1 {
+            let sum = utils::add_mod(log[(temp[i] ^ 1) as usize], temp[m]);
+            temp[i] = mul(temp[i], sum, exp, log);
+        }
+    }
+
+    for i in 0..GF_MODULUS as usize {
+        skew[i] = log[skew[i] as usize];
+    }
+
+    skew
+}

--- a/cryptography/src/reed_solomon/engine/tables.rs
+++ b/cryptography/src/reed_solomon/engine/tables.rs
@@ -174,7 +174,6 @@ pub fn mul(x: GfElement, log_m: GfElement, exp: &Exp, log: &Log) -> GfElement {
 // ======================================================================
 // FUNCTIONS - PRIVATE - initialize tables
 
-#[allow(clippy::needless_range_loop)]
 fn initialize_exp_log() -> ExpLog {
     let mut exp = Box::new([0; GF_ORDER]);
     let mut log = Box::new([0; GF_ORDER]);
@@ -194,19 +193,19 @@ fn initialize_exp_log() -> ExpLog {
     // CONVERT TO CANTOR BASIS
 
     log[0] = 0;
-    for i in 0..GF_BITS {
+    for (i, basis) in CANTOR_BASIS.iter().copied().enumerate().take(GF_BITS) {
         let width = 1usize << i;
         for j in 0..width {
-            log[j + width] = log[j] ^ CANTOR_BASIS[i];
+            log[j + width] = log[j] ^ basis;
         }
     }
 
-    for i in 0..GF_ORDER {
-        log[i] = exp[log[i] as usize];
+    for value in log.iter_mut() {
+        *value = exp[*value as usize];
     }
 
-    for i in 0..GF_ORDER {
-        exp[log[i] as usize] = i as GfElement;
+    for (i, value) in log.iter().copied().enumerate() {
+        exp[value as usize] = i as GfElement;
     }
 
     exp[GF_MODULUS as usize] = exp[0];
@@ -233,11 +232,18 @@ fn initialize_mul16() -> Box<Mul16> {
 
     for log_m in 0..=GF_MODULUS {
         let lut = &mut mul16[log_m as usize];
-        for i in 0..16 {
-            lut[0][i] = mul(i as GfElement, log_m, exp, log);
-            lut[1][i] = mul((i << 4) as GfElement, log_m, exp, log);
-            lut[2][i] = mul((i << 8) as GfElement, log_m, exp, log);
-            lut[3][i] = mul((i << 12) as GfElement, log_m, exp, log);
+        let [row0, row1, row2, row3] = lut;
+        for (i, (((x0, x1), x2), x3)) in row0
+            .iter_mut()
+            .zip(row1.iter_mut())
+            .zip(row2.iter_mut())
+            .zip(row3.iter_mut())
+            .enumerate()
+        {
+            *x0 = mul(i as GfElement, log_m, exp, log);
+            *x1 = mul((i << 4) as GfElement, log_m, exp, log);
+            *x2 = mul((i << 8) as GfElement, log_m, exp, log);
+            *x3 = mul((i << 12) as GfElement, log_m, exp, log);
         }
     }
 
@@ -275,7 +281,6 @@ fn initialize_mul128() -> Box<Mul128> {
     mul128.into_boxed_slice().try_into().unwrap()
 }
 
-#[allow(clippy::needless_range_loop)]
 fn initialize_skew() -> Box<Skew> {
     let exp = &get_exp_log().exp;
     let log = &get_exp_log().log;
@@ -284,8 +289,8 @@ fn initialize_skew() -> Box<Skew> {
 
     let mut temp = [0; GF_BITS - 1];
 
-    for i in 1..GF_BITS {
-        temp[i - 1] = 1 << i;
+    for (i, value) in temp.iter_mut().enumerate() {
+        *value = 1 << (i + 1);
     }
 
     for m in 0..GF_BITS - 1 {
@@ -293,11 +298,11 @@ fn initialize_skew() -> Box<Skew> {
 
         skew[(1 << m) - 1] = 0;
 
-        for i in m..GF_BITS - 1 {
+        for (i, temp_i) in temp.iter().copied().enumerate().skip(m) {
             let s: usize = 1 << (i + 1);
             let mut j = (1 << m) - 1;
             while j < s {
-                skew[j + s] = skew[j] ^ temp[i];
+                skew[j + s] = skew[j] ^ temp_i;
                 j += step;
             }
         }
@@ -310,8 +315,8 @@ fn initialize_skew() -> Box<Skew> {
         }
     }
 
-    for i in 0..GF_MODULUS as usize {
-        skew[i] = log[skew[i] as usize];
+    for value in skew.iter_mut() {
+        *value = log[*value as usize];
     }
 
     skew

--- a/cryptography/src/reed_solomon/engine/utils.rs
+++ b/cryptography/src/reed_solomon/engine/utils.rs
@@ -3,7 +3,7 @@
 //! [`Engine`]: crate::reed_solomon::engine::Engine
 
 use crate::reed_solomon::engine::{
-    fwht, tables, Engine, GfElement, ShardsRefMut, GF_BITS, GF_ORDER,
+    fwht, tables, Engine, GfElement, ShardsRefMut, GF_BITS, GF_ORDER, SHARD_CHUNK_BYTES,
 };
 use core::iter::zip;
 
@@ -32,8 +32,8 @@ pub fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
 
 /// `x[] ^= y[]`
 #[inline(always)]
-pub fn xor(xs: &mut [[u8; 64]], ys: &[[u8; 64]]) {
-    debug_assert_eq!(xs.len(), ys.len());
+pub fn xor(xs: &mut [[u8; SHARD_CHUNK_BYTES]], ys: &[[u8; SHARD_CHUNK_BYTES]]) {
+    assert_eq!(xs.len(), ys.len());
 
     for (x_chunk, y_chunk) in zip(xs.iter_mut(), ys.iter()) {
         for (x, y) in zip(x_chunk.iter_mut(), y_chunk.iter()) {
@@ -46,7 +46,7 @@ pub fn xor(xs: &mut [[u8; 64]], ys: &[[u8; 64]]) {
 ///
 /// Ranges must not overlap.
 #[inline(always)]
-pub fn xor_within(data: &mut ShardsRefMut, x: usize, y: usize, count: usize) {
+pub fn xor_within(data: &mut ShardsRefMut<'_>, x: usize, y: usize, count: usize) {
     let (xs, ys) = data.flat2_mut(x, y, count);
     xor(xs, ys);
 }
@@ -75,7 +75,7 @@ pub(crate) fn sub_mod(x: GfElement, y: GfElement) -> GfElement {
 #[inline(always)]
 pub(crate) fn fft_skew_end(
     engine: &impl Engine,
-    data: &mut ShardsRefMut,
+    data: &mut ShardsRefMut<'_>,
     pos: usize,
     size: usize,
     truncated_size: usize,
@@ -87,7 +87,7 @@ pub(crate) fn fft_skew_end(
 #[inline(always)]
 pub(crate) fn ifft_skew_end(
     engine: &impl Engine,
-    data: &mut ShardsRefMut,
+    data: &mut ShardsRefMut<'_>,
     pos: usize,
     size: usize,
     truncated_size: usize,
@@ -96,7 +96,7 @@ pub(crate) fn ifft_skew_end(
 }
 
 // Formal derivative.
-pub(crate) fn formal_derivative(data: &mut ShardsRefMut) {
+pub(crate) fn formal_derivative(data: &mut ShardsRefMut<'_>) {
     for i in 1..data.len() {
         let width: usize = 1 << i.trailing_zeros();
         xor_within(data, i - width, i, width);

--- a/cryptography/src/reed_solomon/engine/utils.rs
+++ b/cryptography/src/reed_solomon/engine/utils.rs
@@ -1,0 +1,104 @@
+//! A collection of utility functions and helpers to facilitate the implementation of the [`Engine`] trait.
+//!
+//! [`Engine`]: crate::reed_solomon::engine::Engine
+
+use crate::reed_solomon::engine::{
+    fwht, tables, Engine, GfElement, ShardsRefMut, GF_BITS, GF_ORDER,
+};
+use core::iter::zip;
+
+// ======================================================================
+// FUNCTIONS - PUBLIC
+
+/// Evaluate Polynomial using Fast Walsh-Hadamard Transform (FWHT).
+///
+/// This function is designed to be inlined and be compiled with SIMD
+/// features enabled within an Engine's implementation of `eval_poly`.
+///
+/// See `Avx2` for an example on how to do this.
+#[inline(always)]
+pub fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
+    let log_walsh = tables::get_log_walsh();
+
+    fwht::fwht(erasures, truncated_size);
+
+    for (e, factor) in zip(erasures.iter_mut(), log_walsh.iter()) {
+        let product = u32::from(*e) * u32::from(*factor);
+        *e = add_mod(product as GfElement, (product >> GF_BITS) as GfElement);
+    }
+
+    fwht::fwht(erasures, GF_ORDER);
+}
+
+/// `x[] ^= y[]`
+#[inline(always)]
+pub fn xor(xs: &mut [[u8; 64]], ys: &[[u8; 64]]) {
+    debug_assert_eq!(xs.len(), ys.len());
+
+    for (x_chunk, y_chunk) in zip(xs.iter_mut(), ys.iter()) {
+        for (x, y) in zip(x_chunk.iter_mut(), y_chunk.iter()) {
+            *x ^= y;
+        }
+    }
+}
+
+/// `data[x .. x + count] ^= data[y .. y + count]`
+///
+/// Ranges must not overlap.
+#[inline(always)]
+pub fn xor_within(data: &mut ShardsRefMut, x: usize, y: usize, count: usize) {
+    let (xs, ys) = data.flat2_mut(x, y, count);
+    xor(xs, ys);
+}
+
+// ======================================================================
+// FUNCTIONS - CRATE - Galois field operations
+
+/// Some kind of addition.
+#[inline(always)]
+pub(crate) fn add_mod(x: GfElement, y: GfElement) -> GfElement {
+    let sum = u32::from(x) + u32::from(y);
+    (sum + (sum >> GF_BITS)) as GfElement
+}
+
+/// Some kind of subtraction.
+#[inline(always)]
+pub(crate) fn sub_mod(x: GfElement, y: GfElement) -> GfElement {
+    let dif = u32::from(x).wrapping_sub(u32::from(y));
+    dif.wrapping_add(dif >> GF_BITS) as GfElement
+}
+
+// ======================================================================
+// FUNCTIONS - CRATE
+
+/// FFT with `skew_delta = pos + size`.
+#[inline(always)]
+pub(crate) fn fft_skew_end(
+    engine: &impl Engine,
+    data: &mut ShardsRefMut,
+    pos: usize,
+    size: usize,
+    truncated_size: usize,
+) {
+    engine.fft(data, pos, size, truncated_size, pos + size);
+}
+
+/// IFFT with `skew_delta = pos + size`.
+#[inline(always)]
+pub(crate) fn ifft_skew_end(
+    engine: &impl Engine,
+    data: &mut ShardsRefMut,
+    pos: usize,
+    size: usize,
+    truncated_size: usize,
+) {
+    engine.ifft(data, pos, size, truncated_size, pos + size);
+}
+
+// Formal derivative.
+pub(crate) fn formal_derivative(data: &mut ShardsRefMut) {
+    for i in 1..data.len() {
+        let width: usize = 1 << i.trailing_zeros();
+        xor_within(data, i - width, i, width);
+    }
+}

--- a/cryptography/src/reed_solomon/mod.rs
+++ b/cryptography/src/reed_solomon/mod.rs
@@ -10,38 +10,19 @@
 //!   and naming rules.
 //! - Uses workspace dependencies and [`commonware_formatting`] in the test harness.
 //! - Uses [`thiserror`] for error display formatting.
-//! - Uses scoped lint allowances for upstream implementation and test style.
+//! - Renamed upstream `ReedSolomonEncoder` and `ReedSolomonDecoder` to [`Encoder`] and [`Decoder`].
 //! - Uses plain code references for cfg-gated SIMD engine docs so rustdoc works on all targets.
-//! - Allows upstream SIMD unsafe blocks inside this vendor module.
 //!
 //! [`reed_solomon_simd`]: https://crates.io/crates/reed-solomon-simd
 //! [`thiserror`]: https://docs.rs/thiserror
-
-#![allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_ptr_alignment,
-    clippy::inline_always,
-    clippy::large_stack_arrays,
-    clippy::manual_is_multiple_of,
-    clippy::missing_errors_doc,
-    clippy::missing_const_for_fn,
-    clippy::module_inception,
-    clippy::must_use_candidate,
-    clippy::needless_range_loop,
-    clippy::single_range_in_vec_init,
-    clippy::too_many_arguments,
-    clippy::undocumented_unsafe_blocks,
-    clippy::vec_init_then_push,
-    clippy::wildcard_imports,
-    elided_lifetimes_in_paths
-)]
 
 extern crate alloc;
 
 pub use self::{
     decoder_result::{DecoderResult, RestoredOriginal},
     encoder_result::{EncoderResult, Recovery},
-    reed_solomon::{ReedSolomonDecoder, ReedSolomonEncoder},
+    engine::SHARD_CHUNK_BYTES,
+    wrappers::{Decoder, Encoder},
 };
 use alloc::{collections::BTreeMap, vec::Vec};
 use thiserror::Error;
@@ -52,7 +33,7 @@ mod test_util;
 
 mod decoder_result;
 mod encoder_result;
-mod reed_solomon;
+mod wrappers;
 
 pub mod algorithm {
     #![doc = include_str!("algorithm.md")]
@@ -166,7 +147,7 @@ pub enum Error {
     },
 }
 
-/// Encodes in one go using [`ReedSolomonEncoder`], returning generated recovery shards.
+/// Encodes in one go using [`Encoder`], returning generated recovery shards.
 pub fn encode<T>(
     original_count: usize,
     recovery_count: usize,
@@ -176,7 +157,7 @@ where
     T: IntoIterator,
     T::Item: AsRef<[u8]>,
 {
-    if !ReedSolomonEncoder::supports(original_count, recovery_count) {
+    if !Encoder::supports(original_count, recovery_count) {
         return Err(Error::UnsupportedShardCount {
             original_count,
             recovery_count,
@@ -194,7 +175,7 @@ where
         |first| Ok((first.as_ref().len(), first)),
     )?;
 
-    let mut encoder = ReedSolomonEncoder::new(original_count, recovery_count, shard_bytes)?;
+    let mut encoder = Encoder::new(original_count, recovery_count, shard_bytes)?;
 
     encoder.add_original_shard(first)?;
     for original in original {
@@ -206,7 +187,7 @@ where
     Ok(result.recovery_iter().map(<[u8]>::to_vec).collect())
 }
 
-/// Decodes in one go using [`ReedSolomonDecoder`], returning restored original shards
+/// Decodes in one go using [`Decoder`], returning restored original shards
 /// with their indexes.
 pub fn decode<O, R, OT, RT>(
     original_count: usize,
@@ -220,7 +201,7 @@ where
     OT: AsRef<[u8]>,
     RT: AsRef<[u8]>,
 {
-    if !ReedSolomonDecoder::supports(original_count, recovery_count) {
+    if !Decoder::supports(original_count, recovery_count) {
         return Err(Error::UnsupportedShardCount {
             original_count,
             recovery_count,
@@ -245,7 +226,7 @@ where
         });
     };
 
-    let mut decoder = ReedSolomonDecoder::new(original_count, recovery_count, shard_bytes)?;
+    let mut decoder = Decoder::new(original_count, recovery_count, shard_bytes)?;
 
     for (index, original) in original {
         decoder.add_original_shard(index, original)?;
@@ -286,24 +267,24 @@ mod tests {
     #[test]
     fn test_send() {
         fn assert_send<T: Send>() {}
-        assert_send::<ReedSolomonEncoder>();
-        assert_send::<ReedSolomonDecoder>();
+        assert_send::<Encoder>();
+        assert_send::<Decoder>();
         assert_send::<DefaultEngine>();
         assert_send::<DefaultRate<DefaultEngine>>();
-        assert_send::<DecoderResult>();
-        assert_send::<EncoderResult>();
+        assert_send::<DecoderResult<'_>>();
+        assert_send::<EncoderResult<'_>>();
         assert_send::<Error>();
     }
 
     #[test]
     fn test_sync() {
         fn assert_sync<T: Sync>() {}
-        assert_sync::<ReedSolomonEncoder>();
-        assert_sync::<ReedSolomonDecoder>();
+        assert_sync::<Encoder>();
+        assert_sync::<Decoder>();
         assert_sync::<DefaultEngine>();
         assert_sync::<DefaultRate<DefaultEngine>>();
-        assert_sync::<DecoderResult>();
-        assert_sync::<EncoderResult>();
+        assert_sync::<DecoderResult<'_>>();
+        assert_sync::<EncoderResult<'_>>();
         assert_sync::<Error>();
     }
 }

--- a/cryptography/src/reed_solomon/mod.rs
+++ b/cryptography/src/reed_solomon/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! - Moved the crate into `commonware_cryptography::reed_solomon` and rewrote internal
 //!   `crate::` paths accordingly.
+//! - Retained the upstream `LICENSE` file, including the BSD-3-Clause notice for Leopard-RS.
 //! - Removed the build script and README rustdoc generation.
 //! - Removed upstream examples. Kept upstream-style benchmarks under Commonware's benchmark layout
 //!   and naming rules.

--- a/cryptography/src/reed_solomon/mod.rs
+++ b/cryptography/src/reed_solomon/mod.rs
@@ -16,15 +16,12 @@
 //! [`reed_solomon_simd`]: https://crates.io/crates/reed-solomon-simd
 //! [`thiserror`]: https://docs.rs/thiserror
 
-extern crate alloc;
-
 pub use self::{
     decoder_result::{DecoderResult, RestoredOriginal},
     encoder_result::{EncoderResult, Recovery},
     engine::SHARD_CHUNK_BYTES,
     wrappers::{Decoder, Encoder},
 };
-use alloc::{collections::BTreeMap, vec::Vec};
 use thiserror::Error;
 
 #[cfg(test)]
@@ -44,13 +41,10 @@ pub mod rate;
 /// Represents all possible errors that can occur in this library.
 #[derive(Clone, Copy, Debug, Error, PartialEq)]
 pub enum Error {
-    /// Given shard has different size than given or inferred shard size.
-    ///
-    /// - Shard size is given explicitly to encoders/decoders
-    ///   and inferred for [`encode`] and [`decode`].
+    /// Given shard has different size than the configured shard size.
     #[error("different shard size: expected {shard_bytes} bytes, got {got} bytes")]
     DifferentShardSize {
-        /// Given or inferred shard size.
+        /// Configured shard size.
         shard_bytes: usize,
         /// Size of the given shard.
         got: usize,
@@ -90,14 +84,10 @@ pub enum Error {
         index: usize,
     },
 
-    /// Given or inferred shard size is invalid:
-    /// Size must be non-zero and even.
-    ///
-    /// - Shard size is given explicitly to encoders/decoders
-    ///   and inferred for [`encode`] and [`decode`].
+    /// Configured shard size is invalid: size must be non-zero and even.
     #[error("invalid shard size: {shard_bytes} bytes (must non-zero and multiple of 2)")]
     InvalidShardSize {
-        /// Given or inferred shard size.
+        /// Configured shard size.
         shard_bytes: usize,
     },
 
@@ -147,104 +137,6 @@ pub enum Error {
     },
 }
 
-/// Encodes in one go using [`Encoder`], returning generated recovery shards.
-pub fn encode<T>(
-    original_count: usize,
-    recovery_count: usize,
-    original: T,
-) -> Result<Vec<Vec<u8>>, Error>
-where
-    T: IntoIterator,
-    T::Item: AsRef<[u8]>,
-{
-    if !Encoder::supports(original_count, recovery_count) {
-        return Err(Error::UnsupportedShardCount {
-            original_count,
-            recovery_count,
-        });
-    }
-
-    let mut original = original.into_iter();
-    let (shard_bytes, first) = original.next().map_or_else(
-        || {
-            Err(Error::TooFewOriginalShards {
-                original_count,
-                original_received_count: 0,
-            })
-        },
-        |first| Ok((first.as_ref().len(), first)),
-    )?;
-
-    let mut encoder = Encoder::new(original_count, recovery_count, shard_bytes)?;
-
-    encoder.add_original_shard(first)?;
-    for original in original {
-        encoder.add_original_shard(original)?;
-    }
-
-    let result = encoder.encode()?;
-
-    Ok(result.recovery_iter().map(<[u8]>::to_vec).collect())
-}
-
-/// Decodes in one go using [`Decoder`], returning restored original shards
-/// with their indexes.
-pub fn decode<O, R, OT, RT>(
-    original_count: usize,
-    recovery_count: usize,
-    original: O,
-    recovery: R,
-) -> Result<BTreeMap<usize, Vec<u8>>, Error>
-where
-    O: IntoIterator<Item = (usize, OT)>,
-    R: IntoIterator<Item = (usize, RT)>,
-    OT: AsRef<[u8]>,
-    RT: AsRef<[u8]>,
-{
-    if !Decoder::supports(original_count, recovery_count) {
-        return Err(Error::UnsupportedShardCount {
-            original_count,
-            recovery_count,
-        });
-    }
-
-    let original = original.into_iter();
-    let mut recovery = recovery.into_iter();
-
-    let (shard_bytes, first_recovery) = if let Some(first_recovery) = recovery.next() {
-        (first_recovery.1.as_ref().len(), first_recovery)
-    } else {
-        let original_received_count = original.count();
-        if original_received_count == original_count {
-            return Ok(BTreeMap::new());
-        }
-
-        return Err(Error::NotEnoughShards {
-            original_count,
-            original_received_count,
-            recovery_received_count: 0,
-        });
-    };
-
-    let mut decoder = Decoder::new(original_count, recovery_count, shard_bytes)?;
-
-    for (index, original) in original {
-        decoder.add_original_shard(index, original)?;
-    }
-
-    decoder.add_recovery_shard(first_recovery.0, first_recovery.1)?;
-    for (index, recovery) in recovery {
-        decoder.add_recovery_shard(index, recovery)?;
-    }
-
-    let mut result = BTreeMap::new();
-    for (index, original) in decoder.decode()?.restored_original_iter() {
-        result.insert(index, original.to_vec());
-    }
-
-    Ok(result)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -253,15 +145,25 @@ mod tests {
     #[test]
     fn roundtrip() {
         let original = test_util::generate_original(2, 1024, 123);
-        let recovery = encode(2, 3, &original).unwrap();
+
+        let mut encoder = Encoder::new(2, 3, 1024).unwrap();
+        for shard in &original {
+            encoder.add_original_shard(shard).unwrap();
+        }
+        let encoding = encoder.encode().unwrap();
+        let recovery: Vec<_> = encoding.recovery_iter().map(<[u8]>::to_vec).collect();
 
         test_util::assert_hash(&recovery, test_util::LOW_2_3);
 
-        let restored = decode(2, 3, [(0, ""); 0], [(0, &recovery[0]), (1, &recovery[1])]).unwrap();
+        let mut decoder = Decoder::new(2, 3, 1024).unwrap();
+        decoder.add_recovery_shard(0, &recovery[0]).unwrap();
+        decoder.add_recovery_shard(1, &recovery[1]).unwrap();
+        let decoding = decoder.decode().unwrap();
+        let mut restored = decoding.restored_original_iter();
 
-        assert_eq!(restored.len(), 2);
-        assert_eq!(restored[&0], original[0]);
-        assert_eq!(restored[&1], original[1]);
+        assert_eq!(restored.next(), Some((0, original[0].as_slice())));
+        assert_eq!(restored.next(), Some((1, original[1].as_slice())));
+        assert_eq!(restored.next(), None);
     }
 
     #[test]

--- a/cryptography/src/reed_solomon/mod.rs
+++ b/cryptography/src/reed_solomon/mod.rs
@@ -1,0 +1,308 @@
+//! Vendored version of [`reed_solomon_simd`].
+//!
+//! # Changes vs. Upstream
+//!
+//! - Moved the crate into `commonware_cryptography::reed_solomon` and rewrote internal
+//!   `crate::` paths accordingly.
+//! - Removed the build script and README rustdoc generation.
+//! - Removed upstream examples. Kept upstream-style benchmarks under Commonware's benchmark layout
+//!   and naming rules.
+//! - Uses workspace dependencies and [`commonware_formatting`] in the test harness.
+//! - Uses [`thiserror`] for error display formatting.
+//! - Uses scoped lint allowances for upstream implementation and test style.
+//! - Uses plain code references for cfg-gated SIMD engine docs so rustdoc works on all targets.
+//! - Allows upstream SIMD unsafe blocks inside this vendor module.
+//!
+//! [`reed_solomon_simd`]: https://crates.io/crates/reed-solomon-simd
+//! [`thiserror`]: https://docs.rs/thiserror
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_ptr_alignment,
+    clippy::inline_always,
+    clippy::large_stack_arrays,
+    clippy::manual_is_multiple_of,
+    clippy::missing_errors_doc,
+    clippy::missing_const_for_fn,
+    clippy::module_inception,
+    clippy::must_use_candidate,
+    clippy::needless_range_loop,
+    clippy::single_range_in_vec_init,
+    clippy::too_many_arguments,
+    clippy::undocumented_unsafe_blocks,
+    clippy::vec_init_then_push,
+    clippy::wildcard_imports,
+    elided_lifetimes_in_paths
+)]
+
+extern crate alloc;
+
+pub use self::{
+    decoder_result::{DecoderResult, RestoredOriginal},
+    encoder_result::{EncoderResult, Recovery},
+    reed_solomon::{ReedSolomonDecoder, ReedSolomonEncoder},
+};
+use alloc::{collections::BTreeMap, vec::Vec};
+use thiserror::Error;
+
+#[cfg(test)]
+#[macro_use]
+mod test_util;
+
+mod decoder_result;
+mod encoder_result;
+mod reed_solomon;
+
+pub mod algorithm {
+    #![doc = include_str!("algorithm.md")]
+}
+pub mod engine;
+pub mod rate;
+
+/// Represents all possible errors that can occur in this library.
+#[derive(Clone, Copy, Debug, Error, PartialEq)]
+pub enum Error {
+    /// Given shard has different size than given or inferred shard size.
+    ///
+    /// - Shard size is given explicitly to encoders/decoders
+    ///   and inferred for [`encode`] and [`decode`].
+    #[error("different shard size: expected {shard_bytes} bytes, got {got} bytes")]
+    DifferentShardSize {
+        /// Given or inferred shard size.
+        shard_bytes: usize,
+        /// Size of the given shard.
+        got: usize,
+    },
+
+    /// Decoder was given two original shards with same index.
+    #[error("duplicate original shard index: {index}")]
+    DuplicateOriginalShardIndex {
+        /// Given duplicate index.
+        index: usize,
+    },
+
+    /// Decoder was given two recovery shards with same index.
+    #[error("duplicate recovery shard index: {index}")]
+    DuplicateRecoveryShardIndex {
+        /// Given duplicate index.
+        index: usize,
+    },
+
+    /// Decoder was given original shard with invalid index,
+    /// i.e. `index >= original_count`.
+    #[error("invalid original shard index: {index} >= original_count {original_count}")]
+    InvalidOriginalShardIndex {
+        /// Configured number of original shards.
+        original_count: usize,
+        /// Given invalid index.
+        index: usize,
+    },
+
+    /// Decoder was given recovery shard with invalid index,
+    /// i.e. `index >= recovery_count`.
+    #[error("invalid recovery shard index: {index} >= recovery_count {recovery_count}")]
+    InvalidRecoveryShardIndex {
+        /// Configured number of recovery shards.
+        recovery_count: usize,
+        /// Given invalid index.
+        index: usize,
+    },
+
+    /// Given or inferred shard size is invalid:
+    /// Size must be non-zero and even.
+    ///
+    /// - Shard size is given explicitly to encoders/decoders
+    ///   and inferred for [`encode`] and [`decode`].
+    #[error("invalid shard size: {shard_bytes} bytes (must non-zero and multiple of 2)")]
+    InvalidShardSize {
+        /// Given or inferred shard size.
+        shard_bytes: usize,
+    },
+
+    /// Decoder was given too few shards.
+    ///
+    /// Decoding requires as many shards as there were original shards
+    /// in total, in any combination of original shards and recovery shards.
+    #[error(
+        "not enough shards: {original_received_count} original + {recovery_received_count} recovery < {original_count} original_count"
+    )]
+    NotEnoughShards {
+        /// Configured number of original shards.
+        original_count: usize,
+        /// Number of original shards given to decoder.
+        original_received_count: usize,
+        /// Number of recovery shards given to decoder.
+        recovery_received_count: usize,
+    },
+
+    /// Encoder was given less than `original_count` original shards.
+    #[error(
+        "too few original shards: got {original_received_count} shards while original_count is {original_count}"
+    )]
+    TooFewOriginalShards {
+        /// Configured number of original shards.
+        original_count: usize,
+        /// Number of original shards given to encoder.
+        original_received_count: usize,
+    },
+
+    /// Encoder was given more than `original_count` original shards.
+    #[error("too many original shards: got more than original_count ({original_count}) shards")]
+    TooManyOriginalShards {
+        /// Configured number of original shards.
+        original_count: usize,
+    },
+
+    /// Given `original_count` / `recovery_count` combination is not supported.
+    #[error(
+        "unsupported shard count: {original_count} original shards with {recovery_count} recovery shards"
+    )]
+    UnsupportedShardCount {
+        /// Given number of original shards.
+        original_count: usize,
+        /// Given number of recovery shards.
+        recovery_count: usize,
+    },
+}
+
+/// Encodes in one go using [`ReedSolomonEncoder`], returning generated recovery shards.
+pub fn encode<T>(
+    original_count: usize,
+    recovery_count: usize,
+    original: T,
+) -> Result<Vec<Vec<u8>>, Error>
+where
+    T: IntoIterator,
+    T::Item: AsRef<[u8]>,
+{
+    if !ReedSolomonEncoder::supports(original_count, recovery_count) {
+        return Err(Error::UnsupportedShardCount {
+            original_count,
+            recovery_count,
+        });
+    }
+
+    let mut original = original.into_iter();
+    let (shard_bytes, first) = original.next().map_or_else(
+        || {
+            Err(Error::TooFewOriginalShards {
+                original_count,
+                original_received_count: 0,
+            })
+        },
+        |first| Ok((first.as_ref().len(), first)),
+    )?;
+
+    let mut encoder = ReedSolomonEncoder::new(original_count, recovery_count, shard_bytes)?;
+
+    encoder.add_original_shard(first)?;
+    for original in original {
+        encoder.add_original_shard(original)?;
+    }
+
+    let result = encoder.encode()?;
+
+    Ok(result.recovery_iter().map(<[u8]>::to_vec).collect())
+}
+
+/// Decodes in one go using [`ReedSolomonDecoder`], returning restored original shards
+/// with their indexes.
+pub fn decode<O, R, OT, RT>(
+    original_count: usize,
+    recovery_count: usize,
+    original: O,
+    recovery: R,
+) -> Result<BTreeMap<usize, Vec<u8>>, Error>
+where
+    O: IntoIterator<Item = (usize, OT)>,
+    R: IntoIterator<Item = (usize, RT)>,
+    OT: AsRef<[u8]>,
+    RT: AsRef<[u8]>,
+{
+    if !ReedSolomonDecoder::supports(original_count, recovery_count) {
+        return Err(Error::UnsupportedShardCount {
+            original_count,
+            recovery_count,
+        });
+    }
+
+    let original = original.into_iter();
+    let mut recovery = recovery.into_iter();
+
+    let (shard_bytes, first_recovery) = if let Some(first_recovery) = recovery.next() {
+        (first_recovery.1.as_ref().len(), first_recovery)
+    } else {
+        let original_received_count = original.count();
+        if original_received_count == original_count {
+            return Ok(BTreeMap::new());
+        }
+
+        return Err(Error::NotEnoughShards {
+            original_count,
+            original_received_count,
+            recovery_received_count: 0,
+        });
+    };
+
+    let mut decoder = ReedSolomonDecoder::new(original_count, recovery_count, shard_bytes)?;
+
+    for (index, original) in original {
+        decoder.add_original_shard(index, original)?;
+    }
+
+    decoder.add_recovery_shard(first_recovery.0, first_recovery.1)?;
+    for (index, recovery) in recovery {
+        decoder.add_recovery_shard(index, recovery)?;
+    }
+
+    let mut result = BTreeMap::new();
+    for (index, original) in decoder.decode()?.restored_original_iter() {
+        result.insert(index, original.to_vec());
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reed_solomon::{engine::DefaultEngine, rate::DefaultRate};
+
+    #[test]
+    fn roundtrip() {
+        let original = test_util::generate_original(2, 1024, 123);
+        let recovery = encode(2, 3, &original).unwrap();
+
+        test_util::assert_hash(&recovery, test_util::LOW_2_3);
+
+        let restored = decode(2, 3, [(0, ""); 0], [(0, &recovery[0]), (1, &recovery[1])]).unwrap();
+
+        assert_eq!(restored.len(), 2);
+        assert_eq!(restored[&0], original[0]);
+        assert_eq!(restored[&1], original[1]);
+    }
+
+    #[test]
+    fn test_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ReedSolomonEncoder>();
+        assert_send::<ReedSolomonDecoder>();
+        assert_send::<DefaultEngine>();
+        assert_send::<DefaultRate<DefaultEngine>>();
+        assert_send::<DecoderResult>();
+        assert_send::<EncoderResult>();
+        assert_send::<Error>();
+    }
+
+    #[test]
+    fn test_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<ReedSolomonEncoder>();
+        assert_sync::<ReedSolomonDecoder>();
+        assert_sync::<DefaultEngine>();
+        assert_sync::<DefaultRate<DefaultEngine>>();
+        assert_sync::<DecoderResult>();
+        assert_sync::<EncoderResult>();
+        assert_sync::<Error>();
+    }
+}

--- a/cryptography/src/reed_solomon/rate.rs
+++ b/cryptography/src/reed_solomon/rate.rs
@@ -1,0 +1,249 @@
+//! Advanced encoding/decoding using chosen [`Engine`] and [`Rate`].
+//!
+//! **This is an advanced module which is not needed for [simple usage] or [basic usage].**
+//!
+//! This module is relevant if you want to
+//! - encode/decode using other [`Engine`] than [`DefaultEngine`].
+//! - re-use working space of one encoder/decoder in another.
+//! - understand/benchmark/test high or low rate directly.
+//!
+//! # Rates
+//!
+//! See [algorithm > Rate] for details about high/low rate.
+//!
+//! - [`DefaultRate`], [`DefaultRateEncoder`], [`DefaultRateDecoder`]
+//!     - Encoding/decoding using high or low rate as appropriate.
+//!     - These are basically same as [`ReedSolomonEncoder`]
+//!       and [`ReedSolomonDecoder`] except with slightly different API
+//!       which allows specifying [`Engine`] and working space.
+//! - [`HighRate`], [`HighRateEncoder`], [`HighRateDecoder`]
+//!     - Encoding/decoding using only high rate.
+//! - [`LowRate`], [`LowRateEncoder`], [`LowRateDecoder`]
+//!     - Encoding/decoding using only low rate.
+//!
+//! [simple usage]: crate::reed_solomon#simple-usage
+//! [basic usage]: crate::reed_solomon#basic-usage
+//! [algorithm > Rate]: crate::reed_solomon::algorithm#rate
+//! [`ReedSolomonEncoder`]: crate::reed_solomon::ReedSolomonEncoder
+//! [`ReedSolomonDecoder`]: crate::reed_solomon::ReedSolomonDecoder
+//! [`DefaultEngine`]: crate::reed_solomon::engine::DefaultEngine
+
+pub use self::{
+    decoder_work::DecoderWork,
+    encoder_work::EncoderWork,
+    rate_default::{DefaultRate, DefaultRateDecoder, DefaultRateEncoder},
+    rate_high::{HighRate, HighRateDecoder, HighRateEncoder},
+    rate_low::{LowRate, LowRateDecoder, LowRateEncoder},
+};
+use crate::reed_solomon::{engine::Engine, DecoderResult, EncoderResult, Error};
+
+mod decoder_work;
+mod encoder_work;
+mod rate_default;
+mod rate_high;
+mod rate_low;
+
+// ======================================================================
+// Rate - PUBLIC
+
+/// Reed-Solomon encoder/decoder generator using specific rate.
+pub trait Rate<E: Engine> {
+    // ============================================================
+    // REQUIRED
+
+    /// Encoder of this rate.
+    type RateEncoder: RateEncoder<E>;
+    /// Decoder of this rate.
+    type RateDecoder: RateDecoder<E>;
+
+    /// Returns `true` if given `original_count` / `recovery_count`
+    /// combination is supported.
+    fn supports(original_count: usize, recovery_count: usize) -> bool;
+
+    // ============================================================
+    // PROVIDED
+
+    /// Creates new encoder. This is same as [`RateEncoder::new`].
+    fn encoder(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<EncoderWork>,
+    ) -> Result<Self::RateEncoder, Error> {
+        Self::RateEncoder::new(original_count, recovery_count, shard_bytes, engine, work)
+    }
+
+    /// Creates new decoder. This is same as [`RateDecoder::new`].
+    fn decoder(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<DecoderWork>,
+    ) -> Result<Self::RateDecoder, Error> {
+        Self::RateDecoder::new(original_count, recovery_count, shard_bytes, engine, work)
+    }
+
+    /// Returns `Ok(())` if given `original_count` / `recovery_count`
+    /// combination is supported and given `shard_bytes` is valid.
+    fn validate(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        if !Self::supports(original_count, recovery_count) {
+            Err(Error::UnsupportedShardCount {
+                original_count,
+                recovery_count,
+            })
+        } else if shard_bytes == 0 || shard_bytes & 1 != 0 {
+            Err(Error::InvalidShardSize { shard_bytes })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// ======================================================================
+// RateEncoder - PUBLIC
+
+/// Reed-Solomon encoder using specific rate.
+pub trait RateEncoder<E: Engine>
+where
+    Self: Sized,
+{
+    // ============================================================
+    // REQUIRED
+
+    /// Rate of this encoder.
+    type Rate: Rate<E>;
+
+    /// Like [`ReedSolomonEncoder::add_original_shard`](crate::reed_solomon::ReedSolomonEncoder::add_original_shard).
+    fn add_original_shard<T: AsRef<[u8]>>(&mut self, original_shard: T) -> Result<(), Error>;
+
+    /// Like [`ReedSolomonEncoder::encode`](crate::reed_solomon::ReedSolomonEncoder::encode).
+    fn encode(&mut self) -> Result<EncoderResult<'_>, Error>;
+
+    /// Consumes this encoder returning its [`Engine`] and [`EncoderWork`]
+    /// so that they can be re-used by another encoder.
+    fn into_parts(self) -> (E, EncoderWork);
+
+    /// Like [`ReedSolomonEncoder::new`](crate::reed_solomon::ReedSolomonEncoder::new)
+    /// with [`Engine`] to use and optional working space to be re-used.
+    fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<EncoderWork>,
+    ) -> Result<Self, Error>;
+
+    /// Like [`ReedSolomonEncoder::reset`](crate::reed_solomon::ReedSolomonEncoder::reset).
+    fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error>;
+
+    // ============================================================
+    // PROVIDED
+
+    /// Returns `true` if given `original_count` / `recovery_count`
+    /// combination is supported.
+    ///
+    /// This is same as [`Rate::supports`].
+    fn supports(original_count: usize, recovery_count: usize) -> bool {
+        Self::Rate::supports(original_count, recovery_count)
+    }
+
+    /// Returns `Ok(())` if given `original_count` / `recovery_count`
+    /// combination is supported and given `shard_bytes` is valid.
+    ///
+    /// This is same as [`Rate::validate`].
+    fn validate(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        Self::Rate::validate(original_count, recovery_count, shard_bytes)
+    }
+}
+
+// ======================================================================
+// RateDecoder - PUBLIC
+
+/// Reed-Solomon decoder using specific rate.
+pub trait RateDecoder<E: Engine>
+where
+    Self: Sized,
+{
+    // ============================================================
+    // REQUIRED
+
+    /// Rate of this decoder.
+    type Rate: Rate<E>;
+
+    /// Like [`ReedSolomonDecoder::add_original_shard`](crate::reed_solomon::ReedSolomonDecoder::add_original_shard).
+    fn add_original_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        original_shard: T,
+    ) -> Result<(), Error>;
+
+    /// Like [`ReedSolomonDecoder::add_recovery_shard`](crate::reed_solomon::ReedSolomonDecoder::add_recovery_shard).
+    fn add_recovery_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        recovery_shard: T,
+    ) -> Result<(), Error>;
+
+    /// Like [`ReedSolomonDecoder::decode`](crate::reed_solomon::ReedSolomonDecoder::decode).
+    fn decode(&mut self) -> Result<DecoderResult<'_>, Error>;
+
+    /// Consumes this decoder returning its [`Engine`] and [`DecoderWork`]
+    /// so that they can be re-used by another decoder.
+    fn into_parts(self) -> (E, DecoderWork);
+
+    /// Like [`ReedSolomonDecoder::new`](crate::reed_solomon::ReedSolomonDecoder::new)
+    /// with [`Engine`] to use and optional working space to be re-used.
+    fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<DecoderWork>,
+    ) -> Result<Self, Error>;
+
+    /// Like [`ReedSolomonDecoder::reset`](crate::reed_solomon::ReedSolomonDecoder::reset).
+    fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error>;
+
+    // ============================================================
+    // PROVIDED
+
+    /// Returns `true` if given `original_count` / `recovery_count`
+    /// combination is supported.
+    ///
+    /// This is same as [`Rate::supports`].
+    fn supports(original_count: usize, recovery_count: usize) -> bool {
+        Self::Rate::supports(original_count, recovery_count)
+    }
+
+    /// Returns `Ok(())` if given `original_count` / `recovery_count`
+    /// combination is supported and given `shard_bytes` is valid.
+    ///
+    /// This is same as [`Rate::validate`].
+    fn validate(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        Self::Rate::validate(original_count, recovery_count, shard_bytes)
+    }
+}

--- a/cryptography/src/reed_solomon/rate.rs
+++ b/cryptography/src/reed_solomon/rate.rs
@@ -13,8 +13,8 @@
 //!
 //! - [`DefaultRate`], [`DefaultRateEncoder`], [`DefaultRateDecoder`]
 //!     - Encoding/decoding using high or low rate as appropriate.
-//!     - These are basically same as [`ReedSolomonEncoder`]
-//!       and [`ReedSolomonDecoder`] except with slightly different API
+//!     - These are basically same as [`Encoder`]
+//!       and [`Decoder`] except with slightly different API
 //!       which allows specifying [`Engine`] and working space.
 //! - [`HighRate`], [`HighRateEncoder`], [`HighRateDecoder`]
 //!     - Encoding/decoding using only high rate.
@@ -24,8 +24,8 @@
 //! [simple usage]: crate::reed_solomon#simple-usage
 //! [basic usage]: crate::reed_solomon#basic-usage
 //! [algorithm > Rate]: crate::reed_solomon::algorithm#rate
-//! [`ReedSolomonEncoder`]: crate::reed_solomon::ReedSolomonEncoder
-//! [`ReedSolomonDecoder`]: crate::reed_solomon::ReedSolomonDecoder
+//! [`Encoder`]: crate::reed_solomon::Encoder
+//! [`Decoder`]: crate::reed_solomon::Decoder
 //! [`DefaultEngine`]: crate::reed_solomon::engine::DefaultEngine
 
 pub use self::{
@@ -119,17 +119,17 @@ where
     /// Rate of this encoder.
     type Rate: Rate<E>;
 
-    /// Like [`ReedSolomonEncoder::add_original_shard`](crate::reed_solomon::ReedSolomonEncoder::add_original_shard).
+    /// Like [`Encoder::add_original_shard`](crate::reed_solomon::Encoder::add_original_shard).
     fn add_original_shard<T: AsRef<[u8]>>(&mut self, original_shard: T) -> Result<(), Error>;
 
-    /// Like [`ReedSolomonEncoder::encode`](crate::reed_solomon::ReedSolomonEncoder::encode).
+    /// Like [`Encoder::encode`](crate::reed_solomon::Encoder::encode).
     fn encode(&mut self) -> Result<EncoderResult<'_>, Error>;
 
     /// Consumes this encoder returning its [`Engine`] and [`EncoderWork`]
     /// so that they can be re-used by another encoder.
     fn into_parts(self) -> (E, EncoderWork);
 
-    /// Like [`ReedSolomonEncoder::new`](crate::reed_solomon::ReedSolomonEncoder::new)
+    /// Like [`Encoder::new`](crate::reed_solomon::Encoder::new)
     /// with [`Engine`] to use and optional working space to be re-used.
     fn new(
         original_count: usize,
@@ -139,7 +139,7 @@ where
         work: Option<EncoderWork>,
     ) -> Result<Self, Error>;
 
-    /// Like [`ReedSolomonEncoder::reset`](crate::reed_solomon::ReedSolomonEncoder::reset).
+    /// Like [`Encoder::reset`](crate::reed_solomon::Encoder::reset).
     fn reset(
         &mut self,
         original_count: usize,
@@ -185,28 +185,28 @@ where
     /// Rate of this decoder.
     type Rate: Rate<E>;
 
-    /// Like [`ReedSolomonDecoder::add_original_shard`](crate::reed_solomon::ReedSolomonDecoder::add_original_shard).
+    /// Like [`Decoder::add_original_shard`](crate::reed_solomon::Decoder::add_original_shard).
     fn add_original_shard<T: AsRef<[u8]>>(
         &mut self,
         index: usize,
         original_shard: T,
     ) -> Result<(), Error>;
 
-    /// Like [`ReedSolomonDecoder::add_recovery_shard`](crate::reed_solomon::ReedSolomonDecoder::add_recovery_shard).
+    /// Like [`Decoder::add_recovery_shard`](crate::reed_solomon::Decoder::add_recovery_shard).
     fn add_recovery_shard<T: AsRef<[u8]>>(
         &mut self,
         index: usize,
         recovery_shard: T,
     ) -> Result<(), Error>;
 
-    /// Like [`ReedSolomonDecoder::decode`](crate::reed_solomon::ReedSolomonDecoder::decode).
+    /// Like [`Decoder::decode`](crate::reed_solomon::Decoder::decode).
     fn decode(&mut self) -> Result<DecoderResult<'_>, Error>;
 
     /// Consumes this decoder returning its [`Engine`] and [`DecoderWork`]
     /// so that they can be re-used by another decoder.
     fn into_parts(self) -> (E, DecoderWork);
 
-    /// Like [`ReedSolomonDecoder::new`](crate::reed_solomon::ReedSolomonDecoder::new)
+    /// Like [`Decoder::new`](crate::reed_solomon::Decoder::new)
     /// with [`Engine`] to use and optional working space to be re-used.
     fn new(
         original_count: usize,
@@ -216,7 +216,7 @@ where
         work: Option<DecoderWork>,
     ) -> Result<Self, Error>;
 
-    /// Like [`ReedSolomonDecoder::reset`](crate::reed_solomon::ReedSolomonDecoder::reset).
+    /// Like [`Decoder::reset`](crate::reed_solomon::Decoder::reset).
     fn reset(
         &mut self,
         original_count: usize,

--- a/cryptography/src/reed_solomon/rate/decoder_work.rs
+++ b/cryptography/src/reed_solomon/rate/decoder_work.rs
@@ -1,5 +1,5 @@
 use crate::reed_solomon::{
-    engine::{Shards, ShardsRefMut},
+    engine::{Shards, ShardsRefMut, SHARD_CHUNK_BYTES},
     Error,
 };
 use fixedbitset::FixedBitSet;
@@ -28,7 +28,7 @@ pub struct DecoderWork {
 impl DecoderWork {
     /// Creates new [`DecoderWork`] which initially
     /// has no working space allocated.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             original_count: 0,
             recovery_count: 0,
@@ -139,7 +139,7 @@ impl DecoderWork {
         }
     }
 
-    pub(crate) fn original_count(&self) -> usize {
+    pub(crate) const fn original_count(&self) -> usize {
         self.original_count
     }
 
@@ -153,7 +153,7 @@ impl DecoderWork {
         recovery_base_pos: usize,
         work_count: usize,
     ) {
-        assert!(shard_bytes % 2 == 0);
+        assert!(shard_bytes.is_multiple_of(2));
 
         self.original_count = original_count;
         self.recovery_count = recovery_count;
@@ -175,7 +175,8 @@ impl DecoderWork {
             self.received.grow(max_received_pos);
         }
 
-        self.shards.resize(work_count, shard_bytes.div_ceil(64));
+        self.shards
+            .resize(work_count, shard_bytes.div_ceil(SHARD_CHUNK_BYTES));
     }
 
     pub(crate) fn reset_received(&mut self) {
@@ -202,7 +203,7 @@ impl DecoderWork {
         );
     }
 
-    pub(crate) fn missing_original_count(&self) -> usize {
+    pub(crate) const fn missing_original_count(&self) -> usize {
         self.original_count - self.original_received_count
     }
 }

--- a/cryptography/src/reed_solomon/rate/decoder_work.rs
+++ b/cryptography/src/reed_solomon/rate/decoder_work.rs
@@ -1,0 +1,208 @@
+use crate::reed_solomon::{
+    engine::{Shards, ShardsRefMut},
+    Error,
+};
+use fixedbitset::FixedBitSet;
+
+// ======================================================================
+// DecoderWork - PUBLIC
+
+/// Working space for [`RateDecoder`].
+///
+/// [`RateDecoder`]: crate::reed_solomon::rate::RateDecoder
+pub struct DecoderWork {
+    original_count: usize,
+    recovery_count: usize,
+    shard_bytes: usize,
+
+    original_base_pos: usize,
+    recovery_base_pos: usize,
+
+    original_received_count: usize,
+    recovery_received_count: usize,
+    // May contain extra zero bits.
+    received: FixedBitSet,
+    shards: Shards,
+}
+
+impl DecoderWork {
+    /// Creates new [`DecoderWork`] which initially
+    /// has no working space allocated.
+    pub fn new() -> Self {
+        Self {
+            original_count: 0,
+            recovery_count: 0,
+            shard_bytes: 0,
+
+            original_base_pos: 0,
+            recovery_base_pos: 0,
+
+            original_received_count: 0,
+            recovery_received_count: 0,
+            received: FixedBitSet::new(),
+            shards: Shards::new(),
+        }
+    }
+}
+
+// ======================================================================
+// DecoderWork - IMPL Default
+
+impl Default for DecoderWork {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ======================================================================
+// DecoderWork - CRATE
+
+impl DecoderWork {
+    pub(crate) fn add_original_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        original_shard: T,
+    ) -> Result<(), Error> {
+        let pos = self.original_base_pos + index;
+        let original_shard = original_shard.as_ref();
+
+        if index >= self.original_count {
+            Err(Error::InvalidOriginalShardIndex {
+                original_count: self.original_count,
+                index,
+            })
+        } else if self.received[pos] {
+            Err(Error::DuplicateOriginalShardIndex { index })
+        } else if original_shard.len() != self.shard_bytes {
+            Err(Error::DifferentShardSize {
+                shard_bytes: self.shard_bytes,
+                got: original_shard.len(),
+            })
+        } else {
+            self.shards.insert(pos, original_shard);
+
+            self.original_received_count += 1;
+            self.received.set(pos, true);
+            Ok(())
+        }
+    }
+
+    pub(crate) fn add_recovery_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        recovery_shard: T,
+    ) -> Result<(), Error> {
+        let pos = self.recovery_base_pos + index;
+        let recovery_shard = recovery_shard.as_ref();
+
+        if index >= self.recovery_count {
+            Err(Error::InvalidRecoveryShardIndex {
+                recovery_count: self.recovery_count,
+                index,
+            })
+        } else if self.received[pos] {
+            Err(Error::DuplicateRecoveryShardIndex { index })
+        } else if recovery_shard.len() != self.shard_bytes {
+            Err(Error::DifferentShardSize {
+                shard_bytes: self.shard_bytes,
+                got: recovery_shard.len(),
+            })
+        } else {
+            self.shards.insert(pos, recovery_shard);
+
+            self.recovery_received_count += 1;
+            self.received.set(pos, true);
+            Ok(())
+        }
+    }
+
+    // Begin decode.
+    // - Returned `FixedBitSet` may contain extra zero bits.
+    pub(crate) fn decode_begin(
+        &mut self,
+    ) -> Result<Option<(ShardsRefMut<'_>, usize, usize, &FixedBitSet)>, Error> {
+        if self.original_received_count + self.recovery_received_count < self.original_count {
+            Err(Error::NotEnoughShards {
+                original_count: self.original_count,
+                original_received_count: self.original_received_count,
+                recovery_received_count: self.recovery_received_count,
+            })
+        } else if self.original_received_count == self.original_count {
+            Ok(None)
+        } else {
+            Ok(Some((
+                self.shards.as_ref_mut(),
+                self.original_count,
+                self.recovery_count,
+                &self.received,
+            )))
+        }
+    }
+
+    pub(crate) fn original_count(&self) -> usize {
+        self.original_count
+    }
+
+    pub(crate) fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+
+        original_base_pos: usize,
+        recovery_base_pos: usize,
+        work_count: usize,
+    ) {
+        assert!(shard_bytes % 2 == 0);
+
+        self.original_count = original_count;
+        self.recovery_count = recovery_count;
+        self.shard_bytes = shard_bytes;
+
+        self.original_base_pos = original_base_pos;
+        self.recovery_base_pos = recovery_base_pos;
+
+        self.original_received_count = 0;
+        self.recovery_received_count = 0;
+
+        let max_received_pos = core::cmp::max(
+            original_base_pos + original_count,
+            recovery_base_pos + recovery_count,
+        );
+
+        self.received.clear();
+        if self.received.len() < max_received_pos {
+            self.received.grow(max_received_pos);
+        }
+
+        self.shards.resize(work_count, shard_bytes.div_ceil(64));
+    }
+
+    pub(crate) fn reset_received(&mut self) {
+        self.original_received_count = 0;
+        self.recovery_received_count = 0;
+        self.received.clear();
+    }
+
+    // This must only be called by `DecoderResult`.
+    pub(crate) fn restored_original(&self, index: usize) -> Option<&[u8]> {
+        let pos = self.original_base_pos + index;
+
+        if index < self.original_count && !self.received[pos] {
+            Some(&self.shards[pos].as_flattened()[..self.shard_bytes])
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn undo_last_chunk_encoding(&mut self) {
+        self.shards.undo_last_chunk_encoding(
+            self.shard_bytes,
+            self.original_base_pos..self.original_base_pos + self.original_count,
+        );
+    }
+
+    pub(crate) fn missing_original_count(&self) -> usize {
+        self.original_count - self.original_received_count
+    }
+}

--- a/cryptography/src/reed_solomon/rate/encoder_work.rs
+++ b/cryptography/src/reed_solomon/rate/encoder_work.rs
@@ -1,5 +1,5 @@
 use crate::reed_solomon::{
-    engine::{Shards, ShardsRefMut},
+    engine::{Shards, ShardsRefMut, SHARD_CHUNK_BYTES},
     Error,
 };
 
@@ -22,7 +22,7 @@ pub struct EncoderWork {
 impl EncoderWork {
     /// Creates new [`EncoderWork`] which initially
     /// has no working space allocated.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             original_count: 0,
             recovery_count: 0,
@@ -102,17 +102,18 @@ impl EncoderWork {
         shard_bytes: usize,
         work_count: usize,
     ) {
-        assert!(shard_bytes % 2 == 0);
+        assert!(shard_bytes.is_multiple_of(2));
 
         self.original_count = original_count;
         self.recovery_count = recovery_count;
         self.shard_bytes = shard_bytes;
 
         self.original_received_count = 0;
-        self.shards.resize(work_count, shard_bytes.div_ceil(64));
+        self.shards
+            .resize(work_count, shard_bytes.div_ceil(SHARD_CHUNK_BYTES));
     }
 
-    pub(crate) fn reset_received(&mut self) {
+    pub(crate) const fn reset_received(&mut self) {
         self.original_received_count = 0;
     }
 
@@ -121,7 +122,7 @@ impl EncoderWork {
             .undo_last_chunk_encoding(self.shard_bytes, 0..self.recovery_count);
     }
 
-    pub(crate) fn recovery_count(&self) -> usize {
+    pub(crate) const fn recovery_count(&self) -> usize {
         self.recovery_count
     }
 }

--- a/cryptography/src/reed_solomon/rate/encoder_work.rs
+++ b/cryptography/src/reed_solomon/rate/encoder_work.rs
@@ -1,0 +1,127 @@
+use crate::reed_solomon::{
+    engine::{Shards, ShardsRefMut},
+    Error,
+};
+
+// ======================================================================
+// EncoderWork - PUBLIC
+
+/// Working space for [`RateEncoder`].
+///
+/// [`RateEncoder`]: crate::reed_solomon::rate::RateEncoder
+pub struct EncoderWork {
+    original_count: usize,
+    recovery_count: usize,
+
+    pub(crate) shard_bytes: usize,
+
+    original_received_count: usize,
+    shards: Shards,
+}
+
+impl EncoderWork {
+    /// Creates new [`EncoderWork`] which initially
+    /// has no working space allocated.
+    pub fn new() -> Self {
+        Self {
+            original_count: 0,
+            recovery_count: 0,
+            shard_bytes: 0,
+
+            original_received_count: 0,
+            shards: Shards::new(),
+        }
+    }
+}
+
+// ======================================================================
+// EncoderWork - IMPL Default
+
+impl Default for EncoderWork {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ======================================================================
+// EncoderWork - CRATE
+
+impl EncoderWork {
+    pub(crate) fn add_original_shard<T: AsRef<[u8]>>(
+        &mut self,
+        original_shard: T,
+    ) -> Result<(), Error> {
+        let original_shard = original_shard.as_ref();
+
+        if self.original_received_count == self.original_count {
+            Err(Error::TooManyOriginalShards {
+                original_count: self.original_count,
+            })
+        } else if original_shard.len() != self.shard_bytes {
+            Err(Error::DifferentShardSize {
+                shard_bytes: self.shard_bytes,
+                got: original_shard.len(),
+            })
+        } else {
+            self.shards
+                .insert(self.original_received_count, original_shard);
+
+            self.original_received_count += 1;
+            Ok(())
+        }
+    }
+
+    pub(crate) fn encode_begin(&mut self) -> Result<(ShardsRefMut<'_>, usize, usize), Error> {
+        if self.original_received_count == self.original_count {
+            Ok((
+                self.shards.as_ref_mut(),
+                self.original_count,
+                self.recovery_count,
+            ))
+        } else {
+            Err(Error::TooFewOriginalShards {
+                original_count: self.original_count,
+                original_received_count: self.original_received_count,
+            })
+        }
+    }
+
+    // This must only be called by `EncoderResult`.
+    pub(crate) fn recovery(&self, index: usize) -> Option<&[u8]> {
+        if index < self.recovery_count {
+            Some(&self.shards[index].as_flattened()[..self.shard_bytes])
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        work_count: usize,
+    ) {
+        assert!(shard_bytes % 2 == 0);
+
+        self.original_count = original_count;
+        self.recovery_count = recovery_count;
+        self.shard_bytes = shard_bytes;
+
+        self.original_received_count = 0;
+        self.shards.resize(work_count, shard_bytes.div_ceil(64));
+    }
+
+    pub(crate) fn reset_received(&mut self) {
+        self.original_received_count = 0;
+    }
+
+    pub(crate) fn undo_last_chunk_encoding(&mut self) {
+        self.shards
+            .undo_last_chunk_encoding(self.shard_bytes, 0..self.recovery_count);
+    }
+
+    pub(crate) fn recovery_count(&self) -> usize {
+        self.recovery_count
+    }
+}

--- a/cryptography/src/reed_solomon/rate/rate_default.rs
+++ b/cryptography/src/reed_solomon/rate/rate_default.rs
@@ -1,0 +1,470 @@
+use crate::reed_solomon::{
+    engine::{Engine, GF_ORDER},
+    rate::{
+        DecoderWork, EncoderWork, HighRateDecoder, HighRateEncoder, LowRateDecoder, LowRateEncoder,
+        Rate, RateDecoder, RateEncoder,
+    },
+    DecoderResult, EncoderResult, Error,
+};
+use core::{cmp::Ordering, marker::PhantomData};
+
+// ======================================================================
+// FUNCTIONS - PRIVATE
+
+fn use_high_rate(original_count: usize, recovery_count: usize) -> Result<bool, Error> {
+    if original_count > GF_ORDER || recovery_count > GF_ORDER {
+        return Err(Error::UnsupportedShardCount {
+            original_count,
+            recovery_count,
+        });
+    }
+
+    let original_count_pow2 = original_count.next_power_of_two();
+    let recovery_count_pow2 = recovery_count.next_power_of_two();
+
+    let smaller_pow2 = core::cmp::min(original_count_pow2, recovery_count_pow2);
+    let larger = core::cmp::max(original_count, recovery_count);
+
+    if original_count == 0 || recovery_count == 0 || smaller_pow2 + larger > GF_ORDER {
+        return Err(Error::UnsupportedShardCount {
+            original_count,
+            recovery_count,
+        });
+    }
+
+    match original_count_pow2.cmp(&recovery_count_pow2) {
+        Ordering::Less => {
+            // The "correct" rate is generally faster here,
+            // and also must be used if `recovery_count > 32768`.
+
+            Ok(false)
+        }
+
+        Ordering::Greater => {
+            // The "correct" rate is generally faster here,
+            // and also must be used if `original_count > 32768`.
+
+            Ok(true)
+        }
+
+        Ordering::Equal => {
+            // Here counter-intuitively the "wrong" rate is generally faster
+            // in decoding if `original_count` and `recovery_count` differ a lot.
+
+            if original_count <= recovery_count {
+                // Using the "wrong" rate on purpose.
+                Ok(true)
+            } else {
+                // Using the "wrong" rate on purpose.
+                Ok(false)
+            }
+        }
+    }
+}
+
+// ======================================================================
+// DefaultRate - PUBLIC
+
+/// Reed-Solomon encoder/decoder generator using high or low rate as appropriate.
+pub struct DefaultRate<E: Engine>(PhantomData<E>);
+
+impl<E: Engine> Rate<E> for DefaultRate<E> {
+    type RateEncoder = DefaultRateEncoder<E>;
+    type RateDecoder = DefaultRateDecoder<E>;
+
+    fn supports(original_count: usize, recovery_count: usize) -> bool {
+        use_high_rate(original_count, recovery_count).is_ok()
+    }
+}
+
+// ======================================================================
+// InnerEncoder - PRIVATE
+
+#[derive(Default)]
+enum InnerEncoder<E: Engine> {
+    High(HighRateEncoder<E>),
+    Low(LowRateEncoder<E>),
+
+    // This is only used temporarily during `reset`, never anywhere else.
+    #[default]
+    None,
+}
+
+// ======================================================================
+// DefaultRateEncoder - PUBLIC
+
+/// Reed-Solomon encoder using high or low rate as appropriate.
+///
+/// This is basically same as [`ReedSolomonEncoder`]
+/// except with slightly different API which allows
+/// specifying [`Engine`] and [`EncoderWork`].
+///
+/// [`ReedSolomonEncoder`]: crate::reed_solomon::ReedSolomonEncoder
+pub struct DefaultRateEncoder<E: Engine>(InnerEncoder<E>);
+
+impl<E: Engine> RateEncoder<E> for DefaultRateEncoder<E> {
+    type Rate = DefaultRate<E>;
+
+    fn add_original_shard<T: AsRef<[u8]>>(&mut self, original_shard: T) -> Result<(), Error> {
+        match &mut self.0 {
+            InnerEncoder::High(high) => high.add_original_shard(original_shard),
+            InnerEncoder::Low(low) => low.add_original_shard(original_shard),
+            InnerEncoder::None => unreachable!(),
+        }
+    }
+
+    fn encode(&mut self) -> Result<EncoderResult<'_>, Error> {
+        match &mut self.0 {
+            InnerEncoder::High(high) => high.encode(),
+            InnerEncoder::Low(low) => low.encode(),
+            InnerEncoder::None => unreachable!(),
+        }
+    }
+
+    fn into_parts(self) -> (E, EncoderWork) {
+        match self.0 {
+            InnerEncoder::High(high) => high.into_parts(),
+            InnerEncoder::Low(low) => low.into_parts(),
+            InnerEncoder::None => unreachable!(),
+        }
+    }
+
+    fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<EncoderWork>,
+    ) -> Result<Self, Error> {
+        let inner = if use_high_rate(original_count, recovery_count)? {
+            InnerEncoder::High(HighRateEncoder::new(
+                original_count,
+                recovery_count,
+                shard_bytes,
+                engine,
+                work,
+            )?)
+        } else {
+            InnerEncoder::Low(LowRateEncoder::new(
+                original_count,
+                recovery_count,
+                shard_bytes,
+                engine,
+                work,
+            )?)
+        };
+
+        Ok(Self(inner))
+    }
+
+    fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        let new_rate_is_high = use_high_rate(original_count, recovery_count)?;
+
+        self.0 = match core::mem::take(&mut self.0) {
+            InnerEncoder::High(mut high) => {
+                if new_rate_is_high {
+                    high.reset(original_count, recovery_count, shard_bytes)?;
+                    InnerEncoder::High(high)
+                } else {
+                    let (engine, work) = high.into_parts();
+                    InnerEncoder::Low(LowRateEncoder::new(
+                        original_count,
+                        recovery_count,
+                        shard_bytes,
+                        engine,
+                        Some(work),
+                    )?)
+                }
+            }
+
+            InnerEncoder::Low(mut low) => {
+                if new_rate_is_high {
+                    let (engine, work) = low.into_parts();
+                    InnerEncoder::High(HighRateEncoder::new(
+                        original_count,
+                        recovery_count,
+                        shard_bytes,
+                        engine,
+                        Some(work),
+                    )?)
+                } else {
+                    low.reset(original_count, recovery_count, shard_bytes)?;
+                    InnerEncoder::Low(low)
+                }
+            }
+
+            InnerEncoder::None => unreachable!(),
+        };
+
+        Ok(())
+    }
+}
+
+// ======================================================================
+// InnerDecoder - PRIVATE
+
+#[derive(Default)]
+enum InnerDecoder<E: Engine> {
+    High(HighRateDecoder<E>),
+    Low(LowRateDecoder<E>),
+
+    // This is only used temporarily during `reset`, never anywhere else.
+    #[default]
+    None,
+}
+
+// ======================================================================
+// DefaultRateDecoder - PUBLIC
+
+/// Reed-Solomon decoder using high or low rate as appropriate.
+///
+/// This is basically same as [`ReedSolomonDecoder`]
+/// except with slightly different API which allows
+/// specifying [`Engine`] and [`DecoderWork`].
+///
+/// [`ReedSolomonDecoder`]: crate::reed_solomon::ReedSolomonDecoder
+pub struct DefaultRateDecoder<E: Engine>(InnerDecoder<E>);
+
+impl<E: Engine> RateDecoder<E> for DefaultRateDecoder<E> {
+    type Rate = DefaultRate<E>;
+
+    fn add_original_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        original_shard: T,
+    ) -> Result<(), Error> {
+        match &mut self.0 {
+            InnerDecoder::High(high) => high.add_original_shard(index, original_shard),
+            InnerDecoder::Low(low) => low.add_original_shard(index, original_shard),
+            InnerDecoder::None => unreachable!(),
+        }
+    }
+
+    fn add_recovery_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        recovery_shard: T,
+    ) -> Result<(), Error> {
+        match &mut self.0 {
+            InnerDecoder::High(high) => high.add_recovery_shard(index, recovery_shard),
+            InnerDecoder::Low(low) => low.add_recovery_shard(index, recovery_shard),
+            InnerDecoder::None => unreachable!(),
+        }
+    }
+
+    fn decode(&mut self) -> Result<DecoderResult<'_>, Error> {
+        match &mut self.0 {
+            InnerDecoder::High(high) => high.decode(),
+            InnerDecoder::Low(low) => low.decode(),
+            InnerDecoder::None => unreachable!(),
+        }
+    }
+
+    fn into_parts(self) -> (E, DecoderWork) {
+        match self.0 {
+            InnerDecoder::High(high) => high.into_parts(),
+            InnerDecoder::Low(low) => low.into_parts(),
+            InnerDecoder::None => unreachable!(),
+        }
+    }
+
+    fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<DecoderWork>,
+    ) -> Result<Self, Error> {
+        let inner = if use_high_rate(original_count, recovery_count)? {
+            InnerDecoder::High(HighRateDecoder::new(
+                original_count,
+                recovery_count,
+                shard_bytes,
+                engine,
+                work,
+            )?)
+        } else {
+            InnerDecoder::Low(LowRateDecoder::new(
+                original_count,
+                recovery_count,
+                shard_bytes,
+                engine,
+                work,
+            )?)
+        };
+
+        Ok(Self(inner))
+    }
+
+    fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        let new_rate_is_high = use_high_rate(original_count, recovery_count)?;
+
+        self.0 = match core::mem::take(&mut self.0) {
+            InnerDecoder::High(mut high) => {
+                if new_rate_is_high {
+                    high.reset(original_count, recovery_count, shard_bytes)?;
+                    InnerDecoder::High(high)
+                } else {
+                    let (engine, work) = high.into_parts();
+                    InnerDecoder::Low(LowRateDecoder::new(
+                        original_count,
+                        recovery_count,
+                        shard_bytes,
+                        engine,
+                        Some(work),
+                    )?)
+                }
+            }
+
+            InnerDecoder::Low(mut low) => {
+                if new_rate_is_high {
+                    let (engine, work) = low.into_parts();
+                    InnerDecoder::High(HighRateDecoder::new(
+                        original_count,
+                        recovery_count,
+                        shard_bytes,
+                        engine,
+                        Some(work),
+                    )?)
+                } else {
+                    low.reset(original_count, recovery_count, shard_bytes)?;
+                    InnerDecoder::Low(low)
+                }
+            }
+
+            InnerDecoder::None => unreachable!(),
+        };
+
+        Ok(())
+    }
+}
+
+// ======================================================================
+// TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reed_solomon::test_util;
+
+    // ============================================================
+    // ROUNDTRIPS - SINGLE ROUND
+
+    #[test]
+    fn roundtrips_tiny() {
+        for (original_count, recovery_count, seed, recovery_hash) in test_util::DEFAULT_TINY {
+            roundtrip_single!(
+                DefaultRate,
+                *original_count,
+                *recovery_count,
+                1024,
+                recovery_hash,
+                &[*recovery_count..*original_count],
+                &[0..core::cmp::min(*original_count, *recovery_count)],
+                *seed,
+            );
+        }
+    }
+
+    // ============================================================
+    // ROUNDTRIPS - TWO ROUNDS
+
+    #[test]
+    fn two_rounds_implicit_reset() {
+        roundtrip_two_rounds!(
+            DefaultRate,
+            false,
+            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
+            (2, 3, 1024, test_util::LOW_2_3_223, &[0], &[1], 223),
+        );
+    }
+
+    #[test]
+    fn two_rounds_reset_high_to_high() {
+        roundtrip_two_rounds!(
+            DefaultRate,
+            true,
+            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
+            (5, 3, 1024, test_util::HIGH_5_3, &[1, 3], &[0, 1, 2], 153),
+        );
+    }
+
+    #[test]
+    fn two_rounds_reset_high_to_low() {
+        roundtrip_two_rounds!(
+            DefaultRate,
+            true,
+            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
+            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
+        );
+    }
+
+    #[test]
+    fn two_rounds_reset_low_to_high() {
+        roundtrip_two_rounds!(
+            DefaultRate,
+            true,
+            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 1], 123),
+            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
+        );
+    }
+
+    #[test]
+    fn two_rounds_reset_low_to_low() {
+        roundtrip_two_rounds!(
+            DefaultRate,
+            true,
+            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
+            (3, 5, 1024, test_util::LOW_3_5, &[], &[0, 2, 4], 135),
+        );
+    }
+
+    // ============================================================
+    // use_high_rate
+
+    #[test]
+    fn use_high_rate() {
+        fn err(original_count: usize, recovery_count: usize) -> Result<bool, Error> {
+            Err(Error::UnsupportedShardCount {
+                original_count,
+                recovery_count,
+            })
+        }
+
+        for (original_count, recovery_count, expected) in [
+            (0, 1, err(0, 1)),
+            (1, 0, err(1, 0)),
+            // CORRECT/WRONG RATE
+            (3, 3, Ok(true)),
+            (3, 4, Ok(true)),
+            (3, 5, Ok(false)),
+            (4, 3, Ok(false)),
+            (5, 3, Ok(true)),
+            // LOW RATE LIMIT
+            (4096, 61440, Ok(false)),
+            (4096, 61441, err(4096, 61441)),
+            (4097, 61440, err(4097, 61440)),
+            // HIGH RATE LIMIT
+            (61440, 4096, Ok(true)),
+            (61440, 4097, err(61440, 4097)),
+            (61441, 4096, err(61441, 4096)),
+            // OVERFLOW CHECK
+            (usize::MAX, usize::MAX, err(usize::MAX, usize::MAX)),
+        ] {
+            assert_eq!(
+                super::use_high_rate(original_count, recovery_count),
+                expected
+            );
+        }
+    }
+}

--- a/cryptography/src/reed_solomon/rate/rate_default.rs
+++ b/cryptography/src/reed_solomon/rate/rate_default.rs
@@ -1,8 +1,8 @@
 use crate::reed_solomon::{
     engine::{Engine, GF_ORDER},
     rate::{
-        DecoderWork, EncoderWork, HighRateDecoder, HighRateEncoder, LowRateDecoder, LowRateEncoder,
-        Rate, RateDecoder, RateEncoder,
+        DecoderWork, EncoderWork, HighRate, HighRateDecoder, HighRateEncoder, LowRate,
+        LowRateDecoder, LowRateEncoder, Rate, RateDecoder, RateEncoder,
     },
     DecoderResult, EncoderResult, Error,
 };
@@ -62,6 +62,20 @@ fn use_high_rate(original_count: usize, recovery_count: usize) -> Result<bool, E
     }
 }
 
+fn validate_rate<E: Engine>(
+    original_count: usize,
+    recovery_count: usize,
+    shard_bytes: usize,
+) -> Result<bool, Error> {
+    let use_high = use_high_rate(original_count, recovery_count)?;
+    if use_high {
+        HighRate::<E>::validate(original_count, recovery_count, shard_bytes)?;
+    } else {
+        LowRate::<E>::validate(original_count, recovery_count, shard_bytes)?;
+    }
+    Ok(use_high)
+}
+
 // ======================================================================
 // DefaultRate - PUBLIC
 
@@ -85,7 +99,7 @@ enum InnerEncoder<E: Engine> {
     High(HighRateEncoder<E>),
     Low(LowRateEncoder<E>),
 
-    // This is only used temporarily during `reset`, never anywhere else.
+    // Used only after reset validation, while switching rates.
     #[default]
     None,
 }
@@ -163,39 +177,45 @@ impl<E: Engine> RateEncoder<E> for DefaultRateEncoder<E> {
         recovery_count: usize,
         shard_bytes: usize,
     ) -> Result<(), Error> {
-        let new_rate_is_high = use_high_rate(original_count, recovery_count)?;
+        let new_rate_is_high = validate_rate::<E>(original_count, recovery_count, shard_bytes)?;
+
+        match &mut self.0 {
+            InnerEncoder::High(high) if new_rate_is_high => {
+                return high.reset(original_count, recovery_count, shard_bytes);
+            }
+            InnerEncoder::Low(low) if !new_rate_is_high => {
+                return low.reset(original_count, recovery_count, shard_bytes);
+            }
+            _ => {}
+        }
 
         self.0 = match core::mem::take(&mut self.0) {
-            InnerEncoder::High(mut high) => {
-                if new_rate_is_high {
-                    high.reset(original_count, recovery_count, shard_bytes)?;
-                    InnerEncoder::High(high)
-                } else {
-                    let (engine, work) = high.into_parts();
-                    InnerEncoder::Low(LowRateEncoder::new(
+            InnerEncoder::High(high) => {
+                let (engine, work) = high.into_parts();
+                InnerEncoder::Low(
+                    LowRateEncoder::new(
                         original_count,
                         recovery_count,
                         shard_bytes,
                         engine,
                         Some(work),
-                    )?)
-                }
+                    )
+                    .expect("low-rate encoder configuration was validated"),
+                )
             }
 
-            InnerEncoder::Low(mut low) => {
-                if new_rate_is_high {
-                    let (engine, work) = low.into_parts();
-                    InnerEncoder::High(HighRateEncoder::new(
+            InnerEncoder::Low(low) => {
+                let (engine, work) = low.into_parts();
+                InnerEncoder::High(
+                    HighRateEncoder::new(
                         original_count,
                         recovery_count,
                         shard_bytes,
                         engine,
                         Some(work),
-                    )?)
-                } else {
-                    low.reset(original_count, recovery_count, shard_bytes)?;
-                    InnerEncoder::Low(low)
-                }
+                    )
+                    .expect("high-rate encoder configuration was validated"),
+                )
             }
 
             InnerEncoder::None => unreachable!(),
@@ -213,7 +233,7 @@ enum InnerDecoder<E: Engine> {
     High(HighRateDecoder<E>),
     Low(LowRateDecoder<E>),
 
-    // This is only used temporarily during `reset`, never anywhere else.
+    // Used only after reset validation, while switching rates.
     #[default]
     None,
 }
@@ -307,39 +327,45 @@ impl<E: Engine> RateDecoder<E> for DefaultRateDecoder<E> {
         recovery_count: usize,
         shard_bytes: usize,
     ) -> Result<(), Error> {
-        let new_rate_is_high = use_high_rate(original_count, recovery_count)?;
+        let new_rate_is_high = validate_rate::<E>(original_count, recovery_count, shard_bytes)?;
+
+        match &mut self.0 {
+            InnerDecoder::High(high) if new_rate_is_high => {
+                return high.reset(original_count, recovery_count, shard_bytes);
+            }
+            InnerDecoder::Low(low) if !new_rate_is_high => {
+                return low.reset(original_count, recovery_count, shard_bytes);
+            }
+            _ => {}
+        }
 
         self.0 = match core::mem::take(&mut self.0) {
-            InnerDecoder::High(mut high) => {
-                if new_rate_is_high {
-                    high.reset(original_count, recovery_count, shard_bytes)?;
-                    InnerDecoder::High(high)
-                } else {
-                    let (engine, work) = high.into_parts();
-                    InnerDecoder::Low(LowRateDecoder::new(
+            InnerDecoder::High(high) => {
+                let (engine, work) = high.into_parts();
+                InnerDecoder::Low(
+                    LowRateDecoder::new(
                         original_count,
                         recovery_count,
                         shard_bytes,
                         engine,
                         Some(work),
-                    )?)
-                }
+                    )
+                    .expect("low-rate decoder configuration was validated"),
+                )
             }
 
-            InnerDecoder::Low(mut low) => {
-                if new_rate_is_high {
-                    let (engine, work) = low.into_parts();
-                    InnerDecoder::High(HighRateDecoder::new(
+            InnerDecoder::Low(low) => {
+                let (engine, work) = low.into_parts();
+                InnerDecoder::High(
+                    HighRateDecoder::new(
                         original_count,
                         recovery_count,
                         shard_bytes,
                         engine,
                         Some(work),
-                    )?)
-                } else {
-                    low.reset(original_count, recovery_count, shard_bytes)?;
-                    InnerDecoder::Low(low)
-                }
+                    )
+                    .expect("high-rate decoder configuration was validated"),
+                )
             }
 
             InnerDecoder::None => unreachable!(),

--- a/cryptography/src/reed_solomon/rate/rate_default.rs
+++ b/cryptography/src/reed_solomon/rate/rate_default.rs
@@ -95,11 +95,11 @@ enum InnerEncoder<E: Engine> {
 
 /// Reed-Solomon encoder using high or low rate as appropriate.
 ///
-/// This is basically same as [`ReedSolomonEncoder`]
+/// This is basically same as [`Encoder`]
 /// except with slightly different API which allows
 /// specifying [`Engine`] and [`EncoderWork`].
 ///
-/// [`ReedSolomonEncoder`]: crate::reed_solomon::ReedSolomonEncoder
+/// [`Encoder`]: crate::reed_solomon::Encoder
 pub struct DefaultRateEncoder<E: Engine>(InnerEncoder<E>);
 
 impl<E: Engine> RateEncoder<E> for DefaultRateEncoder<E> {
@@ -223,11 +223,11 @@ enum InnerDecoder<E: Engine> {
 
 /// Reed-Solomon decoder using high or low rate as appropriate.
 ///
-/// This is basically same as [`ReedSolomonDecoder`]
+/// This is basically same as [`Decoder`]
 /// except with slightly different API which allows
 /// specifying [`Engine`] and [`DecoderWork`].
 ///
-/// [`ReedSolomonDecoder`]: crate::reed_solomon::ReedSolomonDecoder
+/// [`Decoder`]: crate::reed_solomon::Decoder
 pub struct DefaultRateDecoder<E: Engine>(InnerDecoder<E>);
 
 impl<E: Engine> RateDecoder<E> for DefaultRateDecoder<E> {
@@ -369,8 +369,11 @@ mod tests {
                 *recovery_count,
                 1024,
                 recovery_hash,
-                &[*recovery_count..*original_count],
-                &[0..core::cmp::min(*original_count, *recovery_count)],
+                &[test_util::range(*recovery_count, *original_count)],
+                &[test_util::range(
+                    0,
+                    core::cmp::min(*original_count, *recovery_count)
+                )],
                 *seed,
             );
         }
@@ -384,8 +387,24 @@ mod tests {
         roundtrip_two_rounds!(
             DefaultRate,
             false,
-            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
-            (2, 3, 1024, test_util::LOW_2_3_223, &[0], &[1], 223),
+            (
+                2,
+                3,
+                1024,
+                test_util::LOW_2_3,
+                &[],
+                &[test_util::index(0), test_util::index(2)],
+                123
+            ),
+            (
+                2,
+                3,
+                1024,
+                test_util::LOW_2_3_223,
+                &[test_util::index(0)],
+                &[test_util::index(1)],
+                223
+            ),
         );
     }
 
@@ -394,8 +413,28 @@ mod tests {
         roundtrip_two_rounds!(
             DefaultRate,
             true,
-            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
-            (5, 3, 1024, test_util::HIGH_5_3, &[1, 3], &[0, 1, 2], 153),
+            (
+                3,
+                2,
+                1024,
+                test_util::HIGH_3_2,
+                &[test_util::index(1)],
+                &[test_util::index(0), test_util::index(1)],
+                132
+            ),
+            (
+                5,
+                3,
+                1024,
+                test_util::HIGH_5_3,
+                &[test_util::index(1), test_util::index(3)],
+                &[
+                    test_util::index(0),
+                    test_util::index(1),
+                    test_util::index(2)
+                ],
+                153
+            ),
         );
     }
 
@@ -404,8 +443,24 @@ mod tests {
         roundtrip_two_rounds!(
             DefaultRate,
             true,
-            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
-            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
+            (
+                3,
+                2,
+                1024,
+                test_util::HIGH_3_2,
+                &[test_util::index(1)],
+                &[test_util::index(0), test_util::index(1)],
+                132
+            ),
+            (
+                2,
+                3,
+                1024,
+                test_util::LOW_2_3,
+                &[],
+                &[test_util::index(0), test_util::index(2)],
+                123
+            ),
         );
     }
 
@@ -414,8 +469,24 @@ mod tests {
         roundtrip_two_rounds!(
             DefaultRate,
             true,
-            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 1], 123),
-            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
+            (
+                2,
+                3,
+                1024,
+                test_util::LOW_2_3,
+                &[],
+                &[test_util::index(0), test_util::index(1)],
+                123
+            ),
+            (
+                3,
+                2,
+                1024,
+                test_util::HIGH_3_2,
+                &[test_util::index(1)],
+                &[test_util::index(0), test_util::index(1)],
+                132
+            ),
         );
     }
 
@@ -424,8 +495,28 @@ mod tests {
         roundtrip_two_rounds!(
             DefaultRate,
             true,
-            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
-            (3, 5, 1024, test_util::LOW_3_5, &[], &[0, 2, 4], 135),
+            (
+                2,
+                3,
+                1024,
+                test_util::LOW_2_3,
+                &[],
+                &[test_util::index(0), test_util::index(2)],
+                123
+            ),
+            (
+                3,
+                5,
+                1024,
+                test_util::LOW_3_5,
+                &[],
+                &[
+                    test_util::index(0),
+                    test_util::index(2),
+                    test_util::index(4)
+                ],
+                135
+            ),
         );
     }
 

--- a/cryptography/src/reed_solomon/rate/rate_high.rs
+++ b/cryptography/src/reed_solomon/rate/rate_high.rs
@@ -1,0 +1,627 @@
+use crate::reed_solomon::{
+    engine::{self, Engine, GF_MODULUS, GF_ORDER},
+    rate::{DecoderWork, EncoderWork, Rate, RateDecoder, RateEncoder},
+    DecoderResult, EncoderResult, Error,
+};
+use core::marker::PhantomData;
+
+// ======================================================================
+// HighRate - PUBLIC
+
+/// Reed-Solomon encoder/decoder generator using only high rate.
+pub struct HighRate<E: Engine>(PhantomData<E>);
+
+impl<E: Engine> Rate<E> for HighRate<E> {
+    type RateEncoder = HighRateEncoder<E>;
+    type RateDecoder = HighRateDecoder<E>;
+
+    fn supports(original_count: usize, recovery_count: usize) -> bool {
+        original_count > 0
+            && recovery_count > 0
+            && original_count < GF_ORDER
+            && recovery_count < GF_ORDER
+            && recovery_count.next_power_of_two() + original_count <= GF_ORDER
+    }
+}
+
+// ======================================================================
+// HighRateEncoder - PUBLIC
+
+/// Reed-Solomon encoder using only high rate.
+pub struct HighRateEncoder<E: Engine> {
+    engine: E,
+    work: EncoderWork,
+}
+
+impl<E: Engine> RateEncoder<E> for HighRateEncoder<E> {
+    type Rate = HighRate<E>;
+
+    fn add_original_shard<T: AsRef<[u8]>>(&mut self, original_shard: T) -> Result<(), Error> {
+        self.work.add_original_shard(original_shard)
+    }
+
+    fn encode(&mut self) -> Result<EncoderResult<'_>, Error> {
+        let (mut work, original_count, recovery_count) = self.work.encode_begin()?;
+        let chunk_size = recovery_count.next_power_of_two();
+        let engine = &self.engine;
+
+        // FIRST CHUNK
+
+        let first_count = core::cmp::min(original_count, chunk_size);
+
+        work.zero(first_count..chunk_size);
+        engine::ifft_skew_end(engine, &mut work, 0, chunk_size, first_count);
+
+        if original_count > chunk_size {
+            // FULL CHUNKS
+
+            let mut chunk_start = chunk_size;
+            while chunk_start + chunk_size <= original_count {
+                engine::ifft_skew_end(engine, &mut work, chunk_start, chunk_size, chunk_size);
+                engine::xor_within(&mut work, 0, chunk_start, chunk_size);
+                chunk_start += chunk_size;
+            }
+
+            // FINAL PARTIAL CHUNK
+
+            let last_count = original_count % chunk_size;
+            if last_count > 0 {
+                work.zero(chunk_start + last_count..);
+                engine::ifft_skew_end(engine, &mut work, chunk_start, chunk_size, last_count);
+                engine::xor_within(&mut work, 0, chunk_start, chunk_size);
+            }
+        }
+
+        // FFT
+
+        engine.fft(&mut work, 0, chunk_size, recovery_count, 0);
+
+        // UNDO LAST CHUNK ENCODING
+
+        self.work.undo_last_chunk_encoding();
+
+        // DONE
+
+        Ok(EncoderResult::new(&mut self.work))
+    }
+
+    fn into_parts(self) -> (E, EncoderWork) {
+        (self.engine, self.work)
+    }
+
+    fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<EncoderWork>,
+    ) -> Result<Self, Error> {
+        let mut work = work.unwrap_or_default();
+        Self::reset_work(original_count, recovery_count, shard_bytes, &mut work)?;
+        Ok(Self { engine, work })
+    }
+
+    fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        Self::reset_work(original_count, recovery_count, shard_bytes, &mut self.work)
+    }
+}
+
+// ======================================================================
+// HighRateEncoder - PRIVATE
+
+impl<E: Engine> HighRateEncoder<E> {
+    fn reset_work(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        work: &mut EncoderWork,
+    ) -> Result<(), Error> {
+        Self::validate(original_count, recovery_count, shard_bytes)?;
+        work.reset(
+            original_count,
+            recovery_count,
+            shard_bytes,
+            Self::work_count(original_count, recovery_count),
+        );
+        Ok(())
+    }
+
+    fn work_count(original_count: usize, recovery_count: usize) -> usize {
+        debug_assert!(Self::supports(original_count, recovery_count));
+
+        let chunk_size = recovery_count.next_power_of_two();
+
+        original_count.next_multiple_of(chunk_size)
+    }
+}
+
+// ======================================================================
+// HighRateDecoder - PUBLIC
+
+/// Reed-Solomon decoder using only high rate.
+pub struct HighRateDecoder<E: Engine> {
+    engine: E,
+    work: DecoderWork,
+}
+
+impl<E: Engine> RateDecoder<E> for HighRateDecoder<E> {
+    type Rate = HighRate<E>;
+
+    fn add_original_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        original_shard: T,
+    ) -> Result<(), Error> {
+        self.work.add_original_shard(index, original_shard)
+    }
+
+    fn add_recovery_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        recovery_shard: T,
+    ) -> Result<(), Error> {
+        self.work.add_recovery_shard(index, recovery_shard)
+    }
+
+    fn decode(&mut self) -> Result<DecoderResult<'_>, Error> {
+        let Some((mut work, original_count, recovery_count, received)) =
+            self.work.decode_begin()?
+        else {
+            // Nothing to do, original data is complete.
+            return Ok(DecoderResult::new(&mut self.work));
+        };
+
+        let chunk_size = recovery_count.next_power_of_two();
+        let original_end = chunk_size + original_count;
+        let work_count = work.len();
+
+        // ERASURE LOCATIONS
+
+        let mut erasures = [0; GF_ORDER];
+
+        for i in 0..recovery_count {
+            if !received[i] {
+                erasures[i] = 1;
+            }
+        }
+
+        erasures[recovery_count..chunk_size].fill(1);
+
+        for i in chunk_size..original_end {
+            if !received[i] {
+                erasures[i] = 1;
+            }
+        }
+
+        // EVALUATE POLYNOMIAL
+
+        E::eval_poly(&mut erasures, original_end);
+
+        // MULTIPLY SHARDS
+
+        // work[               .. recovery_count] = recovery * erasures
+        // work[recovery_count .. chunk_size    ] = 0
+        // work[chunk_size     .. original_end  ] = original * erasures
+        // work[original_end   ..               ] = 0
+
+        for i in 0..recovery_count {
+            if received[i] {
+                self.engine.mul(&mut work[i], erasures[i]);
+            } else {
+                work[i].fill([0; 64]);
+            }
+        }
+
+        work.zero(recovery_count..chunk_size);
+
+        for i in chunk_size..original_end {
+            if received[i] {
+                self.engine.mul(&mut work[i], erasures[i]);
+            } else {
+                work[i].fill([0; 64]);
+            }
+        }
+
+        work.zero(original_end..);
+
+        // IFFT / FORMAL DERIVATIVE / FFT
+
+        self.engine.ifft(&mut work, 0, work_count, original_end, 0);
+        engine::formal_derivative(&mut work);
+        self.engine.fft(&mut work, 0, work_count, original_end, 0);
+
+        // REVEAL ERASURES
+
+        for i in chunk_size..original_end {
+            if !received[i] {
+                self.engine.mul(&mut work[i], GF_MODULUS - erasures[i]);
+            }
+        }
+
+        // UNDO LAST CHUNK ENCODING
+
+        self.work.undo_last_chunk_encoding();
+
+        // DONE
+
+        Ok(DecoderResult::new(&mut self.work))
+    }
+
+    fn into_parts(self) -> (E, DecoderWork) {
+        (self.engine, self.work)
+    }
+
+    fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<DecoderWork>,
+    ) -> Result<Self, Error> {
+        let mut work = work.unwrap_or_default();
+        Self::reset_work(original_count, recovery_count, shard_bytes, &mut work)?;
+        Ok(Self { engine, work })
+    }
+
+    fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        Self::reset_work(original_count, recovery_count, shard_bytes, &mut self.work)
+    }
+}
+
+// ======================================================================
+// HighRateDecoder - PRIVATE
+
+impl<E: Engine> HighRateDecoder<E> {
+    fn reset_work(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        work: &mut DecoderWork,
+    ) -> Result<(), Error> {
+        Self::validate(original_count, recovery_count, shard_bytes)?;
+
+        // work[..recovery_count     ]  =  recovery
+        // work[recovery_count_pow2..]  =  original
+        work.reset(
+            original_count,
+            recovery_count,
+            shard_bytes,
+            recovery_count.next_power_of_two(),
+            0,
+            Self::work_count(original_count, recovery_count),
+        );
+
+        Ok(())
+    }
+
+    fn work_count(original_count: usize, recovery_count: usize) -> usize {
+        debug_assert!(Self::supports(original_count, recovery_count));
+
+        (recovery_count.next_power_of_two() + original_count).next_power_of_two()
+    }
+}
+
+// ======================================================================
+// TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reed_solomon::test_util;
+
+    // ============================================================
+    // ROUNDTRIPS - SINGLE ROUND
+
+    #[test]
+    fn roundtrip_all_originals_missing() {
+        roundtrip_single!(
+            HighRate,
+            3,
+            3,
+            1024,
+            test_util::EITHER_3_3,
+            &[],
+            &[0..3],
+            133,
+        );
+    }
+
+    #[test]
+    fn roundtrip_no_originals_missing() {
+        roundtrip_single!(HighRate, 3, 2, 1024, test_util::HIGH_3_2, &[0..3], &[], 132);
+    }
+
+    #[test]
+    fn roundtrips_tiny() {
+        for (original_count, recovery_count, seed, recovery_hash) in test_util::HIGH_TINY {
+            roundtrip_single!(
+                HighRate,
+                *original_count,
+                *recovery_count,
+                1024,
+                recovery_hash,
+                &[*recovery_count..*original_count],
+                &[0..core::cmp::min(*original_count, *recovery_count)],
+                *seed,
+            );
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn roundtrip_3000_30000() {
+        roundtrip_single!(
+            HighRate,
+            3000,
+            30000,
+            64,
+            test_util::HIGH_3000_30000_14,
+            &[],
+            &[0..3000],
+            14,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn roundtrip_32768_32768() {
+        roundtrip_single!(
+            HighRate,
+            32768,
+            32768,
+            64,
+            test_util::EITHER_32768_32768_11,
+            &[],
+            &[0..32768],
+            11,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn roundtrip_60000_3000() {
+        roundtrip_single!(
+            HighRate,
+            60000,
+            3000,
+            64,
+            test_util::HIGH_60000_3000_12,
+            &[3000..60000],
+            &[0..3000],
+            12,
+        );
+    }
+
+    #[test]
+    fn roundtrip_34000_2000_shard_size_8() {
+        roundtrip_single!(
+            HighRate,
+            34000,
+            2000,
+            8,
+            test_util::HIGH_34000_2000_123_8,
+            &[0..32000],
+            &[0..2000],
+            123
+        );
+    }
+
+    // ============================================================
+    // ROUNDTRIPS - TWO ROUNDS
+
+    #[test]
+    fn two_rounds_implicit_reset() {
+        roundtrip_two_rounds!(
+            HighRate,
+            false,
+            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
+            (3, 2, 1024, test_util::HIGH_3_2_232, &[0], &[0, 1], 232),
+        );
+    }
+
+    #[test]
+    fn two_rounds_explicit_reset() {
+        roundtrip_two_rounds!(
+            HighRate,
+            true,
+            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
+            (5, 2, 1024, test_util::HIGH_5_2, &[0, 2, 4], &[0, 1], 152),
+        );
+    }
+
+    // ============================================================
+    // HighRate
+
+    mod high_rate {
+        use crate::reed_solomon::{
+            engine::NoSimd,
+            rate::{HighRate, Rate},
+            Error,
+        };
+
+        #[test]
+        fn decoder() {
+            assert_eq!(
+                HighRate::<NoSimd>::decoder(4096, 61440, 64, NoSimd::new(), None).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 4096,
+                    recovery_count: 61440,
+                })
+            );
+
+            assert!(HighRate::<NoSimd>::decoder(61440, 4096, 64, NoSimd::new(), None).is_ok());
+        }
+
+        #[test]
+        fn encoder() {
+            assert_eq!(
+                HighRate::<NoSimd>::encoder(4096, 61440, 64, NoSimd::new(), None).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 4096,
+                    recovery_count: 61440,
+                })
+            );
+
+            assert!(HighRate::<NoSimd>::encoder(61440, 4096, 64, NoSimd::new(), None).is_ok());
+        }
+
+        #[test]
+        fn supports() {
+            assert!(!HighRate::<NoSimd>::supports(0, 1));
+            assert!(!HighRate::<NoSimd>::supports(1, 0));
+
+            assert!(!HighRate::<NoSimd>::supports(4096, 61440));
+
+            assert!(HighRate::<NoSimd>::supports(61440, 4096));
+            assert!(!HighRate::<NoSimd>::supports(61440, 4097));
+            assert!(!HighRate::<NoSimd>::supports(61441, 4096));
+
+            assert!(!HighRate::<NoSimd>::supports(usize::MAX, usize::MAX));
+        }
+
+        #[test]
+        fn validate() {
+            assert_eq!(
+                HighRate::<NoSimd>::validate(1, 1, 123).err(),
+                Some(Error::InvalidShardSize { shard_bytes: 123 })
+            );
+
+            assert_eq!(
+                HighRate::<NoSimd>::validate(4096, 61440, 64).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 4096,
+                    recovery_count: 61440,
+                })
+            );
+
+            assert!(HighRate::<NoSimd>::validate(61440, 4096, 64).is_ok());
+        }
+    }
+
+    // ============================================================
+    // HighRateEncoder
+
+    mod high_rate_encoder {
+        use crate::reed_solomon::{
+            engine::NoSimd,
+            rate::{HighRateEncoder, RateEncoder},
+            Error,
+        };
+
+        // ==================================================
+        // ERRORS
+
+        test_rate_encoder_errors! {HighRateEncoder}
+
+        // ==================================================
+        // supports
+
+        #[test]
+        fn supports() {
+            assert!(!HighRateEncoder::<NoSimd>::supports(4096, 61440));
+            assert!(HighRateEncoder::<NoSimd>::supports(61440, 4096));
+        }
+
+        // ==================================================
+        // validate
+
+        #[test]
+        fn validate() {
+            assert_eq!(
+                HighRateEncoder::<NoSimd>::validate(1, 1, 123).err(),
+                Some(Error::InvalidShardSize { shard_bytes: 123 })
+            );
+
+            assert_eq!(
+                HighRateEncoder::<NoSimd>::validate(4096, 61440, 64).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 4096,
+                    recovery_count: 61440,
+                })
+            );
+
+            assert!(HighRateEncoder::<NoSimd>::validate(61440, 4096, 64).is_ok());
+        }
+
+        // ==================================================
+        // work_count
+
+        #[test]
+        fn work_count() {
+            assert_eq!(HighRateEncoder::<NoSimd>::work_count(1, 1), 1);
+            assert_eq!(HighRateEncoder::<NoSimd>::work_count(4096, 1024), 4096);
+            assert_eq!(HighRateEncoder::<NoSimd>::work_count(4097, 1024), 5120);
+            assert_eq!(HighRateEncoder::<NoSimd>::work_count(4097, 1025), 6144);
+            assert_eq!(HighRateEncoder::<NoSimd>::work_count(32768, 32768), 32768);
+        }
+    }
+
+    // ============================================================
+    // HighRateDecoder
+
+    mod high_rate_decoder {
+        use crate::reed_solomon::{
+            engine::NoSimd,
+            rate::{HighRateDecoder, RateDecoder},
+            Error,
+        };
+
+        // ==================================================
+        // ERRORS
+
+        test_rate_decoder_errors! {HighRateDecoder}
+
+        // ==================================================
+        // supports
+
+        #[test]
+        fn supports() {
+            assert!(!HighRateDecoder::<NoSimd>::supports(4096, 61440));
+            assert!(HighRateDecoder::<NoSimd>::supports(61440, 4096));
+        }
+
+        // ==================================================
+        // validate
+
+        #[test]
+        fn validate() {
+            assert_eq!(
+                HighRateDecoder::<NoSimd>::validate(1, 1, 123).err(),
+                Some(Error::InvalidShardSize { shard_bytes: 123 })
+            );
+
+            assert_eq!(
+                HighRateDecoder::<NoSimd>::validate(4096, 61440, 64).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 4096,
+                    recovery_count: 61440,
+                })
+            );
+
+            assert!(HighRateDecoder::<NoSimd>::validate(61440, 4096, 64).is_ok());
+        }
+
+        // ==================================================
+        // work_count
+
+        #[test]
+        fn work_count() {
+            assert_eq!(HighRateDecoder::<NoSimd>::work_count(1, 1), 2);
+            assert_eq!(HighRateDecoder::<NoSimd>::work_count(2048, 1025), 4096);
+            assert_eq!(HighRateDecoder::<NoSimd>::work_count(2049, 1025), 8192);
+            assert_eq!(HighRateDecoder::<NoSimd>::work_count(3072, 1024), 4096);
+            assert_eq!(HighRateDecoder::<NoSimd>::work_count(3073, 1024), 8192);
+            assert_eq!(HighRateDecoder::<NoSimd>::work_count(32768, 32768), 65536);
+        }
+    }
+}

--- a/cryptography/src/reed_solomon/rate/rate_high.rs
+++ b/cryptography/src/reed_solomon/rate/rate_high.rs
@@ -1,5 +1,5 @@
 use crate::reed_solomon::{
-    engine::{self, Engine, GF_MODULUS, GF_ORDER},
+    engine::{self, Engine, GF_MODULUS, GF_ORDER, SHARD_CHUNK_BYTES},
     rate::{DecoderWork, EncoderWork, Rate, RateDecoder, RateEncoder},
     DecoderResult, EncoderResult, Error,
 };
@@ -132,7 +132,7 @@ impl<E: Engine> HighRateEncoder<E> {
     }
 
     fn work_count(original_count: usize, recovery_count: usize) -> usize {
-        debug_assert!(Self::supports(original_count, recovery_count));
+        assert!(Self::supports(original_count, recovery_count));
 
         let chunk_size = recovery_count.next_power_of_two();
 
@@ -213,7 +213,7 @@ impl<E: Engine> RateDecoder<E> for HighRateDecoder<E> {
             if received[i] {
                 self.engine.mul(&mut work[i], erasures[i]);
             } else {
-                work[i].fill([0; 64]);
+                work[i].fill([0; SHARD_CHUNK_BYTES]);
             }
         }
 
@@ -223,7 +223,7 @@ impl<E: Engine> RateDecoder<E> for HighRateDecoder<E> {
             if received[i] {
                 self.engine.mul(&mut work[i], erasures[i]);
             } else {
-                work[i].fill([0; 64]);
+                work[i].fill([0; SHARD_CHUNK_BYTES]);
             }
         }
 
@@ -305,7 +305,7 @@ impl<E: Engine> HighRateDecoder<E> {
     }
 
     fn work_count(original_count: usize, recovery_count: usize) -> usize {
-        debug_assert!(Self::supports(original_count, recovery_count));
+        assert!(Self::supports(original_count, recovery_count));
 
         (recovery_count.next_power_of_two() + original_count).next_power_of_two()
     }
@@ -331,14 +331,23 @@ mod tests {
             1024,
             test_util::EITHER_3_3,
             &[],
-            &[0..3],
+            &[test_util::range(0, 3)],
             133,
         );
     }
 
     #[test]
     fn roundtrip_no_originals_missing() {
-        roundtrip_single!(HighRate, 3, 2, 1024, test_util::HIGH_3_2, &[0..3], &[], 132);
+        roundtrip_single!(
+            HighRate,
+            3,
+            2,
+            1024,
+            test_util::HIGH_3_2,
+            &[test_util::range(0, 3)],
+            &[],
+            132
+        );
     }
 
     #[test]
@@ -350,8 +359,11 @@ mod tests {
                 *recovery_count,
                 1024,
                 recovery_hash,
-                &[*recovery_count..*original_count],
-                &[0..core::cmp::min(*original_count, *recovery_count)],
+                &[test_util::range(*recovery_count, *original_count)],
+                &[test_util::range(
+                    0,
+                    core::cmp::min(*original_count, *recovery_count)
+                )],
                 *seed,
             );
         }
@@ -364,10 +376,10 @@ mod tests {
             HighRate,
             3000,
             30000,
-            64,
+            crate::reed_solomon::SHARD_CHUNK_BYTES,
             test_util::HIGH_3000_30000_14,
             &[],
-            &[0..3000],
+            &[test_util::range(0, 3000)],
             14,
         );
     }
@@ -379,10 +391,10 @@ mod tests {
             HighRate,
             32768,
             32768,
-            64,
+            crate::reed_solomon::SHARD_CHUNK_BYTES,
             test_util::EITHER_32768_32768_11,
             &[],
-            &[0..32768],
+            &[test_util::range(0, 32768)],
             11,
         );
     }
@@ -394,10 +406,10 @@ mod tests {
             HighRate,
             60000,
             3000,
-            64,
+            crate::reed_solomon::SHARD_CHUNK_BYTES,
             test_util::HIGH_60000_3000_12,
-            &[3000..60000],
-            &[0..3000],
+            &[test_util::range(3000, 60000)],
+            &[test_util::range(0, 3000)],
             12,
         );
     }
@@ -410,8 +422,8 @@ mod tests {
             2000,
             8,
             test_util::HIGH_34000_2000_123_8,
-            &[0..32000],
-            &[0..2000],
+            &[test_util::range(0, 32000)],
+            &[test_util::range(0, 2000)],
             123
         );
     }
@@ -424,8 +436,24 @@ mod tests {
         roundtrip_two_rounds!(
             HighRate,
             false,
-            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
-            (3, 2, 1024, test_util::HIGH_3_2_232, &[0], &[0, 1], 232),
+            (
+                3,
+                2,
+                1024,
+                test_util::HIGH_3_2,
+                &[test_util::index(1)],
+                &[test_util::index(0), test_util::index(1)],
+                132
+            ),
+            (
+                3,
+                2,
+                1024,
+                test_util::HIGH_3_2_232,
+                &[test_util::index(0)],
+                &[test_util::index(0), test_util::index(1)],
+                232
+            ),
         );
     }
 
@@ -434,8 +462,28 @@ mod tests {
         roundtrip_two_rounds!(
             HighRate,
             true,
-            (3, 2, 1024, test_util::HIGH_3_2, &[1], &[0, 1], 132),
-            (5, 2, 1024, test_util::HIGH_5_2, &[0, 2, 4], &[0, 1], 152),
+            (
+                3,
+                2,
+                1024,
+                test_util::HIGH_3_2,
+                &[test_util::index(1)],
+                &[test_util::index(0), test_util::index(1)],
+                132
+            ),
+            (
+                5,
+                2,
+                1024,
+                test_util::HIGH_5_2,
+                &[
+                    test_util::index(0),
+                    test_util::index(2),
+                    test_util::index(4)
+                ],
+                &[test_util::index(0), test_util::index(1)],
+                152
+            ),
         );
     }
 
@@ -446,33 +494,49 @@ mod tests {
         use crate::reed_solomon::{
             engine::NoSimd,
             rate::{HighRate, Rate},
-            Error,
+            Error, SHARD_CHUNK_BYTES,
         };
 
         #[test]
         fn decoder() {
             assert_eq!(
-                HighRate::<NoSimd>::decoder(4096, 61440, 64, NoSimd::new(), None).err(),
+                HighRate::<NoSimd>::decoder(4096, 61440, SHARD_CHUNK_BYTES, NoSimd::new(), None)
+                    .err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 4096,
                     recovery_count: 61440,
                 })
             );
 
-            assert!(HighRate::<NoSimd>::decoder(61440, 4096, 64, NoSimd::new(), None).is_ok());
+            assert!(HighRate::<NoSimd>::decoder(
+                61440,
+                4096,
+                SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None
+            )
+            .is_ok());
         }
 
         #[test]
         fn encoder() {
             assert_eq!(
-                HighRate::<NoSimd>::encoder(4096, 61440, 64, NoSimd::new(), None).err(),
+                HighRate::<NoSimd>::encoder(4096, 61440, SHARD_CHUNK_BYTES, NoSimd::new(), None)
+                    .err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 4096,
                     recovery_count: 61440,
                 })
             );
 
-            assert!(HighRate::<NoSimd>::encoder(61440, 4096, 64, NoSimd::new(), None).is_ok());
+            assert!(HighRate::<NoSimd>::encoder(
+                61440,
+                4096,
+                SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None
+            )
+            .is_ok());
         }
 
         #[test]
@@ -497,14 +561,14 @@ mod tests {
             );
 
             assert_eq!(
-                HighRate::<NoSimd>::validate(4096, 61440, 64).err(),
+                HighRate::<NoSimd>::validate(4096, 61440, SHARD_CHUNK_BYTES).err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 4096,
                     recovery_count: 61440,
                 })
             );
 
-            assert!(HighRate::<NoSimd>::validate(61440, 4096, 64).is_ok());
+            assert!(HighRate::<NoSimd>::validate(61440, 4096, SHARD_CHUNK_BYTES).is_ok());
         }
     }
 
@@ -515,7 +579,7 @@ mod tests {
         use crate::reed_solomon::{
             engine::NoSimd,
             rate::{HighRateEncoder, RateEncoder},
-            Error,
+            Error, SHARD_CHUNK_BYTES,
         };
 
         // ==================================================
@@ -543,14 +607,14 @@ mod tests {
             );
 
             assert_eq!(
-                HighRateEncoder::<NoSimd>::validate(4096, 61440, 64).err(),
+                HighRateEncoder::<NoSimd>::validate(4096, 61440, SHARD_CHUNK_BYTES).err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 4096,
                     recovery_count: 61440,
                 })
             );
 
-            assert!(HighRateEncoder::<NoSimd>::validate(61440, 4096, 64).is_ok());
+            assert!(HighRateEncoder::<NoSimd>::validate(61440, 4096, SHARD_CHUNK_BYTES).is_ok());
         }
 
         // ==================================================
@@ -573,7 +637,7 @@ mod tests {
         use crate::reed_solomon::{
             engine::NoSimd,
             rate::{HighRateDecoder, RateDecoder},
-            Error,
+            Error, SHARD_CHUNK_BYTES,
         };
 
         // ==================================================
@@ -601,14 +665,14 @@ mod tests {
             );
 
             assert_eq!(
-                HighRateDecoder::<NoSimd>::validate(4096, 61440, 64).err(),
+                HighRateDecoder::<NoSimd>::validate(4096, 61440, SHARD_CHUNK_BYTES).err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 4096,
                     recovery_count: 61440,
                 })
             );
 
-            assert!(HighRateDecoder::<NoSimd>::validate(61440, 4096, 64).is_ok());
+            assert!(HighRateDecoder::<NoSimd>::validate(61440, 4096, SHARD_CHUNK_BYTES).is_ok());
         }
 
         // ==================================================

--- a/cryptography/src/reed_solomon/rate/rate_low.rs
+++ b/cryptography/src/reed_solomon/rate/rate_low.rs
@@ -1,0 +1,627 @@
+use crate::reed_solomon::{
+    engine::{self, Engine, GF_MODULUS, GF_ORDER},
+    rate::{DecoderWork, EncoderWork, Rate, RateDecoder, RateEncoder},
+    DecoderResult, EncoderResult, Error,
+};
+use core::marker::PhantomData;
+
+// ======================================================================
+// LowRate - PUBLIC
+
+/// Reed-Solomon encoder/decoder generator using only low rate.
+pub struct LowRate<E: Engine>(PhantomData<E>);
+
+impl<E: Engine> Rate<E> for LowRate<E> {
+    type RateEncoder = LowRateEncoder<E>;
+    type RateDecoder = LowRateDecoder<E>;
+
+    fn supports(original_count: usize, recovery_count: usize) -> bool {
+        original_count > 0
+            && recovery_count > 0
+            && original_count < GF_ORDER
+            && recovery_count < GF_ORDER
+            && original_count.next_power_of_two() + recovery_count <= GF_ORDER
+    }
+}
+
+// ======================================================================
+// LowRateEncoder - PUBLIC
+
+/// Reed-Solomon encoder using only low rate.
+pub struct LowRateEncoder<E: Engine> {
+    engine: E,
+    work: EncoderWork,
+}
+
+impl<E: Engine> RateEncoder<E> for LowRateEncoder<E> {
+    type Rate = LowRate<E>;
+
+    fn add_original_shard<T: AsRef<[u8]>>(&mut self, original_shard: T) -> Result<(), Error> {
+        self.work.add_original_shard(original_shard)
+    }
+
+    fn encode(&mut self) -> Result<EncoderResult<'_>, Error> {
+        let (mut work, original_count, recovery_count) = self.work.encode_begin()?;
+        let chunk_size = original_count.next_power_of_two();
+        let engine = &self.engine;
+
+        // ZEROPAD ORIGINAL
+
+        work.zero(original_count..chunk_size);
+
+        // IFFT - ORIGINAL
+
+        engine.ifft(&mut work, 0, chunk_size, original_count, 0);
+
+        // COPY IFFT RESULT TO OTHER CHUNKS
+
+        let mut chunk_start = chunk_size;
+        while chunk_start < recovery_count {
+            work.copy_within(0, chunk_start, chunk_size);
+            chunk_start += chunk_size;
+        }
+
+        // FFT - FULL CHUNKS
+
+        let mut chunk_start = 0;
+        while chunk_start + chunk_size <= recovery_count {
+            engine::fft_skew_end(engine, &mut work, chunk_start, chunk_size, chunk_size);
+            chunk_start += chunk_size;
+        }
+
+        // FFT - FINAL PARTIAL CHUNK
+
+        let last_count = recovery_count % chunk_size;
+        if last_count > 0 {
+            engine::fft_skew_end(engine, &mut work, chunk_start, chunk_size, last_count);
+        }
+
+        // UNDO LAST CHUNK ENCODING
+
+        self.work.undo_last_chunk_encoding();
+
+        // DONE
+
+        Ok(EncoderResult::new(&mut self.work))
+    }
+
+    fn into_parts(self) -> (E, EncoderWork) {
+        (self.engine, self.work)
+    }
+
+    fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<EncoderWork>,
+    ) -> Result<Self, Error> {
+        let mut work = work.unwrap_or_default();
+        Self::reset_work(original_count, recovery_count, shard_bytes, &mut work)?;
+        Ok(Self { engine, work })
+    }
+
+    fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        Self::reset_work(original_count, recovery_count, shard_bytes, &mut self.work)
+    }
+}
+
+// ======================================================================
+// LowRateEncoder - PRIVATE
+
+impl<E: Engine> LowRateEncoder<E> {
+    fn reset_work(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        work: &mut EncoderWork,
+    ) -> Result<(), Error> {
+        Self::validate(original_count, recovery_count, shard_bytes)?;
+        work.reset(
+            original_count,
+            recovery_count,
+            shard_bytes,
+            Self::work_count(original_count, recovery_count),
+        );
+        Ok(())
+    }
+
+    fn work_count(original_count: usize, recovery_count: usize) -> usize {
+        debug_assert!(Self::supports(original_count, recovery_count));
+
+        let chunk_size = original_count.next_power_of_two();
+
+        recovery_count.next_multiple_of(chunk_size)
+    }
+}
+
+// ======================================================================
+// LowRateDecoder - PUBLIC
+
+/// Reed-Solomon decoder using only low rate.
+pub struct LowRateDecoder<E: Engine> {
+    engine: E,
+    work: DecoderWork,
+}
+
+impl<E: Engine> RateDecoder<E> for LowRateDecoder<E> {
+    type Rate = LowRate<E>;
+
+    fn add_original_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        original_shard: T,
+    ) -> Result<(), Error> {
+        self.work.add_original_shard(index, original_shard)
+    }
+
+    fn add_recovery_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        recovery_shard: T,
+    ) -> Result<(), Error> {
+        self.work.add_recovery_shard(index, recovery_shard)
+    }
+
+    fn decode(&mut self) -> Result<DecoderResult<'_>, Error> {
+        let Some((mut work, original_count, recovery_count, received)) =
+            self.work.decode_begin()?
+        else {
+            // Nothing to do, original data is complete.
+            return Ok(DecoderResult::new(&mut self.work));
+        };
+
+        let chunk_size = original_count.next_power_of_two();
+        let recovery_end = chunk_size + recovery_count;
+        let work_count = work.len();
+
+        // ERASURE LOCATIONS
+
+        let mut erasures = [0; GF_ORDER];
+
+        for i in 0..original_count {
+            if !received[i] {
+                erasures[i] = 1;
+            }
+        }
+
+        for i in chunk_size..recovery_end {
+            if !received[i] {
+                erasures[i] = 1;
+            }
+        }
+
+        erasures[recovery_end..].fill(1);
+
+        // EVALUATE POLYNOMIAL
+
+        E::eval_poly(&mut erasures, GF_ORDER);
+
+        // MULTIPLY SHARDS
+
+        // work[               .. original_count] = original * erasures
+        // work[original_count .. chunk_size    ] = 0
+        // work[chunk_size     .. original_end  ] = recovery * erasures
+        // work[recovery_end   ..               ] = 0
+
+        for i in 0..original_count {
+            if received[i] {
+                self.engine.mul(&mut work[i], erasures[i]);
+            } else {
+                work[i].fill([0; 64]);
+            }
+        }
+
+        work.zero(original_count..chunk_size);
+
+        for i in chunk_size..recovery_end {
+            if received[i] {
+                self.engine.mul(&mut work[i], erasures[i]);
+            } else {
+                work[i].fill([0; 64]);
+            }
+        }
+
+        work.zero(recovery_end..);
+
+        // IFFT / FORMAL DERIVATIVE / FFT
+
+        self.engine.ifft(&mut work, 0, work_count, recovery_end, 0);
+        engine::formal_derivative(&mut work);
+        self.engine.fft(&mut work, 0, work_count, recovery_end, 0);
+
+        // REVEAL ERASURES
+
+        for i in 0..original_count {
+            if !received[i] {
+                self.engine.mul(&mut work[i], GF_MODULUS - erasures[i]);
+            }
+        }
+
+        // UNDO LAST CHUNK ENCODING
+
+        self.work.undo_last_chunk_encoding();
+
+        // DONE
+
+        Ok(DecoderResult::new(&mut self.work))
+    }
+
+    fn into_parts(self) -> (E, DecoderWork) {
+        (self.engine, self.work)
+    }
+
+    fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        engine: E,
+        work: Option<DecoderWork>,
+    ) -> Result<Self, Error> {
+        let mut work = work.unwrap_or_default();
+        Self::reset_work(original_count, recovery_count, shard_bytes, &mut work)?;
+        Ok(Self { engine, work })
+    }
+
+    fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        Self::reset_work(original_count, recovery_count, shard_bytes, &mut self.work)
+    }
+}
+
+// ======================================================================
+// LowRateDecoder - PRIVATE
+
+impl<E: Engine> LowRateDecoder<E> {
+    fn reset_work(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+        work: &mut DecoderWork,
+    ) -> Result<(), Error> {
+        Self::validate(original_count, recovery_count, shard_bytes)?;
+
+        // work[..original_count     ]  =  original
+        // work[original_count_pow2..]  =  recovery
+        work.reset(
+            original_count,
+            recovery_count,
+            shard_bytes,
+            0,
+            original_count.next_power_of_two(),
+            Self::work_count(original_count, recovery_count),
+        );
+
+        Ok(())
+    }
+
+    fn work_count(original_count: usize, recovery_count: usize) -> usize {
+        debug_assert!(Self::supports(original_count, recovery_count));
+
+        (original_count.next_power_of_two() + recovery_count).next_power_of_two()
+    }
+}
+
+// ======================================================================
+// TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reed_solomon::test_util;
+
+    // ============================================================
+    // ROUNDTRIPS - SINGLE ROUND
+
+    #[test]
+    fn roundtrip_all_originals_missing() {
+        roundtrip_single!(
+            LowRate,
+            3,
+            3,
+            1024,
+            test_util::EITHER_3_3,
+            &[],
+            &[0..3],
+            133
+        );
+    }
+
+    #[test]
+    fn roundtrip_no_originals_missing() {
+        roundtrip_single!(LowRate, 2, 3, 1024, test_util::LOW_2_3, &[0, 1], &[], 123);
+    }
+
+    #[test]
+    fn roundtrips_tiny() {
+        for (original_count, recovery_count, seed, recovery_hash) in test_util::LOW_TINY {
+            roundtrip_single!(
+                LowRate,
+                *original_count,
+                *recovery_count,
+                1024,
+                recovery_hash,
+                &[*recovery_count..*original_count],
+                &[0..core::cmp::min(*original_count, *recovery_count)],
+                *seed,
+            );
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn roundtrip_3000_60000() {
+        roundtrip_single!(
+            LowRate,
+            3000,
+            60000,
+            64,
+            test_util::LOW_3000_60000_13,
+            &[],
+            &[0..3000],
+            13,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn roundtrip_30000_3000() {
+        roundtrip_single!(
+            LowRate,
+            30000,
+            3000,
+            64,
+            test_util::LOW_30000_3000_15,
+            &[3000..30000],
+            &[0..3000],
+            15,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn roundtrip_32768_32768() {
+        roundtrip_single!(
+            LowRate,
+            32768,
+            32768,
+            64,
+            test_util::EITHER_32768_32768_11,
+            &[],
+            &[0..32768],
+            11,
+        );
+    }
+
+    #[test]
+    fn roundtrip_2000_34000_shard_size_8() {
+        roundtrip_single!(
+            LowRate,
+            2000,
+            34000,
+            8,
+            test_util::LOW_2000_34000_123_8,
+            &[0..2000],
+            &[0..32000],
+            123
+        );
+    }
+
+    // ============================================================
+    // ROUNDTRIPS - TWO ROUNDS
+
+    #[test]
+    fn two_rounds_implicit_reset() {
+        roundtrip_two_rounds!(
+            LowRate,
+            false,
+            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
+            (2, 3, 1024, test_util::LOW_2_3_223, &[], &[1, 2], 223),
+        );
+    }
+
+    #[test]
+    fn two_rounds_explicit_reset() {
+        roundtrip_two_rounds!(
+            LowRate,
+            true,
+            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
+            (2, 5, 1024, test_util::LOW_2_5, &[], &[0, 4], 125),
+        );
+    }
+
+    // ============================================================
+    // LowRate
+
+    mod low_rate {
+        use crate::reed_solomon::{
+            engine::NoSimd,
+            rate::{LowRate, Rate},
+            Error,
+        };
+
+        #[test]
+        fn decoder() {
+            assert!(LowRate::<NoSimd>::decoder(4096, 61440, 64, NoSimd::new(), None).is_ok());
+
+            assert_eq!(
+                LowRate::<NoSimd>::decoder(61440, 4096, 64, NoSimd::new(), None).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 61440,
+                    recovery_count: 4096,
+                })
+            );
+        }
+
+        #[test]
+        fn encoder() {
+            assert!(LowRate::<NoSimd>::encoder(4096, 61440, 64, NoSimd::new(), None).is_ok());
+
+            assert_eq!(
+                LowRate::<NoSimd>::encoder(61440, 4096, 64, NoSimd::new(), None).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 61440,
+                    recovery_count: 4096,
+                })
+            );
+        }
+
+        #[test]
+        fn supports() {
+            assert!(!LowRate::<NoSimd>::supports(0, 1));
+            assert!(!LowRate::<NoSimd>::supports(1, 0));
+
+            assert!(LowRate::<NoSimd>::supports(4096, 61440));
+            assert!(!LowRate::<NoSimd>::supports(4096, 61441));
+            assert!(!LowRate::<NoSimd>::supports(4097, 61440));
+
+            assert!(!LowRate::<NoSimd>::supports(61440, 4096));
+
+            assert!(!LowRate::<NoSimd>::supports(usize::MAX, usize::MAX));
+        }
+
+        #[test]
+        fn validate() {
+            assert_eq!(
+                LowRate::<NoSimd>::validate(1, 1, 123).err(),
+                Some(Error::InvalidShardSize { shard_bytes: 123 })
+            );
+
+            assert!(LowRate::<NoSimd>::validate(4096, 61440, 64).is_ok());
+
+            assert_eq!(
+                LowRate::<NoSimd>::validate(61440, 4096, 64).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 61440,
+                    recovery_count: 4096,
+                })
+            );
+        }
+    }
+
+    // ============================================================
+    // LowRateEncoder
+
+    mod low_rate_encoder {
+        use crate::reed_solomon::{
+            engine::NoSimd,
+            rate::{LowRateEncoder, RateEncoder},
+            Error,
+        };
+
+        // ==================================================
+        // ERRORS
+
+        test_rate_encoder_errors! {LowRateEncoder}
+
+        // ==================================================
+        // supports
+
+        #[test]
+        fn supports() {
+            assert!(LowRateEncoder::<NoSimd>::supports(4096, 61440));
+            assert!(!LowRateEncoder::<NoSimd>::supports(61440, 4096));
+        }
+
+        // ==================================================
+        // validate
+
+        #[test]
+        fn validate() {
+            assert_eq!(
+                LowRateEncoder::<NoSimd>::validate(1, 1, 123).err(),
+                Some(Error::InvalidShardSize { shard_bytes: 123 })
+            );
+
+            assert!(LowRateEncoder::<NoSimd>::validate(4096, 61440, 64).is_ok());
+
+            assert_eq!(
+                LowRateEncoder::<NoSimd>::validate(61440, 4096, 64).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 61440,
+                    recovery_count: 4096,
+                })
+            );
+        }
+
+        // ==================================================
+        // work_count
+
+        #[test]
+        fn work_count() {
+            assert_eq!(LowRateEncoder::<NoSimd>::work_count(1, 1), 1);
+            assert_eq!(LowRateEncoder::<NoSimd>::work_count(1024, 4096), 4096);
+            assert_eq!(LowRateEncoder::<NoSimd>::work_count(1024, 4097), 5120);
+            assert_eq!(LowRateEncoder::<NoSimd>::work_count(1025, 4097), 6144);
+            assert_eq!(LowRateEncoder::<NoSimd>::work_count(32768, 32768), 32768);
+        }
+    }
+
+    // ============================================================
+    // LowRateDecoder
+
+    mod low_rate_decoder {
+        use crate::reed_solomon::{
+            engine::NoSimd,
+            rate::{LowRateDecoder, RateDecoder},
+            Error,
+        };
+
+        // ==================================================
+        // ERRORS
+
+        test_rate_decoder_errors! {LowRateDecoder}
+
+        // ==================================================
+        // supports
+
+        #[test]
+        fn supports() {
+            assert!(LowRateDecoder::<NoSimd>::supports(4096, 61440));
+            assert!(!LowRateDecoder::<NoSimd>::supports(61440, 4096));
+        }
+
+        // ==================================================
+        // validate
+
+        #[test]
+        fn validate() {
+            assert_eq!(
+                LowRateDecoder::<NoSimd>::validate(1, 1, 123).err(),
+                Some(Error::InvalidShardSize { shard_bytes: 123 })
+            );
+
+            assert!(LowRateDecoder::<NoSimd>::validate(4096, 61440, 64).is_ok());
+
+            assert_eq!(
+                LowRateDecoder::<NoSimd>::validate(61440, 4096, 64).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 61440,
+                    recovery_count: 4096,
+                })
+            );
+        }
+
+        // ==================================================
+        // work_count
+
+        #[test]
+        fn work_count() {
+            assert_eq!(LowRateDecoder::<NoSimd>::work_count(1, 1), 2);
+            assert_eq!(LowRateDecoder::<NoSimd>::work_count(1024, 3072), 4096);
+            assert_eq!(LowRateDecoder::<NoSimd>::work_count(1024, 3073), 8192);
+            assert_eq!(LowRateDecoder::<NoSimd>::work_count(1025, 2048), 4096);
+            assert_eq!(LowRateDecoder::<NoSimd>::work_count(1025, 2049), 8192);
+            assert_eq!(LowRateDecoder::<NoSimd>::work_count(32768, 32768), 65536);
+        }
+    }
+}

--- a/cryptography/src/reed_solomon/rate/rate_low.rs
+++ b/cryptography/src/reed_solomon/rate/rate_low.rs
@@ -1,5 +1,5 @@
 use crate::reed_solomon::{
-    engine::{self, Engine, GF_MODULUS, GF_ORDER},
+    engine::{self, Engine, GF_MODULUS, GF_ORDER, SHARD_CHUNK_BYTES},
     rate::{DecoderWork, EncoderWork, Rate, RateDecoder, RateEncoder},
     DecoderResult, EncoderResult, Error,
 };
@@ -132,7 +132,7 @@ impl<E: Engine> LowRateEncoder<E> {
     }
 
     fn work_count(original_count: usize, recovery_count: usize) -> usize {
-        debug_assert!(Self::supports(original_count, recovery_count));
+        assert!(Self::supports(original_count, recovery_count));
 
         let chunk_size = original_count.next_power_of_two();
 
@@ -213,7 +213,7 @@ impl<E: Engine> RateDecoder<E> for LowRateDecoder<E> {
             if received[i] {
                 self.engine.mul(&mut work[i], erasures[i]);
             } else {
-                work[i].fill([0; 64]);
+                work[i].fill([0; SHARD_CHUNK_BYTES]);
             }
         }
 
@@ -223,7 +223,7 @@ impl<E: Engine> RateDecoder<E> for LowRateDecoder<E> {
             if received[i] {
                 self.engine.mul(&mut work[i], erasures[i]);
             } else {
-                work[i].fill([0; 64]);
+                work[i].fill([0; SHARD_CHUNK_BYTES]);
             }
         }
 
@@ -305,7 +305,7 @@ impl<E: Engine> LowRateDecoder<E> {
     }
 
     fn work_count(original_count: usize, recovery_count: usize) -> usize {
-        debug_assert!(Self::supports(original_count, recovery_count));
+        assert!(Self::supports(original_count, recovery_count));
 
         (original_count.next_power_of_two() + recovery_count).next_power_of_two()
     }
@@ -331,14 +331,23 @@ mod tests {
             1024,
             test_util::EITHER_3_3,
             &[],
-            &[0..3],
+            &[test_util::range(0, 3)],
             133
         );
     }
 
     #[test]
     fn roundtrip_no_originals_missing() {
-        roundtrip_single!(LowRate, 2, 3, 1024, test_util::LOW_2_3, &[0, 1], &[], 123);
+        roundtrip_single!(
+            LowRate,
+            2,
+            3,
+            1024,
+            test_util::LOW_2_3,
+            &[test_util::index(0), test_util::index(1)],
+            &[],
+            123
+        );
     }
 
     #[test]
@@ -350,8 +359,11 @@ mod tests {
                 *recovery_count,
                 1024,
                 recovery_hash,
-                &[*recovery_count..*original_count],
-                &[0..core::cmp::min(*original_count, *recovery_count)],
+                &[test_util::range(*recovery_count, *original_count)],
+                &[test_util::range(
+                    0,
+                    core::cmp::min(*original_count, *recovery_count)
+                )],
                 *seed,
             );
         }
@@ -364,10 +376,10 @@ mod tests {
             LowRate,
             3000,
             60000,
-            64,
+            crate::reed_solomon::SHARD_CHUNK_BYTES,
             test_util::LOW_3000_60000_13,
             &[],
-            &[0..3000],
+            &[test_util::range(0, 3000)],
             13,
         );
     }
@@ -379,10 +391,10 @@ mod tests {
             LowRate,
             30000,
             3000,
-            64,
+            crate::reed_solomon::SHARD_CHUNK_BYTES,
             test_util::LOW_30000_3000_15,
-            &[3000..30000],
-            &[0..3000],
+            &[test_util::range(3000, 30000)],
+            &[test_util::range(0, 3000)],
             15,
         );
     }
@@ -394,10 +406,10 @@ mod tests {
             LowRate,
             32768,
             32768,
-            64,
+            crate::reed_solomon::SHARD_CHUNK_BYTES,
             test_util::EITHER_32768_32768_11,
             &[],
-            &[0..32768],
+            &[test_util::range(0, 32768)],
             11,
         );
     }
@@ -410,8 +422,8 @@ mod tests {
             34000,
             8,
             test_util::LOW_2000_34000_123_8,
-            &[0..2000],
-            &[0..32000],
+            &[test_util::range(0, 2000)],
+            &[test_util::range(0, 32000)],
             123
         );
     }
@@ -424,8 +436,24 @@ mod tests {
         roundtrip_two_rounds!(
             LowRate,
             false,
-            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
-            (2, 3, 1024, test_util::LOW_2_3_223, &[], &[1, 2], 223),
+            (
+                2,
+                3,
+                1024,
+                test_util::LOW_2_3,
+                &[],
+                &[test_util::index(0), test_util::index(2)],
+                123
+            ),
+            (
+                2,
+                3,
+                1024,
+                test_util::LOW_2_3_223,
+                &[],
+                &[test_util::index(1), test_util::index(2)],
+                223
+            ),
         );
     }
 
@@ -434,8 +462,24 @@ mod tests {
         roundtrip_two_rounds!(
             LowRate,
             true,
-            (2, 3, 1024, test_util::LOW_2_3, &[], &[0, 2], 123),
-            (2, 5, 1024, test_util::LOW_2_5, &[], &[0, 4], 125),
+            (
+                2,
+                3,
+                1024,
+                test_util::LOW_2_3,
+                &[],
+                &[test_util::index(0), test_util::index(2)],
+                123
+            ),
+            (
+                2,
+                5,
+                1024,
+                test_util::LOW_2_5,
+                &[],
+                &[test_util::index(0), test_util::index(4)],
+                125
+            ),
         );
     }
 
@@ -446,15 +490,23 @@ mod tests {
         use crate::reed_solomon::{
             engine::NoSimd,
             rate::{LowRate, Rate},
-            Error,
+            Error, SHARD_CHUNK_BYTES,
         };
 
         #[test]
         fn decoder() {
-            assert!(LowRate::<NoSimd>::decoder(4096, 61440, 64, NoSimd::new(), None).is_ok());
+            assert!(LowRate::<NoSimd>::decoder(
+                4096,
+                61440,
+                SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None
+            )
+            .is_ok());
 
             assert_eq!(
-                LowRate::<NoSimd>::decoder(61440, 4096, 64, NoSimd::new(), None).err(),
+                LowRate::<NoSimd>::decoder(61440, 4096, SHARD_CHUNK_BYTES, NoSimd::new(), None)
+                    .err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 61440,
                     recovery_count: 4096,
@@ -464,10 +516,18 @@ mod tests {
 
         #[test]
         fn encoder() {
-            assert!(LowRate::<NoSimd>::encoder(4096, 61440, 64, NoSimd::new(), None).is_ok());
+            assert!(LowRate::<NoSimd>::encoder(
+                4096,
+                61440,
+                SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None
+            )
+            .is_ok());
 
             assert_eq!(
-                LowRate::<NoSimd>::encoder(61440, 4096, 64, NoSimd::new(), None).err(),
+                LowRate::<NoSimd>::encoder(61440, 4096, SHARD_CHUNK_BYTES, NoSimd::new(), None)
+                    .err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 61440,
                     recovery_count: 4096,
@@ -496,10 +556,10 @@ mod tests {
                 Some(Error::InvalidShardSize { shard_bytes: 123 })
             );
 
-            assert!(LowRate::<NoSimd>::validate(4096, 61440, 64).is_ok());
+            assert!(LowRate::<NoSimd>::validate(4096, 61440, SHARD_CHUNK_BYTES).is_ok());
 
             assert_eq!(
-                LowRate::<NoSimd>::validate(61440, 4096, 64).err(),
+                LowRate::<NoSimd>::validate(61440, 4096, SHARD_CHUNK_BYTES).err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 61440,
                     recovery_count: 4096,
@@ -515,7 +575,7 @@ mod tests {
         use crate::reed_solomon::{
             engine::NoSimd,
             rate::{LowRateEncoder, RateEncoder},
-            Error,
+            Error, SHARD_CHUNK_BYTES,
         };
 
         // ==================================================
@@ -542,10 +602,10 @@ mod tests {
                 Some(Error::InvalidShardSize { shard_bytes: 123 })
             );
 
-            assert!(LowRateEncoder::<NoSimd>::validate(4096, 61440, 64).is_ok());
+            assert!(LowRateEncoder::<NoSimd>::validate(4096, 61440, SHARD_CHUNK_BYTES).is_ok());
 
             assert_eq!(
-                LowRateEncoder::<NoSimd>::validate(61440, 4096, 64).err(),
+                LowRateEncoder::<NoSimd>::validate(61440, 4096, SHARD_CHUNK_BYTES).err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 61440,
                     recovery_count: 4096,
@@ -573,7 +633,7 @@ mod tests {
         use crate::reed_solomon::{
             engine::NoSimd,
             rate::{LowRateDecoder, RateDecoder},
-            Error,
+            Error, SHARD_CHUNK_BYTES,
         };
 
         // ==================================================
@@ -600,10 +660,10 @@ mod tests {
                 Some(Error::InvalidShardSize { shard_bytes: 123 })
             );
 
-            assert!(LowRateDecoder::<NoSimd>::validate(4096, 61440, 64).is_ok());
+            assert!(LowRateDecoder::<NoSimd>::validate(4096, 61440, SHARD_CHUNK_BYTES).is_ok());
 
             assert_eq!(
-                LowRateDecoder::<NoSimd>::validate(61440, 4096, 64).err(),
+                LowRateDecoder::<NoSimd>::validate(61440, 4096, SHARD_CHUNK_BYTES).err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 61440,
                     recovery_count: 4096,

--- a/cryptography/src/reed_solomon/reed_solomon.rs
+++ b/cryptography/src/reed_solomon/reed_solomon.rs
@@ -1,0 +1,282 @@
+use crate::reed_solomon::{
+    engine::DefaultEngine,
+    rate::{DefaultRate, DefaultRateDecoder, DefaultRateEncoder, Rate, RateDecoder, RateEncoder},
+    DecoderResult, EncoderResult, Error,
+};
+
+// ======================================================================
+// ReedSolomonEncoder - PUBLIC
+
+/// Reed-Solomon encoder using [`DefaultEngine`] and [`DefaultRate`].
+///
+/// [`DefaultEngine`]: crate::reed_solomon::engine::DefaultEngine
+pub struct ReedSolomonEncoder(DefaultRateEncoder<DefaultEngine>);
+
+impl ReedSolomonEncoder {
+    /// Adds one original shard to the encoder.
+    ///
+    /// Original shards have indexes `0..original_count` corresponding to the order
+    /// in which they are added and these same indexes must be used when decoding.
+    ///
+    /// See [basic usage](crate::reed_solomon#basic-usage) for an example.
+    pub fn add_original_shard<T: AsRef<[u8]>>(&mut self, original_shard: T) -> Result<(), Error> {
+        self.0.add_original_shard(original_shard)
+    }
+
+    /// Encodes the added original shards returning [`EncoderResult`]
+    /// which contains the generated recovery shards.
+    ///
+    /// When returned [`EncoderResult`] is dropped the encoder is
+    /// automatically [`reset`] and ready for new round of encoding.
+    ///
+    /// See [basic usage](crate::reed_solomon#basic-usage) for an example.
+    ///
+    /// [`reset`]: ReedSolomonEncoder::reset
+    pub fn encode(&mut self) -> Result<EncoderResult<'_>, Error> {
+        self.0.encode()
+    }
+
+    /// Creates new encoder with given configuration
+    /// and allocates required working space.
+    ///
+    /// See [basic usage](crate::reed_solomon#basic-usage) for an example.
+    pub fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<Self, Error> {
+        Ok(Self(DefaultRateEncoder::new(
+            original_count,
+            recovery_count,
+            shard_bytes,
+            DefaultEngine::new(),
+            None,
+        )?))
+    }
+
+    /// Resets encoder to given configuration.
+    ///
+    /// - Added original shards are forgotten.
+    /// - Existing working space is re-used if it's large enough
+    ///   or re-allocated otherwise.
+    pub fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        self.0.reset(original_count, recovery_count, shard_bytes)
+    }
+
+    /// Returns `true` if given `original_count` / `recovery_count`
+    /// combination is supported.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use commonware_cryptography::reed_solomon::ReedSolomonEncoder;
+    ///
+    /// assert_eq!(ReedSolomonEncoder::supports(60_000, 4_000), true);
+    /// assert_eq!(ReedSolomonEncoder::supports(60_000, 5_000), false);
+    /// ```
+    pub fn supports(original_count: usize, recovery_count: usize) -> bool {
+        DefaultRate::<DefaultEngine>::supports(original_count, recovery_count)
+    }
+}
+
+// ======================================================================
+// ReedSolomonDecoder - PUBLIC
+
+/// Reed-Solomon decoder using [`DefaultEngine`] and [`DefaultRate`].
+///
+/// [`DefaultEngine`]: crate::reed_solomon::engine::DefaultEngine
+pub struct ReedSolomonDecoder(DefaultRateDecoder<DefaultEngine>);
+
+impl ReedSolomonDecoder {
+    /// Adds one original shard to the decoder.
+    ///
+    /// - Shards can be added in any order.
+    /// - Index must be the same that was used in encoding.
+    ///
+    /// See [basic usage](crate::reed_solomon#basic-usage) for an example.
+    pub fn add_original_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        original_shard: T,
+    ) -> Result<(), Error> {
+        self.0.add_original_shard(index, original_shard)
+    }
+
+    /// Adds one recovery shard to the decoder.
+    ///
+    /// - Shards can be added in any order.
+    /// - Index must be the same that was used in encoding.
+    ///
+    /// See [basic usage](crate::reed_solomon#basic-usage) for an example.
+    pub fn add_recovery_shard<T: AsRef<[u8]>>(
+        &mut self,
+        index: usize,
+        recovery_shard: T,
+    ) -> Result<(), Error> {
+        self.0.add_recovery_shard(index, recovery_shard)
+    }
+
+    /// Decodes the added shards returning [`DecoderResult`]
+    /// which contains the restored original shards.
+    ///
+    /// When returned [`DecoderResult`] is dropped the decoder is
+    /// automatically [`reset`] and ready for new round of decoding.
+    ///
+    /// See [basic usage](crate::reed_solomon#basic-usage) for an example.
+    ///
+    /// [`reset`]: ReedSolomonDecoder::reset
+    pub fn decode(&mut self) -> Result<DecoderResult<'_>, Error> {
+        self.0.decode()
+    }
+
+    /// Creates new decoder with given configuration
+    /// and allocates required working space.
+    ///
+    /// See [basic usage](crate::reed_solomon#basic-usage) for an example.
+    pub fn new(
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<Self, Error> {
+        Ok(Self(DefaultRateDecoder::new(
+            original_count,
+            recovery_count,
+            shard_bytes,
+            DefaultEngine::new(),
+            None,
+        )?))
+    }
+
+    /// Resets decoder to given configuration.
+    ///
+    /// - Added shards are forgotten.
+    /// - Existing working space is re-used if it's large enough
+    ///   or re-allocated otherwise.
+    pub fn reset(
+        &mut self,
+        original_count: usize,
+        recovery_count: usize,
+        shard_bytes: usize,
+    ) -> Result<(), Error> {
+        self.0.reset(original_count, recovery_count, shard_bytes)
+    }
+
+    /// Returns `true` if given `original_count` / `recovery_count`
+    /// combination is supported.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use commonware_cryptography::reed_solomon::ReedSolomonDecoder;
+    ///
+    /// assert_eq!(ReedSolomonDecoder::supports(60_000, 4_000), true);
+    /// assert_eq!(ReedSolomonDecoder::supports(60_000, 5_000), false);
+    /// ```
+    pub fn supports(original_count: usize, recovery_count: usize) -> bool {
+        DefaultRate::<DefaultEngine>::supports(original_count, recovery_count)
+    }
+}
+
+// ======================================================================
+// TESTS
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reed_solomon::test_util;
+    use fixedbitset::FixedBitSet;
+    use std::collections::BTreeMap;
+
+    // ============================================================
+    // HELPERS
+
+    fn roundtrip(
+        encoder: &mut ReedSolomonEncoder,
+        decoder: &mut ReedSolomonDecoder,
+        original_count: usize,
+        recovery_hash: &str,
+        decoder_original: &[usize],
+        decoder_recovery: &[usize],
+        seed: u8,
+    ) {
+        let original = test_util::generate_original(original_count, 1024, seed);
+
+        for original in &original {
+            encoder.add_original_shard(original).unwrap();
+        }
+
+        let result = encoder.encode().unwrap();
+        let recovery: Vec<_> = result.recovery_iter().collect();
+
+        test_util::assert_hash(&recovery, recovery_hash);
+
+        let mut original_received = FixedBitSet::with_capacity(original_count);
+
+        for i in decoder_original {
+            decoder.add_original_shard(*i, &original[*i]).unwrap();
+            original_received.set(*i, true);
+        }
+
+        for i in decoder_recovery {
+            decoder.add_recovery_shard(*i, recovery[*i]).unwrap();
+        }
+
+        let result = decoder.decode().unwrap();
+        let restored: BTreeMap<_, _> = result.restored_original_iter().collect();
+
+        for i in 0..original_count {
+            if !original_received[i] {
+                assert_eq!(restored[&i], original[i]);
+            }
+        }
+    }
+
+    // ============================================================
+    // ROUNDTRIP - TWO ROUNDS
+
+    #[test]
+    fn roundtrip_two_rounds_reset_low_to_high() {
+        let mut encoder = ReedSolomonEncoder::new(2, 3, 1024).unwrap();
+        let mut decoder = ReedSolomonDecoder::new(2, 3, 1024).unwrap();
+
+        roundtrip(
+            &mut encoder,
+            &mut decoder,
+            2,
+            test_util::LOW_2_3,
+            &[],
+            &[0, 1],
+            123,
+        );
+
+        encoder.reset(3, 2, 1024).unwrap();
+        decoder.reset(3, 2, 1024).unwrap();
+
+        roundtrip(
+            &mut encoder,
+            &mut decoder,
+            3,
+            test_util::HIGH_3_2,
+            &[1],
+            &[0, 1],
+            132,
+        );
+    }
+
+    // ==================================================
+    // supports
+
+    #[test]
+    fn supports() {
+        assert!(ReedSolomonEncoder::supports(4096, 61440));
+        assert!(ReedSolomonEncoder::supports(61440, 4096));
+
+        assert!(ReedSolomonDecoder::supports(4096, 61440));
+        assert!(ReedSolomonDecoder::supports(61440, 4096));
+    }
+}

--- a/cryptography/src/reed_solomon/test_util.rs
+++ b/cryptography/src/reed_solomon/test_util.rs
@@ -10,33 +10,39 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
 // ======================================================================
-// IntOrRange - CRATE
+// ShardSelection - CRATE
 
-pub(crate) trait IntOrRange {
-    // incluside
-    fn min(&self) -> usize;
-    // exclusive
-    fn max(&self) -> usize;
+#[derive(Debug)]
+pub(crate) enum ShardSelection {
+    Index(usize),
+    Range(Range<usize>),
 }
 
-impl IntOrRange for usize {
-    fn min(&self) -> usize {
-        *self
-    }
-
-    fn max(&self) -> usize {
-        self + 1
+impl ShardSelection {
+    fn indices(&self) -> Range<usize> {
+        match self {
+            Self::Index(index) => *index..*index + 1,
+            Self::Range(range) => range.clone(),
+        }
     }
 }
 
-impl IntOrRange for Range<usize> {
-    fn min(&self) -> usize {
-        self.start
-    }
+pub(crate) const fn index(index: usize) -> ShardSelection {
+    ShardSelection::Index(index)
+}
 
-    fn max(&self) -> usize {
-        self.end
-    }
+pub(crate) const fn range(start: usize, end: usize) -> ShardSelection {
+    ShardSelection::Range(start..end)
+}
+
+pub(crate) struct Roundtrip<'a> {
+    pub(crate) original_count: usize,
+    pub(crate) recovery_count: usize,
+    pub(crate) shard_bytes: usize,
+    pub(crate) recovery_hash: &'a str,
+    pub(crate) decoder_original: &'a [ShardSelection],
+    pub(crate) decoder_recovery: &'a [ShardSelection],
+    pub(crate) seed: u8,
 }
 
 // ======================================================================
@@ -83,17 +89,12 @@ pub(crate) fn generate_original(
 // ======================================================================
 // RATE ENCODER/DECODER - TEST SINGLE-ROUND ROUNDTRIP
 
-pub(crate) fn roundtrip<R: Rate<E>, E: Engine, T: IntOrRange>(
+pub(crate) fn roundtrip<R: Rate<E>, E: Engine>(
     encoder: &mut R::RateEncoder,
     decoder: &mut R::RateDecoder,
-    original_count: usize,
-    shard_bytes: usize,
-    recovery_hash: &str,
-    decoder_original: &[T],
-    decoder_recovery: &[T],
-    seed: u8,
+    cfg: &Roundtrip<'_>,
 ) {
-    let original = generate_original(original_count, shard_bytes, seed);
+    let original = generate_original(cfg.original_count, cfg.shard_bytes, cfg.seed);
 
     for original in &original {
         encoder.add_original_shard(original).unwrap();
@@ -102,71 +103,65 @@ pub(crate) fn roundtrip<R: Rate<E>, E: Engine, T: IntOrRange>(
     let result = encoder.encode().unwrap();
     let recovery: Vec<_> = result.recovery_iter().collect();
 
-    assert_hash(&recovery, recovery_hash);
+    assert_hash(&recovery, cfg.recovery_hash);
 
-    let mut original_received = FixedBitSet::with_capacity(original_count);
+    let mut original_received = FixedBitSet::with_capacity(cfg.original_count);
 
-    for x in decoder_original {
-        for i in x.min()..x.max() {
-            decoder.add_original_shard(i, &original[i]).unwrap();
+    for selection in cfg.decoder_original {
+        let indices = selection.indices();
+        for (i, shard) in original
+            .iter()
+            .enumerate()
+            .take(indices.end)
+            .skip(indices.start)
+        {
+            decoder.add_original_shard(i, shard).unwrap();
             original_received.set(i, true);
         }
     }
 
-    for x in decoder_recovery {
-        for i in x.min()..x.max() {
-            decoder.add_recovery_shard(i, recovery[i]).unwrap();
+    for selection in cfg.decoder_recovery {
+        let indices = selection.indices();
+        for (i, shard) in recovery
+            .iter()
+            .enumerate()
+            .take(indices.end)
+            .skip(indices.start)
+        {
+            decoder.add_recovery_shard(i, *shard).unwrap();
         }
     }
 
     let result = decoder.decode().unwrap();
     let restored: BTreeMap<_, _> = result.restored_original_iter().collect();
 
-    for i in 0..original_count {
+    for i in 0..cfg.original_count {
         if !original_received[i] {
             assert_eq!(restored[&i], original[i]);
         }
     }
 }
 
-pub(crate) fn roundtrip_single<R: Rate<E>, E: Engine, T: IntOrRange>(
-    new_engine: fn() -> E,
-    original_count: usize,
-    recovery_count: usize,
-    shard_bytes: usize,
-    recovery_hash: &str,
-    decoder_original: &[T],
-    decoder_recovery: &[T],
-    seed: u8,
-) {
+pub(crate) fn roundtrip_single<R: Rate<E>, E: Engine>(new_engine: fn() -> E, cfg: &Roundtrip<'_>) {
     let mut encoder = R::encoder(
-        original_count,
-        recovery_count,
-        shard_bytes,
+        cfg.original_count,
+        cfg.recovery_count,
+        cfg.shard_bytes,
         new_engine(),
         None,
     )
     .unwrap();
 
     let mut decoder = R::decoder(
-        original_count,
-        recovery_count,
-        shard_bytes,
+        cfg.original_count,
+        cfg.recovery_count,
+        cfg.shard_bytes,
         new_engine(),
         None,
     )
     .unwrap();
 
-    roundtrip::<R, E, T>(
-        &mut encoder,
-        &mut decoder,
-        original_count,
-        shard_bytes,
-        recovery_hash,
-        decoder_original,
-        decoder_recovery,
-        seed,
-    );
+    roundtrip::<R, E>(&mut encoder, &mut decoder, cfg);
 }
 
 macro_rules! roundtrip_single {
@@ -175,30 +170,28 @@ macro_rules! roundtrip_single {
      $recovery_count: expr,
      $shard_bytes: expr,
      $recovery_hash: expr,
-     $decoder_original: expr,
+    $decoder_original: expr,
      $decoder_recovery: expr,
      $seed: expr $(,)?
     ) => {
-        crate::reed_solomon::test_util::roundtrip_single::<$Rate<_>, _, _>(
+        let cfg = crate::reed_solomon::test_util::Roundtrip {
+            original_count: $original_count,
+            recovery_count: $recovery_count,
+            shard_bytes: $shard_bytes,
+            recovery_hash: $recovery_hash,
+            decoder_original: $decoder_original,
+            decoder_recovery: $decoder_recovery,
+            seed: $seed,
+        };
+
+        crate::reed_solomon::test_util::roundtrip_single::<$Rate<_>, _>(
             crate::reed_solomon::engine::Naive::new,
-            $original_count,
-            $recovery_count,
-            $shard_bytes,
-            $recovery_hash,
-            $decoder_original,
-            $decoder_recovery,
-            $seed,
+            &cfg,
         );
 
-        crate::reed_solomon::test_util::roundtrip_single::<$Rate<_>, _, _>(
+        crate::reed_solomon::test_util::roundtrip_single::<$Rate<_>, _>(
             crate::reed_solomon::engine::NoSimd::new,
-            $original_count,
-            $recovery_count,
-            $shard_bytes,
-            $recovery_hash,
-            $decoder_original,
-            $decoder_recovery,
-            $seed,
+            &cfg,
         );
     };
 }
@@ -323,16 +316,17 @@ macro_rules! roundtrip_two_rounds_inner {
         )
         .unwrap();
 
-        test_util::roundtrip::<$Rate<_>, _, _>(
-            &mut encoder,
-            &mut decoder,
-            $original_count_a,
-            $shard_bytes_a,
-            $recovery_hash_a,
-            $decoder_original_a,
-            $decoder_recovery_a,
-            $seed_a,
-        );
+        let cfg_a = test_util::Roundtrip {
+            original_count: $original_count_a,
+            recovery_count: $recovery_count_a,
+            shard_bytes: $shard_bytes_a,
+            recovery_hash: $recovery_hash_a,
+            decoder_original: $decoder_original_a,
+            decoder_recovery: $decoder_recovery_a,
+            seed: $seed_a,
+        };
+
+        test_util::roundtrip::<$Rate<_>, _>(&mut encoder, &mut decoder, &cfg_a);
 
         if $explicit_reset {
             encoder
@@ -344,16 +338,17 @@ macro_rules! roundtrip_two_rounds_inner {
                 .unwrap();
         }
 
-        test_util::roundtrip::<$Rate<_>, _, _>(
-            &mut encoder,
-            &mut decoder,
-            $original_count_b,
-            $shard_bytes_b,
-            $recovery_hash_b,
-            $decoder_original_b,
-            $decoder_recovery_b,
-            $seed_b,
-        );
+        let cfg_b = test_util::Roundtrip {
+            original_count: $original_count_b,
+            recovery_count: $recovery_count_b,
+            shard_bytes: $shard_bytes_b,
+            recovery_hash: $recovery_hash_b,
+            decoder_original: $decoder_original_b,
+            decoder_recovery: $decoder_recovery_b,
+            seed: $seed_b,
+        };
+
+        test_util::roundtrip::<$Rate<_>, _>(&mut encoder, &mut decoder, &cfg_b);
     };
 }
 
@@ -364,12 +359,19 @@ macro_rules! test_rate_encoder_errors {
     ($Encoder:ident) => {
         #[test]
         fn different_shard_size_in_add_original_shard() {
-            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut encoder = $Encoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
-                encoder.add_original_shard([0; 128]),
+                encoder.add_original_shard([0; crate::reed_solomon::SHARD_CHUNK_BYTES * 2]),
                 Err(Error::DifferentShardSize {
-                    shard_bytes: 64,
-                    got: 128
+                    shard_bytes: crate::reed_solomon::SHARD_CHUNK_BYTES,
+                    got: crate::reed_solomon::SHARD_CHUNK_BYTES * 2
                 }),
             );
         }
@@ -384,7 +386,14 @@ macro_rules! test_rate_encoder_errors {
 
         #[test]
         fn invalid_shard_size_in_reset() {
-            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut encoder = $Encoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
                 encoder.reset(1, 1, 123),
                 Err(Error::InvalidShardSize { shard_bytes: 123 }),
@@ -393,7 +402,14 @@ macro_rules! test_rate_encoder_errors {
 
         #[test]
         fn too_few_original_shards() {
-            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut encoder = $Encoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
                 encoder.encode().err(),
                 Some(Error::TooFewOriginalShards {
@@ -405,10 +421,19 @@ macro_rules! test_rate_encoder_errors {
 
         #[test]
         fn too_many_original_shards() {
-            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
-            encoder.add_original_shard([0; 64]).unwrap();
+            let mut encoder = $Encoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
+            encoder
+                .add_original_shard([0; crate::reed_solomon::SHARD_CHUNK_BYTES])
+                .unwrap();
             assert_eq!(
-                encoder.add_original_shard([0; 64]),
+                encoder.add_original_shard([0; crate::reed_solomon::SHARD_CHUNK_BYTES]),
                 Err(Error::TooManyOriginalShards { original_count: 1 }),
             );
         }
@@ -416,7 +441,14 @@ macro_rules! test_rate_encoder_errors {
         #[test]
         fn unsupported_shard_count_in_new() {
             assert_eq!(
-                $Encoder::new(0, 1, 64, NoSimd::new(), None).err(),
+                $Encoder::new(
+                    0,
+                    1,
+                    crate::reed_solomon::SHARD_CHUNK_BYTES,
+                    NoSimd::new(),
+                    None
+                )
+                .err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 0,
                     recovery_count: 1,
@@ -426,9 +458,16 @@ macro_rules! test_rate_encoder_errors {
 
         #[test]
         fn unsupported_shard_count_in_reset() {
-            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut encoder = $Encoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
-                encoder.reset(0, 1, 64),
+                encoder.reset(0, 1, crate::reed_solomon::SHARD_CHUNK_BYTES),
                 Err(Error::UnsupportedShardCount {
                     original_count: 0,
                     recovery_count: 1,
@@ -445,53 +484,92 @@ macro_rules! test_rate_decoder_errors {
     ($Decoder:ident) => {
         #[test]
         fn different_shard_size_in_add_original_shard() {
-            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut decoder = $Decoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
-                decoder.add_original_shard(0, [0; 128]),
+                decoder.add_original_shard(0, [0; crate::reed_solomon::SHARD_CHUNK_BYTES * 2]),
                 Err(Error::DifferentShardSize {
-                    shard_bytes: 64,
-                    got: 128
+                    shard_bytes: crate::reed_solomon::SHARD_CHUNK_BYTES,
+                    got: crate::reed_solomon::SHARD_CHUNK_BYTES * 2
                 }),
             );
         }
 
         #[test]
         fn different_shard_size_in_add_recovery_shard() {
-            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut decoder = $Decoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
-                decoder.add_recovery_shard(0, [0; 128]),
+                decoder.add_recovery_shard(0, [0; crate::reed_solomon::SHARD_CHUNK_BYTES * 2]),
                 Err(Error::DifferentShardSize {
-                    shard_bytes: 64,
-                    got: 128
+                    shard_bytes: crate::reed_solomon::SHARD_CHUNK_BYTES,
+                    got: crate::reed_solomon::SHARD_CHUNK_BYTES * 2
                 }),
             );
         }
 
         #[test]
         fn duplicate_shard_index_in_add_original_shard() {
-            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
-            decoder.add_original_shard(0, [0; 64]).unwrap();
+            let mut decoder = $Decoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
+            decoder
+                .add_original_shard(0, [0; crate::reed_solomon::SHARD_CHUNK_BYTES])
+                .unwrap();
             assert_eq!(
-                decoder.add_original_shard(0, [0; 64]),
+                decoder.add_original_shard(0, [0; crate::reed_solomon::SHARD_CHUNK_BYTES]),
                 Err(Error::DuplicateOriginalShardIndex { index: 0 }),
             );
         }
 
         #[test]
         fn duplicate_shard_index_in_add_recovert_shard() {
-            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
-            decoder.add_recovery_shard(0, [0; 64]).unwrap();
+            let mut decoder = $Decoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
+            decoder
+                .add_recovery_shard(0, [0; crate::reed_solomon::SHARD_CHUNK_BYTES])
+                .unwrap();
             assert_eq!(
-                decoder.add_recovery_shard(0, [0; 64]),
+                decoder.add_recovery_shard(0, [0; crate::reed_solomon::SHARD_CHUNK_BYTES]),
                 Err(Error::DuplicateRecoveryShardIndex { index: 0 }),
             );
         }
 
         #[test]
         fn invalid_original_shard_index() {
-            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut decoder = $Decoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
-                decoder.add_original_shard(1, [0; 64]),
+                decoder.add_original_shard(1, [0; crate::reed_solomon::SHARD_CHUNK_BYTES]),
                 Err(Error::InvalidOriginalShardIndex {
                     original_count: 1,
                     index: 1,
@@ -501,9 +579,16 @@ macro_rules! test_rate_decoder_errors {
 
         #[test]
         fn invalid_recovery_shard_index() {
-            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut decoder = $Decoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
-                decoder.add_recovery_shard(1, [0; 64]),
+                decoder.add_recovery_shard(1, [0; crate::reed_solomon::SHARD_CHUNK_BYTES]),
                 Err(Error::InvalidRecoveryShardIndex {
                     recovery_count: 1,
                     index: 1,
@@ -521,7 +606,14 @@ macro_rules! test_rate_decoder_errors {
 
         #[test]
         fn invalid_shard_size_in_reset() {
-            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut decoder = $Decoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
                 decoder.reset(1, 1, 123),
                 Err(Error::InvalidShardSize { shard_bytes: 123 }),
@@ -530,7 +622,14 @@ macro_rules! test_rate_decoder_errors {
 
         #[test]
         fn not_enough_shards() {
-            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut decoder = $Decoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
                 decoder.decode().err(),
                 Some(Error::NotEnoughShards {
@@ -544,7 +643,14 @@ macro_rules! test_rate_decoder_errors {
         #[test]
         fn unsupported_shard_count_in_new() {
             assert_eq!(
-                $Decoder::new(0, 1, 64, NoSimd::new(), None).err(),
+                $Decoder::new(
+                    0,
+                    1,
+                    crate::reed_solomon::SHARD_CHUNK_BYTES,
+                    NoSimd::new(),
+                    None
+                )
+                .err(),
                 Some(Error::UnsupportedShardCount {
                     original_count: 0,
                     recovery_count: 1,
@@ -554,9 +660,16 @@ macro_rules! test_rate_decoder_errors {
 
         #[test]
         fn unsupported_shard_count_in_reset() {
-            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            let mut decoder = $Decoder::new(
+                1,
+                1,
+                crate::reed_solomon::SHARD_CHUNK_BYTES,
+                NoSimd::new(),
+                None,
+            )
+            .unwrap();
             assert_eq!(
-                decoder.reset(0, 1, 64),
+                decoder.reset(0, 1, crate::reed_solomon::SHARD_CHUNK_BYTES),
                 Err(Error::UnsupportedShardCount {
                     original_count: 0,
                     recovery_count: 1,
@@ -570,7 +683,7 @@ macro_rules! test_rate_decoder_errors {
 // RECOVERY HASHES
 
 // SHA256 hashes of some recovery shards.
-// - shard_bytes = 1024 (or 64 if mentioned explicitly)
+// - shard_bytes = 1024 (or `SHARD_CHUNK_BYTES` if mentioned explicitly)
 // - Original shards are from `generate_original`.
 
 // ==================================================
@@ -776,7 +889,7 @@ pub(crate) const EITHER_3_4: &str =
 pub(crate) const EITHER_4_3: &str =
     "e43d0903b619f4b17c5389ce869317ce549e3f6d2fe3aa2805ef4d4fb7adce74";
 
-// 32768 original ; 32768 recovery ; 11 seed ; shard_bytes = 64
+// 32768 original ; 32768 recovery ; 11 seed ; shard_bytes = SHARD_CHUNK_BYTES
 pub(crate) const EITHER_32768_32768_11: &str =
     "432025ead0e3f432f74e30500076a8c2b5554f5dfb7767b62fc3a8126eef7389";
 
@@ -799,12 +912,12 @@ pub(crate) const HIGH_5_2: &str =
 pub(crate) const HIGH_5_3: &str =
     "6f53d5175900d70b4821d1d0c947d0c47a802add0d620bfa72d57dd983dfc156";
 
-// 3000 original ; 30000 recovery ; 14 seed ; shard_bytes = 64
+// 3000 original ; 30000 recovery ; 14 seed ; shard_bytes = SHARD_CHUNK_BYTES
 // NOTE: Chunk size is 4096, with partial chunk at end.
 pub(crate) const HIGH_3000_30000_14: &str =
     "2d7d97fd92be0721b4fcfac8814fe0dd9ad07959eb40558c6ed9af09943fed4e";
 
-// 60000 original ; 3000 recovery ; 12 seed ; shard_bytes = 64
+// 60000 original ; 3000 recovery ; 12 seed ; shard_bytes = SHARD_CHUNK_BYTES
 // NOTE: Chunk size is 4096, with partial chunk at end.
 pub(crate) const HIGH_60000_3000_12: &str =
     "88e68e1d86a0fc168a549e195845d20b49ff85734db20d560c36ff2e14f78676";
@@ -829,12 +942,12 @@ pub(crate) const LOW_2_5: &str = "24449ae058f54a33b3b7ee568761e68e36bd7171ee2a32
 // 3 original ; 5 recovery ; 135 seed
 pub(crate) const LOW_3_5: &str = "c23920347f00328dceca9cb6012d797d97f366617cf27aae5c45b4f0b8491552";
 
-// 3000 original ; 60000 recovery ; 13 seed ; shard_bytes = 64
+// 3000 original ; 60000 recovery ; 13 seed ; shard_bytes = SHARD_CHUNK_BYTES
 // NOTE: Chunk size is 4096, with partial chunk at end.
 pub(crate) const LOW_3000_60000_13: &str =
     "d44f9c9ed9158f8aad140794e64a730577327f195753af21b810090966b4b4df";
 
-// 30000 original ; 3000 recovery ; 15 seed ; shard_bytes = 64
+// 30000 original ; 3000 recovery ; 15 seed ; shard_bytes = SHARD_CHUNK_BYTES
 // NOTE: Chunk size is 4096, with partial chunk at end.
 pub(crate) const LOW_30000_3000_15: &str =
     "202f99a2ade121d2404e967d5c04ff390f7a147070a2dcbe71dcf3baeafdf93a";

--- a/cryptography/src/reed_solomon/test_util.rs
+++ b/cryptography/src/reed_solomon/test_util.rs
@@ -1,0 +1,844 @@
+use crate::reed_solomon::{
+    engine::Engine,
+    rate::{Rate, RateDecoder, RateEncoder},
+};
+use core::ops::Range;
+use fixedbitset::FixedBitSet;
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+// ======================================================================
+// IntOrRange - CRATE
+
+pub(crate) trait IntOrRange {
+    // incluside
+    fn min(&self) -> usize;
+    // exclusive
+    fn max(&self) -> usize;
+}
+
+impl IntOrRange for usize {
+    fn min(&self) -> usize {
+        *self
+    }
+
+    fn max(&self) -> usize {
+        self + 1
+    }
+}
+
+impl IntOrRange for Range<usize> {
+    fn min(&self) -> usize {
+        self.start
+    }
+
+    fn max(&self) -> usize {
+        self.end
+    }
+}
+
+// ======================================================================
+// FUNCTIONS - CRATE
+
+pub(crate) fn assert_hash<T>(shards: T, expected: &str)
+where
+    T: IntoIterator,
+    T::Item: AsRef<[u8]>,
+{
+    let mut sha = Sha256::new();
+    for shard in shards {
+        sha.update(shard);
+    }
+    let got = sha.finalize();
+
+    if got.as_slice() != commonware_formatting::from_hex(expected).unwrap() {
+        #[cfg(feature = "std")]
+        {
+            print!("GOT     : ");
+            for x in got {
+                print!("{:02x}", x);
+            }
+            println!();
+            println!("EXPECTED: {}", expected);
+        }
+        panic!("recovery shards hash doesn't match");
+    }
+}
+
+pub(crate) fn generate_original(
+    original_count: usize,
+    shard_bytes: usize,
+    seed: u8,
+) -> Vec<Vec<u8>> {
+    let mut rng = ChaCha8Rng::from_seed([seed; 32]);
+    let mut original = vec![vec![0u8; shard_bytes]; original_count];
+    for original in &mut original {
+        rng.fill_bytes(original);
+    }
+    original
+}
+
+// ======================================================================
+// RATE ENCODER/DECODER - TEST SINGLE-ROUND ROUNDTRIP
+
+pub(crate) fn roundtrip<R: Rate<E>, E: Engine, T: IntOrRange>(
+    encoder: &mut R::RateEncoder,
+    decoder: &mut R::RateDecoder,
+    original_count: usize,
+    shard_bytes: usize,
+    recovery_hash: &str,
+    decoder_original: &[T],
+    decoder_recovery: &[T],
+    seed: u8,
+) {
+    let original = generate_original(original_count, shard_bytes, seed);
+
+    for original in &original {
+        encoder.add_original_shard(original).unwrap();
+    }
+
+    let result = encoder.encode().unwrap();
+    let recovery: Vec<_> = result.recovery_iter().collect();
+
+    assert_hash(&recovery, recovery_hash);
+
+    let mut original_received = FixedBitSet::with_capacity(original_count);
+
+    for x in decoder_original {
+        for i in x.min()..x.max() {
+            decoder.add_original_shard(i, &original[i]).unwrap();
+            original_received.set(i, true);
+        }
+    }
+
+    for x in decoder_recovery {
+        for i in x.min()..x.max() {
+            decoder.add_recovery_shard(i, recovery[i]).unwrap();
+        }
+    }
+
+    let result = decoder.decode().unwrap();
+    let restored: BTreeMap<_, _> = result.restored_original_iter().collect();
+
+    for i in 0..original_count {
+        if !original_received[i] {
+            assert_eq!(restored[&i], original[i]);
+        }
+    }
+}
+
+pub(crate) fn roundtrip_single<R: Rate<E>, E: Engine, T: IntOrRange>(
+    new_engine: fn() -> E,
+    original_count: usize,
+    recovery_count: usize,
+    shard_bytes: usize,
+    recovery_hash: &str,
+    decoder_original: &[T],
+    decoder_recovery: &[T],
+    seed: u8,
+) {
+    let mut encoder = R::encoder(
+        original_count,
+        recovery_count,
+        shard_bytes,
+        new_engine(),
+        None,
+    )
+    .unwrap();
+
+    let mut decoder = R::decoder(
+        original_count,
+        recovery_count,
+        shard_bytes,
+        new_engine(),
+        None,
+    )
+    .unwrap();
+
+    roundtrip::<R, E, T>(
+        &mut encoder,
+        &mut decoder,
+        original_count,
+        shard_bytes,
+        recovery_hash,
+        decoder_original,
+        decoder_recovery,
+        seed,
+    );
+}
+
+macro_rules! roundtrip_single {
+    ($Rate: ident,
+     $original_count: expr,
+     $recovery_count: expr,
+     $shard_bytes: expr,
+     $recovery_hash: expr,
+     $decoder_original: expr,
+     $decoder_recovery: expr,
+     $seed: expr $(,)?
+    ) => {
+        crate::reed_solomon::test_util::roundtrip_single::<$Rate<_>, _, _>(
+            crate::reed_solomon::engine::Naive::new,
+            $original_count,
+            $recovery_count,
+            $shard_bytes,
+            $recovery_hash,
+            $decoder_original,
+            $decoder_recovery,
+            $seed,
+        );
+
+        crate::reed_solomon::test_util::roundtrip_single::<$Rate<_>, _, _>(
+            crate::reed_solomon::engine::NoSimd::new,
+            $original_count,
+            $recovery_count,
+            $shard_bytes,
+            $recovery_hash,
+            $decoder_original,
+            $decoder_recovery,
+            $seed,
+        );
+    };
+}
+
+// ======================================================================
+// RATE ENCODER/DECODER - TEST TWO-ROUND ROUNDTRIP
+
+macro_rules! roundtrip_two_rounds {
+    (
+        $Rate: ident,
+        $explicit_reset: expr,
+        (
+            $original_count_a: expr,
+            $recovery_count_a: expr,
+            $shard_bytes_a: expr,
+            $recovery_hash_a: expr,
+            $decoder_original_a: expr,
+            $decoder_recovery_a: expr,
+            $seed_a: expr $(,)?
+        ),
+        (
+            $original_count_b: expr,
+            $recovery_count_b: expr,
+            $shard_bytes_b: expr,
+            $recovery_hash_b: expr,
+            $decoder_original_b: expr,
+            $decoder_recovery_b: expr,
+            $seed_b: expr $(,)?
+        ) $(,)?
+    ) => {
+        use crate::reed_solomon::engine::{Naive, NoSimd};
+
+        roundtrip_two_rounds_inner!(
+            $Rate,
+            Naive,
+            $explicit_reset,
+            (
+                $original_count_a,
+                $recovery_count_a,
+                $shard_bytes_a,
+                $recovery_hash_a,
+                $decoder_original_a,
+                $decoder_recovery_a,
+                $seed_a,
+            ),
+            (
+                $original_count_b,
+                $recovery_count_b,
+                $shard_bytes_b,
+                $recovery_hash_b,
+                $decoder_original_b,
+                $decoder_recovery_b,
+                $seed_b,
+            ),
+        );
+
+        roundtrip_two_rounds_inner!(
+            $Rate,
+            NoSimd,
+            $explicit_reset,
+            (
+                $original_count_a,
+                $recovery_count_a,
+                $shard_bytes_a,
+                $recovery_hash_a,
+                $decoder_original_a,
+                $decoder_recovery_a,
+                $seed_a,
+            ),
+            (
+                $original_count_b,
+                $recovery_count_b,
+                $shard_bytes_b,
+                $recovery_hash_b,
+                $decoder_original_b,
+                $decoder_recovery_b,
+                $seed_b,
+            ),
+        );
+    };
+}
+
+macro_rules! roundtrip_two_rounds_inner {
+    (
+        $Rate: ident,
+        $Engine: ident,
+        $explicit_reset: expr,
+        (
+            $original_count_a: expr,
+            $recovery_count_a: expr,
+            $shard_bytes_a: expr,
+            $recovery_hash_a: expr,
+            $decoder_original_a: expr,
+            $decoder_recovery_a: expr,
+            $seed_a: expr $(,)?
+        ),
+        (
+            $original_count_b: expr,
+            $recovery_count_b: expr,
+            $shard_bytes_b: expr,
+            $recovery_hash_b: expr,
+            $decoder_original_b: expr,
+            $decoder_recovery_b: expr,
+            $seed_b: expr $(,)?
+        ) $(,)?
+    ) => {
+        let mut encoder = $Rate::encoder(
+            $original_count_a,
+            $recovery_count_a,
+            $shard_bytes_a,
+            $Engine::new(),
+            None,
+        )
+        .unwrap();
+
+        let mut decoder = $Rate::decoder(
+            $original_count_a,
+            $recovery_count_a,
+            $shard_bytes_a,
+            $Engine::new(),
+            None,
+        )
+        .unwrap();
+
+        test_util::roundtrip::<$Rate<_>, _, _>(
+            &mut encoder,
+            &mut decoder,
+            $original_count_a,
+            $shard_bytes_a,
+            $recovery_hash_a,
+            $decoder_original_a,
+            $decoder_recovery_a,
+            $seed_a,
+        );
+
+        if $explicit_reset {
+            encoder
+                .reset($original_count_b, $recovery_count_b, $shard_bytes_b)
+                .unwrap();
+
+            decoder
+                .reset($original_count_b, $recovery_count_b, $shard_bytes_b)
+                .unwrap();
+        }
+
+        test_util::roundtrip::<$Rate<_>, _, _>(
+            &mut encoder,
+            &mut decoder,
+            $original_count_b,
+            $shard_bytes_b,
+            $recovery_hash_b,
+            $decoder_original_b,
+            $decoder_recovery_b,
+            $seed_b,
+        );
+    };
+}
+
+// ======================================================================
+// RATE ENCODER - TEST ERRORS
+
+macro_rules! test_rate_encoder_errors {
+    ($Encoder:ident) => {
+        #[test]
+        fn different_shard_size_in_add_original_shard() {
+            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                encoder.add_original_shard([0; 128]),
+                Err(Error::DifferentShardSize {
+                    shard_bytes: 64,
+                    got: 128
+                }),
+            );
+        }
+
+        #[test]
+        fn invalid_shard_size_in_new() {
+            assert_eq!(
+                $Encoder::new(1, 1, 123, NoSimd::new(), None).err(),
+                Some(Error::InvalidShardSize { shard_bytes: 123 }),
+            );
+        }
+
+        #[test]
+        fn invalid_shard_size_in_reset() {
+            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                encoder.reset(1, 1, 123),
+                Err(Error::InvalidShardSize { shard_bytes: 123 }),
+            );
+        }
+
+        #[test]
+        fn too_few_original_shards() {
+            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                encoder.encode().err(),
+                Some(Error::TooFewOriginalShards {
+                    original_count: 1,
+                    original_received_count: 0
+                }),
+            );
+        }
+
+        #[test]
+        fn too_many_original_shards() {
+            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            encoder.add_original_shard([0; 64]).unwrap();
+            assert_eq!(
+                encoder.add_original_shard([0; 64]),
+                Err(Error::TooManyOriginalShards { original_count: 1 }),
+            );
+        }
+
+        #[test]
+        fn unsupported_shard_count_in_new() {
+            assert_eq!(
+                $Encoder::new(0, 1, 64, NoSimd::new(), None).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 0,
+                    recovery_count: 1,
+                }),
+            );
+        }
+
+        #[test]
+        fn unsupported_shard_count_in_reset() {
+            let mut encoder = $Encoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                encoder.reset(0, 1, 64),
+                Err(Error::UnsupportedShardCount {
+                    original_count: 0,
+                    recovery_count: 1,
+                }),
+            );
+        }
+    };
+}
+
+// ======================================================================
+// RATE DECODER - TEST ERRORS
+
+macro_rules! test_rate_decoder_errors {
+    ($Decoder:ident) => {
+        #[test]
+        fn different_shard_size_in_add_original_shard() {
+            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                decoder.add_original_shard(0, [0; 128]),
+                Err(Error::DifferentShardSize {
+                    shard_bytes: 64,
+                    got: 128
+                }),
+            );
+        }
+
+        #[test]
+        fn different_shard_size_in_add_recovery_shard() {
+            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                decoder.add_recovery_shard(0, [0; 128]),
+                Err(Error::DifferentShardSize {
+                    shard_bytes: 64,
+                    got: 128
+                }),
+            );
+        }
+
+        #[test]
+        fn duplicate_shard_index_in_add_original_shard() {
+            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            decoder.add_original_shard(0, [0; 64]).unwrap();
+            assert_eq!(
+                decoder.add_original_shard(0, [0; 64]),
+                Err(Error::DuplicateOriginalShardIndex { index: 0 }),
+            );
+        }
+
+        #[test]
+        fn duplicate_shard_index_in_add_recovert_shard() {
+            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            decoder.add_recovery_shard(0, [0; 64]).unwrap();
+            assert_eq!(
+                decoder.add_recovery_shard(0, [0; 64]),
+                Err(Error::DuplicateRecoveryShardIndex { index: 0 }),
+            );
+        }
+
+        #[test]
+        fn invalid_original_shard_index() {
+            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                decoder.add_original_shard(1, [0; 64]),
+                Err(Error::InvalidOriginalShardIndex {
+                    original_count: 1,
+                    index: 1,
+                }),
+            );
+        }
+
+        #[test]
+        fn invalid_recovery_shard_index() {
+            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                decoder.add_recovery_shard(1, [0; 64]),
+                Err(Error::InvalidRecoveryShardIndex {
+                    recovery_count: 1,
+                    index: 1,
+                }),
+            );
+        }
+
+        #[test]
+        fn invalid_shard_size_in_new() {
+            assert_eq!(
+                $Decoder::new(1, 1, 123, NoSimd::new(), None).err(),
+                Some(Error::InvalidShardSize { shard_bytes: 123 }),
+            );
+        }
+
+        #[test]
+        fn invalid_shard_size_in_reset() {
+            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                decoder.reset(1, 1, 123),
+                Err(Error::InvalidShardSize { shard_bytes: 123 }),
+            );
+        }
+
+        #[test]
+        fn not_enough_shards() {
+            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                decoder.decode().err(),
+                Some(Error::NotEnoughShards {
+                    original_count: 1,
+                    original_received_count: 0,
+                    recovery_received_count: 0,
+                }),
+            );
+        }
+
+        #[test]
+        fn unsupported_shard_count_in_new() {
+            assert_eq!(
+                $Decoder::new(0, 1, 64, NoSimd::new(), None).err(),
+                Some(Error::UnsupportedShardCount {
+                    original_count: 0,
+                    recovery_count: 1,
+                }),
+            );
+        }
+
+        #[test]
+        fn unsupported_shard_count_in_reset() {
+            let mut decoder = $Decoder::new(1, 1, 64, NoSimd::new(), None).unwrap();
+            assert_eq!(
+                decoder.reset(0, 1, 64),
+                Err(Error::UnsupportedShardCount {
+                    original_count: 0,
+                    recovery_count: 1,
+                }),
+            );
+        }
+    };
+}
+
+// ============================================================
+// RECOVERY HASHES
+
+// SHA256 hashes of some recovery shards.
+// - shard_bytes = 1024 (or 64 if mentioned explicitly)
+// - Original shards are from `generate_original`.
+
+// ==================================================
+// TINY
+
+// (original_count, recovery_count, seed, hash)
+
+#[rustfmt::skip]
+pub(crate) const DEFAULT_TINY: &[(usize, usize, u8, &str)] = &[
+    // single original/recovery
+    (1, 1, 111, "17e3108283196d04f027f01c23577076a1db3c4caeed6269995733ffef6d3398"), // EITHER
+    (1, 2, 112, "cabef22cfe49d9167b4cd40a6a6437b52496af28ff1dcfb6e207c9c337d5affa"), // LOW
+    (1, 3, 113, "fda3b35bb91a71b0ba7b6ea437fbf74648ea6e94a4ce2be885b0cd14f0d8005b"), // LOW
+    (2, 1, 121, "7fc8ed9211851121e4a80cf995b113f498c20646e18dc312db7d27efd6cd60d2"), // HIGH
+    (3, 1, 131, "1f118cce8f4c528a4f68c9215d6996e982bce81ba7c0132193a65961f777943a"), // HIGH
+
+    // 2 .. 8
+    (2, 2, 122, "7d53725125394f5913300b40f09055bb75e6335a936305070da3707c9211dd26"), // EITHER
+    (2, 3, 123, LOW_2_3),                                                            // LOW
+    (2, 4, 124, "3ce3eab3625dae68e164daee1e2bd3304ac7cdcf1ffdd8f81560c2def733e567"), // LOW
+    (2, 5, 125, LOW_2_5),                                                            // LOW
+    (2, 6, 126, "f7d65a6334421428930e8223962f5e280a6ed75a252cb82b9ae6a27314708013"), // LOW
+    (2, 7, 127, "cd75f744cf44cf7036758b3bc096192317b962cf2f32039bd67a535ae8b5d251"), // LOW
+    (2, 8, 128, "07964065a913b631645d6e251908650fc4eba4a8b5844cdaab43d76d5f4f3a79"), // LOW
+    (3, 2, 132, HIGH_3_2),                                                           // HIGH
+    (3, 3, 133, EITHER_3_3),                                                         // EITHER
+    (3, 4, 134, EITHER_3_4),                                                         // EITHER
+    (3, 5, 135, LOW_3_5),                                                            // LOW
+    (3, 6, 136, "531b4db2b2148c609fe1b3d6ab4e6a012193f28647c0eb1ed13344a94057c6fe"), // LOW
+    (3, 7, 137, "053434cf04886f7f3bef43743700046f57d2e38cb5682ceaeaccf893c5120c78"), // LOW
+    (3, 8, 138, "848b7bc12174a1a74a30aaeccf875fe2be82d4cc8f9b992f04e45607839cd4ff"), // LOW
+    (4, 2, 142, "e0c05cb0f4e699694907ce9a5c16034e5b1d8b4eee51942ba87854149036d8f1"), // HIGH
+    (4, 3, 143, EITHER_4_3),                                                         // EITHER
+    (4, 4, 144, "df2c520f15464bfe3448ebbbfbb6bfc2f64237a7a20cfa65bc6f1046e97470d2"), // EITHER
+    (4, 5, 145, "e7709cc3f00e377e15e624df78a7a0a76b49ed5e4c0bc9035dda9e846935746a"), // LOW
+    (4, 6, 146, "8852c9526508d934315a3e07dd90f9389f5a6639ed7f3aaee74b066cccbcf033"), // LOW
+    (4, 7, 147, "4475531153c9ea65743a64e4f661746dc5cd4c7a70bdc06812f1b73d00d65f36"), // LOW
+    (4, 8, 148, "b682387ee7e5e6a42ff5c8b8050c301225f84f98961ba5aee739f3f20d3cae02"), // LOW
+    (5, 2, 152, HIGH_5_2),                                                           // HIGH
+    (5, 3, 153, HIGH_5_3),                                                           // HIGH
+    (5, 4, 154, "3eb67a0993903f688d767928d2d35d5762f25fdb196a5f6a0e49b36f9a5a229b"), // HIGH
+    (5, 5, 155, "41b83349a18ec3c20fb19879e0e513512c60078e57b4ff98f57cae0d93effc7c"), // EITHER
+    (5, 6, 156, "67766507a7cedaa663f798354f274829703143cd068f68075f6380976a65c99a"), // EITHER
+    (5, 7, 157, "a47d23ed58eec1c809799b1c63bcfe75e527489985cf91c0f42f7ae10c9e8abe"), // EITHER
+    (5, 8, 158, "ff33eb1539f0573faaf0993c63507ed61d809527505fd26e8e2aa2511e3622c5"), // EITHER
+    (6, 2, 162, "6e45e014adf6201172f45c23e2918e2b628c55bc60d9e88c359337758ca63e27"), // HIGH
+    (6, 3, 163, "b2295f7f0f055476f9385cdfbba27512d3fef0aee872b9794193a457132af7d4"), // HIGH
+    (6, 4, 164, "0242981363ddab69e3f3f7bac4e0aeb8d64ed040eb1925d0d63fbba864a7aebc"), // HIGH
+    (6, 5, 165, "0619cf8025f6c6f25b2c4c3609f71224de518108b4d6f577762c5160f2753733"), // EITHER
+    (6, 6, 166, "27472dea67ef5470579f8f2fcab5f9370334a91af49382780a6ccf0df6027a98"), // EITHER
+    (6, 7, 167, "afffabb84e4987e15af741ac0f919fa73af954fe44c0da223cb67bdcfd3415c2"), // EITHER
+    (6, 8, 168, "129b44878eef071c0b2e92b17cdb15139d2d0744f8f5306fa6a4c100396a1e3c"), // EITHER
+    (7, 2, 172, "b07a9064742825258206c4c4ab041305ad6d3646380740bb54b938962630df6c"), // HIGH
+    (7, 3, 173, "64061b0af048381c22e8b08c19a1148de6859a7bcc26ddee348bdf6006554578"), // HIGH
+    (7, 4, 174, "4cdab47a556582096b8195a5bf30f63d3effbb1f9ad9e25a48b41ba260739247"), // HIGH
+    (7, 5, 175, "feb342a8e0b9c33d120983c3f4df95ca19fded3e0ed3484a0d02f5ec27961d4b"), // EITHER
+    (7, 6, 176, "7f127b5c827854f721c7592faecb11a239894c653ac6efb95cfcf54e1348c326"), // EITHER
+    (7, 7, 177, "b03e8b01d887050f762c40cce37042a8b5a8afb601a2476eb138f65b9234efe7"), // EITHER
+    (7, 8, 178, "eacf451d3112d43be2619b01bbc40915a109d387e21f7b3c083f00fa7abcdf68"), // EITHER
+    (8, 2, 182, "dcf2306c7f9aab2dd0590708864d68ba1a6484632c3a7a4b1c1c56a3d6b0bb50"), // HIGH
+    (8, 3, 183, "83c2cdcc981c627f778f061c7eadc6be49e7665c4ed591a0884cfa4adc3a20cf"), // HIGH
+    (8, 4, 184, "356d75c370e3ed29c7d458a9d5f5b48798119d0d32dc8e742a423f94647eb085"), // HIGH
+    (8, 5, 185, "4b0a3bd10e64f8db57abeddb028ce7c93b89d84b59c2e4805eecf1ef43aef858"), // EITHER
+    (8, 6, 186, "44ffaeac7c1585d8b8c3afd813ea388b3dcceeebe3ef46bab4219df554ef057f"), // EITHER
+    (8, 7, 187, "2627846d37793df3ddeb1922892c2723a5fefe36b6d244506fa810c11fb70df7"), // EITHER
+    (8, 8, 188, "b8da62e75f305a59128b2257162605e541fd252aca8f74ceb2a91fb2a3276d6e"), // EITHER
+];
+
+#[rustfmt::skip]
+pub(crate) const HIGH_TINY: &[(usize, usize, u8, &str)] = &[
+    // single original/recovery
+    (1, 1, 111, "17e3108283196d04f027f01c23577076a1db3c4caeed6269995733ffef6d3398"), // EITHER
+    (1, 2, 112, "a5bdc2eb1cd88327a675d2fa1df587ea3e7fa42e74975fd8577c5c248ab51824"),
+    (1, 3, 113, "ea7c19a1de8308599d84334059c6ca6c1e574ea3cfbe680f749754af986a0b18"),
+    (2, 1, 121, "7fc8ed9211851121e4a80cf995b113f498c20646e18dc312db7d27efd6cd60d2"),
+    (3, 1, 131, "1f118cce8f4c528a4f68c9215d6996e982bce81ba7c0132193a65961f777943a"),
+
+    // 2 .. 8
+    (2, 2, 122, "7d53725125394f5913300b40f09055bb75e6335a936305070da3707c9211dd26"), // EITHER
+    (2, 3, 123, "19fb5ce2d7a3db95f819017cf49050eb8cd4b3c626cedf5ca13f6d2ab4eb43c4"),
+    (2, 4, 124, "ed0d8db29d770cbafc4fa2ebe5ab991b3a0ee2dd8089f82cbb35de4670ccee50"),
+    (2, 5, 125, "9b2818b4442619aed74f277ea7a97aa9d0a92f1c1413fea97091fcd2e696f03a"),
+    (2, 6, 126, "cac3955636c60dfa82d0a8383949bbdf0a7c5bbb89422fa764cccea0a927d5d7"),
+    (2, 7, 127, "42f34812f503a419fc6ddaee8f3947afc1fc533e9c8b29eae746addceebc1748"),
+    (2, 8, 128, "1212dc3e1f8e8743996c303a05a0401d03c72b67dfefc1aaaa2cc07c31f47710"),
+    (3, 2, 132, HIGH_3_2),
+    (3, 3, 133, EITHER_3_3),
+    (3, 4, 134, EITHER_3_4),
+    (3, 5, 135, "eb5dc236bdd7aa7d8a927524118161f2dd8e51526653cd31194ee8ff007a8062"),
+    (3, 6, 136, "2338d6073e4e5103483f748312f5872141f51dc2fa510695837ea99e3508892c"),
+    (3, 7, 137, "6559a2478ce0f362e08934dbec840f3be6a42e3fa9591824548b15811717cf49"),
+    (3, 8, 138, "afe6ecd8baf01b3514787a593c73276f1e24d29b4bd909ee0a26d16ea3d07844"),
+    (4, 2, 142, "e0c05cb0f4e699694907ce9a5c16034e5b1d8b4eee51942ba87854149036d8f1"),
+    (4, 3, 143, EITHER_4_3),
+    (4, 4, 144, "df2c520f15464bfe3448ebbbfbb6bfc2f64237a7a20cfa65bc6f1046e97470d2"), // EITHER
+    (4, 5, 145, "57e72af02f975404d6d3905394782da034581c137c08c5ebe73acb2d071b38bb"),
+    (4, 6, 146, "d07ad54dc275f3c16d68a86fb4893c4e7a2dda9edd4dcf5c90d09ee5c647993a"),
+    (4, 7, 147, "32266a50e6f97a901f8eae8d633fcf98d27a2c9e71c8369fbe17acc290d5f817"),
+    (4, 8, 148, "0f157da98d800fe60dbb381f3473e122e15549d418bc2cb5f3e57e32fad033b8"),
+    (5, 2, 152, HIGH_5_2),
+    (5, 3, 153, HIGH_5_3),
+    (5, 4, 154, "3eb67a0993903f688d767928d2d35d5762f25fdb196a5f6a0e49b36f9a5a229b"),
+    (5, 5, 155, "41b83349a18ec3c20fb19879e0e513512c60078e57b4ff98f57cae0d93effc7c"), // EITHER
+    (5, 6, 156, "67766507a7cedaa663f798354f274829703143cd068f68075f6380976a65c99a"), // EITHER
+    (5, 7, 157, "a47d23ed58eec1c809799b1c63bcfe75e527489985cf91c0f42f7ae10c9e8abe"), // EITHER
+    (5, 8, 158, "ff33eb1539f0573faaf0993c63507ed61d809527505fd26e8e2aa2511e3622c5"), // EITHER
+    (6, 2, 162, "6e45e014adf6201172f45c23e2918e2b628c55bc60d9e88c359337758ca63e27"),
+    (6, 3, 163, "b2295f7f0f055476f9385cdfbba27512d3fef0aee872b9794193a457132af7d4"),
+    (6, 4, 164, "0242981363ddab69e3f3f7bac4e0aeb8d64ed040eb1925d0d63fbba864a7aebc"),
+    (6, 5, 165, "0619cf8025f6c6f25b2c4c3609f71224de518108b4d6f577762c5160f2753733"), // EITHER
+    (6, 6, 166, "27472dea67ef5470579f8f2fcab5f9370334a91af49382780a6ccf0df6027a98"), // EITHER
+    (6, 7, 167, "afffabb84e4987e15af741ac0f919fa73af954fe44c0da223cb67bdcfd3415c2"), // EITHER
+    (6, 8, 168, "129b44878eef071c0b2e92b17cdb15139d2d0744f8f5306fa6a4c100396a1e3c"), // EITHER
+    (7, 2, 172, "b07a9064742825258206c4c4ab041305ad6d3646380740bb54b938962630df6c"),
+    (7, 3, 173, "64061b0af048381c22e8b08c19a1148de6859a7bcc26ddee348bdf6006554578"),
+    (7, 4, 174, "4cdab47a556582096b8195a5bf30f63d3effbb1f9ad9e25a48b41ba260739247"),
+    (7, 5, 175, "feb342a8e0b9c33d120983c3f4df95ca19fded3e0ed3484a0d02f5ec27961d4b"), // EITHER
+    (7, 6, 176, "7f127b5c827854f721c7592faecb11a239894c653ac6efb95cfcf54e1348c326"), // EITHER
+    (7, 7, 177, "b03e8b01d887050f762c40cce37042a8b5a8afb601a2476eb138f65b9234efe7"), // EITHER
+    (7, 8, 178, "eacf451d3112d43be2619b01bbc40915a109d387e21f7b3c083f00fa7abcdf68"), // EITHER
+    (8, 2, 182, "dcf2306c7f9aab2dd0590708864d68ba1a6484632c3a7a4b1c1c56a3d6b0bb50"),
+    (8, 3, 183, "83c2cdcc981c627f778f061c7eadc6be49e7665c4ed591a0884cfa4adc3a20cf"),
+    (8, 4, 184, "356d75c370e3ed29c7d458a9d5f5b48798119d0d32dc8e742a423f94647eb085"),
+    (8, 5, 185, "4b0a3bd10e64f8db57abeddb028ce7c93b89d84b59c2e4805eecf1ef43aef858"), // EITHER
+    (8, 6, 186, "44ffaeac7c1585d8b8c3afd813ea388b3dcceeebe3ef46bab4219df554ef057f"), // EITHER
+    (8, 7, 187, "2627846d37793df3ddeb1922892c2723a5fefe36b6d244506fa810c11fb70df7"), // EITHER
+    (8, 8, 188, "b8da62e75f305a59128b2257162605e541fd252aca8f74ceb2a91fb2a3276d6e"), // EITHER
+];
+
+#[rustfmt::skip]
+pub(crate) const LOW_TINY: &[(usize, usize, u8, &str)] = &[
+    // single original/recovery
+    (1, 1, 111, "17e3108283196d04f027f01c23577076a1db3c4caeed6269995733ffef6d3398"), // EITHER
+    (1, 2, 112, "cabef22cfe49d9167b4cd40a6a6437b52496af28ff1dcfb6e207c9c337d5affa"),
+    (1, 3, 113, "fda3b35bb91a71b0ba7b6ea437fbf74648ea6e94a4ce2be885b0cd14f0d8005b"),
+    (2, 1, 121, "446657e70765196f11c9df04fcacc74ef915cdb634633e0d5755c1ca6e46e323"),
+    (3, 1, 131, "b93350bf3318af823674c954d274f51ed1bef1a49a5240338d31440aebbf8af5"),
+
+    // 2 .. 8
+    (2, 2, 122, "7d53725125394f5913300b40f09055bb75e6335a936305070da3707c9211dd26"), // EITHER
+    (2, 3, 123, LOW_2_3),
+    (2, 4, 124, "3ce3eab3625dae68e164daee1e2bd3304ac7cdcf1ffdd8f81560c2def733e567"),
+    (2, 5, 125, LOW_2_5),
+    (2, 6, 126, "f7d65a6334421428930e8223962f5e280a6ed75a252cb82b9ae6a27314708013"),
+    (2, 7, 127, "cd75f744cf44cf7036758b3bc096192317b962cf2f32039bd67a535ae8b5d251"),
+    (2, 8, 128, "07964065a913b631645d6e251908650fc4eba4a8b5844cdaab43d76d5f4f3a79"),
+    (3, 2, 132, "1e4d449a4d59f974258ff2fb8dfde7ea6554bd1b5a7d524d801cc9e0503c0f0a"),
+    (3, 3, 133, EITHER_3_3),
+    (3, 4, 134, EITHER_3_4),
+    (3, 5, 135, LOW_3_5),
+    (3, 6, 136, "531b4db2b2148c609fe1b3d6ab4e6a012193f28647c0eb1ed13344a94057c6fe"),
+    (3, 7, 137, "053434cf04886f7f3bef43743700046f57d2e38cb5682ceaeaccf893c5120c78"),
+    (3, 8, 138, "848b7bc12174a1a74a30aaeccf875fe2be82d4cc8f9b992f04e45607839cd4ff"),
+    (4, 2, 142, "35a5d572f75bbf8b2a850d503bf988a10dc2f30f15ff5cde611f73ea6cc44d55"),
+    (4, 3, 143, EITHER_4_3),
+    (4, 4, 144, "df2c520f15464bfe3448ebbbfbb6bfc2f64237a7a20cfa65bc6f1046e97470d2"), // EITHER
+    (4, 5, 145, "e7709cc3f00e377e15e624df78a7a0a76b49ed5e4c0bc9035dda9e846935746a"),
+    (4, 6, 146, "8852c9526508d934315a3e07dd90f9389f5a6639ed7f3aaee74b066cccbcf033"),
+    (4, 7, 147, "4475531153c9ea65743a64e4f661746dc5cd4c7a70bdc06812f1b73d00d65f36"),
+    (4, 8, 148, "b682387ee7e5e6a42ff5c8b8050c301225f84f98961ba5aee739f3f20d3cae02"),
+    (5, 2, 152, "6728e606f2f9dd9559b0370b495685444519c04ffdcfa5120398a0516858a83f"),
+    (5, 3, 153, "b458c5b07fbacfebb9a836251548505b43d5cbca872eecfad098f2bdda111824"),
+    (5, 4, 154, "e82d6583b78c42479c98311daa5aa620b64979259bf49ff13c75daf889d3bf22"),
+    (5, 5, 155, "41b83349a18ec3c20fb19879e0e513512c60078e57b4ff98f57cae0d93effc7c"), // EITHER
+    (5, 6, 156, "67766507a7cedaa663f798354f274829703143cd068f68075f6380976a65c99a"), // EITHER
+    (5, 7, 157, "a47d23ed58eec1c809799b1c63bcfe75e527489985cf91c0f42f7ae10c9e8abe"), // EITHER
+    (5, 8, 158, "ff33eb1539f0573faaf0993c63507ed61d809527505fd26e8e2aa2511e3622c5"), // EITHER
+    (6, 2, 162, "218e25db4678002119fe557c7fc7c6d80fd43c1a9cfc779623ce35455dc8ff75"),
+    (6, 3, 163, "ac7d0eeb90253d1e846b2e741557320b80bcf2ae0a8901a18c2d137230e8994b"),
+    (6, 4, 164, "c42c4deb89c2c3f19856628e887cc7db72165e5d836e584ac4fdbfac0a356b56"),
+    (6, 5, 165, "0619cf8025f6c6f25b2c4c3609f71224de518108b4d6f577762c5160f2753733"), // EITHER
+    (6, 6, 166, "27472dea67ef5470579f8f2fcab5f9370334a91af49382780a6ccf0df6027a98"), // EITHER
+    (6, 7, 167, "afffabb84e4987e15af741ac0f919fa73af954fe44c0da223cb67bdcfd3415c2"), // EITHER
+    (6, 8, 168, "129b44878eef071c0b2e92b17cdb15139d2d0744f8f5306fa6a4c100396a1e3c"), // EITHER
+    (7, 2, 172, "1a435f1723561eead67bf9a37bda196814afe2c7b77cd82c3c438600ef616e61"),
+    (7, 3, 173, "86ab51f58f9a0f24deeb1ab83cff451983cf679ab9df81ef1a4daf9c3405495a"),
+    (7, 4, 174, "192979d61b5dbe112839bc0c4051945568a9ac7c4dc4c1d8e7cc6c4c27213bb9"),
+    (7, 5, 175, "feb342a8e0b9c33d120983c3f4df95ca19fded3e0ed3484a0d02f5ec27961d4b"), // EITHER
+    (7, 6, 176, "7f127b5c827854f721c7592faecb11a239894c653ac6efb95cfcf54e1348c326"), // EITHER
+    (7, 7, 177, "b03e8b01d887050f762c40cce37042a8b5a8afb601a2476eb138f65b9234efe7"), // EITHER
+    (7, 8, 178, "eacf451d3112d43be2619b01bbc40915a109d387e21f7b3c083f00fa7abcdf68"), // EITHER
+    (8, 2, 182, "ed7c5de1bd38abf2aeda70670ecc61caac6a133d742fe56e52c69e464ba2e9f5"),
+    (8, 3, 183, "98e3bbaf60b13e1b11d7a1ed3cc11686e10177ecfab8c7bfecf83c3f011ab353"),
+    (8, 4, 184, "dee6491a8007d007db853485dc55b013d2243b7ed9f3a62cd2d3fc77f0fd0899"),
+    (8, 5, 185, "4b0a3bd10e64f8db57abeddb028ce7c93b89d84b59c2e4805eecf1ef43aef858"), // EITHER
+    (8, 6, 186, "44ffaeac7c1585d8b8c3afd813ea388b3dcceeebe3ef46bab4219df554ef057f"), // EITHER
+    (8, 7, 187, "2627846d37793df3ddeb1922892c2723a5fefe36b6d244506fa810c11fb70df7"), // EITHER
+    (8, 8, 188, "b8da62e75f305a59128b2257162605e541fd252aca8f74ceb2a91fb2a3276d6e"), // EITHER
+];
+
+// ==================================================
+// EITHER RATE
+
+// 3 original ; 3 recovery ; 133 seed
+pub(crate) const EITHER_3_3: &str =
+    "9502b325f6f50a25e6816144603f1b0cda09e00b4949965babbaf8266ff81e84";
+
+// 3 original ; 4 recovery ; 134 seed
+pub(crate) const EITHER_3_4: &str =
+    "e534a7260f1e8aca3c2983503138f158d8977b82f1d3c09b2cedb66d01c01e0b";
+
+// 4 original ; 3 recovery ; 143 seed
+pub(crate) const EITHER_4_3: &str =
+    "e43d0903b619f4b17c5389ce869317ce549e3f6d2fe3aa2805ef4d4fb7adce74";
+
+// 32768 original ; 32768 recovery ; 11 seed ; shard_bytes = 64
+pub(crate) const EITHER_32768_32768_11: &str =
+    "432025ead0e3f432f74e30500076a8c2b5554f5dfb7767b62fc3a8126eef7389";
+
+// ==================================================
+// HIGH RATE
+
+// 3 original ; 2 recovery ; 132 seed
+pub(crate) const HIGH_3_2: &str =
+    "afd47751b63fb0a62671e0e4a124a8ba51eb6d4b55f79c3dd54a60c28583634f";
+
+// 3 original ; 2 recovery ; 232 seed
+pub(crate) const HIGH_3_2_232: &str =
+    "2ee88d495ae1fff216f2865dbbdda2e1a051c5d98c7117a2a0b2ebcdfb57cd33";
+
+// 5 original ; 2 recovery ; 152 seed
+pub(crate) const HIGH_5_2: &str =
+    "5387208d6756e3e79558a9b9ddebe0439eb3b08eec2393d4acafce6fc5332683";
+
+// 5 original ; 3 recovery ; 153 seed
+pub(crate) const HIGH_5_3: &str =
+    "6f53d5175900d70b4821d1d0c947d0c47a802add0d620bfa72d57dd983dfc156";
+
+// 3000 original ; 30000 recovery ; 14 seed ; shard_bytes = 64
+// NOTE: Chunk size is 4096, with partial chunk at end.
+pub(crate) const HIGH_3000_30000_14: &str =
+    "2d7d97fd92be0721b4fcfac8814fe0dd9ad07959eb40558c6ed9af09943fed4e";
+
+// 60000 original ; 3000 recovery ; 12 seed ; shard_bytes = 64
+// NOTE: Chunk size is 4096, with partial chunk at end.
+pub(crate) const HIGH_60000_3000_12: &str =
+    "88e68e1d86a0fc168a549e195845d20b49ff85734db20d560c36ff2e14f78676";
+
+// 34000 original ; 2000 recovery ; 123 seed ; shard_bytes = 8
+pub(crate) const HIGH_34000_2000_123_8: &str =
+    "8bd33dbe0189b5bffcb843fd93fd8c85daada2533cc7df0c352773e846b701f5";
+
+// ==================================================
+// LOW RATE
+
+// 2 original ; 3 recovery ; 123 seed
+pub(crate) const LOW_2_3: &str = "f682a6c87c2bcd3e0feddbeff5c34f9d14026b78c44e5fdb5cf3cf71ec15e1f4";
+
+// 2 original ; 3 recovery ; 223 seed
+pub(crate) const LOW_2_3_223: &str =
+    "2dc25a5dc42b2d1f94a80489e9f357a48f011f931cdac3ed7c85e2abb07063a2";
+
+// 2 original ; 5 recovery ; 125 seed
+pub(crate) const LOW_2_5: &str = "24449ae058f54a33b3b7ee568761e68e36bd7171ee2a3271a0fbd2f07ac65a7c";
+
+// 3 original ; 5 recovery ; 135 seed
+pub(crate) const LOW_3_5: &str = "c23920347f00328dceca9cb6012d797d97f366617cf27aae5c45b4f0b8491552";
+
+// 3000 original ; 60000 recovery ; 13 seed ; shard_bytes = 64
+// NOTE: Chunk size is 4096, with partial chunk at end.
+pub(crate) const LOW_3000_60000_13: &str =
+    "d44f9c9ed9158f8aad140794e64a730577327f195753af21b810090966b4b4df";
+
+// 30000 original ; 3000 recovery ; 15 seed ; shard_bytes = 64
+// NOTE: Chunk size is 4096, with partial chunk at end.
+pub(crate) const LOW_30000_3000_15: &str =
+    "202f99a2ade121d2404e967d5c04ff390f7a147070a2dcbe71dcf3baeafdf93a";
+
+// 2000 original ; 34000 recovery ; 123 seed ; shard_bytes = 8
+pub(crate) const LOW_2000_34000_123_8: &str =
+    "9bd2da4d03580d3e2471c60a49595b209a6f9a5f1d504d0c4bd017b953efdd99";

--- a/cryptography/src/reed_solomon/wrappers.rs
+++ b/cryptography/src/reed_solomon/wrappers.rs
@@ -5,14 +5,14 @@ use crate::reed_solomon::{
 };
 
 // ======================================================================
-// ReedSolomonEncoder - PUBLIC
+// Encoder - PUBLIC
 
 /// Reed-Solomon encoder using [`DefaultEngine`] and [`DefaultRate`].
 ///
 /// [`DefaultEngine`]: crate::reed_solomon::engine::DefaultEngine
-pub struct ReedSolomonEncoder(DefaultRateEncoder<DefaultEngine>);
+pub struct Encoder(DefaultRateEncoder<DefaultEngine>);
 
-impl ReedSolomonEncoder {
+impl Encoder {
     /// Adds one original shard to the encoder.
     ///
     /// Original shards have indexes `0..original_count` corresponding to the order
@@ -31,7 +31,7 @@ impl ReedSolomonEncoder {
     ///
     /// See [basic usage](crate::reed_solomon#basic-usage) for an example.
     ///
-    /// [`reset`]: ReedSolomonEncoder::reset
+    /// [`reset`]: Encoder::reset
     pub fn encode(&mut self) -> Result<EncoderResult<'_>, Error> {
         self.0.encode()
     }
@@ -74,10 +74,10 @@ impl ReedSolomonEncoder {
     /// # Examples
     ///
     /// ```rust
-    /// use commonware_cryptography::reed_solomon::ReedSolomonEncoder;
+    /// use commonware_cryptography::reed_solomon::Encoder;
     ///
-    /// assert_eq!(ReedSolomonEncoder::supports(60_000, 4_000), true);
-    /// assert_eq!(ReedSolomonEncoder::supports(60_000, 5_000), false);
+    /// assert_eq!(Encoder::supports(60_000, 4_000), true);
+    /// assert_eq!(Encoder::supports(60_000, 5_000), false);
     /// ```
     pub fn supports(original_count: usize, recovery_count: usize) -> bool {
         DefaultRate::<DefaultEngine>::supports(original_count, recovery_count)
@@ -85,14 +85,14 @@ impl ReedSolomonEncoder {
 }
 
 // ======================================================================
-// ReedSolomonDecoder - PUBLIC
+// Decoder - PUBLIC
 
 /// Reed-Solomon decoder using [`DefaultEngine`] and [`DefaultRate`].
 ///
 /// [`DefaultEngine`]: crate::reed_solomon::engine::DefaultEngine
-pub struct ReedSolomonDecoder(DefaultRateDecoder<DefaultEngine>);
+pub struct Decoder(DefaultRateDecoder<DefaultEngine>);
 
-impl ReedSolomonDecoder {
+impl Decoder {
     /// Adds one original shard to the decoder.
     ///
     /// - Shards can be added in any order.
@@ -129,7 +129,7 @@ impl ReedSolomonDecoder {
     ///
     /// See [basic usage](crate::reed_solomon#basic-usage) for an example.
     ///
-    /// [`reset`]: ReedSolomonDecoder::reset
+    /// [`reset`]: Decoder::reset
     pub fn decode(&mut self) -> Result<DecoderResult<'_>, Error> {
         self.0.decode()
     }
@@ -172,10 +172,10 @@ impl ReedSolomonDecoder {
     /// # Examples
     ///
     /// ```rust
-    /// use commonware_cryptography::reed_solomon::ReedSolomonDecoder;
+    /// use commonware_cryptography::reed_solomon::Decoder;
     ///
-    /// assert_eq!(ReedSolomonDecoder::supports(60_000, 4_000), true);
-    /// assert_eq!(ReedSolomonDecoder::supports(60_000, 5_000), false);
+    /// assert_eq!(Decoder::supports(60_000, 4_000), true);
+    /// assert_eq!(Decoder::supports(60_000, 5_000), false);
     /// ```
     pub fn supports(original_count: usize, recovery_count: usize) -> bool {
         DefaultRate::<DefaultEngine>::supports(original_count, recovery_count)
@@ -196,8 +196,8 @@ mod tests {
     // HELPERS
 
     fn roundtrip(
-        encoder: &mut ReedSolomonEncoder,
-        decoder: &mut ReedSolomonDecoder,
+        encoder: &mut Encoder,
+        decoder: &mut Decoder,
         original_count: usize,
         recovery_hash: &str,
         decoder_original: &[usize],
@@ -241,8 +241,8 @@ mod tests {
 
     #[test]
     fn roundtrip_two_rounds_reset_low_to_high() {
-        let mut encoder = ReedSolomonEncoder::new(2, 3, 1024).unwrap();
-        let mut decoder = ReedSolomonDecoder::new(2, 3, 1024).unwrap();
+        let mut encoder = Encoder::new(2, 3, 1024).unwrap();
+        let mut decoder = Decoder::new(2, 3, 1024).unwrap();
 
         roundtrip(
             &mut encoder,
@@ -273,10 +273,10 @@ mod tests {
 
     #[test]
     fn supports() {
-        assert!(ReedSolomonEncoder::supports(4096, 61440));
-        assert!(ReedSolomonEncoder::supports(61440, 4096));
+        assert!(Encoder::supports(4096, 61440));
+        assert!(Encoder::supports(61440, 4096));
 
-        assert!(ReedSolomonDecoder::supports(4096, 61440));
-        assert!(ReedSolomonDecoder::supports(61440, 4096));
+        assert!(Decoder::supports(4096, 61440));
+        assert!(Decoder::supports(61440, 4096));
     }
 }

--- a/cryptography/src/reed_solomon/wrappers.rs
+++ b/cryptography/src/reed_solomon/wrappers.rs
@@ -268,6 +268,51 @@ mod tests {
         );
     }
 
+    #[test]
+    fn failed_encoder_reset_preserves_state() {
+        let original = test_util::generate_original(2, 1024, 123);
+        let mut encoder = Encoder::new(2, 3, 1024).unwrap();
+
+        assert_eq!(
+            encoder.reset(3, 2, 3),
+            Err(Error::InvalidShardSize { shard_bytes: 3 })
+        );
+
+        for shard in &original {
+            encoder.add_original_shard(shard).unwrap();
+        }
+        let result = encoder.encode().unwrap();
+        let recovery: Vec<_> = result.recovery_iter().collect();
+
+        test_util::assert_hash(&recovery, test_util::LOW_2_3);
+    }
+
+    #[test]
+    fn failed_decoder_reset_preserves_state() {
+        let original = test_util::generate_original(2, 1024, 123);
+        let mut encoder = Encoder::new(2, 3, 1024).unwrap();
+        for shard in &original {
+            encoder.add_original_shard(shard).unwrap();
+        }
+        let result = encoder.encode().unwrap();
+        let recovery: Vec<_> = result.recovery_iter().map(<[u8]>::to_vec).collect();
+
+        let mut decoder = Decoder::new(2, 3, 1024).unwrap();
+
+        assert_eq!(
+            decoder.reset(3, 2, 3),
+            Err(Error::InvalidShardSize { shard_bytes: 3 })
+        );
+
+        decoder.add_recovery_shard(0, &recovery[0]).unwrap();
+        decoder.add_recovery_shard(1, &recovery[1]).unwrap();
+        let result = decoder.decode().unwrap();
+        let restored: BTreeMap<_, _> = result.restored_original_iter().collect();
+
+        assert_eq!(restored[&0], original[0]);
+        assert_eq!(restored[&1], original[1]);
+    }
+
     // ==================================================
     // supports
 


### PR DESCRIPTION
To better optimize `commonware-coding`, we've decided to vendor `reed-solomon-simd`.

This will allow us to reduce some internal copies and ensure block formatting doesn't break #4091.