### PR TITLE
[storage/index] Factor out helpers

### DIFF
--- a/storage/src/index/partitioned/ordered/cursor.rs
+++ b/storage/src/index/partitioned/ordered/cursor.rs
@@ -1,0 +1,289 @@
+//! A mutable cursor over a single translated key's values.
+//!
+//! A [Cursor] iterates and edits the value run for one translated key. That run lives in one of two
+//! representations -- an inline sorted-array [Partition] or a spilled `BTreeMap` (see the parent
+//! module) -- abstracted behind [Backing]. The iteration protocol (the [State] machine, the
+//! must-call-`next` guards, and the metric bookkeeping) is identical for both representations, so it
+//! is written once here; [Backing] holds the only thing that differs: the positional store
+//! operations.
+
+use super::partition::Partition;
+use crate::index::Cursor as CursorTrait;
+use commonware_runtime::telemetry::metrics::{Counter, Gauge};
+use std::{
+    collections::{btree_map, hash_map, BTreeMap, HashMap},
+    ops::Range,
+};
+
+const MUST_CALL_NEXT: &str = "must call Cursor::next()";
+const NO_ACTIVE_ITEM: &str = "no active item in Cursor";
+
+/// Position of a [Cursor] within its key's value run (offset 0 is the run's first value).
+enum State {
+    /// Before the first `next()` or after an `insert()`/`delete()`: the next `next()` returns the
+    /// value at run offset `from`.
+    NeedNext { from: usize },
+    /// `next()` returned the value at run offset `offset`; `update`/`delete`/`insert` are valid.
+    Active { offset: usize },
+    /// `next()` returned `None`; only `insert()` (which appends) is valid.
+    Done,
+}
+
+/// The store holding a [Cursor]'s value run, abstracting the inline and spilled representations
+/// behind a common positional interface. All offsets are relative to the start of the key's run.
+enum Backing<'a, K: Ord + Copy, V> {
+    /// Inline sorted-array partition: the key's values occupy the contiguous index range `run`.
+    ///
+    /// `run.start` is fixed for the cursor's lifetime: the cursor borrows the partition exclusively
+    /// and only ever adds or removes its own key's values, so nothing shifts the entries before the
+    /// run. `run.end` is adjusted by one on each insert/remove to stay aligned with the array.
+    Soa {
+        partition: &'a mut Partition<K, V>,
+        key: K,
+        run: Range<usize>,
+    },
+    /// Spilled partition: the key's values live in the side-table's `BTreeMap`, re-resolved on each
+    /// access (spilling is the rare case, so the extra descent is off the hot path).
+    Spilled {
+        spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
+        partition: usize,
+        key: K,
+    },
+}
+
+impl<K: Ord + Copy, V> Backing<'_, K, V> {
+    /// The number of values in the run (zero if the key is absent).
+    fn len(&self) -> usize {
+        match self {
+            Self::Soa { run, .. } => run.len(),
+            Self::Spilled {
+                spilled,
+                partition,
+                key,
+            } => spilled
+                .get(partition)
+                .and_then(|inner| inner.get(key))
+                .map_or(0, Vec::len),
+        }
+    }
+
+    /// The value at run offset `off`. The caller ensures `off < len()`.
+    fn get(&self, off: usize) -> &V {
+        match self {
+            Self::Soa { partition, run, .. } => partition.value_at(run.start + off),
+            Self::Spilled {
+                spilled,
+                partition,
+                key,
+            } => &spilled
+                .get(partition)
+                .and_then(|inner| inner.get(key))
+                .expect("active cursor must reference a present key")[off],
+        }
+    }
+
+    /// Overwrite the value at run offset `off`. The caller ensures `off < len()`.
+    fn set(&mut self, off: usize, value: V) {
+        match self {
+            Self::Soa { partition, run, .. } => partition.set(run.start + off, value),
+            Self::Spilled {
+                spilled,
+                partition,
+                key,
+            } => {
+                spilled
+                    .get_mut(partition)
+                    .and_then(|inner| inner.get_mut(key))
+                    .expect("active cursor must reference a present key")[off] = value;
+            }
+        }
+    }
+
+    /// Insert `value` at run offset `off`, returning whether this created the key (its first value).
+    fn insert(&mut self, off: usize, value: V) -> bool {
+        match self {
+            Self::Soa {
+                partition,
+                key,
+                run,
+            } => {
+                let created = run.start == run.end; // empty run => key absent => this creates it
+                partition.insert_at(run.start + off, *key, value);
+                run.end += 1;
+                created
+            }
+            Self::Spilled {
+                spilled,
+                partition,
+                key,
+            } => match spilled.entry(*partition).or_default().entry(*key) {
+                btree_map::Entry::Occupied(mut run) => {
+                    run.get_mut().insert(off, value);
+                    false
+                }
+                btree_map::Entry::Vacant(run) => {
+                    run.insert(vec![value]);
+                    true
+                }
+            },
+        }
+    }
+
+    /// Remove the value at run offset `off`, returning whether that emptied (and so removed) the key.
+    fn remove(&mut self, off: usize) -> bool {
+        match self {
+            Self::Soa { partition, run, .. } => {
+                partition.remove(run.start + off);
+                run.end -= 1;
+                run.start == run.end
+            }
+            Self::Spilled {
+                spilled,
+                partition,
+                key,
+            } => {
+                let hash_map::Entry::Occupied(mut part) = spilled.entry(*partition) else {
+                    unreachable!("active cursor must reference a present partition")
+                };
+                let btree_map::Entry::Occupied(mut run) = part.get_mut().entry(*key) else {
+                    unreachable!("active cursor must reference a present key")
+                };
+                run.get_mut().remove(off);
+                if !run.get().is_empty() {
+                    return false;
+                }
+                // Removed the key's last value; drop the key, and de-spill the partition (back to an
+                // empty sorted array) if that was its last key.
+                run.remove();
+                if part.get().is_empty() {
+                    part.remove();
+                }
+                true
+            }
+        }
+    }
+}
+
+/// A [crate::index::Cursor] over a single translated key's values.
+///
+/// Both representations -- the inline sorted array and the spilled `BTreeMap` -- share one
+/// iteration protocol; see the module docs.
+pub struct Cursor<'a, K: Ord + Copy, V> {
+    backing: Backing<'a, K, V>,
+    state: State,
+    keys: &'a Gauge,
+    items: &'a Gauge,
+    pruned: &'a Counter,
+}
+
+impl<'a, K: Ord + Copy, V> Cursor<'a, K, V> {
+    /// A cursor over a key's values held inline in a sorted-array partition. `run` is the (non-empty)
+    /// index range of `key`'s values within the partition.
+    pub(super) const fn soa(
+        partition: &'a mut Partition<K, V>,
+        key: K,
+        run: Range<usize>,
+        keys: &'a Gauge,
+        items: &'a Gauge,
+        pruned: &'a Counter,
+    ) -> Self {
+        Self {
+            backing: Backing::Soa {
+                partition,
+                key,
+                run,
+            },
+            state: State::NeedNext { from: 0 },
+            keys,
+            items,
+            pruned,
+        }
+    }
+
+    /// A cursor over a key's values held in a spilled partition's `BTreeMap`.
+    pub(super) const fn spilled(
+        spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
+        partition: usize,
+        key: K,
+        keys: &'a Gauge,
+        items: &'a Gauge,
+        pruned: &'a Counter,
+    ) -> Self {
+        Self {
+            backing: Backing::Spilled {
+                spilled,
+                partition,
+                key,
+            },
+            state: State::NeedNext { from: 0 },
+            keys,
+            items,
+            pruned,
+        }
+    }
+}
+
+impl<K: Ord + Copy + Send + Sync, V: Send + Sync> CursorTrait for Cursor<'_, K, V> {
+    type Value = V;
+
+    fn next(&mut self) -> Option<&V> {
+        let off = match self.state {
+            State::Done => return None,
+            State::NeedNext { from } => from,
+            State::Active { offset } => offset + 1,
+        };
+        if off >= self.backing.len() {
+            self.state = State::Done;
+            return None;
+        }
+        self.state = State::Active { offset: off };
+        Some(self.backing.get(off))
+    }
+
+    fn update(&mut self, value: V) {
+        match self.state {
+            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
+            State::Done => panic!("{NO_ACTIVE_ITEM}"),
+            State::Active { offset } => self.backing.set(offset, value),
+        }
+    }
+
+    fn insert(&mut self, value: V) {
+        match self.state {
+            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
+            State::Active { offset } => {
+                // Place immediately after the current value (never a new key, so the return is
+                // ignored); `next()` then returns the value after the inserted one, skipping both
+                // the current and the inserted.
+                self.backing.insert(offset + 1, value);
+                self.items.inc();
+                self.state = State::NeedNext { from: offset + 2 };
+            }
+            State::Done => {
+                // Append at the oldest position (run end), re-creating the key if it was emptied.
+                let end = self.backing.len();
+                if self.backing.insert(end, value) {
+                    self.keys.inc();
+                }
+                self.items.inc();
+            }
+        }
+    }
+
+    fn delete(&mut self) {
+        let offset = match self.state {
+            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
+            State::Done => panic!("{NO_ACTIVE_ITEM}"),
+            State::Active { offset } => offset,
+        };
+        if self.backing.remove(offset) {
+            // Removed the key's last value; the key is gone.
+            self.keys.dec();
+        }
+        self.items.dec();
+        self.pruned.inc();
+
+        // The value after the deleted one shifted into `offset`.
+        self.state = State::NeedNext { from: offset };
+    }
+}

