### PR TITLE
[coding/zoda][math] Parallelize ZODA NTT via Strategy and add SIMD Goldilocks dense NTT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,7 @@ version = "2026.5.0"
 dependencies = [
  "arbitrary",
  "bytes",
+ "cfg-if",
  "commonware-codec",
  "commonware-conformance",
  "commonware-invariants",

--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -537,7 +537,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
         let encoded_data = data
             .as_polynomials(topology.encoded_rows)
             .expect("data has too many rows")
-            .evaluate()
+            .evaluate_with(strategy)
             .data();
 
         // Step 3: Commit to the rows of the data using a Binary Merkle Tree.
@@ -561,7 +561,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
         // Step 5: Generate a checking matrix and checksum with the commitment.
         let mut transcript = Transcript::resume(commitment);
         let checking_matrix = checking_matrix(&transcript, &topology);
-        let checksum = Arc::new(data.mul(&checking_matrix));
+        let checksum = Arc::new(data.mul_with(&checking_matrix, strategy));
         // Bind index sampling to this checksum to prevent follower-specific malleability.
         // It's important to commit to the checksum itself, rather than its encoding,
         // because followers have to encode the checksum itself to prevent the leader from
@@ -636,7 +636,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
         commitment: &Self::Commitment,
         checking_data: Self::CheckingData,
         shards: impl Iterator<Item = &'a Self::CheckedShard>,
-        _strategy: &impl Strategy,
+        strategy: &impl Strategy,
     ) -> Result<Vec<u8>, Self::Error> {
         if checking_data.commitment != *commitment {
             return Err(Error::InvalidShard);
@@ -677,7 +677,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
             data_bytes,
             F::stream_to_u64s(
                 evaluation
-                    .recover()
+                    .recover_with(strategy)
                     .coefficients_up_to(data_rows)
                     .flatten()
                     .copied(),
@@ -697,10 +697,60 @@ mod tests {
         algebra::{FieldNTT as _, Ring as _},
         ntt::PolynomialVector,
     };
-    use commonware_parallel::Sequential;
-    use commonware_utils::NZU16;
+    use commonware_parallel::{Rayon, Sequential};
+    use commonware_utils::{NZUsize, NZU16};
 
     const STRATEGY: Sequential = Sequential;
+
+    #[test]
+    fn rayon_matches_sequential() {
+        let rayon = Rayon::new(NZUsize!(13)).unwrap();
+        let config = Config {
+            minimum_shards: NZU16!(8),
+            extra_shards: NZU16!(4),
+        };
+        let data = vec![0xA5u8; 256 * 1024];
+
+        let (sequential_commitment, sequential_shards) =
+            Zoda::<Sha256>::encode(b"", &config, data.as_slice(), &STRATEGY).unwrap();
+        let (rayon_commitment, rayon_shards) =
+            Zoda::<Sha256>::encode(b"", &config, data.as_slice(), &rayon).unwrap();
+
+        assert_eq!(rayon_commitment, sequential_commitment);
+        assert_eq!(rayon_shards, sequential_shards);
+
+        let checked = rayon_shards
+            .iter()
+            .take(config.minimum_shards.get() as usize)
+            .enumerate()
+            .map(|(index, shard)| {
+                let (checking_data, checked, _) = Zoda::<Sha256>::weaken(
+                    b"",
+                    &config,
+                    &rayon_commitment,
+                    index as u16,
+                    shard.clone(),
+                )
+                .unwrap();
+                (checking_data, checked)
+            })
+            .collect::<Vec<_>>();
+        let checking_data = checked[0].0.clone();
+        let checked = checked
+            .iter()
+            .map(|(_, checked)| checked)
+            .collect::<Vec<_>>();
+
+        let decoded = Zoda::<Sha256>::decode(
+            &config,
+            &rayon_commitment,
+            checking_data,
+            checked.into_iter(),
+            &rayon,
+        )
+        .unwrap();
+        assert_eq!(decoded, data);
+    }
 
     #[test]
     fn decode_rejects_duplicate_indices() {

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -35,6 +35,7 @@ fuzz = [ "arbitrary", "arbitrary/derive", "dep:arbitrary", "std" ]
 [dependencies]
 arbitrary = { workspace = true, optional = true }
 bytes.workspace = true
+cfg-if.workspace = true
 commonware-codec.workspace = true
 commonware-invariants = { workspace = true, optional = true }
 commonware-macros.workspace = true
@@ -57,3 +58,8 @@ bench = false
 name = "interpolation"
 harness = false
 path = "benches/interpolation.rs"
+
+[[bench]]
+name = "ntt"
+harness = false
+path = "benches/ntt.rs"

--- a/math/benches/ntt.rs
+++ b/math/benches/ntt.rs
@@ -1,0 +1,36 @@
+use commonware_math::{fields::goldilocks::F, ntt::Matrix};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use std::hint::black_box;
+
+/// Benchmark the forward dense NTT (`PolynomialVector::evaluate`) at sizes that
+/// mirror ZODA encoding (`2^15` encoded rows; `cols` grows with the block size,
+/// reaching ~192 for an 8 MiB block).
+fn bench_evaluate(c: &mut Criterion) {
+    let lg_rows = 15u32;
+    let rows = 1usize << lg_rows;
+    for &cols in &[1usize, 4, 16, 64, 192] {
+        let data: Vec<F> = F::stream_from_u64s((0..).map(|i| i as u64 | 1))
+            .take(rows * cols)
+            .collect();
+        let matrix = Matrix::init(rows, cols, data.into_iter());
+        let poly = matrix
+            .as_polynomials(rows)
+            .expect("min_coefficients == rows");
+
+        let label = format!("{}::evaluate/lg_rows={lg_rows} cols={cols}", module_path!());
+        c.bench_function(&label, |b| {
+            b.iter_batched(
+                || poly.clone(),
+                |p| black_box(p.evaluate()),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = bench_evaluate,
+}
+criterion_main!(benches);

--- a/math/src/algebra.rs
+++ b/math/src/algebra.rs
@@ -358,6 +358,17 @@ pub trait FieldNTT: Field {
     fn div_2(&self) -> Self {
         (Self::one() + &Self::one()).inv() * self
     }
+
+    /// In-place NTT (inverse NTT when `FORWARD` is false) over a dense, row-major
+    /// `rows x cols` slice, treating each column as an independent lane.
+    ///
+    /// This is the kernel used for [`crate::ntt::Matrix`] NTTs. The default is a
+    /// scalar implementation equivalent to a row-major matrix NTT; fields may
+    /// override it with a vectorized version. `data.len()` must equal `rows * cols`,
+    /// and `rows` must be a power of two.
+    fn ntt_dense<const FORWARD: bool>(rows: usize, cols: usize, data: &mut [Self]) {
+        crate::ntt::ntt_dense_scalar::<FORWARD, Self>(rows, cols, data)
+    }
 }
 
 /// A group suitable for use in cryptography.

--- a/math/src/fields/goldilocks/mod.rs
+++ b/math/src/fields/goldilocks/mod.rs
@@ -3,13 +3,19 @@ use commonware_codec::{FixedSize, Read, Write};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::CryptoRngCore;
 
+mod simd;
+
 /// The modulus P := 2^64 - 2^32 + 1.
 ///
 /// This is a prime number, and we use it to form a field of this order.
 const P: u64 = u64::wrapping_neg(1 << 32) + 1;
 
 /// An element of the [Goldilocks field](https://xn--2-umb.com/22/goldilocks/).
+///
+/// `repr(transparent)` guarantees the same layout as `u64`, which the SIMD NTT
+/// kernels rely on to reinterpret `&[F]` as `&[u64]`.
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct F(u64);
 
 impl FixedSize for F {
@@ -423,6 +429,10 @@ impl FieldNTT for F {
             let (addition, carry) = self.0.overflowing_add(P);
             Self((u64::from(carry) << 63) | (addition >> 1))
         }
+    }
+
+    fn ntt_dense<const FORWARD: bool>(rows: usize, cols: usize, data: &mut [Self]) {
+        simd::ntt_dense::<FORWARD>(rows, cols, data)
     }
 }
 

--- a/math/src/fields/goldilocks/simd.rs
+++ b/math/src/fields/goldilocks/simd.rs
@@ -1,0 +1,633 @@
+//! Vectorized dense NTT for the Goldilocks field.
+//!
+//! Each column of a row-major `rows x cols` matrix is an independent NTT lane, and
+//! the butterfly inner loop walks contiguous columns with a shared twiddle. That is
+//! the natural SIMD axis: broadcast the twiddle, then process `WIDTH` contiguous
+//! columns per instruction with packed field arithmetic, handling the
+//! `cols % WIDTH` remainder with the scalar field.
+//!
+//! The packed `add`/`sub`/`mul` mirror [`super::F`]'s `add_inner`/`sub_inner`/
+//! `reduce_128` operation-for-operation, so the vector result is bit-identical to the
+//! scalar field (verified exhaustively against [`super::F`] in tests). Dispatch picks
+//! AVX2 (x86-64), NEON (aarch64), or the scalar fallback once per NTT.
+
+use super::F;
+// `P` is used only by the arch-specific SIMD submodules; gate its import to the
+// same conditions so the scalar-only build (no_std x86, or non-x86/non-aarch64)
+// does not see an unused import.
+#[cfg(any(all(target_arch = "x86_64", feature = "std"), target_arch = "aarch64"))]
+use super::P;
+use crate::algebra::FieldNTT;
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+/// `2^32 - 1`, i.e. `2^64 mod P`. Used throughout the Goldilocks reduction.
+#[allow(dead_code)]
+const EPSILON: u64 = 0xFFFF_FFFF;
+
+/// Reinterpret a slice of field elements as raw `u64`s.
+///
+/// Sound because [`F`] is `#[repr(transparent)]` over `u64`.
+#[allow(dead_code)]
+#[inline]
+const fn as_u64_mut(data: &mut [F]) -> &mut [u64] {
+    let len = data.len();
+    // SAFETY: `F` is `#[repr(transparent)]` over `u64`, so the layouts match.
+    unsafe { core::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<u64>(), len) }
+}
+
+/// Dense NTT (inverse when `FORWARD` is false) over a row-major `rows x cols` slice.
+pub(super) fn ntt_dense<const FORWARD: bool>(rows: usize, cols: usize, data: &mut [F]) {
+    cfg_if::cfg_if! {
+        if #[cfg(all(target_arch = "x86_64", feature = "std"))] {
+            if std::is_x86_feature_detected!("avx2") {
+                // SAFETY: avx2 was just detected at runtime.
+                unsafe { avx2::ntt_dense::<FORWARD>(rows, cols, data) }
+            } else {
+                crate::ntt::ntt_dense_scalar::<FORWARD, F>(rows, cols, data)
+            }
+        } else if #[cfg(target_arch = "aarch64")] {
+            // SAFETY: NEON is part of the aarch64 baseline, so it is always present.
+            unsafe { neon::ntt_dense::<FORWARD>(rows, cols, data) }
+        } else {
+            crate::ntt::ntt_dense_scalar::<FORWARD, F>(rows, cols, data)
+        }
+    }
+}
+
+/// Compute the per-stage twiddle schedule (shared by every backend).
+///
+/// Returns, for each stage in application order, the base twiddle whose powers the
+/// butterflies of that stage step through.
+#[allow(dead_code)]
+fn twiddle_stages<const FORWARD: bool>(lg_rows: usize) -> Vec<(usize, F)> {
+    use crate::algebra::{Additive, Ring};
+    let w = {
+        let w = F::root_of_unity(lg_rows as u8).expect("too many rows to perform NTT");
+        if FORWARD {
+            w
+        } else {
+            w.exp(&[(1 << lg_rows) - 1])
+        }
+    };
+    let mut out = vec![(0usize, F::zero()); lg_rows];
+    let mut w_i = w;
+    for i in (0..lg_rows).rev() {
+        out[i] = (i, w_i);
+        w_i = w_i * w_i;
+    }
+    if !FORWARD {
+        out.reverse();
+    }
+    out
+}
+
+// Gated on `std` to match the dispatch in `ntt_dense`: runtime AVX2 detection
+// (`is_x86_feature_detected!`) is only available with `std`, so without it this
+// module would be uncallable dead code.
+#[cfg(all(target_arch = "x86_64", feature = "std"))]
+mod avx2 {
+    use super::{as_u64_mut, twiddle_stages, F, P};
+    use crate::algebra::{FieldNTT, Ring};
+    use core::arch::x86_64::*;
+
+    /// Number of `u64` lanes per AVX2 register.
+    const WIDTH: usize = 4;
+
+    #[inline(always)]
+    unsafe fn load(p: *const u64) -> __m256i {
+        _mm256_loadu_si256(p.cast::<__m256i>())
+    }
+    #[inline(always)]
+    unsafe fn store(p: *mut u64, v: __m256i) {
+        _mm256_storeu_si256(p.cast::<__m256i>(), v);
+    }
+    #[inline(always)]
+    unsafe fn splat(x: u64) -> __m256i {
+        _mm256_set1_epi64x(x as i64)
+    }
+    /// Per-lane unsigned `a < b`, returning an all-ones / all-zeros mask.
+    #[inline(always)]
+    unsafe fn ult(a: __m256i, b: __m256i) -> __m256i {
+        // No unsigned 64-bit compare in AVX2: flip the sign bit and use signed `>`.
+        let s = _mm256_set1_epi64x(i64::MIN);
+        _mm256_cmpgt_epi64(_mm256_xor_si256(b, s), _mm256_xor_si256(a, s))
+    }
+    /// Per-lane unsigned `a >= b`.
+    #[inline(always)]
+    unsafe fn uge(a: __m256i, b: __m256i) -> __m256i {
+        _mm256_xor_si256(ult(a, b), _mm256_set1_epi64x(-1))
+    }
+    /// Per-lane `mask ? t : f` (mask must be all-ones / all-zeros).
+    #[inline(always)]
+    unsafe fn select(mask: __m256i, t: __m256i, f: __m256i) -> __m256i {
+        _mm256_blendv_epi8(f, t, mask)
+    }
+
+    /// Field add; mirrors `F::add_inner` (also valid for the partially reduced
+    /// operands produced inside the reduction).
+    #[inline(always)]
+    unsafe fn add(x: __m256i, y: __m256i) -> __m256i {
+        let p = splat(P);
+        let sum = _mm256_add_epi64(x, y);
+        let overflow = ult(sum, x);
+        let ge_p = uge(sum, p);
+        let cond = _mm256_or_si256(overflow, ge_p);
+        select(cond, _mm256_sub_epi64(sum, p), sum)
+    }
+    /// Field sub; mirrors `F::sub_inner`.
+    #[inline(always)]
+    unsafe fn sub(x: __m256i, y: __m256i) -> __m256i {
+        let p = splat(P);
+        let diff = _mm256_sub_epi64(x, y);
+        let borrow = ult(x, y);
+        select(borrow, _mm256_add_epi64(diff, p), diff)
+    }
+    /// Widening `64 x 64 -> 128` per lane, returning `(lo, hi)`.
+    #[inline(always)]
+    unsafe fn mul_wide(a: __m256i, b: __m256i) -> (__m256i, __m256i) {
+        let mask32 = _mm256_set1_epi64x(0xFFFF_FFFF);
+        let a_h = _mm256_srli_epi64(a, 32);
+        let b_h = _mm256_srli_epi64(b, 32);
+        // 32x32 -> 64 partial products (mul_epu32 uses the low 32 bits of each lane).
+        let ll = _mm256_mul_epu32(a, b);
+        let lh = _mm256_mul_epu32(a, b_h);
+        let hl = _mm256_mul_epu32(a_h, b);
+        let hh = _mm256_mul_epu32(a_h, b_h);
+        // Combine columns; each 64-bit add below is overflow-free for 32-bit inputs.
+        let ll_hi = _mm256_srli_epi64(ll, 32);
+        let t = _mm256_add_epi64(lh, ll_hi);
+        let t_lo = _mm256_and_si256(t, mask32);
+        let t_hi = _mm256_srli_epi64(t, 32);
+        let u = _mm256_add_epi64(hl, t_lo);
+        let lo = _mm256_or_si256(
+            _mm256_and_si256(ll, mask32),
+            _mm256_slli_epi64(_mm256_and_si256(u, mask32), 32),
+        );
+        let hi = _mm256_add_epi64(_mm256_add_epi64(hh, t_hi), _mm256_srli_epi64(u, 32));
+        (lo, hi)
+    }
+    /// Field mul; mirrors `F::reduce_128(a*b)`.
+    #[inline(always)]
+    unsafe fn mul(a: __m256i, b: __m256i) -> __m256i {
+        let (lo, hi) = mul_wide(a, b);
+        let mask32 = _mm256_set1_epi64x(0xFFFF_FFFF);
+        // x = lo + mid*2^64 + top*2^96, with 2^64 = EPSILON, 2^96 = -1 (mod P):
+        // result = (lo - top) + mid*EPSILON.
+        let mid = _mm256_and_si256(hi, mask32);
+        let top = _mm256_srli_epi64(hi, 32);
+        let beps = _mm256_sub_epi64(_mm256_slli_epi64(mid, 32), mid);
+        add(sub(lo, top), beps)
+    }
+    /// Field halving; mirrors `F::div_2`.
+    #[inline(always)]
+    unsafe fn div2(x: __m256i) -> __m256i {
+        let one = _mm256_set1_epi64x(1);
+        let odd = _mm256_cmpeq_epi64(_mm256_and_si256(x, one), one);
+        let even = _mm256_srli_epi64(x, 1);
+        let addp = _mm256_add_epi64(x, splat(P));
+        let carry = ult(addp, x);
+        let carry_hi = _mm256_and_si256(carry, _mm256_set1_epi64x(i64::MIN));
+        let odd_res = _mm256_or_si256(carry_hi, _mm256_srli_epi64(addp, 1));
+        select(odd, odd_res, even)
+    }
+
+    #[target_feature(enable = "avx2")]
+    pub(super) unsafe fn ntt_dense<const FORWARD: bool>(rows: usize, cols: usize, data: &mut [F]) {
+        let lg_rows = crate::ntt::dense_ntt_lg_rows(rows, cols, data.len());
+        let raw = as_u64_mut(data);
+        let ptr = raw.as_mut_ptr();
+        let main = cols - cols % WIDTH;
+        for (stage, w_stage) in twiddle_stages::<FORWARD>(lg_rows) {
+            let skip = 1usize << stage;
+            let mut i = 0;
+            while i < rows {
+                let mut w_j = F::one();
+                for j in 0..skip {
+                    let base_a = (i + j) * cols;
+                    let base_b = (i + j + skip) * cols;
+                    let wv = splat(w_j.0);
+                    let mut k = 0;
+                    while k < main {
+                        let pa = ptr.add(base_a + k);
+                        let pb = ptr.add(base_b + k);
+                        let a = load(pa);
+                        let b = load(pb);
+                        if FORWARD {
+                            let t = mul(wv, b);
+                            store(pa, add(a, t));
+                            store(pb, sub(a, t));
+                        } else {
+                            let s = add(a, b);
+                            let d = sub(a, b);
+                            store(pa, div2(s));
+                            store(pb, div2(mul(d, wv)));
+                        }
+                        k += WIDTH;
+                    }
+                    // Remainder columns: scalar field, accessed through `ptr` so all
+                    // reads/writes share one provenance.
+                    for k in main..cols {
+                        let a = F(*ptr.add(base_a + k));
+                        let b = F(*ptr.add(base_b + k));
+                        if FORWARD {
+                            let t = w_j * b;
+                            *ptr.add(base_a + k) = (a + t).0;
+                            *ptr.add(base_b + k) = (a - t).0;
+                        } else {
+                            *ptr.add(base_a + k) = (a + b).div_2().0;
+                            *ptr.add(base_b + k) = ((a - b) * w_j).div_2().0;
+                        }
+                    }
+                    w_j *= &w_stage;
+                }
+                i += 2 * skip;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{super::EPSILON, add, div2, mul, sub, F, P};
+        use crate::algebra::FieldNTT;
+        use core::arch::x86_64::*;
+
+        fn lanes_of(
+            op: unsafe fn(__m256i, __m256i) -> __m256i,
+            a: [u64; 4],
+            b: [u64; 4],
+        ) -> [u64; 4] {
+            // SAFETY: callers gate on `is_x86_feature_detected!("avx2")`.
+            unsafe {
+                let va = _mm256_loadu_si256(a.as_ptr().cast());
+                let vb = _mm256_loadu_si256(b.as_ptr().cast());
+                let r = op(va, vb);
+                let mut out = [0u64; 4];
+                _mm256_storeu_si256(out.as_mut_ptr().cast(), r);
+                out
+            }
+        }
+
+        unsafe fn div2_bin(x: __m256i, _y: __m256i) -> __m256i {
+            div2(x)
+        }
+
+        fn samples() -> Vec<u64> {
+            let mut v = vec![
+                0u64,
+                1,
+                2,
+                P - 1,
+                P - 2,
+                EPSILON,
+                EPSILON + 1,
+                1 << 32,
+                (1 << 32) - 1,
+                (1 << 63),
+                u64::MAX % P,
+                P / 2,
+                12345678901234567 % P,
+            ];
+            // Deterministic pseudo-random canonical elements.
+            let mut x = 0x1234_5678_9abc_def0u64;
+            for _ in 0..200 {
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                v.push(x % P);
+            }
+            v
+        }
+
+        #[test]
+        fn avx2_field_ops_match_scalar() {
+            if !std::is_x86_feature_detected!("avx2") {
+                return;
+            }
+            let s = samples();
+            for &a in &s {
+                for &b in &s {
+                    let aa = [a, b, (a + 1) % P, (b + 2) % P];
+                    let bb = [b, a, (b + 3) % P, (a + 5) % P];
+                    let exp_add: [u64; 4] = core::array::from_fn(|i| (F(aa[i]) + F(bb[i])).0);
+                    let exp_sub: [u64; 4] = core::array::from_fn(|i| (F(aa[i]) - F(bb[i])).0);
+                    let exp_mul: [u64; 4] = core::array::from_fn(|i| (F(aa[i]) * F(bb[i])).0);
+                    assert_eq!(lanes_of(add, aa, bb), exp_add);
+                    assert_eq!(lanes_of(sub, aa, bb), exp_sub);
+                    assert_eq!(lanes_of(mul, aa, bb), exp_mul);
+                }
+            }
+        }
+
+        #[test]
+        fn avx2_div2_matches_scalar() {
+            if !std::is_x86_feature_detected!("avx2") {
+                return;
+            }
+            let s = samples();
+            for chunk in s.chunks(4) {
+                let mut aa = [0u64; 4];
+                aa[..chunk.len()].copy_from_slice(chunk);
+                let exp: [u64; 4] = core::array::from_fn(|i| F(aa[i]).div_2().0);
+                let got = lanes_of(div2_bin, aa, aa);
+                assert_eq!(got, exp);
+            }
+        }
+    }
+}
+
+#[cfg(all(test, any(target_arch = "x86_64", target_arch = "aarch64")))]
+mod dense_tests {
+    use super::{ntt_dense, F, P};
+
+    #[cfg(target_arch = "x86_64")]
+    fn simd_available() -> bool {
+        std::is_x86_feature_detected!("avx2")
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    const fn simd_available() -> bool {
+        true
+    }
+
+    fn rand_data(n: usize, seed: u64) -> Vec<F> {
+        let mut x = seed | 1;
+        (0..n)
+            .map(|_| {
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                F(x % P)
+            })
+            .collect()
+    }
+
+    /// The dispatched SIMD dense NTT must equal the scalar reference, across directions,
+    /// sizes, and SIMD-width remainders.
+    #[test]
+    fn dense_matches_scalar() {
+        if !simd_available() {
+            return;
+        }
+        for lg in [0usize, 1, 2, 4, 8, 12] {
+            let rows = 1usize << lg;
+            for cols in [1usize, 2, 3, 4, 5, 7, 8, 9, 16, 17, 33, 64] {
+                let base = rand_data(rows * cols, (lg as u64) * 1_000 + cols as u64);
+
+                let mut got = base.clone();
+                let mut want = base.clone();
+                ntt_dense::<true>(rows, cols, &mut got);
+                crate::ntt::ntt_dense_scalar::<true, F>(rows, cols, &mut want);
+                assert_eq!(got, want, "forward lg={lg} cols={cols}");
+
+                let mut got = base.clone();
+                let mut want = base;
+                ntt_dense::<false>(rows, cols, &mut got);
+                crate::ntt::ntt_dense_scalar::<false, F>(rows, cols, &mut want);
+                assert_eq!(got, want, "inverse lg={lg} cols={cols}");
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "data length must equal rows * cols")]
+    fn dense_rejects_short_data() {
+        let mut data = vec![F(0); 3];
+        ntt_dense::<true>(2, 2, &mut data);
+    }
+
+    #[test]
+    #[should_panic(expected = "rows should be a non-zero power of 2")]
+    fn dense_rejects_zero_rows() {
+        let mut data = Vec::new();
+        ntt_dense::<true>(0, 0, &mut data);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+mod neon {
+    use super::{as_u64_mut, twiddle_stages, F, P};
+    use crate::algebra::{FieldNTT, Ring};
+    use core::arch::aarch64::*;
+
+    /// Number of `u64` lanes per NEON register.
+    const WIDTH: usize = 2;
+
+    #[inline(always)]
+    unsafe fn load(p: *const u64) -> uint64x2_t {
+        vld1q_u64(p)
+    }
+    #[inline(always)]
+    unsafe fn store(p: *mut u64, v: uint64x2_t) {
+        vst1q_u64(p, v);
+    }
+    #[inline(always)]
+    unsafe fn splat(x: u64) -> uint64x2_t {
+        vdupq_n_u64(x)
+    }
+    /// Per-lane `mask ? t : f` (mask must be all-ones / all-zeros).
+    #[inline(always)]
+    unsafe fn select(mask: uint64x2_t, t: uint64x2_t, f: uint64x2_t) -> uint64x2_t {
+        vbslq_u64(mask, t, f)
+    }
+
+    /// Field add; mirrors `F::add_inner`.
+    #[inline(always)]
+    unsafe fn add(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
+        let p = splat(P);
+        let sum = vaddq_u64(x, y);
+        let overflow = vcltq_u64(sum, x);
+        let ge_p = vcgeq_u64(sum, p);
+        let cond = vorrq_u64(overflow, ge_p);
+        select(cond, vsubq_u64(sum, p), sum)
+    }
+    /// Field sub; mirrors `F::sub_inner`.
+    #[inline(always)]
+    unsafe fn sub(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
+        let p = splat(P);
+        let diff = vsubq_u64(x, y);
+        let borrow = vcltq_u64(x, y);
+        select(borrow, vaddq_u64(diff, p), diff)
+    }
+    /// Widening `64 x 64 -> 128` per lane, returning `(lo, hi)`.
+    #[inline(always)]
+    unsafe fn mul_wide(a: uint64x2_t, b: uint64x2_t) -> (uint64x2_t, uint64x2_t) {
+        let mask32 = vdupq_n_u64(0xFFFF_FFFF);
+        let a_lo = vmovn_u64(a);
+        let a_hi = vshrn_n_u64(a, 32);
+        let b_lo = vmovn_u64(b);
+        let b_hi = vshrn_n_u64(b, 32);
+        // 32x32 -> 64 partial products.
+        let ll = vmull_u32(a_lo, b_lo);
+        let lh = vmull_u32(a_lo, b_hi);
+        let hl = vmull_u32(a_hi, b_lo);
+        let hh = vmull_u32(a_hi, b_hi);
+        // Combine columns; each 64-bit add below is overflow-free for 32-bit inputs.
+        let ll_hi = vshrq_n_u64(ll, 32);
+        let t = vaddq_u64(lh, ll_hi);
+        let t_lo = vandq_u64(t, mask32);
+        let t_hi = vshrq_n_u64(t, 32);
+        let u = vaddq_u64(hl, t_lo);
+        let lo = vorrq_u64(vandq_u64(ll, mask32), vshlq_n_u64(vandq_u64(u, mask32), 32));
+        let hi = vaddq_u64(vaddq_u64(hh, t_hi), vshrq_n_u64(u, 32));
+        (lo, hi)
+    }
+    /// Field mul; mirrors `F::reduce_128(a*b)`.
+    #[inline(always)]
+    unsafe fn mul(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
+        let (lo, hi) = mul_wide(a, b);
+        let mask32 = vdupq_n_u64(0xFFFF_FFFF);
+        let mid = vandq_u64(hi, mask32);
+        let top = vshrq_n_u64(hi, 32);
+        let beps = vsubq_u64(vshlq_n_u64(mid, 32), mid);
+        add(sub(lo, top), beps)
+    }
+    /// Field halving; mirrors `F::div_2`.
+    #[inline(always)]
+    unsafe fn div2(x: uint64x2_t) -> uint64x2_t {
+        let one = vdupq_n_u64(1);
+        let odd = vceqq_u64(vandq_u64(x, one), one);
+        let even = vshrq_n_u64(x, 1);
+        let addp = vaddq_u64(x, splat(P));
+        let carry = vcltq_u64(addp, x);
+        let carry_hi = vandq_u64(carry, vdupq_n_u64(0x8000_0000_0000_0000));
+        let odd_res = vorrq_u64(carry_hi, vshrq_n_u64(addp, 1));
+        select(odd, odd_res, even)
+    }
+
+    #[target_feature(enable = "neon")]
+    pub(super) unsafe fn ntt_dense<const FORWARD: bool>(rows: usize, cols: usize, data: &mut [F]) {
+        let lg_rows = crate::ntt::dense_ntt_lg_rows(rows, cols, data.len());
+        let raw = as_u64_mut(data);
+        let ptr = raw.as_mut_ptr();
+        let main = cols - cols % WIDTH;
+        for (stage, w_stage) in twiddle_stages::<FORWARD>(lg_rows) {
+            let skip = 1usize << stage;
+            let mut i = 0;
+            while i < rows {
+                let mut w_j = F::one();
+                for j in 0..skip {
+                    let base_a = (i + j) * cols;
+                    let base_b = (i + j + skip) * cols;
+                    let wv = splat(w_j.0);
+                    let mut k = 0;
+                    while k < main {
+                        let pa = ptr.add(base_a + k);
+                        let pb = ptr.add(base_b + k);
+                        let a = load(pa);
+                        let b = load(pb);
+                        if FORWARD {
+                            let t = mul(wv, b);
+                            store(pa, add(a, t));
+                            store(pb, sub(a, t));
+                        } else {
+                            let s = add(a, b);
+                            let d = sub(a, b);
+                            store(pa, div2(s));
+                            store(pb, div2(mul(d, wv)));
+                        }
+                        k += WIDTH;
+                    }
+                    for k in main..cols {
+                        let a = F(*ptr.add(base_a + k));
+                        let b = F(*ptr.add(base_b + k));
+                        if FORWARD {
+                            let t = w_j * b;
+                            *ptr.add(base_a + k) = (a + t).0;
+                            *ptr.add(base_b + k) = (a - t).0;
+                        } else {
+                            *ptr.add(base_a + k) = (a + b).div_2().0;
+                            *ptr.add(base_b + k) = ((a - b) * w_j).div_2().0;
+                        }
+                    }
+                    w_j *= &w_stage;
+                }
+                i += 2 * skip;
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{super::EPSILON, add, div2, mul, sub, F, P};
+        use crate::algebra::FieldNTT;
+        use core::arch::aarch64::*;
+
+        fn lanes_of(
+            op: unsafe fn(uint64x2_t, uint64x2_t) -> uint64x2_t,
+            a: [u64; 2],
+            b: [u64; 2],
+        ) -> [u64; 2] {
+            // SAFETY: NEON is part of the aarch64 baseline.
+            unsafe {
+                let va = vld1q_u64(a.as_ptr());
+                let vb = vld1q_u64(b.as_ptr());
+                let r = op(va, vb);
+                let mut out = [0u64; 2];
+                vst1q_u64(out.as_mut_ptr(), r);
+                out
+            }
+        }
+
+        unsafe fn div2_bin(x: uint64x2_t, _y: uint64x2_t) -> uint64x2_t {
+            div2(x)
+        }
+
+        fn samples() -> Vec<u64> {
+            let mut v = vec![
+                0u64,
+                1,
+                2,
+                P - 1,
+                P - 2,
+                EPSILON,
+                EPSILON + 1,
+                1 << 32,
+                (1 << 32) - 1,
+                1 << 63,
+                u64::MAX % P,
+                P / 2,
+                12345678901234567 % P,
+            ];
+            let mut x = 0x1234_5678_9abc_def0u64;
+            for _ in 0..200 {
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                v.push(x % P);
+            }
+            v
+        }
+
+        #[test]
+        fn neon_field_ops_match_scalar() {
+            let s = samples();
+            for &a in &s {
+                for &b in &s {
+                    let aa = [a, b];
+                    let bb = [b, (a + 3) % P];
+                    let exp_add: [u64; 2] = core::array::from_fn(|i| (F(aa[i]) + F(bb[i])).0);
+                    let exp_sub: [u64; 2] = core::array::from_fn(|i| (F(aa[i]) - F(bb[i])).0);
+                    let exp_mul: [u64; 2] = core::array::from_fn(|i| (F(aa[i]) * F(bb[i])).0);
+                    assert_eq!(lanes_of(add, aa, bb), exp_add);
+                    assert_eq!(lanes_of(sub, aa, bb), exp_sub);
+                    assert_eq!(lanes_of(mul, aa, bb), exp_mul);
+                }
+            }
+        }
+
+        #[test]
+        fn neon_div2_matches_scalar() {
+            let s = samples();
+            for chunk in s.chunks(2) {
+                let mut aa = [0u64; 2];
+                aa[..chunk.len()].copy_from_slice(chunk);
+                let exp: [u64; 2] = core::array::from_fn(|i| F(aa[i]).div_2().0);
+                let got = lanes_of(div2_bin, aa, aa);
+                assert_eq!(got, exp);
+            }
+        }
+    }
+}

--- a/math/src/ntt.rs
+++ b/math/src/ntt.rs
@@ -162,6 +162,85 @@ fn ntt<const FORWARD: bool, F: FieldNTT, M: IndexMut<(usize, usize), Output = F>
     }
 }
 
+/// Validate a dense NTT's shape and return `log2(rows)`.
+pub(crate) fn dense_ntt_lg_rows(rows: usize, cols: usize, data_len: usize) -> usize {
+    assert!(
+        rows.is_power_of_two(),
+        "rows should be a non-zero power of 2"
+    );
+    let expected_len = rows.checked_mul(cols).expect("rows * cols overflows usize");
+    assert_eq!(data_len, expected_len, "data length must equal rows * cols");
+    rows.ilog2() as usize
+}
+
+/// In-place NTT (inverse when `FORWARD` is false) over a dense, row-major
+/// `rows x cols` slice, treating each column as an independent lane.
+///
+/// This is the default kernel behind [`crate::algebra::FieldNTT::ntt_dense`] and is
+/// equivalent to running [`ntt`] over a row-major [`Matrix`]. It operates on whole
+/// row slices (rather than an indexable view) so that a field can override
+/// `ntt_dense` with a vectorized kernel over the contiguous columns. Single-column
+/// and partial-segment NTTs continue to use [`ntt`].
+pub(crate) fn ntt_dense_scalar<const FORWARD: bool, F: FieldNTT>(
+    rows: usize,
+    cols: usize,
+    data: &mut [F],
+) {
+    let lg_rows = dense_ntt_lg_rows(rows, cols, data.len());
+    let w = {
+        let w = F::root_of_unity(lg_rows as u8).expect("too many rows to perform NTT");
+        if FORWARD {
+            w
+        } else {
+            w.exp(&[(1 << lg_rows) - 1])
+        }
+    };
+    let stages = {
+        let mut out = vec![(0usize, F::zero()); lg_rows];
+        let mut w_i = w;
+        for i in (0..lg_rows).rev() {
+            out[i] = (i, w_i.clone());
+            w_i = w_i.clone() * &w_i;
+        }
+        if !FORWARD {
+            out.reverse();
+        }
+        out
+    };
+    for (stage, w) in stages.into_iter() {
+        let skip = 1 << stage;
+        let mut i = 0;
+        while i < rows {
+            let mut w_j = F::one();
+            for j in 0..skip {
+                let index_a = i + j;
+                let index_b = index_a + skip;
+                // `index_a < index_b`, so the two row slices are disjoint.
+                let (left, right) = data.split_at_mut(index_b * cols);
+                let a = &mut left[index_a * cols..index_a * cols + cols];
+                let b = &mut right[..cols];
+                if FORWARD {
+                    for k in 0..cols {
+                        let w_j_b = w_j.clone() * &b[k];
+                        let a_k = a[k].clone();
+                        a[k] = a_k.clone() + &w_j_b;
+                        b[k] = a_k - &w_j_b;
+                    }
+                } else {
+                    for k in 0..cols {
+                        let a_k = a[k].clone();
+                        let b_k = b[k].clone();
+                        a[k] = (a_k.clone() + &b_k).div_2();
+                        b[k] = ((a_k - &b_k) * &w_j).div_2();
+                    }
+                }
+                w_j *= &w;
+            }
+            i += 2 * skip;
+        }
+    }
+}
+
 /// Columns of some larger piece of data.
 ///
 /// This allows us to easily do NTTs over partial segments of some bigger matrix.
@@ -837,20 +916,35 @@ impl<F: Additive> Matrix<F> {
         }
         assert_eq!(self.cols, other.rows);
         let out_cols = other.cols;
-        let rows: Vec<Vec<F>> = strategy.map_collect_vec(0..self.rows, |i| {
-            let mut row = vec![F::zero(); out_cols];
-            for j in 0..self.cols {
-                let c = self[(i, j)].clone();
-                let other_j = &other[j];
-                for (k, out_k) in row.iter_mut().enumerate() {
-                    *out_k += &(c.clone() * &other_j[k]);
+        if self.rows == 0 || out_cols == 0 {
+            return Self {
+                rows: self.rows,
+                cols: out_cols,
+                data: Vec::new(),
+            };
+        }
+        let num_blocks = strategy.parallelism_hint().clamp(1, self.rows);
+        let block_rows = self.rows.div_ceil(num_blocks);
+        let num_blocks = self.rows.div_ceil(block_rows);
+        let blocks: Vec<Vec<F>> = strategy.map_collect_vec(0..num_blocks, |b| {
+            let row_start = b * block_rows;
+            let row_end = (row_start + block_rows).min(self.rows);
+            let mut block = vec![F::zero(); (row_end - row_start) * out_cols];
+            for (local_i, i) in (row_start..row_end).enumerate() {
+                let row = &mut block[local_i * out_cols..(local_i + 1) * out_cols];
+                for j in 0..self.cols {
+                    let c = self[(i, j)].clone();
+                    let other_j = &other[j];
+                    for (k, out_k) in row.iter_mut().enumerate() {
+                        *out_k += &(c.clone() * &other_j[k]);
+                    }
                 }
             }
-            row
+            block
         });
         let mut data = Vec::with_capacity(self.rows * out_cols);
-        for row in rows {
-            data.extend(row);
+        for block in blocks {
+            data.extend(block);
         }
         Self {
             rows: self.rows,
@@ -863,19 +957,25 @@ impl<F: Additive> Matrix<F> {
 /// Perform a (possibly parallel) NTT over the columns of a [`Matrix`].
 ///
 /// Each column is an independent NTT lane (the per-stage butterflies mix rows, never
-/// columns), so transforming the columns in groups is identical to running [`ntt`] in
-/// place over the whole matrix. We split the columns into one contiguous block per
+/// columns), so transforming the columns in groups is identical to running the dense
+/// NTT over the whole matrix. We split the columns into one contiguous block per
 /// worker (per [`Strategy::parallelism_hint`]) and let `strategy` run the blocks
-/// concurrently. A sequential strategy hints a single block, so it transforms the
-/// matrix in place with no copies. Each block is copied out as a small row-major
-/// sub-matrix so both the copy and the transform stay on contiguous memory (a strided,
-/// column-at-a-time gather is an order of magnitude slower).
-fn par_matrix_ntt<const FORWARD: bool, F: FieldNTT, S: Strategy>(data: &mut Matrix<F>, strategy: &S) {
+/// concurrently, applying the per-field [`FieldNTT::ntt_dense`] kernel (which may be
+/// SIMD-accelerated) to each block. A sequential strategy hints a single block, so it
+/// runs `ntt_dense` over the matrix in place with no copies. Each parallel block is
+/// copied out as a small row-major sub-matrix so both the copy and the transform stay
+/// on contiguous memory (a strided, column-at-a-time gather is an order of magnitude
+/// slower). This composes thread-level parallelism (across blocks) with SIMD (within
+/// each block's `ntt_dense`).
+fn par_matrix_ntt<const FORWARD: bool, F: FieldNTT, S: Strategy>(
+    data: &mut Matrix<F>,
+    strategy: &S,
+) {
     let rows = data.rows;
     let cols = data.cols;
     let num_blocks = strategy.parallelism_hint().clamp(1, cols.max(1));
     if num_blocks <= 1 {
-        ntt::<FORWARD, F, Matrix<F>>(rows, cols, data);
+        F::ntt_dense::<FORWARD>(rows, cols, &mut data.data);
         return;
     }
     let block_cols = cols.div_ceil(num_blocks);
@@ -894,7 +994,8 @@ fn par_matrix_ntt<const FORWARD: bool, F: FieldNTT, S: Strategy>(data: &mut Matr
                 cols: cn,
                 data: buf,
             };
-            ntt::<FORWARD, F, Matrix<F>>(rows, cn, &mut block);
+            // Each worker runs the (possibly SIMD) per-field dense NTT on its block.
+            F::ntt_dense::<FORWARD>(rows, cn, &mut block.data);
             block
         })
     };
@@ -1603,6 +1704,7 @@ mod test {
         ));
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn strategy_methods_match_sequential() {
         use commonware_parallel::Rayon;

--- a/math/src/ntt.rs
+++ b/math/src/ntt.rs
@@ -2,6 +2,7 @@ use crate::algebra::{Additive, FieldNTT, Ring};
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use commonware_codec::{EncodeSize, RangeCfg, Read, Write};
+use commonware_parallel::{Sequential, Strategy};
 use commonware_utils::bitmap::BitMap;
 use core::{
     num::NonZeroU32,
@@ -825,11 +826,90 @@ impl<F: Additive> Matrix<F> {
         }
         out
     }
+
+    /// Like [Self::mul], but computing the (independent) output rows across `strategy`.
+    pub fn mul_with<S: Strategy>(&self, other: &Self, strategy: &S) -> Self
+    where
+        F: Clone + Ring,
+    {
+        if strategy.parallelism_hint() <= 1 {
+            return self.mul(other);
+        }
+        assert_eq!(self.cols, other.rows);
+        let out_cols = other.cols;
+        let rows: Vec<Vec<F>> = strategy.map_collect_vec(0..self.rows, |i| {
+            let mut row = vec![F::zero(); out_cols];
+            for j in 0..self.cols {
+                let c = self[(i, j)].clone();
+                let other_j = &other[j];
+                for (k, out_k) in row.iter_mut().enumerate() {
+                    *out_k += &(c.clone() * &other_j[k]);
+                }
+            }
+            row
+        });
+        let mut data = Vec::with_capacity(self.rows * out_cols);
+        for row in rows {
+            data.extend(row);
+        }
+        Self {
+            rows: self.rows,
+            cols: out_cols,
+            data,
+        }
+    }
+}
+
+/// Perform a (possibly parallel) NTT over the columns of a [`Matrix`].
+///
+/// Each column is an independent NTT lane (the per-stage butterflies mix rows, never
+/// columns), so transforming the columns in groups is identical to running [`ntt`] in
+/// place over the whole matrix. We split the columns into one contiguous block per
+/// worker (per [`Strategy::parallelism_hint`]) and let `strategy` run the blocks
+/// concurrently. A sequential strategy hints a single block, so it transforms the
+/// matrix in place with no copies. Each block is copied out as a small row-major
+/// sub-matrix so both the copy and the transform stay on contiguous memory (a strided,
+/// column-at-a-time gather is an order of magnitude slower).
+fn par_matrix_ntt<const FORWARD: bool, F: FieldNTT, S: Strategy>(data: &mut Matrix<F>, strategy: &S) {
+    let rows = data.rows;
+    let cols = data.cols;
+    let num_blocks = strategy.parallelism_hint().clamp(1, cols.max(1));
+    if num_blocks <= 1 {
+        ntt::<FORWARD, F, Matrix<F>>(rows, cols, data);
+        return;
+    }
+    let block_cols = cols.div_ceil(num_blocks);
+    let num_blocks = cols.div_ceil(block_cols);
+    let blocks: Vec<Matrix<F>> = {
+        let src: &Matrix<F> = data;
+        strategy.map_collect_vec(0..num_blocks, |b| {
+            let c0 = b * block_cols;
+            let cn = block_cols.min(cols - c0);
+            let mut buf = Vec::with_capacity(rows * cn);
+            for i in 0..rows {
+                buf.extend_from_slice(&src[i][c0..c0 + cn]);
+            }
+            let mut block = Matrix {
+                rows,
+                cols: cn,
+                data: buf,
+            };
+            ntt::<FORWARD, F, Matrix<F>>(rows, cn, &mut block);
+            block
+        })
+    };
+    for (b, block) in blocks.into_iter().enumerate() {
+        let c0 = b * block_cols;
+        let cn = block.cols;
+        for i in 0..rows {
+            data[i][c0..c0 + cn].clone_from_slice(&block[i]);
+        }
+    }
 }
 
 impl<F: FieldNTT> Matrix<F> {
-    fn ntt<const FORWARD: bool>(&mut self) {
-        ntt::<FORWARD, F, Self>(self.rows, self.cols, self)
+    fn ntt_with<const FORWARD: bool, S: Strategy>(&mut self, strategy: &S) {
+        par_matrix_ntt::<FORWARD, F, S>(self, strategy)
     }
 }
 
@@ -954,8 +1034,13 @@ impl<F: Additive> PolynomialVector<F> {
 
 impl<F: FieldNTT> PolynomialVector<F> {
     /// Evaluate each polynomial in this vector over all points in an interpolation domain.
-    pub fn evaluate(mut self) -> EvaluationVector<F> {
-        self.data.ntt::<true>();
+    pub fn evaluate(self) -> EvaluationVector<F> {
+        self.evaluate_with(&Sequential)
+    }
+
+    /// Like [Self::evaluate], but spreading the per-column NTTs across `strategy`.
+    pub fn evaluate_with<S: Strategy>(mut self, strategy: &S) -> EvaluationVector<F> {
+        self.data.ntt_with::<true, S>(strategy);
         let active_rows = VanishingPoints::all_non_vanishing(self.data.rows().ilog2());
         EvaluationVector {
             data: self.data,
@@ -1025,7 +1110,11 @@ impl<F: FieldNTT> PolynomialVector<F> {
     ///
     /// If `q` doesn't divide a partiular polynomial in this vector, the result
     /// for that polynomial is not guaranteed to be anything meaningful.
-    fn divide(&mut self, mut q: PolynomialColumn<F>) {
+    fn divide(&mut self, q: PolynomialColumn<F>) {
+        self.divide_with(q, &Sequential)
+    }
+
+    fn divide_with<S: Strategy>(&mut self, mut q: PolynomialColumn<F>, strategy: &S) {
         // The algorithm operates column wise.
         //
         // You can compute P(X) / Q(X) by evaluating each polynomial, then computing
@@ -1054,7 +1143,7 @@ impl<F: FieldNTT> PolynomialVector<F> {
         let skew_inv = F::coset_shift_inv();
         self.divide_roots(skew.clone());
         q.divide_roots(skew);
-        ntt::<true, F, _>(self.data.rows, self.data.cols, &mut self.data);
+        par_matrix_ntt::<true, F, S>(&mut self.data, strategy);
         ntt::<true, F, _>(
             q.coefficients.len(),
             1,
@@ -1075,7 +1164,7 @@ impl<F: FieldNTT> PolynomialVector<F> {
             }
         }
         // Interpolate back, using the inverse skew
-        ntt::<false, F, _>(self.data.rows, self.data.cols, &mut self.data);
+        par_matrix_ntt::<false, F, S>(&mut self.data, strategy);
         self.divide_roots(skew_inv);
     }
 }
@@ -1119,8 +1208,12 @@ impl<F: FieldNTT> EvaluationVector<F> {
     /// i.e. the inverse of [PolynomialVector::evaluate].
     ///
     /// (This makes all the rows count as filled).
-    fn interpolate(mut self) -> PolynomialVector<F> {
-        self.data.ntt::<false>();
+    fn interpolate(self) -> PolynomialVector<F> {
+        self.interpolate_with(&Sequential)
+    }
+
+    fn interpolate_with<S: Strategy>(mut self, strategy: &S) -> PolynomialVector<F> {
+        self.data.ntt_with::<false, S>(strategy);
         PolynomialVector { data: self.data }
     }
 
@@ -1147,6 +1240,20 @@ impl<F: FieldNTT> EvaluationVector<F> {
         if non_vanishing == 0 || non_vanishing == self.data.rows as u64 {
             return self.interpolate();
         }
+        // See [Self::recover_with] for the algorithm; this is the sequential path.
+        let (_, vanishing) = EvaluationColumn::vanishing(&self.active_rows);
+        self.multiply(&vanishing);
+        let mut out = self.interpolate();
+        out.divide(vanishing.interpolate());
+        out
+    }
+
+    /// Like [Self::recover], but spreading the per-column NTTs across `strategy`.
+    pub fn recover_with<S: Strategy>(mut self, strategy: &S) -> PolynomialVector<F> {
+        let non_vanishing = self.active_rows.count_non_vanishing();
+        if non_vanishing == 0 || non_vanishing == self.data.rows as u64 {
+            return self.interpolate_with(strategy);
+        }
 
         // If we had all of the rows, we could simply call [Self::interpolate],
         // in order to recover the original polynomial. If we do this while missing some
@@ -1162,8 +1269,8 @@ impl<F: FieldNTT> EvaluationVector<F> {
         // with the same vanishing polynomial.
         let (_, vanishing) = EvaluationColumn::vanishing(&self.active_rows);
         self.multiply(&vanishing);
-        let mut out = self.interpolate();
-        out.divide(vanishing.interpolate());
+        let mut out = self.interpolate_with(strategy);
+        out.divide_with(vanishing.interpolate(), strategy);
         out
     }
 }
@@ -1494,6 +1601,33 @@ mod test {
                 "matrix element count does not match dimensions"
             ))
         ));
+    }
+
+    #[test]
+    fn strategy_methods_match_sequential() {
+        use commonware_parallel::Rayon;
+        use core::num::NonZeroUsize;
+
+        let strategy = Rayon::new(NonZeroUsize::new(3).unwrap()).unwrap();
+        let matrix = Matrix::init(16, 5, (0..80).map(|i| F::from((i * 7 + 3) as u64)));
+        let polynomial = matrix.as_polynomials(16).unwrap();
+
+        assert_eq!(
+            polynomial.clone().evaluate_with(&strategy),
+            polynomial.clone().evaluate()
+        );
+
+        let mut parallel = polynomial.clone().evaluate_with(&strategy);
+        parallel.remove_row(3);
+        parallel.remove_row(12);
+        let mut sequential = polynomial.evaluate();
+        sequential.remove_row(3);
+        sequential.remove_row(12);
+        assert_eq!(parallel.recover_with(&strategy), sequential.recover());
+
+        let left = Matrix::init(5, 3, (0..15).map(|i| F::from(i + 1)));
+        let right = Matrix::init(3, 4, (0..12).map(|i| F::from((i * 7 + 3) as u64)));
+        assert_eq!(left.mul_with(&right, &strategy), left.mul(&right));
     }
 
     fn assert_vanishing_points_correct(points: &VanishingPoints) {


### PR DESCRIPTION
## Summary

`Zoda::encode` and `Zoda::decode` spend most of their time in dense Goldilocks NTTs (encode evaluation, decode recovery) and the checksum matrix multiply. Both already take a `Strategy`, but those kernels ran sequentially, so `conc > 1` did not speed them up. This makes two changes:

- Thread the `Strategy` through the dense NTT, recovery, and checksum multiply (`evaluate_with`, `recover_with`, `Matrix::mul_with`). The no-argument methods stay as `Sequential` wrappers, so existing callers are unchanged and `conc > 1` now parallelizes the NTT across independent column blocks. No unsafe.
- Add a Goldilocks dense-NTT SIMD backend behind `FieldNTT::ntt_dense`: AVX2 on x86-64 (with `std`), NEON on aarch64, and the scalar kernel as the fallback (including x86-64 without runtime AVX2). Single-column and sparse paths stay scalar.

The two changes compose: the `Strategy` adds cores, the backend adds lanes.

## Soundness

The parallel path is bit-identical to sequential, since the column blocks are independent. The packed add, sub, mul, and div-by-two mirror the scalar field operation by operation, so AVX2, NEON, and scalar produce byte-identical output. ZODA is not on the consensus path today, but this keeps it safe to run there later: a node on any backend derives the same commitment, so mixed hardware is not a divergence risk.

The SIMD kernels are `unsafe` (intrinsics and raw-pointer indexing). A shape assertion (`rows` is a power of two, `len == rows * cols`) guards the indexing precondition, and the scalar field is the equivalence oracle in the tests.

## Benchmark

AMD EPYC 9354 (x86-64, AVX2), patched vs `main` (`a0f1680`). The box is shared, so treat absolute times as indicative.

End-to-end ZODA, 8 MiB message, 100 chunks (`min` 33, `extra` 67), via `cargo bench -p commonware-coding --bench phased_coding_scheme_times -- 'msg_len=8388608 chunks=100'` (ms):

| | main conc=1 | main conc=8 | patched conc=1 | patched conc=8 |
|---|---:|---:|---:|---:|
| encode | 311 | 263 | 193 | 108 |
| decode | 1410 | 1410 | 427 | 308 |

On main, decode `conc=8` matches `conc=1`: the recovery path did not use the caller's concurrency, which is what this fixes. After the change both encode and decode scale with `conc`.

Dense NTT kernel, AVX2 vs scalar, same box (`cargo bench -p commonware-math --bench ntt`, `lg_rows=15`, ms):

| cols | scalar | AVX2 | speedup |
|---:|---:|---:|---:|
| 16 | 11.82 | 5.46 | 2.16x |
| 64 | 44.66 | 20.46 | 2.18x |
| 192 | 136.52 | 61.72 | 2.21x |

AVX2 processes 4 `u64` lanes, NEON 2. As a cross-check, a quiet Apple M4 (NEON) runs end-to-end encode `conc=8` at 128 -> 70 ms and decode `conc=8` at ~433 -> 190 ms.

## Testing

- `ntt::strategy_methods_match_sequential` and `zoda::rayon_matches_sequential`: parallel output equals sequential.
- `dense_matches_scalar` and `avx2_field_ops_match_scalar` (NEON equivalents on aarch64): the SIMD kernel equals the scalar field.
- `should_panic` tests cover the shape assertion guarding the unsafe indexing.
- `zoda::checksum_malleability`, `zoda::decode_rejects_duplicate_indices`, and the ZODA round-trip minifuzz.
- nightly `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p commonware-math -p commonware-coding`.
