### PR TITLE
[storage/qmdb] Cache decoded keys during snapshot init to avoid redundant log reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,6 +1811,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "paste",
  "rand 0.8.5",
+ "rand_distr",
  "rstest",
  "thiserror 2.0.17",
  "tracing",

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -48,7 +48,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
             page_cache,
         },
         translator: Translator::default(),
-        init_cache_size: 1 << 16,
+        init_cache_size: Some(NZUsize!(1 << 16)),
     }
 }
 

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -48,6 +48,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
             page_cache,
         },
         translator: Translator::default(),
+        init_cache_size: 1 << 16,
     }
 }
 

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -71,7 +71,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
         },
         grafted_metadata_partition: "grafted-mmr-metadata".into(),
         translator: Translator::default(),
-        init_cache_size: 1 << 16,
+        init_cache_size: Some(NZUsize!(1 << 16)),
     }
 }
 

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -71,6 +71,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
         },
         grafted_metadata_partition: "grafted-mmr-metadata".into(),
         translator: Translator::default(),
+        init_cache_size: 1 << 16,
     }
 }
 

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -49,6 +49,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, FConfig,
             page_cache,
         },
         translator: commonware_storage::translator::EightCap,
+        init_cache_size: 1 << 16,
     }
 }
 

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -49,7 +49,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, FConfig,
             page_cache,
         },
         translator: commonware_storage::translator::EightCap,
-        init_cache_size: 1 << 16,
+        init_cache_size: Some(NZUsize!(1 << 16)),
     }
 }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -1567,7 +1567,7 @@ mod tests {
                 write_buffer: IO_BUFFER_SIZE,
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -1567,6 +1567,7 @@ mod tests {
                 write_buffer: IO_BUFFER_SIZE,
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1068,6 +1068,7 @@ mod tests {
             },
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 
@@ -1095,6 +1096,7 @@ mod tests {
             },
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1068,7 +1068,7 @@ mod tests {
             },
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 
@@ -1096,7 +1096,7 @@ mod tests {
             },
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -584,7 +584,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -584,6 +584,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -506,7 +506,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -506,6 +506,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -440,6 +440,7 @@ impl EngineDefinition for MultiDbEngine {
                 write_buffer: IO_BUFFER_SIZE,
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         };
         // One witness entry per section so the periodic prune actually drops entries
         // (pruning is section-aligned).

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -440,7 +440,7 @@ impl EngineDefinition for MultiDbEngine {
                 write_buffer: IO_BUFFER_SIZE,
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         };
         // One witness entry per section so the periodic prune actually drops entries
         // (pruning is section-aligned).

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -365,7 +365,7 @@ impl EngineDefinition for SingleDbEngine {
                 write_buffer: IO_BUFFER_SIZE,
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         };
 
         // Destructure the 7 channels.

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -365,6 +365,7 @@ impl EngineDefinition for SingleDbEngine {
                 write_buffer: IO_BUFFER_SIZE,
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         };
 
         // Destructure the 7 channels.

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -42,6 +42,7 @@ criterion.workspace = true
 governor.workspace = true
 paste.workspace = true
 rand.workspace = true
+rand_distr.workspace = true
 rstest.workspace = true
 tracing-subscriber.workspace = true
 
@@ -89,6 +90,12 @@ path = "src/qmdb/benches/constantinople.rs"
 name = "qmdb"
 harness = false
 path = "src/qmdb/benches/bench.rs"
+required-features = ["test-traits"]
+
+[[bench]]
+name = "init_scale"
+harness = false
+path = "src/qmdb/benches/init_scale.rs"
 required-features = ["test-traits"]
 
 [[bench]]

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -23,7 +23,7 @@ use commonware_storage::{
     },
     translator::TwoCap,
 };
-use commonware_utils::{sequence::FixedBytes, NZU64};
+use commonware_utils::{sequence::FixedBytes, NZUsize, NZU64};
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::HashMap,
@@ -120,7 +120,7 @@ fn make_config(
         },
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
-        init_cache_size: 3,
+        init_cache_size: Some(NZUsize!(3)),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -120,6 +120,7 @@ fn make_config(
         },
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
+        init_cache_size: 1024,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -120,7 +120,7 @@ fn make_config(
         },
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
-        init_cache_size: 1024,
+        init_cache_size: 3,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -164,7 +164,7 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         },
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
-        init_cache_size: 1024,
+        init_cache_size: 3,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -164,6 +164,7 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         },
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
+        init_cache_size: 1024,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -164,7 +164,7 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         },
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
-        init_cache_size: 3,
+        init_cache_size: Some(NZUsize!(3)),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -158,6 +158,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             },
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
+            init_cache_size: 1024,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -158,7 +158,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             },
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
-            init_cache_size: 3,
+            init_cache_size: Some(NZUsize!(3)),
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -158,7 +158,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             },
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: 3,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -95,6 +95,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
+        init_cache_size: 1024,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -95,7 +95,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
-        init_cache_size: 1024,
+        init_cache_size: 3,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -95,7 +95,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
-        init_cache_size: 3,
+        init_cache_size: Some(NZUsize!(3)),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -148,7 +148,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             },
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
-            init_cache_size: 3,
+            init_cache_size: Some(NZUsize!(3)),
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -148,6 +148,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             },
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
+            init_cache_size: 1024,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -148,7 +148,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             },
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: 3,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -111,7 +111,7 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
             page_cache,
         },
         translator: TwoCap,
-        init_cache_size: 1024,
+        init_cache_size: 3,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -111,6 +111,7 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
             page_cache,
         },
         translator: TwoCap,
+        init_cache_size: 1024,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -111,7 +111,7 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
             page_cache,
         },
         translator: TwoCap,
-        init_cache_size: 3,
+        init_cache_size: Some(NZUsize!(3)),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -162,7 +162,7 @@ fn test_config(
             page_cache,
         },
         translator: TwoCap,
-        init_cache_size: 1024,
+        init_cache_size: 3,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -162,7 +162,7 @@ fn test_config(
             page_cache,
         },
         translator: TwoCap,
-        init_cache_size: 3,
+        init_cache_size: Some(NZUsize!(3)),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -162,6 +162,7 @@ fn test_config(
             page_cache,
         },
         translator: TwoCap,
+        init_cache_size: 1024,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -118,7 +118,7 @@ fn db_config(
             page_cache,
         },
         translator: TwoCap,
-        init_cache_size: 1024,
+        init_cache_size: 3,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -118,6 +118,7 @@ fn db_config(
             page_cache,
         },
         translator: TwoCap,
+        init_cache_size: 1024,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -118,7 +118,7 @@ fn db_config(
             page_cache,
         },
         translator: TwoCap,
-        init_cache_size: 3,
+        init_cache_size: Some(NZUsize!(3)),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -106,6 +106,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
+                init_cache_size: 1024,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -106,7 +106,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
-                init_cache_size: 3,
+                init_cache_size: Some(NZUsize!(3)),
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -106,7 +106,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
-                init_cache_size: 1024,
+                init_cache_size: 3,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -134,7 +134,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
-                init_cache_size: 3,
+                init_cache_size: Some(NZUsize!(3)),
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -134,6 +134,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
+                init_cache_size: 1024,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -134,7 +134,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
-                init_cache_size: 1024,
+                init_cache_size: 3,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -94,6 +94,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
             page_cache,
         },
         translator: OneCap,
+        init_cache_size: 1024,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -94,7 +94,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
             page_cache,
         },
         translator: OneCap,
-        init_cache_size: 3,
+        init_cache_size: Some(NZUsize!(3)),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -94,7 +94,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
             page_cache,
         },
         translator: OneCap,
-        init_cache_size: 1024,
+        init_cache_size: 3,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -109,7 +109,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
-                init_cache_size: 3,
+                init_cache_size: Some(NZUsize!(3)),
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -109,6 +109,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
+                init_cache_size: 1024,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -109,7 +109,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     page_cache,
                 },
                 translator: EightCap,
-                init_cache_size: 1024,
+                init_cache_size: 3,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/store_operations.rs
+++ b/storage/fuzz/fuzz_targets/store_operations.rs
@@ -107,7 +107,7 @@ fn test_config(
             page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
         },
         translator: TwoCap,
-        init_cache_size: 1024,
+        init_cache_size: 3,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/store_operations.rs
+++ b/storage/fuzz/fuzz_targets/store_operations.rs
@@ -107,6 +107,7 @@ fn test_config(
             page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
         },
         translator: TwoCap,
+        init_cache_size: 1024,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/store_operations.rs
+++ b/storage/fuzz/fuzz_targets/store_operations.rs
@@ -107,7 +107,7 @@ fn test_config(
             page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
         },
         translator: TwoCap,
-        init_cache_size: 3,
+        init_cache_size: Some(NZUsize!(3)),
     }
 }
 

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -448,10 +448,11 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         if self.is_empty() {
             return None;
         }
-        let (i, sub) = partition_index_and_sub_key::<P>(key);
-        let k = self.translator.transform(sub);
+
         // The largest translated key strictly less than `k`: within the partition first, then the
         // last key of the nearest lower partition, else cycle to the global last key.
+        let (i, sub) = partition_index_and_sub_key::<P>(key);
+        let k = self.translator.transform(sub);
         if let Some(vals) = self.partition_prev_before(i, &k) {
             return Some((vals.iter(), false));
         }
@@ -479,10 +480,11 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         if self.is_empty() {
             return None;
         }
-        let (i, sub) = partition_index_and_sub_key::<P>(key);
-        let k = self.translator.transform(sub);
+
         // The smallest translated key strictly greater than `k`: within the partition first, then
         // the first key of the nearest higher partition, else cycle to the global first key.
+        let (i, sub) = partition_index_and_sub_key::<P>(key);
+        let k = self.translator.transform(sub);
         if let Some(vals) = self.partition_next_after(i, &k) {
             return Some((vals.iter(), false));
         }
@@ -507,6 +509,8 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         if self.is_empty() {
             return None;
         }