--- a/storage/src/index/partitioned/ordered/cursor.rs
+++ b/storage/src/index/partitioned/ordered/cursor.rs
@@ -107,7 +107,8 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 key,
                 run,
             } => {
-                let created = run.start == run.end; // empty run => key absent => this creates it
+                #[allow(unstable_name_collisions)]
+                let created = run.is_empty(); // empty run => key absent => this creates it
                 partition.insert_at(run.start + off, *key, value);
                 run.end += 1;
                 created
@@ -135,7 +136,8 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
             Self::Soa { partition, run, .. } => {
                 partition.remove(run.start + off);
                 run.end -= 1;
-                run.start == run.end
+                #[allow(unstable_name_collisions)]
+                run.is_empty()
             }
             Self::Spilled {
                 spilled,

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -24,8 +24,10 @@
 //! average ~1) and is the price of this layout's density. Callers that need O(1) collision appends
 //! can use the flat `crate::index::ordered::Index`, which keeps a per-key overflow vector instead.
 
+mod cursor;
 mod partition;
 
+pub use self::cursor::Cursor;
 use self::partition::Partition;
 use crate::{
     index::{
@@ -40,322 +42,8 @@ use commonware_runtime::{
 };
 use std::{
     collections::{btree_map, hash_map, BTreeMap, HashMap},
-    ops::{Bound, Range},
+    ops::Bound,
 };
-
-const MUST_CALL_NEXT: &str = "must call Cursor::next()";
-const NO_ACTIVE_ITEM: &str = "no active item in Cursor";
-
-/// Position of a [Cursor] within its key's value run (offset 0 is the run's first value).
-enum State {
-    /// Before the first `next()` or after an `insert()`/`delete()`: the next `next()` returns the
-    /// value at run offset `from`.
-    NeedNext { from: usize },
-    /// `next()` returned the value at run offset `offset`; `update`/`delete`/`insert` are valid.
-    Active { offset: usize },
-    /// `next()` returned `None`; only `insert()` (which appends) is valid.
-    Done,
-}
-
-/// A [Cursor] over a single translated key's values, held inline in a partition's sorted arrays
-/// where they occupy a contiguous index range (`run`).
-///
-/// The cursor resolves `run` once, when created, and caches it so each operation indexes straight
-/// into the arrays instead of searching for the key again. The cache stays correct because the
-/// cursor borrows the partition exclusively: it is the sole writer and only ever adds or removes
-/// this key's own values. Nothing shifts the entries before the run, so `run.start` is fixed, and
-/// each `insert`/`delete` adjusts `run.end` by one to stay aligned with the array.
-struct SoaCursor<'a, K: Ord + Copy, V> {
-    partition: &'a mut Partition<K, V>,
-    key: K,
-    run: Range<usize>,
-    state: State,
-    keys: &'a Gauge,
-    items: &'a Gauge,
-    pruned: &'a Counter,
-}
-
-impl<'a, K: Ord + Copy, V> SoaCursor<'a, K, V> {
-    const fn new(
-        partition: &'a mut Partition<K, V>,
-        key: K,
-        run: Range<usize>,
-        keys: &'a Gauge,
-        items: &'a Gauge,
-        pruned: &'a Counter,
-    ) -> Self {
-        Self {
-            partition,
-            key,
-            run,
-            state: State::NeedNext { from: 0 },
-            keys,
-            items,
-            pruned,
-        }
-    }
-}
-
-impl<K: Ord + Copy + Send + Sync, V: Send + Sync> CursorTrait for SoaCursor<'_, K, V> {
-    type Value = V;
-
-    fn next(&mut self) -> Option<&V> {
-        let off = match self.state {
-            State::Done => return None,
-            State::NeedNext { from } => from,
-            State::Active { offset } => offset + 1,
-        };
-        if off >= self.run.len() {
-            self.state = State::Done;
-            return None;
-        }
-        self.state = State::Active { offset: off };
-        Some(self.partition.value_at(self.run.start + off))
-    }
-
-    fn update(&mut self, value: V) {
-        match self.state {
-            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
-            State::Done => panic!("{NO_ACTIVE_ITEM}"),
-            State::Active { offset } => self.partition.set(self.run.start + offset, value),
-        }
-    }
-
-    fn insert(&mut self, value: V) {
-        match self.state {
-            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
-            State::Active { offset } => {
-                // Place immediately after the current value; `next()` then returns the value after
-                // the inserted one (skipping both the current and the inserted).
-                self.partition
-                    .insert_at(self.run.start + offset + 1, self.key, value);
-                self.run.end += 1;
-                self.items.inc();
-                self.state = State::NeedNext { from: offset + 2 };
-            }
-            State::Done => {
-                // Append at the oldest position (run end), re-creating the key if it was emptied.
-                if self.run.is_empty() {
-                    self.keys.inc();
-                }
-                self.partition.insert_at(self.run.end, self.key, value);
-                self.run.end += 1;
-                self.items.inc();
-            }
-        }
-    }
-
-    fn delete(&mut self) {
-        let offset = match self.state {
-            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
-            State::Done => panic!("{NO_ACTIVE_ITEM}"),
-            State::Active { offset } => offset,
-        };
-        self.partition.remove(self.run.start + offset);
-        self.run.end -= 1;
-        self.items.dec();
-        self.pruned.inc();
-        if self.run.is_empty() {
-            // Removed the key's last value; the key is gone.
-            self.keys.dec();
-        }
-
-        // The value after the deleted one shifted into `offset`.
-        self.state = State::NeedNext { from: offset };
-    }
-}
-
-/// A [Cursor] over a translated key's values held in a spilled partition's `BTreeMap`.
-///
-/// A spilled partition lives in the index's `spilled` side-table, each key mapping to its values
-/// newest-first. The cursor re-resolves the key's value vector through the side-table on each
-/// operation: spilling is the rare, non-uniform key distribution case, so the extra `BTreeMap`
-/// descent is off the hot path. Deleting a key's last value drops its entry, and emptying the
-/// partition's last key removes it from the side-table (reverting it to an empty sorted-array
-/// partition).
-struct SpilledCursor<'a, K: Ord + Copy, V> {
-    spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
-    partition: usize,
-    key: K,
-    state: State,
-    keys: &'a Gauge,
-    items: &'a Gauge,
-    pruned: &'a Counter,
-}
-
-impl<'a, K: Ord + Copy, V> SpilledCursor<'a, K, V> {
-    const fn new(
-        spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
-        partition: usize,
-        key: K,
-        keys: &'a Gauge,
-        items: &'a Gauge,
-        pruned: &'a Counter,
-    ) -> Self {
-        Self {
-            spilled,
-            partition,
-            key,
-            state: State::NeedNext { from: 0 },
-            keys,
-            items,
-            pruned,
-        }
-    }
-
-    /// The values stored for the cursor's key, or `None` if the key has no values -- either its
-    /// entry was removed or the whole partition de-spilled.
-    fn vals(&self) -> Option<&Vec<V>> {
-        self.spilled
-            .get(&self.partition)
-            .and_then(|inner| inner.get(&self.key))
-    }
-
-    fn vals_mut(&mut self) -> Option<&mut Vec<V>> {
-        self.spilled
-            .get_mut(&self.partition)
-            .and_then(|inner| inner.get_mut(&self.key))
-    }
-}
-
-impl<K: Ord + Copy + Send + Sync, V: Send + Sync> CursorTrait for SpilledCursor<'_, K, V> {
-    type Value = V;
-
-    fn next(&mut self) -> Option<&V> {
-        let off = match self.state {
-            State::Done => return None,
-            State::NeedNext { from } => from,
-            State::Active { offset } => offset + 1,
-        };
-
-        // Two resolutions (length, then value): collapsing them needs the resolved borrow held
-        // across the `self.state` write, which NLL rejects (the returned value re-borrows `self`).
-        if off >= self.vals().map_or(0, Vec::len) {
-            self.state = State::Done;
-            return None;
-        }
-        self.state = State::Active { offset: off };
-        Some(&self.vals().unwrap()[off])
-    }
-
-    fn update(&mut self, value: V) {
-        match self.state {
-            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
-            State::Done => panic!("{NO_ACTIVE_ITEM}"),
-            State::Active { offset } => self.vals_mut().unwrap()[offset] = value,
-        }
-    }
-
-    fn insert(&mut self, value: V) {
-        match self.state {
-            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
-            State::Active { offset } => {
-                // Place immediately after the current value (newest-first); `next()` then returns
-                // the value after the inserted one.
-                self.vals_mut().unwrap().insert(offset + 1, value);
-                self.items.inc();
-                self.state = State::NeedNext { from: offset + 2 };
-            }
-            State::Done => {
-                // Append at the oldest position (vector end), re-creating the key (and partition
-                // entry) if it was emptied; a vacant key entry is a new key.
-                let inner = self.spilled.entry(self.partition).or_default();
-                match inner.entry(self.key) {
-                    btree_map::Entry::Occupied(mut run) => run.get_mut().push(value),
-                    btree_map::Entry::Vacant(run) => {
-                        run.insert(vec![value]);
-                        self.keys.inc();
-                    }
-                }
-                self.items.inc();
-            }
-        }
-    }
-
-    fn delete(&mut self) {
-        let offset = match self.state {
-            State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
-            State::Done => panic!("{NO_ACTIVE_ITEM}"),
-            State::Active { offset } => offset,
-        };
-
-        // The cursor's partition and key must both be present when active.
-        let hash_map::Entry::Occupied(mut partition) = self.spilled.entry(self.partition) else {
-            unreachable!()
-        };
-        let btree_map::Entry::Occupied(mut run) = partition.get_mut().entry(self.key) else {
-            unreachable!()
-        };
-        let vals = run.get_mut();
-        vals.remove(offset);
-        let key_emptied = vals.is_empty();
-        self.items.dec();
-        self.pruned.inc();
-
-        if key_emptied {
-            // Removed the key's last value; drop the key, and de-spill the partition (back to an
-            // empty sorted array) if that was its last key.
-            self.keys.dec();
-            run.remove();
-            if partition.get().is_empty() {
-                partition.remove();
-            }
-        }
-
-        // The value after the deleted one shifted into `offset`.
-        self.state = State::NeedNext { from: offset };
-    }
-}
-
-/// A [crate::index::Cursor] over a translated key's values.
-pub struct Cursor<'a, K: Ord + Copy, V>(CursorInner<'a, K, V>);
-
-enum CursorInner<'a, K: Ord + Copy, V> {
-    Soa(SoaCursor<'a, K, V>),
-    Spilled(SpilledCursor<'a, K, V>),
-}
-
-impl<'a, K: Ord + Copy, V> Cursor<'a, K, V> {
-    const fn soa(cursor: SoaCursor<'a, K, V>) -> Self {
-        Self(CursorInner::Soa(cursor))
-    }
-
-    const fn spilled(cursor: SpilledCursor<'a, K, V>) -> Self {
-        Self(CursorInner::Spilled(cursor))
-    }
-}
-
-impl<K: Ord + Copy + Send + Sync, V: Send + Sync> CursorTrait for Cursor<'_, K, V> {
-    type Value = V;
-
-    fn next(&mut self) -> Option<&V> {
-        match &mut self.0 {
-            CursorInner::Soa(c) => c.next(),
-            CursorInner::Spilled(c) => c.next(),
-        }
-    }
-
-    fn update(&mut self, value: V) {
-        match &mut self.0 {
-            CursorInner::Soa(c) => c.update(value),
-            CursorInner::Spilled(c) => c.update(value),
-        }
-    }
-
-    fn insert(&mut self, value: V) {
-        match &mut self.0 {
-            CursorInner::Soa(c) => c.insert(value),
-            CursorInner::Spilled(c) => c.insert(value),
-        }
-    }
-
-    fn delete(&mut self) {
-        match &mut self.0 {
-            CursorInner::Soa(c) => c.delete(),
-            CursorInner::Spilled(c) => c.delete(),
-        }
-    }
-}
 
 /// Sorted-array length at which a partition spills to a `BTreeMap`. Set well above any honest
 /// occupancy (even ~1B keys at P=3 averages ~60 entries per partition) so uniformly distributed
