### PR TITLE
[coding/rs] Zero-copy original shards via owned-input encode API

### DIFF
--- a/coding/fuzz/src/lib.rs
+++ b/coding/fuzz/src/lib.rs
@@ -72,7 +72,7 @@ pub fn fuzz<S: Scheme>(input: FuzzInput) {
         minimum_shards: NZU16!(min),
         extra_shards: NZU16!(recovery),
     };
-    let (commitment, shards) = S::encode(&config, data.as_slice(), &STRATEGY).unwrap();
+    let (commitment, shards) = S::encode(&config, data.clone(), &STRATEGY).unwrap();
     assert_eq!(shards.len(), (recovery + min) as usize);
     let mut shards = (0u16..).zip(shards).collect::<Vec<_>>();
     shuffle.shuffle(&mut shards);
@@ -101,7 +101,7 @@ pub fn fuzz_phased<S: PhasedScheme>(input: FuzzInput) {
         minimum_shards: NZU16!(min),
         extra_shards: NZU16!(recovery),
     };
-    let (commitment, shards) = S::encode(b"", &config, data.as_slice(), &STRATEGY).unwrap();
+    let (commitment, shards) = S::encode(b"", &config, data.clone(), &STRATEGY).unwrap();
     assert_eq!(shards.len(), (recovery + min) as usize);
     let mut shards = (0u16..).zip(shards).collect::<Vec<_>>();
     shuffle.shuffle(&mut shards);