+
+        // Scan partitions in ascending order for the global first key.
         for p in 0..self.partitions.len() {
             if let Some(vals) = self.partition_first(p) {
                 return Some(vals.iter());
@@ -523,6 +527,8 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         if self.is_empty() {
             return None;
         }
+
+        // Scan partitions in descending order for the global last key.
         for p in (0..self.partitions.len()).rev() {
             if let Some(vals) = self.partition_last(p) {
                 return Some(vals.iter());

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -167,6 +167,11 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         })
     }
 
+    /// Whether the index currently holds no keys.
+    fn is_empty(&self) -> bool {
+        self.keys.get() == 0
+    }
+
     /// Values of the smallest key strictly greater than `k` in partition `i`.
     fn partition_next_after(&self, i: usize, k: &T::Key) -> Option<&[V]> {
         self.partitions[i].next_values_after(k).or_else(|| {
@@ -439,6 +444,10 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
     where
         V: 'a,
     {
+        // Skip the all-partitions scan when there is nothing to find.
+        if self.is_empty() {
+            return None;
+        }
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
         // The largest translated key strictly less than `k`: within the partition first, then the
@@ -466,6 +475,10 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
     where
         V: 'a,
     {
+        // Skip the all-partitions scan when there is nothing to find.
+        if self.is_empty() {
+            return None;
+        }
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
         // The smallest translated key strictly greater than `k`: within the partition first, then
@@ -490,6 +503,10 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
     where
         V: 'a,
     {
+        // Skip the all-partitions scan when there is nothing to find.
+        if self.is_empty() {
+            return None;
+        }
         for p in 0..self.partitions.len() {
             if let Some(vals) = self.partition_first(p) {
                 return Some(vals.iter());
@@ -502,6 +519,10 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
     where
         V: 'a,
     {
+        // Skip the all-partitions scan when there is nothing to find.
+        if self.is_empty() {
+            return None;
+        }
         for p in (0..self.partitions.len()).rev() {
             if let Some(vals) = self.partition_last(p) {
                 return Some(vals.iter());
@@ -528,6 +549,67 @@ mod tests {
     /// so keys sharing a first byte land in one partition.
     fn new_index_spilling(context: deterministic::Context) -> Index<OneCap, u64, 1> {
         Index::with_threshold(context, OneCap, 2)
+    }
+
+    #[test_traced]
+    fn test_empty_and_sparse_nav() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut index = new_index(context);
+
+            // Empty index: every ordered navigation returns None (via the empty fast path, without
+            // scanning all partitions).
+            assert!(index.first_translated_key().is_none());
+            assert!(index.last_translated_key().is_none());
+            assert!(index.prev_translated_key(&[0x80, 0x00]).is_none());
+            assert!(index.next_translated_key(&[0x80, 0x00]).is_none());
+
+            // Two keys in widely separated partitions (0x05 and 0xF0): neighbor scans must still
+            // cross the large empty gap between them.
+            index.insert(&[0x05, 0x01], 1);
+            index.insert(&[0xF0, 0x02], 2);
+            assert_eq!(index.keys(), 2);
+            assert_eq!(
+                index
+                    .first_translated_key()
+                    .unwrap()
+                    .copied()
+                    .collect::<Vec<_>>(),
+                vec![1]
+            );
+            assert_eq!(
+                index
+                    .last_translated_key()
+                    .unwrap()
+                    .copied()
+                    .collect::<Vec<_>>(),
+                vec![2]
+            );
+
+            // Forward across the gap, then wrap from the global last key.
+            let (it, wrapped) = index.next_translated_key(&[0x05, 0x01]).unwrap();
+            assert_eq!((it.copied().collect::<Vec<_>>(), wrapped), (vec![2], false));
+            let (it, wrapped) = index.next_translated_key(&[0xF0, 0x02]).unwrap();
+            assert_eq!((it.copied().collect::<Vec<_>>(), wrapped), (vec![1], true));
+
+            // Backward across the gap, then wrap from the global first key.
+            let (it, wrapped) = index.prev_translated_key(&[0xF0, 0x02]).unwrap();
+            assert_eq!((it.copied().collect::<Vec<_>>(), wrapped), (vec![1], false));
+            let (it, wrapped) = index.prev_translated_key(&[0x05, 0x01]).unwrap();
+            assert_eq!((it.copied().collect::<Vec<_>>(), wrapped), (vec![2], true));
+
+            // A query landing in an empty partition between the two finds both neighbors.
+            let (it, wrapped) = index.prev_translated_key(&[0x80, 0x00]).unwrap();
+            assert_eq!((it.copied().collect::<Vec<_>>(), wrapped), (vec![1], false));
+            let (it, wrapped) = index.next_translated_key(&[0x80, 0x00]).unwrap();
+            assert_eq!((it.copied().collect::<Vec<_>>(), wrapped), (vec![2], false));
+
+            // Removing all keys returns to the empty fast path.
+            index.remove(&[0x05, 0x01]);
+            index.remove(&[0xF0, 0x02]);
+            assert_eq!(index.keys(), 0);
+            assert!(index.prev_translated_key(&[0x80, 0x00]).is_none());
+            assert!(index.next_translated_key(&[0x80, 0x00]).is_none());
+        });
     }
 
     #[test_traced]

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -669,6 +669,7 @@ where
         mut index: I,
         log: AuthenticatedLog<F, E, C, H, S>,
         shared_bitmap: Option<Arc<Shared<N>>>,
+        cache_size: usize,
         metrics: Metrics<E>,
     ) -> Result<Self, crate::qmdb::Error<F>> {
         let (last_commit_loc, inactivity_floor_loc, active_keys, bitmap) = {
@@ -720,6 +721,7 @@ where
                     inactivity_floor_loc,
                     &log,
                     &mut index,
+                    cache_size,
                     |is_active, old_loc| {
                         let mut guard = bitmap.write();
                         guard.push(is_active);

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -25,7 +25,7 @@ use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
 use commonware_utils::bitmap;
-use core::num::NonZeroU64;
+use core::num::{NonZeroU64, NonZeroUsize};
 use std::{collections::HashMap, sync::Arc};
 
 /// Estimate of the number of keys per shard at which parallelizing [`Db::get_many_map`]'s
@@ -669,7 +669,7 @@ where
         mut index: I,
         log: AuthenticatedLog<F, E, C, H, S>,
         shared_bitmap: Option<Arc<Shared<N>>>,
-        cache_size: usize,
+        cache_size: Option<NonZeroUsize>,
         metrics: Metrics<E>,
     ) -> Result<Self, crate::qmdb::Error<F>> {
         let (last_commit_loc, inactivity_floor_loc, active_keys, bitmap) = {

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -110,6 +110,11 @@ pub struct Config<T: Translator, J, S: Strategy> {
 
     /// The translator used by the compressed index.
     pub translator: T,
+
+    /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
+    /// collisions without re-reading the log; `0` disables it. The cache is held only for the
+    /// duration of init.
+    pub init_cache_size: usize,
 }
 
 /// Configuration for an `Any` authenticated db with fixed-size values.
@@ -174,7 +179,7 @@ where
 
     let index = I::new(context.child("index"), cfg.translator);
     let metrics = db::Metrics::new(context);
-    db::Db::init_from_log(index, log, bitmap, metrics).await
+    db::Db::init_from_log(index, log, bitmap, cfg.init_cache_size, metrics).await
 }
 
 #[cfg(test)]
@@ -233,6 +238,7 @@ pub(crate) mod test {
                 write_buffer: NZUsize!(1024),
             },
             translator: T::default(),
+            init_cache_size: 1024,
         }
     }
 
@@ -259,6 +265,7 @@ pub(crate) mod test {
                 write_buffer: NZUsize!(1024),
             },
             translator: T::default(),
+            init_cache_size: 1024,
         }
     }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -83,6 +83,7 @@ use commonware_codec::CodecShared;
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
+use core::num::NonZeroUsize;
 use std::sync::Arc;
 use tracing::warn;
 
@@ -112,8 +113,8 @@ pub struct Config<T: Translator, J, S: Strategy> {
     pub translator: T,
 
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
-    /// collisions without re-reading the log; `0` disables it.
-    pub init_cache_size: usize,
+    /// collisions without re-reading the log; `None` disables it.
+    pub init_cache_size: Option<NonZeroUsize>,
 }
 
 /// Configuration for an `Any` authenticated db with fixed-size values.
@@ -237,7 +238,7 @@ pub(crate) mod test {
                 write_buffer: NZUsize!(1024),
             },
             translator: T::default(),
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 
@@ -264,7 +265,7 @@ pub(crate) mod test {
                 write_buffer: NZUsize!(1024),
             },
             translator: T::default(),
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -112,8 +112,7 @@ pub struct Config<T: Translator, J, S: Strategy> {
     pub translator: T,
 
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
-    /// collisions without re-reading the log; `0` disables it. The cache is held only for the
-    /// duration of init.
+    /// collisions without re-reading the log; `0` disables it.
     pub init_cache_size: usize,
 }
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -192,6 +192,7 @@ pub(crate) mod test {
                 page_cache,
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -192,7 +192,7 @@ pub(crate) mod test {
                 page_cache,
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -60,6 +60,7 @@ async fn build_db<F, E, U, I, H, C, T, S>(
     pinned_nodes: Option<Vec<H::Digest>>,
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
+    cache_size: usize,
 ) -> Result<Db<F, E, C, I, H, U, { crate::qmdb::any::BITMAP_CHUNK_BYTES }, S>, qmdb::Error<F>>
 where
     F: merkle::Family,
@@ -94,7 +95,7 @@ where
     )
     .await?;
     let metrics = Metrics::new(context);
-    let db = Db::init_from_log(index, log, None, metrics).await?;
+    let db = Db::init_from_log(index, log, None, cache_size, metrics).await?;
 
     Ok(db)
 }
@@ -133,6 +134,7 @@ macro_rules! impl_sync_database {
             ) -> Result<Self, qmdb::Error<F>> {
                 let merkle_config = config.merkle_config.clone();
                 let translator = config.translator.clone();
+                let cache_size = config.init_cache_size;
                 build_db::<F, _, $update<K, V>, _, H, _, T, S>(
                     context,
                     merkle_config,
@@ -141,6 +143,7 @@ macro_rules! impl_sync_database {
                     pinned_nodes,
                     range,
                     apply_batch_size,
+                    cache_size,
                 )
                 .await
             }

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -46,6 +46,7 @@ use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use commonware_utils::{range::NonEmptyRange, Array};
+use core::num::NonZeroUsize;
 
 #[cfg(test)]
 pub(crate) mod tests;
@@ -60,7 +61,7 @@ async fn build_db<F, E, U, I, H, C, T, S>(
     pinned_nodes: Option<Vec<H::Digest>>,
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
-    cache_size: usize,
+    cache_size: Option<NonZeroUsize>,
 ) -> Result<Db<F, E, C, I, H, U, { crate::qmdb::any::BITMAP_CHUNK_BYTES }, S>, qmdb::Error<F>>
 where
     F: merkle::Family,

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -142,7 +142,8 @@ pub(crate) mod test {
         deterministic::{self, Context},
         Metrics as _, Runner as _, Supervisor as _,
     };
-    use commonware_utils::{test_rng_seeded, NZU64};
+    use commonware_utils::{test_rng_seeded, NZUsize, NZU64};
+    use core::num::NonZeroUsize;
     use rand::RngCore;
     use std::collections::HashMap;
 
@@ -255,7 +256,7 @@ pub(crate) mod test {
     }
 
     /// The init-time `(location -> key)` cache only memoizes log reads, so rebuilding the snapshot
-    /// with the cache disabled (`init_cache_size = 0`) or enabled must produce the identical root.
+    /// with the cache disabled (`init_cache_size = None`) or enabled must produce the identical root.
     #[test_traced("WARN")]
     fn test_unordered_fixed_init_cache_equivalence() {
         deterministic::Runner::default().start(|context| async move {
@@ -271,12 +272,18 @@ pub(crate) mod test {
 
             // Reopen with the cache disabled and with a large cache; both rebuild the snapshot by
             // replaying the same immutable log, so both roots must equal the pre-drop root.
-            for cache_size in [0, 1 << 20] {
+            for cache_size in [None, Some(NZUsize!(1 << 20))] {
                 let mut cfg = fixed_db_config::<TwoCap>("cache_equiv", &context);
                 cfg.init_cache_size = cache_size;
-                let ctx = context.child("reopen").with_attribute("cache", cache_size);
+                let ctx = context
+                    .child("reopen")
+                    .with_attribute("cache", cache_size.map_or(0, NonZeroUsize::get));
                 let db = AnyTest::init(ctx, cfg).await.unwrap();
-                assert_eq!(db.root(), root, "root mismatch at cache_size={cache_size}");
+                assert_eq!(
+                    db.root(),
+                    root,
+                    "root mismatch at cache_size={cache_size:?}"
+                );
                 drop(db);
             }
         });

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -254,6 +254,34 @@ pub(crate) mod test {
         Sha256::hash(&(i + 10000).to_be_bytes())
     }
 
+    /// The init-time `(location -> key)` cache only memoizes log reads, so rebuilding the snapshot
+    /// with the cache disabled (`init_cache_size = 0`) or enabled must produce the identical root.
+    #[test_traced("WARN")]
+    fn test_unordered_fixed_init_cache_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            // Populate a database with churny operations (repeated updates and deletes drive the
+            // collision resolution that the cache accelerates), then commit and drop it.
+            let cfg = fixed_db_config::<TwoCap>("cache_equiv", &context);
+            let mut db = AnyTest::init(context.child("populate"), cfg).await.unwrap();
+            apply_ops(&mut db, create_test_ops(10_000)).await;
+            db.commit().await.unwrap();
+            db.sync().await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            // Reopen with the cache disabled and with a large cache; both rebuild the snapshot by
+            // replaying the same immutable log, so both roots must equal the pre-drop root.
+            for cache_size in [0, 1 << 20] {
+                let mut cfg = fixed_db_config::<TwoCap>("cache_equiv", &context);
+                cfg.init_cache_size = cache_size;
+                let ctx = context.child("reopen").with_attribute("cache", cache_size);
+                let db = AnyTest::init(ctx, cfg).await.unwrap();
+                assert_eq!(db.root(), root, "root mismatch at cache_size={cache_size}");
+                drop(db);
+            }
+        });
+    }
+
     #[test_traced("INFO")]
     fn test_any_unordered_fixed_metrics() {
         deterministic::Runner::default().start(|ctx| async move {

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -173,7 +173,7 @@ pub(crate) mod test {
                 page_cache,
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -173,6 +173,7 @@ pub(crate) mod test {
                 page_cache,
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 

--- a/storage/src/qmdb/benches/apply_batch.rs
+++ b/storage/src/qmdb/benches/apply_batch.rs
@@ -2,7 +2,7 @@
 
 use crate::common::{
     any_fix_cfg_with, imm_fix_cfg_with, make_fixed_value, seed_db, AnyOFixP256Db, AnyUFixDb,
-    Digest, ImmFixDb, CHUNK_SIZE,
+    Digest, ImmFixDb, CHUNK_SIZE, PAGE_CACHE_SIZE,
 };
 use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_macros::boxed;
@@ -50,9 +50,12 @@ fn write_updates<D: BatchableDb<K = Digest, V = Digest>>(
 }
 
 async fn open_db(ctx: &Context) -> Db {
-    Db::init(ctx.child("storage"), any_fix_cfg_with(ctx, ITEMS_PER_BLOB))
-        .await
-        .unwrap()
+    Db::init(
+        ctx.child("storage"),
+        any_fix_cfg_with(ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE),
+    )
+    .await
+    .unwrap()
 }
 
 #[boxed]
@@ -73,9 +76,12 @@ async fn bench_direct_apply(ctx: &Context, updates: u64) -> Duration {
 }
 
 async fn open_ord_db(ctx: &Context) -> ODb {
-    ODb::init(ctx.child("storage"), any_fix_cfg_with(ctx, ITEMS_PER_BLOB))
-        .await
-        .unwrap()
+    ODb::init(
+        ctx.child("storage"),
+        any_fix_cfg_with(ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE),
+    )
+    .await
+    .unwrap()
 }
 
 #[boxed]

--- a/storage/src/qmdb/benches/chained_growth.rs
+++ b/storage/src/qmdb/benches/chained_growth.rs
@@ -86,6 +86,7 @@ fn cur_fix_cfg(
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
+        init_cache_size: crate::common::INIT_CACHE_SIZE,
     }
 }
 

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -44,6 +44,9 @@ pub const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(512);
 pub const DELETE_FREQUENCY: u32 = 10;
 pub const VARIABLE_VALUE_MAX_LEN: usize = 256;
 pub const WRITE_BUFFER_SIZE: NonZeroUsize = NZUsize!(2 * 1024 * 1024);
+/// Default init-time `(location -> key)` cache size for bench databases. The init benchmark
+/// overrides this per-case to sweep cache sizes.
+pub const INIT_CACHE_SIZE: usize = 1 << 18;
 
 // -- Fixed value (Digest), fixed storage layout --
 
@@ -149,6 +152,7 @@ pub fn any_fix_cfg_with(
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         translator: EightCap,
+        init_cache_size: INIT_CACHE_SIZE,
     }
 }
 
@@ -161,6 +165,7 @@ pub fn imm_fix_cfg_with(
         merkle_config: merkle_cfg(PARTITION_IMM, ctx, page_cache.clone(), items_per_blob),
         log: fix_log_cfg(PARTITION_IMM, page_cache, items_per_blob),
         translator: EightCap,
+        init_cache_size: INIT_CACHE_SIZE,
     }
 }
 
@@ -180,6 +185,7 @@ pub fn cur_fix_cfg_with(
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_FIX}"),
         translator: EightCap,
+        init_cache_size: INIT_CACHE_SIZE,
     }
 }
 
@@ -198,6 +204,7 @@ pub fn any_var_digest_cfg_with(
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         translator: EightCap,
+        init_cache_size: INIT_CACHE_SIZE,
     }
 }
 
@@ -217,6 +224,7 @@ pub fn cur_var_digest_cfg_with(
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
+        init_cache_size: INIT_CACHE_SIZE,
     }
 }
 
@@ -243,6 +251,7 @@ pub fn any_var_vec_cfg_with(
             items_per_blob,
         ),
         translator: EightCap,
+        init_cache_size: INIT_CACHE_SIZE,
     }
 }
 
@@ -267,6 +276,7 @@ pub fn cur_var_vec_cfg_with(
         ),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
+        init_cache_size: INIT_CACHE_SIZE,
     }
 }
 
@@ -344,12 +354,13 @@ macro_rules! define_db_variants {
 
         #[allow(unused_macros)]
         macro_rules! $timed_dispatch_name {
-            ($ctx_expr:expr, $variant_expr:expr, $iters:expr, |$db_name:ident| $body:expr) => {
+            ($ctx_expr:expr, $variant_expr:expr, $iters:expr, $cache_size:expr, |$db_name:ident| $body:expr) => {
                 match $variant_expr {
                     $(
                         $enum_name::$entry => {
                             let ctx = $ctx_expr;
-                            let cfg = $cfg(&ctx);
+                            let mut cfg = $cfg(&ctx);
+                            cfg.init_cache_size = $cache_size;
                             let start = std::time::Instant::now();
                             for _ in 0..$iters {
                                 #[allow(unused_mut)]

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -47,7 +47,7 @@ pub const VARIABLE_VALUE_MAX_LEN: usize = 256;
 pub const WRITE_BUFFER_SIZE: NonZeroUsize = NZUsize!(2 * 1024 * 1024);
 /// Default init-time `(location -> key)` cache size for bench databases. The init benchmark
 /// overrides this per-case to sweep cache sizes.
-pub const INIT_CACHE_SIZE: usize = 1 << 18;
+pub const INIT_CACHE_SIZE: Option<NonZeroUsize> = Some(NZUsize!(1 << 18));
 
 // -- Fixed value (Digest), fixed storage layout --
 

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -570,6 +570,10 @@ pub(crate) use define_vec_variants;
 /// Seed a database with `num_elements` entries, then perform `num_operations` random
 /// updates/deletes. Commits periodically when `commit_frequency` is `Some`.
 ///
+/// `seed_batch` caps how many seeds accumulate before each merkleize+apply+commit (bounding peak
+/// memory); `None` seeds in a single batch. `prune_frequency` prunes to the inactivity floor every
+/// `Some(n)` commits to bound on-disk growth; `None` never prunes during generation.
+///
 /// `key_zipf_exponent` selects how update/delete keys are sampled: `None` is uniform; `Some(s)`
 /// draws keys from a Zipf distribution with exponent `s`, so a hot subset is churned far more than
 /// the long tail (a more realistic workload than uniform churn).
@@ -579,6 +583,7 @@ pub(crate) use define_vec_variants;
 /// `k >= num_elements`) seeds a uniform-random subset of `num_elements` keys out of `k` and samples
 /// updates over all of `k`, so some updates land on unseeded keys and insert them organically -- a
 /// growing keyspace rather than a fixed population.
+#[allow(clippy::too_many_arguments)]
 pub async fn gen_random_kv<F, M>(
     db: &mut M,
     num_elements: u64,
@@ -610,10 +615,7 @@ pub async fn gen_random_kv<F, M>(
         for i in 0u64..num_elements {
             // With a sparse `keyspace`, seed a uniform-random subset of it (so later updates can land
             // on unseeded keys and insert them); otherwise seed keys 0..num_elements.
-            let idx = match keyspace {
-                Some(k) => rng.next_u64() % k,
-                None => i,
-            };
+            let idx = keyspace.map_or(i, |k| rng.next_u64() % k);
             let key = Sha256::hash(&idx.to_be_bytes());
             batch = batch.write(key, Some(make_value(&mut rng)));
             pending += 1;
@@ -622,7 +624,7 @@ pub async fn gen_random_kv<F, M>(
                 db.apply_batch(merkleized).await.unwrap();
                 db.commit().await.unwrap();
                 commits += 1;
-                if prune_frequency.is_some_and(|n| commits % n == 0) {
+                if prune_frequency.is_some_and(|n| commits.is_multiple_of(n)) {
                     let boundary = db.sync_boundary().await;
                     db.prune(boundary).await.unwrap();
                 }
@@ -662,7 +664,7 @@ pub async fn gen_random_kv<F, M>(
                     db.apply_batch(merkleized).await.unwrap();
                     db.commit().await.unwrap();
                     commits += 1;
-                    if prune_frequency.is_some_and(|n| commits % n == 0) {
+                    if prune_frequency.is_some_and(|n| commits.is_multiple_of(n)) {
                         let boundary = db.sync_boundary().await;
                         db.prune(boundary).await.unwrap();
                     }

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -28,7 +28,8 @@ use commonware_storage::{
     translator::EightCap,
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{distributions::Distribution, rngs::StdRng, RngCore, SeedableRng};
+use rand_distr::Zipf;
 use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
 
 pub type Digest = <Sha256 as Hasher>::Digest;
@@ -140,14 +141,15 @@ fn var_log_cfg<C>(
 }
 
 pub fn any_fix_cfg(ctx: &(impl BufferPooler + ThreadPooler)) -> AnyFixedConfig<EightCap, Rayon> {
-    any_fix_cfg_with(ctx, ITEMS_PER_BLOB)
+    any_fix_cfg_with(ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE)
 }
 
 pub fn any_fix_cfg_with(
     ctx: &(impl BufferPooler + ThreadPooler),
     items_per_blob: NonZeroU64,
+    page_cache_size: NonZeroUsize,
 ) -> AnyFixedConfig<EightCap, Rayon> {
-    let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
+    let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, page_cache_size);
     AnyFixedConfig {
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
@@ -567,11 +569,25 @@ pub(crate) use define_vec_variants;
 
 /// Seed a database with `num_elements` entries, then perform `num_operations` random
 /// updates/deletes. Commits periodically when `commit_frequency` is `Some`.
+///
+/// `key_zipf_exponent` selects how update/delete keys are sampled: `None` is uniform; `Some(s)`
+/// draws keys from a Zipf distribution with exponent `s`, so a hot subset is churned far more than
+/// the long tail (a more realistic workload than uniform churn).
+///
+/// `keyspace` sets the index space that keys are drawn from. `None` means `num_elements` (every key
+/// is seeded once, 0..num_elements, and updates only touch seeded keys). `Some(k)` (with
+/// `k >= num_elements`) seeds a uniform-random subset of `num_elements` keys out of `k` and samples
+/// updates over all of `k`, so some updates land on unseeded keys and insert them organically -- a
+/// growing keyspace rather than a fixed population.
 pub async fn gen_random_kv<F, M>(
     db: &mut M,
     num_elements: u64,
     num_operations: u64,
     commit_frequency: Option<u32>,
+    seed_batch: Option<u64>,
+    prune_frequency: Option<u32>,
+    key_zipf_exponent: Option<f64>,
+    keyspace: Option<u64>,
     make_value: impl Fn(&mut StdRng) -> M::Value,
 ) where
     F: Family,
@@ -579,22 +595,62 @@ pub async fn gen_random_kv<F, M>(
 {
     let mut rng = StdRng::seed_from_u64(42);
 
-    // Seed the db with `num_elements` entries.
+    // Count commits across both phases so `prune_frequency` can prune to the inactivity floor every
+    // N commits, bounding on-disk growth instead of accumulating the whole (re-appended) log until
+    // the end. Pruning below the floor never affects an `init` replay, which starts at the floor.
+    let mut commits = 0u32;
+
+    // Seed the db with `num_elements` entries. `seed_batch` caps how many seeds accumulate before a
+    // merkleize+apply (bounding the batch); `None` seeds in a single batch. Each apply is followed by
+    // a `commit`, whose `merkle.flush()` writes the in-memory merkle nodes to the journal and prunes
+    // them from memory -- without that, a large build accumulates the whole merkle in RAM.
     {
         let mut batch = db.new_batch();
+        let mut pending = 0u64;
         for i in 0u64..num_elements {
-            let k = Sha256::hash(&i.to_be_bytes());
-            batch = batch.write(k, Some(make_value(&mut rng)));
+            // With a sparse `keyspace`, seed a uniform-random subset of it (so later updates can land
+            // on unseeded keys and insert them); otherwise seed keys 0..num_elements.
+            let idx = match keyspace {
+                Some(k) => rng.next_u64() % k,
+                None => i,
+            };
+            let key = Sha256::hash(&idx.to_be_bytes());
+            batch = batch.write(key, Some(make_value(&mut rng)));
+            pending += 1;
+            if seed_batch.is_some_and(|n| pending >= n) {
+                let merkleized = batch.merkleize(db, None).await.unwrap();
+                db.apply_batch(merkleized).await.unwrap();
+                db.commit().await.unwrap();
+                commits += 1;
+                if prune_frequency.is_some_and(|n| commits % n == 0) {
+                    let boundary = db.sync_boundary().await;
+                    db.prune(boundary).await.unwrap();
+                }
+                batch = db.new_batch();
+                pending = 0;
+            }
         }
-        let merkleized = batch.merkleize(db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        if pending > 0 {
+            let merkleized = batch.merkleize(db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap();
+        }
     }
 
-    // Perform `num_operations` random updates/deletes, committing periodically.
+    // Perform `num_operations` random updates/deletes, committing periodically. Each apply is
+    // followed by a `commit` so the merkle structure is flushed out of memory (see the seed phase).
     {
+        // Sample over the full keyspace (which may exceed the seeded set, so some samples hit unseeded
+        // keys and insert them). `Zipf::new` samples a rank in `[1, space]`; map it to a 0-based index.
+        let space = keyspace.unwrap_or(num_elements);
+        let zipf = key_zipf_exponent.map(|s| Zipf::new(space, s).expect("valid zipf parameters"));
         let mut batch = db.new_batch();
         for _ in 0u64..num_operations {
-            let rand_key = Sha256::hash(&(rng.next_u64() % num_elements).to_be_bytes());
+            let idx = match &zipf {
+                Some(z) => ((z.sample(&mut rng) as u64).saturating_sub(1)).min(space - 1),
+                None => rng.next_u64() % space,
+            };
+            let rand_key = Sha256::hash(&idx.to_be_bytes());
             if rng.next_u32() % DELETE_FREQUENCY == 0 {
                 batch = batch.write(rand_key, None);
                 continue;
@@ -604,12 +660,19 @@ pub async fn gen_random_kv<F, M>(
                 if rng.next_u32() % freq == 0 {
                     let merkleized = batch.merkleize(db, None).await.unwrap();
                     db.apply_batch(merkleized).await.unwrap();
+                    db.commit().await.unwrap();
+                    commits += 1;
+                    if prune_frequency.is_some_and(|n| commits % n == 0) {
+                        let boundary = db.sync_boundary().await;
+                        db.prune(boundary).await.unwrap();
+                    }
                     batch = db.new_batch();
                 }
             }
         }
         let merkleized = batch.merkleize(db, None).await.unwrap();
         db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
     }
 }
 

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -576,11 +576,10 @@ pub(crate) use define_vec_variants;
 /// draws keys from a Zipf distribution with exponent `s`, so a hot subset is churned far more than
 /// the long tail (a more realistic workload than uniform churn).
 ///
-/// `keyspace` sets the index space that keys are drawn from. `None` means `num_elements` (every key
-/// is seeded once, 0..num_elements, and updates only touch seeded keys). `Some(k)` (with
-/// `k >= num_elements`) seeds a uniform-random subset of `num_elements` keys out of `k` and samples
-/// updates over all of `k`, so some updates land on unseeded keys and insert them organically -- a
-/// growing keyspace rather than a fixed population.
+/// `keyspace` sets the index space that updates are drawn from; the seed is always the distinct keys
+/// `0..num_elements`. `None` means updates also draw from `0..num_elements`, so they only touch seeded
+/// keys. `Some(k)` (with `k >= num_elements`) draws updates over all of `0..k`, so some updates land on
+/// unseeded keys and insert them organically -- a growing keyspace rather than a fixed population.
 #[allow(clippy::too_many_arguments)]
 pub async fn gen_random_kv<F, M>(
     db: &mut M,
@@ -611,10 +610,7 @@ pub async fn gen_random_kv<F, M>(
         let mut batch = db.new_batch();
         let mut pending = 0u64;
         for i in 0u64..num_elements {
-            // With a sparse `keyspace`, seed a uniform-random subset of it (so later updates can land
-            // on unseeded keys and insert them); otherwise seed keys 0..num_elements.
-            let idx = keyspace.map_or(i, |k| rng.next_u64() % k);
-            let key = Sha256::hash(&idx.to_be_bytes());
+            let key = Sha256::hash(&i.to_be_bytes());
             batch = batch.write(key, Some(make_value(&mut rng)));
             pending += 1;
             if seed_batch.is_some_and(|n| pending >= n) {

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -45,8 +45,6 @@ pub const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(512);
 pub const DELETE_FREQUENCY: u32 = 10;
 pub const VARIABLE_VALUE_MAX_LEN: usize = 256;
 pub const WRITE_BUFFER_SIZE: NonZeroUsize = NZUsize!(2 * 1024 * 1024);
-/// Default init-time `(location -> key)` cache size for bench databases. The init benchmark
-/// overrides this per-case to sweep cache sizes.
 pub const INIT_CACHE_SIZE: Option<NonZeroUsize> = Some(NZUsize!(1 << 18));
 
 // -- Fixed value (Digest), fixed storage layout --

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -326,7 +326,7 @@ fn main() {
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
-                    init_cache_size: 1 << 18,
+                    init_cache_size: Some(NZUsize!(1 << 18)),
                 };
                 let db = CurrentDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(
@@ -342,7 +342,7 @@ fn main() {
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
-                    init_cache_size: 1 << 18,
+                    init_cache_size: Some(NZUsize!(1 << 18)),
                 };
                 let db = CurrentOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(
@@ -357,7 +357,7 @@ fn main() {
                     merkle_config,
                     journal_config,
                     translator: EightCap,
-                    init_cache_size: 1 << 18,
+                    init_cache_size: Some(NZUsize!(1 << 18)),
                 };
                 let db = AnyOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::ordered::fixed::mmb", AnyOrderedMerkleized)
@@ -374,7 +374,7 @@ fn main() {
                         write_buffer: WRITE_BUFFER,
                     },
                     translator: EightCap,
-                    init_cache_size: 1 << 18,
+                    init_cache_size: Some(NZUsize!(1 << 18)),
                 };
                 let db = AnyVarDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::unordered::variable::mmb", AnyVarMerkleized)
@@ -384,7 +384,7 @@ fn main() {
                     merkle_config,
                     journal_config,
                     translator: EightCap,
-                    init_cache_size: 1 << 18,
+                    init_cache_size: Some(NZUsize!(1 << 18)),
                 };
                 let db = AnyDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::unordered::fixed::mmb", AnyMerkleized)

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -326,6 +326,7 @@ fn main() {
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
+                    init_cache_size: 1 << 18,
                 };
                 let db = CurrentDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(
@@ -341,6 +342,7 @@ fn main() {
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
+                    init_cache_size: 1 << 18,
                 };
                 let db = CurrentOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(
@@ -355,6 +357,7 @@ fn main() {
                     merkle_config,
                     journal_config,
                     translator: EightCap,
+                    init_cache_size: 1 << 18,
                 };
                 let db = AnyOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::ordered::fixed::mmb", AnyOrderedMerkleized)
@@ -371,6 +374,7 @@ fn main() {
                         write_buffer: WRITE_BUFFER,
                     },
                     translator: EightCap,
+                    init_cache_size: 1 << 18,
                 };
                 let db = AnyVarDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::unordered::variable::mmb", AnyVarMerkleized)
@@ -380,6 +384,7 @@ fn main() {
                     merkle_config,
                     journal_config,
                     translator: EightCap,
+                    init_cache_size: 1 << 18,
                 };
                 let db = AnyDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::unordered::fixed::mmb", AnyMerkleized)

--- a/storage/src/qmdb/benches/generate.rs
+++ b/storage/src/qmdb/benches/generate.rs
@@ -42,6 +42,10 @@ async fn bench_db<F: Family, C: DbAny<F, Key = Digest>>(
         elements,
         operations,
         Some(commit_frequency),
+        None, // seed_batch
+        None, // prune_frequency
+        None, // key_zipf_exponent (uniform churn)
+        None, // keyspace (all keys seeded)
         make_value,
     )
     .await;

--- a/storage/src/qmdb/benches/init.rs
+++ b/storage/src/qmdb/benches/init.rs
@@ -19,6 +19,10 @@ const NUM_ELEMENTS: u64 = 100_000;
 const NUM_OPERATIONS: u64 = 1_000_000;
 const COMMIT_FREQUENCY: u32 = 10_000;
 
+/// Init-time `(location -> key)` cache sizes to compare: `0` disables the cache (the no-cache
+/// baseline), and a reasonably sized cache that covers the bench's working set.
+const CACHE_SIZES: [usize; 2] = [0, 1 << 18];
+
 cfg_if::cfg_if! {
     if #[cfg(not(full_bench))] {
         const CASES: [(u64, u64); 1] = [(NUM_ELEMENTS, NUM_OPERATIONS)];
@@ -55,42 +59,46 @@ fn bench_fixed_value_init(c: &mut Criterion) {
     let cfg = Config::default();
     for (elements, operations) in CASES {
         for &variant in FIXED_VARIANTS {
+            // Populated lazily on the first sample of the first matched cache size, then reused by
+            // every cache size for this variant (all read the same on-disk database).
             let mut initialized = false;
-            let runner = tokio::Runner::new(cfg.clone());
-            c.bench_function(
-                &format!(
-                    "{}/variant={} elements={elements} operations={operations}",
-                    module_path!(),
-                    variant.name(),
-                ),
-                |b| {
-                    // Setup: populate database (once, on first sample).
-                    if !initialized {
-                        commonware_runtime::tokio::Runner::new(cfg.clone()).start(
-                            |ctx| async move {
-                                dispatch_fixed!(ctx, variant, |db| {
-                                    populate_and_sync(
-                                        &mut db,
-                                        elements,
-                                        operations,
-                                        make_fixed_value,
-                                    )
-                                    .await;
-                                });
-                            },
-                        );
-                        initialized = true;
-                    }
+            for &cache_size in &CACHE_SIZES {
+                let runner = tokio::Runner::new(cfg.clone());
+                c.bench_function(
+                    &format!(
+                        "{}/variant={} cache={cache_size} elements={elements}",
+                        module_path!(),
+                        variant.name(),
+                    ),
+                    |b| {
+                        // Setup: populate database (once, on first matched sample).
+                        if !initialized {
+                            commonware_runtime::tokio::Runner::new(cfg.clone()).start(
+                                |ctx| async move {
+                                    dispatch_fixed!(ctx, variant, |db| {
+                                        populate_and_sync(
+                                            &mut db,
+                                            elements,
+                                            operations,
+                                            make_fixed_value,
+                                        )
+                                        .await;
+                                    });
+                                },
+                            );
+                            initialized = true;
+                        }
 
-                    // Benchmark: measure init time.
-                    b.to_async(&runner).iter_custom(|iters| async move {
-                        let ctx = context::get::<Context>();
-                        dispatch_fixed_timed_init!(ctx, variant, iters, |db| {
-                            assert_ne!(db.bounds().end, 0);
-                        })
-                    });
-                },
-            );
+                        // Benchmark: measure init time at this cache size.
+                        b.to_async(&runner).iter_custom(move |iters| async move {
+                            let ctx = context::get::<Context>();
+                            dispatch_fixed_timed_init!(ctx, variant, iters, cache_size, |db| {
+                                assert_ne!(db.bounds().end, 0);
+                            })
+                        });
+                    },
+                );
+            }
 
             // Cleanup: destroy database.
             if initialized {
@@ -117,42 +125,46 @@ fn bench_var_value_init(c: &mut Criterion) {
     let cfg = Config::default();
     for (elements, operations) in CASES {
         for &variant in VEC_VARIANTS {
+            // Populated lazily on the first sample of the first matched cache size, then reused by
+            // every cache size for this variant (all read the same on-disk database).
             let mut initialized = false;
-            let runner = tokio::Runner::new(cfg.clone());
-            c.bench_function(
-                &format!(
-                    "{}/variant={} elements={elements} operations={operations}",
-                    module_path!(),
-                    variant.name(),
-                ),
-                |b| {
-                    // Setup: populate database (once, on first sample).
-                    if !initialized {
-                        commonware_runtime::tokio::Runner::new(cfg.clone()).start(
-                            |ctx| async move {
-                                dispatch_var!(ctx, variant, |db| {
-                                    populate_and_sync(
-                                        &mut db,
-                                        elements,
-                                        operations,
-                                        make_var_value,
-                                    )
-                                    .await;
-                                });
-                            },
-                        );
-                        initialized = true;
-                    }
+            for &cache_size in &CACHE_SIZES {
+                let runner = tokio::Runner::new(cfg.clone());
+                c.bench_function(
+                    &format!(
+                        "{}/variant={} cache={cache_size} elements={elements}",
+                        module_path!(),
+                        variant.name(),
+                    ),
+                    |b| {
+                        // Setup: populate database (once, on first matched sample).
+                        if !initialized {
+                            commonware_runtime::tokio::Runner::new(cfg.clone()).start(
+                                |ctx| async move {
+                                    dispatch_var!(ctx, variant, |db| {
+                                        populate_and_sync(
+                                            &mut db,
+                                            elements,
+                                            operations,
+                                            make_var_value,
+                                        )
+                                        .await;
+                                    });
+                                },
+                            );
+                            initialized = true;
+                        }
 
-                    // Benchmark: measure init time.
-                    b.to_async(&runner).iter_custom(|iters| async move {
-                        let ctx = context::get::<Context>();
-                        dispatch_var_timed_init!(ctx, variant, iters, |db| {
-                            assert_ne!(db.bounds().end, 0);
-                        })
-                    });
-                },
-            );
+                        // Benchmark: measure init time at this cache size.
+                        b.to_async(&runner).iter_custom(move |iters| async move {
+                            let ctx = context::get::<Context>();
+                            dispatch_var_timed_init!(ctx, variant, iters, cache_size, |db| {
+                                assert_ne!(db.bounds().end, 0);
+                            })
+                        });
+                    },
+                );
+            }
 
             // Cleanup: destroy database.
             if initialized {

--- a/storage/src/qmdb/benches/init.rs
+++ b/storage/src/qmdb/benches/init.rs
@@ -41,7 +41,18 @@ async fn populate_and_sync<F: Family, C: DbAny<F, Key = Digest>>(
     operations: u64,
     make_value: impl Fn(&mut rand::rngs::StdRng) -> C::Value,
 ) {
-    gen_random_kv::<F, _>(db, elements, operations, Some(COMMIT_FREQUENCY), make_value).await;
+    gen_random_kv::<F, _>(
+        db,
+        elements,
+        operations,
+        Some(COMMIT_FREQUENCY),
+        None, // seed_batch
+        None, // prune_frequency
+        None, // key_zipf_exponent (uniform churn)
+        None, // keyspace (all keys seeded)
+        make_value,
+    )
+    .await;
     db.prune(db.sync_boundary().await).await.unwrap();
     db.sync().await.unwrap();
 }

--- a/storage/src/qmdb/benches/init.rs
+++ b/storage/src/qmdb/benches/init.rs
@@ -13,15 +13,17 @@ use commonware_runtime::{
     Runner as _, Supervisor as _,
 };
 use commonware_storage::{merkle::Family, qmdb::any::traits::DbAny};
+use commonware_utils::NZUsize;
+use core::num::NonZeroUsize;
 use criterion::{criterion_group, Criterion};
 
 const NUM_ELEMENTS: u64 = 100_000;
 const NUM_OPERATIONS: u64 = 1_000_000;
 const COMMIT_FREQUENCY: u32 = 10_000;
 
-/// Init-time `(location -> key)` cache sizes to compare: `0` disables the cache (the no-cache
+/// Init-time `(location -> key)` cache sizes to compare: `None` disables the cache (the no-cache
 /// baseline), and a reasonably sized cache that covers the bench's working set.
-const CACHE_SIZES: [usize; 2] = [0, 1 << 18];
+const CACHE_SIZES: [Option<NonZeroUsize>; 2] = [None, Some(NZUsize!(1 << 18))];
 
 cfg_if::cfg_if! {
     if #[cfg(not(full_bench))] {
@@ -74,10 +76,11 @@ fn bench_fixed_value_init(c: &mut Criterion) {
             // every cache size for this variant (all read the same on-disk database).
             let mut initialized = false;
             for &cache_size in &CACHE_SIZES {
+                let cache = cache_size.map_or(0, NonZeroUsize::get);
                 let runner = tokio::Runner::new(cfg.clone());
                 c.bench_function(
                     &format!(
-                        "{}/variant={} cache={cache_size} elements={elements}",
+                        "{}/variant={} cache={cache} elements={elements}",
                         module_path!(),
                         variant.name(),
                     ),
@@ -140,10 +143,11 @@ fn bench_var_value_init(c: &mut Criterion) {
             // every cache size for this variant (all read the same on-disk database).
             let mut initialized = false;
             for &cache_size in &CACHE_SIZES {
+                let cache = cache_size.map_or(0, NonZeroUsize::get);
                 let runner = tokio::Runner::new(cfg.clone());
                 c.bench_function(
                     &format!(
-                        "{}/variant={} cache={cache_size} elements={elements}",
+                        "{}/variant={} cache={cache} elements={elements}",
                         module_path!(),
                         variant.name(),
                     ),

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -1,5 +1,6 @@
-//! Standalone, opt-in large-scale measurement of QMDB init (snapshot rebuild) with the init-time
-//! `(location -> key)` cache off vs on.
+//! Standalone, opt-in large-scale measurement of two QMDB operations at multi-GB scale: building a
+//! database (`generate`) and reopening it, i.e. rebuilding the snapshot (`bench`), with the
+//! init-time `(location -> key)` cache off vs on.
 //!
 //! The criterion init benchmark ([init](super::init)) can't reach these sizes: it resamples, and the
 //! database is multi-GB. This binary instead builds a *real* on-disk database once and then times a
@@ -7,7 +8,9 @@
 //! cache's effect on the redundant collision-resolution log reads shows at scale.
 //!
 //! Generation and benchmarking are split so the (multi-minute, multi-GB) database is built once and
-//! reused across many measurement runs. A folder names the database's on-disk location:
+//! reused across many reopen runs -- but generation is itself an interesting benchmark: building a
+//! database of this size is a large-scale seed/churn/commit workload, and `generate` reports its
+//! elapsed build time. A folder names the database's on-disk location:
 //!
 //! ```text
 //! cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db 50000000
@@ -19,9 +22,9 @@
 //! keyspace) then `elements * CHURN` Zipf-distributed updates over that whole keyspace -- so churn is
 //! skewed (a hot subset is re-updated, which makes collision resolution, and thus the cache, matter)
 //! and some updates land on unseeded keys, inserting them (a growing keyspace). It then prunes and
-//! syncs. `bench` reopens it (read-only) at cache off / a quarter of the replay region / the whole
-//! replay region, reporting each init time plus the replay-region size `R` (what the cache must cover
-//! to avoid eviction).
+//! syncs, reporting the total build time. `bench` reopens it (read-only) at cache off / a quarter of
+//! the replay region / the whole replay region, reporting each init time plus the replay-region size
+//! `R` (what the cache must cover to avoid eviction).
 
 #[allow(dead_code, unused_imports, unused_macros)]
 #[path = "common.rs"]
@@ -102,8 +105,9 @@ fn main() {
     }
 }
 
-/// Build a database of `elements` keys (plus `elements * CHURN` random updates) at `folder` and
-/// leave it on disk for later `bench` runs.
+/// Build a database of `elements` keys (plus `elements * CHURN` random updates) at `folder`, leaving
+/// it on disk for later `bench` runs. Reports the elapsed build time -- a large-scale
+/// seed/churn/commit benchmark in its own right, not just setup for the reopen measurement.
 fn generate(folder: &str, elements: u64) {
     if db_dir_nonempty(folder) {
         eprintln!("{folder} already contains data; `destroy` it first or pick a new folder");
@@ -111,13 +115,15 @@ fn generate(folder: &str, elements: u64) {
     }
     let operations = elements * CHURN;
     let cfg = Config::default().with_storage_directory(folder);
-    Runner::new(cfg).start(|ctx| async move {
+    let elapsed = Runner::new(cfg).start(|ctx| async move {
         let mut db = AnyOFixDb::<Mmr>::init(
             ctx.child("storage"),
             any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE),
         )
         .await
         .unwrap();
+        // Time the build itself (seed + churn + prune + sync); opening the empty db above is cheap.
+        let start = Instant::now();
         gen_random_kv::<Mmr, _>(
             &mut db,
             elements,
@@ -132,8 +138,9 @@ fn generate(folder: &str, elements: u64) {
         .await;
         db.prune(db.sync_boundary()).await.unwrap();
         db.sync().await.unwrap();
+        start.elapsed()
     });
-    println!("generated {elements} keys + {operations} updates at {folder}");
+    println!("generated {elements} keys + {operations} updates at {folder} in {elapsed:?}");
 }
 
 /// Reopen the database at `folder` (read-only) and time `init` at three cache regimes: off, a

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -1,0 +1,194 @@
+//! Standalone, opt-in large-scale measurement of QMDB init (snapshot rebuild) with the init-time
+//! `(location -> key)` cache off vs on.
+//!
+//! The criterion init benchmark ([init](super::init)) can't reach these sizes: it resamples, and the
+//! database is multi-GB. This binary instead builds a *real* on-disk database once and then times a
+//! *real* reopen ([`Db::init`], i.e. `build_snapshot_from_log`) at several cache sizes, so the
+//! cache's effect on the redundant collision-resolution log reads shows at scale.
+//!
+//! Generation and benchmarking are split so the (multi-minute, multi-GB) database is built once and
+//! reused across many measurement runs. A folder names the database's on-disk location:
+//!
+//! ```text
+//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db 50000000
+//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db
+//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- destroy  /tmp/db
+//! ```
+//!
+//! `generate` seeds `elements` keys (a uniform-random subset of a `KEYSPACE_MULTIPLIER`x larger
+//! keyspace) then `elements * CHURN` Zipf-distributed updates over that whole keyspace -- so churn is
+//! skewed (a hot subset is re-updated, which makes collision resolution, and thus the cache, matter)
+//! and some updates land on unseeded keys, inserting them (a growing keyspace). It then prunes and
+//! syncs. `bench` reopens it (read-only) at cache off / a quarter of the replay region / the whole
+//! replay region, reporting each init time plus the replay-region size `R` (what the cache must cover
+//! to avoid eviction).
+
+#[allow(dead_code, unused_imports, unused_macros)]
+#[path = "common.rs"]
+mod common;
+
+use common::{any_fix_cfg_with, gen_random_kv, make_fixed_value, AnyOFixDb};
+use commonware_runtime::{
+    tokio::{Config, Runner},
+    Runner as _, Supervisor as _,
+};
+use commonware_storage::{merkle::mmr::Family as Mmr, qmdb::any::traits::DbAny as _};
+use commonware_utils::{NZUsize, NZU64};
+use std::{
+    io::Write as _,
+    num::{NonZeroU64, NonZeroUsize},
+    time::{Duration, Instant},
+};
+
+/// Items per blob for the generated database. Much larger than the shared bench default (50k) so a
+/// multi-GB database is split across far fewer blob files, which keeps the partition-directory scan
+/// on reopen cheap. Note this only reduces the file count, not the on-disk byte growth.
+const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(1_000_000);
+
+/// Page cache size, realistic for a multi-GB database rather than the shared bench default of 8 MB
+/// (512 pages). Both `generate` and `bench` use it, so the init-cache benefit is measured on top of
+/// a realistic page cache instead of an unrealistically tiny one. 65536 * 16 KiB = 1 GiB.
+const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(65536);
+
+/// Random updates per element after the initial seed. Higher = more re-updates above the inactivity
+/// floor = more collision-resolution reads for the cache to eliminate.
+const CHURN: u64 = 5;
+
+/// Commit (and prune-eligible) cadence during population.
+const COMMIT_FREQUENCY: u32 = 10_000;
+
+/// Prune to the inactivity floor every this many commits during population, so the on-disk log stays
+/// bounded to roughly the active region instead of accumulating every re-appended operation until
+/// the end. At `COMMIT_FREQUENCY` this is ~1 prune per `COMMIT_FREQUENCY * PRUNE_FREQUENCY` ops.
+const PRUNE_FREQUENCY: u32 = 100;
+
+/// Zipf exponent for update/delete key selection: churn follows a power law (a hot subset of keys is
+/// updated far more than the long tail) rather than uniform, which is more representative of real
+/// workloads. Higher = more skew; ~1.0 is classic Zipf (near YCSB's 0.99).
+const KEY_ZIPF_EXPONENT: f64 = 1.0;
+
+/// Keyspace size as a multiple of the seeded `elements`. The seed is a uniform-random `elements`-key
+/// subset of this larger space, and updates draw (via Zipf) from the whole space, so some updates land
+/// on unseeded keys and insert them. This models a growing keyspace (inserts interleaved with updates)
+/// rather than churning a fixed population.
+const KEYSPACE_MULTIPLIER: u64 = 4;
+
+/// Cap on seeds accumulated before a merkleize+apply, so seeding a huge key set stays bounded in
+/// memory instead of buffering every entry in one batch.
+const SEED_BATCH: u64 = 100_000;
+
+fn usage() {
+    eprintln!(
+        "usage:\n  generate <folder> <elements>   build a database once and keep it\n  bench    <folder>              reopen + time init at cache off / R/4 / R\n  destroy  <folder>              delete the database"
+    );
+}
+
+fn main() {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    match argv.first().map(String::as_str) {
+        Some("generate") => match (argv.get(1), argv.get(2).and_then(|a| a.parse().ok())) {
+            (Some(folder), Some(elements)) => generate(folder, elements),
+            _ => usage(),
+        },
+        Some("bench") => match argv.get(1) {
+            Some(folder) => bench(folder),
+            None => usage(),
+        },
+        Some("destroy") => match argv.get(1) {
+            Some(folder) => destroy(folder),
+            None => usage(),
+        },
+        _ => usage(),
+    }
+}
+
+/// Build a database of `elements` keys (plus `elements * CHURN` random updates) at `folder` and
+/// leave it on disk for later `bench` runs.
+fn generate(folder: &str, elements: u64) {
+    if db_dir_nonempty(folder) {
+        eprintln!("{folder} already contains data; `destroy` it first or pick a new folder");
+        return;
+    }
+    let operations = elements * CHURN;
+    let cfg = Config::default().with_storage_directory(folder);
+    Runner::new(cfg).start(|ctx| async move {
+        let mut db = AnyOFixDb::<Mmr>::init(
+            ctx.child("storage"),
+            any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE),
+        )
+        .await
+        .unwrap();
+        gen_random_kv::<Mmr, _>(
+            &mut db,
+            elements,
+            operations,
+            Some(COMMIT_FREQUENCY),
+            Some(SEED_BATCH),
+            Some(PRUNE_FREQUENCY),
+            Some(KEY_ZIPF_EXPONENT),
+            Some(KEYSPACE_MULTIPLIER * elements),
+            make_fixed_value,
+        )
+        .await;
+        db.prune(db.sync_boundary()).await.unwrap();
+        db.sync().await.unwrap();
+    });
+    println!("generated {elements} keys + {operations} updates at {folder}");
+}
+
+/// Reopen the database at `folder` (read-only) and time `init` at three cache regimes: off, a
+/// quarter of the replay region (fills + evicts), and the whole replay region (no eviction).
+fn bench(folder: &str) {
+    let cfg = Config::default().with_storage_directory(folder);
+
+    // No-cache baseline; also learn the replay region R (ops above the inactivity floor) -- what the
+    // location cache must cover to avoid eviction (a key-cache would need only the key count).
+    let (baseline, region) = time_init(&cfg, 0);
+    if region == 0 {
+        eprintln!("no database at {folder}; run `generate {folder} <elements>` first");
+        return;
+    }
+    println!("init_scale: {folder}  (any::ordered::fixed::mmr)");
+    println!("  replay region R = {region} ops");
+    println!("  cache=off          : {baseline:?}");
+    let _ = std::io::stdout().flush();
+
+    for cache_size in [(region / 4) as usize, region as usize] {
+        let (elapsed, _) = time_init(&cfg, cache_size);
+        println!("  cache={cache_size:>11}: {elapsed:?}");
+        let _ = std::io::stdout().flush();
+    }
+}
+
+/// Delete the database at `folder`.
+fn destroy(folder: &str) {
+    match std::fs::remove_dir_all(folder) {
+        Ok(()) => println!("destroyed {folder}"),
+        Err(e) => eprintln!("failed to destroy {folder}: {e}"),
+    }
+}
+
+/// Time a single `init` of the database at `cfg`'s folder with the given cache size, returning the
+/// elapsed time and the replay-region size (`0` if the database is empty/absent).
+fn time_init(cfg: &Config, cache_size: usize) -> (Duration, u64) {
+    Runner::new(cfg.clone()).start(|ctx| async move {
+        let mut config = any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE);
+        config.init_cache_size = cache_size;
+        let start = Instant::now();
+        let db = AnyOFixDb::<Mmr>::init(ctx.child("storage"), config)
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+        let end: u64 = *db.bounds().await.end;
+        let floor: u64 = *db.inactivity_floor_loc().await;
+        (elapsed, end.saturating_sub(floor))
+    })
+}
+
+/// Whether `folder` exists and contains any entries (used to avoid silently appending to an existing
+/// database during `generate`).
+fn db_dir_nonempty(folder: &str) -> bool {
+    std::fs::read_dir(folder)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
+}

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -116,6 +116,10 @@ fn main() {
 /// `zipf_exponent` sets the key distribution: `None` is uniform, `Some(e)` is Zipf with exponent `e`.
 /// The populated set fills organically as updates sample the keyspace (no separate seed phase).
 fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option<f64>) {
+    if keyspace == 0 {
+        eprintln!("keyspace must be > 0");
+        return;
+    }
     if db_dir_nonempty(folder) {
         eprintln!("{folder} already contains data; `destroy` it first or pick a new folder");
         return;

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -150,7 +150,7 @@ fn bench(folder: &str) {
 
     // No-cache baseline; also learn the replay region R (ops above the inactivity floor) -- what the
     // location cache must cover to avoid eviction (a key-cache would need only the key count).
-    let (baseline, region) = time_init(&cfg, 0);
+    let (baseline, region) = time_init(&cfg, None);
     if region == 0 {
         eprintln!("no database at {folder}; run `generate {folder} <elements>` first");
         return;
@@ -160,9 +160,12 @@ fn bench(folder: &str) {
     println!("  cache=off          : {baseline:?}");
     let _ = std::io::stdout().flush();
 
-    for cache_size in [(region / 4) as usize, region as usize] {
+    for cache_size in [
+        NonZeroUsize::new((region / 4) as usize),
+        NonZeroUsize::new(region as usize),
+    ] {
         let (elapsed, _) = time_init(&cfg, cache_size);
-        println!("  cache={cache_size:>11}: {elapsed:?}");
+        println!("  cache={cache_size:?}: {elapsed:?}");
         let _ = std::io::stdout().flush();
     }
 }
@@ -177,7 +180,7 @@ fn destroy(folder: &str) {
 
 /// Time a single `init` of the database at `cfg`'s folder with the given cache size, returning the
 /// elapsed time and the replay-region size (`0` if the database is empty/absent).
-fn time_init(cfg: &Config, cache_size: usize) -> (Duration, u64) {
+fn time_init(cfg: &Config, cache_size: Option<NonZeroUsize>) -> (Duration, u64) {
     Runner::new(cfg.clone()).start(|ctx| async move {
         let mut config = any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE);
         config.init_cache_size = cache_size;
@@ -186,7 +189,7 @@ fn time_init(cfg: &Config, cache_size: usize) -> (Duration, u64) {
             .await
             .unwrap();
         let elapsed = start.elapsed();
-        let end: u64 = *db.bounds().await.end;
+        let end: u64 = *db.bounds().end;
         let floor: u64 = *db.inactivity_floor_loc().await;
         (elapsed, end.saturating_sub(floor))
     })

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -13,18 +13,19 @@
 //! elapsed build time. A folder names the database's on-disk location:
 //!
 //! ```text
-//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db 50000000
+//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db 50000000 250000000
 //! cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db
 //! cargo bench -p commonware-storage --bench init_scale --features test-traits -- destroy  /tmp/db
 //! ```
 //!
-//! `generate` seeds `elements` keys (a uniform-random subset of a `KEYSPACE_MULTIPLIER`x larger
-//! keyspace) then `elements * CHURN` Zipf-distributed updates over that whole keyspace -- so churn is
-//! skewed (a hot subset is re-updated, which makes collision resolution, and thus the cache, matter)
-//! and some updates land on unseeded keys, inserting them (a growing keyspace). It then prunes and
-//! syncs, reporting the total build time. `bench` reopens it (read-only) at cache off / a quarter of
-//! the replay region / the whole replay region, reporting each init time plus the replay-region size
-//! `R` (what the cache must cover to avoid eviction).
+//! `generate` applies `num_updates` random updates (~1 in `DELETE_FREQUENCY` are deletes) over a
+//! `keyspace`-key index space, sampling each key uniformly or via Zipf -- there is no separate seed
+//! phase, so the populated set fills organically as keys are sampled. The optional `zipf_exponent`
+//! arg selects the distribution -- omitted is the default Zipf (`KEY_ZIPF_EXPONENT`), `0` is uniform
+//! -- so a uniform and a skewed database differ only in that distribution. It then prunes and syncs,
+//! reporting the total build time. `bench` reopens it (read-only) at cache off / a quarter of the
+//! replay region / the whole replay region, reporting each init time plus the replay-region size `R`
+//! (what the cache must cover to avoid eviction).
 
 #[allow(dead_code, unused_imports, unused_macros)]
 #[path = "common.rs"]
@@ -53,10 +54,6 @@ const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(1_000_000);
 /// a realistic page cache instead of an unrealistically tiny one. 65536 * 16 KiB = 1 GiB.
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(65536);
 
-/// Random updates per element after the initial seed. Higher = more re-updates above the inactivity
-/// floor = more collision-resolution reads for the cache to eliminate.
-const CHURN: u64 = 5;
-
 /// Commit (and prune-eligible) cadence during population.
 const COMMIT_FREQUENCY: u32 = 10_000;
 
@@ -70,27 +67,34 @@ const PRUNE_FREQUENCY: u32 = 100;
 /// workloads. Higher = more skew; ~1.0 is classic Zipf (near YCSB's 0.99).
 const KEY_ZIPF_EXPONENT: f64 = 1.0;
 
-/// Keyspace size as a multiple of the seeded `elements`. The seed is a uniform-random `elements`-key
-/// subset of this larger space, and updates draw (via Zipf) from the whole space, so some updates land
-/// on unseeded keys and insert them. This models a growing keyspace (inserts interleaved with updates)
-/// rather than churning a fixed population.
-const KEYSPACE_MULTIPLIER: u64 = 4;
-
-/// Cap on seeds accumulated before a merkleize+apply, so seeding a huge key set stays bounded in
-/// memory instead of buffering every entry in one batch.
-const SEED_BATCH: u64 = 100_000;
-
 fn usage() {
     eprintln!(
-        "usage:\n  generate <folder> <elements>   build a database once and keep it\n  bench    <folder>              reopen + time init at cache off / R/4 / R\n  destroy  <folder>              delete the database"
+        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench    <folder>              reopen + time init at cache off / R/4 / R\n  destroy  <folder>              delete the database"
     );
 }
 
 fn main() {
     let argv: Vec<String> = std::env::args().skip(1).collect();
     match argv.first().map(String::as_str) {
-        Some("generate") => match (argv.get(1), argv.get(2).and_then(|a| a.parse().ok())) {
-            (Some(folder), Some(elements)) => generate(folder, elements),
+        Some("generate") => match (
+            argv.get(1),
+            argv.get(2).and_then(|a| a.parse().ok()),
+            argv.get(3).and_then(|a| a.parse().ok()),
+        ) {
+            (Some(folder), Some(keyspace), Some(num_updates)) => {
+                // Optional zipf exponent (5th arg): omitted => default skew (KEY_ZIPF_EXPONENT);
+                // `0` => uniform sampling (`None`).
+                let zipf_exponent = match argv.get(4).map(|a| a.parse::<f64>()) {
+                    None => Some(KEY_ZIPF_EXPONENT),
+                    Some(Ok(e)) if e > 0.0 => Some(e),
+                    Some(Ok(_)) => None,
+                    Some(Err(_)) => {
+                        usage();
+                        return;
+                    }
+                };
+                generate(folder, keyspace, num_updates, zipf_exponent)
+            }
             _ => usage(),
         },
         Some("bench") => match argv.get(1) {
@@ -105,15 +109,17 @@ fn main() {
     }
 }
 
-/// Build a database of `elements` keys (plus `elements * CHURN` random updates) at `folder`, leaving
-/// it on disk for later `bench` runs. Reports the elapsed build time -- a large-scale
-/// seed/churn/commit benchmark in its own right, not just setup for the reopen measurement.
-fn generate(folder: &str, elements: u64) {
+/// Build a database at `folder` by applying `num_updates` random updates over a `keyspace`-key index
+/// space, leaving it on disk for later `bench` runs. Reports the elapsed build time -- a large-scale
+/// churn/commit benchmark in its own right, not just setup for the reopen measurement.
+///
+/// `zipf_exponent` sets the key distribution: `None` is uniform, `Some(e)` is Zipf with exponent `e`.
+/// The populated set fills organically as updates sample the keyspace (no separate seed phase).
+fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option<f64>) {
     if db_dir_nonempty(folder) {
         eprintln!("{folder} already contains data; `destroy` it first or pick a new folder");
         return;
     }
-    let operations = elements * CHURN;
     let cfg = Config::default().with_storage_directory(folder);
     let elapsed = Runner::new(cfg).start(|ctx| async move {
         let mut db = AnyOFixDb::<Mmr>::init(
@@ -122,17 +128,17 @@ fn generate(folder: &str, elements: u64) {
         )
         .await
         .unwrap();
-        // Time the build itself (seed + churn + prune + sync); opening the empty db above is cheap.
+        // Time the build itself (updates + prune + sync); opening the empty db above is cheap.
         let start = Instant::now();
         gen_random_kv::<Mmr, _>(
             &mut db,
-            elements,
-            operations,
+            0, // num_elements: no seed phase; the keyspace fills organically as updates sample it
+            num_updates,
             Some(COMMIT_FREQUENCY),
-            Some(SEED_BATCH),
+            None, // seed_batch
             Some(PRUNE_FREQUENCY),
-            Some(KEY_ZIPF_EXPONENT),
-            Some(KEYSPACE_MULTIPLIER * elements),
+            zipf_exponent,
+            Some(keyspace),
             make_fixed_value,
         )
         .await;
@@ -140,19 +146,27 @@ fn generate(folder: &str, elements: u64) {
         db.sync().await.unwrap();
         start.elapsed()
     });
-    println!("generated {elements} keys + {operations} updates at {folder} in {elapsed:?}");
+    println!("generated {num_updates} updates over keyspace {keyspace} at {folder} in {elapsed:?}");
 }
 
 /// Reopen the database at `folder` (read-only) and time `init` at three cache regimes: off, a
 /// quarter of the replay region (fills + evicts), and the whole replay region (no eviction).
 fn bench(folder: &str) {
+    if !db_dir_nonempty(folder) {
+        eprintln!(
+            "no database at {folder}; run `generate {folder} <keyspace> <num_updates>` first"
+        );
+        return;
+    }
     let cfg = Config::default().with_storage_directory(folder);
 
     // No-cache baseline; also learn the replay region R (ops above the inactivity floor) -- what the
     // location cache must cover to avoid eviction (a key-cache would need only the key count).
     let (baseline, region) = time_init(&cfg, None);
     if region == 0 {
-        eprintln!("no database at {folder}; run `generate {folder} <elements>` first");
+        eprintln!(
+            "database at {folder} is empty; run `generate {folder} <keyspace> <num_updates>` first"
+        );
         return;
     }
     println!("init_scale: {folder}  (any::ordered::fixed::mmr)");

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -328,6 +328,7 @@ fn any_fix_cfg(
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         translator: EightCap,
+        init_cache_size: crate::common::INIT_CACHE_SIZE,
     }
 }
 
@@ -340,6 +341,7 @@ fn any_var_cfg(
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         translator: EightCap,
+        init_cache_size: crate::common::INIT_CACHE_SIZE,
     }
 }
 
@@ -353,6 +355,7 @@ fn cur_fix_cfg(
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
+        init_cache_size: crate::common::INIT_CACHE_SIZE,
     }
 }
 
@@ -366,6 +369,7 @@ fn cur_var_cfg(
         journal_config: var_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
+        init_cache_size: crate::common::INIT_CACHE_SIZE,
     }
 }
 

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -187,6 +187,7 @@ fn any_fixed_config(
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
+        init_cache_size: 1024,
     }
 }
 
@@ -199,6 +200,7 @@ fn any_variable_config(
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
+        init_cache_size: 1024,
     }
 }
 
@@ -212,6 +214,7 @@ fn current_fixed_config(
         journal_config: fixed_log_config(suffix, pc),
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
+        init_cache_size: 1024,
     }
 }
 
@@ -225,6 +228,7 @@ fn current_variable_config(
         journal_config: variable_log_config(suffix, pc, ((), ())),
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
+        init_cache_size: 1024,
     }
 }
 
@@ -237,6 +241,7 @@ fn immutable_fixed_config(
         merkle_config: merkle_config(suffix, &pc),
         log: fixed_log_config(suffix, pc),
         translator: TwoCap,
+        init_cache_size: 1024,
     }
 }
 
@@ -249,6 +254,7 @@ fn immutable_variable_config(
         merkle_config: merkle_config(suffix, &pc),
         log: variable_log_config(suffix, pc, ((), ())),
         translator: TwoCap,
+        init_cache_size: 1024,
     }
 }
 

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -187,7 +187,7 @@ fn any_fixed_config(
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
-        init_cache_size: 1024,
+        init_cache_size: Some(NZUsize!(1024)),
     }
 }
 
@@ -200,7 +200,7 @@ fn any_variable_config(
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
-        init_cache_size: 1024,
+        init_cache_size: Some(NZUsize!(1024)),
     }
 }
 
@@ -214,7 +214,7 @@ fn current_fixed_config(
         journal_config: fixed_log_config(suffix, pc),
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
-        init_cache_size: 1024,
+        init_cache_size: Some(NZUsize!(1024)),
     }
 }
 
@@ -228,7 +228,7 @@ fn current_variable_config(
         journal_config: variable_log_config(suffix, pc, ((), ())),
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
-        init_cache_size: 1024,
+        init_cache_size: Some(NZUsize!(1024)),
     }
 }
 
@@ -241,7 +241,7 @@ fn immutable_fixed_config(
         merkle_config: merkle_config(suffix, &pc),
         log: fixed_log_config(suffix, pc),
         translator: TwoCap,
-        init_cache_size: 1024,
+        init_cache_size: Some(NZUsize!(1024)),
     }
 }
 
@@ -254,7 +254,7 @@ fn immutable_variable_config(
         merkle_config: merkle_config(suffix, &pc),
         log: variable_log_config(suffix, pc, ((), ())),
         translator: TwoCap,
-        init_cache_size: 1024,
+        init_cache_size: Some(NZUsize!(1024)),
     }
 }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -349,6 +349,7 @@ use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
 use commonware_utils::bitmap::Prunable as BitMap;
+use core::num::NonZeroUsize;
 use std::sync::Arc;
 
 pub mod batch;
@@ -378,8 +379,8 @@ pub struct Config<T: Translator, J, S: Strategy> {
     pub translator: T,
 
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
-    /// collisions without re-reading the log; `0` disables it.
-    pub init_cache_size: usize,
+    /// collisions without re-reading the log; `None` disables it.
+    pub init_cache_size: Option<NonZeroUsize>,
 }
 
 impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S> {
@@ -572,7 +573,7 @@ pub mod tests {
             },
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 
@@ -601,7 +602,7 @@ pub mod tests {
             },
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 
@@ -1403,7 +1404,7 @@ pub mod tests {
                 },
                 grafted_metadata_partition: "forged-exclusion-grafted".to_string(),
                 translator: OneCap,
-                init_cache_size: 1024,
+                init_cache_size: Some(NZUsize!(1024)),
             };
             let mut db = ForgedExclusionDb::init(context.child("db"), cfg)
                 .await

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -376,6 +376,11 @@ pub struct Config<T: Translator, J, S: Strategy> {
 
     /// The translator used by the compressed index.
     pub translator: T,
+
+    /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
+    /// collisions without re-reading the log; `0` disables it. The cache is held only for the
+    /// duration of init.
+    pub init_cache_size: usize,
 }
 
 impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S> {
@@ -384,6 +389,7 @@ impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S>
             merkle_config: cfg.merkle_config,
             journal_config: cfg.journal_config,
             translator: cfg.translator,
+            init_cache_size: cfg.init_cache_size,
         }
     }
 }
@@ -567,6 +573,7 @@ pub mod tests {
             },
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
+            init_cache_size: 1024,
         }
     }
 
@@ -595,6 +602,7 @@ pub mod tests {
             },
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
+            init_cache_size: 1024,
         }
     }
 
@@ -1396,6 +1404,7 @@ pub mod tests {
                 },
                 grafted_metadata_partition: "forged-exclusion-grafted".to_string(),
                 translator: OneCap,
+                init_cache_size: 1024,
             };
             let mut db = ForgedExclusionDb::init(context.child("db"), cfg)
                 .await

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -378,8 +378,7 @@ pub struct Config<T: Translator, J, S: Strategy> {
     pub translator: T,
 
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
-    /// collisions without re-reading the log; `0` disables it. The cache is held only for the
-    /// duration of init.
+    /// collisions without re-reading the log; `0` disables it.
     pub init_cache_size: usize,
 }
 

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -71,6 +71,7 @@ use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_parallel::Strategy;
 use commonware_utils::{bitmap::Prunable as BitMap, channel::oneshot, range::NonEmptyRange, Array};
+use core::num::NonZeroUsize;
 use std::sync::Arc;
 
 #[cfg(test)]
@@ -100,7 +101,7 @@ async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
     pinned_nodes: Option<Vec<H::Digest>>,
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
-    cache_size: usize,
+    cache_size: Option<NonZeroUsize>,
     metadata_partition: String,
     strategy: S,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, qmdb::Error<F>>

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -100,6 +100,7 @@ async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
     pinned_nodes: Option<Vec<H::Digest>>,
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
+    cache_size: usize,
     metadata_partition: String,
     strategy: S,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, qmdb::Error<F>>
@@ -149,7 +150,7 @@ where
     // during replay.
     let any_metrics = AnyMetrics::new(context.child("any"));
     let any: AnyDb<F, E, J, I, H, U, N, S> =
-        AnyDb::init_from_log(index, log, Some(bitmap), any_metrics).await?;
+        AnyDb::init_from_log(index, log, Some(bitmap), cache_size, any_metrics).await?;
 
     // Fetch grafted pinned nodes from the ops tree. For each position the grafted family
     // needs at its pruning boundary, source the digest from the ops tree via the zero-chunk
@@ -283,6 +284,7 @@ macro_rules! impl_current_sync_database {
                 let metadata_partition = config.grafted_metadata_partition.clone();
                 let strategy = config.merkle_config.strategy.clone();
                 let translator = config.translator.clone();
+                let cache_size = config.init_cache_size;
                 build_db::<F, _, $update<K, V>, _, H, _, T, N, _>(
                     context,
                     merkle_config,
@@ -291,6 +293,7 @@ macro_rules! impl_current_sync_database {
                     pinned_nodes,
                     range,
                     apply_batch_size,
+                    cache_size,
                     metadata_partition,
                     strategy,
                 )

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -113,7 +113,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -60,7 +60,7 @@ impl<
             ROOT_BAGGING,
         )
         .await?;
-        Self::init_from_journal(journal, context, cfg.translator).await
+        Self::init_from_journal(journal, context, cfg.translator, cfg.init_cache_size).await
     }
 }
 
@@ -113,6 +113,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -99,7 +99,8 @@ use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher as CHasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use std::{num::NonZeroU64, ops::Range, sync::Arc};
+use core::num::{NonZeroU64, NonZeroUsize};
+use std::{ops::Range, sync::Arc};
 use tracing::warn;
 
 /// Metrics for Immutable QMDBs.
@@ -150,8 +151,8 @@ pub struct Config<T: Translator, J, S: Strategy> {
     pub translator: T,
 
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
-    /// collisions without re-reading the log; `0` disables it.
-    pub init_cache_size: usize,
+    /// collisions without re-reading the log; `None` disables it.
+    pub init_cache_size: Option<NonZeroUsize>,
 }
 
 /// An authenticated database that only supports adding new keyed values (no updates or
@@ -221,7 +222,7 @@ where
         mut journal: authenticated::Journal<F, E, C, H, S>,
         context: E,
         translator: T,
-        cache_size: usize,
+        cache_size: Option<NonZeroUsize>,
     ) -> Result<Self, Error<F>> {
         if journal.size() == 0 {
             warn!("Authenticated log is empty, initialized new db.");

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -148,6 +148,11 @@ pub struct Config<T: Translator, J, S: Strategy> {
 
     /// The translator used by the compressed index.
     pub translator: T,
+
+    /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
+    /// collisions without re-reading the log; `0` disables it. The cache is held only for the
+    /// duration of init.
+    pub init_cache_size: usize,
 }
 
 /// An authenticated database that only supports adding new keyed values (no updates or
@@ -217,6 +222,7 @@ where
         mut journal: authenticated::Journal<F, E, C, H, S>,
         context: E,
         translator: T,
+        cache_size: usize,
     ) -> Result<Self, Error<F>> {
         if journal.size() == 0 {
             warn!("Authenticated log is empty, initialized new db.");
@@ -247,6 +253,7 @@ where
                 inactivity_floor_loc,
                 &journal.journal,
                 &mut snapshot,
+                cache_size,
                 |_, _| {},
             )
             .await?;

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -150,8 +150,7 @@ pub struct Config<T: Translator, J, S: Strategy> {
     pub translator: T,
 
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
-    /// collisions without re-reading the log; `0` disables it. The cache is held only for the
-    /// duration of init.
+    /// collisions without re-reading the log; `0` disables it.
     pub init_cache_size: usize,
 }
 

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -111,6 +111,7 @@ where
                 inactivity_floor_loc,
                 &journal.journal,
                 &mut snapshot,
+                db_config.init_cache_size,
                 |_, _| {},
             )
             .await?;

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -893,6 +893,7 @@ pub(crate) mod harnesses {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 
@@ -1191,6 +1192,7 @@ mod compact_variable_mmr {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 
@@ -1897,6 +1899,7 @@ mod compact_variable_mmb {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -893,7 +893,7 @@ pub(crate) mod harnesses {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 
@@ -1192,7 +1192,7 @@ mod compact_variable_mmr {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 
@@ -1899,7 +1899,7 @@ mod compact_variable_mmb {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -135,7 +135,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         }
     }
 

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -64,7 +64,7 @@ impl<
             ROOT_BAGGING,
         )
         .await?;
-        Self::init_from_journal(journal, context, cfg.translator).await
+        Self::init_from_journal(journal, context, cfg.translator, cfg.init_cache_size).await
     }
 }
 
@@ -135,6 +135,7 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         }
     }
 

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     qmdb::operation::Operation,
 };
 use commonware_cryptography::Hasher as CryptoHasher;
-use commonware_utils::NZUsize;
+use commonware_utils::{cache::Clock, NZUsize};
 use core::num::NonZeroUsize;
 use futures::{pin_mut, StreamExt as _};
 use thiserror::Error;
@@ -230,10 +230,15 @@ const SNAPSHOT_READ_BUFFER_SIZE: NonZeroUsize = NZUsize!(1 << 16);
 /// operation, indicating activity status updates. The first argument of the callback is the
 /// activity status of the operation, and the second argument is the location of the operation it
 /// inactivates (if any). Returns the number of active keys in the db.
+///
+/// `cache_size` bounds a `(location -> key)` cache that lets collision resolution resolve
+/// candidates from memory instead of re-reading the log; `0` disables it. The cache is sized to
+/// the smaller of `cache_size` and the replay region.
 pub(super) async fn build_snapshot_from_log<F, C, I, Fn>(
     inactivity_floor_loc: crate::merkle::Location<F>,
     reader: &C,
     snapshot: &mut I,
+    cache_size: usize,
     mut callback: Fn,
 ) -> Result<usize, Error<F>>
 where
@@ -248,22 +253,34 @@ where
         .await?;
     pin_mut!(stream);
     let last_commit_loc = bounds.end.saturating_sub(1);
+
+    // Memoize `(location -> key)` for replayed update ops so collision resolution in
+    // `find_update_op` resolves candidates from memory instead of re-reading (and re-decoding) the
+    // log. The mapping is immutable (append-only log), so the cache never goes stale.
+    let replay_len = bounds.end.saturating_sub(*inactivity_floor_loc) as usize;
+    let mut cache = NonZeroUsize::new(cache_size.min(replay_len))
+        .map(Clock::<u64, <C::Item as Operation<F>>::Key>::new);
+
     let mut active_keys: usize = 0;
     while let Some(result) = stream.next().await {
         let (loc, op) = result?;
         if let Some(key) = op.key() {
             if op.is_delete() {
-                let old_loc = delete_key(snapshot, reader, key).await?;
+                let old_loc = delete_key(snapshot, reader, key, cache.as_mut()).await?;
                 callback(false, old_loc);
                 if old_loc.is_some() {
                     active_keys -= 1;
                 }
             } else if op.is_update() {
                 let new_loc = crate::merkle::Location::new(loc);
-                let old_loc = update_key(snapshot, reader, key, new_loc).await?;
+                let old_loc = update_key(snapshot, reader, key, new_loc, cache.as_mut()).await?;
                 callback(true, old_loc);
                 if old_loc.is_none() {
                     active_keys += 1;
+                }
+                // This update op is now a `find_update_op` candidate for later ops of its key.
+                if let Some(cache) = cache.as_mut() {
+                    cache.put(loc, key.clone());
                 }
             }
         } else if op.has_floor().is_some() {
@@ -280,6 +297,7 @@ async fn delete_key<F, I, R>(
     snapshot: &mut I,
     reader: &R,
     key: &<R::Item as Operation<F>>::Key,
+    cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -293,7 +311,7 @@ where
     };
 
     // Find the matching key among all conflicts, then delete it.
-    let Some(loc) = find_update_op::<F, _>(reader, &mut cursor, key).await? else {
+    let Some(loc) = find_update_op::<F, _>(reader, &mut cursor, key, cache).await? else {
         return Ok(None);
     };
     cursor.delete();
@@ -307,6 +325,7 @@ async fn update_key<F, I, R>(
     reader: &R,
     key: &<R::Item as Operation<F>>::Key,
     new_loc: Location<F>,
+    cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -321,7 +340,7 @@ where
     };
 
     // Find the matching key among all conflicts, then update its location.
-    if let Some(loc) = find_update_op::<F, _>(reader, &mut cursor, key).await? {
+    if let Some(loc) = find_update_op::<F, _>(reader, &mut cursor, key, cache).await? {
         assert!(new_loc > loc);
         cursor.update(new_loc);
         return Ok(Some(loc));
@@ -343,6 +362,7 @@ async fn find_update_op<F, R>(
     reader: &R,
     cursor: &mut impl Cursor<Value = Location<F>>,
     key: &<R::Item as Operation<F>>::Key,
+    mut cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -350,9 +370,19 @@ where
     R::Item: Operation<F>,
 {
     while let Some(&loc) = cursor.next() {
-        let op = reader.read(*loc).await?;
-        let k = op.key().expect("operation without key");
-        if *k == *key {
+        // Consult the cache first; on a miss, read the log and populate.
+        let matches = if let Some(k) = cache.as_deref().and_then(|c| c.get(&*loc)) {
+            *k == *key
+        } else {
+            let op = reader.read(*loc).await?;
+            let k = op.key().expect("operation without key");
+            let matches = *k == *key;
+            if let Some(cache) = cache.as_deref_mut() {
+                cache.put(*loc, k.clone());
+            }
+            matches
+        };
+        if matches {
             return Ok(Some(loc));
         }
     }

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -232,8 +232,7 @@ const SNAPSHOT_READ_BUFFER_SIZE: NonZeroUsize = NZUsize!(1 << 16);
 /// inactivates (if any). Returns the number of active keys in the db.
 ///
 /// `cache_size` bounds a `(location -> key)` cache that lets collision resolution resolve
-/// candidates from memory instead of re-reading the log; `0` disables it. The cache is sized to
-/// the smaller of `cache_size` and the replay region.
+/// candidates from memory instead of re-reading the log; `0` disables it.
 pub(super) async fn build_snapshot_from_log<F, C, I, Fn>(
     inactivity_floor_loc: crate::merkle::Location<F>,
     reader: &C,
@@ -256,10 +255,9 @@ where
 
     // Memoize `(location -> key)` for replayed update ops so collision resolution in
     // `find_update_op` resolves candidates from memory instead of re-reading (and re-decoding) the
-    // log. The mapping is immutable (append-only log), so the cache never goes stale.
-    let replay_len = bounds.end.saturating_sub(*inactivity_floor_loc) as usize;
-    let mut cache = NonZeroUsize::new(cache_size.min(replay_len))
-        .map(Clock::<u64, <C::Item as Operation<F>>::Key>::new);
+    // log.
+    let mut cache =
+        NonZeroUsize::new(cache_size).map(Clock::<u64, <C::Item as Operation<F>>::Key>::new);
 
     let mut active_keys: usize = 0;
     while let Some(result) = stream.next().await {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -232,12 +232,12 @@ const SNAPSHOT_READ_BUFFER_SIZE: NonZeroUsize = NZUsize!(1 << 16);
 /// inactivates (if any). Returns the number of active keys in the db.
 ///
 /// `cache_size` bounds a `(location -> key)` cache that lets collision resolution resolve
-/// candidates from memory instead of re-reading the log; `0` disables it.
+/// candidates from memory instead of re-reading the log; `None` disables it.
 pub(super) async fn build_snapshot_from_log<F, C, I, Fn>(
     inactivity_floor_loc: crate::merkle::Location<F>,
     reader: &C,
     snapshot: &mut I,
-    cache_size: usize,
+    cache_size: Option<NonZeroUsize>,
     mut callback: Fn,
 ) -> Result<usize, Error<F>>
 where
@@ -256,8 +256,7 @@ where
     // Memoize `(location -> key)` for replayed update ops so collision resolution in
     // `find_update_op` resolves candidates from memory instead of re-reading (and re-decoding) the
     // log.
-    let mut cache =
-        NonZeroUsize::new(cache_size).map(Clock::<u64, <C::Item as Operation<F>>::Key>::new);
+    let mut cache = cache_size.map(Clock::<u64, <C::Item as Operation<F>>::Key>::new);
 
     let mut active_keys: usize = 0;
     while let Some(result) = stream.next().await {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -275,6 +275,7 @@ where
                 if old_loc.is_none() {
                     active_keys += 1;
                 }
+
                 // This update op is now a `find_update_op` candidate for later ops of its key.
                 if let Some(cache) = cache.as_mut() {
                     cache.put(loc, key.clone());

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -31,7 +31,7 @@
 //!             page_cache: CacheRef::from_pooler(&ctx, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
 //!         },
 //!         translator: TwoCap,
-//!         init_cache_size: 1 << 16,
+//!         init_cache_size: Some(NZUsize!(1 << 16)),
 //!     };
 //!     let mut db =
 //!         Db::<_, Digest, Digest, TwoCap>::init(ctx.child("store"), config)
@@ -96,7 +96,7 @@ use crate::{
 use commonware_codec::{CodecShared, Read};
 use commonware_macros::boxed;
 use commonware_utils::Array;
-use core::ops::Range;
+use core::{num::NonZeroUsize, ops::Range};
 use std::collections::BTreeMap;
 use tracing::{debug, warn};
 
@@ -112,8 +112,8 @@ pub struct Config<T: Translator, C> {
     pub translator: T,
 
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
-    /// collisions without re-reading the log; `0` disables it.
-    pub init_cache_size: usize,
+    /// collisions without re-reading the log; `None` disables it.
+    pub init_cache_size: Option<NonZeroUsize>,
 }
 
 /// A finalized batch of writes and deletes ready to be applied to the store.
@@ -452,9 +452,13 @@ where
                     .append(&Operation::Update(Update(key, value)))
                     .await?;
             } else {
-                let deleted =
-                    delete_key::<crate::mmr::Family, _, _>(&mut self.snapshot, &self.log, &key, None)
-                        .await?;
+                let deleted = delete_key::<crate::mmr::Family, _, _>(
+                    &mut self.snapshot,
+                    &self.log,
+                    &key,
+                    None,
+                )
+                .await?;
                 if deleted.is_some() {
                     self.log.append(&Operation::Delete(key)).await?;
                     self.steps += 1;
@@ -526,7 +530,7 @@ mod test {
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             },
             translator: TwoCap,
-            init_cache_size: 1024,
+            init_cache_size: Some(NZUsize!(1024)),
         };
         TestStore::init(context, cfg).await.unwrap()
     }

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -31,6 +31,7 @@
 //!             page_cache: CacheRef::from_pooler(&ctx, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
 //!         },
 //!         translator: TwoCap,
+//!         init_cache_size: 1 << 16,
 //!     };
 //!     let mut db =
 //!         Db::<_, Digest, Digest, TwoCap>::init(ctx.child("store"), config)
@@ -109,6 +110,11 @@ pub struct Config<T: Translator, C> {
 
     /// The [Translator] used by the [Index].
     pub translator: T,
+
+    /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
+    /// collisions without re-reading the log; `0` disables it. The cache is held only for the
+    /// duration of init.
+    pub init_cache_size: usize,
 }
 
 /// A finalized batch of writes and deletes ready to be applied to the store.
@@ -357,6 +363,7 @@ where
             Location::new(log.size().checked_sub(1).expect("commit should exist"));
 
         // Build the snapshot.
+        let cache_size = cfg.init_cache_size;
         let mut snapshot = Index::new(context.child("snapshot"), cfg.translator);
         let (inactivity_floor_loc, active_keys) = {
             let op = log.read(*last_commit_loc).await?;
@@ -366,9 +373,14 @@ where
                     "inactivity floor exceeds last commit",
                 ));
             }
-            let active_keys =
-                build_snapshot_from_log(inactivity_floor_loc, &log, &mut snapshot, |_, _| {})
-                    .await?;
+            let active_keys = build_snapshot_from_log(
+                inactivity_floor_loc,
+                &log,
+                &mut snapshot,
+                cache_size,
+                |_, _| {},
+            )
+            .await?;
             (inactivity_floor_loc, active_keys)
         };
 
@@ -428,6 +440,7 @@ where
                         &self.log,
                         &key,
                         Location::new(new_loc),
+                        None,
                     )
                     .await?
                 };
@@ -441,7 +454,7 @@ where
                     .await?;
             } else {
                 let deleted =
-                    delete_key::<crate::mmr::Family, _, _>(&mut self.snapshot, &self.log, &key)
+                    delete_key::<crate::mmr::Family, _, _>(&mut self.snapshot, &self.log, &key, None)
                         .await?;
                 if deleted.is_some() {
                     self.log.append(&Operation::Delete(key)).await?;
@@ -514,6 +527,7 @@ mod test {
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             },
             translator: TwoCap,
+            init_cache_size: 1024,
         };
         TestStore::init(context, cfg).await.unwrap()
     }

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -112,8 +112,7 @@ pub struct Config<T: Translator, C> {
     pub translator: T,
 
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
-    /// collisions without re-reading the log; `0` disables it. The cache is held only for the
-    /// duration of init.
+    /// collisions without re-reading the log; `0` disables it.
     pub init_cache_size: usize,
 }
 


### PR DESCRIPTION
## Summary

Speeds up QMDB startup by eliminating redundant log reads during snapshot construction.

During init, `build_snapshot_from_log` replays the operations log and resolves translated-key collisions via `find_update_op`, which re-reads (and re-decodes) each candidate operation from the log just to recover its key. The journal's replay function does not put replayed data (either raw or decoded) into any cache, so each re-read is a system call + decode.  (After the first re-read, however, the *page* of the operation will be cached in the page cache.)

This PR caches `(location -> key)` mappings in a special purpose`Clock` cache that is populated & used only during the qmdb init phase:
- replayed update ops populate it as they stream by, and
- `find_update_op` consults it before falling back to a log read.

## Configurable

The cache capacity is a per-database config field, **`init_cache_size`** (in entries), where **`0` disables** the cache. The cache is sized to exactly `init_cache_size` and is held only for the duration of init. There is no hard-coded cap or default; callers choose the size for their workload.

## Why it's correct

There is no control-flow change: a cache hit only replaces a `reader.read`. Roots and recovery are unaffected, verified by the full qmdb suite (1544 tests), including a new test that reopens the same database with `init_cache_size = 0` and a large cache and asserts identical roots. The cache is threaded as `Option<&mut Clock>`: populated during init, `None` on the live `apply_batch` path.

## Benchmarks

Serial-init, cache disabled vs enabled (`cache=262144`), 100K elements / 1M updates+deletes, idle machine (`cargo bench -p commonware-storage --bench qmdb --features test-traits -- init`). The init benchmark sweeps `cache=0` (the no-cache baseline) vs an enabled cache in one process, so the baseline needs no branch switching.

| variant | off | on | change |
|---|---|---|---|
| `any::ordered::variable::mmr` | 55.76 ms | 37.92 ms | **-32.0%** |
| `current::ordered::variable::mmr` | 60.56 ms | 41.31 ms | **-31.8%** |
| `any::ordered::fixed::mmr` | 42.02 ms | 30.99 ms | **-26.3%** |
| `current::ordered::fixed::mmr` | 46.73 ms | 34.79 ms | **-25.5%** |
| `any::unordered::variable::mmr` | 37.31 ms | 32.16 ms | **-13.8%** |
| `any::unordered::fixed::mmr` | 26.58 ms | 23.29 ms | **-12.4%** |
| `current::unordered::variable::mmr` | 40.49 ms | 35.61 ms | **-12.1%** |
| `current::unordered::fixed::mmr` | 29.83 ms | 27.39 ms | **-8.2%** |

The cache elides the log reads that update resolution (`find_update_op`) performs during replay, so the gain tracks how much read/decode work that resolution does:

- **Variable vs fixed:** a variable-value log lookup is two reads (one for the offset, then one for the item) versus one for a fixed-value log, so variable shapes benefit more at each tier.
- **Ordered vs unordered:** ordered operations are larger (each carries the successor key for the ordered ring, ~1.5x the bytes), and every insert and delete also rewrites the predecessor's operation to relink the ring. Ordered databases therefore replay more, larger operations, so `find_update_op` does proportionally more read/decode work for the cache to eliminate.

These compound, so ordered + variable benefits most. The effect is tier-independent (`any` and `current` alike), and nothing regresses.

## Benchmarks at scale (`init_scale`)

The table above tops out at 100K elements / 1M ops; the cache's payoff **grows with database size**. It eliminates the redundant `find_update_op` reads, and the journal's page cache holds only raw pages (evicted during the sequential replay), so at multi-GB scale those reads increasingly miss the page cache. This PR adds a standalone `init_scale` benchmark that builds a real, multi-GB database once (applying `num_updates` random operations -- ~10% deletes -- sampled over a `keyspace`-key index space, uniformly or via Zipf, reporting its build time) and then reopens it (snapshot rebuild) at several cache sizes:

```
cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db 50000000 250000000 0    # uniform
cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db 50000000 250000000      # Zipf (default exponent 1.0)
cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db
cargo bench -p commonware-storage --bench init_scale --features test-traits -- destroy  /tmp/db
```

Reopen time, `any::ordered::fixed::mmr`, 50M-key keyspace / 250M updates, OS page cache warm (1 GiB), at cache off / a quarter of the replay region (`R/4`) / the whole replay region (`R`):

| workload | size | `R` (ops) | off | R/4 | R (full) |
|---|---|---|---|---|---|
| uniform | ~10 GB | 64.6M | 134.9 s | 89.7 s (-33%) | 41.5 s (**-69% / 3.25x**) |
| Zipf (s=1.0) | ~6.1 GB | 38.2M | 43.0 s | 31.5 s (-27%) | 22.4 s (**-48% / 1.92x**) |

At production scale a full-coverage cache cuts startup by **~2-3x** (up to **3.25x** on uniform churn, versus ~30% at 100K elements): the larger the replay region, the more collision-resolution reads miss the page cache and the more the cache elides. A partial (`R/4`) cache still recovers ~30%. Uniform churn benefits most -- every key is distinct, so resolution reads scatter across the whole log and are rarely page-cache-resident; Zipf concentrates updates on a hot subset (whose recent prior ops the page cache already holds) and lifts the inactivity floor faster, leaving a smaller `R`. The cache affects only the reopen path; generation is unchanged.

## Why not just cache the replayed pages?

Since each re-read is a syscall whose *page* then lands in the page cache, a natural alternative is to have `replay` populate the page cache as it streams, so even the first re-read is a memory hit and no dedicated cache is needed. We implemented that and measured it head-to-head against this PR's loc->key cache, warm, 50M keys, at full replay-region coverage:

| shape | replay-populated page cache | loc->key cache (this PR) |
|---|---|---|
| fixed (~10 GB db) | 41.8 s, ~6 GB resident | 43.0 s, ~4 GB |
| variable (~15 GB db) | 49.6 s, ~12.5 GB resident | 47.0 s, ~4 GB |

Init speed is comparable (within ~5%); the small crossover flips with shape, since a variable re-read is two reads plus offset resolution that the key cache skips. The loc->key cache wins on memory, robustness, and parallelizability:

- **Memory.** It stores only the 32-byte key per active location, so its footprint tracks key *count*, not log *bytes* (~4 GB for both shapes), and it is freed after init. Matching that speed with the page cache means pinning the entire active log for the process lifetime: ~6 GB (fixed) to ~12.5 GB (variable), growing with value size.
- **Robustness.** Undersize the page cache below the active log and re-reads miss again, ~2x slower at quarter-coverage (84 s fixed, 82 s variable); the key cache holds full coverage in ~4 GB and degrades gracefully.
- **Parallelizable.** Parallel snapshot construction shards cleanly: each worker can own a private, conflict-free key cache (disjoint partition ranges, hence disjoint keys; no lock, no cross-worker eviction). A shared page cache would instead serialize workers on its lock and let them thrash each other's pages, needing ~Nx the capacity to compensate.



Resolves #4133