@@ -434,73 +122,62 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         self.spilled.insert(i, inner);
     }
 
+    /// The `BTreeMap` of spilled partition `i`, or `None` if `i` has not spilled. The empty-map
+    /// check skips hashing `i` in the common case where no partition has ever spilled.
+    fn spilled_partition(&self, i: usize) -> Option<&BTreeMap<T::Key, Vec<V>>> {
+        if self.spilled.is_empty() {
+            return None;
+        }
+        self.spilled.get(&i)
+    }
+
     /// The values for translated key `k` in partition `i` (empty if absent), from whichever
     /// representation the partition currently uses.
     fn partition_values(&self, i: usize, k: &T::Key) -> &[V] {
-        if self.partitions[i].is_empty() && !self.spilled.is_empty() {
-            if let Some(inner) = self.spilled.get(&i) {
-                return inner.get(k).map_or(&[], Vec::as_slice);
-            }
+        if !self.partitions[i].is_empty() {
+            return self.partitions[i].values(k);
         }
-        self.partitions[i].values(k)
+        self.spilled_partition(i)
+            .and_then(|inner| inner.get(k))
+            .map_or(&[], Vec::as_slice)
     }
 
     /// Values of the smallest key in partition `i` (None if the partition is empty).
     fn partition_first(&self, i: usize) -> Option<&[V]> {
-        if let Some(vals) = self.partitions[i].first_values() {
-            return Some(vals);
-        }
-        if !self.spilled.is_empty() {
-            if let Some(inner) = self.spilled.get(&i) {
-                return inner.first_key_value().map(|(_, v)| v.as_slice());
-            }
-        }
-        None
+        self.partitions[i].first_values().or_else(|| {
+            self.spilled_partition(i)?
+                .first_key_value()
+                .map(|(_, v)| v.as_slice())
+        })
     }
 
     /// Values of the largest key in partition `i` (None if the partition is empty).
     fn partition_last(&self, i: usize) -> Option<&[V]> {
-        if let Some(vals) = self.partitions[i].last_values() {
-            return Some(vals);
-        }
-        if !self.spilled.is_empty() {
-            if let Some(inner) = self.spilled.get(&i) {
-                return inner.last_key_value().map(|(_, v)| v.as_slice());
-            }
-        }
-        None
+        self.partitions[i].last_values().or_else(|| {
+            self.spilled_partition(i)?
+                .last_key_value()
+                .map(|(_, v)| v.as_slice())
+        })
     }
 
     /// Values of the smallest key strictly greater than `k` in partition `i`.
     fn partition_next_after(&self, i: usize, k: &T::Key) -> Option<&[V]> {
-        if let Some(vals) = self.partitions[i].next_values_after(k) {
-            return Some(vals);
-        }
-        if !self.spilled.is_empty() {
-            if let Some(inner) = self.spilled.get(&i) {
-                return inner
-                    .range((Bound::Excluded(*k), Bound::Unbounded))
-                    .next()
-                    .map(|(_, v)| v.as_slice());
-            }
-        }
-        None
+        self.partitions[i].next_values_after(k).or_else(|| {
+            self.spilled_partition(i)?
+                .range((Bound::Excluded(*k), Bound::Unbounded))
+                .next()
+                .map(|(_, v)| v.as_slice())
+        })
     }
 
     /// Values of the largest key strictly less than `k` in partition `i`.
     fn partition_prev_before(&self, i: usize, k: &T::Key) -> Option<&[V]> {
-        if let Some(vals) = self.partitions[i].prev_values_before(k) {
-            return Some(vals);
-        }
-        if !self.spilled.is_empty() {
-            if let Some(inner) = self.spilled.get(&i) {
-                return inner
-                    .range((Bound::Unbounded, Bound::Excluded(*k)))
-                    .next_back()
-                    .map(|(_, v)| v.as_slice());
-            }
-        }
-        None
+        self.partitions[i].prev_values_before(k).or_else(|| {
+            self.spilled_partition(i)?
+                .range((Bound::Unbounded, Bound::Excluded(*k)))
+                .next_back()
+                .map(|(_, v)| v.as_slice())
+        })
     }
 
     /// Number of partitions currently spilled to the side-table.
@@ -563,31 +240,29 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
             if run.is_empty() {
                 return None;
             }
-            return Some(Cursor::soa(SoaCursor::new(
+            return Some(Cursor::soa(
                 &mut self.partitions[i],
                 k,
                 run,
                 &self.keys,
                 &self.items,
                 &self.pruned,
-            )));
+            ));
         }
 
         // Hand out a spilled cursor if the partition has spilled and holds `k`.