--- a/coding/src/benches/bench.rs
+++ b/coding/src/benches/bench.rs
@@ -35,9 +35,9 @@ pub(crate) fn bench_encode_generic<S: Scheme>(name: &str, c: &mut Criterion) {
                             |data| {
                                 // Encode data
                                 if conc > 1 {
-                                    S::encode(&config, data.as_slice(), &strategy).unwrap()
+                                    S::encode(&config, data, &strategy).unwrap()
                                 } else {
-                                    S::encode(&config, data.as_slice(), &Sequential).unwrap()
+                                    S::encode(&config, data, &Sequential).unwrap()
                                 }
                             },
                             BatchSize::SmallInput,
@@ -76,9 +76,9 @@ pub(crate) fn bench_decode_generic<S: Scheme>(name: &str, c: &mut Criterion) {
 
                                     // Encode data
                                     let (commitment, shards) = if conc > 1 {
-                                        S::encode(&config, data.as_slice(), &strategy).unwrap()
+                                        S::encode(&config, data, &strategy).unwrap()
                                     } else {
-                                        S::encode(&config, data.as_slice(), &Sequential).unwrap()
+                                        S::encode(&config, data, &Sequential).unwrap()
                                     };
 
                                     let indices = selection.indices(min);

--- a/coding/src/benches/bench_phased.rs
+++ b/coding/src/benches/bench_phased.rs
@@ -32,9 +32,9 @@ pub(crate) fn bench_encode_generic<S: PhasedScheme>(name: &str, c: &mut Criterio
                             },
                             |data| {
                                 if conc > 1 {
-                                    S::encode(b"", &config, data.as_slice(), &strategy).unwrap()
+                                    S::encode(b"", &config, data, &strategy).unwrap()
                                 } else {
-                                    S::encode(b"", &config, data.as_slice(), &Sequential).unwrap()
+                                    S::encode(b"", &config, data, &Sequential).unwrap()
                                 }
                             },
                             BatchSize::SmallInput,
@@ -71,9 +71,9 @@ pub(crate) fn bench_decode_generic<S: PhasedScheme>(name: &str, c: &mut Criterio
                                     rng.fill_bytes(&mut data);
 
                                     let (commitment, mut shards) = if conc > 1 {
-                                        S::encode(b"", &config, data.as_slice(), &strategy).unwrap()
+                                        S::encode(b"", &config, data, &strategy).unwrap()
                                     } else {
-                                        S::encode(b"", &config, data.as_slice(), &Sequential).unwrap()
+                                        S::encode(b"", &config, data, &Sequential).unwrap()
                                     };
 
                                     let my_shard = shards.pop().unwrap();

--- a/coding/src/benches/bench_phased_size.rs
+++ b/coding/src/benches/bench_phased_size.rs
@@ -27,7 +27,7 @@ fn bench_size<S: PhasedScheme>(name: &str) {
             };
 
             let (commitment, mut shards) =
-                S::encode(b"", &config, data.as_slice(), &STRATEGY).unwrap();
+                S::encode(b"", &config, data, &STRATEGY).unwrap();
             let strong_shard = shards.pop().unwrap();
             let my_index = config.minimum_shards.get() + config.extra_shards.get() - 1;
             let (_, _, weak_shard) =

--- a/coding/src/benches/bench_size.rs
+++ b/coding/src/benches/bench_size.rs
@@ -26,7 +26,7 @@ fn bench_size<S: Scheme>(name: &str) {
                 data
             };
 
-            let (_, shards) = S::encode(&config, data.as_slice(), &STRATEGY).unwrap();
+            let (_, shards) = S::encode(&config, data, &STRATEGY).unwrap();
             let shard = &shards[0];
             println!(
                 "{} (shard)/msg_len={} chunks={}: {} B",

--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -10,7 +10,7 @@
 )]
 
 commonware_macros::stability_scope!(ALPHA {
-    use bytes::Buf;
+    use bytes::{Buf, Bytes};
     use commonware_codec::{Codec, FixedSize, Read, Write};
     use commonware_cryptography::Digest;
     use commonware_parallel::Strategy;
@@ -176,7 +176,7 @@ commonware_macros::stability_scope!(ALPHA {
         #[allow(clippy::type_complexity)]
         fn encode(
             config: &Config,
-            data: impl Buf,
+            data: impl Into<Bytes>,
             strategy: &impl Strategy,
         ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error>;
 
@@ -317,7 +317,7 @@ commonware_macros::stability_scope!(ALPHA {
         fn encode(
             namespace: &[u8],
             config: &Config,
-            data: impl Buf,
+            data: impl Into<Bytes>,
             strategy: &impl Strategy,
         ) -> Result<(Self::Commitment, Vec<Self::StrongShard>), Self::Error>;
 
@@ -422,7 +422,7 @@ commonware_macros::stability_scope!(ALPHA {
 
         fn encode(
             config: &Config,
-            data: impl Buf,
+            data: impl Into<Bytes>,
             strategy: &impl Strategy,
         ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error> {
             P::encode(b"", config, data, strategy).map_err(PhasedAsSchemeError::Scheme)
@@ -534,7 +534,7 @@ mod test {
         use commonware_parallel::Sequential;
 
         fn roundtrip<S: Scheme>(config: &Config, data: &[u8], selected: &[u16]) {
-            let (commitment, shards) = S::encode(config, data, &Sequential).unwrap();
+            let (commitment, shards) = S::encode(config, Bytes::copy_from_slice(data), &Sequential).unwrap();
             let read_cfg = CodecConfig {
                 maximum_shard_size: MAX_SHARD_SIZE,
             };
@@ -563,8 +563,8 @@ mod test {
             data_a: &[u8],
             data_b: &[u8],
         ) {
-            let (commitment_a, shards_a) = S::encode(config, data_a, &Sequential).unwrap();
-            let (commitment_b, shards_b) = S::encode(config, data_b, &Sequential).unwrap();
+            let (commitment_a, shards_a) = S::encode(config, Bytes::copy_from_slice(data_a), &Sequential).unwrap();
+            let (commitment_b, shards_b) = S::encode(config, Bytes::copy_from_slice(data_b), &Sequential).unwrap();
 
             let checked_a = S::check(config, &commitment_a, 0, &shards_a[0]).unwrap();
             let checked_b = S::check(config, &commitment_b, 1, &shards_b[1]).unwrap();
@@ -582,7 +582,7 @@ mod test {
         }
 
         fn decode_rejects_empty_checked_shards<S: Scheme>(config: &Config, data: &[u8]) {
-            let (commitment, _) = S::encode(config, data, &Sequential).unwrap();
+            let (commitment, _) = S::encode(config, Bytes::copy_from_slice(data), &Sequential).unwrap();
             let result = S::decode(config, &commitment, core::iter::empty(), &Sequential);
             assert!(
                 result.is_err(),
@@ -669,7 +669,7 @@ mod test {
 
         fn roundtrip<S: PhasedScheme>(config: &Config, data: &[u8], selected: &[u16]) {
             let owner = *selected.first().expect("selected must not be empty");
-            let (commitment, shards) = S::encode(b"", config, data, &Sequential).unwrap();
+            let (commitment, shards) = S::encode(b"", config, Bytes::copy_from_slice(data), &Sequential).unwrap();
             let read_cfg = CodecConfig {
                 maximum_shard_size: MAX_SHARD_SIZE,
             };
@@ -725,8 +725,8 @@ mod test {
             data_a: &[u8],
             data_b: &[u8],
         ) {
-            let (commitment_a, shards_a) = S::encode(b"", config, data_a, &Sequential).unwrap();
-            let (commitment_b, shards_b) = S::encode(b"", config, data_b, &Sequential).unwrap();
+            let (commitment_a, shards_a) = S::encode(b"", config, Bytes::copy_from_slice(data_a), &Sequential).unwrap();
+            let (commitment_b, shards_b) = S::encode(b"", config, Bytes::copy_from_slice(data_b), &Sequential).unwrap();
 
             let (checking_data_a, checked_a, _) =
                 S::weaken(b"", config, &commitment_a, 0, shards_a[0].clone()).unwrap();

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -186,23 +186,49 @@ where
     }
 }
 
-/// Prepare data for encoding.
+/// Build the `k` original shards for encoding from owned `data`.
 ///
-/// Returns a contiguous buffer of `k` padded shards and the shard length.
-/// The buffer layout is `[length_prefix | data | zero_padding]` split into
-/// `k` equal-sized shards of `shard_len` bytes each.
-fn prepare_data(mut data: impl Buf, k: usize) -> (Vec<u8>, usize) {
-    // Compute shard length
-    let data_len = data.remaining();
-    let shard_len = canonical_shard_len(data_len, k);
+/// The logical layout is `[length_prefix(4) | data | zero_padding]` split into `k`
+/// equal-sized shards of `shard_len` bytes each. Shards whose byte range lies entirely
+/// within the `data` region are returned as zero-copy [`Bytes`] views into `data`; only
+/// the shards that straddle the length prefix or the trailing padding are materialized
+/// into freshly allocated buffers. This keeps the common case (large `data`, many shards)
+/// nearly copy-free: only the first shard (prefix) and the final shard(s) (padding) are
+/// copied.
+fn build_original_shards(data: &Bytes, k: usize, shard_len: usize) -> Vec<Bytes> {
+    let data_len = data.len();
+    let prefix = (data_len as u32).to_be_bytes();
+    let prefix_len = u32::SIZE;
+    let data_start = prefix_len;
+    let data_end = prefix_len + data_len;
 
-    // Prepare data
-    let length_bytes = (data_len as u32).to_be_bytes();
-    let mut padded = vec![0u8; k * shard_len];
-    padded[..u32::SIZE].copy_from_slice(&length_bytes);
-    data.copy_to_slice(&mut padded[u32::SIZE..u32::SIZE + data_len]);
+    let mut shards = Vec::with_capacity(k);
+    for i in 0..k {
+        let lo = i * shard_len;
+        let hi = lo + shard_len;
+        if lo >= data_start && hi <= data_end {
+            // Entirely within the data region: zero-copy view.
+            shards.push(data.slice((lo - data_start)..(hi - data_start)));
+            continue;
+        }
 
-    (padded, shard_len)
+        // Straddles the prefix and/or the padding: materialize the shard.
+        let mut shard = vec![0u8; shard_len];
+        // Copy any overlap with the length prefix.
+        let pfx_hi = hi.min(prefix_len);
+        if lo < pfx_hi {
+            shard[..pfx_hi - lo].copy_from_slice(&prefix[lo..pfx_hi]);
+        }
+        // Copy any overlap with the data region.
+        let d_lo = lo.max(data_start);
+        let d_hi = hi.min(data_end);
+        if d_lo < d_hi {
+            shard[d_lo - lo..d_hi - lo].copy_from_slice(&data[d_lo - data_start..d_hi - data_start]);
+        }
+        // Remaining bytes stay zero (canonical padding).
+        shards.push(Bytes::from(shard));
+    }
+    shards
 }
 
 /// Return the canonical shard width for a payload and shard count.
@@ -315,27 +341,29 @@ type Encoding<D> = (D, Vec<Chunk<D>>);
 fn encode<H: Hasher, S: Strategy>(
     total: u16,
     min: u16,
-    data: impl Buf,
+    data: impl Into<Bytes>,
     strategy: &S,
 ) -> Result<Encoding<H::Digest>, Error> {
     // Validate parameters
     assert!(total > min);
     assert!(min > 0);
+    let data: Bytes = data.into();
     let n = total as usize;
     let k = min as usize;
     let m = n - k;
-    let data_len = data.remaining();
+    let data_len = data.len();
     if data_len > u32::MAX as usize {
         return Err(Error::InvalidDataLength(data_len));
     }
 
-    // Prepare data as a contiguous buffer of k shards
-    let (padded, shard_len) = prepare_data(data, k);
+    // Build the k original shards, copying only the shards that straddle the length
+    // prefix or the trailing padding; interior shards are zero-copy views into `data`.
+    let shard_len = canonical_shard_len(data_len, k);
+    let original_shards = build_original_shards(&data, k, shard_len);
 
     // Compute recovery shards, striping large shard widths across the strategy
     let recovery_buf = match striped::ranges(shard_len, strategy.parallelism_hint()) {
         Some(ranges) => {
-            let original_shards = padded.chunks(shard_len).collect::<Vec<_>>();
             let mut buf = vec![0u8; m * shard_len];
             let groups = striped::stripe_columns(&mut buf, shard_len, &ranges);
             let stripes: Vec<_> = ranges.into_iter().zip(groups).collect();
@@ -351,9 +379,9 @@ fn encode<H: Hasher, S: Strategy>(
                 |enc| enc.reset(k, m, shard_len),
             )
             .map_err(Error::ReedSolomon)?;
-            for shard in padded.chunks(shard_len) {
+            for shard in &original_shards {
                 encoder
-                    .add_original_shard(shard)
+                    .add_original_shard(shard.as_ref())
                     .map_err(Error::ReedSolomon)?;
             }
 
@@ -367,14 +395,13 @@ fn encode<H: Hasher, S: Strategy>(
         }
     };
 
-    // Create zero-copy Bytes views into the original and recovery buffers
-    let originals: Bytes = padded.into();
+    // Create zero-copy Bytes views into the recovery buffer
     let recoveries: Bytes = recovery_buf.into();
 
-    // Build Merkle tree
+    // Build Merkle tree over the original shards (zero-copy) and recovery shard views
     let mut builder = Builder::<H>::new(n);
-    let shard_slices: Vec<Bytes> = (0..k)
-        .map(|i| originals.slice(i * shard_len..(i + 1) * shard_len))
+    let shard_slices: Vec<Bytes> = original_shards
+        .into_iter()
         .chain((0..m).map(|i| recoveries.slice(i * shard_len..(i + 1) * shard_len)))
         .collect();
     let shard_hashes = strategy.map_init_collect_vec(&shard_slices, H::new, |hasher, shard| {
@@ -1138,13 +1165,13 @@ impl<H: Hasher> Scheme for ReedSolomon<H> {
 
     fn encode(
         config: &Config,
-        data: impl Buf,
+        data: impl Into<Bytes>,
         strategy: &impl Strategy,
     ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error> {
         encode::<H, _>(
             total_shards(config)?,
             config.minimum_shards.get(),
-            data,
+            data.into(),
             strategy,
         )
     }
@@ -1198,6 +1225,19 @@ mod tests {
 
     type RS = ReedSolomon<Sha256>;
     const STRATEGY: Sequential = Sequential;
+
+    /// Build the contiguous `[length_prefix | data | zero_padding]` buffer of `k` shards.
+    ///
+    /// Tests that construct malicious or non-canonical shards need the flat buffer
+    /// layout that production encoding builds lazily via [`build_original_shards`].
+    fn prepare_data(data: &[u8], k: usize) -> (Vec<u8>, usize) {
+        let shard_len = canonical_shard_len(data.len(), k);
+        let mut padded = vec![0u8; k * shard_len];
+        padded[..u32::SIZE].copy_from_slice(&(data.len() as u32).to_be_bytes());
+        padded[u32::SIZE..u32::SIZE + data.len()].copy_from_slice(data);
+        (padded, shard_len)
+    }
+
     const FUZZ_MAX_MIN_SHARDS: u16 = 8;
     const FUZZ_MAX_EXTRA_SHARDS: u16 = 8;
     const FUZZ_MAX_DATA_LEN: usize = 256;
@@ -1270,7 +1310,7 @@ mod tests {
             return;
         };
         let (canonical_root, _) =
-            encode::<Sha256, _>(total, min, decoded.as_slice(), &STRATEGY).unwrap();
+            encode::<Sha256, _>(total, min, Bytes::copy_from_slice(decoded.as_ref()), &STRATEGY).unwrap();
         assert_eq!(
             root, canonical_root,
             "decode accepted a root not produced by canonical encode"
@@ -1327,7 +1367,7 @@ mod tests {
         let data_len = u.int_in_range(0..=FUZZ_MAX_DATA_LEN)?;
         let data = u.bytes(data_len)?.to_vec();
         let (_canonical_root, chunks) =
-            encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+            encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
         let mut shards = chunks
             .iter()
             .map(|chunk| chunk.shard.to_vec())
@@ -1352,7 +1392,7 @@ mod tests {
         let min = 3u16;
 
         // Encode the data
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // Use a mix of original and recovery pieces
         let pieces: Vec<_> = vec![
@@ -1373,7 +1413,7 @@ mod tests {
         let min = 4u16;
 
         // Encode data
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // Try with fewer than min
         let pieces: Vec<_> = chunks
@@ -1394,7 +1434,7 @@ mod tests {
         let min = 3u16;
 
         // Encode data
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // Include duplicate index by cloning the first chunk
         let pieces = [
@@ -1415,7 +1455,7 @@ mod tests {
         let min = 3u16;
 
         // Encode data
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // Verify all proofs at invalid index
         for i in 0..total {
@@ -1429,7 +1469,7 @@ mod tests {
         let data = b"Test parameter validation";
 
         // The total shard count must exceed the recovery threshold.
-        encode::<Sha256, _>(3, 3, data.as_slice(), &STRATEGY).unwrap();
+        encode::<Sha256, _>(3, 3, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
     }
 
     #[test]
@@ -1438,7 +1478,7 @@ mod tests {
         let data = b"Test parameter validation";
 
         // The recovery threshold must be non-zero.
-        encode::<Sha256, _>(5, 0, data.as_slice(), &STRATEGY).unwrap();
+        encode::<Sha256, _>(5, 0, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
     }
 
     #[test]
@@ -1448,7 +1488,7 @@ mod tests {
         let min = 30u16;
 
         // Encode data
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // Try to decode with min
         let minimal = chunks
@@ -1467,7 +1507,7 @@ mod tests {
         let min = 4u16;
 
         // Encode data
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // Try to decode with min
         let minimal = chunks
@@ -1487,9 +1527,9 @@ mod tests {
         let min = 8u16;
 
         let (sequential_root, sequential_chunks) =
-            encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+            encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
         let (parallel_root, parallel_chunks) =
-            encode::<Sha256, _>(total, min, data.as_slice(), &strategy).unwrap();
+            encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &strategy).unwrap();
 
         assert_eq!(sequential_root, parallel_root);
         assert_eq!(sequential_chunks, parallel_chunks);
@@ -1502,7 +1542,7 @@ mod tests {
         let total = 24u16;
         let min = 8u16;
 
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &strategy).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &strategy).unwrap();
 
         let minimal = chunks
             .into_iter()
@@ -1528,7 +1568,7 @@ mod tests {
                     .map(|i| (i as u8) ^ ((i >> 7) as u8))
                     .collect();
                 let (root, chunks) =
-                    encode::<Sha256, _>(total, min, data.as_slice(), &Sequential).unwrap();
+                    encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &Sequential).unwrap();
                 let recovery_only = chunks
                     .into_iter()
                     .skip(min as usize)
@@ -1563,7 +1603,7 @@ mod tests {
         let total = 24u16;
         let min = 8u16;
 
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &strategy).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &strategy).unwrap();
 
         // Assert the striped path actually engages (>= 2 stripes); otherwise this would silently
         // exercise the sequential path.
@@ -1645,7 +1685,7 @@ mod tests {
         tamper: fn(&mut [Vec<u8>], usize, usize),
         strategy: &S,
     ) -> Result<Vec<u8>, Error> {
-        let (_root, chunks) = encode::<Sha256, _>(total, min, data, &Sequential).unwrap();
+        let (_root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data), &Sequential).unwrap();
         let mut shards = chunks.iter().map(|c| c.shard.to_vec()).collect::<Vec<_>>();
         let shard_len = shards[0].len();
         tamper(&mut shards, min as usize, shard_len);
@@ -1739,7 +1779,7 @@ mod tests {
 
         // Sanity: an untampered mixed (some originals + a recovery) set still decodes via the
         // striped path, forcing striped::decode_reveal to reconstruct an original.
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &Sequential).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &Sequential).unwrap();
         let mixed = [0u16, 1, 2, 4]
             .into_iter()
             .map(|i| checked(root, chunks[i as usize].clone()))
@@ -1789,7 +1829,7 @@ mod tests {
         let total = 24u16;
         let min = 8u16;
 
-        let (_root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &strategy).unwrap();
+        let (_root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &strategy).unwrap();
         let mut shards = chunks
             .iter()
             .map(|chunk| chunk.shard.to_vec())
@@ -1828,7 +1868,7 @@ mod tests {
 
         // Encode data correctly to get valid chunks
         let (_correct_root, chunks) =
-            encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+            encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // Create a malicious/fake root (simulating a malicious encoder)
         let mut hasher = Sha256::new();
@@ -1869,7 +1909,7 @@ mod tests {
         };
 
         let data = b"leaf_count mismatch proof";
-        let (commitment, shards) = RS::encode(&config_actual, data.as_slice(), &STRATEGY).unwrap();
+        let (commitment, shards) = RS::encode(&config_actual, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // A proof generated under a different shard configuration is invalid
         // for this commitment.
@@ -1884,7 +1924,7 @@ mod tests {
         let min = 3u16;
 
         // Encode data
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
         let mut pieces: Vec<_> = chunks.into_iter().map(|c| checked(root, c)).collect();
 
         // Tamper with one of the checked chunks by modifying the shard data.
@@ -2056,7 +2096,7 @@ mod tests {
         let oversized_root = oversized_tree.root();
 
         let (canonical_root, _) =
-            encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+            encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
         assert_ne!(oversized_root, canonical_root);
 
         let pieces = [0u16, 1u16, 4u16]
@@ -2080,7 +2120,7 @@ mod tests {
         let total = 6u16;
         let min = 3u16;
 
-        let (_root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (_root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
         let mut shards = chunks
             .iter()
             .map(|chunk| chunk.shard.to_vec())
@@ -2116,7 +2156,7 @@ mod tests {
         let total = 6u16;
         let min = 3u16;
 
-        let (_root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (_root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
         let mut shards = chunks
             .iter()
             .map(|chunk| chunk.shard.to_vec())
@@ -2178,7 +2218,7 @@ mod tests {
         let min = 3u16;
 
         // Encode the data
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // Use a mix of original and recovery pieces
         let mut invalid = checked(root, chunks[1].clone());
@@ -2201,7 +2241,7 @@ mod tests {
         let min = u16::MAX / 2;
 
         // Encode data
-        let (root, chunks) = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY).unwrap();
+        let (root, chunks) = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
 
         // Try to decode with min
         let minimal = chunks
@@ -2220,7 +2260,7 @@ mod tests {
         let min = u16::MAX / 2 - 1;
 
         // Encode data
-        let result = encode::<Sha256, _>(total, min, data.as_slice(), &STRATEGY);
+        let result = encode::<Sha256, _>(total, min, Bytes::copy_from_slice(data.as_ref()), &STRATEGY);
         assert!(matches!(
             result,
             Err(Error::ReedSolomon(RsError::UnsupportedShardCount {
@@ -2250,7 +2290,7 @@ mod tests {
             let pool = context.network_buffer_pool();
 
             let data = b"pool encoding test";
-            let (_root, chunks) = encode::<Sha256, _>(5, 3, data.as_slice(), &STRATEGY).unwrap();
+            let (_root, chunks) = encode::<Sha256, _>(5, 3, Bytes::copy_from_slice(data.as_ref()), &STRATEGY).unwrap();
             let chunk = &chunks[0];
 
             let encoded = chunk.encode();

--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -521,11 +521,12 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
     fn encode(
         namespace: &[u8],
         config: &Config,
-        data: impl bytes::Buf,
+        data: impl Into<bytes::Bytes>,
         strategy: &impl Strategy,
     ) -> Result<(Self::Commitment, Vec<Self::StrongShard>), Self::Error> {
         // Step 1: arrange the data as a matrix.
-        let data_bytes = data.remaining();
+        let data: bytes::Bytes = data.into();
+        let data_bytes = data.len();
         let topology = Topology::reckon(config, data_bytes);
         let data = Matrix::init(
             topology.data_rows,
@@ -706,7 +707,8 @@ mod tests {
         };
         let data = b"duplicate shard coverage";
         let (commitment, shards) =
-            Zoda::<Sha256>::encode(b"", &config, &data[..], &STRATEGY).unwrap();
+            Zoda::<Sha256>::encode(b"", &config, bytes::Bytes::copy_from_slice(data), &STRATEGY)
+                .unwrap();
         let shard0 = shards[0].clone();
         let (checking_data, checked_shard0, _weak_shard0) =
             Zoda::<Sha256>::weaken(b"", &config, &commitment, 0, shard0).unwrap();
@@ -762,7 +764,7 @@ mod tests {
         };
         let data = vec![0x5Au8; 256 * 1024];
         let (commitment, mut shards) =
-            Zoda::<Sha256>::encode(b"", &config, &data[..], &STRATEGY).unwrap();
+            Zoda::<Sha256>::encode(b"", &config, data, &STRATEGY).unwrap();
 
         let leader_i = 0usize;
         let a_i = 1usize;

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -168,7 +168,7 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
         inner.write(&mut buf);
         config.write(&mut buf);
 
-        C::encode(&config, buf.as_slice(), strategy).expect("must encode block successfully")
+        C::encode(&config, buf, strategy).expect("must encode block successfully")
     }
 
     /// Create a new [`CodedBlock`] from a [`Block`] and a configuration.
@@ -346,7 +346,7 @@ impl<B: Block, C: Scheme, H: Hasher> Read for CodedBlock<B, C, H> {
         inner.write(&mut buf);
         config.write(&mut buf);
         let (commitment, shards) =
-            C::encode(&config, buf.as_slice(), &Sequential).map_err(|_| {
+            C::encode(&config, buf, &Sequential).map_err(|_| {
                 commonware_codec::Error::Invalid("CodedBlock", "Failed to re-commit to block")
             })?;
 


### PR DESCRIPTION
Eliminate the prep memcpy in the Reed-Solomon encode path by taking ownership of the input and constructing original shards as zero-copy views.

## Changes

- `Scheme::encode` and `PhasedScheme::encode` now take `impl Into<bytes::Bytes>` instead of `impl Buf`, letting callers move ownership of the input buffer in.
- `build_original_shards` constructs the `k` original shards as zero-copy `Bytes::slice` views into the owned input. Only the two edge shards (the one carrying the length prefix and the trailing padded one) are copied; all interior shards are sliced.
- Hashing, Merkle tree construction, and chunk generation now operate over these zero-copy views plus the recovery shard slices.

## Wire format

Unchanged. The `[length_prefix | data | zero_padding]` layout is preserved exactly, so commitments remain byte-identical (verified by the format-pinned unique-commitment tests).

## Impact

Prep memcpy dropped from ~13% to ~1% of encode time (32 MiB, 100 shards, hardware SHA). Callers updated: consensus marshal coding moves its owned `Vec`, the coding fuzz target clones (it reuses the input), plus zoda and benches.

Verified: `cargo build -p commonware-coding --all-targets`, `just test -p commonware-coding` (42 passed),
`cargo clippy -p commonware-coding --all-targets`, `cargo build -p commonware-consensus`.