-        if !self.spilled.is_empty()
-            && self
-                .spilled
-                .get(&i)
-                .is_some_and(|inner| inner.contains_key(&k))
+        if self
+            .spilled_partition(i)
+            .is_some_and(|inner| inner.contains_key(&k))
         {
-            return Some(Cursor::spilled(SpilledCursor::new(
+            return Some(Cursor::spilled(
                 &mut self.spilled,
                 i,
                 k,
                 &self.keys,
                 &self.items,
                 &self.pruned,
-            )));
+            ));
         }
 
         // Partition is genuinely empty.
@@ -604,14 +279,14 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         if !self.partitions[i].is_empty() {
             let run = self.partitions[i].run_range(&k);
             if !run.is_empty() {
-                return Some(Cursor::soa(SoaCursor::new(
+                return Some(Cursor::soa(
                     &mut self.partitions[i],
                     k,
                     run,
                     &self.keys,
                     &self.items,
                     &self.pruned,
-                )));
+                ));
             }
             self.partitions[i].insert_at(run.start, k, value);
             self.keys.inc();
@@ -622,23 +297,21 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
 
         // Partition i is empty. If it's because it has spilled, serve or create the key in its
         // `BTreeMap`.
-        if !self.spilled.is_empty() {
-            if let Some(inner) = self.spilled.get(&i) {
-                if inner.contains_key(&k) {
-                    return Some(Cursor::spilled(SpilledCursor::new(
-                        &mut self.spilled,
-                        i,
-                        k,
-                        &self.keys,
-                        &self.items,
-                        &self.pruned,
-                    )));
-                }
-                self.spilled.get_mut(&i).unwrap().insert(k, vec![value]);
-                self.keys.inc();
-                self.items.inc();
-                return None;
+        if let Some(inner) = self.spilled_partition(i) {
+            if inner.contains_key(&k) {
+                return Some(Cursor::spilled(
+                    &mut self.spilled,
+                    i,
+                    k,
+                    &self.keys,
+                    &self.items,
+                    &self.pruned,
+                ));
             }
+            self.spilled.get_mut(&i).unwrap().insert(k, vec![value]);
+            self.keys.inc();
+            self.items.inc();
+            return None;
         }
 
         // Partition i is genuinely empty: start a fresh sorted array.
@@ -973,8 +646,8 @@ mod tests {
             assert_eq!(index.keys(), 2);
             assert_eq!(index.items(), 2);
 
-            // Spilled -> empty, draining both keys through a SpilledCursor (the cursor de-spill
-            // path); the partition reverts only once its last key is gone.
+            // Spilled -> empty, draining both keys through a cursor over the spilled representation
+            // (the cursor de-spill path); the partition reverts only once its last key is gone.
             {
                 let mut cursor = index.get_mut(&[0x10, 0x01]).unwrap();
                 assert_eq!(cursor.next().copied(), Some(1));
@@ -1061,7 +734,7 @@ mod tests {
             let mut index = new_index_spilling(context);
             index.insert(&[0x10, 0x01], 1);
             index.insert(&[0x10, 0x02], 2); // spills
-            let mut cursor = index.get_mut(&[0x10, 0x01]).unwrap(); // SpilledCursor
+            let mut cursor = index.get_mut(&[0x10, 0x01]).unwrap(); // cursor over the spilled partition
             cursor.delete();
         });
     }


### PR DESCRIPTION
- **One cursor instead of two.** The `next`/`update`/`insert`/`delete` state machine was duplicated across `SoaCursor` and `SpilledCursor` (plus a forwarding `Cursor` enum). Now a single `Cursor` runs that protocol once over a `Backing` enum (`len`/`get`/`set`/`insert`/`remove`); only the store ops differ. Removes the hand-synced duplication; 4 cursor types → 2.
- **Move cursor machinery to `cursor.rs`.** Leaves `mod.rs` as the index (routing, spill, nav); `Cursor` re-exported to keep its public path.
- **`spilled_partition(i)` accessor.** Replaces 7 copies of `if !spilled.is_empty() { if let Some(inner) = spilled.get(&i) {…} }` (5 nav helpers + 2 routing checks), keeping the empty-map fast path in one place.

Note: `run.is_empty()` → `run.start == run.end` — `is_empty()` on the `&mut Range` binding trips `-D unstable-name-collisions`.
