### PR TITLE
[stoarge/journal/contiguous] Fold `Reader` into `Contiguous`

### DIFF
--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -136,7 +136,7 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn size(&self) -> Location {
-        self.bounds().await.end
+        self.bounds().end
     }
 
     async fn sync_boundary(&self) -> Location {

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -160,7 +160,7 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn size(&self) -> Location {
-        self.bounds().await.end
+        self.bounds().end
     }
 
     async fn sync_boundary(&self) -> Location {

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -143,7 +143,7 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn size(&self) -> Location {
-        self.bounds().await.end
+        self.bounds().end
     }
 
     async fn sync_boundary(&self) -> Location {
@@ -173,6 +173,6 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn target(&self) -> compact::Target<Self::Family, Key> {
-        compact::Target::new(self.root(), self.bounds().await.end)
+        compact::Target::new(self.root(), self.bounds().end)
     }
 }

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -138,7 +138,7 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn size(&self) -> Location {
-        self.bounds().await.end
+        self.bounds().end
     }
 
     async fn sync_boundary(&self) -> Location {
@@ -164,7 +164,7 @@ where
     E: Storage + Clock + Metrics,
 {
     async fn target(&self) -> compact::Target<Self::Family, Key> {
-        compact::Target::new(self.root(), self.bounds().await.end)
+        compact::Target::new(self.root(), self.bounds().end)
     }
 }
 

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -389,7 +389,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         AnySyncTarget::new(
             self.root(),
             non_empty_range!(self.sync_boundary(), bounds.end),
@@ -486,7 +486,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         AnySyncTarget::new(
             self.root(),
             non_empty_range!(self.sync_boundary(), bounds.end),

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -387,7 +387,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         CurrentSyncTarget::new(
             self.ops_root(),
             non_empty_range!(self.sync_boundary(), bounds.end),
@@ -481,7 +481,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         CurrentSyncTarget::new(
             self.ops_root(),
             non_empty_range!(self.sync_boundary(), bounds.end),
@@ -652,7 +652,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         CurrentSyncTarget::new(
             self.ops_root(),
             non_empty_range!(self.sync_boundary(), bounds.end),
@@ -751,7 +751,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         CurrentSyncTarget::new(
             self.ops_root(),
             non_empty_range!(self.sync_boundary(), bounds.end),

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -732,7 +732,7 @@ mod tests {
             source.sync().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
 
             let floor = source.inactivity_floor_loc();
@@ -744,7 +744,7 @@ mod tests {
             source.sync().await.unwrap();
             let latest_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
 
             let (stale_request_tx, mut stale_request_rx) = mpsc::channel(1);

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -309,7 +309,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         AnySyncTarget::new(
             self.root(),
             non_empty_range!(self.sync_boundary(), bounds.end),
@@ -394,7 +394,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         AnySyncTarget::new(
             self.root(),
             non_empty_range!(self.sync_boundary(), bounds.end),

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -746,7 +746,7 @@ mod tests {
             source.sync().await.unwrap();
             let first_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
 
             let floor = source.inactivity_floor_loc();
@@ -759,7 +759,7 @@ mod tests {
             source.sync().await.unwrap();
             let second_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
 
             let (update_tx, update_rx) = mpsc::channel(1);

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -281,7 +281,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         AnySyncTarget::new(
             self.root(),
             non_empty_range!(self.sync_boundary(), bounds.end),
@@ -359,7 +359,7 @@ where
     }
 
     async fn sync_target(&self) -> Self::SyncTarget {
-        let bounds = self.bounds().await;
+        let bounds = self.bounds();
         AnySyncTarget::new(
             self.root(),
             non_empty_range!(self.sync_boundary(), bounds.end),

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -550,7 +550,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let (mut actor, _mailbox) = TestActor::new(context.child("actor"), test_config(None));
             let db = init_db(context.child("resolver_db"), "resolver-after-attach").await;
-            let op_count = db.read().await.bounds().await.end;
+            let op_count = db.read().await.bounds().end;
             actor.handle_mailbox_message(mailbox::Message::AttachDatabase(db));
 
             let (response_tx, response_rx) = oneshot::channel();
@@ -570,7 +570,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let (mut actor, _mailbox) = TestActor::new(context.child("actor"), test_config(None));
             let db = init_db(context.child("resolver_db"), "resolver-unbounded-max-ops").await;
-            let op_count = db.read().await.bounds().await.end;
+            let op_count = db.read().await.bounds().end;
             actor.handle_mailbox_message(mailbox::Message::AttachDatabase(db));
 
             let request = handler::Request {

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -664,7 +664,7 @@ impl EngineDefinition for MultiDbEngine {
             let mailbox = prune_observer.clone();
             Box::pin(async move {
                 let (a, _b) = mailbox.subscribe_databases().await;
-                let oldest_a = *a.read().await.bounds().await.start;
+                let oldest_a = *a.read().await.bounds().start;
                 oldest_a
             })
         });

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -534,7 +534,7 @@ impl EngineDefinition for SingleDbEngine {
             Box::pin(async move {
                 let databases = mailbox.subscribe_databases().await;
                 let guard = databases.read().await;
-                let bounds = guard.bounds().await;
+                let bounds = guard.bounds();
                 *bounds.start
             })
         });

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -329,7 +329,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
 
             // Verify range proofs over the recovered DB.
             let floor = *db.sync_boundary();
-            let size = *db.bounds().await.end;
+            let size = *db.bounds().end;
             for i in floor..size {
                 let loc = Location::<F>::new(i);
                 let (proof, ops, chunks) = db

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -181,8 +181,8 @@ async fn apply_pending(db: &mut Db, writes: &[(Key, Option<Value>)]) {
 
 async fn assert_matches_reference(db: &Db, reference_db: &Db, context: &str) {
     assert_eq!(
-        db.bounds().await.end,
-        reference_db.bounds().await.end,
+        db.bounds().end,
+        reference_db.bounds().end,
         "op count mismatch after {context}"
     );
     assert_eq!(
@@ -232,7 +232,7 @@ async fn reopen_pruned_db(
 ) -> Db {
     let root_before = db.root();
     let ops_root_before = db.ops_root();
-    let bounds_before = db.bounds().await;
+    let bounds_before = db.bounds();
     let pruned_bits_before = db.pruned_bits();
     drop(db);
 
@@ -253,7 +253,7 @@ async fn reopen_pruned_db(
         "ops root changed after reopen"
     );
     assert_eq!(
-        reopened.bounds().await,
+        reopened.bounds(),
         bounds_before,
         "bounds changed after reopen"
     );
@@ -516,8 +516,8 @@ fn fuzz(data: FuzzInput) {
 
         prune_to_floor(&mut db, &reference_db, "final").await;
         assert_eq!(
-            db.bounds().await.end,
-            reference_db.bounds().await.end,
+            db.bounds().end,
+            reference_db.bounds().end,
             "final op count mismatch"
         );
 

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -188,7 +188,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 &mut pending_deletes,
             )
             .await;
-            committed_op_count = db.bounds().await.end;
+            committed_op_count = db.bounds().end;
         }
 
         for op in &operations {
@@ -239,7 +239,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 }
 
                 CurrentOperation::OpCount => {
-                    let actual = db.bounds().await.end;
+                    let actual = db.bounds().end;
                     assert_eq!(
                         actual, committed_op_count,
                         "Op count mismatch: expected {committed_op_count}, got {actual}"
@@ -251,7 +251,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         &mut db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                 }
 
                 CurrentOperation::Prune => {
@@ -259,7 +259,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         &mut db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                     db.prune(db.sync_boundary()).await.expect("Prune should not fail");
                 }
 
@@ -268,12 +268,12 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         &mut db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                     let _root = db.root();
                 }
 
                 CurrentOperation::RangeProof { start_loc, max_ops } => {
-                    let current_op_count = db.bounds().await.end;
+                    let current_op_count = db.bounds().end;
                     if current_op_count == 0 {
                         continue;
                     }
@@ -282,10 +282,10 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         &mut db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
-                    let current_op_count = db.bounds().await.end;
+                    let current_op_count = db.bounds().end;
                     let start_loc = Location::<F>::new(start_loc % *current_op_count);
 
                     let oldest_loc = db.sync_boundary();
@@ -317,7 +317,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     max_ops,
                     chunk_xor,
                 } => {
-                    let current_op_count = db.bounds().await.end;
+                    let current_op_count = db.bounds().end;
                     if current_op_count == 0 {
                         continue;
                     }
@@ -325,9 +325,9 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         &mut db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
 
-                    let current_op_count = db.bounds().await.end;
+                    let current_op_count = db.bounds().end;
                     let start_loc = Location::<F>::new(start_loc % current_op_count.as_u64());
                     let root = db.root();
 
@@ -408,7 +408,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         &mut db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
                     match db.key_value_proof(&hasher, k.clone()).await {
@@ -439,7 +439,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         &mut db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
                     match db.exclusion_proof(&hasher, &k).await {

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -176,7 +176,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 &mut pending_expected,
             )
             .await;
-            committed_op_count = db.bounds().await.end;
+            committed_op_count = db.bounds().end;
         }
 
         for op in &operations {
@@ -226,7 +226,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 }
 
                 CurrentOperation::OpCount => {
-                    let actual = db.bounds().await.end;
+                    let actual = db.bounds().end;
                     assert_eq!(
                         actual, committed_op_count,
                         "Op count mismatch: expected {committed_op_count}, got {actual}"
@@ -235,32 +235,32 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
 
                 CurrentOperation::Commit => {
                     commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                 }
 
                 CurrentOperation::Prune => {
                     commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                     db.prune(db.sync_boundary()).await.expect("Prune should not fail");
                 }
 
                 CurrentOperation::Root => {
                     commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                     let _root = db.root();
                 }
 
                 CurrentOperation::RangeProof { start_loc, max_ops } => {
-                    let current_op_count = db.bounds().await.end;
+                    let current_op_count = db.bounds().end;
                     if current_op_count == 0 {
                         continue;
                     }
 
                     commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
-                    let current_op_count = db.bounds().await.end;
+                    let current_op_count = db.bounds().end;
                     let start_loc = Location::<F>::new(start_loc % *current_op_count);
                     let oldest_loc = db.sync_boundary();
                     if start_loc >= oldest_loc {
@@ -291,14 +291,14 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     max_ops,
                     chunk_xor,
                 } => {
-                    let current_op_count = db.bounds().await.end;
+                    let current_op_count = db.bounds().end;
                     if current_op_count == 0 {
                         continue;
                     }
                     commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
 
-                    let current_op_count = db.bounds().await.end;
+                    let current_op_count = db.bounds().end;
                     let start_loc = Location::<F>::new(start_loc % current_op_count.as_u64());
                     let root = db.root();
 
@@ -376,7 +376,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     let k = Key::new(*key);
 
                     commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
-                    committed_op_count = db.bounds().await.end;
+                    committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
                     match db.key_value_proof(&hasher, k.clone()).await {

--- a/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
@@ -6,7 +6,7 @@ use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervi
 use commonware_storage::journal::{
     contiguous::{
         fixed::{Config as JournalConfig, Journal},
-        Many, Mutable as _, Reader,
+        Contiguous, Many, Mutable as _,
     },
     Error,
 };
@@ -150,16 +150,14 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 JournalOperation::Read { pos } => {
-                    let reader = journal.reader();
-                    let bounds = reader.bounds();
+                    let bounds = journal.bounds();
                     if bounds.contains(pos) {
-                        reader.read(*pos).await.unwrap();
+                        journal.read(*pos).await.unwrap();
                     }
                 }
 
                 JournalOperation::ReadMany { positions } => {
-                    let reader = journal.reader();
-                    let bounds = reader.bounds();
+                    let bounds = journal.bounds();
                     // Map fuzz positions into valid, sorted, deduplicated positions
                     let mut mapped: Vec<u64> = positions
                         .iter()
@@ -174,11 +172,11 @@ fn fuzz(input: FuzzInput) {
                     mapped.sort_unstable();
                     mapped.dedup();
                     if !mapped.is_empty() {
-                        let batch = reader.read_many(&mapped).await.unwrap();
+                        let batch = journal.read_many(&mapped).await.unwrap();
                         assert_eq!(batch.len(), mapped.len());
                         // Cross-check against individual reads
                         for (i, &pos) in mapped.iter().enumerate() {
-                            let single = reader.read(pos).await.unwrap();
+                            let single = journal.read(pos).await.unwrap();
                             assert_eq!(batch[i], single);
                         }
                     }
@@ -198,26 +196,25 @@ fn fuzz(input: FuzzInput) {
                         journal.rewind(*size).await.unwrap();
                         journal.sync().await.unwrap();
                         journal_size = *size;
-                        oldest_retained_pos = journal.reader().bounds().start;
+                        oldest_retained_pos = journal.bounds().start;
                     }
                 }
 
                 JournalOperation::Bounds => {
-                    let _bounds = journal.reader().bounds();
+                    let _bounds = journal.bounds();
                 }
 
                 JournalOperation::Prune { min_pos } => {
                     if *min_pos <= journal_size {
                         journal.prune(*min_pos).await.unwrap();
-                        oldest_retained_pos = journal.reader().bounds().start;
+                        oldest_retained_pos = journal.bounds().start;
                     }
                 }
 
                 JournalOperation::Replay { buffer, start_pos } => {
-                    let reader = journal.reader();
-                    let bounds = reader.bounds();
+                    let bounds = journal.bounds();
                     let start_pos = bounds.start + (*start_pos % (bounds.end - bounds.start + 1));
-                    let replay = reader.replay(NZUsize!(*buffer), start_pos).await;
+                    let replay = journal.replay(NZUsize!(*buffer), start_pos).await;
 
                     match replay {
                         Ok(stream) => {
@@ -249,7 +246,7 @@ fn fuzz(input: FuzzInput) {
                     restarts += 1;
                     // Reset tracking variables to match recovered state
                     journal_size = journal.size();
-                    oldest_retained_pos = journal.reader().bounds().start;
+                    oldest_retained_pos = journal.bounds().start;
                 }
 
                 JournalOperation::Destroy => {
@@ -318,17 +315,16 @@ fn fuzz(input: FuzzInput) {
                         let new_size = journal.rewind_to(|item| *item == target).await.unwrap();
                         journal.sync().await.unwrap();
                         journal_size = new_size;
-                        oldest_retained_pos = journal.reader().bounds().start;
+                        oldest_retained_pos = journal.bounds().start;
                     }
                 }
 
                 JournalOperation::TryReadSync { pos } => {
-                    let reader = journal.reader();
-                    let bounds = reader.bounds();
+                    let bounds = journal.bounds();
                     if bounds.contains(pos) {
                         // Cross-check: sync result must match async result
-                        if let Some(sync_val) = reader.try_read_sync(*pos) {
-                            let async_val = reader.read(*pos).await.unwrap();
+                        if let Some(sync_val) = journal.try_read_sync(*pos) {
+                            let async_val = journal.read(*pos).await.unwrap();
                             assert_eq!(sync_val, async_val);
                         }
                     }
@@ -359,7 +355,7 @@ fn fuzz(input: FuzzInput) {
                         Err(e) => panic!("unexpected init_at_size error: {e:?}"),
                     };
                     journal_size = journal.size();
-                    oldest_retained_pos = journal.reader().bounds().start;
+                    oldest_retained_pos = journal.bounds().start;
                 }
             }
         }

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -47,7 +47,7 @@ use commonware_storage::journal::{
     contiguous::{
         fixed::{Config as FixedConfig, Journal as FixedJournal},
         variable::{Config as VariableConfig, Journal as VariableJournal},
-        Reader,
+        Contiguous,
     },
     Error,
 };
@@ -287,7 +287,7 @@ trait FuzzJournal: Sized {
     ) -> impl Future<Output = Result<Self, Error>> + Send;
 
     fn size(&self) -> impl Future<Output = u64> + Send;
-    fn bounds(&self) -> impl Future<Output = Range<u64>> + Send;
+    fn bounds(&self) -> Range<u64>;
 
     fn append(&mut self, item: Item) -> impl Future<Output = Result<u64, Error>> + Send;
     fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send;
@@ -306,8 +306,8 @@ trait FuzzJournal: Sized {
 }
 
 /// Drain a reader's replay stream into a `(position, item)` vector.
-async fn collect_replay<R: Reader<Item = Item>>(
-    reader: R,
+async fn collect_replay<C: Contiguous<Item = Item>>(
+    reader: &C,
     buffer: NonZeroUsize,
     start_pos: u64,
 ) -> Result<Vec<(u64, Item)>, Error> {
@@ -344,20 +344,16 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::size(self)
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
-    #[allow(clippy::manual_async_fn)]
-    fn bounds(&self) -> impl Future<Output = Range<u64>> + Send {
-        async { self.reader().bounds() }
+    fn bounds(&self) -> Range<u64> {
+        Contiguous::bounds(self)
     }
 
     async fn append(&mut self, item: Item) -> Result<u64, Error> {
         FixedJournal::append(self, &item).await
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
-    #[allow(clippy::manual_async_fn)]
-    fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send {
-        async move { self.reader().read(pos).await }
+    async fn read(&self, pos: u64) -> Result<Item, Error> {
+        Contiguous::read(self, pos).await
     }
 
     async fn sync(&mut self) -> Result<(), Error> {
@@ -376,14 +372,12 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         FixedJournal::prune(self, min_pos).await
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
-    #[allow(clippy::manual_async_fn)]
-    fn replay(
+    async fn replay(
         &self,
         buffer: NonZeroUsize,
         start_pos: u64,
-    ) -> impl Future<Output = Result<Vec<(u64, Item)>, Error>> + Send {
-        async move { collect_replay(self.reader(), buffer, start_pos).await }
+    ) -> Result<Vec<(u64, Item)>, Error> {
+        collect_replay(self, buffer, start_pos).await
     }
 
     async fn destroy(self) -> Result<(), Error> {
@@ -417,20 +411,16 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::size(self)
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
-    #[allow(clippy::manual_async_fn)]
-    fn bounds(&self) -> impl Future<Output = Range<u64>> + Send {
-        async { self.reader().bounds() }
+    fn bounds(&self) -> Range<u64> {
+        Contiguous::bounds(self)
     }
 
     async fn append(&mut self, item: Item) -> Result<u64, Error> {
         VariableJournal::append(self, &item).await
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
-    #[allow(clippy::manual_async_fn)]
-    fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send {
-        async move { self.reader().read(pos).await }
+    async fn read(&self, pos: u64) -> Result<Item, Error> {
+        Contiguous::read(self, pos).await
     }
 
     async fn sync(&mut self) -> Result<(), Error> {
@@ -445,14 +435,12 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         VariableJournal::prune(self, min_pos).await
     }
 
-    // Cannot use `async fn` here due to RPITIT Send auto-trait limitation.
-    #[allow(clippy::manual_async_fn)]
-    fn replay(
+    async fn replay(
         &self,
         buffer: NonZeroUsize,
         start_pos: u64,
-    ) -> impl Future<Output = Result<Vec<(u64, Item)>, Error>> + Send {
-        async move { collect_replay(self.reader(), buffer, start_pos).await }
+    ) -> Result<Vec<(u64, Item)>, Error> {
+        collect_replay(self, buffer, start_pos).await
     }
 
     async fn commit(&mut self) -> Result<(), Error> {
@@ -469,7 +457,7 @@ async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expecte
     let Range {
         start: boundary,
         end: size,
-    } = journal.bounds().await;
+    } = journal.bounds();
     assert!(size >= boundary, "size {size} < boundary {boundary}");
 
     // Size and boundary fall within the expected bounds.
@@ -542,7 +530,7 @@ async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expecte
 
 /// Read the recovered journal back into an `Expected` pinned to exactly that state.
 async fn to_expected<J: FuzzJournal>(journal: &J) -> Expected {
-    let bounds = journal.bounds().await;
+    let bounds = journal.bounds();
     let items = journal
         .replay(NZUsize!(VERIFY_REPLAY_BUF), bounds.start)
         .await
@@ -648,7 +636,7 @@ async fn run_ops<J: FuzzJournal>(
             }
 
             JournalOperation::Read { pos } => {
-                let bounds = journal.bounds().await;
+                let bounds = journal.bounds();
                 if !bounds.is_empty() {
                     let target = bounds.start + (*pos % (bounds.end - bounds.start));
                     assert_read(journal.read(target).await, target, &bounds);
@@ -659,7 +647,7 @@ async fn run_ops<J: FuzzJournal>(
 
             JournalOperation::Sync => match journal.sync().await {
                 Ok(()) => {
-                    expected.synced(journal.bounds().await);
+                    expected.synced(journal.bounds());
                     true
                 }
                 Err(_) => false,
@@ -674,7 +662,7 @@ async fn run_ops<J: FuzzJournal>(
             },
 
             JournalOperation::Rewind { size } => {
-                let bounds = journal.bounds().await;
+                let bounds = journal.bounds();
                 if bounds.is_empty() {
                     true
                 } else {
@@ -718,7 +706,7 @@ async fn run_ops<J: FuzzJournal>(
                 let size = journal.size().await;
                 match journal.prune(*min_pos).await {
                     Ok(_) => {
-                        expected.pruned(journal.bounds().await.start);
+                        expected.pruned(journal.bounds().start);
                         true
                     }
                     Err(_) => {
@@ -735,7 +723,7 @@ async fn run_ops<J: FuzzJournal>(
             JournalOperation::Replay { buffer, start_pos } => {
                 // The clamped replay must return the full suffix matching `read()`, or hit a
                 // tail-repair I/O fault.
-                let bounds = journal.bounds().await;
+                let bounds = journal.bounds();
                 let clamped = bounds.start + (*start_pos % (bounds.end - bounds.start + 1));
                 let clamped_ok = match journal.replay(NZUsize!(*buffer), clamped).await {
                     Ok(items) => {
@@ -883,7 +871,7 @@ where
         assert_eq!(pos, size);
         expected.appended(sentinel.clone());
         journal.sync().await.expect("final sync");
-        expected.synced(journal.bounds().await);
+        expected.synced(journal.bounds());
         drop(journal);
 
         // Reopen and confirm the synced sentinel survived the restart.

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -220,7 +220,7 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
                 }
 
                 Operation::SyncFull { fetch_batch_size } => {
-                    if db.bounds().await.end == 0 {
+                    if db.bounds().end == 0 {
                         continue;
                     }
                     input.commit_counter += 1;
@@ -240,7 +240,7 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
                     db.commit().await.expect("Commit should not fail");
                     let target = sync::Target::new(
                         db.root(),
-                        non_empty_range!(db.sync_boundary(), db.bounds().await.end),
+                        non_empty_range!(db.sync_boundary(), db.bounds().end),
                     );
 
                     let wrapped_src = Arc::new(db);

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -207,7 +207,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         .await
                         .expect("commit should not fail");
                     db.commit().await.expect("Commit should not fail");
-                    historical_roots.insert(db.bounds().await.end, db.root());
+                    historical_roots.insert(db.bounds().end, db.root());
                 }
 
                 Operation::Prune => {
@@ -235,9 +235,9 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         .await
                         .expect("commit should not fail");
                     db.commit().await.expect("Commit should not fail");
-                    historical_roots.insert(db.bounds().await.end, db.root());
+                    historical_roots.insert(db.bounds().end, db.root());
                     let start_loc = Location::<F>::new(*start_loc % (*F::MAX_LEAVES + 1));
-                    let op_count = db.bounds().await.end;
+                    let op_count = db.bounds().end;
                     let oldest_retained_loc = db.sync_boundary();
                     if start_loc >= oldest_retained_loc && start_loc < op_count {
                         if let Ok((proof, log)) = db.proof(start_loc, *max_ops).await {
@@ -262,7 +262,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         .await
                         .expect("commit should not fail");
                     db.commit().await.expect("Commit should not fail");
-                    historical_roots.insert(db.bounds().await.end, db.root());
+                    historical_roots.insert(db.bounds().end, db.root());
                     let op_count = {
                         let idx = (*size as usize) % historical_roots.len();
                         *historical_roots
@@ -295,7 +295,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                     db.apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
-                    historical_roots.insert(db.bounds().await.end, db.root());
+                    historical_roots.insert(db.bounds().end, db.root());
                     db.sync().await.expect("Sync should not fail");
                 }
 
@@ -304,7 +304,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                 }
 
                 Operation::OpCount => {
-                    let _ = db.bounds().await.end;
+                    let _ = db.bounds().end;
                 }
 
                 Operation::Root => {
@@ -318,7 +318,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         .await
                         .expect("commit should not fail");
                     db.commit().await.expect("Commit should not fail");
-                    historical_roots.insert(db.bounds().await.end, db.root());
+                    historical_roots.insert(db.bounds().end, db.root());
                     let _ = db.root();
                 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -190,7 +190,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             None
                         };
 
-                        let end = db.bounds().await.end;
+                        let end = db.bounds().end;
                         let pending_count = pending_sets.len() as u64;
                         assign_pending_locations(
                             &pending_sets,
@@ -213,7 +213,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         let merkleized = batch.merkleize(&db, metadata, floor);
                         db.apply_batch(merkleized).await.unwrap();
                         db.commit().await.unwrap();
-                        last_commit_loc = Some(db.bounds().await.end - 1);
+                        last_commit_loc = Some(db.bounds().end - 1);
                     }
 
                     ImmutableOperation::Prune { loc } => {
@@ -222,7 +222,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             let safe_loc = Location::new(safe_loc);
                             assign_pending_locations(
                                 &pending_sets,
-                                db.bounds().await.end,
+                                db.bounds().end,
                                 &mut keys_set,
                                 &mut set_locations,
                             );
@@ -236,9 +236,9 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             let merkleized = batch.merkleize(&db, None, floor);
                             db.apply_batch(merkleized).await.unwrap();
                             db.commit().await.unwrap();
-                            last_commit_loc = Some(db.bounds().await.end - 1);
+                            last_commit_loc = Some(db.bounds().end - 1);
                             db.prune(safe_loc).await.expect("prune should not fail");
-                            let oldest = db.bounds().await.start;
+                            let oldest = db.bounds().start;
                             set_locations.retain(|(_, l)| *l >= oldest);
                             keys_set.retain(|(_, l)| *l >= oldest);
                         }
@@ -248,7 +248,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         start_index,
                         max_ops,
                     } => {
-                        let op_count = db.bounds().await.end;
+                        let op_count = db.bounds().end;
                         if op_count > 0 {
                             let safe_start = start_index % op_count.as_u64();
                             let safe_start = Location::new(safe_start);
@@ -256,7 +256,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                                 NonZeroU64::new((max_ops % MAX_PROOF_OPS).max(1)).unwrap();
                             assign_pending_locations(
                                 &pending_sets,
-                                db.bounds().await.end,
+                                db.bounds().end,
                                 &mut keys_set,
                                 &mut set_locations,
                             );
@@ -268,7 +268,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             let merkleized = batch.merkleize(&db, None, floor);
                             db.apply_batch(merkleized).await.unwrap();
                             db.commit().await.unwrap();
-                            last_commit_loc = Some(db.bounds().await.end - 1);
+                            last_commit_loc = Some(db.bounds().end - 1);
                             if let Ok((proof, ops)) = db.proof(safe_start, safe_max_ops).await {
                                 let root = db.root();
                                 let _ = verify_proof(&hasher, &proof, safe_start, &ops, &root);
@@ -281,7 +281,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         start_loc,
                         max_ops,
                     } => {
-                        let op_count = db.bounds().await.end;
+                        let op_count = db.bounds().end;
                         if op_count > 0 && pending_sets.is_empty() {
                             let safe_size = (size % op_count.as_u64()).max(1);
                             let safe_size = Location::new(safe_size);
@@ -294,8 +294,8 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             let batch = db.new_batch().merkleize(&db, None, floor);
                             db.apply_batch(batch).await.unwrap();
                             db.commit().await.unwrap();
-                            last_commit_loc = Some(db.bounds().await.end - 1);
-                            if safe_start >= db.bounds().await.start {
+                            last_commit_loc = Some(db.bounds().end - 1);
+                            if safe_start >= db.bounds().start {
                                 let _ = db
                                     .historical_proof(safe_size, safe_start, safe_max_ops)
                                     .await;
@@ -308,17 +308,17 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                     }
 
                     ImmutableOperation::OpCount => {
-                        let _ = db.bounds().await.end;
+                        let _ = db.bounds().end;
                     }
 
                     ImmutableOperation::OldestRetainedLoc => {
-                        let _ = db.bounds().await.start;
+                        let _ = db.bounds().start;
                     }
 
                     ImmutableOperation::Root => {
                         assign_pending_locations(
                             &pending_sets,
-                            db.bounds().await.end,
+                            db.bounds().end,
                             &mut keys_set,
                             &mut set_locations,
                         );
@@ -330,7 +330,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         let merkleized = batch.merkleize(&db, None, floor);
                         db.apply_batch(merkleized).await.unwrap();
                         db.commit().await.unwrap();
-                        last_commit_loc = Some(db.bounds().await.end - 1);
+                        last_commit_loc = Some(db.bounds().end - 1);
                         let _ = db.root();
                     }
                 }
@@ -338,7 +338,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
 
             assign_pending_locations(
                 &pending_sets,
-                db.bounds().await.end,
+                db.bounds().end,
                 &mut keys_set,
                 &mut set_locations,
             );

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -239,7 +239,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
 
                 Operation::Commit { metadata_bytes, floor_kind } => {
                     let pending_count = pending_appends.len() as u64;
-                    let end = db.bounds().await.end;
+                    let end = db.bounds().end;
                     let commit_loc = end.as_u64() + pending_count;
                     let current_floor = db.inactivity_floor_loc();
 
@@ -292,7 +292,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                 }
 
                 Operation::BadChainedCommit { ancestor_kind } => {
-                    let end = db.bounds().await.end;
+                    let end = db.bounds().end;
                     let current_floor = db.inactivity_floor_loc();
 
                     // Parent batch: base = end, 1 append lands at `end`, commit lands at `end + 1`.
@@ -342,7 +342,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                 }
 
                 Operation::Get { loc_offset } => {
-                    let op_count = db.bounds().await.end;
+                    let op_count = db.bounds().end;
                     if op_count > 0 {
                         let loc = (*loc_offset as u64) % op_count.as_u64();
                         let _ = db.get(loc.into()).await;
@@ -362,7 +362,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                     // Advance the floor to the new commit location so the subsequent prune
                     // actually removes data. This exercises more of the code path than pruning
                     // at a stale floor would.
-                    let end = db.bounds().await.end;
+                    let end = db.bounds().end;
                     let floor = Location::<F>::new(end.as_u64() + pending_count);
                     let merkleized = batch.merkleize(&db, None, floor);
                     db.apply_batch(merkleized).await.expect("Commit should not fail");
@@ -383,7 +383,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                 }
 
                 Operation::OpCount => {
-                    let _ = db.bounds().await.end;
+                    let _ = db.bounds().end;
                 }
 
                 Operation::LastCommitLoc => {
@@ -391,7 +391,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                 }
 
                 Operation::OldestRetainedLoc => {
-                    let _ = db.bounds().await.start;
+                    let _ = db.bounds().start;
                 }
 
                 Operation::Root => {
@@ -409,7 +409,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                     start_offset,
                     max_ops,
                 } => {
-                    let op_count = db.bounds().await.end;
+                    let op_count = db.bounds().end;
                     if op_count == 0 {
                         continue;
                     }
@@ -442,7 +442,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                     start_offset,
                     max_ops,
                 } => {
-                    let op_count = db.bounds().await.end;
+                    let op_count = db.bounds().end;
                     if op_count == 0 {
                         continue;
                     }
@@ -454,7 +454,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                     db.apply_batch(merkleized).await.expect("Commit should not fail");
                     db.commit().await.expect("Commit should not fail");
                     // Use post-commit op_count so it's consistent with the root.
-                    let op_count = db.bounds().await.end;
+                    let op_count = db.bounds().end;
                     let size = ((*size_offset as u64) % op_count.as_u64()) + 1;
                     let size: Location<F> = Location::new(size);
                     let start_loc = (*start_offset as u64) % *size;

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -169,7 +169,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     }
 
                     QmdbOperation::OpCount => {
-                        let _ = db.bounds().await.end;
+                        let _ = db.bounds().end;
                     }
 
                     QmdbOperation::Commit => {
@@ -192,7 +192,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             &mut db, &mut pending_writes, &mut committed_state,
                             &mut pending_inserts, &mut pending_deletes,
                         ).await;
-                        let actual_op_count = db.bounds().await.end;
+                        let actual_op_count = db.bounds().end;
 
                         if actual_op_count > 0 {
                             let current_root = db.root();
@@ -219,7 +219,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             &mut db, &mut pending_writes, &mut committed_state,
                             &mut pending_inserts, &mut pending_deletes,
                         ).await;
-                        let actual_op_count = db.bounds().await.end;
+                        let actual_op_count = db.bounds().end;
 
                         let proof = Proof {
                             leaves: Location::<F>::new(*proof_leaves),

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -148,7 +148,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     }
 
                     QmdbOperation::OpCount => {
-                        let _ = db.bounds().await.end;
+                        let _ = db.bounds().end;
                     }
 
                     QmdbOperation::Commit => {
@@ -161,14 +161,14 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     }
 
                     QmdbOperation::Proof { start_loc, max_ops } => {
-                        let actual_op_count = db.bounds().await.end;
+                        let actual_op_count = db.bounds().end;
                         if actual_op_count == 0 || *max_ops == 0 {
                             continue;
                         }
 
                         commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                         let current_root = db.root();
-                        let actual_op_count = db.bounds().await.end;
+                        let actual_op_count = db.bounds().end;
                         let adjusted_start = Location::<F>::new(*start_loc % *actual_op_count);
                         let adjusted_max_ops = (*max_ops % 100).max(1);
 

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     journal::{
-        contiguous::{fixed, variable, Contiguous, Many, Mutable, Reader},
+        contiguous::{fixed, variable, Contiguous, Many, Mutable},
         Error as JournalError,
     },
     merkle::{
@@ -27,8 +27,11 @@ use commonware_codec::{CodecFixedShared, CodecShared, Encode, EncodeShared};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use core::num::NonZeroU64;
-use futures::{try_join, TryFutureExt as _};
+use core::{
+    num::{NonZeroU64, NonZeroUsize},
+    ops::Range,
+};
+use futures::{try_join, Stream, TryFutureExt as _};
 use thiserror::Error;
 use tracing::{debug, warn};
 
@@ -274,8 +277,8 @@ where
     S: Strategy,
 {
     /// Returns the Location of the next item appended to the journal.
-    pub async fn size(&self) -> Location<F> {
-        Location::new(self.journal.size().await)
+    pub fn size(&self) -> Location<F> {
+        Location::new(self.journal.bounds().end)
     }
 
     /// Compute the root of the Merkle structure using `inactive_peaks` and the bagging carried by
@@ -396,7 +399,7 @@ where
         apply_batch_size: u64,
     ) -> Result<(), Error<F>> {
         // Rewind Merkle structure elements that are ahead of the journal.
-        let journal_size = journal.size().await;
+        let journal_size = journal.bounds().end;
         let mut merkle_leaves = merkle.leaves();
         if merkle_leaves > journal_size {
             let rewind_count = merkle_leaves - journal_size;
@@ -417,13 +420,12 @@ where
                 replay_count, "Merkle structure lags behind journal, replaying journal to catch up"
             );
 
-            let reader = journal.reader().await;
             while merkle_leaves < journal_size {
                 let batch = {
                     let mut batch = merkle.new_batch();
                     let mut count = 0u64;
                     while count < apply_batch_size && merkle_leaves < journal_size {
-                        let op = reader.read(*merkle_leaves).await?;
+                        let op = journal.read(*merkle_leaves).await?;
                         batch = batch.add(hasher, &op.encode());
                         merkle_leaves += 1;
                         count += 1;
@@ -437,7 +439,7 @@ where
         }
 
         // At this point the Merkle structure and journal should be consistent.
-        assert_eq!(journal.size().await, *merkle.leaves());
+        assert_eq!(journal.bounds().end, *merkle.leaves());
 
         Ok(())
     }
@@ -493,7 +495,7 @@ where
         // batches are skipped by tracking cumulative leaf count.
         // Batches are collected into a single append_many call to acquire the
         // journal's write lock once instead of per-batch.
-        let committed_leaves = self.journal.size().await;
+        let committed_leaves = self.journal.bounds().end;
         let base_leaves = *Location::<F>::try_from(base_size)?;
         let mut batch_leaf_end = base_leaves;
         let mut batches: Vec<&[C::Item]> = Vec::with_capacity(batch.ancestor_items.len() + 1);
@@ -512,7 +514,7 @@ where
         }
 
         self.merkle.apply_batch(&batch.inner)?;
-        assert_eq!(*self.merkle.leaves(), self.journal.size().await);
+        assert_eq!(*self.merkle.leaves(), self.journal.bounds().end);
         Ok(())
     }
 
@@ -544,7 +546,7 @@ where
     ) -> Result<(Location<F>, bool), Error<F>> {
         if self.merkle.size() == 0 {
             // DB is empty, nothing to prune.
-            return Ok((Location::new(self.reader().await.bounds().start), false));
+            return Ok((Location::new(self.journal.bounds().start), false));
         }
 
         // Sync the Merkle structure before pruning the journal, otherwise its last element could
@@ -553,7 +555,7 @@ where
         self.merkle.sync().await?;
 
         let journal_pruned = self.journal.prune(*prune_loc).await?;
-        let bounds = self.reader().await.bounds();
+        let bounds = self.journal.bounds();
         let boundary = Location::new(bounds.start);
         let merkle_boundary = self.merkle.bounds().start;
 
@@ -593,7 +595,7 @@ where
         max_ops: NonZeroU64,
         inactive_peaks: usize,
     ) -> Result<(Proof<F, H::Digest>, Vec<C::Item>), Error<F>> {
-        self.historical_proof(self.size().await, start_loc, max_ops, inactive_peaks)
+        self.historical_proof(self.size(), start_loc, max_ops, inactive_peaks)
             .await
     }
 
@@ -616,8 +618,7 @@ where
         max_ops: NonZeroU64,
         inactive_peaks: usize,
     ) -> Result<(Proof<F, H::Digest>, Vec<C::Item>), Error<F>> {
-        let reader = self.journal.reader().await;
-        let bounds = reader.bounds();
+        let bounds = self.journal.bounds();
 
         if *historical_leaves > bounds.end {
             return Err(merkle::Error::RangeOutOfBounds(Location::new(bounds.end)).into());
@@ -640,7 +641,7 @@ where
             .await?;
 
         let positions: Vec<u64> = (*start_loc..*end_loc).collect();
-        let ops = reader.read_many(&positions).await?;
+        let ops = self.journal.read_many(&positions).await?;
 
         Ok((proof, ops))
     }
@@ -737,12 +738,28 @@ where
 {
     type Item = C::Item;
 
-    async fn reader(&self) -> impl Reader<Item = C::Item> + '_ {
-        self.journal.reader().await
+    fn bounds(&self) -> Range<u64> {
+        self.journal.bounds()
     }
 
-    async fn size(&self) -> u64 {
-        self.journal.size().await
+    async fn read(&self, position: u64) -> Result<C::Item, JournalError> {
+        self.journal.read(position).await
+    }
+
+    async fn read_many(&self, positions: &[u64]) -> Result<Vec<C::Item>, JournalError> {
+        self.journal.read_many(positions).await
+    }
+
+    fn try_read_sync(&self, position: u64) -> Option<C::Item> {
+        self.journal.try_read_sync(position)
+    }
+
+    async fn replay(
+        &self,
+        buffer: NonZeroUsize,
+        start_pos: u64,
+    ) -> Result<impl Stream<Item = Result<(u64, C::Item), JournalError>> + Send, JournalError> {
+        self.journal.replay(buffer, start_pos).await
     }
 }
 
@@ -762,8 +779,7 @@ where
 
     async fn prune(&mut self, min_position: u64) -> Result<bool, JournalError> {
         let prune_to = {
-            let reader = self.journal.reader().await;
-            let bounds = reader.bounds();
+            let bounds = self.journal.bounds();
             min_position.min(bounds.end)
         };
 
@@ -807,26 +823,6 @@ pub trait Inner<E: Context>: Mutable {
     where
         Self: Sized,
         Self::Item: EncodeShared;
-}
-
-#[cfg(test)]
-impl<F, E, C, H, S> Journal<F, E, C, H, S>
-where
-    F: Family,
-    E: Context,
-    C: Contiguous<Item: EncodeShared>,
-    S: Strategy,
-    H: Hasher,
-{
-    /// Test helper: Read the item at the given location.
-    pub(crate) async fn read(&self, loc: Location<F>) -> Result<C::Item, Error<F>> {
-        self.journal
-            .reader()
-            .await
-            .read(*loc)
-            .await
-            .map_err(Error::Journal)
-    }
 }
 
 #[cfg(test)]
@@ -1035,7 +1031,7 @@ mod tests {
     async fn test_new_creates_empty_journal_inner<F: Family + PartialEq>(context: Context) {
         let journal = create_empty_journal::<F>(context, "new-empty").await;
 
-        let bounds = journal.reader().await.bounds();
+        let bounds = journal.bounds();
         assert_eq!(bounds.end, 0);
         assert_eq!(bounds.start, 0);
         assert!(bounds.is_empty());
@@ -1179,7 +1175,7 @@ mod tests {
 
         // Don't sync - these are uncommitted
         // After alignment, they should be discarded
-        let size_before = journal.size().await;
+        let size_before = journal.size();
         assert_eq!(size_before, 20);
 
         // Drop and recreate to simulate restart (which calls align internally)
@@ -1188,7 +1184,7 @@ mod tests {
         let journal = create_empty_journal::<F>(context.child("second"), "mismatched").await;
 
         // Uncommitted operations should be gone
-        assert_eq!(journal.size().await, 0);
+        assert_eq!(journal.size(), 0);
     }
 
     #[test_traced("INFO")]
@@ -1317,7 +1313,7 @@ mod tests {
 
             // Prune up to position 8 (this will prune section 0, items 0-6, keeping 7+)
             journal.prune(8).await.unwrap();
-            assert_eq!(journal.reader().bounds().start, 7);
+            assert_eq!(journal.bounds().start, 7);
 
             // Add more uncommitted operations
             for i in 15..20 {
@@ -1358,7 +1354,7 @@ mod tests {
             // Prune up to position 8 (this prunes section 0, including the commit at pos 5)
             // Pruning boundary will be at position 7 (start of section 1)
             journal.prune(8).await.unwrap();
-            assert_eq!(journal.reader().bounds().start, 7);
+            assert_eq!(journal.bounds().start, 7);
 
             // Add uncommitted operations with no commits (in section 1: 7-13)
             for i in 10..14 {
@@ -1414,13 +1410,13 @@ mod tests {
             for i in 6..10 {
                 journal.append(&create_operation::<F>(i)).await.unwrap();
             }
-            assert_eq!(journal.size().await, 10);
+            assert_eq!(journal.size(), 10);
 
             journal.rewind(2).await.unwrap();
-            assert_eq!(journal.size().await, 2);
+            assert_eq!(journal.size(), 2);
             assert_eq!(journal.merkle.leaves(), 2);
             assert_eq!(journal.merkle.size(), 3);
-            let bounds = journal.reader().await.bounds();
+            let bounds = journal.bounds();
             assert_eq!(bounds.start, 0);
             assert!(!bounds.is_empty());
 
@@ -1430,10 +1426,10 @@ mod tests {
             ));
 
             journal.rewind(0).await.unwrap();
-            assert_eq!(journal.size().await, 0);
+            assert_eq!(journal.size(), 0);
             assert_eq!(journal.merkle.leaves(), 0);
             assert_eq!(journal.merkle.size(), 0);
-            let bounds = journal.reader().await.bounds();
+            let bounds = journal.bounds();
             assert_eq!(bounds.start, 0);
             assert!(bounds.is_empty());
 
@@ -1442,14 +1438,14 @@ mod tests {
                 journal.append(&create_operation::<F>(i)).await.unwrap();
             }
             journal.prune(Location::<F>::new(100)).await.unwrap();
-            assert_eq!(journal.reader().await.bounds().start, 98);
+            assert_eq!(journal.bounds().start, 98);
             let res = journal.rewind(97).await;
             assert!(matches!(
                 res,
                 Err(Error::Journal(JournalError::ItemPruned(97)))
             ));
             journal.rewind(98).await.unwrap();
-            let bounds = journal.reader().await.bounds();
+            let bounds = journal.bounds();
             assert_eq!(bounds.end, 98);
             assert_eq!(journal.merkle.leaves(), 98);
             assert_eq!(bounds.start, 98);
@@ -1474,22 +1470,22 @@ mod tests {
     async fn test_apply_op_and_read_operations_inner<F: Family + PartialEq>(context: Context) {
         let mut journal = create_empty_journal::<F>(context, "apply_op").await;
 
-        assert_eq!(journal.size().await, 0);
+        assert_eq!(journal.size(), 0);
 
         // Add 50 operations
         let expected_ops: Vec<_> = (0..50).map(|i| create_operation::<F>(i as u8)).collect();
         for (i, op) in expected_ops.iter().enumerate() {
             let loc = journal.append(op).await.unwrap();
             assert_eq!(loc, Location::<F>::new(i as u64));
-            assert_eq!(journal.size().await, (i + 1) as u64);
+            assert_eq!(journal.size(), (i + 1) as u64);
         }
 
-        assert_eq!(journal.size().await, 50);
+        assert_eq!(journal.size(), 50);
 
         // Verify all operations can be read back correctly
         journal.sync().await.unwrap();
         for (i, expected_op) in expected_ops.iter().enumerate() {
-            let read_op = journal.read(Location::<F>::new(i as u64)).await.unwrap();
+            let read_op = journal.read(*Location::<F>::new(i as u64)).await.unwrap();
             assert_eq!(read_op, *expected_op);
         }
     }
@@ -1513,20 +1509,20 @@ mod tests {
         let journal = create_journal_with_ops::<F>(context, "read", 50).await;
 
         // Verify reading first operation
-        let first_op = journal.read(Location::<F>::new(0)).await.unwrap();
+        let first_op = journal.read(*Location::<F>::new(0)).await.unwrap();
         assert_eq!(first_op, create_operation::<F>(0));
 
         // Verify reading middle operation
-        let middle_op = journal.read(Location::<F>::new(25)).await.unwrap();
+        let middle_op = journal.read(*Location::<F>::new(25)).await.unwrap();
         assert_eq!(middle_op, create_operation::<F>(25));
 
         // Verify reading last operation
-        let last_op = journal.read(Location::<F>::new(49)).await.unwrap();
+        let last_op = journal.read(*Location::<F>::new(49)).await.unwrap();
         assert_eq!(last_op, create_operation::<F>(49));
 
         // Verify all operations match expected values
         for i in 0..50 {
-            let op = journal.read(Location::<F>::new(i)).await.unwrap();
+            let op = journal.read(*Location::<F>::new(i)).await.unwrap();
             assert_eq!(op, create_operation::<F>(i as u8));
         }
     }
@@ -1564,11 +1560,8 @@ mod tests {
         // Try to read an operation before the pruned boundary
         let read_loc = Location::<F>::new(0);
         if read_loc < pruned_boundary {
-            let result = journal.read(read_loc).await;
-            assert!(matches!(
-                result,
-                Err(Error::Journal(crate::journal::Error::ItemPruned(_)))
-            ));
+            let result = journal.read(*read_loc).await;
+            assert!(matches!(result, Err(crate::journal::Error::ItemPruned(_))));
         }
     }
 
@@ -1593,10 +1586,10 @@ mod tests {
         let journal = create_journal_with_ops::<F>(context, "read_oob", 3).await;
 
         // Try to read beyond the end
-        let result = journal.read(Location::<F>::new(10)).await;
+        let result = journal.read(*Location::<F>::new(10)).await;
         assert!(matches!(
             result,
-            Err(Error::Journal(crate::journal::Error::ItemOutOfRange(_)))
+            Err(crate::journal::Error::ItemOutOfRange(_))
         ));
     }
 
@@ -1618,11 +1611,11 @@ mod tests {
     ) {
         let journal = create_journal_with_ops::<F>(context, "read_all", 50).await;
 
-        assert_eq!(journal.size().await, 50);
+        assert_eq!(journal.size(), 50);
 
         // Verify all operations can be read back and match expected values
         for i in 0..50 {
-            let op = journal.read(Location::<F>::new(i)).await.unwrap();
+            let op = journal.read(*Location::<F>::new(i)).await.unwrap();
             assert_eq!(op, create_operation::<F>(i as u8));
         }
     }
@@ -1665,11 +1658,11 @@ mod tests {
         // Reopen and verify the operations persisted
         drop(journal);
         let journal = create_empty_journal::<F>(context.child("second"), "close_pending").await;
-        assert_eq!(journal.size().await, 21);
+        assert_eq!(journal.size(), 21);
 
         // Verify all operations can be read back
         for (i, expected_op) in expected_ops.iter().enumerate() {
-            let read_op = journal.read(Location::<F>::new(i as u64)).await.unwrap();
+            let read_op = journal.read(*Location::<F>::new(i as u64)).await.unwrap();
             assert_eq!(read_op, *expected_op);
         }
     }
@@ -1750,7 +1743,7 @@ mod tests {
         let actual = journal.prune(requested).await.unwrap();
 
         // Actual boundary should match bounds.start
-        let bounds = journal.reader().await.bounds();
+        let bounds = journal.bounds();
         assert!(!bounds.is_empty());
         assert_eq!(actual, bounds.start);
 
@@ -1787,7 +1780,7 @@ mod tests {
             .unwrap();
         assert!(pruned);
 
-        let item_boundary = journal.reader().await.bounds().start;
+        let item_boundary = journal.bounds().start;
         let merkle_boundary = journal.merkle.bounds().start;
         assert_eq!(Location::<F>::new(item_boundary), merkle_boundary);
         assert!(merkle_boundary > Location::<F>::new(0));
@@ -1796,7 +1789,7 @@ mod tests {
             .await
             .unwrap();
         assert!(!pruned);
-        assert_eq!(journal.reader().await.bounds().start, item_boundary);
+        assert_eq!(journal.bounds().start, item_boundary);
         assert_eq!(journal.merkle.bounds().start, merkle_boundary);
     }
 
@@ -1822,9 +1815,9 @@ mod tests {
             .unwrap();
         journal.sync().await.unwrap();
 
-        let count_before = journal.size().await;
+        let count_before = journal.size();
         journal.prune(Location::<F>::new(50)).await.unwrap();
-        let count_after = journal.size().await;
+        let count_after = journal.size();
 
         assert_eq!(count_before, count_after);
     }
@@ -1845,12 +1838,12 @@ mod tests {
     async fn test_bounds_empty_and_pruned_inner<F: Family + PartialEq>(context: Context) {
         // Test empty journal
         let journal = create_empty_journal::<F>(context.child("empty"), "oldest").await;
-        assert!(journal.reader().await.bounds().is_empty());
+        assert!(journal.bounds().is_empty());
         journal.destroy().await.unwrap();
 
         // Test no pruning
         let journal = create_journal_with_ops::<F>(context.child("no_prune"), "oldest", 100).await;
-        let bounds = journal.reader().await.bounds();
+        let bounds = journal.bounds();
         assert!(!bounds.is_empty());
         assert_eq!(bounds.start, 0);
         journal.destroy().await.unwrap();
@@ -1867,7 +1860,7 @@ mod tests {
         let pruned_boundary = journal.prune(Location::<F>::new(50)).await.unwrap();
 
         // Should match the pruned boundary (may be <= 50 due to section alignment)
-        let bounds = journal.reader().await.bounds();
+        let bounds = journal.bounds();
         assert!(!bounds.is_empty());
         assert_eq!(bounds.start, pruned_boundary);
         // Should be <= requested location (50)
@@ -1891,12 +1884,12 @@ mod tests {
     async fn test_bounds_start_after_prune_inner<F: Family + PartialEq>(context: Context) {
         // Test empty journal
         let journal = create_empty_journal::<F>(context.child("empty"), "boundary").await;
-        assert_eq!(journal.reader().await.bounds().start, 0);
+        assert_eq!(journal.bounds().start, 0);
 
         // Test no pruning
         let journal =
             create_journal_with_ops::<F>(context.child("no_prune"), "boundary", 100).await;
-        assert_eq!(journal.reader().await.bounds().start, 0);
+        assert_eq!(journal.bounds().start, 0);
 
         // Test after pruning
         let mut journal =
@@ -1909,7 +1902,7 @@ mod tests {
 
         let pruned_boundary = journal.prune(Location::<F>::new(50)).await.unwrap();
 
-        assert_eq!(journal.reader().await.bounds().start, pruned_boundary);
+        assert_eq!(journal.bounds().start, pruned_boundary);
     }
 
     #[test_traced("INFO")]
@@ -1937,7 +1930,7 @@ mod tests {
         let pruned_boundary = journal.prune(Location::<F>::new(25)).await.unwrap();
 
         // Verify Merkle and journal remain in sync
-        let bounds = journal.reader().await.bounds();
+        let bounds = journal.bounds();
         assert!(!bounds.is_empty());
         assert_eq!(pruned_boundary, bounds.start);
 
@@ -1945,7 +1938,7 @@ mod tests {
         assert!(pruned_boundary <= Location::<F>::new(25));
 
         // Verify operation count is unchanged
-        assert_eq!(journal.size().await, 51);
+        assert_eq!(journal.size(), 51);
     }
 
     #[test_traced("INFO")]
@@ -2004,7 +1997,7 @@ mod tests {
     ) {
         let journal = create_journal_with_ops::<F>(context, "proof_limit", 50).await;
 
-        let size = journal.size().await;
+        let size = journal.size();
         let (proof, ops) = journal
             .historical_proof(size, Location::<F>::new(0), NZU64!(20), 0)
             .await
@@ -2050,7 +2043,7 @@ mod tests {
     ) {
         let journal = create_journal_with_ops::<F>(context, "proof_end", 50).await;
 
-        let size = journal.size().await;
+        let size = journal.size();
         // Request proof starting near the end
         let (proof, ops) = journal
             .historical_proof(size, Location::<F>::new(40), NZU64!(20), 0)
@@ -2126,7 +2119,7 @@ mod tests {
     ) {
         let journal = create_journal_with_ops::<F>(context, "proof_start_oob", 5).await;
 
-        let size = journal.size().await;
+        let size = journal.size();
         // Request proof starting at size (should fail)
         let result = journal.historical_proof(size, size, NZU64!(1), 0).await;
 
@@ -2160,7 +2153,7 @@ mod tests {
         // Capture root at historical state
         let hasher = StandardHasher::new(ForwardFold);
         let historical_root = journal_root(&journal);
-        let historical_size = journal.size().await;
+        let historical_size = journal.size();
 
         // Add more operations after the historical state
         for i in 50..100 {
@@ -2219,7 +2212,7 @@ mod tests {
         let pruned_boundary = journal.prune(Location::<F>::new(25)).await.unwrap();
 
         // Try to get proof starting at a location before the pruned boundary
-        let size = journal.size().await;
+        let size = journal.size();
         let start_loc = Location::<F>::new(0);
         if start_loc < pruned_boundary {
             let result = journal
@@ -2251,15 +2244,13 @@ mod tests {
     async fn test_replay_operations_inner<F: Family + PartialEq>(context: Context) {
         // Test empty journal
         let journal = create_empty_journal::<F>(context.child("empty"), "replay").await;
-        let reader = journal.reader().await;
-        let stream = reader.replay(NZUsize!(10), 0).await.unwrap();
+        let stream = journal.replay(NZUsize!(10), 0).await.unwrap();
         futures::pin_mut!(stream);
         assert!(stream.next().await.is_none());
 
         // Test replaying all operations
         let journal = create_journal_with_ops::<F>(context.child("with_ops"), "replay", 50).await;
-        let reader = journal.reader().await;
-        let stream = reader.replay(NZUsize!(100), 0).await.unwrap();
+        let stream = journal.replay(NZUsize!(100), 0).await.unwrap();
         futures::pin_mut!(stream);
 
         for i in 0..50 {
@@ -2286,8 +2277,7 @@ mod tests {
     /// Verify replay() starting from a middle location.
     async fn test_replay_from_middle_inner<F: Family + PartialEq>(context: Context) {
         let journal = create_journal_with_ops::<F>(context, "replay_middle", 50).await;
-        let reader = journal.reader().await;
-        let stream = reader.replay(NZUsize!(100), 25).await.unwrap();
+        let stream = journal.replay(NZUsize!(100), 25).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut count = 0;
@@ -2345,7 +2335,7 @@ mod tests {
 
         // Journal should now match the applied batch's root.
         assert_eq!(journal_root(&journal), expected_root);
-        assert_eq!(*journal.size().await, 11);
+        assert_eq!(*journal.size(), 11);
     }
 
     #[test_traced("INFO")]
@@ -2382,12 +2372,12 @@ mod tests {
         drop(merkleized_a);
 
         assert_eq!(journal_root(&journal), expected_root);
-        assert_eq!(*journal.size().await, 12);
+        assert_eq!(*journal.size(), 12);
 
         // Verify both items were appended correctly.
-        let read_a = journal.read(Location::<F>::new(10)).await.unwrap();
+        let read_a = journal.read(*Location::<F>::new(10)).await.unwrap();
         assert_eq!(read_a, op_a);
-        let read_b = journal.read(Location::<F>::new(11)).await.unwrap();
+        let read_b = journal.read(*Location::<F>::new(11)).await.unwrap();
         assert_eq!(read_b, op_b);
     }
 
@@ -2415,7 +2405,7 @@ mod tests {
         let batch_a = journal.new_batch().add(op_a.clone());
         let merkleized_a = journal.merkle.with_mem(|mem| batch_a.merkleize(mem));
         journal.apply_batch(&merkleized_a).await.unwrap();
-        assert_eq!(*journal.size().await, 11);
+        assert_eq!(*journal.size(), 11);
 
         // Apply batch B (built on top of the committed A).
         let batch_b = journal.new_batch().add(op_b.clone());
@@ -2424,12 +2414,12 @@ mod tests {
         journal.apply_batch(&merkleized_b).await.unwrap();
 
         assert_eq!(journal_root(&journal), expected_root);
-        assert_eq!(*journal.size().await, 12);
+        assert_eq!(*journal.size(), 12);
 
         // Verify both items were appended correctly.
-        let read_a = journal.read(Location::<F>::new(10)).await.unwrap();
+        let read_a = journal.read(*Location::<F>::new(10)).await.unwrap();
         assert_eq!(read_a, op_a);
-        let read_b = journal.read(Location::<F>::new(11)).await.unwrap();
+        let read_b = journal.read(*Location::<F>::new(11)).await.unwrap();
         assert_eq!(read_b, op_b);
     }
 
@@ -2459,7 +2449,7 @@ mod tests {
         // Apply A -- should succeed.
         journal.apply_batch(&merkleized_a).await.unwrap();
         let expected_root = journal_root(&journal);
-        let expected_size = journal.size().await;
+        let expected_size = journal.size();
 
         // Apply B -- should fail (stale).
         let result = journal.apply_batch(&merkleized_b).await;
@@ -2473,7 +2463,7 @@ mod tests {
 
         // The stale batch must not mutate the journal or desync it from the Merkle.
         assert_eq!(journal_root(&journal), expected_root);
-        assert_eq!(journal.size().await, expected_size);
+        assert_eq!(journal.size(), expected_size);
         let (_, ops) = journal
             .proof(Location::<F>::new(0), NZU64!(1), 0)
             .await
@@ -2545,7 +2535,7 @@ mod tests {
         journal.apply_batch(&child).await.unwrap();
 
         assert_eq!(journal_root(&journal), expected_root);
-        assert_eq!(*journal.size().await, 2);
+        assert_eq!(*journal.size(), 2);
     }
 
     #[test_traced("INFO")]
@@ -2673,7 +2663,7 @@ mod tests {
         journal.apply_batch(&child).await.unwrap();
 
         // All 8 items (2 base + 3 + 2 + 1) should be present.
-        assert_eq!(*journal.size().await, 8);
+        assert_eq!(*journal.size(), 8);
 
         // Verify the actual items at each location.
         let (_, ops) = journal
@@ -2752,11 +2742,10 @@ mod tests {
         journal.apply_batch(&merkleized).await.unwrap();
 
         assert_eq!(journal_root(&journal), expected_root);
-        assert_eq!(*journal.size().await, 7);
+        assert_eq!(*journal.size(), 7);
 
-        let reader = journal.reader().await;
-        assert_eq!(reader.read(5).await.unwrap(), ops[0]);
-        assert_eq!(reader.read(6).await.unwrap(), ops[1]);
+        assert_eq!(journal.read(5).await.unwrap(), ops[0]);
+        assert_eq!(journal.read(6).await.unwrap(), ops[1]);
     }
 
     #[test_traced("INFO")]
@@ -2791,7 +2780,7 @@ mod tests {
         journal.apply_batch(&c).await.unwrap();
 
         // All 3 items should be in the journal.
-        assert_eq!(*journal.size().await, 3);
+        assert_eq!(*journal.size(), 3);
 
         // Build a reference that applies all three sequentially.
         let mut reference =

--- a/storage/src/journal/benches/fixed_read_random.rs
+++ b/storage/src/journal/benches/fixed_read_random.rs
@@ -4,7 +4,7 @@ use commonware_runtime::{
     tokio::{Config, Context, Runner},
     Runner as _, Supervisor as _,
 };
-use commonware_storage::journal::contiguous::{fixed::Journal, Reader as _};
+use commonware_storage::journal::contiguous::{fixed::Journal, Contiguous as _};
 use commonware_utils::{sequence::FixedBytes, NZU64};
 use criterion::{criterion_group, Criterion};
 use futures::future::try_join_all;
@@ -30,7 +30,7 @@ const ITEM_SIZE: usize = 32;
 /// Read `items_to_read` random items from the given `journal`, awaiting each
 /// result before continuing.
 async fn bench_run_serial(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, items_to_read: usize) {
-    let reader = journal.reader();
+    let reader = journal.snapshot();
     let mut rng = StdRng::seed_from_u64(0);
     for _ in 0..items_to_read {
         let pos = rng.gen_range(0..ITEMS_TO_WRITE);
@@ -43,7 +43,7 @@ async fn bench_run_concurrent(
     journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
 ) {
-    let reader = journal.reader();
+    let reader = journal.snapshot();
     let mut rng = StdRng::seed_from_u64(0);
     let mut futures = Vec::with_capacity(items_to_read);
     for _ in 0..items_to_read {
@@ -58,7 +58,7 @@ async fn bench_run_read_many(
     journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
 ) {
-    let reader = journal.reader();
+    let reader = journal.snapshot();
     let mut rng = StdRng::seed_from_u64(0);
     let mut positions: Vec<u64> = (0..items_to_read)
         .map(|_| rng.gen_range(0..ITEMS_TO_WRITE))

--- a/storage/src/journal/benches/fixed_read_sequential.rs
+++ b/storage/src/journal/benches/fixed_read_sequential.rs
@@ -3,7 +3,7 @@ use commonware_runtime::{
     benchmarks::{context, tokio},
     tokio::Context,
 };
-use commonware_storage::journal::contiguous::{fixed::Journal, Reader as _};
+use commonware_storage::journal::contiguous::{fixed::Journal, Contiguous as _};
 use commonware_utils::{sequence::FixedBytes, NZU64};
 use criterion::{criterion_group, Criterion};
 use std::{
@@ -23,7 +23,7 @@ const ITEM_SIZE: usize = 32;
 
 /// Sequentially read `items_to_read` items in the given `journal` starting from item 0.
 async fn bench_run(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, items_to_read: u64) {
-    let reader = journal.reader();
+    let reader = journal.snapshot();
     for pos in 0..items_to_read {
         black_box(reader.read(pos).await.expect("failed to read data"));
     }

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -4,7 +4,7 @@ use commonware_runtime::{
     tokio::{Config, Context, Runner},
     Runner as _, Supervisor as _,
 };
-use commonware_storage::journal::contiguous::{fixed::Journal, Reader as _};
+use commonware_storage::journal::contiguous::{fixed::Journal, Contiguous as _};
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use criterion::{criterion_group, Criterion};
 use futures::{pin_mut, StreamExt};
@@ -18,7 +18,7 @@ const PARTITION: &str = "test-partition";
 
 /// Replay all items in the given `journal`.
 async fn bench_run(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: usize) {
-    let reader = journal.reader();
+    let reader = journal.snapshot();
     let stream = reader
         .replay(NZUsize!(buffer), 0)
         .await

--- a/storage/src/journal/benches/variable_read_random.rs
+++ b/storage/src/journal/benches/variable_read_random.rs
@@ -4,7 +4,7 @@ use commonware_runtime::{
     tokio::{Config, Context, Runner},
     Runner as _, Supervisor as _,
 };
-use commonware_storage::journal::contiguous::{variable::Journal, Reader as _};
+use commonware_storage::journal::contiguous::{variable::Journal, Contiguous as _};
 use commonware_utils::{sequence::FixedBytes, NZU64};
 use criterion::{criterion_group, Criterion};
 use futures::future::try_join_all;
@@ -30,7 +30,7 @@ const ITEM_SIZE: usize = 32;
 /// Read `items_to_read` random items from the given `journal`, awaiting each
 /// result before continuing.
 async fn bench_run_serial(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, items_to_read: usize) {
-    let reader = journal.reader();
+    let reader = journal.snapshot();
     let mut rng = StdRng::seed_from_u64(0);
     for _ in 0..items_to_read {
         let pos = rng.gen_range(0..ITEMS_TO_WRITE);
@@ -43,7 +43,7 @@ async fn bench_run_concurrent(
     journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
 ) {
-    let reader = journal.reader();
+    let reader = journal.snapshot();
     let mut rng = StdRng::seed_from_u64(0);
     let mut futures = Vec::with_capacity(items_to_read);
     for _ in 0..items_to_read {
@@ -58,7 +58,7 @@ async fn bench_run_read_many(
     journal: &Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
 ) {
-    let reader = journal.reader();
+    let reader = journal.snapshot();
     let mut rng = StdRng::seed_from_u64(0);
     let mut positions: Vec<u64> = (0..items_to_read)
         .map(|_| rng.gen_range(0..ITEMS_TO_WRITE))

--- a/storage/src/journal/benches/variable_replay.rs
+++ b/storage/src/journal/benches/variable_replay.rs
@@ -4,7 +4,7 @@ use commonware_runtime::{
     tokio::{Config, Context, Runner},
     Runner as _, Supervisor as _,
 };
-use commonware_storage::journal::contiguous::{variable::Journal, Reader as _};
+use commonware_storage::journal::contiguous::{variable::Journal, Contiguous as _};
 use commonware_utils::{sequence::FixedBytes, NZUsize};
 use criterion::{criterion_group, Criterion};
 use futures::{pin_mut, StreamExt};
@@ -18,7 +18,7 @@ const PARTITION: &str = "variable-test-partition";
 
 /// Replay all items in the given `journal`.
 async fn bench_run(journal: &Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: usize) {
-    let reader = journal.reader();
+    let reader = journal.snapshot();
     let stream = reader
         .replay(NZUsize!(buffer), 0)
         .await

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -5,7 +5,7 @@ use commonware_formatting::hex;
 use commonware_runtime::{
     buffer::paged::{self, CacheRef, Sealed, Writer},
     telemetry::metrics::{Counter, Gauge, GaugeExt as _, MetricsExt as _},
-    Blob, Error as RError, IoBuf, IoBufMut, IoBufs,
+    Blob as RBlob, Error as RError, IoBuf, IoBufMut, IoBufs,
 };
 use futures::future::try_join_all;
 use std::{
@@ -139,7 +139,7 @@ impl<E: Context> Partition<E> {
 }
 
 /// A journal's blobs: contiguous sealed blobs ending in one writable tail.
-pub(super) struct Blobs<E: Context> {
+pub(super) struct Writable<E: Context> {
     partition: Partition<E>,
     metrics: Metrics,
 
@@ -152,11 +152,11 @@ pub(super) struct Blobs<E: Context> {
     /// Sealed historical blobs, ascending and contiguous from `oldest_blob_index`.
     sealed: Arc<[Sealed<E::Blob>]>,
 
-    /// Number of live readers. Gates in-place truncation during rewind.
-    readers: Arc<AtomicUsize>,
+    /// Number of live [`Snapshot`]s. Gates in-place truncation during rewind.
+    snapshots: Arc<AtomicUsize>,
 }
 
-impl<E: Context> Blobs<E> {
+impl<E: Context> Writable<E> {
     /// Build from recovered writers: seal every blob below `tail_blob` and install the tail,
     /// opening an empty one if absent.
     ///
@@ -216,7 +216,7 @@ impl<E: Context> Blobs<E> {
             oldest_blob_index,
             tail,
             sealed: sealed.into(),
-            readers: Arc::new(AtomicUsize::new(0)),
+            snapshots: Arc::new(AtomicUsize::new(0)),
         })
     }
 
@@ -235,24 +235,24 @@ impl<E: Context> Blobs<E> {
         &self.tail
     }
 
-    /// Whether any [`Snapshot`] is live. A new reader can't be created while the caller holds
-    /// `&mut self`, so this only accounts for snapshots taken earlier. The Acquire load pairs
-    /// with the Release in [`Snapshot`]'s drop, so a `false` result means their reads are done.
-    pub(super) fn readers_outstanding(&self) -> bool {
-        self.readers.load(Ordering::Acquire) != 0
+    /// Whether any [`Snapshot`] is alive. A new one can't be created while the
+    /// caller holds `&mut self`, so this only accounts for snapshots taken earlier. The Acquire
+    /// load pairs with the Release in [`Snapshot`]'s drop, so `false` means their reads are done.
+    pub(super) fn snapshots_alive(&self) -> bool {
+        self.snapshots.load(Ordering::Acquire) != 0
     }
 
     /// Capture an owned [`Snapshot`] of the current blobs, readable within `bounds`. The
-    /// snapshot counts itself in `readers` until dropped, gating in-place truncation during
+    /// snapshot counts itself in `snapshots` until dropped, gating in-place truncation during
     /// rewind.
     pub(super) fn to_snapshot(&self, bounds: Range<u64>) -> Snapshot<E::Blob> {
-        self.readers.fetch_add(1, Ordering::Relaxed);
+        self.snapshots.fetch_add(1, Ordering::Relaxed);
         Snapshot {
             oldest_blob_index: self.oldest_blob_index,
             sealed: self.sealed.clone(),
-            tail_reader: self.tail.reader(),
+            tail: self.tail.reader(),
             bounds,
-            readers: self.readers.clone(),
+            snapshots: self.snapshots.clone(),
         }
     }
 
@@ -307,14 +307,14 @@ impl<E: Context> Blobs<E> {
     /// - `byte_offset <= tail size`
     ///
     /// # Errors
-    /// Returns [Error::BlobInUse] if there are outstanding readers: the tail is shared mutable
+    /// Returns [Error::BlobInUse] if there are live [`Snapshot`]s: the tail is shared mutable
     /// state, so truncating it could tear a live snapshot's reads of bytes a later append reuses.
     pub(super) async fn rewind_tail(&mut self, byte_offset: u64) -> Result<(), Error> {
         let current_bytes = self.tail.size().await;
         debug_assert!(byte_offset <= current_bytes);
         if byte_offset < current_bytes {
             // Refuse the in-place truncation while any snapshot is live.
-            if self.readers_outstanding() {
+            if self.snapshots_alive() {
                 return Err(Error::BlobInUse(self.tail_blob_index()));
             }
             self.tail
@@ -333,7 +333,7 @@ impl<E: Context> Blobs<E> {
     /// - `blob < tail_blob_index`
     ///
     /// # Errors
-    /// Returns [Error::BlobInUse] if there are outstanding readers.
+    /// Returns [Error::BlobInUse] if there are live [`Snapshot`]s.
     pub(super) async fn rewind_into_sealed(
         &mut self,
         blob: u64,
@@ -346,7 +346,7 @@ impl<E: Context> Blobs<E> {
             .ok_or_else(|| Error::Corruption(format!("rewind target blob {blob} not retained")))?;
 
         // Refuse the in-place truncation while any snapshot is live.
-        if self.readers_outstanding() {
+        if self.snapshots_alive() {
             return Err(Error::BlobInUse(blob));
         }
 
@@ -386,7 +386,7 @@ impl<E: Context> Blobs<E> {
 
     /// Remove every blob and start an empty journal with its tail at `tail_blob`.
     ///
-    /// Safe with live readers, like [Self::prune]: snapshots keep their own handles, which the
+    /// Safe with live [`Snapshot`]s, like [Self::prune]: snapshots keep their own handles, which the
     /// runtime's read-after-remove contract keeps valid.
     pub(super) async fn clear(&mut self, tail_blob: u64) -> Result<(), Error> {
         for blob in self.oldest_blob_index..=self.tail_blob_index() {
@@ -425,13 +425,13 @@ impl<E: Context> Blobs<E> {
     }
 }
 
-/// A read handle for one blob, resolved from a [`Snapshot`].
-pub(super) enum Handle<'a, B: Blob> {
+/// A read handle for one blob.
+pub(super) enum Blob<'a, B: RBlob> {
     Sealed(&'a Sealed<B>),
-    Tail(&'a paged::Reader<B>),
+    Tail(paged::Reader<B>),
 }
 
-impl<B: Blob> Handle<'_, B> {
+impl<B: RBlob> Blob<'_, B> {
     pub(super) async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, Error> {
         match self {
             Self::Sealed(s) => s.read_at(offset, len).await.map_err(Error::Runtime),
@@ -498,12 +498,12 @@ impl<B: Blob> Handle<'_, B> {
     }
 }
 
-/// An owned copy of the journal's blob handles and bounds, captured by [`Blobs::to_snapshot`].
+/// An owned copy of the journal's blob handles and bounds, captured by [`Writable::to_snapshot`].
 /// Later appends, seals, and prunes are invisible to it: it serves the positions in its frozen
 /// `bounds` from the handles retained at capture, so even pruned blobs stay readable. A rewind
 /// would mutate the tail (shared with the writer) or a sealed blob in place, so it counts itself
-/// in `readers` for its lifetime and rewind refuses ([Error::BlobInUse]) while the count is nonzero.
-pub(super) struct Snapshot<B: Blob> {
+/// in `snapshots` for its lifetime and rewind refuses ([Error::BlobInUse]) while the count is nonzero.
+pub(super) struct Snapshot<B: RBlob> {
     /// Index of the first blob in [Self::sealed].
     pub(super) oldest_blob_index: u64,
 
@@ -511,65 +511,77 @@ pub(super) struct Snapshot<B: Blob> {
     pub(super) sealed: Arc<[Sealed<B>]>,
 
     /// Read handle for the tail, blob [`Self::tail_blob_index`].
-    pub(super) tail_reader: paged::Reader<B>,
+    pub(super) tail: paged::Reader<B>,
 
     /// The positions readable through this snapshot.
     pub(super) bounds: Range<u64>,
 
-    /// The journal's live-reader count, shared with [`Blobs`]. Incremented at capture and
+    /// The journal's live-reader count, shared with [`Writable`]. Incremented at capture and
     /// decremented on drop; a nonzero count blocks in-place truncation of the tail and of
     /// sealed blobs during rewind.
-    readers: Arc<AtomicUsize>,
+    snapshots: Arc<AtomicUsize>,
 }
 
-impl<B: Blob> Snapshot<B> {
-    /// Validate a position to be read: must lie within `bounds`.
-    pub(super) const fn validate_readable(&self, pos: u64) -> Result<(), Error> {
-        if pos >= self.bounds.end {
-            return Err(Error::ItemOutOfRange(pos));
-        }
-        if pos < self.bounds.start {
-            return Err(Error::ItemPruned(pos));
-        }
-        Ok(())
-    }
-
-    /// Validate a replay start cursor, which may also sit at `bounds.end`.
-    pub(super) const fn validate_cursor(&self, pos: u64) -> Result<(), Error> {
-        if pos > self.bounds.end {
-            return Err(Error::ItemOutOfRange(pos));
-        }
-        if pos < self.bounds.start {
-            return Err(Error::ItemPruned(pos));
-        }
-        Ok(())
-    }
-
+impl<B: RBlob> Snapshot<B> {
     /// Index of the newest blob.
     pub(super) fn tail_blob_index(&self) -> u64 {
         self.oldest_blob_index + self.sealed.len() as u64
     }
+}
 
-    /// Resolve the read handle for `blob`, if retained.
-    pub(super) fn handle(&self, blob: u64) -> Option<Handle<'_, B>> {
-        if blob == self.tail_blob_index() {
-            return Some(Handle::Tail(&self.tail_reader));
-        }
-        let idx = blob.checked_sub(self.oldest_blob_index)?;
-        self.sealed.get(idx as usize).map(Handle::Sealed)
-    }
-
-    /// Resolve the read handle for `blob`, treating absence as corruption: callers only ask
-    /// for blobs implied by positions validated against `bounds`.
-    pub(super) fn require_handle(&self, blob: u64) -> Result<Handle<'_, B>, Error> {
-        self.handle(blob)
-            .ok_or_else(|| Error::Corruption(format!("blob {blob} missing from snapshot")))
+impl<B: RBlob> Drop for Snapshot<B> {
+    fn drop(&mut self) {
+        self.snapshots.fetch_sub(1, Ordering::Release);
     }
 }
 
-impl<B: Blob> Drop for Snapshot<B> {
-    fn drop(&mut self) {
-        self.readers.fetch_sub(1, Ordering::Release);
+/// Resolves a blob index to a blob, over either a [`Snapshot`] or the live [`Writable`]
+/// (borrowed). The per-position read logic is written once against this.
+pub(super) enum Blobs<'a, E: Context> {
+    Snapshot(Snapshot<E::Blob>),
+    Writable {
+        writable: &'a Writable<E>,
+        bounds: Range<u64>,
+    },
+}
+
+impl<E: Context> Blobs<'_, E> {
+    /// Validate a position to be read: must lie within `bounds`.
+    pub(super) fn validate_readable(&self, pos: u64) -> Result<(), Error> {
+        let bounds = self.bounds();
+        if pos >= bounds.end {
+            return Err(Error::ItemOutOfRange(pos));
+        }
+        if pos < bounds.start {
+            return Err(Error::ItemPruned(pos));
+        }
+        Ok(())
+    }
+
+    /// The readable position range `[start, end)`.
+    pub(super) fn bounds(&self) -> Range<u64> {
+        match self {
+            Self::Snapshot(s) => s.bounds.clone(),
+            Self::Writable { bounds, .. } => bounds.clone(),
+        }
+    }
+
+    /// Resolve the read handle for `blob`, if retained.
+    pub(super) fn get(&self, blob: u64) -> Option<Blob<'_, E::Blob>> {
+        let (oldest, sealed) = match self {
+            Self::Snapshot(s) => (s.oldest_blob_index, &*s.sealed),
+            Self::Writable { writable, .. } => (writable.oldest_blob_index, &*writable.sealed),
+        };
+        if blob == oldest + sealed.len() as u64 {
+            let tail = match self {
+                Self::Snapshot(s) => s.tail.clone(),
+                Self::Writable { writable, .. } => writable.tail.reader(),
+            };
+            return Some(Blob::Tail(tail));
+        }
+        sealed
+            .get(blob.checked_sub(oldest)? as usize)
+            .map(Blob::Sealed)
     }
 }
 
@@ -577,7 +589,7 @@ impl<B: Blob> Drop for Snapshot<B> {
 mod tests {
     use super::*;
 
-    impl<E: Context> Blobs<E> {
+    impl<E: Context> Writable<E> {
         /// Open `blob` as an independent writer, outside this journal's tracking
         /// (simulates a crash-artifact blob).
         pub(crate) async fn open_blob(&self, blob: u64) -> Result<Writer<E::Blob>, Error> {

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -242,16 +242,14 @@ impl<E: Context> Writable<E> {
         self.snapshots.load(Ordering::Acquire) != 0
     }
 
-    /// Capture an owned [`Snapshot`] of the current blobs, readable within `bounds`. The
-    /// snapshot counts itself in `snapshots` until dropped, gating in-place truncation during
-    /// rewind.
-    pub(super) fn to_snapshot(&self, bounds: Range<u64>) -> Snapshot<E::Blob> {
+    /// Capture an owned [`Snapshot`] of the current blobs. The snapshot counts itself in
+    /// `snapshots` until dropped, gating in-place truncation during rewind.
+    pub(super) fn to_snapshot(&self) -> Snapshot<E::Blob> {
         self.snapshots.fetch_add(1, Ordering::Relaxed);
         Snapshot {
             oldest_blob_index: self.oldest_blob_index,
             sealed: self.sealed.clone(),
             tail: self.tail.reader(),
-            bounds,
             snapshots: self.snapshots.clone(),
         }
     }
@@ -498,11 +496,11 @@ impl<B: RBlob> Blob<'_, B> {
     }
 }
 
-/// An owned copy of the journal's blob handles and bounds, captured by [`Writable::to_snapshot`].
-/// Later appends, seals, and prunes are invisible to it: it serves the positions in its frozen
-/// `bounds` from the handles retained at capture, so even pruned blobs stay readable. A rewind
-/// would mutate the tail (shared with the writer) or a sealed blob in place, so it counts itself
-/// in `snapshots` for its lifetime and rewind refuses ([Error::BlobInUse]) while the count is nonzero.
+/// An owned copy of the journal's blob handles, captured by [`Writable::to_snapshot`]. Later
+/// appends, seals, and prunes are invisible to it: it serves reads from the handles retained at
+/// capture, so even pruned blobs stay readable. A rewind would mutate the tail (shared with the
+/// writer) or a sealed blob in place, so it counts itself in `snapshots` for its lifetime and
+/// rewind refuses ([Error::BlobInUse]) while the count is nonzero.
 pub(super) struct Snapshot<B: RBlob> {
     /// Index of the first blob in [Self::sealed].
     pub(super) oldest_blob_index: u64,
@@ -510,23 +508,13 @@ pub(super) struct Snapshot<B: RBlob> {
     /// Sealed historical blobs, ascending and contiguous from `oldest_blob_index`.
     pub(super) sealed: Arc<[Sealed<B>]>,
 
-    /// Read handle for the tail, blob [`Self::tail_blob_index`].
+    /// Read handle for the tail (the newest blob).
     pub(super) tail: paged::Reader<B>,
-
-    /// The positions readable through this snapshot.
-    pub(super) bounds: Range<u64>,
 
     /// The journal's live-reader count, shared with [`Writable`]. Incremented at capture and
     /// decremented on drop; a nonzero count blocks in-place truncation of the tail and of
     /// sealed blobs during rewind.
     snapshots: Arc<AtomicUsize>,
-}
-
-impl<B: RBlob> Snapshot<B> {
-    /// Index of the newest blob.
-    pub(super) fn tail_blob_index(&self) -> u64 {
-        self.oldest_blob_index + self.sealed.len() as u64
-    }
 }
 
 impl<B: RBlob> Drop for Snapshot<B> {
@@ -535,10 +523,13 @@ impl<B: RBlob> Drop for Snapshot<B> {
     }
 }
 
-/// Resolves a blob index to a blob, over either a [`Snapshot`] or the live [`Writable`]
-/// (borrowed). The per-position read logic is written once against this.
+/// Resolves a blob index to a blob within a frozen `bounds`, over either a [`Snapshot`] or the
+/// live [`Writable`] (borrowed). The per-position read logic is written once against this.
 pub(super) enum Blobs<'a, E: Context> {
-    Snapshot(Snapshot<E::Blob>),
+    Snapshot {
+        snapshot: Snapshot<E::Blob>,
+        bounds: Range<u64>,
+    },
     Writable {
         writable: &'a Writable<E>,
         bounds: Range<u64>,
@@ -561,27 +552,49 @@ impl<E: Context> Blobs<'_, E> {
     /// The readable position range `[start, end)`.
     pub(super) fn bounds(&self) -> Range<u64> {
         match self {
-            Self::Snapshot(s) => s.bounds.clone(),
-            Self::Writable { bounds, .. } => bounds.clone(),
+            Self::Snapshot { bounds, .. } | Self::Writable { bounds, .. } => bounds.clone(),
         }
     }
 
     /// Resolve the read handle for `blob`, if retained.
     pub(super) fn get(&self, blob: u64) -> Option<Blob<'_, E::Blob>> {
-        let (oldest, sealed) = match self {
-            Self::Snapshot(s) => (s.oldest_blob_index, &*s.sealed),
-            Self::Writable { writable, .. } => (writable.oldest_blob_index, &*writable.sealed),
-        };
+        let oldest = self.oldest_blob_index();
+        let sealed = self.sealed();
         if blob == oldest + sealed.len() as u64 {
-            let tail = match self {
-                Self::Snapshot(s) => s.tail.clone(),
-                Self::Writable { writable, .. } => writable.tail.reader(),
-            };
-            return Some(Blob::Tail(tail));
+            return Some(Blob::Tail(self.tail_reader()));
         }
         sealed
             .get(blob.checked_sub(oldest)? as usize)
             .map(Blob::Sealed)
+    }
+
+    /// Index of the first sealed blob.
+    pub(super) const fn oldest_blob_index(&self) -> u64 {
+        match self {
+            Self::Snapshot { snapshot, .. } => snapshot.oldest_blob_index,
+            Self::Writable { writable, .. } => writable.oldest_blob_index,
+        }
+    }
+
+    /// Index of the newest blob (the tail).
+    pub(super) fn tail_blob_index(&self) -> u64 {
+        self.oldest_blob_index() + self.sealed().len() as u64
+    }
+
+    /// Sealed historical blobs, ascending and contiguous from [`Self::oldest_blob_index`].
+    pub(super) fn sealed(&self) -> &[Sealed<E::Blob>] {
+        match self {
+            Self::Snapshot { snapshot, .. } => &snapshot.sealed,
+            Self::Writable { writable, .. } => &writable.sealed,
+        }
+    }
+
+    /// A read handle for the tail blob.
+    pub(super) fn tail_reader(&self) -> paged::Reader<E::Blob> {
+        match self {
+            Self::Snapshot { snapshot, .. } => snapshot.tail.clone(),
+            Self::Writable { writable, .. } => writable.tail.reader(),
+        }
     }
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -96,7 +96,7 @@
 //! The `replay` method supports fast reading of all unpruned items into memory.
 
 use super::{
-    blobs::{Blob, Blobs, Partition, Snapshot, Writable},
+    blobs::{Blob, Blobs, Partition, Writable},
     checkpoint::Checkpoint,
     replay::{self, Source as _},
 };
@@ -709,7 +709,10 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// into its range is refused ([Error::BlobInUse]) while it is alive.
     pub fn snapshot(&self) -> Reader<'static, E, A> {
         Reader {
-            blobs: Blobs::Snapshot(self.blobs.to_snapshot(self.bounds.clone())),
+            blobs: Blobs::Snapshot {
+                snapshot: self.blobs.to_snapshot(),
+                bounds: self.bounds.clone(),
+            },
             items_per_blob: self.items_per_blob,
             metrics: self.metrics.clone(),
             _phantom: PhantomData,
@@ -1160,38 +1163,27 @@ impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Contiguous for
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
-        // `replay` returns a stream that outlives this call, so it reads from an owned snapshot
-        // whose Arc-shared handles the stream owns. A snapshot already has one.
-        match &self.blobs {
-            Blobs::Snapshot(snapshot) => {
-                replay_stream::<E, A>(snapshot, self.items_per_blob.get(), buffer, start_pos)
-            }
-            Blobs::Writable { writable, bounds } => replay_stream::<E, A>(
-                &writable.to_snapshot(bounds.clone()),
-                self.items_per_blob.get(),
-                buffer,
-                start_pos,
-            ),
-        }
+        replay_stream::<E, A>(&self.blobs, self.items_per_blob.get(), buffer, start_pos)
     }
 }
 
-/// Build the replay stream over `snapshot`, starting at `start_pos`.
+/// Build the replay stream over `blobs`, starting at `start_pos`.
 ///
 /// The returned stream owns everything it reads (seeded sealed-blob replays and a cloned tail
-/// reader), so it borrows nothing from `snapshot` (`use<E, A>` keeps the snapshot's lifetime out
-/// of the return type). Shared by [`Reader`] and [`Journal`]'s [`super::Contiguous`] impl.
+/// reader), so it borrows nothing from `blobs` (`use<E, A>` keeps the borrow's lifetime out of
+/// the return type). Shared by [`Reader`] and [`Journal`]'s [`super::Contiguous`] impl.
 fn replay_stream<E: Context, A: CodecFixedShared>(
-    snapshot: &Snapshot<E::Blob>,
+    blobs: &Blobs<'_, E>,
     items_per_blob: u64,
     buffer: NonZeroUsize,
     start_pos: u64,
 ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send + use<E, A>, Error> {
-    let pruning_boundary = snapshot.bounds.start;
+    let bounds = blobs.bounds();
+    let pruning_boundary = bounds.start;
     let chunk_size = A::SIZE;
     let chunk_size_u64 = Journal::<E, A>::CHUNK_SIZE_U64;
 
-    if start_pos > snapshot.bounds.end {
+    if start_pos > bounds.end {
         return Err(Error::ItemOutOfRange(start_pos));
     }
     if start_pos < pruning_boundary {
@@ -1204,14 +1196,15 @@ fn replay_stream<E: Context, A: CodecFixedShared>(
 
     // Check all middle blobs (not oldest, not tail) in range are complete. Sealed blob
     // sizes are known synchronously.
-    let oldest = snapshot.oldest_blob_index;
-    let tail_blob = snapshot.tail_blob_index();
+    let oldest = blobs.oldest_blob_index();
+    let tail_blob = blobs.tail_blob_index();
+    let sealed_blobs = blobs.sealed();
     let first_to_check = oldest
         .checked_add(1)
         .map_or(tail_blob, |after_oldest| start_blob.max(after_oldest));
     for blob in first_to_check..tail_blob {
         let idx = (blob - oldest) as usize;
-        let len = snapshot.sealed[idx].size() / chunk_size_u64;
+        let len = sealed_blobs[idx].size() / chunk_size_u64;
         if len < items_per_blob {
             return Err(Error::Corruption(format!(
                 "blob {blob} incomplete: expected {items_per_blob} items, got {len}"
@@ -1220,12 +1213,12 @@ fn replay_stream<E: Context, A: CodecFixedShared>(
     }
 
     // Seed each sealed blob's `Replay` upfront so the returned stream borrows nothing from
-    // `snapshot`. The tail is streamed through the snapshot's read handle instead: a `Replay`
-    // reads physical pages from the blob and would miss the tail's buffered bytes.
+    // `blobs`. The tail is streamed through its read handle instead: a `Replay` reads physical
+    // pages from the blob and would miss the tail's buffered bytes.
     let mut per_blob_replays: Vec<(u64, Replay<E::Blob>, u64)> = Vec::new();
-    for blob in start_blob..tail_blob.min(snapshot.bounds.end / items_per_blob) {
+    for blob in start_blob..tail_blob.min(bounds.end / items_per_blob) {
         let idx = (blob - oldest) as usize;
-        let sealed = &snapshot.sealed[idx];
+        let sealed = &sealed_blobs[idx];
         let mut replay = sealed.replay(buffer).map_err(Error::Runtime)?;
         let initial_offset = if blob == start_blob {
             let start_byte = Journal::<E, A>::items_to_bytes(start_pos_in_blob)?;
@@ -1254,7 +1247,7 @@ fn replay_stream<E: Context, A: CodecFixedShared>(
             .into_batches()
         });
 
-    // Stream the tail in `buffer`-sized batches, bounded by the snapshot's size.
+    // Stream the tail in `buffer`-sized batches, bounded by the view's end bound.
     let tail_first = first_in_blob(pruning_boundary, tail_blob, items_per_blob)?;
     let tail_start = if start_blob == tail_blob {
         start_pos
@@ -1262,8 +1255,8 @@ fn replay_stream<E: Context, A: CodecFixedShared>(
         tail_first
     };
     let tail_batches = TailReplayState::<E::Blob, A> {
-        reader: snapshot.tail.clone(),
-        positions: tail_start.max(tail_first)..snapshot.bounds.end,
+        reader: blobs.tail_reader(),
+        positions: tail_start.max(tail_first)..bounds.end,
         tail_first,
         items_per_batch: (buffer.get() / chunk_size).max(1),
         _marker: PhantomData,
@@ -1310,10 +1303,10 @@ impl<B: RBlob, A: CodecFixedShared> replay::Source for BlobReplayState<B, A> {
     }
 }
 
-/// Replays the writable tail through the snapshot's read handle.
+/// Replays the writable tail through a cloned tail read handle.
 struct TailReplayState<B: RBlob, A> {
     reader: paged::Reader<B>,
-    /// Positions still to emit; `positions.end` is the snapshot's size.
+    /// Positions still to emit; `positions.end` is the view's end bound.
     positions: Range<u64>,
     /// First retained position in the tail; origin for byte offsets.
     tail_first: u64,
@@ -1377,12 +1370,11 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Journal<E, A> {
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
-        replay_stream::<E, A>(
-            &self.blobs.to_snapshot(self.bounds.clone()),
-            self.items_per_blob.get(),
-            buffer,
-            start_pos,
-        )
+        let blobs = Blobs::Writable {
+            writable: &self.blobs,
+            bounds: self.bounds.clone(),
+        };
+        replay_stream::<E, A>(&blobs, self.items_per_blob.get(), buffer, start_pos)
     }
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -34,28 +34,15 @@
 //!   and byte offset, and remembers which blobs have writes that are not yet fsynced
 //!   (`dirty_from_blob`) so commit/sync only fsync what changed.
 //!
-//! - `Blobs` owns the files: the contiguous sealed blobs plus the one writable tail, and the
-//!   live-reader count that gates rewind.
+//! - `Writable` owns the files: the contiguous sealed blobs plus the one writable tail, and the
+//!   snapshot count that gates rewind.
 //!
 //! - `Checkpoint` owns the durable recovery hints (mid-blob pruning boundary, recovery
 //!   watermark, staged clear target) consulted before trusting blob state on startup.
 //!
-//! # Concurrency
-//!
-//! Readers are snapshots. [`Journal::reader`] copies the journal's current blobs and bounds into
-//! an owned value whose bounds never change: every position within them stays readable for the
-//! reader's life, even if the journal prunes those items afterward. Reading never blocks the
-//! journal. A reader does not see later appends; take a new reader for that.
-//!
-//! Operations that add or drop blobs never mutate the journal's sealed-blob slice; they replace it
-//! whole, so a reader's snapshot keeps valid handles. The journal and its readers share one piece
-//! of mutable state: a count of live readers. Rewind truncates a blob (sealed or tail) in place,
-//! which is the one operation that could change bytes under a live reader, so it checks that count
-//! and is refused with [Error::BlobInUse] while any reader is outstanding.
-//!
 //! # Open Blobs
 //!
-//! Every retained blob is held open; a pruned blob stays open until the last reader holding it
+//! Every retained blob is held open; a pruned blob stays open until the last snapshot holding it
 //! drops. Use a larger `items_per_blob` or prune to bound the count.
 //!
 //! # Partition
@@ -109,7 +96,7 @@
 //! The `replay` method supports fast reading of all unpruned items into memory.
 
 use super::{
-    blobs::{Blobs, Handle, Partition, Snapshot},
+    blobs::{Blob, Blobs, Partition, Snapshot, Writable},
     checkpoint::Checkpoint,
     replay::{self, Source as _},
 };
@@ -123,7 +110,7 @@ use crate::{
 use commonware_codec::{CodecFixedShared, DecodeExt as _, ReadExt as _};
 use commonware_runtime::{
     buffer::paged::{self, CacheRef, Replay, Writer},
-    Blob, Buf, IoBuf,
+    Blob as RBlob, Buf, IoBuf,
 };
 use futures::{
     stream::{self, Stream},
@@ -211,7 +198,7 @@ pub struct Config {
 /// underlying blob will be truncated to the last valid item). Repair is performed during init.
 pub struct Journal<E: Context, A> {
     /// The blobs that comprise the journal.
-    blobs: Blobs<E>,
+    blobs: Writable<E>,
 
     /// The durable recovery checkpoint.
     checkpoint: Checkpoint<E>,
@@ -259,7 +246,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
     /// Construct a journal from recovered blobs.
     fn from_blobs(
-        blobs: Blobs<E>,
+        blobs: Writable<E>,
         checkpoint: Checkpoint<E>,
         bounds: Range<u64>,
         dirty_from_blob: Option<u64>,
@@ -370,7 +357,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         }
 
         // Seal every blob below the tail and assemble the blobs.
-        let blobs = Blobs::recover(partition, pending, tail_blob).await?;
+        let blobs = Writable::recover(partition, pending, tail_blob).await?;
 
         // Bytes beyond the persisted recovery watermark may be readable after reopen without
         // being crash-durable, so the next commit/sync must force a data sync before advancing it.
@@ -409,7 +396,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             cfg.write_buffer,
         );
         let tail_blob = clear_target / cfg.items_per_blob.get();
-        let blobs = Blobs::recover(partition, BTreeMap::new(), tail_blob).await?;
+        let blobs = Writable::recover(partition, BTreeMap::new(), tail_blob).await?;
         checkpoint
             .finish_clear(cfg.items_per_blob.get(), clear_target)
             .await?;
@@ -717,15 +704,25 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .await
     }
 
-    /// Return an owned snapshot of the journal. Bounds are frozen at creation; take a new
-    /// reader to observe later appends.
-    ///
-    /// Readers must be dropped before re-initializing the journal's partition: a freshly
-    /// initialized journal's reader gate cannot see readers taken from this one, so its
-    /// init-time repairs and rewinds may truncate blobs in place under them.
-    pub fn reader(&self) -> Reader<E, A> {
+    /// Capture an owned snapshot ([`Reader`]) over the current journal. Bounds are frozen at
+    /// creation; the snapshot stays readable across concurrent appends and prunes, and a rewind
+    /// into its range is refused ([Error::BlobInUse]) while it is alive.
+    pub fn snapshot(&self) -> Reader<'static, E, A> {
         Reader {
-            snapshot: self.blobs.to_snapshot(self.bounds.clone()),
+            blobs: Blobs::Snapshot(self.blobs.to_snapshot(self.bounds.clone())),
+            items_per_blob: self.items_per_blob,
+            metrics: self.metrics.clone(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// A reader borrowing the journal's live state.
+    pub(super) fn reader(&self) -> Reader<'_, E, A> {
+        Reader {
+            blobs: Blobs::Writable {
+                writable: &self.blobs,
+                bounds: self.bounds.clone(),
+            },
             items_per_blob: self.items_per_blob,
             metrics: self.metrics.clone(),
             _phantom: PhantomData,
@@ -864,8 +861,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// the current size, or [Error::ItemPruned] if it precedes the pruning boundary. The journal
     /// is not synced after rewinding.
     ///
-    /// Returns [Error::BlobInUse] if any [Reader] snapshot is outstanding: rewinding truncates a
-    /// blob in place, which could tear a live reader's bytes. Retry after readers are dropped.
+    /// Returns [Error::BlobInUse] if any [`snapshot`](Self::snapshot) is alive:
+    /// rewinding truncates a blob in place, which could tear its bytes. Retry after they drop.
     ///
     /// # Warnings
     ///
@@ -891,7 +888,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // Refuse before persisting a lowered watermark: a refused rewind is retryable and
         // should leave no side effects (a lowered watermark is safe but forces consumers to
         // re-replay synced items after a crash). The truncation paths below re-check the gate.
-        if self.blobs.readers_outstanding() {
+        if self.blobs.snapshots_alive() {
             return Err(Error::BlobInUse(blob));
         }
 
@@ -1027,70 +1024,52 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     }
 }
 
-/// An owned snapshot of the journal. Bounds are frozen at creation and every position within
-/// `bounds()` remains readable, including across a concurrent prune. A rewind into the snapshot's
-/// range is refused ([Error::BlobInUse]) while it is alive, so its bytes never change underneath it.
-pub struct Reader<E: Context, A> {
-    snapshot: Snapshot<E::Blob>,
+/// A reader over a fixed journal.
+pub struct Reader<'a, E: Context, A> {
+    blobs: Blobs<'a, E>,
     items_per_blob: NonZeroU64,
     metrics: Arc<Metrics<E>>,
     _phantom: PhantomData<A>,
 }
 
-impl<E: Context, A: CodecFixedShared> Reader<E, A> {
+impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
     /// Resolve `pos` to its read handle and byte offset within the blob.
-    fn locate(&self, pos: u64) -> Result<(Handle<'_, E::Blob>, u64), Error> {
-        self.snapshot.validate_readable(pos)?;
+    fn locate(&self, pos: u64) -> Result<(Blob<'_, E::Blob>, u64), Error> {
+        self.blobs.validate_readable(pos)?;
         let items_per_blob = self.items_per_blob.get();
         let blob = pos / items_per_blob;
-        let pos_in_blob = pos - first_in_blob(self.snapshot.bounds.start, blob, items_per_blob)?;
+        let pos_in_blob = pos - first_in_blob(self.blobs.bounds().start, blob, items_per_blob)?;
         let offset = Journal::<E, A>::items_to_bytes(pos_in_blob)?;
-        let handle = self.snapshot.require_handle(blob)?;
+        let handle = self
+            .blobs
+            .get(blob)
+            .expect("position in bounds maps to a retained blob");
         Ok((handle, offset))
     }
 
-    /// Read the item at position `pos` in the journal.
-    ///
-    /// # Errors
-    ///
-    ///  - [Error::ItemPruned] if the item at position `pos` is pruned.
-    ///  - [Error::ItemOutOfRange] if the item at position `pos` does not exist.
-    async fn read_inner(&self, pos: u64) -> Result<A, Error> {
-        let (handle, offset) = self.locate(pos)?;
-        let bufs = handle.read_at(offset, A::SIZE).await?;
-        A::decode(bufs.coalesce()).map_err(Error::Codec)
-    }
-
-    /// Read an item if it can be done synchronously (e.g. without I/O), returning `None`
-    /// otherwise.
-    fn try_read_sync_inner(&self, pos: u64) -> Option<A> {
-        let mut buf = vec![0u8; A::SIZE];
-        self.try_read_sync_into(pos, &mut buf)
-    }
-
-    /// Read an item synchronously using caller-provided buffer.
-    fn try_read_sync_into(&self, pos: u64, buf: &mut [u8]) -> Option<A> {
+    /// Read the item at `pos` synchronously if its bytes are cached, else `None`.
+    fn try_read_sync_cached(&self, pos: u64) -> Option<A> {
         let (handle, offset) = self.locate(pos).ok()?;
-        let buf = &mut buf[..A::SIZE];
-        if !handle.try_read_sync(offset, buf) {
+        let mut buf = vec![0u8; A::SIZE];
+        if !handle.try_read_sync(offset, &mut buf) {
             return None;
         }
         A::decode(&buf[..]).ok()
     }
 }
 
-impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Reader for Reader<E, A> {
+impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Contiguous for Reader<'_, E, A> {
     type Item = A;
 
     fn bounds(&self) -> Range<u64> {
-        self.snapshot.bounds.clone()
+        self.blobs.bounds()
     }
 
     async fn read(&self, pos: u64) -> Result<A, Error> {
         self.metrics.read_calls.inc();
 
         // Serve from the page cache synchronously when possible, avoiding the async storage path.
-        if let Some(item) = self.try_read_sync_inner(pos) {
+        if let Some(item) = self.try_read_sync_cached(pos) {
             self.metrics.record_cache_hits(1);
             self.metrics.items_read.inc();
             return Ok(item);
@@ -1098,7 +1077,9 @@ impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Reader for Rea
         self.metrics.record_cache_misses(1);
 
         let _timer = self.metrics.read_timer();
-        let item = self.read_inner(pos).await?;
+        let (handle, offset) = self.locate(pos)?;
+        let bufs = handle.read_at(offset, A::SIZE).await?;
+        let item = A::decode(bufs.coalesce()).map_err(Error::Codec)?;
         self.metrics.items_read.inc();
         Ok(item)
     }
@@ -1115,19 +1096,17 @@ impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Reader for Rea
                 return Err(Error::PositionsNotIncreasing);
             }
             prev = Some(pos);
-            self.snapshot.validate_readable(pos)?;
+            self.blobs.validate_readable(pos)?;
         }
 
         let items_per_blob = self.items_per_blob.get();
-        let pruning_boundary = self.snapshot.bounds.start;
+        let pruning_boundary = self.blobs.bounds().start;
         let chunk_size = A::SIZE;
 
-        // Read all positions grouped by blob. Positions are sorted, so `chunk_by` splits them
-        // into maximal runs that share one blob. Each group goes through the blob handle's
-        // batched read, which serves page-cache and tip-buffer hits under a single lock
-        // acquisition and reads only true misses from the blob (concurrently). This avoids one
-        // lock acquisition per item that a per-item synchronous probe would incur for the warm
-        // steady state.
+        // Read all positions grouped by blob. Positions are sorted, so `chunk_by` splits them into
+        // maximal runs that share one blob. Each group goes through the blob handle's batched read,
+        // which serves page-cache and tip-buffer hits under a single lock acquisition and reads only
+        // true misses from the blob (concurrently).
         let mut result: Vec<A> = Vec::with_capacity(positions.len());
         let mut reusable_buf = vec![0u8; positions.len() * chunk_size];
         let mut hits = 0u64;
@@ -1139,7 +1118,10 @@ impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Reader for Rea
                 .map(|&pos| Journal::<E, A>::items_to_bytes(pos - first_position))
                 .collect::<Result<_, _>>()?;
 
-            let handle = self.snapshot.require_handle(blob)?;
+            let handle = self
+                .blobs
+                .get(blob)
+                .expect("positions in bounds map to a retained blob");
             let buf = &mut reusable_buf[..group.len() * chunk_size];
             let group_hits = handle
                 .read_many_into(buf, &blob_offsets, Journal::<E, A>::CHUNK_SIZE)
@@ -1159,7 +1141,7 @@ impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Reader for Rea
     }
 
     fn try_read_sync(&self, pos: u64) -> Option<A> {
-        self.try_read_sync_inner(pos).map_or_else(
+        self.try_read_sync_cached(pos).map_or_else(
             || {
                 self.metrics.record_cache_misses(1);
                 None
@@ -1178,92 +1160,121 @@ impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Reader for Rea
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
-        let items_per_blob = self.items_per_blob.get();
-        let pruning_boundary = self.snapshot.bounds.start;
-        let chunk_size = A::SIZE;
-        let chunk_size_u64 = Journal::<E, A>::CHUNK_SIZE_U64;
-
-        self.snapshot.validate_cursor(start_pos)?;
-
-        let start_blob = start_pos / items_per_blob;
-        let start_pos_in_blob =
-            start_pos - first_in_blob(pruning_boundary, start_blob, items_per_blob)?;
-
-        // Check all middle blobs (not oldest, not tail) in range are complete. Sealed blob
-        // sizes are known synchronously.
-        let oldest = self.snapshot.oldest_blob_index;
-        let tail_blob = self.snapshot.tail_blob_index();
-        let first_to_check = oldest
-            .checked_add(1)
-            .map_or(tail_blob, |after_oldest| start_blob.max(after_oldest));
-        for blob in first_to_check..tail_blob {
-            let idx = (blob - oldest) as usize;
-            let len = self.snapshot.sealed[idx].size() / chunk_size_u64;
-            if len < items_per_blob {
-                return Err(Error::Corruption(format!(
-                    "blob {blob} incomplete: expected {items_per_blob} items, got {len}"
-                )));
+        // `replay` returns a stream that outlives this call, so it reads from an owned snapshot
+        // whose Arc-shared handles the stream owns. A snapshot already has one.
+        match &self.blobs {
+            Blobs::Snapshot(snapshot) => {
+                replay_stream::<E, A>(snapshot, self.items_per_blob.get(), buffer, start_pos)
             }
+            Blobs::Writable { writable, bounds } => replay_stream::<E, A>(
+                &writable.to_snapshot(bounds.clone()),
+                self.items_per_blob.get(),
+                buffer,
+                start_pos,
+            ),
         }
-
-        // Seed each sealed blob's `Replay` upfront so the returned stream borrows nothing
-        // from `self`. The tail is streamed through the snapshot's read handle instead: a
-        // `Replay` reads physical pages from the blob and would miss the tail's buffered bytes.
-        let mut per_blob_replays: Vec<(u64, Replay<E::Blob>, u64)> = Vec::new();
-        for blob in start_blob..tail_blob.min(self.snapshot.bounds.end / items_per_blob) {
-            let idx = (blob - oldest) as usize;
-            let sealed = &self.snapshot.sealed[idx];
-            let mut replay = sealed.replay(buffer).map_err(Error::Runtime)?;
-            let initial_offset = if blob == start_blob {
-                let start_byte = Journal::<E, A>::items_to_bytes(start_pos_in_blob)?;
-                if start_byte > sealed.size() {
-                    return Err(Error::ItemOutOfRange(start_pos));
-                }
-                replay.seek_to(start_byte).map_err(Error::Runtime)?;
-                start_pos_in_blob
-            } else {
-                0
-            };
-            let blob_first = first_in_blob(pruning_boundary, blob, items_per_blob)?;
-            per_blob_replays.push((blob_first, replay, initial_offset));
-        }
-
-        // Stream the sealed blobs in ascending order, then the tail. Each source yields batches
-        // of items; the trailing `flat_map(stream::iter)` flattens batches back into items.
-        let sealed_batches = stream::iter(per_blob_replays).flat_map(
-            move |(blob_first, replay, initial_position)| {
-                BlobReplayState::<E::Blob, A> {
-                    blob_first,
-                    replay,
-                    position: initial_position,
-                    _marker: PhantomData,
-                }
-                .into_batches()
-            },
-        );
-
-        // Stream the tail in `buffer`-sized batches, bounded by the snapshot's size.
-        let tail_first = first_in_blob(pruning_boundary, tail_blob, items_per_blob)?;
-        let tail_start = if start_blob == tail_blob {
-            start_pos
-        } else {
-            tail_first
-        };
-        let tail_batches = TailReplayState::<E::Blob, A> {
-            reader: self.snapshot.tail_reader.clone(),
-            positions: tail_start.max(tail_first)..self.snapshot.bounds.end,
-            tail_first,
-            items_per_batch: (buffer.get() / chunk_size).max(1),
-            _marker: PhantomData,
-        }
-        .into_batches();
-
-        Ok(sealed_batches.chain(tail_batches).flat_map(stream::iter))
     }
 }
 
+/// Build the replay stream over `snapshot`, starting at `start_pos`.
+///
+/// The returned stream owns everything it reads (seeded sealed-blob replays and a cloned tail
+/// reader), so it borrows nothing from `snapshot` (`use<E, A>` keeps the snapshot's lifetime out
+/// of the return type). Shared by [`Reader`] and [`Journal`]'s [`super::Contiguous`] impl.
+fn replay_stream<E: Context, A: CodecFixedShared>(
+    snapshot: &Snapshot<E::Blob>,
+    items_per_blob: u64,
+    buffer: NonZeroUsize,
+    start_pos: u64,
+) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send + use<E, A>, Error> {
+    let pruning_boundary = snapshot.bounds.start;
+    let chunk_size = A::SIZE;
+    let chunk_size_u64 = Journal::<E, A>::CHUNK_SIZE_U64;
+
+    if start_pos > snapshot.bounds.end {
+        return Err(Error::ItemOutOfRange(start_pos));
+    }
+    if start_pos < pruning_boundary {
+        return Err(Error::ItemPruned(start_pos));
+    }
+
+    let start_blob = start_pos / items_per_blob;
+    let start_pos_in_blob =
+        start_pos - first_in_blob(pruning_boundary, start_blob, items_per_blob)?;
+
+    // Check all middle blobs (not oldest, not tail) in range are complete. Sealed blob
+    // sizes are known synchronously.
+    let oldest = snapshot.oldest_blob_index;
+    let tail_blob = snapshot.tail_blob_index();
+    let first_to_check = oldest
+        .checked_add(1)
+        .map_or(tail_blob, |after_oldest| start_blob.max(after_oldest));
+    for blob in first_to_check..tail_blob {
+        let idx = (blob - oldest) as usize;
+        let len = snapshot.sealed[idx].size() / chunk_size_u64;
+        if len < items_per_blob {
+            return Err(Error::Corruption(format!(
+                "blob {blob} incomplete: expected {items_per_blob} items, got {len}"
+            )));
+        }
+    }
+
+    // Seed each sealed blob's `Replay` upfront so the returned stream borrows nothing from
+    // `snapshot`. The tail is streamed through the snapshot's read handle instead: a `Replay`
+    // reads physical pages from the blob and would miss the tail's buffered bytes.
+    let mut per_blob_replays: Vec<(u64, Replay<E::Blob>, u64)> = Vec::new();
+    for blob in start_blob..tail_blob.min(snapshot.bounds.end / items_per_blob) {
+        let idx = (blob - oldest) as usize;
+        let sealed = &snapshot.sealed[idx];
+        let mut replay = sealed.replay(buffer).map_err(Error::Runtime)?;
+        let initial_offset = if blob == start_blob {
+            let start_byte = Journal::<E, A>::items_to_bytes(start_pos_in_blob)?;
+            if start_byte > sealed.size() {
+                return Err(Error::ItemOutOfRange(start_pos));
+            }
+            replay.seek_to(start_byte).map_err(Error::Runtime)?;
+            start_pos_in_blob
+        } else {
+            0
+        };
+        let blob_first = first_in_blob(pruning_boundary, blob, items_per_blob)?;
+        per_blob_replays.push((blob_first, replay, initial_offset));
+    }
+
+    // Stream the sealed blobs in ascending order, then the tail. Each source yields batches
+    // of items; the trailing `flat_map(stream::iter)` flattens batches back into items.
+    let sealed_batches =
+        stream::iter(per_blob_replays).flat_map(move |(blob_first, replay, initial_position)| {
+            BlobReplayState::<E::Blob, A> {
+                blob_first,
+                replay,
+                position: initial_position,
+                _marker: PhantomData,
+            }
+            .into_batches()
+        });
+
+    // Stream the tail in `buffer`-sized batches, bounded by the snapshot's size.
+    let tail_first = first_in_blob(pruning_boundary, tail_blob, items_per_blob)?;
+    let tail_start = if start_blob == tail_blob {
+        start_pos
+    } else {
+        tail_first
+    };
+    let tail_batches = TailReplayState::<E::Blob, A> {
+        reader: snapshot.tail.clone(),
+        positions: tail_start.max(tail_first)..snapshot.bounds.end,
+        tail_first,
+        items_per_batch: (buffer.get() / chunk_size).max(1),
+        _marker: PhantomData,
+    }
+    .into_batches();
+
+    Ok(sealed_batches.chain(tail_batches).flat_map(stream::iter))
+}
+
 /// Replays a single sealed blob through its `Replay`.
-struct BlobReplayState<B: Blob, A> {
+struct BlobReplayState<B: RBlob, A> {
     /// First retained position in the blob.
     blob_first: u64,
     /// Sequential reader over the blob's logical bytes.
@@ -1273,7 +1284,7 @@ struct BlobReplayState<B: Blob, A> {
     _marker: PhantomData<A>,
 }
 
-impl<B: Blob, A: CodecFixedShared> replay::Source for BlobReplayState<B, A> {
+impl<B: RBlob, A: CodecFixedShared> replay::Source for BlobReplayState<B, A> {
     type Item = A;
 
     /// Decode every whole item currently buffered. Positions are consecutive, so overflow is
@@ -1300,7 +1311,7 @@ impl<B: Blob, A: CodecFixedShared> replay::Source for BlobReplayState<B, A> {
 }
 
 /// Replays the writable tail through the snapshot's read handle.
-struct TailReplayState<B: Blob, A> {
+struct TailReplayState<B: RBlob, A> {
     reader: paged::Reader<B>,
     /// Positions still to emit; `positions.end` is the snapshot's size.
     positions: Range<u64>,
@@ -1311,7 +1322,7 @@ struct TailReplayState<B: Blob, A> {
     _marker: PhantomData<A>,
 }
 
-impl<B: Blob, A: CodecFixedShared> replay::Source for TailReplayState<B, A> {
+impl<B: RBlob, A: CodecFixedShared> replay::Source for TailReplayState<B, A> {
     type Item = A;
 
     /// Read and decode up to `items_per_batch` fixed-size items from the tail.
@@ -1342,16 +1353,36 @@ impl<B: Blob, A: CodecFixedShared> replay::Source for TailReplayState<B, A> {
     }
 }
 
-// Implement Contiguous trait for fixed-length journals
 impl<E: Context, A: CodecFixedShared> super::Contiguous for Journal<E, A> {
     type Item = A;
 
-    async fn reader(&self) -> impl super::Reader<Item = A> + '_ {
-        Self::reader(self)
+    fn bounds(&self) -> Range<u64> {
+        self.bounds.clone()
     }
 
-    async fn size(&self) -> u64 {
-        Self::size(self)
+    async fn read(&self, pos: u64) -> Result<A, Error> {
+        self.reader().read(pos).await
+    }
+
+    async fn read_many(&self, positions: &[u64]) -> Result<Vec<A>, Error> {
+        self.reader().read_many(positions).await
+    }
+
+    fn try_read_sync(&self, pos: u64) -> Option<A> {
+        self.reader().try_read_sync(pos)
+    }
+
+    async fn replay(
+        &self,
+        buffer: NonZeroUsize,
+        start_pos: u64,
+    ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
+        replay_stream::<E, A>(
+            &self.blobs.to_snapshot(self.bounds.clone()),
+            self.items_per_blob.get(),
+            buffer,
+            start_pos,
+        )
     }
 }
 
@@ -1417,7 +1448,7 @@ impl<E: Context, A: CodecFixedShared> crate::journal::authenticated::Inner<E> fo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::journal::contiguous::Reader as _;
+    use crate::journal::contiguous::Contiguous as _;
     use commonware_codec::FixedSize;
     use commonware_cryptography::{sha256::Digest, Hasher as _, Sha256};
     use commonware_macros::test_traced;
@@ -1453,16 +1484,6 @@ mod tests {
     }
 
     impl<E: crate::Context, A: CodecFixedShared> Journal<E, A> {
-        /// Test helper: Read the item at the given position.
-        pub(crate) async fn read(&self, pos: u64) -> Result<A, Error> {
-            self.reader().read(pos).await
-        }
-
-        /// Test helper: Return the bounds of the journal.
-        pub(crate) fn bounds(&self) -> Range<u64> {
-            self.reader().bounds()
-        }
-
         /// Test helper: Get the oldest blob from the blob store.
         pub(crate) const fn test_oldest_blob(&self) -> Option<u64> {
             Some(self.blobs.oldest_blob_index())
@@ -1743,18 +1764,18 @@ mod tests {
 
             // Replaying from 0 should fail since all items before bounds.start are pruned
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let result = reader.replay(NZUsize!(1024), 0).await;
                 assert!(matches!(result, Err(Error::ItemPruned(0))));
             }
 
             // Replaying from pruning_boundary should return empty stream
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let res = reader.replay(NZUsize!(1024), 0).await;
                 assert!(matches!(res, Err(Error::ItemPruned(_))));
 
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader
                     .replay(NZUsize!(1024), journal.bounds().start)
                     .await
@@ -1840,7 +1861,7 @@ mod tests {
 
             // Replay should return all items
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader
                     .replay(NZUsize!(1024), 0)
                     .await
@@ -1897,7 +1918,7 @@ mod tests {
             // Replay all items.
             {
                 let mut error_found = false;
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader
                     .replay(NZUsize!(1024), 0)
                     .await
@@ -1976,7 +1997,7 @@ mod tests {
 
             // Replay should return all items except the first `START_POS`.
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader
                     .replay(NZUsize!(1024), START_POS)
                     .await
@@ -4027,7 +4048,7 @@ mod tests {
 
             // Replay from pruning_boundary
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader
                     .replay(NZUsize!(1024), 7)
                     .await
@@ -4048,7 +4069,7 @@ mod tests {
 
             // Replay from mid-stream (position 12)
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader
                     .replay(NZUsize!(1024), 12)
                     .await
@@ -4383,7 +4404,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let items = journal.reader().read_many(&[]).await.unwrap();
+            let items = journal.snapshot().read_many(&[]).await.unwrap();
             assert!(items.is_empty());
 
             journal.destroy().await.unwrap();
@@ -4403,7 +4424,7 @@ mod tests {
             }
             assert_eq!(journal.size(), 5);
 
-            let items = journal.reader().read_many(&[0, 2, 4]).await.unwrap();
+            let items = journal.snapshot().read_many(&[0, 2, 4]).await.unwrap();
             assert_eq!(items, vec![test_digest(0), test_digest(2), test_digest(4)]);
 
             journal.destroy().await.unwrap();
@@ -4422,12 +4443,12 @@ mod tests {
             }
 
             assert!(matches!(
-                journal.reader().read_many(&[2, 1]).await,
+                journal.snapshot().read_many(&[2, 1]).await,
                 Err(Error::PositionsNotIncreasing)
             ));
             // Duplicates are not strictly increasing either.
             assert!(matches!(
-                journal.reader().read_many(&[1, 1]).await,
+                journal.snapshot().read_many(&[1, 1]).await,
                 Err(Error::PositionsNotIncreasing)
             ));
 
@@ -4449,7 +4470,7 @@ mod tests {
             assert_eq!(journal.size(), 9);
             // Blobs: [0,1,2], [3,4,5], [6,7,8]
 
-            let items = journal.reader().read_many(&[1, 4, 7]).await.unwrap();
+            let items = journal.snapshot().read_many(&[1, 4, 7]).await.unwrap();
             assert_eq!(items, vec![test_digest(1), test_digest(4), test_digest(7)]);
 
             journal.destroy().await.unwrap();
@@ -4474,11 +4495,11 @@ mod tests {
             journal.prune(3).await.unwrap();
             assert_eq!(journal.bounds(), 3..9);
 
-            let items = journal.reader().read_many(&[3, 5, 8]).await.unwrap();
+            let items = journal.snapshot().read_many(&[3, 5, 8]).await.unwrap();
             assert_eq!(items, vec![test_digest(3), test_digest(5), test_digest(8)]);
 
             // Pruned position should error.
-            let err = journal.reader().read_many(&[1]).await.unwrap_err();
+            let err = journal.snapshot().read_many(&[1]).await.unwrap_err();
             assert!(matches!(err, Error::ItemPruned(1)));
 
             journal.destroy().await.unwrap();
@@ -4497,7 +4518,7 @@ mod tests {
             }
             assert_eq!(journal.size(), 3);
 
-            let err = journal.reader().read_many(&[0, 5]).await.unwrap_err();
+            let err = journal.snapshot().read_many(&[0, 5]).await.unwrap_err();
             assert!(matches!(err, Error::ItemOutOfRange(5)));
 
             journal.destroy().await.unwrap();
@@ -4519,7 +4540,7 @@ mod tests {
             journal.sync().await.unwrap();
 
             let positions: Vec<u64> = (0..20).collect();
-            let reader = journal.reader();
+            let reader = journal.snapshot();
             let batch = reader.read_many(&positions).await.unwrap();
 
             for &pos in &positions {
@@ -4547,9 +4568,9 @@ mod tests {
             journal.append(&test_digest(5)).await.unwrap();
             journal.commit().await.unwrap();
             journal.sync().await.unwrap();
-            journal.reader().read(0).await.unwrap();
-            journal.reader().try_read_sync(0).unwrap();
-            journal.reader().read_many(&[1, 2, 4]).await.unwrap();
+            journal.snapshot().read(0).await.unwrap();
+            journal.snapshot().try_read_sync(0).unwrap();
+            journal.snapshot().read_many(&[1, 2, 4]).await.unwrap();
             journal.prune(2).await.unwrap();
             journal.rewind(4).await.unwrap();
 
@@ -4596,7 +4617,7 @@ mod tests {
                 journal.append(&test_digest(i)).await.unwrap();
             }
 
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert_eq!(snapshot.bounds(), 0..7);
 
             // Appending past the blob boundary rolls the snapshot's tail blob into
@@ -4613,7 +4634,7 @@ mod tests {
                 Err(Error::ItemOutOfRange(7))
             ));
 
-            let fresh = journal.reader();
+            let fresh = journal.snapshot();
             assert_eq!(fresh.bounds(), 0..23);
             assert_eq!(fresh.read(22).await.unwrap(), test_digest(22));
 
@@ -4638,7 +4659,7 @@ mod tests {
             }
             journal.sync().await.unwrap();
 
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert!(journal.prune(12).await.unwrap());
 
             // The straggler reads the pruned range through its own handles.
@@ -4647,7 +4668,7 @@ mod tests {
                 assert_eq!(snapshot.read(i).await.unwrap(), test_digest(i));
             }
 
-            let fresh = journal.reader();
+            let fresh = journal.snapshot();
             assert_eq!(fresh.bounds(), 10..17);
             assert!(matches!(fresh.read(3).await, Err(Error::ItemPruned(3))));
 
@@ -4657,7 +4678,7 @@ mod tests {
         });
     }
 
-    /// Rewind into a sealed blob refuses while any snapshot is outstanding and succeeds once
+    /// Rewind into a sealed blob refuses while any snapshot is alive and succeeds once
     /// readers drop.
     #[test_traced]
     fn test_rewind_sealed_blob_in_use() {
@@ -4672,7 +4693,7 @@ mod tests {
             }
             journal.sync().await.unwrap();
 
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert!(matches!(journal.rewind(3).await, Err(Error::BlobInUse(0))));
 
             // The refused rewind left the journal fully usable and had no side effects: the
@@ -4710,7 +4731,7 @@ mod tests {
 
             // A live snapshot blocks the tail rewind (it would tear the snapshot's bytes once
             // the rewound offsets are reappended).
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert!(matches!(journal.rewind(2).await, Err(Error::BlobInUse(_))));
             // The refused rewind had no side effects: the watermark was not lowered.
             assert_eq!(journal.recovery_watermark(), 8);
@@ -4725,7 +4746,7 @@ mod tests {
             }
 
             // A fresh reader observes the new data; no stale reader is alive to see torn bytes.
-            let fresh = journal.reader();
+            let fresh = journal.snapshot();
             assert_eq!(fresh.read(6).await.unwrap(), test_digest(106));
             assert_eq!(fresh.read(1).await.unwrap(), test_digest(1));
 
@@ -4745,7 +4766,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            let (mut tx, mut rx) = futures::channel::mpsc::channel::<Reader<Context, Digest>>(8);
+            let (mut tx, mut rx) =
+                futures::channel::mpsc::channel::<Reader<'static, Context, Digest>>(8);
             let validator = context.child("validator").spawn(|_| async move {
                 let mut validated = 0usize;
                 while let Some(snapshot) = rx.next().await {
@@ -4761,7 +4783,7 @@ mod tests {
             for i in 0..40u64 {
                 journal.append(&test_digest(i)).await.unwrap();
                 if i % 7 == 0 {
-                    let snapshot = journal.reader();
+                    let snapshot = journal.snapshot();
                     if tx.try_send(snapshot).is_err() {
                         break;
                     }
@@ -4789,7 +4811,7 @@ mod tests {
             }
 
             // Positions 5..7 live in the snapshot's tail blob.
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert_eq!(snapshot.bounds(), 0..7);
 
             // Roll the snapshot's tail into history, then prune both of its blobs away.
@@ -4833,7 +4855,7 @@ mod tests {
             // Prune mid-blob so first_in_blob differs from the blob start.
             journal.prune(11).await.unwrap();
 
-            let reader = journal.reader();
+            let reader = journal.snapshot();
 
             fn counter(buffer: &str, name: &str) -> u64 {
                 buffer
@@ -4900,7 +4922,7 @@ mod tests {
             journal.sync().await.unwrap();
 
             // The page cache cannot hold every page, so some position must be cold.
-            let reader = journal.reader();
+            let reader = journal.snapshot();
             let pos = (0..20)
                 .find(|&pos| reader.try_read_sync(pos).is_none())
                 .expect("some position should be cold");

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -19,16 +19,11 @@ pub mod variable;
 #[cfg(test)]
 mod tests;
 
-/// A consistent view of the journal.
+/// A read-only, position-based view of a contiguous journal.
 ///
-/// Bounds are stable for the reader's lifetime, and every position within `bounds()` stays
-/// readable through it, even if the journal prunes those items afterward. A reader never
-/// observes appends made after it was created.
-///
-/// A rewind below `bounds().end` would mutate bytes a reader can still see, so the journal
-/// refuses it while any reader is alive (the rewind returns an error); it never proceeds and
-/// leaves a reader observing changed data.
-pub trait Reader: Send + Sync {
+/// Maintains a monotonically increasing position counter where each appended item receives a unique
+/// position starting from 0.
+pub trait Contiguous: Send + Sync {
     /// The type of items stored in the journal.
     type Item;
 
@@ -67,7 +62,7 @@ pub trait Reader: Send + Sync {
         None
     }
 
-    /// Return a stream of all items starting from `start_pos`, bounded by the reader's `bounds()`.
+    /// Return a stream of all items starting from `start_pos`, bounded by `bounds()`.
     fn replay(
         &self,
         buffer: NonZeroUsize,
@@ -77,31 +72,9 @@ pub trait Reader: Send + Sync {
     > + Send;
 }
 
-/// Journals that support sequential append operations.
-///
-/// Maintains a monotonically increasing position counter where each appended item receives a unique
-/// position starting from 0.
-pub trait Contiguous: Send + Sync {
-    /// The type of items stored in the journal.
-    type Item;
-
-    /// Acquire a reader that holds a consistent view of the journal.
-    ///
-    /// Any position within `reader.bounds()` remains readable for the
-    /// reader's lifetime (see [Reader]).
-    fn reader(&self) -> impl Future<Output = impl Reader<Item = Self::Item> + '_> + Send;
-
-    /// Return the total number of items that have been appended to the journal.
-    ///
-    /// This count is NOT affected by pruning. The next appended item will receive this
-    /// position as its value. Equivalent to [`Reader::bounds`]`.end`.
-    fn size(&self) -> impl Future<Output = u64> + Send;
-}
-
 /// Items to append via [`Mutable::append_many`].
 ///
-/// `Flat` wraps a single contiguous slice; `Nested` wraps multiple slices that are
-/// appended in order under a single lock acquisition.
+/// `Flat` wraps a single contiguous slice; `Nested` wraps multiple slices appended in order.
 pub enum Many<'a, T> {
     /// A single contiguous slice of items.
     Flat(&'a [T]),
@@ -161,7 +134,7 @@ pub trait Mutable: Contiguous + Send + Sync {
             if items.is_empty() {
                 return Err(Error::EmptyAppend);
             }
-            let mut last_pos = self.size().await;
+            let mut last_pos = self.bounds().end;
             match items {
                 Many::Flat(items) => {
                     for item in items {
@@ -265,21 +238,15 @@ pub trait Mutable: Contiguous + Send + Sync {
         P: FnMut(&Self::Item) -> bool + Send + 'a,
     {
         async move {
-            let (bounds, rewind_size) = {
-                let reader = self.reader().await;
-                let bounds = reader.bounds();
-                let mut rewind_size = bounds.end;
-
-                while rewind_size > bounds.start {
-                    let item = reader.read(rewind_size - 1).await?;
-                    if predicate(&item) {
-                        break;
-                    }
-                    rewind_size -= 1;
+            let bounds = self.bounds();
+            let mut rewind_size = bounds.end;
+            while rewind_size > bounds.start {
+                let item = self.read(rewind_size - 1).await?;
+                if predicate(&item) {
+                    break;
                 }
-
-                (bounds, rewind_size)
-            };
+                rewind_size -= 1;
+            }
 
             if rewind_size != bounds.end {
                 let rewound_items = bounds.end - rewind_size;

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -1,6 +1,6 @@
 //! Generic test suite for [Contiguous] trait implementations.
 
-use super::{Contiguous, Many, Reader as _};
+use super::{Contiguous, Many};
 use crate::journal::{contiguous::Mutable, Error};
 use commonware_macros::boxed;
 use commonware_utils::NZUsize;
@@ -178,16 +178,6 @@ pub(super) mod partition_sync_fault {
     }
 }
 
-async fn get_bounds<J: Contiguous>(journal: &J) -> std::ops::Range<u64> {
-    let reader = journal.reader().await;
-    reader.bounds()
-}
-
-async fn read_item<J: Contiguous>(journal: &J, position: u64) -> Result<J::Item, Error> {
-    let reader = journal.reader().await;
-    reader.read(position).await
-}
-
 /// Run the full suite of generic tests on a [Contiguous] implementation.
 ///
 /// The factory function receives a test identifier string and a unique index
@@ -257,7 +247,7 @@ where
     J: Mutable<Item = u64>,
 {
     let journal = factory("empty".into()).await.unwrap();
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.start, 0);
     assert_eq!(bounds.end, 0);
     assert!(bounds.is_empty());
@@ -277,7 +267,7 @@ where
         journal.append(&(i * 100)).await.unwrap();
     }
 
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.start, 0);
     assert_eq!(bounds.end, 10);
     assert!(!bounds.is_empty());
@@ -300,7 +290,7 @@ where
     }
 
     // Initially bounds should be 0..30
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.start, 0);
     assert_eq!(bounds.end, 30);
 
@@ -308,7 +298,7 @@ where
     journal.prune(10).await.unwrap();
 
     // Assumed blob-aligned pruning and items_per_blob = 10.
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.start, 10);
     assert_eq!(bounds.end, 30);
 
@@ -316,13 +306,13 @@ where
     journal.prune(25).await.unwrap();
 
     // bounds.start should have advanced to 20 (section-aligned)
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.start, 20);
     assert_eq!(bounds.end, 30);
 
     // Prune all
     journal.prune(30).await.unwrap();
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.start, 30);
     assert_eq!(bounds.end, 30);
     assert!(bounds.is_empty());
@@ -331,7 +321,7 @@ where
     journal.sync().await.unwrap();
     drop(journal);
     let journal = factory("bounds-after-prune".into()).await.unwrap();
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert!(bounds.is_empty());
     journal.destroy().await.unwrap();
 }
@@ -351,12 +341,12 @@ where
     assert_eq!(pos1, 0);
     assert_eq!(pos2, 1);
     assert_eq!(pos3, 2);
-    assert_eq!(get_bounds(&journal).await.end, 3);
+    assert_eq!(journal.bounds().end, 3);
 
     // Verify values can be read back
-    assert_eq!(read_item(&journal, 0).await.unwrap(), 100);
-    assert_eq!(read_item(&journal, 1).await.unwrap(), 200);
-    assert_eq!(read_item(&journal, 2).await.unwrap(), 300);
+    assert_eq!(journal.read(0).await.unwrap(), 100);
+    assert_eq!(journal.read(1).await.unwrap(), 200);
+    assert_eq!(journal.read(2).await.unwrap(), 300);
 
     journal.destroy().await.unwrap();
 }
@@ -374,10 +364,10 @@ where
         assert_eq!(pos, i);
     }
 
-    assert_eq!(get_bounds(&journal).await.end, 25);
+    assert_eq!(journal.bounds().end, 25);
 
     for i in 0..25u64 {
-        assert_eq!(read_item(&journal, i).await.unwrap(), i * 10);
+        assert_eq!(journal.read(i).await.unwrap(), i * 10);
     }
 
     journal.destroy().await.unwrap();
@@ -396,8 +386,7 @@ where
     }
 
     {
-        let reader = journal.reader().await;
-        let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -428,8 +417,7 @@ where
     }
 
     {
-        let reader = journal.reader().await;
-        let stream = reader.replay(NZUsize!(1024), 7).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 7).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -459,22 +447,22 @@ where
         journal.append(&i).await.unwrap();
     }
 
-    let size_before = get_bounds(&journal).await.end;
+    let size_before = journal.bounds().end;
     journal.prune(10).await.unwrap();
-    let size_after = get_bounds(&journal).await.end;
+    let size_after = journal.bounds().end;
 
     assert_eq!(size_before, size_after);
     assert_eq!(size_after, 20);
 
     journal.prune(20).await.unwrap();
-    let size_after_all = get_bounds(&journal).await.end;
+    let size_after_all = journal.bounds().end;
     assert_eq!(size_after, size_after_all);
 
     journal.sync().await.unwrap();
     drop(journal);
 
     let journal = factory("prune-retains-size".into()).await.unwrap();
-    let size_after_close = get_bounds(&journal).await.end;
+    let size_after_close = journal.bounds().end;
     assert_eq!(size_after_close, size_after_all);
 
     journal.destroy().await.unwrap();
@@ -494,7 +482,7 @@ where
     assert_eq!(pos1, 0);
     assert_eq!(pos2, 1);
 
-    let size = Contiguous::size(&journal).await;
+    let size = Contiguous::bounds(&journal).end;
     assert_eq!(size, 2);
 
     journal.destroy().await.unwrap();
@@ -517,8 +505,7 @@ where
     {
         // Replay from a position that may or may not be pruned (section-aligned)
         // We replay from position 10 which should be safe
-        let reader = journal.reader().await;
-        let stream = reader.replay(NZUsize!(1024), 10).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 10).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -554,13 +541,13 @@ where
 
     // Prune all items at a blob boundary.
     journal.prune(10).await.unwrap();
-    assert!(get_bounds(&journal).await.is_empty());
+    assert!(journal.bounds().is_empty());
 
     // Append new items after pruning - position should continue from 10
     let pos = journal.append(&999).await.unwrap();
     assert_eq!(pos, 10);
 
-    assert_eq!(get_bounds(&journal).await.end, 11);
+    assert_eq!(journal.bounds().end, 11);
 
     journal.destroy().await.unwrap();
 }
@@ -588,15 +575,14 @@ where
     }
 
     // Verify reads work for retained items after pruning
-    assert_eq!(read_item(&journal, 10).await.unwrap(), 1000);
-    assert_eq!(read_item(&journal, 15).await.unwrap(), 1500);
-    assert_eq!(read_item(&journal, 20).await.unwrap(), 2000);
-    assert_eq!(read_item(&journal, 24).await.unwrap(), 2400);
+    assert_eq!(journal.read(10).await.unwrap(), 1000);
+    assert_eq!(journal.read(15).await.unwrap(), 1500);
+    assert_eq!(journal.read(20).await.unwrap(), 2000);
+    assert_eq!(journal.read(24).await.unwrap(), 2400);
 
     {
         // Replay from position 10 and verify positions
-        let reader = journal.reader().await;
-        let stream = reader.replay(NZUsize!(1024), 10).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 10).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -630,12 +616,12 @@ where
     journal.sync().await.unwrap();
 
     // Verify operations work after sync
-    assert_eq!(read_item(&journal, 0).await.unwrap(), 0);
+    assert_eq!(journal.read(0).await.unwrap(), 0);
     let pos = journal.append(&100).await.unwrap();
     assert_eq!(pos, 5);
-    assert_eq!(read_item(&journal, 5).await.unwrap(), 100);
+    assert_eq!(journal.read(5).await.unwrap(), 100);
 
-    assert_eq!(get_bounds(&journal).await.end, 6);
+    assert_eq!(journal.bounds().end, 6);
 
     journal.destroy().await.unwrap();
 }
@@ -649,8 +635,7 @@ where
     let journal = factory("replay-on-empty".into()).await.unwrap();
 
     {
-        let reader = journal.reader().await;
-        let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -676,11 +661,10 @@ where
         journal.append(&i).await.unwrap();
     }
 
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
 
     {
-        let reader = journal.reader().await;
-        let stream = reader.replay(NZUsize!(1024), bounds.end).await.unwrap();
+        let stream = journal.replay(NZUsize!(1024), bounds.end).await.unwrap();
         futures::pin_mut!(stream);
 
         let mut items = Vec::new();
@@ -712,9 +696,9 @@ where
     assert!(pruned1);
     assert!(!pruned2); // Second prune should return false (nothing to prune)
 
-    assert_eq!(get_bounds(&journal).await.end, 20);
-    assert_eq!(read_item(&journal, 10).await.unwrap(), 10);
-    assert_eq!(read_item(&journal, 19).await.unwrap(), 19);
+    assert_eq!(journal.bounds().end, 20);
+    assert_eq!(journal.read(10).await.unwrap(), 10);
+    assert_eq!(journal.read(19).await.unwrap(), 19);
 
     journal.destroy().await.unwrap();
 }
@@ -735,11 +719,11 @@ where
     journal.prune(100).await.unwrap();
 
     // Verify journal still works
-    assert_eq!(get_bounds(&journal).await.end, 10);
+    assert_eq!(journal.bounds().end, 10);
 
     let pos = journal.append(&999).await.unwrap();
     assert_eq!(pos, 10);
-    assert_eq!(read_item(&journal, 10).await.unwrap(), 999);
+    assert_eq!(journal.read(10).await.unwrap(), 999);
 
     journal.destroy().await.unwrap();
 }
@@ -761,7 +745,7 @@ where
             assert_eq!(pos, i);
         }
 
-        assert_eq!(get_bounds(&journal).await.end, 15);
+        assert_eq!(journal.bounds().end, 15);
 
         journal.sync().await.unwrap();
     }
@@ -770,17 +754,16 @@ where
     {
         let journal = factory(test_name.clone()).await.unwrap();
 
-        assert_eq!(get_bounds(&journal).await.end, 15);
+        assert_eq!(journal.bounds().end, 15);
 
         // Verify reads work after persistence
         for i in 0..15u64 {
-            assert_eq!(read_item(&journal, i).await.unwrap(), i * 10);
+            assert_eq!(journal.read(i).await.unwrap(), i * 10);
         }
 
         // Replay and verify all items
         {
-            let reader = journal.reader().await;
-            let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
+            let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut items = Vec::new();
@@ -819,7 +802,7 @@ where
         let pruned = journal.prune(10).await.unwrap();
         assert!(pruned);
 
-        assert_eq!(get_bounds(&journal).await.end, 25);
+        assert_eq!(journal.bounds().end, 25);
 
         journal.sync().await.unwrap();
     }
@@ -829,25 +812,21 @@ where
         let mut journal = factory(test_name.clone()).await.unwrap();
 
         // size should still be 25
-        assert_eq!(get_bounds(&journal).await.end, 25);
+        assert_eq!(journal.bounds().end, 25);
 
         // Verify pruned positions cannot be read
         for i in 0..10u64 {
-            assert!(matches!(
-                read_item(&journal, i).await,
-                Err(Error::ItemPruned(_))
-            ));
+            assert!(matches!(journal.read(i).await, Err(Error::ItemPruned(_))));
         }
 
         // Verify non-pruned positions can be read
         for i in 10..25u64 {
-            assert_eq!(read_item(&journal, i).await.unwrap(), i * 100);
+            assert_eq!(journal.read(i).await.unwrap(), i * 100);
         }
 
         // Replay from position 10 (first non-pruned position)
         {
-            let reader = journal.reader().await;
-            let stream = reader.replay(NZUsize!(1024), 10).await.unwrap();
+            let stream = journal.replay(NZUsize!(1024), 10).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut items = Vec::new();
@@ -868,7 +847,7 @@ where
         assert_eq!(pos, 25);
 
         // Verify the newly appended item can be read
-        assert_eq!(read_item(&journal, 25).await.unwrap(), 999);
+        assert_eq!(journal.read(25).await.unwrap(), 999);
 
         journal.destroy().await.unwrap();
     }
@@ -884,12 +863,12 @@ where
 
     for i in 0..1000u64 {
         journal.append(&(i * 100)).await.unwrap();
-        assert_eq!(read_item(&journal, i).await.unwrap(), i * 100);
+        assert_eq!(journal.read(i).await.unwrap(), i * 100);
     }
 
     // Verify we can still read all items
     for i in 0..1000u64 {
-        assert_eq!(read_item(&journal, i).await.unwrap(), i * 100);
+        assert_eq!(journal.read(i).await.unwrap(), i * 100);
     }
 
     journal.destroy().await.unwrap();
@@ -907,10 +886,8 @@ where
         journal.append(&(i * 100)).await.unwrap();
     }
 
-    let reader = journal.reader().await;
-    let items = reader.read_many(&[1, 4, 12]).await.unwrap();
+    let items = journal.read_many(&[1, 4, 12]).await.unwrap();
     assert_eq!(items, vec![100, 400, 1200]);
-    drop(reader);
 
     journal.destroy().await.unwrap();
 }
@@ -926,7 +903,7 @@ where
     journal.append(&42).await.unwrap();
 
     // Try to read beyond size
-    let result = read_item(&journal, 10).await;
+    let result = journal.read(10).await;
     assert!(matches!(result, Err(Error::ItemOutOfRange(_))));
 
     journal.destroy().await.unwrap();
@@ -946,8 +923,8 @@ where
 
     journal.prune(10).await.unwrap();
 
-    let bounds = get_bounds(&journal).await;
-    let result = read_item(&journal, bounds.start - 1).await;
+    let bounds = journal.bounds();
+    let result = journal.read(bounds.start - 1).await;
     assert!(matches!(result, Err(Error::ItemPruned(_))));
 
     journal.destroy().await.unwrap();
@@ -969,17 +946,17 @@ where
     // Rewind to 12 items
     journal.rewind(12).await.unwrap();
 
-    assert_eq!(get_bounds(&journal).await.end, 12);
+    assert_eq!(journal.bounds().end, 12);
 
     // Verify first 12 items are still readable
     for i in 0..12u64 {
-        assert_eq!(read_item(&journal, i).await.unwrap(), i * 100);
+        assert_eq!(journal.read(i).await.unwrap(), i * 100);
     }
 
     // Verify items 12-19 are gone
     for i in 12..20u64 {
         assert!(matches!(
-            read_item(&journal, i).await,
+            journal.read(i).await,
             Err(Error::ItemOutOfRange(_))
         ));
     }
@@ -987,7 +964,7 @@ where
     // Next append should get position 12
     let pos = journal.append(&999).await.unwrap();
     assert_eq!(pos, 12);
-    assert_eq!(read_item(&journal, 12).await.unwrap(), 999);
+    assert_eq!(journal.read(12).await.unwrap(), 999);
 
     journal.destroy().await.unwrap();
 }
@@ -1006,7 +983,7 @@ where
 
     journal.rewind(0).await.unwrap();
 
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.end, 0);
     assert!(bounds.is_empty());
 
@@ -1031,7 +1008,7 @@ where
 
     // Rewind to current size should be no-op
     journal.rewind(10).await.unwrap();
-    assert_eq!(get_bounds(&journal).await.end, 10);
+    assert_eq!(journal.bounds().end, 10);
 
     journal.destroy().await.unwrap();
 }
@@ -1100,8 +1077,8 @@ where
 
     assert_eq!(pos1, 8);
     assert_eq!(pos2, 9);
-    assert_eq!(read_item(&journal, 8).await.unwrap(), 888);
-    assert_eq!(read_item(&journal, 9).await.unwrap(), 999);
+    assert_eq!(journal.read(8).await.unwrap(), 888);
+    assert_eq!(journal.read(9).await.unwrap(), 999);
 
     journal.destroy().await.unwrap();
 }
@@ -1123,15 +1100,15 @@ where
     journal.rewind(0).await.unwrap();
 
     // Verify journal is empty
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.end, 0);
     assert!(bounds.is_empty());
 
     // Append should work
     let pos = journal.append(&42).await.unwrap();
     assert_eq!(pos, 0);
-    assert_eq!(get_bounds(&journal).await.end, 1);
-    assert_eq!(read_item(&journal, 0).await.unwrap(), 42);
+    assert_eq!(journal.bounds().end, 1);
+    assert_eq!(journal.read(0).await.unwrap(), 42);
 
     journal.destroy().await.unwrap();
 }
@@ -1152,18 +1129,18 @@ where
 
     // Prune first section (items 0-9)
     journal.prune(10).await.unwrap();
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.start, 10);
 
     // Rewind to position 20 (still in retained range)
     journal.rewind(20).await.unwrap();
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.end, 20);
     assert_eq!(bounds.start, 10);
 
     // Verify items in range [bounds.start, 20) are still readable
     for i in bounds.start..20 {
-        assert_eq!(read_item(&journal, i).await.unwrap(), i * 100);
+        assert_eq!(journal.read(i).await.unwrap(), i * 100);
     }
 
     // Attempt to rewind to a pruned position should fail
@@ -1171,15 +1148,15 @@ where
     assert!(matches!(result, Err(Error::ItemPruned(5))));
 
     // Verify journal state is unchanged after failed rewind
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.end, 20);
     assert_eq!(bounds.start, 10);
 
     // Append should continue from position 20
     let pos = journal.append(&999).await.unwrap();
     assert_eq!(pos, 20);
-    assert_eq!(read_item(&journal, 20).await.unwrap(), 999);
-    assert_eq!(get_bounds(&journal).await.start, 10);
+    assert_eq!(journal.read(20).await.unwrap(), 999);
+    assert_eq!(journal.bounds().start, 10);
 
     journal.destroy().await.unwrap();
 }
@@ -1200,42 +1177,39 @@ where
     }
 
     // Verify we're at a blob boundary.
-    assert_eq!(get_bounds(&journal).await.end, 10);
+    assert_eq!(journal.bounds().end, 10);
 
     // Append one more item to cross the boundary
     let pos = journal.append(&999).await.unwrap();
     assert_eq!(pos, 10);
-    assert_eq!(get_bounds(&journal).await.end, 11);
+    assert_eq!(journal.bounds().end, 11);
 
     // Prune exactly at the blob boundary.
     journal.prune(10).await.unwrap();
-    assert_eq!(get_bounds(&journal).await.start, 10);
+    assert_eq!(journal.bounds().start, 10);
 
     // Verify only the item after the boundary is readable
-    assert!(matches!(
-        read_item(&journal, 9).await,
-        Err(Error::ItemPruned(_))
-    ));
-    assert_eq!(read_item(&journal, 10).await.unwrap(), 999);
+    assert!(matches!(journal.read(9).await, Err(Error::ItemPruned(_))));
+    assert_eq!(journal.read(10).await.unwrap(), 999);
 
     // Append another item to move past the boundary
     let pos = journal.append(&888).await.unwrap();
     assert_eq!(pos, 11);
-    assert_eq!(get_bounds(&journal).await.end, 12);
+    assert_eq!(journal.bounds().end, 12);
 
     // Rewind to exactly the blob boundary (position 10).
     // This leaves bounds.end=10, bounds.start=10, making the journal fully pruned
     journal.rewind(10).await.unwrap();
-    let bounds = get_bounds(&journal).await;
+    let bounds = journal.bounds();
     assert_eq!(bounds.end, 10);
     assert!(bounds.is_empty());
 
     // Append after rewinding to boundary should continue from position 10
     let pos = journal.append(&777).await.unwrap();
     assert_eq!(pos, 10);
-    assert_eq!(get_bounds(&journal).await.end, 11);
-    assert_eq!(read_item(&journal, 10).await.unwrap(), 777);
-    assert_eq!(get_bounds(&journal).await.start, 10);
+    assert_eq!(journal.bounds().end, 11);
+    assert_eq!(journal.read(10).await.unwrap(), 777);
+    assert_eq!(journal.bounds().start, 10);
 
     journal.destroy().await.unwrap();
 }
@@ -1260,8 +1234,8 @@ where
         }
 
         journal.prune(10).await.unwrap();
-        assert_eq!(get_bounds(&journal).await.end, 20);
-        assert!(!get_bounds(&journal).await.is_empty());
+        assert_eq!(journal.bounds().end, 20);
+        assert!(!journal.bounds().is_empty());
 
         // Explicitly destroy the journal
         journal.destroy().await.unwrap();
@@ -1272,14 +1246,13 @@ where
         let journal = factory(test_name.clone()).await.unwrap();
 
         // Journal should be completely empty, not contain previous data
-        let bounds = get_bounds(&journal).await;
+        let bounds = journal.bounds();
         assert_eq!(bounds.end, 0);
         assert!(bounds.is_empty());
 
         // Replay should yield no items
         {
-            let reader = journal.reader().await;
-            let stream = reader.replay(NZUsize!(1024), 0).await.unwrap();
+            let stream = journal.replay(NZUsize!(1024), 0).await.unwrap();
             futures::pin_mut!(stream);
 
             let mut items = Vec::new();
@@ -1310,7 +1283,7 @@ where
         journal.append_many(Many::Flat(&[])).await,
         Err(Error::EmptyAppend)
     ));
-    assert_eq!(get_bounds(&journal).await.end, 2);
+    assert_eq!(journal.bounds().end, 2);
 
     journal.destroy().await.unwrap();
 }
@@ -1328,11 +1301,11 @@ where
         .await
         .unwrap();
     assert_eq!(pos, 2);
-    assert_eq!(get_bounds(&journal).await.end, 3);
+    assert_eq!(journal.bounds().end, 3);
 
-    assert_eq!(read_item(&journal, 0).await.unwrap(), 100);
-    assert_eq!(read_item(&journal, 1).await.unwrap(), 200);
-    assert_eq!(read_item(&journal, 2).await.unwrap(), 300);
+    assert_eq!(journal.read(0).await.unwrap(), 100);
+    assert_eq!(journal.read(1).await.unwrap(), 200);
+    assert_eq!(journal.read(2).await.unwrap(), 300);
 
     journal.destroy().await.unwrap();
 }
@@ -1349,10 +1322,10 @@ where
     let items: Vec<u64> = (0..25).map(|i| i * 10).collect();
     let pos = journal.append_many(Many::Flat(&items)).await.unwrap();
     assert_eq!(pos, 24);
-    assert_eq!(get_bounds(&journal).await.end, 25);
+    assert_eq!(journal.bounds().end, 25);
 
     for i in 0..25u64 {
-        assert_eq!(read_item(&journal, i).await.unwrap(), i * 10);
+        assert_eq!(journal.read(i).await.unwrap(), i * 10);
     }
 
     journal.destroy().await.unwrap();
@@ -1373,10 +1346,10 @@ where
     let pos = journal.append(&40).await.unwrap();
     assert_eq!(pos, 3);
 
-    assert_eq!(read_item(&journal, 0).await.unwrap(), 10);
-    assert_eq!(read_item(&journal, 1).await.unwrap(), 20);
-    assert_eq!(read_item(&journal, 2).await.unwrap(), 30);
-    assert_eq!(read_item(&journal, 3).await.unwrap(), 40);
+    assert_eq!(journal.read(0).await.unwrap(), 10);
+    assert_eq!(journal.read(1).await.unwrap(), 20);
+    assert_eq!(journal.read(2).await.unwrap(), 30);
+    assert_eq!(journal.read(3).await.unwrap(), 40);
 
     journal.destroy().await.unwrap();
 }
@@ -1391,7 +1364,7 @@ where
 
     let pos = journal.append_many(Many::Flat(&[42])).await.unwrap();
     assert_eq!(pos, 0);
-    assert_eq!(read_item(&journal, 0).await.unwrap(), 42);
+    assert_eq!(journal.read(0).await.unwrap(), 42);
 
     journal.destroy().await.unwrap();
 }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -4,7 +4,7 @@
 //! the preferred recovery point for replaying data to rebuild offset entries.
 
 use super::{
-    blobs::{Blob, Blobs, Partition, Snapshot, Writable},
+    blobs::{Blob, Blobs, Partition, Writable},
     fixed,
     metrics::VariableMetrics as Metrics,
     replay::{self, Source as _},
@@ -482,16 +482,15 @@ impl<E: Context, V: CodecShared> Reader<'_, E, V> {
         .ok()
     }
 
-    /// Build the replay stream over `snapshot`, starting at `start_pos`. The stream owns its
-    /// handles, so it borrows neither `snapshot` nor `self` (hence `use<E, V>`).
+    /// Build the replay stream over [`Self::data`], starting at `start_pos`. The stream owns its
+    /// handles, so it borrows neither `self.data` nor `self` (hence `use<E, V>`).
     async fn replay_from(
         &self,
-        snapshot: &Snapshot<E::Blob>,
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send + use<E, V>, Error> {
         let items_per_blob = self.items_per_blob.get();
-        let bounds = snapshot.bounds.clone();
+        let bounds = self.data.bounds();
         if start_pos > bounds.end {
             return Err(Error::ItemOutOfRange(start_pos));
         }
@@ -500,7 +499,7 @@ impl<E: Context, V: CodecShared> Reader<'_, E, V> {
         }
 
         let start_blob = position_to_blob(start_pos, items_per_blob);
-        let tail_blob = snapshot.tail_blob_index();
+        let tail_blob = self.data.tail_blob_index();
 
         // The byte offset of the first replayed item; later blobs start at byte 0 (a data blob's
         // first item is at byte 0 even when the pruning boundary is mid-blob).
@@ -511,15 +510,16 @@ impl<E: Context, V: CodecShared> Reader<'_, E, V> {
         };
 
         // Seed each sealed blob's `Replay` upfront so the returned stream borrows nothing from
-        // `snapshot`. The tail is streamed through the snapshot's read handle instead: a `Replay`
-        // reads physical pages from the blob and would miss the tail's buffered bytes.
+        // `self.data`. The tail is streamed through its read handle instead: a `Replay` reads
+        // physical pages from the blob and would miss the tail's buffered bytes.
         //
         // Each entry is (first position to emit, one past the last position, replay).
         let mut per_blob_replays: Vec<(u64, u64, Replay<E::Blob>)> = Vec::new();
         let end_blob = tail_blob.min(position_to_blob(bounds.end, items_per_blob));
+        let sealed_blobs = self.data.sealed();
         for blob in start_blob..end_blob {
-            let idx = (blob - snapshot.oldest_blob_index) as usize;
-            let sealed = &snapshot.sealed[idx];
+            let idx = (blob - self.data.oldest_blob_index()) as usize;
+            let sealed = &sealed_blobs[idx];
             let mut replay = sealed.replay(buffer).map_err(Error::Runtime)?;
             let first_pos = if blob == start_blob {
                 if start_byte > sealed.size() {
@@ -560,7 +560,7 @@ impl<E: Context, V: CodecShared> Reader<'_, E, V> {
             blob_first_position(tail_blob, items_per_blob)?.max(bounds.start)
         };
         let tail_batches = TailReplayState::<E::Blob, V> {
-            reader: snapshot.tail.clone(),
+            reader: self.data.tail_reader(),
             positions: tail_first..bounds.end,
             byte_offset: if start_blob == tail_blob {
                 start_byte
@@ -714,15 +714,7 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
-        // `replay` returns a stream that outlives this call, so it reads from an owned snapshot
-        // whose Arc-shared handles the stream owns. A snapshot already has one.
-        match &self.data {
-            Blobs::Snapshot(snapshot) => self.replay_from(snapshot, buffer, start_pos).await,
-            Blobs::Writable { writable, bounds } => {
-                self.replay_from(&writable.to_snapshot(bounds.clone()), buffer, start_pos)
-                    .await
-            }
-        }
+        self.replay_from(buffer, start_pos).await
     }
 }
 
@@ -1183,7 +1175,10 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// into its range is refused ([Error::BlobInUse]) while it is alive.
     pub fn snapshot(&self) -> Reader<'static, E, V> {
         Reader {
-            data: Blobs::Snapshot(self.blobs.to_snapshot(self.bounds.clone())),
+            data: Blobs::Snapshot {
+                snapshot: self.blobs.to_snapshot(),
+                bounds: self.bounds.clone(),
+            },
             offsets: self.offsets.snapshot(),
             items_per_blob: self.items_per_blob,
             codec_config: self.codec_config.clone(),
@@ -1831,10 +1826,10 @@ impl<B: RBlob, V: CodecShared> replay::Source for SealedReplayState<B, V> {
     }
 }
 
-/// Replays the writable tail through the snapshot's read handle.
+/// Replays the writable tail through a cloned tail read handle.
 struct TailReplayState<B: RBlob, V: CodecShared> {
     reader: paged::Reader<B>,
-    /// Positions still to emit; `positions.end` is the snapshot's size.
+    /// Positions still to emit; `positions.end` is the view's end bound.
     positions: Range<u64>,
     /// Byte offset of the next frame.
     byte_offset: u64,
@@ -1896,7 +1891,7 @@ impl<B: RBlob, V: CodecShared> replay::Source for TailReplayState<B, V> {
         }
 
         // No whole frame fit in the chunk: either the item is larger than the chunk, or the tail
-        // ended before the snapshot's bounds (corruption). A decodable header for a frame that
+        // ended before the view's bounds (corruption). A decodable header for a frame that
         // extends past the chunk identifies the former.
         let mut cursor = Cursor::new(chunk);
         let header = decode_length_prefix(&mut cursor)
@@ -1957,13 +1952,7 @@ impl<E: Context, V: CodecShared> Contiguous for Journal<E, V> {
         buffer: NonZeroUsize,
         start_pos: u64,
     ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
-        self.reader()
-            .replay_from(
-                &self.blobs.to_snapshot(self.bounds.clone()),
-                buffer,
-                start_pos,
-            )
-            .await
+        self.reader().replay_from(buffer, start_pos).await
     }
 }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -4,11 +4,11 @@
 //! the preferred recovery point for replaying data to rebuild offset entries.
 
 use super::{
-    blobs::{Blobs, Handle, Partition, Snapshot},
+    blobs::{Blob, Blobs, Partition, Snapshot, Writable},
     fixed,
     metrics::VariableMetrics as Metrics,
     replay::{self, Source as _},
-    Contiguous, Many, Mutable, Reader as _,
+    Contiguous, Many, Mutable,
 };
 use crate::{
     journal::{
@@ -21,7 +21,7 @@ use commonware_codec::{varint::MAX_U32_VARINT_SIZE, Codec, CodecShared};
 use commonware_macros::boxed;
 use commonware_runtime::{
     buffer::paged::{self, CacheRef, Replay, Writer},
-    Blob, Buf, IoBuf, IoBufMut,
+    Blob as RBlob, Buf, IoBuf, IoBufMut,
 };
 use commonware_utils::NZUsize;
 use futures::{stream, Stream, StreamExt as _};
@@ -65,7 +65,7 @@ enum Frame {
 }
 
 /// Scans varint frames over a blob's bytes during recovery.
-struct FrameScanner<'a, B: Blob, V: Codec> {
+struct FrameScanner<'a, B: RBlob, V: Codec> {
     replay: Replay<B>,
     /// Byte offset of the next frame.
     offset: u64,
@@ -73,7 +73,7 @@ struct FrameScanner<'a, B: Blob, V: Codec> {
     compressed: bool,
 }
 
-impl<'a, B: Blob, V: CodecShared> FrameScanner<'a, B, V> {
+impl<'a, B: RBlob, V: CodecShared> FrameScanner<'a, B, V> {
     const fn new(replay: Replay<B>, codec_config: &'a V::Cfg, compressed: bool) -> Self {
         Self {
             replay,
@@ -257,7 +257,7 @@ impl<C> Config<C> {
 /// blobs so the recovered journal remains a contiguous prefix.
 pub struct Journal<E: Context, V: Codec> {
     /// The data blobs: sealed history plus the writable tail.
-    blobs: Blobs<E>,
+    blobs: Writable<E>,
 
     /// Index mapping positions to byte offsets within their data blob. Its checkpoint is also
     /// this journal's durable recovery record.
@@ -287,13 +287,13 @@ pub struct Journal<E: Context, V: Codec> {
     metrics: Arc<Metrics<E>>,
 }
 
-/// A reader over a snapshot of the variable journal.
-pub struct Reader<E: Context, V: Codec> {
-    /// Owned snapshot of the journal's data blobs at snapshot time.
-    data: Snapshot<E::Blob>,
+/// A reader over a variable journal.
+pub struct Reader<'a, E: Context, V: Codec> {
+    /// Resolves a data-blob index to a read handle.
+    data: Blobs<'a, E>,
 
     /// Maps positions to byte offsets within the data blobs.
-    offsets: fixed::Reader<E, u64>,
+    offsets: fixed::Reader<'a, E, u64>,
 
     /// The number of items in each blob.
     items_per_blob: NonZeroU64,
@@ -308,9 +308,9 @@ pub struct Reader<E: Context, V: Codec> {
     metrics: Arc<Metrics<E>>,
 }
 
-impl<E: Context, V: CodecShared> Reader<E, V> {
+impl<E: Context, V: CodecShared> Reader<'_, E, V> {
     /// Read the varint-framed item at byte `offset` via `handle`.
-    async fn read_at_offset(&self, handle: &Handle<'_, E::Blob>, offset: u64) -> Result<V, Error> {
+    async fn read_at_offset(&self, handle: &Blob<'_, E::Blob>, offset: u64) -> Result<V, Error> {
         // Read the varint header (max 5 bytes for u32).
         let (buf, available) = handle.read_up_to(offset, MAX_U32_VARINT_SIZE).await?;
         let mut cursor = Cursor::new(buf.slice(..available));
@@ -351,7 +351,7 @@ impl<E: Context, V: CodecShared> Reader<E, V> {
     /// strictly increasing.
     async fn read_consecutive(
         &self,
-        handle: &Handle<'_, E::Blob>,
+        handle: &Blob<'_, E::Blob>,
         blob: u64,
         offsets: &[u64],
     ) -> Result<Vec<V>, Error> {
@@ -401,8 +401,8 @@ impl<E: Context, V: CodecShared> Reader<E, V> {
                 });
             }
 
-            // Validation above guarantees strictly increasing offsets, so `data_end` never exceeds
-            // `range_len` and these additions stay in bounds.
+            // Validation above guarantees strictly increasing offsets, so `data_end` never
+            // exceeds `range_len` and these additions stay in bounds.
             let data_start = local_offset
                 .checked_add(varint_len)
                 .ok_or(Error::OffsetOverflow)?;
@@ -428,7 +428,7 @@ impl<E: Context, V: CodecShared> Reader<E, V> {
         let offset = self.offsets.try_read_sync(position)?;
         let handle = self
             .data
-            .handle(position_to_blob(position, self.items_per_blob.get()))?;
+            .get(position_to_blob(position, self.items_per_blob.get()))?;
         let remaining = handle.try_size()?.checked_sub(offset)?;
         let header_len = usize::try_from(remaining.min(MAX_U32_VARINT_SIZE as u64)).ok()?;
         if header_len == 0 {
@@ -481,146 +481,26 @@ impl<E: Context, V: CodecShared> Reader<E, V> {
         )
         .ok()
     }
-}
 
-impl<E: Context, V: CodecShared> super::Reader for Reader<E, V> {
-    type Item = V;
-
-    fn bounds(&self) -> Range<u64> {
-        self.data.bounds.clone()
-    }
-
-    async fn read(&self, position: u64) -> Result<V, Error> {
-        self.metrics.read_calls.inc();
-
-        // Serve from the page cache synchronously when possible, collapsing the offsets and data
-        // lookups into buffer copies and avoiding the async storage path on a hit.
-        let mut buf = Vec::new();
-        if let Some(item) = self.try_read_sync_into(position, &mut buf) {
-            self.metrics.items_read.inc();
-            return Ok(item);
-        }
-
-        let _timer = self.metrics.read_timer();
-        self.data.validate_readable(position)?;
-        let offset = self.offsets.read(position).await?;
-        let handle = self
-            .data
-            .require_handle(position_to_blob(position, self.items_per_blob.get()))?;
-        let item = self.read_at_offset(&handle, offset).await?;
-        self.metrics.items_read.inc();
-        Ok(item)
-    }
-
-    async fn read_many(&self, positions: &[u64]) -> Result<Vec<V>, Error> {
-        if positions.is_empty() {
-            return Ok(Vec::new());
-        }
-        let _timer = self.metrics.read_many_timer();
-        self.metrics.read_many_calls.inc();
-        if positions[0] < self.data.bounds.start {
-            return Err(Error::ItemPruned(positions[0]));
-        }
-        let last_position = *positions.last().expect("positions is not empty");
-        if last_position >= self.data.bounds.end {
-            return Err(Error::ItemOutOfRange(last_position));
-        }
-
-        // Read the items from cache if possible.
-        let mut result: Vec<Option<V>> = Vec::with_capacity(positions.len());
-        let mut miss_indices = Vec::with_capacity(positions.len());
-        let mut miss_positions = Vec::with_capacity(positions.len());
-        let mut buf = Vec::new();
-        let mut prev: Option<u64> = None;
-        for (i, &position) in positions.iter().enumerate() {
-            if prev.is_some_and(|p| position <= p) {
-                return Err(Error::PositionsNotIncreasing);
-            }
-            prev = Some(position);
-            if let Some(item) = self.try_read_sync_into(position, &mut buf) {
-                result.push(Some(item));
-            } else {
-                result.push(None);
-                miss_indices.push(i);
-                miss_positions.push(position);
-            }
-        }
-
-        if miss_positions.is_empty() {
-            self.metrics.items_read.inc_by(positions.len() as u64);
-            return Ok(result.into_iter().map(|r| r.unwrap()).collect());
-        }
-
-        // Read the offsets of all items that were not found in the cache.
-        let miss_offsets = self
-            .offsets
-            .read_many(&miss_positions)
-            .await
-            .map_err(|e| match e {
-                Error::ItemOutOfRange(e) | Error::ItemPruned(e) => {
-                    Error::Corruption(format!("blob/item should be found, but got: {e}"))
-                }
-                other => other,
-            })?;
-
-        // Group runs of consecutive positions that fall into the same blob and perform a
-        // consecutive read for each run.
-        let items_per_blob = self.items_per_blob.get();
-        let mut group_start = 0;
-        while group_start < miss_positions.len() {
-            let blob = position_to_blob(miss_positions[group_start], items_per_blob);
-            let mut group_end = group_start + 1;
-            while group_end < miss_positions.len()
-                && position_to_blob(miss_positions[group_end], items_per_blob) == blob
-            {
-                group_end += 1;
-            }
-
-            let handle = self.data.require_handle(blob)?;
-            let mut run_start = group_start;
-            while run_start < group_end {
-                let mut run_end = run_start + 1;
-                while run_end < group_end
-                    && miss_positions[run_end - 1].checked_add(1) == Some(miss_positions[run_end])
-                {
-                    run_end += 1;
-                }
-
-                let items = self
-                    .read_consecutive(&handle, blob, &miss_offsets[run_start..run_end])
-                    .await?;
-
-                for (item, &miss_idx) in items.into_iter().zip(&miss_indices[run_start..run_end]) {
-                    result[miss_idx] = Some(item);
-                }
-                run_start = run_end;
-            }
-            group_start = group_end;
-        }
-
-        self.metrics.items_read.inc_by(positions.len() as u64);
-        Ok(result.into_iter().map(|r| r.unwrap()).collect())
-    }
-
-    fn try_read_sync(&self, position: u64) -> Option<V> {
-        let mut buf = Vec::new();
-        let item = self.try_read_sync_into(position, &mut buf)?;
-        self.metrics.try_read_sync_hits.inc();
-        self.metrics.items_read.inc();
-        Some(item)
-    }
-
-    async fn replay(
+    /// Build the replay stream over `snapshot`, starting at `start_pos`. The stream owns its
+    /// handles, so it borrows neither `snapshot` nor `self` (hence `use<E, V>`).
+    async fn replay_from(
         &self,
+        snapshot: &Snapshot<E::Blob>,
         buffer: NonZeroUsize,
         start_pos: u64,
-    ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
+    ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send + use<E, V>, Error> {
         let items_per_blob = self.items_per_blob.get();
-        self.data.validate_cursor(start_pos)?;
+        let bounds = snapshot.bounds.clone();
+        if start_pos > bounds.end {
+            return Err(Error::ItemOutOfRange(start_pos));
+        }
+        if start_pos < bounds.start {
+            return Err(Error::ItemPruned(start_pos));
+        }
 
-        let bounds = self.data.bounds.clone();
         let start_blob = position_to_blob(start_pos, items_per_blob);
-        let tail_blob = self.data.tail_blob_index();
+        let tail_blob = snapshot.tail_blob_index();
 
         // The byte offset of the first replayed item; later blobs start at byte 0 (a data blob's
         // first item is at byte 0 even when the pruning boundary is mid-blob).
@@ -630,16 +510,16 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<E, V> {
             0
         };
 
-        // Seed each sealed blob's `Replay` upfront so the returned stream borrows nothing
-        // from `self`. The tail is streamed through the snapshot's read handle instead: a
-        // `Replay` reads physical pages from the blob and would miss the tail's buffered bytes.
+        // Seed each sealed blob's `Replay` upfront so the returned stream borrows nothing from
+        // `snapshot`. The tail is streamed through the snapshot's read handle instead: a `Replay`
+        // reads physical pages from the blob and would miss the tail's buffered bytes.
         //
         // Each entry is (first position to emit, one past the last position, replay).
         let mut per_blob_replays: Vec<(u64, u64, Replay<E::Blob>)> = Vec::new();
         let end_blob = tail_blob.min(position_to_blob(bounds.end, items_per_blob));
         for blob in start_blob..end_blob {
-            let idx = (blob - self.data.oldest_blob_index) as usize;
-            let sealed = &self.data.sealed[idx];
+            let idx = (blob - snapshot.oldest_blob_index) as usize;
+            let sealed = &snapshot.sealed[idx];
             let mut replay = sealed.replay(buffer).map_err(Error::Runtime)?;
             let first_pos = if blob == start_blob {
                 if start_byte > sealed.size() {
@@ -680,7 +560,7 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<E, V> {
             blob_first_position(tail_blob, items_per_blob)?.max(bounds.start)
         };
         let tail_batches = TailReplayState::<E::Blob, V> {
-            reader: self.data.tail_reader.clone(),
+            reader: snapshot.tail.clone(),
             positions: tail_first..bounds.end,
             byte_offset: if start_blob == tail_blob {
                 start_byte
@@ -694,6 +574,155 @@ impl<E: Context, V: CodecShared> super::Reader for Reader<E, V> {
         .into_batches();
 
         Ok(sealed_batches.chain(tail_batches).flat_map(stream::iter))
+    }
+}
+
+impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
+    type Item = V;
+
+    fn bounds(&self) -> Range<u64> {
+        self.data.bounds()
+    }
+
+    async fn read(&self, position: u64) -> Result<V, Error> {
+        self.metrics.read_calls.inc();
+
+        // Serve from the page cache synchronously when possible, collapsing the offsets and data
+        // lookups into buffer copies and avoiding the async storage path on a hit.
+        let mut buf = Vec::new();
+        if let Some(item) = self.try_read_sync_into(position, &mut buf) {
+            self.metrics.items_read.inc();
+            return Ok(item);
+        }
+
+        let _timer = self.metrics.read_timer();
+        self.data.validate_readable(position)?;
+        let offset = self.offsets.read(position).await?;
+        let handle = self
+            .data
+            .get(position_to_blob(position, self.items_per_blob.get()))
+            .expect("position in bounds maps to a retained blob");
+        let item = self.read_at_offset(&handle, offset).await?;
+        self.metrics.items_read.inc();
+        Ok(item)
+    }
+
+    async fn read_many(&self, positions: &[u64]) -> Result<Vec<V>, Error> {
+        if positions.is_empty() {
+            return Ok(Vec::new());
+        }
+        let _timer = self.metrics.read_many_timer();
+        self.metrics.read_many_calls.inc();
+        let bounds = self.data.bounds();
+        if positions[0] < bounds.start {
+            return Err(Error::ItemPruned(positions[0]));
+        }
+        let last_position = *positions.last().expect("positions is not empty");
+        if last_position >= bounds.end {
+            return Err(Error::ItemOutOfRange(last_position));
+        }
+
+        // Read the items from cache if possible.
+        let mut result: Vec<Option<V>> = Vec::with_capacity(positions.len());
+        let mut miss_indices = Vec::with_capacity(positions.len());
+        let mut miss_positions = Vec::with_capacity(positions.len());
+        let mut buf = Vec::new();
+        let mut prev: Option<u64> = None;
+        for (i, &position) in positions.iter().enumerate() {
+            if prev.is_some_and(|p| position <= p) {
+                return Err(Error::PositionsNotIncreasing);
+            }
+            prev = Some(position);
+            if let Some(item) = self.try_read_sync_into(position, &mut buf) {
+                result.push(Some(item));
+            } else {
+                result.push(None);
+                miss_indices.push(i);
+                miss_positions.push(position);
+            }
+        }
+
+        if miss_positions.is_empty() {
+            self.metrics.items_read.inc_by(positions.len() as u64);
+            return Ok(result.into_iter().map(|r| r.unwrap()).collect());
+        }
+
+        // Read the offsets of all items that were not found in the cache.
+        let miss_offsets = self
+            .offsets
+            .read_many(&miss_positions)
+            .await
+            .map_err(|e| match e {
+                Error::ItemOutOfRange(e) | Error::ItemPruned(e) => {
+                    Error::Corruption(format!("blob/item should be found, but got: {e}"))
+                }
+                other => other,
+            })?;
+
+        // Group runs of consecutive positions that fall into the same blob and perform a consecutive
+        // read for each run.
+        let items_per_blob = self.items_per_blob.get();
+        let mut group_start = 0;
+        while group_start < miss_positions.len() {
+            let blob = position_to_blob(miss_positions[group_start], items_per_blob);
+            let mut group_end = group_start + 1;
+            while group_end < miss_positions.len()
+                && position_to_blob(miss_positions[group_end], items_per_blob) == blob
+            {
+                group_end += 1;
+            }
+
+            let handle = self
+                .data
+                .get(blob)
+                .expect("positions in bounds map to a retained blob");
+            let mut run_start = group_start;
+            while run_start < group_end {
+                let mut run_end = run_start + 1;
+                while run_end < group_end
+                    && miss_positions[run_end - 1].checked_add(1) == Some(miss_positions[run_end])
+                {
+                    run_end += 1;
+                }
+
+                let items = self
+                    .read_consecutive(&handle, blob, &miss_offsets[run_start..run_end])
+                    .await?;
+
+                for (item, &miss_idx) in items.into_iter().zip(&miss_indices[run_start..run_end]) {
+                    result[miss_idx] = Some(item);
+                }
+                run_start = run_end;
+            }
+            group_start = group_end;
+        }
+
+        self.metrics.items_read.inc_by(positions.len() as u64);
+        Ok(result.into_iter().map(|r| r.unwrap()).collect())
+    }
+
+    fn try_read_sync(&self, position: u64) -> Option<V> {
+        let mut buf = Vec::new();
+        let item = self.try_read_sync_into(position, &mut buf)?;
+        self.metrics.try_read_sync_hits.inc();
+        self.metrics.items_read.inc();
+        Some(item)
+    }
+
+    async fn replay(
+        &self,
+        buffer: NonZeroUsize,
+        start_pos: u64,
+    ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
+        // `replay` returns a stream that outlives this call, so it reads from an owned snapshot
+        // whose Arc-shared handles the stream owns. A snapshot already has one.
+        match &self.data {
+            Blobs::Snapshot(snapshot) => self.replay_from(snapshot, buffer, start_pos).await,
+            Blobs::Writable { writable, bounds } => {
+                self.replay_from(&writable.to_snapshot(bounds.clone()), buffer, start_pos)
+                    .await
+            }
+        }
     }
 }
 
@@ -754,7 +783,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
         // Seal every blob below the tail and assemble the blobs.
         let tail_blob = position_to_blob(bounds.end, items_per_blob);
-        let blobs = Blobs::recover(partition, pending, tail_blob).await?;
+        let blobs = Writable::recover(partition, pending, tail_blob).await?;
 
         let metrics = Metrics::new(context);
         metrics.update(bounds.end, bounds.start, items_per_blob);
@@ -807,7 +836,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             cfg.page_cache,
             cfg.write_buffer,
         );
-        let blobs = Blobs::recover(
+        let blobs = Writable::recover(
             partition,
             BTreeMap::new(),
             position_to_blob(size, items_per_blob),
@@ -933,8 +962,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// Returns [Error::InvalidRewind] if `size` is larger than current size.
     /// Returns [Error::ItemPruned] if `size` is smaller than the pruning boundary.
-    /// Returns [Error::BlobInUse] if any [Reader] snapshot is outstanding: rewinding truncates a
-    /// blob in place, which could tear a live reader's bytes. Retry after readers are dropped.
+    /// Returns [Error::BlobInUse] if any [`snapshot`](Self::snapshot) is alive:
+    /// rewinding truncates a blob in place, which could tear its bytes. Retry after they drop.
     ///
     /// # Warning
     ///
@@ -954,12 +983,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // Refuse before any side effect: a refused rewind is retryable. The truncation paths
         // below re-check the gate.
         let discard_blob = position_to_blob(size, self.items_per_blob.get());
-        if self.blobs.readers_outstanding() {
+        if self.blobs.snapshots_alive() {
             return Err(Error::BlobInUse(discard_blob));
         }
 
         // The byte offset of the first discarded item is the data truncation point.
-        let discard_offset = self.offsets.reader().read(size).await?;
+        let discard_offset = self.offsets.read(size).await?;
 
         // Rewind offsets before data. Rewinding the offsets journal persists a lowered recovery
         // watermark before any state moves backward, so a crash anywhere in this sequence leaves
@@ -1149,10 +1178,27 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok(self.bounds.end - 1)
     }
 
-    /// Acquire a reader that holds an owned, consistent snapshot of the journal.
-    pub fn reader(&self) -> Reader<E, V> {
+    /// Capture an owned snapshot ([`Reader`]) over the current journal. Bounds are frozen at
+    /// creation; the snapshot stays readable across concurrent appends and prunes, and a rewind
+    /// into its range is refused ([Error::BlobInUse]) while it is alive.
+    pub fn snapshot(&self) -> Reader<'static, E, V> {
         Reader {
-            data: self.blobs.to_snapshot(self.bounds.clone()),
+            data: Blobs::Snapshot(self.blobs.to_snapshot(self.bounds.clone())),
+            offsets: self.offsets.snapshot(),
+            items_per_blob: self.items_per_blob,
+            codec_config: self.codec_config.clone(),
+            compressed: self.compression.is_some(),
+            metrics: self.metrics.clone(),
+        }
+    }
+
+    /// A reader borrowing the journal's live state.
+    fn reader(&self) -> Reader<'_, E, V> {
+        Reader {
+            data: Blobs::Writable {
+                writable: &self.blobs,
+                bounds: self.bounds.clone(),
+            },
             offsets: self.offsets.reader(),
             items_per_blob: self.items_per_blob,
             codec_config: self.codec_config.clone(),
@@ -1311,7 +1357,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// The data blobs are the source of truth. This function replays them as needed to verify or
     /// rebuild the offsets suffix, then fixes any mismatches. Final blob-index contiguity is
-    /// enforced by [Blobs::recover]. Repairs mutate `pending` in place.
+    /// enforced by [Writable::recover]. Repairs mutate `pending` in place.
     ///
     /// Returns the recovered bounds (`pruning_boundary..size`).
     async fn align(
@@ -1735,7 +1781,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 }
 
 /// Replays a single sealed blob through its `Replay`.
-struct SealedReplayState<B: Blob, V: CodecShared> {
+struct SealedReplayState<B: RBlob, V: CodecShared> {
     /// Sequential reader over the blob's logical bytes.
     replay: Replay<B>,
     /// Positions still to emit (the blob is full, so `positions.end` is its boundary).
@@ -1744,7 +1790,7 @@ struct SealedReplayState<B: Blob, V: CodecShared> {
     compressed: bool,
 }
 
-impl<B: Blob, V: CodecShared> replay::Source for SealedReplayState<B, V> {
+impl<B: RBlob, V: CodecShared> replay::Source for SealedReplayState<B, V> {
     type Item = V;
 
     /// Decode one buffered batch of frames.
@@ -1786,7 +1832,7 @@ impl<B: Blob, V: CodecShared> replay::Source for SealedReplayState<B, V> {
 }
 
 /// Replays the writable tail through the snapshot's read handle.
-struct TailReplayState<B: Blob, V: CodecShared> {
+struct TailReplayState<B: RBlob, V: CodecShared> {
     reader: paged::Reader<B>,
     /// Positions still to emit; `positions.end` is the snapshot's size.
     positions: Range<u64>,
@@ -1798,7 +1844,7 @@ struct TailReplayState<B: Blob, V: CodecShared> {
     compressed: bool,
 }
 
-impl<B: Blob, V: CodecShared> replay::Source for TailReplayState<B, V> {
+impl<B: RBlob, V: CodecShared> replay::Source for TailReplayState<B, V> {
     type Item = V;
 
     /// Decode every whole frame in one chunk-sized read. A frame larger than the chunk is read
@@ -1887,16 +1933,37 @@ impl<B: Blob, V: CodecShared> replay::Source for TailReplayState<B, V> {
     }
 }
 
-// Implement Contiguous trait for variable-length items
 impl<E: Context, V: CodecShared> Contiguous for Journal<E, V> {
     type Item = V;
 
-    async fn reader(&self) -> impl super::Reader<Item = V> + '_ {
-        Self::reader(self)
+    fn bounds(&self) -> Range<u64> {
+        self.bounds.clone()
     }
 
-    async fn size(&self) -> u64 {
-        Self::size(self)
+    async fn read(&self, position: u64) -> Result<V, Error> {
+        self.reader().read(position).await
+    }
+
+    async fn read_many(&self, positions: &[u64]) -> Result<Vec<V>, Error> {
+        self.reader().read_many(positions).await
+    }
+
+    fn try_read_sync(&self, position: u64) -> Option<V> {
+        self.reader().try_read_sync(position)
+    }
+
+    async fn replay(
+        &self,
+        buffer: NonZeroUsize,
+        start_pos: u64,
+    ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
+        self.reader()
+            .replay_from(
+                &self.blobs.to_snapshot(self.bounds.clone()),
+                buffer,
+                start_pos,
+            )
+            .await
     }
 }
 
@@ -1961,16 +2028,6 @@ impl<E: Context, V: CodecShared> crate::journal::authenticated::Inner<E> for Jou
 
 #[cfg(test)]
 impl<E: Context, V: CodecShared> Journal<E, V> {
-    /// Test helper: Read the item at the given position.
-    pub(crate) async fn read(&self, position: u64) -> Result<V, Error> {
-        self.reader().read(position).await
-    }
-
-    /// Test helper: Return the bounds of the journal.
-    pub(crate) fn bounds(&self) -> Range<u64> {
-        self.bounds.clone()
-    }
-
     /// Test helper: Prune the data blobs directly (simulates crash scenario).
     pub(crate) async fn test_prune_data(&mut self, min_blob: u64) -> Result<bool, Error> {
         let min_blob = min_blob.min(self.blobs.tail_blob_index());
@@ -2009,7 +2066,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         &mut self,
         position: u64,
     ) -> Result<(), Error> {
-        let offset = self.offsets.reader().read(position).await?;
+        let offset = self.offsets.read(position).await?;
         let blob = position_to_blob(position, self.items_per_blob.get());
         if blob == self.blobs.tail_blob_index() {
             self.blobs.rewind_tail(offset).await
@@ -2232,7 +2289,7 @@ mod tests {
             let journal = Journal::<_, u64>::init(context.child("second"), cfg)
                 .await
                 .unwrap();
-            let reader = journal.reader();
+            let reader = journal.snapshot();
             let items = reader.read_many(&[1, 2, 3, 7, 8, 12, 18]).await.unwrap();
             assert_eq!(items, vec![100, 200, 300, 700, 800, 1200, 1800]);
             drop(reader);
@@ -2262,7 +2319,7 @@ mod tests {
             }
             journal.sync().await.unwrap();
 
-            let reader = journal.reader();
+            let reader = journal.snapshot();
             assert!(matches!(
                 reader.read_many(&[2, 1]).await,
                 Err(Error::PositionsNotIncreasing)
@@ -2306,7 +2363,7 @@ mod tests {
             let journal = Journal::<_, u64>::init(context.child("second"), cfg)
                 .await
                 .unwrap();
-            let reader = journal.reader();
+            let reader = journal.snapshot();
             let positions: Vec<u64> = (3..10).collect();
             let items = reader.read_many(&positions).await.unwrap();
             assert_eq!(items, vec![300, 400, 500, 600, 700, 800, 900]);
@@ -2461,7 +2518,7 @@ mod tests {
 
             // Test 1: Full replay
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader.replay(NZUsize!(20), 0).await.unwrap();
                 futures::pin_mut!(stream);
                 for i in 0..40u64 {
@@ -2474,7 +2531,7 @@ mod tests {
 
             // Test 2: Partial replay from middle of blob
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader.replay(NZUsize!(20), 15).await.unwrap();
                 futures::pin_mut!(stream);
                 for i in 15..40u64 {
@@ -2487,7 +2544,7 @@ mod tests {
 
             // Test 3: Partial replay from blob boundary
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader.replay(NZUsize!(20), 20).await.unwrap();
                 futures::pin_mut!(stream);
                 for i in 20..40u64 {
@@ -2501,19 +2558,19 @@ mod tests {
             // Test 4: Prune and verify replay from pruned
             journal.prune(20).await.unwrap();
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let res = reader.replay(NZUsize!(20), 0).await;
                 assert!(matches!(res, Err(crate::journal::Error::ItemPruned(_))));
             }
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let res = reader.replay(NZUsize!(20), 19).await;
                 assert!(matches!(res, Err(crate::journal::Error::ItemPruned(_))));
             }
 
             // Test 5: Replay from exactly at pruning boundary after prune
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader.replay(NZUsize!(20), 20).await.unwrap();
                 futures::pin_mut!(stream);
                 for i in 20..40u64 {
@@ -2526,7 +2583,7 @@ mod tests {
 
             // Test 6: Replay from the end
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let stream = reader.replay(NZUsize!(20), 40).await.unwrap();
                 futures::pin_mut!(stream);
                 assert!(stream.next().await.is_none());
@@ -2534,7 +2591,7 @@ mod tests {
 
             // Test 7: Replay beyond the end (should error)
             {
-                let reader = journal.reader();
+                let reader = journal.snapshot();
                 let res = reader.replay(NZUsize!(20), 41).await;
                 assert!(matches!(
                     res,
@@ -3959,7 +4016,7 @@ mod tests {
                 .await
                 .unwrap();
             let offset = {
-                let offsets = journal.offsets.reader();
+                let offsets = journal.offsets.snapshot();
                 offsets.read(12).await.unwrap()
             };
             drop(journal);
@@ -6072,7 +6129,7 @@ mod tests {
             let items = [0, 1, 2, 3, 4];
             journal.append_many(Many::Flat(&items)).await.unwrap();
             journal.append(&5).await.unwrap();
-            let reader = journal.reader();
+            let reader = journal.snapshot();
             reader.read(0).await.unwrap();
             reader.read_many(&[1, 2]).await.unwrap();
             reader.try_read_sync(3).unwrap();
@@ -6143,7 +6200,7 @@ mod tests {
             journal.sync().await.unwrap();
 
             // The page cache cannot hold every page, so some position must be cold.
-            let reader = journal.reader();
+            let reader = journal.snapshot();
             let pos = (0..200)
                 .find(|&pos| reader.try_read_sync(pos).is_none())
                 .expect("some position should be cold");
@@ -6176,7 +6233,7 @@ mod tests {
                 journal.append(&(i * 100)).await.unwrap();
             }
 
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert_eq!(snapshot.bounds(), 0..7);
 
             // Appending past the blob boundary rolls the snapshot's tail blob into
@@ -6193,7 +6250,7 @@ mod tests {
                 Err(Error::ItemOutOfRange(7))
             ));
 
-            let fresh = journal.reader();
+            let fresh = journal.snapshot();
             assert_eq!(fresh.bounds(), 0..23);
             assert_eq!(fresh.read(22).await.unwrap(), 2200);
 
@@ -6223,7 +6280,7 @@ mod tests {
             }
             journal.sync().await.unwrap();
 
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert!(journal.prune(12).await.unwrap());
 
             // The straggler reads the pruned range through its own handles.
@@ -6236,7 +6293,7 @@ mod tests {
                 vec![100, 200, 300, 1100, 1600]
             );
 
-            let fresh = journal.reader();
+            let fresh = journal.snapshot();
             assert_eq!(fresh.bounds(), 10..17);
             assert!(matches!(fresh.read(3).await, Err(Error::ItemPruned(3))));
 
@@ -6266,7 +6323,7 @@ mod tests {
             }
             journal.sync().await.unwrap();
 
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert!(matches!(journal.rewind(3).await, Err(Error::BlobInUse(0))));
 
             // The refused rewind left the journal fully usable and had no side effects.
@@ -6306,7 +6363,7 @@ mod tests {
 
             // A live snapshot blocks the tail rewind (it would tear the snapshot's bytes once
             // the rewound offsets are reappended).
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert!(matches!(journal.rewind(2).await, Err(Error::BlobInUse(_))));
             // The snapshot still reads its original, unchanged bytes.
             assert_eq!(snapshot.read(6).await.unwrap(), 600);
@@ -6319,7 +6376,7 @@ mod tests {
             }
 
             // A fresh reader observes the new data; no stale reader is alive to see torn bytes.
-            let fresh = journal.reader();
+            let fresh = journal.snapshot();
             assert_eq!(fresh.read(6).await.unwrap(), 106);
             assert_eq!(fresh.read(1).await.unwrap(), 100);
 
@@ -6345,7 +6402,7 @@ mod tests {
                 .unwrap();
 
             let (mut tx, mut rx) =
-                futures::channel::mpsc::channel::<Reader<deterministic::Context, u64>>(8);
+                futures::channel::mpsc::channel::<Reader<'static, deterministic::Context, u64>>(8);
             let validator = context.child("validator").spawn(|_| async move {
                 let mut validated = 0usize;
                 while let Some(snapshot) = rx.next().await {
@@ -6361,7 +6418,7 @@ mod tests {
             for i in 0..40u64 {
                 journal.append(&(i * 100)).await.unwrap();
                 if i % 7 == 0 {
-                    let snapshot = journal.reader();
+                    let snapshot = journal.snapshot();
                     if tx.try_send(snapshot).is_err() {
                         break;
                     }
@@ -6394,7 +6451,7 @@ mod tests {
             }
 
             // Positions 5..7 live in the snapshot's tail blob.
-            let snapshot = journal.reader();
+            let snapshot = journal.snapshot();
             assert_eq!(snapshot.bounds(), 0..7);
 
             // Roll the snapshot's tail into history, then prune both of its blobs away.

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -10,7 +10,7 @@ use crate::{
     journal::{
         contiguous::{
             fixed::{Config as JConfig, Journal},
-            Many, Reader,
+            Contiguous, Many,
         },
         Error as JError,
     },
@@ -195,7 +195,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
 
         // If a node isn't found in the metadata, it might still be in the journal.
         debug!(?pos, "reading node from journal");
-        let node = journal.reader().read(*pos).await;
+        let node = journal.read(*pos).await;
         match node {
             Ok(node) => Ok(node),
             Err(JError::ItemPruned(_)) => {
@@ -283,12 +283,12 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
             )
         }));
         let metadata_prune_pos = Position::try_from(metadata_pruned_to)?;
-        let journal_bounds_start = journal.reader().bounds().start;
+        let journal_bounds_start = journal.bounds().start;
         if *metadata_prune_pos > journal_bounds_start {
             // Metadata is ahead of journal (crashed before completing journal prune).
             // Prune the journal to match metadata.
             journal.prune(*metadata_prune_pos).await?;
-            if journal.reader().bounds().start != journal_bounds_start {
+            if journal.bounds().start != journal_bounds_start {
                 // This should only happen in the event of some failure during the last attempt to
                 // prune the journal.
                 warn!(
@@ -334,7 +334,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
             );
             // Check if there is an intact leaf following the last valid size, from which we can
             // recover its missing parents.
-            let recovered_item = journal.reader().read(*last_valid_size).await;
+            let recovered_item = journal.read(*last_valid_size).await;
             if let Ok(item) = recovered_item {
                 orphaned_leaf = Some(item);
             }
@@ -556,7 +556,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
             return Ok(Some(node));
         }
 
-        match self.journal.reader().read(*position).await {
+        match self.journal.read(*position).await {
             Ok(item) => Ok(Some(item)),
             Err(JError::ItemPruned(_)) => Ok(None),
             Err(e) => Err(Error::Journal(e)),

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -4,7 +4,7 @@ use crate::{
     index::{Ordered as OrderedIndex, Unordered as UnorderedIndex},
     journal::{
         authenticated,
-        contiguous::{Contiguous, Mutable, Reader},
+        contiguous::{Contiguous, Mutable},
     },
     merkle::{Family, Location},
     qmdb::{
@@ -568,7 +568,7 @@ where
     /// Batch and ancestor regions resolve in memory. All committed locations are served by
     /// one batched read, which serves page-cache hits under a single lock acquisition per
     /// section instead of paying a cache lock acquisition per location.
-    async fn read_ops<R: Reader<Item = Operation<F, U>>>(
+    async fn read_ops<R: Contiguous<Item = Operation<F, U>>>(
         &self,
         locations: &[Location<F>],
         batch_ops: &[Operation<F, U>],
@@ -709,7 +709,7 @@ where
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
     /// merkleize, diff merge, and `MerkleizedBatch` construction.
     #[allow(clippy::too_many_arguments)]
-    async fn finish<E, C, I, R, const N: usize>(
+    async fn finish<E, C, I, const N: usize>(
         self,
         mut ops: Vec<Operation<F, U>>,
         mut diff: DiffVec<U::Key, F, U::Value>,
@@ -717,14 +717,12 @@ where
         user_steps: u64,
         metadata: Option<U::Value>,
         mut fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
-        reader: R,
         db: &Db<F, E, C, I, H, U, N, S>,
     ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U, S>>, crate::qmdb::Error<F>>
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>>,
-        R: Reader<Item = Operation<F, U>>,
     {
         // Floor raise.
         // Steps = user_steps + 1 (+1 for previous commit becoming inactive).
@@ -754,7 +752,7 @@ where
 
                 // Batch-read candidates: page-cache hits are served by one batched read,
                 // disk misses are fetched concurrently.
-                let resolved = self.read_ops(&candidates, &ops, &reader).await?;
+                let resolved = self.read_ops(&candidates, &ops, &db.log).await?;
 
                 // Classify every candidate against the pre-raise state (see [`FloorOutcome`]).
                 // Revalidation is required even for candidates whose committed bitmap bit is
@@ -863,10 +861,6 @@ where
             floor = Location::new(self.base_size + ops.len() as u64);
             debug!(tip = ?floor, "db is empty, raising floor to tip");
         }
-
-        // Release the reader guard before CPU-only work (merkleization) so
-        // concurrent writers are not blocked.
-        drop(reader);
 
         // CommitFloor operation.
         let commit_loc = Location::<F>::new(self.base_size + ops.len() as u64);
@@ -1144,8 +1138,7 @@ where
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, false);
-        let reader = db.log.reader().await;
-        let results = m.read_ops(&locations, &[], &reader).await?;
+        let results = m.read_ops(&locations, &[], &db.log).await?;
 
         // Generate user mutation operations.
         let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
@@ -1268,7 +1261,6 @@ where
             user_steps,
             metadata,
             fill_candidates,
-            reader,
             db,
         )
         .await
@@ -1362,7 +1354,6 @@ where
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);
-        let reader = db.log.reader().await;
 
         // Classify mutations into deleted, created, updated. `next_candidates` and
         // `prev_candidates` are built as unsorted `Vec`s here and sorted+deduped once below,
@@ -1373,7 +1364,7 @@ where
         let mut updated: Vec<(K, V::Value, Location<F>)> = Vec::new();
 
         for (op, &old_loc) in m
-            .read_ops(&locations, &[], &reader)
+            .read_ops(&locations, &[], &db.log)
             .await?
             .into_iter()
             .zip(&locations)
@@ -1456,7 +1447,7 @@ where
         prev_locations.sort();
         prev_locations.dedup();
 
-        let prev_results = m.read_ops(&prev_locations, &[], &reader).await?;
+        let prev_results = m.read_ops(&prev_locations, &[], &db.log).await?;
 
         for (op, &old_loc) in prev_results.into_iter().zip(&prev_locations) {
             let data = match op {
@@ -1531,7 +1522,7 @@ where
         let ancestor_locs: Vec<Location<F>> =
             ancestor_active.iter().map(|&(_, _, loc)| loc).collect();
         for (op, (key, value, loc)) in m
-            .read_ops(&ancestor_locs, &[], &reader)
+            .read_ops(&ancestor_locs, &[], &db.log)
             .await?
             .into_iter()
             .zip(ancestor_active)
@@ -1706,7 +1697,6 @@ where
             user_steps,
             metadata,
             fill_candidates,
-            reader,
             db,
         )
         .await
@@ -1991,7 +1981,7 @@ where
         // Return range of operations that were written to the log.
         let end_loc = Location::new(*self.last_commit_loc + 1);
         let range = start_loc..end_loc;
-        self.update_metrics().await;
+        self.update_metrics();
         self.metrics
             .operations
             .operations_applied
@@ -2836,16 +2826,14 @@ mod tests {
 
             // read_ops should resolve all three sources correctly while preserving order and
             // duplicates across the disk-backed subset.
-            let reader = db.log.reader().await;
             let ops = merkleizer
                 .read_ops(
                     &[current_loc, committed_loc, parent_loc, committed_loc],
                     &batch_ops,
-                    &reader,
+                    &db.log,
                 )
                 .await
                 .unwrap();
-            drop(reader);
 
             assert_eq!(
                 ops,

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -7,7 +7,7 @@ use crate::{
     index::Unordered as UnorderedIndex,
     journal::{
         authenticated,
-        contiguous::{Contiguous, Mutable, Reader},
+        contiguous::{Contiguous, Mutable},
         Error as JournalError,
     },
     merkle::{Family, Location, Proof},
@@ -176,7 +176,7 @@ where
 
     /// Get the metadata associated with the last commit.
     pub async fn get_metadata(&self) -> Result<Option<U::Value>, crate::qmdb::Error<F>> {
-        match self.log.reader().await.read(*self.last_commit_loc).await? {
+        match self.log.read(*self.last_commit_loc).await? {
             Operation::CommitFloor(metadata, _) => Ok(metadata),
             _ => unreachable!("last commit is not a CommitFloor operation"),
         }
@@ -208,10 +208,9 @@ where
         self.metrics.reads.keys_requested.inc();
         // Collect to avoid holding a borrow across await points (rust-lang/rust#100013).
         let locs: Vec<Location<F>> = self.snapshot.get(key).copied().collect();
-        let reader = self.log.reader().await;
         let mut result = None;
         for loc in locs {
-            let op = reader.read(*loc).await?;
+            let op = self.log.read(*loc).await?;
             let Operation::Update(data) = op else {
                 panic!("location does not reference update operation. loc={loc}");
             };
@@ -298,8 +297,7 @@ where
         }
 
         // Phase 3: Batch-read from the journal (one reader acquisition, one I/O batch).
-        let reader = self.log.reader().await;
-        let ops = reader.read_many(&positions).await?;
+        let ops = self.log.read_many(&positions).await?;
 
         // Phase 4: Match operations back to keys via binary search (no HashMap).
         for &(key_idx, pos) in &candidates {
@@ -322,14 +320,14 @@ where
 
     /// Return [start, end) where `start` and `end - 1` are the Locations of the oldest and newest
     /// retained operations respectively.
-    pub async fn bounds(&self) -> std::ops::Range<Location<F>> {
-        let bounds = self.log.reader().await.bounds();
+    pub fn bounds(&self) -> std::ops::Range<Location<F>> {
+        let bounds = self.log.bounds();
         Location::new(bounds.start)..Location::new(bounds.end)
     }
 
     /// Update state gauges from the current database state.
-    pub(crate) async fn update_metrics(&self) {
-        let bounds = self.log.reader().await.bounds();
+    pub(crate) fn update_metrics(&self) {
+        let bounds = self.log.bounds();
         self.metrics.state.set(
             bounds.end,
             bounds.start,
@@ -409,7 +407,7 @@ where
         self.metrics.operations.prune_calls.inc();
         let actual_pruned = self.prune_log(prune_loc).await?;
         self.prune_bitmap(actual_pruned);
-        self.update_metrics().await;
+        self.update_metrics();
         Ok(())
     }
 
@@ -443,19 +441,17 @@ where
         start_loc: Location<F>,
         max_ops: NonZeroU64,
     ) -> Result<(Proof<F, H::Digest>, Vec<Operation<F, U>>), crate::qmdb::Error<F>> {
-        if historical_size > self.log.size().await {
+        if historical_size > self.log.size() {
             return Err(crate::qmdb::Error::Merkle(
                 crate::merkle::Error::RangeOutOfBounds(historical_size),
             ));
         }
 
-        let inactivity_floor = {
-            let reader = self.log.reader().await;
-            crate::qmdb::find_inactivity_floor_at::<F, _>(&reader, historical_size, |op| {
+        let inactivity_floor =
+            crate::qmdb::find_inactivity_floor_at::<F, _>(&self.log, historical_size, |op| {
                 op.has_floor()
             })
-            .await?
-        };
+            .await?;
         let inactive_peaks = self.inactive_peaks(historical_size, inactivity_floor);
         self.log
             .historical_proof(historical_size, start_loc, max_ops, inactive_peaks)
@@ -468,8 +464,7 @@ where
         loc: Location<F>,
         max_ops: NonZeroU64,
     ) -> Result<(Proof<F, H::Digest>, Vec<Operation<F, U>>), crate::qmdb::Error<F>> {
-        self.historical_proof(self.log.size().await, loc, max_ops)
-            .await
+        self.historical_proof(self.log.size(), loc, max_ops).await
     }
 
     /// Rewind the database to `size` operations, where `size` is the location of the next append.
@@ -513,15 +508,14 @@ where
 
         // Read everything needed for rewind before mutating storage.
         let (rewind_floor, undos, active_keys_delta) = {
-            let reader = self.log.reader().await;
-            let bounds = reader.bounds();
+            let bounds = self.log.bounds();
             let rewind_last_loc = Location::new(rewind_size - 1);
             if rewind_size <= bounds.start {
                 return Err(Error::<F>::Journal(JournalError::ItemPruned(
                     *rewind_last_loc,
                 )));
             }
-            let rewind_last_op = reader.read(*rewind_last_loc).await?;
+            let rewind_last_op = self.log.read(*rewind_last_loc).await?;
             let Some(rewind_floor) = rewind_last_op.has_floor() else {
                 return Err(Error::UnexpectedData(rewind_last_loc));
             };
@@ -535,7 +529,7 @@ where
 
             // Reconstruct key state once in a single pass from the rewind floor.
             for loc in *rewind_floor..current_size {
-                let op = reader.read(loc).await?;
+                let op = self.log.read(loc).await?;
                 let op_loc = Location::new(loc);
                 match op {
                     Operation::CommitFloor(_, _) => {}
@@ -645,7 +639,7 @@ where
         self.root = self
             .log
             .root(self.inactive_peaks(Location::new(rewind_size), rewind_floor))?;
-        self.update_metrics().await;
+        self.update_metrics();
 
         Ok(())
     }
@@ -678,8 +672,7 @@ where
         metrics: Metrics<E>,
     ) -> Result<Self, crate::qmdb::Error<F>> {
         let (last_commit_loc, inactivity_floor_loc, active_keys, bitmap) = {
-            let reader = log.reader().await;
-            let bounds = reader.bounds();
+            let bounds = log.bounds();
             let last_commit_loc = Location::new(
                 bounds
                     .end
@@ -687,7 +680,7 @@ where
                     .ok_or(Error::HistoricalFloorPruned(Location::new(bounds.end)))?,
             );
             let inactivity_floor_loc = crate::qmdb::find_inactivity_floor_at::<F, _>(
-                &reader,
+                &log,
                 Location::new(bounds.end),
                 |op| op.has_floor(),
             )
@@ -725,7 +718,7 @@ where
                 let bitmap = &bitmap;
                 build_snapshot_from_log(
                     inactivity_floor_loc,
-                    &reader,
+                    &log,
                     &mut index,
                     |is_active, old_loc| {
                         let mut guard = bitmap.write();
@@ -747,7 +740,7 @@ where
         };
 
         // The bitmap must have exactly one bit per retained log location.
-        if bitmap::Readable::<N>::len(bitmap.as_ref()) != log.size().await {
+        if bitmap::Readable::<N>::len(bitmap.as_ref()) != log.size() {
             return Err(crate::qmdb::Error::DataCorrupted(
                 "bitmap length diverged from log size during init",
             ));
@@ -770,7 +763,7 @@ where
             metrics,
             _update: core::marker::PhantomData,
         };
-        db.update_metrics().await;
+        db.update_metrics();
         Ok(db)
     }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -165,7 +165,7 @@ where
     )
     .await?;
 
-    if log.size().await == 0 {
+    if log.size() == 0 {
         warn!("Authenticated log is empty, initializing new db");
         let commit_floor = Operation::CommitFloor(None, Location::new(0));
         log.append(&commit_floor).await?;
@@ -324,11 +324,11 @@ pub(crate) mod test {
         db.commit().await.unwrap();
         db.prune(db.sync_boundary().await).await.unwrap();
         let root = db.root();
-        let op_count = db.size().await;
+        let op_count = db.size();
         let inactivity_floor_loc = db.inactivity_floor_loc().await;
 
         let db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
-        assert_eq!(db.size().await, op_count);
+        assert_eq!(db.size(), op_count);
         assert_eq!(db.inactivity_floor_loc().await, inactivity_floor_loc);
         assert_eq!(db.root(), root);
 
@@ -343,7 +343,7 @@ pub(crate) mod test {
             let _merkleized = batch.merkleize(&db, None).await.unwrap();
         }
         let db = reopen_db(context.child("reopen").with_attribute("index", 2)).await;
-        assert_eq!(db.size().await, op_count);
+        assert_eq!(db.size(), op_count);
         assert_eq!(db.inactivity_floor_loc().await, inactivity_floor_loc);
         assert_eq!(db.root(), root);
 
@@ -358,7 +358,7 @@ pub(crate) mod test {
             let _merkleized = batch.merkleize(&db, None).await.unwrap();
         }
         let db = reopen_db(context.child("reopen").with_attribute("index", 3)).await;
-        assert_eq!(db.size().await, op_count);
+        assert_eq!(db.size(), op_count);
         assert_eq!(db.root(), root);
 
         // Three rounds of unapplied batches.
@@ -372,7 +372,7 @@ pub(crate) mod test {
             let _merkleized = batch.merkleize(&db, None).await.unwrap();
         }
         let mut db = reopen_db(context.child("reopen").with_attribute("index", 4)).await;
-        assert_eq!(db.size().await, op_count);
+        assert_eq!(db.size(), op_count);
         assert_eq!(db.root(), root);
 
         // Now actually commit a batch.
@@ -388,7 +388,7 @@ pub(crate) mod test {
         }
         db.commit().await.unwrap();
         let db = reopen_db(context.child("reopen").with_attribute("index", 5)).await;
-        assert!(db.size().await > op_count);
+        assert!(db.size() > op_count);
         assert_ne!(db.inactivity_floor_loc().await, inactivity_floor_loc);
         assert_ne!(db.root(), root);
 
@@ -407,7 +407,7 @@ pub(crate) mod test {
         let root = db.root();
 
         let db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
-        assert_eq!(db.size().await, 1);
+        assert_eq!(db.size(), 1);
         assert_eq!(db.root(), root);
 
         // Write without applying (unapplied batch should be lost on reopen).
@@ -421,7 +421,7 @@ pub(crate) mod test {
             let _merkleized = batch.merkleize(&db, None).await.unwrap();
         }
         let db = reopen_db(context.child("reopen").with_attribute("index", 2)).await;
-        assert_eq!(db.size().await, 1);
+        assert_eq!(db.size(), 1);
         assert_eq!(db.root(), root);
 
         // Write without applying again.
@@ -436,7 +436,7 @@ pub(crate) mod test {
         }
         drop(db);
         let db = reopen_db(context.child("reopen").with_attribute("index", 3)).await;
-        assert_eq!(db.size().await, 1);
+        assert_eq!(db.size(), 1);
         assert_eq!(db.root(), root);
 
         // Three rounds of unapplied batches.
@@ -451,7 +451,7 @@ pub(crate) mod test {
         }
         drop(db);
         let mut db = reopen_db(context.child("reopen").with_attribute("index", 4)).await;
-        assert_eq!(db.size().await, 1);
+        assert_eq!(db.size(), 1);
         assert_eq!(db.root(), root);
 
         // Now actually commit a batch.
@@ -468,7 +468,7 @@ pub(crate) mod test {
         db.commit().await.unwrap();
         drop(db);
         let db = reopen_db(context.child("reopen").with_attribute("index", 5)).await;
-        assert!(db.size().await > 1);
+        assert!(db.size() > 1);
         assert_ne!(db.root(), root);
 
         db.destroy().await.unwrap();
@@ -510,12 +510,12 @@ pub(crate) mod test {
         db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
         let committed_root = db.root();
-        let committed_size = db.size().await;
+        let committed_size = db.size();
         drop(db);
 
         let db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
         assert_eq!(db.root(), committed_root);
-        assert_eq!(db.size().await, committed_size);
+        assert_eq!(db.size(), committed_size);
         assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
         assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
 
@@ -536,7 +536,7 @@ pub(crate) mod test {
         let key1 = Sha256::hash(&1u64.to_be_bytes());
         let key2 = Sha256::hash(&2u64.to_be_bytes());
         let initial_root = db.root();
-        let initial_size = db.size().await;
+        let initial_size = db.size();
         let initial_floor = db.inactivity_floor_loc().await;
 
         // Empty-batch rewind on an otherwise empty DB should apply no snapshot undos.
@@ -544,10 +544,10 @@ pub(crate) mod test {
         let empty_range = db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
         assert_eq!(empty_range.start, initial_size);
-        assert_eq!(db.size().await, empty_range.end);
+        assert_eq!(db.size(), empty_range.end);
         db.rewind_to_size(initial_size).await.unwrap();
         assert_eq!(db.root(), initial_root);
-        assert_eq!(db.size().await, initial_size);
+        assert_eq!(db.size(), initial_size);
         assert_eq!(db.inactivity_floor_loc().await, initial_floor);
         assert_eq!(db.get_metadata().await.unwrap(), None);
 
@@ -566,7 +566,7 @@ pub(crate) mod test {
         db.commit().await.unwrap();
 
         let root_a = db.root();
-        let size_a = db.size().await;
+        let size_a = db.size();
         let floor_a = db.inactivity_floor_loc().await;
         assert_eq!(size_a, range_a.end);
 
@@ -606,7 +606,7 @@ pub(crate) mod test {
         // - `key1` was deleted then recreated (exercises net-zero active_keys_delta path)
         db.rewind_to_size(size_a).await.unwrap();
         assert_eq!(db.root(), root_a);
-        assert_eq!(db.size().await, size_a);
+        assert_eq!(db.size(), size_a);
         assert_eq!(db.inactivity_floor_loc().await, floor_a);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_a.clone()));
         assert_eq!(db.get(&key0).await.unwrap(), Some(value0_a));
@@ -617,7 +617,7 @@ pub(crate) mod test {
         drop(db);
         let mut db = reopen_db(context.child("reopen_after_rewind")).await;
         assert_eq!(db.root(), root_a);
-        assert_eq!(db.size().await, size_a);
+        assert_eq!(db.size(), size_a);
         assert_eq!(db.inactivity_floor_loc().await, floor_a);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_a));
         assert_eq!(db.get(&key0).await.unwrap(), Some(make_value(10)));
@@ -651,7 +651,7 @@ pub(crate) mod test {
         // Rewind all the way to the initial commit boundary (`first_commit_loc + 1`).
         db.rewind_to_size(initial_size).await.unwrap();
         assert_eq!(db.root(), initial_root);
-        assert_eq!(db.size().await, initial_size);
+        assert_eq!(db.size(), initial_size);
         assert_eq!(db.inactivity_floor_loc().await, initial_floor);
         assert_eq!(db.get_metadata().await.unwrap(), None);
         assert_eq!(db.get(&key0).await.unwrap(), None);
@@ -662,7 +662,7 @@ pub(crate) mod test {
         drop(db);
         let db = reopen_db(context.child("reopen_initial_boundary")).await;
         assert_eq!(db.root(), initial_root);
-        assert_eq!(db.size().await, initial_size);
+        assert_eq!(db.size(), initial_size);
         assert_eq!(db.inactivity_floor_loc().await, initial_floor);
         assert_eq!(db.get_metadata().await.unwrap(), None);
         assert_eq!(db.get(&key0).await.unwrap(), None);
@@ -747,7 +747,7 @@ pub(crate) mod test {
         }
 
         let hasher = qmdb::hasher::<Sha256>();
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         let inactivity_floor = db.inactivity_floor_loc().await;
         for loc in *inactivity_floor..*bounds.end {
             let loc = Location::new(loc);
@@ -822,7 +822,7 @@ pub(crate) mod test {
             db.apply_batch(merkleized).await.unwrap();
         }
         let root_hash = db.root();
-        let original_op_count = db.size().await;
+        let original_op_count = db.size();
 
         // Historical proof should match "regular" proof when historical size == current database size
         let max_ops = NZU64!(10);
@@ -903,7 +903,7 @@ pub(crate) mod test {
                 .unwrap();
             db.apply_batch(merkleized).await.unwrap();
             if i == 0 {
-                historical_op_count = db.bounds().await.end;
+                historical_op_count = db.bounds().end;
             }
         }
 
@@ -1033,7 +1033,7 @@ pub(crate) mod test {
         // commit boundary when the db commits to an inactive peak boundary, so we anchor each test on
         // one of the boundaries we recorded here rather than hardcoding sizes that depend
         // on internal floor-raising behavior.
-        let initial_size = db.bounds().await.end;
+        let initial_size = db.bounds().end;
         let mut boundaries = vec![initial_size];
         for i in 0u64..5 {
             let k = Sha256::hash(&i.to_be_bytes());
@@ -1045,7 +1045,7 @@ pub(crate) mod test {
                 .await
                 .unwrap();
             db.apply_batch(merkleized).await.unwrap();
-            boundaries.push(db.bounds().await.end);
+            boundaries.push(db.bounds().end);
         }
 
         // Singleton historical state: only the initial CommitFloor is visible.
@@ -2176,13 +2176,13 @@ pub(crate) mod test {
                 commit_writes(&mut db, updates, None).await;
 
                 db.prune(db.sync_boundary()).await.unwrap();
-                let bounds = db.bounds().await;
+                let bounds = db.bounds();
                 if bounds.start > first_range.start {
                     break;
                 }
             }
 
-            let oldest_retained = db.bounds().await.start;
+            let oldest_retained = db.bounds().start;
             let boundary_err = db.rewind(oldest_retained).await.unwrap_err();
             assert!(
                 matches!(
@@ -2219,10 +2219,10 @@ pub(crate) mod test {
             .unwrap();
 
             let root_before = db.root();
-            let size_before = db.size().await;
+            let size_before = db.size();
             db.rewind(size_before).await.unwrap();
             assert_eq!(db.root(), root_before);
-            assert_eq!(db.size().await, size_before);
+            assert_eq!(db.size(), size_before);
 
             let zero_err = db.rewind(Location::new(0)).await.unwrap_err();
             assert!(
@@ -2233,7 +2233,7 @@ pub(crate) mod test {
                 "unexpected rewind error: {zero_err:?}"
             );
             assert_eq!(db.root(), root_before);
-            assert_eq!(db.size().await, size_before);
+            assert_eq!(db.size(), size_before);
 
             let too_large_target = Location::new(*size_before + 1);
             let too_large_err = db.rewind(too_large_target).await.unwrap_err();
@@ -2246,7 +2246,7 @@ pub(crate) mod test {
                 "unexpected rewind error: {too_large_err:?}"
             );
             assert_eq!(db.root(), root_before);
-            assert_eq!(db.size().await, size_before);
+            assert_eq!(db.size(), size_before);
 
             db.destroy().await.unwrap();
         });
@@ -2274,7 +2274,7 @@ pub(crate) mod test {
             )
             .await;
 
-            let rewind_target = db.size().await;
+            let rewind_target = db.size();
             let target_floor = db.inactivity_floor_loc();
             let prune_loc = Location::new(*target_floor + (KEYS / 2));
             assert!(
@@ -2298,7 +2298,7 @@ pub(crate) mod test {
             }
 
             db.prune(prune_loc).await.unwrap();
-            let bounds = db.bounds().await;
+            let bounds = db.bounds();
             assert!(
                 bounds.start > *target_floor,
                 "test setup expected pruned start beyond target floor; bounds={bounds:?}, target_floor={target_floor:?}"
@@ -2348,7 +2348,7 @@ pub(crate) mod test {
                 UnorderedVariableDb::init(ctx.child("storage"), cfg).await.unwrap();
 
             commit_writes(&mut db, (0..100).map(|i| (key(i), Some(val(i)))), None).await;
-            let rewind_target = db.size().await;
+            let rewind_target = db.size();
             // Rewind target must lie below the chunk boundary the buggy prune would advance
             // to; otherwise the unfixed code would not panic on truncate.
             assert!(
@@ -2372,7 +2372,7 @@ pub(crate) mod test {
 
             // Pre-rewind size must actually exceed the rewind target so the rewind is not a
             // no-op.
-            let pre_prune_size = db.size().await;
+            let pre_prune_size = db.size();
             assert!(pre_prune_size > rewind_target);
 
             let prune_loc = Location::new(600);
@@ -2394,7 +2394,7 @@ pub(crate) mod test {
 
             // Journal could not prune any section, so it still retains from 0. The bitmap
             // must therefore also remain at 0.
-            let bounds = db.bounds().await;
+            let bounds = db.bounds();
             assert_eq!(bounds.start, Location::new(0));
             assert_eq!(
                 db.bitmap.pruned_bits(),
@@ -2405,7 +2405,7 @@ pub(crate) mod test {
             // Rewind to the still-retained early commit must succeed and restore visible
             // state (root match implies the snapshot was rebuilt correctly).
             db.rewind(rewind_target).await.unwrap();
-            assert_eq!(db.size().await, rewind_target);
+            assert_eq!(db.size(), rewind_target);
             assert_eq!(db.root(), root_at_target);
 
             db.destroy().await.unwrap();
@@ -2533,14 +2533,14 @@ pub(crate) mod test {
             commit_writes_mmb(&mut db, [(key(1), Some(val(1)))], None).await;
 
             let root = db.root();
-            let bounds = db.bounds().await;
+            let bounds = db.bounds();
             db.sync().await.unwrap();
             drop(db);
 
             // Reopen and verify state.
             let db = open_mmb_db(context.child("db").with_attribute("index", 1), "recovery").await;
             assert_eq!(db.root(), root);
-            assert_eq!(db.bounds().await, bounds);
+            assert_eq!(db.bounds(), bounds);
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
             assert_eq!(db.get_metadata().await.unwrap(), None);

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -656,7 +656,7 @@ pub(crate) mod test {
             // Make sure size-constrained batches of operations are provable from the oldest
             // retained op to tip.
             let max_ops = NZU64!(4);
-            let end_loc = db.bounds().await.end;
+            let end_loc = db.bounds().end;
             let start_loc = db.log.merkle.bounds().start;
             // Raise the inactivity floor via an empty batch and make sure historical inactive
             // operations are still provable.
@@ -698,12 +698,12 @@ pub(crate) mod test {
             }
             db.prune(db.sync_boundary()).await.unwrap();
             let root = db.root();
-            let op_count = db.bounds().await.end;
+            let op_count = db.bounds().end;
             let inactivity_floor_loc = db.inactivity_floor_loc();
 
             // Reopen DB without clean shutdown and make sure the state is the same.
             let mut db = open_db(context.child("second")).await;
-            assert_eq!(db.bounds().await.end, op_count);
+            assert_eq!(db.bounds().end, op_count);
             assert_eq!(db.inactivity_floor_loc(), inactivity_floor_loc);
             assert_eq!(db.root(), root);
 
@@ -722,7 +722,7 @@ pub(crate) mod test {
             write_unapplied_batch(&mut db);
             drop(db);
             let mut db = open_db(context.child("third")).await;
-            assert_eq!(db.bounds().await.end, op_count);
+            assert_eq!(db.bounds().end, op_count);
             assert_eq!(db.inactivity_floor_loc(), inactivity_floor_loc);
             assert_eq!(db.root(), root);
 
@@ -731,7 +731,7 @@ pub(crate) mod test {
             write_unapplied_batch(&mut db);
             drop(db);
             let mut db = open_db(context.child("fourth")).await;
-            assert_eq!(db.bounds().await.end, op_count);
+            assert_eq!(db.bounds().end, op_count);
             assert_eq!(db.root(), root);
 
             // One last check that re-open without proper shutdown still recovers the correct state.
@@ -740,7 +740,7 @@ pub(crate) mod test {
             write_unapplied_batch(&mut db);
             write_unapplied_batch(&mut db);
             let mut db = open_db(context.child("fifth")).await;
-            assert_eq!(db.bounds().await.end, op_count);
+            assert_eq!(db.bounds().end, op_count);
             assert_eq!(db.root(), root);
 
             // Apply the ops one last time but fully commit them this time, then clean up.
@@ -757,7 +757,7 @@ pub(crate) mod test {
                 db.commit().await.unwrap();
             }
             let db = open_db(context.child("sixth")).await;
-            assert!(db.bounds().await.end > op_count);
+            assert!(db.bounds().end > op_count);
             assert_ne!(db.inactivity_floor_loc(), inactivity_floor_loc);
             assert_ne!(db.root(), root);
 
@@ -777,7 +777,7 @@ pub(crate) mod test {
 
             // Reopen DB without clean shutdown and make sure the state is the same.
             let mut db = open_db(context.child("second")).await;
-            assert_eq!(db.bounds().await.end, 1);
+            assert_eq!(db.bounds().end, 1);
             assert_eq!(db.root(), root);
 
             fn write_unapplied_batch(db: &mut AnyTest) {
@@ -795,7 +795,7 @@ pub(crate) mod test {
             write_unapplied_batch(&mut db);
             drop(db);
             let mut db = open_db(context.child("third")).await;
-            assert_eq!(db.bounds().await.end, 1);
+            assert_eq!(db.bounds().end, 1);
             assert_eq!(db.root(), root);
 
             // Repeat, drop without cleanup again.
@@ -803,7 +803,7 @@ pub(crate) mod test {
             write_unapplied_batch(&mut db);
             drop(db);
             let mut db = open_db(context.child("fourth")).await;
-            assert_eq!(db.bounds().await.end, 1);
+            assert_eq!(db.bounds().end, 1);
             assert_eq!(db.root(), root);
 
             // One last check that re-open without proper shutdown still recovers the correct state.
@@ -812,7 +812,7 @@ pub(crate) mod test {
             write_unapplied_batch(&mut db);
             write_unapplied_batch(&mut db);
             let mut db = open_db(context.child("fifth")).await;
-            assert_eq!(db.bounds().await.end, 1);
+            assert_eq!(db.bounds().end, 1);
             assert_eq!(db.root(), root);
 
             // Apply the ops one last time but fully commit them this time, then clean up.
@@ -829,7 +829,7 @@ pub(crate) mod test {
                 db.commit().await.unwrap();
             }
             let db = open_db(context.child("sixth")).await;
-            assert!(db.bounds().await.end > 1);
+            assert!(db.bounds().end > 1);
             assert_ne!(db.root(), root);
 
             db.destroy().await.unwrap();
@@ -898,7 +898,7 @@ pub(crate) mod test {
             apply_ops(&mut db, ops.clone()).await;
             let hasher = qmdb::hasher::<Sha256>();
             let root_hash = db.root();
-            let original_op_count = db.bounds().await.end;
+            let original_op_count = db.bounds().end;
 
             // Historical proof should match "regular" proof when historical size == current database size
             let max_ops = NZU64!(10);
@@ -958,11 +958,11 @@ pub(crate) mod test {
             let mut commit_boundary_sizes: Vec<Location> = Vec::new();
             for _ in 0..5 {
                 apply_ops(&mut db, create_test_ops(10)).await;
-                commit_boundary_sizes.push(db.bounds().await.end);
+                commit_boundary_sizes.push(db.bounds().end);
             }
 
             let root = db.root();
-            let full_size = db.bounds().await.end;
+            let full_size = db.bounds().end;
             assert_eq!(full_size, *commit_boundary_sizes.last().unwrap());
 
             // Verify a single-op proof at the full commit size.
@@ -1029,7 +1029,7 @@ pub(crate) mod test {
             let (proof, ops) = db.proof(start_loc, max_ops).await.unwrap();
 
             // Now keep adding operations and make sure we can still generate a historical proof that matches the original.
-            let historical_size = db.bounds().await.end;
+            let historical_size = db.bounds().end;
 
             for i in 1..10 {
                 // Use different seed per iteration to avoid key collisions

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     index::Ordered as Index,
-    journal::contiguous::{Contiguous, Reader},
+    journal::contiguous::Contiguous,
     merkle::{Family, Location},
     qmdb::{
         any::{db::Db, ValueEncoding},
@@ -39,7 +39,7 @@ where
     Operation<F, K, V>: Codec,
 {
     async fn get_update_op(
-        reader: &impl Reader<Item = Operation<F, K, V>>,
+        reader: &impl Contiguous<Item = Operation<F, K, V>>,
         loc: Location<F>,
     ) -> Result<Update<K, V>, crate::qmdb::Error<F>> {
         match reader.read(*loc).await? {
@@ -71,10 +71,9 @@ where
         locs: impl IntoIterator<Item = Location<F>>,
         key: &K,
     ) -> Result<LocatedKey<F, K, V>, crate::qmdb::Error<F>> {
-        let reader = self.log.reader().await;
         for loc in locs {
             // Iterate over conflicts in the snapshot entry to find the span.
-            let data = Self::get_update_op(&reader, loc).await?;
+            let data = Self::get_update_op(&self.log, loc).await?;
             if Self::span_contains(&data.key, &data.next_key, key) {
                 return Ok(Some((loc, data)));
             }
@@ -127,9 +126,8 @@ where
     ) -> Result<Option<(Update<K, V>, Location<F>)>, crate::qmdb::Error<F>> {
         // Collect to avoid holding a borrow across await points (rust-lang/rust#100013).
         let locs: Vec<Location<F>> = self.snapshot.get(key).copied().collect();
-        let reader = self.log.reader().await;
         for loc in locs {
-            let op = reader.read(*loc).await?;
+            let op = self.log.read(*loc).await?;
             assert!(
                 op.is_update(),
                 "location does not reference update operation. loc={loc}"
@@ -202,10 +200,9 @@ where
         &self,
         locs: impl IntoIterator<Item = &Location<F>>,
     ) -> Result<Vec<Update<K, V>>, crate::qmdb::Error<F>> {
-        let reader = self.log.reader().await;
         let futures = locs
             .into_iter()
-            .map(|loc| Self::get_update_op(&reader, *loc));
+            .map(|loc| Self::get_update_op(&self.log, *loc));
         let mut updates = try_join_all(futures).await?;
         updates.sort_by(|a, b| b.key.cmp(&a.key));
 
@@ -541,10 +538,10 @@ mod test {
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
         let _ = db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
-        let op_count = db.bounds().await.end;
+        let op_count = db.bounds().end;
         let root = db.root();
         let mut db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
-        assert_eq!(db.bounds().await.end, op_count);
+        assert_eq!(db.bounds().end, op_count);
         assert_eq!(db.root(), root);
 
         // Re-activate the keys by updating them.
@@ -599,12 +596,12 @@ mod test {
         db.commit().await.unwrap();
 
         // Confirm close/reopen gets us back to the same state.
-        let op_count = db.bounds().await.end;
+        let op_count = db.bounds().end;
         let root = db.root();
         let mut db = reopen_db(context.child("reopen").with_attribute("index", 2)).await;
 
         assert_eq!(db.root(), root);
-        assert_eq!(db.bounds().await.end, op_count);
+        assert_eq!(db.bounds().end, op_count);
 
         // Commit will raise the inactivity floor, which won't affect state but will affect the
         // root.

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     index::Factory as IndexFactory,
     journal::{
         authenticated,
-        contiguous::{fixed, variable, Contiguous, Mutable, Reader as _},
+        contiguous::{fixed, variable, Contiguous, Mutable},
     },
     merkle::{self, full, Location},
     qmdb::{
@@ -155,14 +155,12 @@ macro_rules! impl_sync_database {
                     return Ok(None);
                 }
 
-                let reader = Contiguous::reader(journal).await;
-                let bounds = reader.bounds();
+                let bounds = journal.bounds();
                 if Location::new(bounds.start) > target.range.start()
                     || Location::new(bounds.end) != target.range.end()
                 {
                     return Ok(None);
                 }
-                drop(reader);
 
                 let hasher = qmdb::hasher::<H>();
                 let merkle = full::Merkle::<F, _, _, S>::init(

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -236,7 +236,7 @@ where
             .await
             .unwrap();
 
-        let target_op_count = target_db.bounds().await.end;
+        let target_op_count = target_db.bounds().end;
         let target_inactivity_floor = target_db.inactivity_floor_loc().await;
         let sync_root = H::sync_target_root(&target_db);
         let verification_root = target_db.root();
@@ -267,7 +267,7 @@ where
         let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         // Verify database state (root hash is the key verification)
-        assert_eq!(synced_db.bounds().await.end, target_op_count);
+        assert_eq!(synced_db.bounds().end, target_op_count);
         assert_eq!(
             synced_db.inactivity_floor_loc().await,
             target_inactivity_floor
@@ -276,13 +276,13 @@ where
 
         // Verify persistence
         let final_root = synced_db.root();
-        let final_op_count = synced_db.bounds().await.end;
+        let final_op_count = synced_db.bounds().end;
         let final_inactivity_floor = synced_db.inactivity_floor_loc().await;
 
         // Reopen and verify state persisted
         drop(synced_db);
         let reopened_db = H::init_db_with_config(client_context.child("reopened"), db_config).await;
-        assert_eq!(reopened_db.bounds().await.end, final_op_count);
+        assert_eq!(reopened_db.bounds().end, final_op_count);
         assert_eq!(
             reopened_db.inactivity_floor_loc().await,
             final_inactivity_floor
@@ -315,7 +315,7 @@ where
         target_db = H::apply_ops(target_db, target_ops[0..target_db_ops - 1].to_vec()).await;
         // commit already done in apply_ops
 
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
         let sync_root = H::sync_target_root(&target_db);
         let verification_root = target_db.root();
         let lower_bound = target_db.sync_boundary().await;
@@ -349,7 +349,7 @@ where
 
         // Verify the synced database has the correct range of operations
         assert_eq!(synced_db.sync_boundary().await, lower_bound);
-        assert_eq!(synced_db.bounds().await.end, upper_bound);
+        assert_eq!(synced_db.bounds().end, upper_bound);
 
         // Verify the final root digest matches our target
         assert_eq!(synced_db.root(), verification_root);
@@ -399,7 +399,7 @@ where
         let sync_root = H::sync_target_root(&target_db);
         let verification_root = target_db.root();
         let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
 
         // Reopen the sync database and sync it to the target database
         let target_db = Arc::new(target_db);
@@ -422,13 +422,13 @@ where
         let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         // Verify database state
-        let bounds = synced_db.bounds().await;
+        let bounds = synced_db.bounds();
         assert_eq!(bounds.end, upper_bound);
         assert_eq!(
             synced_db.inactivity_floor_loc().await,
             target_db.inactivity_floor_loc().await
         );
-        assert_eq!(bounds.end, target_db.bounds().await.end);
+        assert_eq!(bounds.end, target_db.bounds().end);
         // Verify the root digest matches the target
         assert_eq!(synced_db.root(), verification_root);
 
@@ -496,7 +496,7 @@ where
         let sync_root = H::sync_target_root(&target_db);
         let verification_root = target_db.root();
         let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
 
         // sync_db should never ask the resolver for operations
         // because it is already complete. Use a resolver that always fails
@@ -521,9 +521,9 @@ where
         let synced_db: H::Db = sync::sync(config).await.unwrap();
 
         // Verify database state
-        let bounds = synced_db.bounds().await;
+        let bounds = synced_db.bounds();
         assert_eq!(bounds.end, upper_bound);
-        assert_eq!(bounds.end, target_db.bounds().await.end);
+        assert_eq!(bounds.end, target_db.bounds().end);
         assert_eq!(synced_db.sync_boundary().await, lower_bound);
 
         // Verify the root digest matches the target
@@ -566,7 +566,7 @@ where
             *initial_lower_bound > 0,
             "test setup requires non-zero inactivity floor"
         );
-        let initial_upper_bound = target_db.bounds().await.end;
+        let initial_upper_bound = target_db.bounds().end;
         let initial_root = H::sync_target_root(&target_db);
 
         // Create client with initial target
@@ -635,7 +635,7 @@ where
 
         // Capture initial target state
         let initial_lower_bound = target_db.sync_boundary().await;
-        let initial_upper_bound = target_db.bounds().await.end;
+        let initial_upper_bound = target_db.bounds().end;
         let initial_root = H::sync_target_root(&target_db);
 
         // Create client with initial target
@@ -704,7 +704,7 @@ where
 
         // Capture initial target state
         let initial_lower_bound = target_db.sync_boundary().await;
-        let initial_upper_bound = target_db.bounds().await.end;
+        let initial_upper_bound = target_db.bounds().end;
         let initial_root = H::sync_target_root(&target_db);
 
         // Apply more operations to the target database
@@ -716,7 +716,7 @@ where
 
             // Capture new target state
             let new_lower_bound = target_db.sync_boundary().await;
-            let new_upper_bound = target_db.bounds().await.end;
+            let new_upper_bound = target_db.bounds().end;
             let new_sync_root = H::sync_target_root(&target_db);
             let new_verification_root = target_db.root();
 
@@ -755,7 +755,7 @@ where
 
             // Verify the synced database has the expected final state
             assert_eq!(synced_db.root(), new_verification_root);
-            assert_eq!(synced_db.bounds().await.end, new_upper_bound);
+            assert_eq!(synced_db.bounds().end, new_upper_bound);
             assert_eq!(synced_db.sync_boundary().await, new_lower_bound);
 
             synced_db.destroy().await.unwrap();
@@ -789,7 +789,7 @@ where
 
         // Capture target state
         let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
         let sync_root = H::sync_target_root(&target_db);
         let verification_root = target_db.root();
 
@@ -828,7 +828,7 @@ where
 
         // Verify the synced database has the expected state
         assert_eq!(synced_db.root(), verification_root);
-        assert_eq!(synced_db.bounds().await.end, upper_bound);
+        assert_eq!(synced_db.bounds().end, upper_bound);
         assert_eq!(synced_db.sync_boundary().await, lower_bound);
 
         synced_db.destroy().await.unwrap();
@@ -858,7 +858,7 @@ where
             *initial_lower_bound > 1,
             "test setup requires lower bound that can advance twice"
         );
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
         let root = H::sync_target_root(&target_db);
 
         let (update_sender, update_receiver) = mpsc::channel(2);
@@ -921,15 +921,12 @@ where
         target_db = H::apply_ops(target_db, H::create_ops(10)).await;
         let initial_target = Target {
             root: H::sync_target_root(&target_db),
-            range: non_empty_range!(
-                target_db.sync_boundary().await,
-                target_db.bounds().await.end
-            ),
+            range: non_empty_range!(target_db.sync_boundary().await, target_db.bounds().end),
         };
 
         target_db = H::apply_ops(target_db, H::create_ops_seeded(5, 1)).await;
         let updated_lower_bound = target_db.sync_boundary().await;
-        let updated_upper_bound = target_db.bounds().await.end;
+        let updated_upper_bound = target_db.bounds().end;
         let updated_target = Target {
             root: H::sync_target_root(&target_db),
             range: non_empty_range!(updated_lower_bound, updated_upper_bound),
@@ -999,7 +996,7 @@ where
             .await
             .expect("sync should succeed after finish signal");
         assert_eq!(synced_db.root(), updated_verification_root);
-        assert_eq!(synced_db.bounds().await.end, updated_upper_bound);
+        assert_eq!(synced_db.bounds().end, updated_upper_bound);
         assert_eq!(synced_db.sync_boundary().await, updated_lower_bound);
 
         synced_db.destroy().await.unwrap();
@@ -1045,7 +1042,7 @@ where
             root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.sync_boundary().await,
-                target_db.bounds().await.end
+                target_db.bounds().end
             ),
         };
 
@@ -1054,7 +1051,7 @@ where
             root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.sync_boundary().await,
-                target_db.bounds().await.end
+                target_db.bounds().end
             ),
         };
 
@@ -1063,7 +1060,7 @@ where
             root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.sync_boundary().await,
-                target_db.bounds().await.end
+                target_db.bounds().end
             ),
         };
         let final_root = target_db.root();
@@ -1138,7 +1135,7 @@ where
             .await
             .expect("sync should succeed after finish signal");
         assert_eq!(synced_db.root(), final_root);
-        assert_eq!(synced_db.bounds().await.end, *second_update.range.end());
+        assert_eq!(synced_db.bounds().end, *second_update.range.end());
         assert_eq!(synced_db.sync_boundary().await, *second_update.range.start());
 
         synced_db.destroy().await.unwrap();
@@ -1162,7 +1159,7 @@ where
         let mut target_db = H::init_db(context.child("target")).await;
         target_db = H::apply_ops(target_db, H::create_ops(30)).await;
         let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
         let target = Target {
             root: H::sync_target_root(&target_db),
             range: non_empty_range!(lower_bound, upper_bound),
@@ -1201,7 +1198,7 @@ where
 
         assert_eq!(reached, target);
         assert_eq!(synced_db.root(), verification_root);
-        assert_eq!(synced_db.bounds().await.end, upper_bound);
+        assert_eq!(synced_db.bounds().end, upper_bound);
         assert_eq!(synced_db.sync_boundary().await, lower_bound);
 
         synced_db.destroy().await.unwrap();
@@ -1225,7 +1222,7 @@ where
         let mut target_db = H::init_db(context.child("target")).await;
         target_db = H::apply_ops(target_db, H::create_ops(10)).await;
         let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
 
         let (finish_sender, finish_receiver) = mpsc::channel(1);
         drop(finish_sender);
@@ -1274,7 +1271,7 @@ where
         let mut target_db = H::init_db(context.child("target")).await;
         target_db = H::apply_ops(target_db, H::create_ops(10)).await;
         let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
         let verification_root = target_db.root();
 
         let (reached_sender, reached_receiver) = mpsc::channel(1);
@@ -1302,7 +1299,7 @@ where
             .await
             .expect("sync should succeed when reached-target receiver is dropped");
         assert_eq!(synced_db.root(), verification_root);
-        assert_eq!(synced_db.bounds().await.end, upper_bound);
+        assert_eq!(synced_db.bounds().end, upper_bound);
         assert_eq!(synced_db.sync_boundary().await, lower_bound);
 
         synced_db.destroy().await.unwrap();
@@ -1333,7 +1330,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
 
         // Capture initial target state
         let initial_lower_bound = target_db.sync_boundary().await;
-        let initial_upper_bound = target_db.bounds().await.end;
+        let initial_upper_bound = target_db.bounds().end;
         let initial_sync_root = H::sync_target_root(&target_db);
 
         // Wrap target database for shared mutable access (using Option so we can take ownership)
@@ -1366,7 +1363,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
                     NextStep::Continue(new_client) => new_client,
                     NextStep::Complete(_) => panic!("client should not be complete"),
                 };
-                let log_size = client.journal().size().await;
+                let log_size = Contiguous::bounds(client.journal()).end;
                 if log_size > initial_lower_bound {
                     break client;
                 }
@@ -1383,7 +1380,7 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
 
             // Capture new target state
             let new_lower_bound = db.sync_boundary().await;
-            let new_upper_bound = db.bounds().await.end;
+            let new_upper_bound = db.bounds().end;
             let new_sync_root = H::sync_target_root(&db);
             let new_verification_root = db.root();
             *db_guard = Some(db);
@@ -1412,8 +1409,8 @@ pub(crate) fn test_target_update_during_sync<H: SyncTestHarness>(
             |rw_lock| rw_lock.into_inner().expect("db should be present"),
         );
         {
-            let synced_bounds = synced_db.bounds().await;
-            let target_bounds = target_db.bounds().await;
+            let synced_bounds = synced_db.bounds();
+            let target_bounds = target_db.bounds();
             assert_eq!(synced_bounds.end, target_bounds.end);
             assert_eq!(
                 synced_db.inactivity_floor_loc().await,
@@ -1446,7 +1443,7 @@ where
         let sync_root = H::sync_target_root(&target_db);
         let verification_root = target_db.root();
         let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
 
         // Perform sync
         let db_config = H::config(&context.next_u64().to_string(), &context);
@@ -1475,7 +1472,7 @@ where
 
         // Save state before dropping
         let expected_root = synced_db.root();
-        let expected_op_count = synced_db.bounds().await.end;
+        let expected_op_count = synced_db.bounds().end;
         let expected_inactivity_floor_loc = synced_db.inactivity_floor_loc().await;
 
         // Re-open the database
@@ -1484,7 +1481,7 @@ where
 
         // Verify the state is unchanged
         assert_eq!(reopened_db.root(), expected_root);
-        assert_eq!(reopened_db.bounds().await.end, expected_op_count);
+        assert_eq!(reopened_db.bounds().end, expected_op_count);
         assert_eq!(
             reopened_db.inactivity_floor_loc().await,
             expected_inactivity_floor_loc
@@ -1515,7 +1512,7 @@ where
 
         let sync_root = H::sync_target_root(&target_db);
         let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
         let target_db = Arc::new(target_db);
 
         let config = H::config(&context.next_u64().to_string(), &context);
@@ -1545,7 +1542,7 @@ where
 
         // Root should change after applying more ops.
         assert_ne!(synced_db.root(), root_after_sync);
-        assert!(synced_db.bounds().await.end > upper_bound);
+        assert!(synced_db.bounds().end > upper_bound);
 
         synced_db.destroy().await.unwrap();
         Arc::try_unwrap(target_db)
@@ -1572,7 +1569,7 @@ where
         // commit already done in apply_ops
 
         let sync_lower_bound = db.sync_boundary().await;
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         let sync_upper_bound = bounds.end;
         let target_db_op_count = bounds.end;
         let target_db_inactivity_floor_loc = db.inactivity_floor_loc().await;
@@ -1592,7 +1589,7 @@ where
         .unwrap();
 
         // Verify database state
-        assert_eq!(sync_db.bounds().await.end, target_db_op_count);
+        assert_eq!(sync_db.bounds().end, target_db_op_count);
         assert_eq!(
             sync_db.inactivity_floor_loc().await,
             target_db_inactivity_floor_loc
@@ -1640,7 +1637,7 @@ where
         // commit already done in apply_ops
 
         // Capture target db state for comparison
-        let bounds = target_db.bounds().await;
+        let bounds = target_db.bounds();
         let target_db_op_count = bounds.end;
         let target_db_inactivity_floor_loc = target_db.inactivity_floor_loc().await;
         let sync_lower_bound = target_db.sync_boundary().await;
@@ -1665,7 +1662,7 @@ where
         .unwrap();
 
         // Verify database state
-        assert_eq!(sync_db.bounds().await.end, target_db_op_count);
+        assert_eq!(sync_db.bounds().end, target_db_op_count);
         assert_eq!(
             sync_db.inactivity_floor_loc().await,
             target_db_inactivity_floor_loc
@@ -1702,12 +1699,12 @@ where
             .unwrap();
 
         let lower_bound = source_db.sync_boundary().await;
-        let upper_bound = source_db.bounds().await.end;
+        let upper_bound = source_db.bounds().end;
 
         // Get pinned nodes and target hash before deconstructing source_db
         let pinned_nodes = source_db.pinned_nodes_at(lower_bound).await;
         let target_hash = source_db.root();
-        let target_op_count = source_db.bounds().await.end;
+        let target_op_count = source_db.bounds().end;
         let target_inactivity_floor = source_db.inactivity_floor_loc().await;
 
         let (mmr, journal) = source_db.into_log_components();
@@ -1727,7 +1724,7 @@ where
         .unwrap();
 
         // Verify database state
-        assert_eq!(db.bounds().await.end, target_op_count);
+        assert_eq!(db.bounds().end, target_op_count);
         assert_eq!(db.inactivity_floor_loc().await, target_inactivity_floor);
         assert_eq!(db.sync_boundary().await, lower_bound);
 
@@ -1752,7 +1749,7 @@ where
         let source_db = H::init_db(context.child("source")).await;
 
         // An empty database has exactly 1 operation (the initial CommitFloor)
-        assert_eq!(source_db.bounds().await.end, Location::new(1));
+        assert_eq!(source_db.bounds().end, Location::new(1));
 
         let target_hash = source_db.root();
         let (mmr, journal) = source_db.into_log_components();
@@ -1772,7 +1769,7 @@ where
         .unwrap();
 
         // Verify database state
-        assert_eq!(synced_db.bounds().await.end, Location::new(1));
+        assert_eq!(synced_db.bounds().end, Location::new(1));
         assert_eq!(synced_db.inactivity_floor_loc().await, Location::new(0));
         assert_eq!(synced_db.root(), target_hash);
 
@@ -1781,7 +1778,7 @@ where
         synced_db = H::apply_ops(synced_db, ops).await;
 
         // Verify the operations worked
-        assert!(synced_db.bounds().await.end > Location::new(1));
+        assert!(synced_db.bounds().end > Location::new(1));
 
         synced_db.destroy().await.unwrap();
         mmr.destroy().await.unwrap();
@@ -1860,7 +1857,7 @@ where
 
         let sync_root = H::sync_target_root(&target_db);
         let lower_bound = target_db.sync_boundary().await;
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
 
         let db_config = H::config(&context.next_u64().to_string(), &context);
 
@@ -2008,7 +2005,7 @@ where
             root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.inactivity_floor_loc().await,
-                target_db.bounds().await.end
+                target_db.bounds().end
             ),
         };
 
@@ -2017,7 +2014,7 @@ where
             root: H::sync_target_root(&target_db),
             range: non_empty_range!(
                 target_db.inactivity_floor_loc().await,
-                target_db.bounds().await.end
+                target_db.bounds().end
             ),
         };
         let verification_root = target_db.root();
@@ -2067,7 +2064,7 @@ where
 
         let _ = release_historical_gap_tx.send(());
 
-        let journal_start = engine.journal().size().await;
+        let journal_start = engine.journal().bounds().end;
         for step_idx in 0..4 {
             let next_step = engine.step();
             pin_mut!(next_step);
@@ -2079,7 +2076,7 @@ where
                         NextStep::Complete(_) => panic!("boundary retry should still be required"),
                     };
                     assert_eq!(
-                        engine.journal().size().await,
+                        engine.journal().bounds().end,
                         journal_start,
                         "replayed fresh boundary responses must not advance the journal"
                     );

--- a/storage/src/qmdb/any/traits.rs
+++ b/storage/src/qmdb/any/traits.rs
@@ -88,11 +88,11 @@ pub trait DbAny<F: Family>:
 
     /// Return [start, end) where `start` and `end - 1` are the Locations of the oldest and newest
     /// retained operations respectively.
-    fn bounds(&self) -> impl Future<Output = Range<Location<F>>> + Send;
+    fn bounds(&self) -> Range<Location<F>>;
 
     /// Return the Location of the next operation appended to this db.
-    fn size(&self) -> impl Future<Output = Location<F>> + Send {
-        async { self.bounds().await.end }
+    fn size(&self) -> Location<F> {
+        self.bounds().end
     }
 
     /// Get the metadata associated with the last commit.
@@ -145,7 +145,7 @@ pub trait Provable<F: Family>: DbAny<F> {
     ) -> impl Future<Output = Result<(Proof<F, Self::Digest>, Vec<Self::Operation>), Error<F>>> + Send
     {
         async move {
-            self.historical_proof(self.bounds().await.end, start_loc, max_ops)
+            self.historical_proof(self.bounds().end, start_loc, max_ops)
                 .await
         }
     }
@@ -192,8 +192,8 @@ macro_rules! impl_db_any {
                 <$ty>::root(self)
             }
 
-            async fn bounds(&self) -> ::std::ops::Range<$crate::merkle::Location<$fam>> {
-                <$ty>::bounds(self).await
+            fn bounds(&self) -> ::std::ops::Range<$crate::merkle::Location<$fam>> {
+                <$ty>::bounds(self)
             }
 
             async fn get_metadata(

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -858,7 +858,7 @@ pub(crate) mod test {
             let ops = create_test_ops(20);
             apply_ops(&mut db, ops.clone()).await;
             let root_hash = db.root();
-            let original_op_count = db.bounds().await.end;
+            let original_op_count = db.bounds().end;
 
             // Historical proof should match "regular" proof when historical size == current database size
             let max_ops = NZU64!(10);
@@ -906,7 +906,7 @@ pub(crate) mod test {
             // Try to get historical proof with op_count > number of operations and confirm it
             // returns RangeOutOfBounds error.
             assert!(matches!(
-                db.historical_proof(db.bounds().await.end + 1, Location::new(6), NZU64!(10))
+                db.historical_proof(db.bounds().end + 1, Location::new(6), NZU64!(10))
                     .await,
                 Err(Error::Merkle(crate::mmr::Error::RangeOutOfBounds(_)))
             ));
@@ -927,11 +927,11 @@ pub(crate) mod test {
             let mut commit_boundary_sizes: Vec<Location> = Vec::new();
             for _ in 0..5 {
                 apply_ops(&mut db, create_test_ops(10)).await;
-                commit_boundary_sizes.push(db.bounds().await.end);
+                commit_boundary_sizes.push(db.bounds().end);
             }
 
             let root = db.root();
-            let full_size = db.bounds().await.end;
+            let full_size = db.bounds().end;
             assert_eq!(full_size, *commit_boundary_sizes.last().unwrap());
 
             // Verify a single-op proof at the full commit size.
@@ -999,7 +999,7 @@ pub(crate) mod test {
                 apply_ops(&mut db, ops[offset..offset + chunk].to_vec()).await;
                 offset += chunk;
 
-                let end_loc = db.bounds().await.end;
+                let end_loc = db.bounds().end;
                 let root = db.root();
                 let (proof, proof_ops) = db.proof(start_loc, max_ops).await.unwrap();
                 checkpoints.push((end_loc, root, proof, proof_ops));

--- a/storage/src/qmdb/any/unordered/mod.rs
+++ b/storage/src/qmdb/any/unordered/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     index::Unordered as Index,
-    journal::contiguous::{Contiguous, Reader},
+    journal::contiguous::Contiguous,
     merkle::{Family, Location},
     qmdb::{
         any::{db::Db, ValueEncoding},
@@ -39,9 +39,8 @@ where
         // Collect to avoid holding a borrow across await points (rust-lang/rust#100013).
         let locs: Vec<Location<F>> = self.snapshot.get(key).copied().collect();
 
-        let reader = self.log.reader().await;
         for loc in locs {
-            let op = reader.read(*loc).await?;
+            let op = self.log.read(*loc).await?;
             match &op {
                 Operation::Update(Update(k, value)) => {
                     if k == key {

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -378,7 +378,7 @@ pub(crate) mod test {
             let inactivity_floor = db.inactivity_floor_loc();
             db.sync().await.unwrap(); // test pruning boundary after sync w/ prune
             db.prune(inactivity_floor).await.unwrap();
-            let bounds = db.bounds().await;
+            let bounds = db.bounds();
             let snapshot_items = db.snapshot.items();
 
             db.sync().await.unwrap();
@@ -387,7 +387,7 @@ pub(crate) mod test {
             // Confirm state is preserved after reopen.
             let db = open_db(context.child("open").with_attribute("index", 5)).await;
             assert_eq!(root, db.root());
-            assert_eq!(db.bounds().await, bounds);
+            assert_eq!(db.bounds(), bounds);
             assert_eq!(db.inactivity_floor_loc(), inactivity_floor);
             assert_eq!(db.snapshot.items(), snapshot_items);
 
@@ -457,7 +457,7 @@ pub(crate) mod test {
             // Apply the first -- should succeed.
             db.apply_batch(batch_a).await.unwrap();
             let expected_root = db.root();
-            let expected_bounds = db.bounds().await;
+            let expected_bounds = db.bounds();
             assert_eq!(db.get(&key1).await.unwrap(), Some(vec![10]));
             assert_eq!(db.get(&key2).await.unwrap(), None);
 
@@ -468,7 +468,7 @@ pub(crate) mod test {
                 "expected StaleBatch error, got {result:?}"
             );
             assert_eq!(db.root(), expected_root);
-            assert_eq!(db.bounds().await, expected_bounds);
+            assert_eq!(db.bounds(), expected_bounds);
             assert_eq!(db.get(&key1).await.unwrap(), Some(vec![10]));
             assert_eq!(db.get(&key2).await.unwrap(), None);
 

--- a/storage/src/qmdb/benches/init.rs
+++ b/storage/src/qmdb/benches/init.rs
@@ -86,7 +86,7 @@ fn bench_fixed_value_init(c: &mut Criterion) {
                     b.to_async(&runner).iter_custom(|iters| async move {
                         let ctx = context::get::<Context>();
                         dispatch_fixed_timed_init!(ctx, variant, iters, |db| {
-                            assert_ne!(db.bounds().await.end, 0);
+                            assert_ne!(db.bounds().end, 0);
                         })
                     });
                 },
@@ -148,7 +148,7 @@ fn bench_var_value_init(c: &mut Criterion) {
                     b.to_async(&runner).iter_custom(|iters| async move {
                         let ctx = context::get::<Context>();
                         dispatch_var_timed_init!(ctx, variant, iters, |db| {
-                            assert_ne!(db.bounds().await.end, 0);
+                            assert_ne!(db.bounds().end, 0);
                         })
                     });
                 },

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -14,7 +14,7 @@
 //! entry is never pruned.
 
 use crate::{
-    journal::contiguous::{variable, Reader as _},
+    journal::contiguous::{variable, Contiguous},
     merkle::{
         self, compact, Family, Location, Proof, MAX_PINNED_NODES, MAX_PROOF_DIGESTS_PER_ELEMENT,
     },
@@ -332,17 +332,14 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     pub(crate) async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
         self.check_import_persisted()?;
 
-        let reader = self.journal.reader();
-        let bounds = reader.bounds();
+        let bounds = self.journal.bounds();
         if bounds.is_empty() {
             return Ok(());
         }
         // Clamp below the tip so the journal never empties: the tip is the current state.
-        let pos = Self::first_at_or_above(&reader, pruning_boundary)
+        let pos = Self::first_at_or_above(&self.journal, pruning_boundary)
             .await?
             .min(bounds.end - 1);
-        // Release the read guard before mutating the journal.
-        drop(reader);
         self.journal.prune(pos).await?;
         self.journal.sync().await?;
         Ok(())
@@ -368,19 +365,18 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         &self,
         target: Location<F>,
     ) -> Result<Option<(u64, Witness<F, D>)>, Error<F>> {
-        let reader = self.journal.reader();
-        let pos = Self::first_at_or_above(&reader, target).await?;
-        if pos >= reader.bounds().end {
+        let pos = Self::first_at_or_above(&self.journal, target).await?;
+        if pos >= self.journal.bounds().end {
             return Ok(None);
         }
-        let entry = reader.read(pos).await?;
+        let entry = self.journal.read(pos).await?;
         Ok((entry.proof.leaves == target).then_some((pos, entry)))
     }
 
     /// Binary search for the first retained position whose entry commits at least `leaf_count`
     /// leaves, or the end of the journal if none does.
     async fn first_at_or_above(
-        reader: &variable::Reader<E, Witness<F, D>>,
+        reader: &impl Contiguous<Item = Witness<F, D>>,
         leaf_count: Location<F>,
     ) -> Result<u64, Error<F>> {
         let bounds = reader.bounds();
@@ -484,10 +480,7 @@ where
     if size == 0 {
         return Err(Error::DataCorrupted("missing compact witness"));
     }
-    let entry = {
-        let reader = journal.reader();
-        reader.read(size - 1).await?
-    };
+    let entry = journal.read(size - 1).await?;
     rebuild_and_verify::<F, H::Digest, H, S, Op>(
         entry,
         merkle,
@@ -632,9 +625,8 @@ pub(crate) mod tests {
     {
         let mut entries = Vec::new();
         {
-            let reader = journal.reader();
-            for p in pos..reader.bounds().end {
-                entries.push(reader.read(p).await.unwrap());
+            for p in pos..journal.bounds().end {
+                entries.push(journal.read(p).await.unwrap());
             }
         }
         f(&mut entries[0]);
@@ -653,10 +645,7 @@ pub(crate) mod tests {
         D: Digest,
     {
         let size = journal.size();
-        let entry = {
-            let reader = journal.reader();
-            reader.read(size - 1).await.unwrap()
-        };
+        let entry = journal.read(size - 1).await.unwrap();
         (entry.op_bytes, entry.proof, entry.pinned_nodes)
     }
 

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -5,7 +5,7 @@
 use crate::{
     index::Unordered as UnorderedIndex,
     journal::{
-        contiguous::{Contiguous, Mutable, Reader},
+        contiguous::{Contiguous, Mutable},
         Error as JournalError,
     },
     merkle::{
@@ -199,8 +199,8 @@ where
 
     /// Return [start, end) where `start` and `end - 1` are the Locations of the oldest and newest
     /// retained operations respectively.
-    pub async fn bounds(&self) -> std::ops::Range<Location<F>> {
-        self.any.bounds().await
+    pub fn bounds(&self) -> std::ops::Range<Location<F>> {
+        self.any.bounds()
     }
 
     /// Return true if the given sequence of `ops` were applied starting at location `start_loc`
@@ -545,7 +545,7 @@ where
         self.sync_metadata().await?;
 
         self.any.prune_log(prune_loc).await?;
-        self.any.update_metrics().await;
+        self.any.update_metrics();
         self.update_metrics();
         Ok(())
     }
@@ -604,9 +604,8 @@ where
         // to a commit with floor below `pruned_bits` would require bitmap chunks we've already
         // discarded.
         {
-            let reader = self.any.log.reader().await;
             let rewind_last_loc = Location::<F>::new(rewind_size - 1);
-            let rewind_last_op = reader.read(*rewind_last_loc).await?;
+            let rewind_last_op = self.any.log.read(*rewind_last_loc).await?;
             let Some(rewind_floor) = rewind_last_op.has_floor() else {
                 return Err(Error::<F>::UnexpectedData(rewind_last_loc));
             };

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -763,12 +763,12 @@ pub mod tests {
             .await
             .unwrap();
         let committed_root = db.root();
-        let committed_size = db.size().await;
+        let committed_size = db.size();
         drop(db);
 
         let db: C = Box::pin(open_db(context.child("second"), partition)).await;
         assert_eq!(db.root(), committed_root);
-        assert_eq!(db.size().await, committed_size);
+        assert_eq!(db.size(), committed_size);
         assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
         assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
 
@@ -798,7 +798,7 @@ pub mod tests {
             .unwrap();
         commit_writes(&mut db, []).await.unwrap();
         let committed_root = db.root();
-        let committed_op_count = db.bounds().await.end;
+        let committed_op_count = db.bounds().end;
         db.prune(db.sync_boundary().await).await.unwrap();
 
         // Perform more random operations without committing any of them.
@@ -815,7 +815,7 @@ pub mod tests {
         ))
         .await;
         assert_eq!(db.root(), committed_root);
-        assert_eq!(db.bounds().await.end, committed_op_count);
+        assert_eq!(db.bounds().end, committed_op_count);
 
         // Re-apply the exact same operations, this time committed.
         let db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed + 1, db)
@@ -825,7 +825,7 @@ pub mod tests {
         // SCENARIO #2: Simulate a crash that happens after the any db has been committed, but
         // before sync/prune is called. We do this by dropping the db without calling
         // sync or prune.
-        let committed_op_count = db.bounds().await.end;
+        let committed_op_count = db.bounds().end;
         drop(db);
 
         // We should be able to recover, so the root should differ from the previous commit, and
@@ -850,7 +850,7 @@ pub mod tests {
             .unwrap();
         db.prune(db.sync_boundary().await).await.unwrap();
         // State from scenario #2 should match that of a successful commit.
-        assert_eq!(db.bounds().await.end, committed_op_count);
+        assert_eq!(db.bounds().end, committed_op_count);
         assert_eq!(db.root(), scenario_2_root);
 
         db.destroy().await.unwrap();
@@ -970,7 +970,7 @@ pub mod tests {
             "pruned_bits_before={}, inactivity_floor={}, op_count={}",
             pruned_bits_before,
             *db.inactivity_floor_loc().await,
-            *db.bounds().await.end
+            *db.bounds().end
         );
 
         // Verify we actually have some pruning (otherwise the test is meaningless).
@@ -1120,7 +1120,7 @@ pub mod tests {
 
         db.apply_batch(batch_a).await.unwrap();
         let expected_root = db.root();
-        let expected_bounds = db.bounds().await;
+        let expected_bounds = db.bounds();
         let expected_metadata = db.get_metadata().await.unwrap();
         assert_eq!(db.get(&key1).await.unwrap(), Some(value1.clone()));
         assert_eq!(db.get(&key2).await.unwrap(), None);
@@ -1131,7 +1131,7 @@ pub mod tests {
             "expected StaleBatch error, got {result:?}"
         );
         assert_eq!(db.root(), expected_root);
-        assert_eq!(db.bounds().await, expected_bounds);
+        assert_eq!(db.bounds(), expected_bounds);
         assert_eq!(db.get_metadata().await.unwrap(), expected_metadata);
         assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
         assert_eq!(db.get(&key2).await.unwrap(), None);
@@ -1564,7 +1564,7 @@ pub mod tests {
             )
             .await
             .unwrap();
-            let initial_size = db.bounds().await.end;
+            let initial_size = db.bounds().end;
             let initial_root = db.root();
             let initial_ops_root = db.ops_root();
             let initial_floor = db.inactivity_floor_loc();
@@ -1577,7 +1577,7 @@ pub mod tests {
             )
             .await;
             assert_eq!(first_range.start, initial_size);
-            let size_before = db.bounds().await.end;
+            let size_before = db.bounds().end;
             let root_before = db.root();
             let ops_root_before = db.ops_root();
             let floor_before = db.inactivity_floor_loc();
@@ -1602,7 +1602,7 @@ pub mod tests {
             assert_eq!(db.get(&key(2)).await.unwrap(), Some(val(2)));
 
             db.rewind(size_before).await.unwrap();
-            assert_eq!(db.bounds().await.end, size_before);
+            assert_eq!(db.bounds().end, size_before);
             assert_eq!(db.root(), root_before);
             assert_eq!(db.ops_root(), ops_root_before);
             assert_eq!(db.inactivity_floor_loc(), floor_before);
@@ -1620,7 +1620,7 @@ pub mod tests {
             )
             .await
             .unwrap();
-            assert_eq!(reopened.bounds().await.end, size_before);
+            assert_eq!(reopened.bounds().end, size_before);
             assert_eq!(reopened.root(), root_before);
             assert_eq!(reopened.ops_root(), ops_root_before);
             assert_eq!(reopened.inactivity_floor_loc(), floor_before);
@@ -1631,7 +1631,7 @@ pub mod tests {
 
             let mut reopened = reopened;
             reopened.rewind(initial_size).await.unwrap();
-            assert_eq!(reopened.bounds().await.end, initial_size);
+            assert_eq!(reopened.bounds().end, initial_size);
             assert_eq!(reopened.root(), initial_root);
             assert_eq!(reopened.ops_root(), initial_ops_root);
             assert_eq!(reopened.inactivity_floor_loc(), initial_floor);
@@ -1649,7 +1649,7 @@ pub mod tests {
             )
             .await
             .unwrap();
-            assert_eq!(reopened_initial.bounds().await.end, initial_size);
+            assert_eq!(reopened_initial.bounds().end, initial_size);
             assert_eq!(reopened_initial.root(), initial_root);
             assert_eq!(reopened_initial.ops_root(), initial_ops_root);
             assert_eq!(reopened_initial.inactivity_floor_loc(), initial_floor);
@@ -1685,7 +1685,7 @@ pub mod tests {
                 )
                 .await;
                 history.push((
-                    db.bounds().await.end,
+                    db.bounds().end,
                     db.inactivity_floor_loc(),
                     db.root(),
                     db.ops_root(),
@@ -1698,7 +1698,7 @@ pub mod tests {
             db.prune(Location::new(1)).await.unwrap();
             let pruned_bits = db.pruned_bits();
             assert!(pruned_bits > 0, "expected bitmap pruning for rewind test");
-            let bounds = db.bounds().await;
+            let bounds = db.bounds();
 
             let (target_size, target_root, target_ops_root, target_value) = history
                 .iter()
@@ -1721,7 +1721,7 @@ pub mod tests {
             db.rewind(target_size).await.unwrap();
             assert_eq!(db.root(), target_root);
             assert_eq!(db.ops_root(), target_ops_root);
-            assert_eq!(db.bounds().await.end, target_size);
+            assert_eq!(db.bounds().end, target_size);
             assert_eq!(db.get(&key0).await.unwrap(), Some(target_value));
 
             db.commit().await.unwrap();
@@ -1735,7 +1735,7 @@ pub mod tests {
             .unwrap();
             assert_eq!(reopened.root(), target_root);
             assert_eq!(reopened.ops_root(), target_ops_root);
-            assert_eq!(reopened.bounds().await.end, target_size);
+            assert_eq!(reopened.bounds().end, target_size);
             assert_eq!(reopened.get(&key0).await.unwrap(), Some(target_value));
 
             let metadata_after_rewind = val(30_000);
@@ -1750,7 +1750,7 @@ pub mod tests {
             .end;
             let root_after_new_write = reopened.root();
             let ops_root_after_new_write = reopened.ops_root();
-            assert_eq!(reopened.bounds().await.end, expected_end);
+            assert_eq!(reopened.bounds().end, expected_end);
             assert_eq!(reopened.get_metadata().await.unwrap(), Some(metadata_after_rewind));
             assert_eq!(reopened.get(&key0).await.unwrap(), Some(target_value));
             assert_eq!(reopened.get(&new_key).await.unwrap(), Some(new_value));
@@ -1764,7 +1764,7 @@ pub mod tests {
             .unwrap();
             assert_eq!(reopened_after_new_write.root(), root_after_new_write);
             assert_eq!(reopened_after_new_write.ops_root(), ops_root_after_new_write);
-            assert_eq!(reopened_after_new_write.bounds().await.end, expected_end);
+            assert_eq!(reopened_after_new_write.bounds().end, expected_end);
             assert_eq!(
                 reopened_after_new_write.get_metadata().await.unwrap(),
                 Some(metadata_after_rewind)
@@ -1871,7 +1871,7 @@ pub mod tests {
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
                 db.apply_batch(merkleized).await.unwrap();
                 db.commit().await.unwrap();
-                history.push((db.bounds().await.end, db.inactivity_floor_loc()));
+                history.push((db.bounds().end, db.inactivity_floor_loc()));
             }
 
             db.prune(db.sync_boundary()).await.unwrap();
@@ -1961,10 +1961,10 @@ pub mod tests {
                 "delayed-merge lag must be strictly active: boundary={boundary}, floor={floor}"
             );
             assert!(
-                db.bounds().await.start <= boundary,
+                db.bounds().start <= boundary,
                 "ops journal was pruned past the settled bitmap boundary: \
                  bounds.start={}, boundary={boundary}",
-                db.bounds().await.start
+                db.bounds().start
             );
 
             db.destroy().await.unwrap();
@@ -2009,9 +2009,9 @@ pub mod tests {
                 "MMR lag should be only chunk alignment: boundary={boundary}, floor={floor}, chunk_bits={chunk_bits}"
             );
             assert!(
-                db.bounds().await.start <= boundary,
+                db.bounds().start <= boundary,
                 "ops journal bounds must be <= sync_boundary: bounds.start={}, boundary={boundary}",
-                db.bounds().await.start
+                db.bounds().start
             );
 
             db.destroy().await.unwrap();
@@ -2044,9 +2044,9 @@ pub mod tests {
             db.prune(small).await.unwrap();
 
             assert!(
-                db.bounds().await.start <= small,
+                db.bounds().start <= small,
                 "journal pruning exceeded the caller-supplied target: bounds.start={}, requested={small}",
-                db.bounds().await.start
+                db.bounds().start
             );
 
             db.destroy().await.unwrap();
@@ -2479,7 +2479,7 @@ pub mod tests {
                 .await;
 
                 history.push((
-                    db.bounds().await.end,
+                    db.bounds().end,
                     db.root(),
                     db.ops_root(),
                     key0_value,
@@ -2493,7 +2493,7 @@ pub mod tests {
             let (target_size, target_root, target_ops_root, target_key0, target_key1) = target;
 
             db.rewind(target_size).await.unwrap();
-            assert_eq!(db.bounds().await.end, target_size);
+            assert_eq!(db.bounds().end, target_size);
             assert_eq!(db.root(), target_root);
             assert_eq!(db.ops_root(), target_ops_root);
             assert_eq!(db.get(&key0).await.unwrap(), Some(target_key0));
@@ -2508,7 +2508,7 @@ pub mod tests {
             )
             .await
             .unwrap();
-            assert_eq!(reopened.bounds().await.end, target_size);
+            assert_eq!(reopened.bounds().end, target_size);
             assert_eq!(reopened.root(), target_root);
             assert_eq!(reopened.ops_root(), target_ops_root);
             assert_eq!(reopened.get(&key0).await.unwrap(), Some(target_key0));
@@ -2552,7 +2552,7 @@ pub mod tests {
                 first_range.start
             );
 
-            let oldest_retained = db.bounds().await.start;
+            let oldest_retained = db.bounds().start;
             let boundary_err = db.rewind(oldest_retained).await.unwrap_err();
             assert!(
                 matches!(
@@ -2598,7 +2598,7 @@ pub mod tests {
                     None,
                 )
                 .await;
-                history.push((db.bounds().await.end, db.inactivity_floor_loc()));
+                history.push((db.bounds().end, db.inactivity_floor_loc()));
             }
             assert!(db.inactivity_floor_loc() > Location::new(64));
 
@@ -2608,7 +2608,7 @@ pub mod tests {
             db.prune(prune_loc).await.unwrap();
             let pruned_bits = db.pruned_bits();
             assert!(pruned_bits > 0);
-            let retained_start = db.bounds().await.start;
+            let retained_start = db.bounds().start;
 
             // Pick a historical commit that is still within retained log bounds but whose floor is
             // below the bitmap pruning boundary.
@@ -3789,7 +3789,7 @@ pub mod tests {
             commit_writes(&mut db, writes).await.unwrap();
 
             let ops_root = db.ops_root();
-            let historical_size = db.bounds().await.end;
+            let historical_size = db.bounds().end;
             let (proof, ops) = db
                 .ops_historical_proof(historical_size, Location::new(0), NZU64!(32))
                 .await

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     index::Ordered as OrderedIndex,
-    journal::contiguous::{Contiguous, Mutable, Reader},
+    journal::contiguous::{Contiguous, Mutable},
     merkle::{self, hasher::Standard as StandardHasher, Location},
     qmdb::{
         any::{
@@ -243,13 +243,7 @@ where
                 // The DB is empty. Use the last CommitFloor to prove emptiness. The Commit proof
                 // variant requires the CommitFloor's floor to equal its own location (genuinely
                 // empty at commit time). If this doesn't hold, the persisted state is inconsistent.
-                let op = self
-                    .any
-                    .log
-                    .reader()
-                    .await
-                    .read(*self.any.last_commit_loc)
-                    .await?;
+                let op = self.any.log.read(*self.any.last_commit_loc).await?;
                 let Operation::CommitFloor(value, floor) = op else {
                     unreachable!("last_commit_loc should always point to a CommitFloor");
                 };

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -151,7 +151,7 @@ pub mod tests {
     use super::{db, ExclusionProof};
     use crate::{
         index::ordered::Index,
-        journal::contiguous::Mutable,
+        journal::contiguous::{Contiguous as _, Mutable},
         merkle::{Graftable, Location, Proof},
         mmb,
         qmdb::{
@@ -273,7 +273,7 @@ pub mod tests {
         assert_ne!(root3, root2);
 
         // Confirm all activity bits except the last are false.
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         for i in 0..*bounds.end - 1 {
             assert!(!db.get_bit(i));
         }
@@ -503,7 +503,7 @@ pub mod tests {
             // Make sure size-constrained batches of operations are provable from the oldest
             // retained op to tip.
             let max_ops = 4;
-            let end_loc = db.bounds().await.end;
+            let end_loc = db.bounds().end;
             let start_loc = db.any.inactivity_floor_loc();
 
             for loc in *start_loc..*end_loc {
@@ -571,7 +571,7 @@ pub mod tests {
                 }
                 // Found an active operation! Create a proof for its active current key/value if
                 // it's a key-updating operation.
-                let op = db.any.log.read(Location::<F>::new(i)).await.unwrap();
+                let op = db.any.log.read(*Location::<F>::new(i)).await.unwrap();
                 let (key, value) = match op {
                     Operation::Update(key_data) => (key_data.key, key_data.value),
                     Operation::CommitFloor(_, _) => continue,
@@ -851,7 +851,7 @@ pub mod tests {
             // This root should be different than the empty root from earlier since the DB now has a
             // non-zero number of operations.
             assert!(db.is_empty());
-            assert_ne!(db.bounds().await.end, 0);
+            assert_ne!(db.bounds().end, 0);
             assert_ne!(root, empty_root);
 
             let proof = db.exclusion_proof(&hasher, &key_exists_1).await.unwrap();

--- a/storage/src/qmdb/current/ordered/test_trait_impls.rs
+++ b/storage/src/qmdb/current/ordered/test_trait_impls.rs
@@ -83,7 +83,7 @@ impl<
     }
 
     async fn oldest_retained(&self) -> u64 {
-        *self.any.bounds().await.start
+        *self.any.bounds().start
     }
 }
 
@@ -109,7 +109,7 @@ where
     }
 
     async fn oldest_retained(&self) -> u64 {
-        *self.any.bounds().await.start
+        *self.any.bounds().start
     }
 }
 
@@ -154,7 +154,7 @@ impl<
     }
 
     async fn oldest_retained(&self) -> u64 {
-        *self.any.bounds().await.start
+        *self.any.bounds().start
     }
 }
 
@@ -201,6 +201,6 @@ where
     }
 
     async fn oldest_retained(&self) -> u64 {
-        *self.any.bounds().await.start
+        *self.any.bounds().start
     }
 }

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -28,7 +28,7 @@
 //! pending hashes in before partial.
 
 use crate::{
-    journal::contiguous::{Contiguous, Reader as _},
+    journal::contiguous::Contiguous,
     merkle::{
         self,
         hasher::{Hasher, Standard as StandardHasher},
@@ -282,9 +282,8 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         .await?;
 
         // Collect the operations necessary to verify the proof.
-        let reader = log.reader().await;
         let futures = (*request.start_loc..*end_loc)
-            .map(|i| reader.read(i))
+            .map(|i| log.read(i))
             .collect::<Vec<_>>();
         let ops = try_join_all(futures).await?;
 

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     index::Factory as IndexFactory,
     journal::{
         authenticated,
-        contiguous::{fixed, variable, Contiguous, Mutable, Reader as _},
+        contiguous::{fixed, variable, Contiguous, Mutable},
     },
     merkle::{
         full::{self, Merkle},
@@ -307,8 +307,7 @@ macro_rules! impl_current_sync_database {
                     return Ok(None);
                 }
 
-                let reader = Contiguous::reader(journal).await;
-                let bounds = reader.bounds();
+                let bounds = journal.bounds();
                 if Location::new(bounds.start) > target.range.start()
                     || Location::new(bounds.end) != target.range.end()
                 {
@@ -316,12 +315,11 @@ macro_rules! impl_current_sync_database {
                 }
 
                 let inactivity_floor = qmdb::find_inactivity_floor_at::<F, _>(
-                    &reader,
+                    journal,
                     target.range.end(),
                     |op| op.has_floor(),
                 )
                 .await?;
-                drop(reader);
 
                 let hasher = qmdb::hasher::<H>();
                 let merkle = Merkle::<F, _, _, S>::init(

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -521,7 +521,7 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
         let sync_root = SyncDatabase::root(&target_db);
         let verification_root = target_db.root();
         let lower_bound = target_db.sync_boundary();
-        let upper_bound = target_db.bounds().await.end;
+        let upper_bound = target_db.bounds().end;
 
         let client_suffix = context.next_u64().to_string();
         let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
@@ -606,7 +606,7 @@ fn test_current_local_boundary_nodes_rejects_target_before_local_lower_bound() {
         assert!(db.sync_boundary() >= prune_loc);
         db.prune(prune_loc).await.unwrap();
 
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         let local_start = bounds.start;
         let local_end = bounds.end;
         let sync_root = SyncDatabase::root(&db);

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -20,7 +20,7 @@ pub mod tests {
     use super::db;
     use crate::{
         index::unordered::Index,
-        journal::contiguous::Mutable,
+        journal::contiguous::{Contiguous as _, Mutable},
         merkle::{Graftable, Location, Proof},
         qmdb::{
             any::{
@@ -139,7 +139,7 @@ pub mod tests {
         assert_eq!(db.root(), root3);
 
         // Confirm all activity bits are false except for the last commit.
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         for i in 0..*bounds.end - 1 {
             assert!(!db.get_bit(i));
         }
@@ -354,7 +354,7 @@ pub mod tests {
             // Make sure size-constrained batches of operations are provable from the oldest
             // retained op to tip.
             let max_ops = 4;
-            let end_loc = db.bounds().await.end;
+            let end_loc = db.bounds().end;
             let start_loc = db.any.inactivity_floor_loc();
 
             for loc in *start_loc..*end_loc {
@@ -422,7 +422,7 @@ pub mod tests {
                 }
                 // Found an active operation! Create a proof for its active current key/value if
                 // it's a key-updating operation.
-                let (key, value) = match db.any.log.read(Location::<F>::new(i)).await.unwrap() {
+                let (key, value) = match db.any.log.read(*Location::<F>::new(i)).await.unwrap() {
                     Operation::Update(UnorderedUpdate(key, value)) => (key, value),
                     Operation::CommitFloor(_, _) => continue,
                     Operation::Delete(_) => {

--- a/storage/src/qmdb/current/unordered/test_trait_impls.rs
+++ b/storage/src/qmdb/current/unordered/test_trait_impls.rs
@@ -82,7 +82,7 @@ impl<
     }
 
     async fn oldest_retained(&self) -> u64 {
-        *self.any.bounds().await.start
+        *self.any.bounds().start
     }
 }
 
@@ -108,7 +108,7 @@ where
     }
 
     async fn oldest_retained(&self) -> u64 {
-        *self.any.bounds().await.start
+        *self.any.bounds().start
     }
 }
 
@@ -152,7 +152,7 @@ impl<
     }
 
     async fn oldest_retained(&self) -> u64 {
-        *self.any.bounds().await.start
+        *self.any.bounds().start
     }
 }
 
@@ -199,6 +199,6 @@ where
     }
 
     async fn oldest_retained(&self) -> u64 {
-        *self.any.bounds().await.start
+        *self.any.bounds().start
     }
 }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -81,7 +81,7 @@ use crate::{
     index::{unordered::Index, Unordered as _},
     journal::{
         authenticated,
-        contiguous::{Contiguous, Mutable, Reader},
+        contiguous::{Contiguous, Mutable},
     },
     merkle::{full::Config as MerkleConfig, Family, Location, Proof},
     qmdb::{
@@ -218,7 +218,7 @@ where
         context: E,
         translator: T,
     ) -> Result<Self, Error<F>> {
-        if journal.size().await == 0 {
+        if journal.size() == 0 {
             warn!("Authenticated log is empty, initialized new db.");
             journal
                 .append(&Operation::Commit(None, Location::new(0)))
@@ -229,13 +229,12 @@ where
         let mut snapshot = Index::new(context.child("snapshot"), translator);
 
         let (last_commit_loc, inactivity_floor_loc) = {
-            let reader = journal.journal.reader().await;
-            let bounds = reader.bounds();
+            let bounds = journal.journal.bounds();
             let last_commit_loc =
                 Location::new(bounds.end.checked_sub(1).expect("commit should exist"));
 
             // Read the floor from the last commit operation.
-            let last_op = reader.read(*last_commit_loc).await?;
+            let last_op = journal.journal.read(*last_commit_loc).await?;
             let inactivity_floor_loc = last_op
                 .has_floor()
                 .expect("last operation should be a commit with floor");
@@ -246,7 +245,7 @@ where
             // Replay the log from the inactivity floor to build the snapshot.
             build_snapshot_from_log::<F, _, _, _>(
                 inactivity_floor_loc,
-                &reader,
+                &journal.journal,
                 &mut snapshot,
                 |_, _| {},
             )
@@ -269,7 +268,7 @@ where
             inactivity_floor_loc,
             metrics,
         };
-        db.update_metrics().await;
+        db.update_metrics();
         Ok(db)
     }
 
@@ -279,20 +278,19 @@ where
     }
 
     /// Return the Location of the next operation appended to this db.
-    pub async fn size(&self) -> Location<F> {
-        self.bounds().await.end
+    pub fn size(&self) -> Location<F> {
+        self.bounds().end
     }
 
     /// Return [start, end) where `start` and `end - 1` are the Locations of the oldest and newest
     /// retained operations respectively.
-    pub async fn bounds(&self) -> Range<Location<F>> {
-        let bounds = self.journal.reader().await.bounds();
-        Location::new(bounds.start)..Location::new(bounds.end)
+    pub fn bounds(&self) -> Range<Location<F>> {
+        Location::new(self.journal.bounds().start)..Location::new(self.journal.bounds().end)
     }
 
     /// Update state gauges from the current database state.
-    async fn update_metrics(&self) {
-        let bounds = self.journal.reader().await.bounds();
+    fn update_metrics(&self) {
+        let bounds = self.journal.bounds();
         self.metrics.state.set(
             bounds.end,
             bounds.start,
@@ -315,14 +313,13 @@ where
         self.metrics.reads.get_calls.inc();
         self.metrics.reads.keys_requested.inc();
         let iter = self.snapshot.get(key);
-        let reader = self.journal.reader().await;
-        let oldest = reader.bounds().start;
+        let oldest = self.journal.bounds().start;
         let mut result = None;
         for &loc in iter {
             if loc < oldest {
                 continue;
             }
-            if let Some(v) = Self::get_from_loc(&reader, key, loc).await? {
+            if let Some(v) = Self::get_from_loc(&self.journal, key, loc).await? {
                 result = Some(v);
                 break;
             }
@@ -345,8 +342,7 @@ where
         let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(keys.len());
         let mut results: Vec<Option<V::Value>> = vec![None; keys.len()];
 
-        let reader = self.journal.reader().await;
-        let oldest = reader.bounds().start;
+        let oldest = self.journal.bounds().start;
 
         for (key_idx, key) in keys.iter().enumerate() {
             for &loc in self.snapshot.get(key) {
@@ -370,7 +366,7 @@ where
             }
         }
 
-        let ops = reader.read_many(&positions).await?;
+        let ops = self.journal.read_many(&positions).await?;
 
         for &(key_idx, pos) in &candidates {
             if results[key_idx].is_some() {
@@ -394,7 +390,7 @@ where
     /// [`crate::qmdb::Error::OperationPruned`] if loc precedes the oldest retained location. The
     /// location is otherwise assumed valid.
     async fn get_from_loc(
-        reader: &impl Reader<Item = Operation<F, K, V>>,
+        reader: &impl Contiguous<Item = Operation<F, K, V>>,
         key: &K,
         loc: Location<F>,
     ) -> Result<Option<V::Value>, Error<F>> {
@@ -416,13 +412,8 @@ where
     /// Get the metadata associated with the last commit.
     pub async fn get_metadata(&self) -> Result<Option<V::Value>, Error<F>> {
         let last_commit_loc = self.last_commit_loc;
-        let Operation::Commit(metadata, _floor) = self
-            .journal
-            .journal
-            .reader()
-            .await
-            .read(*last_commit_loc)
-            .await?
+        let Operation::Commit(metadata, _floor) =
+            self.journal.journal.read(*last_commit_loc).await?
         else {
             unreachable!("no commit operation at location of last commit {last_commit_loc}");
         };
@@ -466,13 +457,13 @@ where
         start_loc: Location<F>,
         max_ops: NonZeroU64,
     ) -> Result<(Proof<F, H::Digest>, Vec<Operation<F, K, V>>), Error<F>> {
-        if op_count > self.journal.size().await {
+        if op_count > self.journal.size() {
             return Err(crate::merkle::Error::RangeOutOfBounds(op_count).into());
         }
 
-        let reader = self.journal.reader().await;
         let inactive_peaks =
-            crate::qmdb::inactive_peaks_at::<F, _>(&reader, op_count, |op| op.has_floor()).await?;
+            crate::qmdb::inactive_peaks_at::<F, _>(&self.journal, op_count, |op| op.has_floor())
+                .await?;
 
         Ok(self
             .journal
@@ -491,7 +482,7 @@ where
         start_index: Location<F>,
         max_ops: NonZeroU64,
     ) -> Result<(Proof<F, H::Digest>, Vec<Operation<F, K, V>>), Error<F>> {
-        let op_count = self.bounds().await.end;
+        let op_count = self.bounds().end;
         self.historical_proof(op_count, start_index, max_ops).await
     }
 
@@ -519,7 +510,7 @@ where
             ));
         }
         self.journal.prune(loc).await?;
-        self.update_metrics().await;
+        self.update_metrics();
         Ok(())
     }
 
@@ -556,15 +547,14 @@ where
         }
 
         let (rewind_last_loc, rewind_floor, rewound_keys) = {
-            let reader = self.journal.reader().await;
-            let bounds = reader.bounds();
+            let bounds = self.journal.bounds();
             let rewind_last_loc = Location::new(rewind_size - 1);
             if rewind_size <= bounds.start {
                 return Err(Error::Journal(crate::journal::Error::ItemPruned(
                     *rewind_last_loc,
                 )));
             }
-            let rewind_last_op = reader.read(*rewind_last_loc).await?;
+            let rewind_last_op = self.journal.read(*rewind_last_loc).await?;
             let Operation::Commit(_, rewind_floor) = &rewind_last_op else {
                 return Err(Error::UnexpectedData(rewind_last_loc));
             };
@@ -577,7 +567,7 @@ where
 
             let mut rewound_keys = Vec::new();
             for loc in rewind_size..current_size {
-                if let Operation::Set(key, _) = reader.read(loc).await? {
+                if let Operation::Set(key, _) = self.journal.read(loc).await? {
                     rewound_keys.push(key);
                 }
             }
@@ -605,10 +595,9 @@ where
         // Iterate in reverse so front-insertion preserves ascending loc order
         // for repeated keys, matching the ordering that apply_batch produces.
         if rewind_floor < old_floor {
-            let reader = self.journal.journal.reader().await;
             let gap_end = core::cmp::min(*old_floor, rewind_size);
             for loc in (*rewind_floor..gap_end).rev() {
-                if let Operation::Set(key, _) = reader.read(loc).await? {
+                if let Operation::Set(key, _) = self.journal.journal.read(loc).await? {
                     self.snapshot.insert(&key, Location::new(loc));
                 }
             }
@@ -618,7 +607,7 @@ where
         self.inactivity_floor_loc = rewind_floor;
         let inactive_peaks = F::inactive_peaks(F::location_to_position(size), rewind_floor);
         self.root = self.journal.root(inactive_peaks)?;
-        self.update_metrics().await;
+        self.update_metrics();
 
         Ok(())
     }
@@ -722,7 +711,7 @@ where
         //
         // `seen` is only consulted when at least one ancestor diff will be applied, so it is
         // skipped entirely otherwise.
-        let bounds = self.journal.reader().await.bounds();
+        let bounds = self.journal.bounds();
         let track_shadow = batch.bounds.ancestors.iter().any(|a| a.end > db_size);
         let seen_cap = if track_shadow {
             batch.diff.len()
@@ -762,7 +751,7 @@ where
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
         self.root = batch.root;
         let range = start_loc..Location::new(batch.bounds.total_size);
-        self.update_metrics().await;
+        self.update_metrics();
         self.metrics
             .operations
             .operations_applied
@@ -811,7 +800,7 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         let db = open_db(context.child("first")).await;
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         assert_eq!(bounds.end, 1);
         assert_eq!(bounds.start, Location::new(0));
         assert_eq!(db.inactivity_floor_loc(), Location::new(0));
@@ -828,14 +817,14 @@ pub(super) mod test {
         drop(db);
         let mut db = open_db(context.child("second")).await;
         assert_eq!(db.root(), root);
-        assert_eq!(db.bounds().await.end, 1);
+        assert_eq!(db.bounds().end, 1);
 
         // Test calling commit on an empty db which should make it (durably) non-empty.
         db.apply_batch(db.new_batch().merkleize(&db, None, Location::new(0)))
             .await
             .unwrap();
         db.commit().await.unwrap();
-        assert_eq!(db.bounds().await.end, 2); // commit op added
+        assert_eq!(db.bounds().end, 2); // commit op added
         let root = db.root();
         drop(db);
 
@@ -868,12 +857,12 @@ pub(super) mod test {
 
         // Commit a second key without syncing; reopen must replay it from journal data.
         commit_sets(&mut db, [(k2, v2)], None).await;
-        let committed_bounds = db.bounds().await;
+        let committed_bounds = db.bounds();
         let committed_root = db.root();
         drop(db);
 
         let db = open_db(context.child("second")).await;
-        assert_eq!(db.bounds().await, committed_bounds);
+        assert_eq!(db.bounds(), committed_bounds);
         assert_eq!(db.root(), committed_root);
         assert_eq!(db.get(&k1).await.unwrap(), Some(v1));
         assert_eq!(db.get(&k2).await.unwrap(), Some(v2));
@@ -915,7 +904,7 @@ pub(super) mod test {
         db.commit().await.unwrap();
         assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
         assert!(db.get(&k2).await.unwrap().is_none());
-        assert_eq!(db.bounds().await.end, 3);
+        assert_eq!(db.bounds().end, 3);
         assert_eq!(db.get_metadata().await.unwrap(), Some(Sha256::fill(99u8)));
 
         // Set and commit the second key.
@@ -929,7 +918,7 @@ pub(super) mod test {
         db.commit().await.unwrap();
         assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
         assert_eq!(db.get(&k2).await.unwrap().unwrap(), v2);
-        assert_eq!(db.bounds().await.end, 5);
+        assert_eq!(db.bounds().end, 5);
         assert_eq!(db.get_metadata().await.unwrap(), None);
 
         // Capture state.
@@ -950,7 +939,7 @@ pub(super) mod test {
         assert_eq!(db.root(), root);
         assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
         assert_eq!(db.get(&k2).await.unwrap().unwrap(), v2);
-        assert_eq!(db.bounds().await.end, 5);
+        assert_eq!(db.bounds().end, 5);
         assert_eq!(db.get_metadata().await.unwrap(), None);
 
         // Cleanup.
@@ -1005,7 +994,7 @@ pub(super) mod test {
         for i in 0..20u8 {
             let key = Sha256::fill(i);
             let value = Sha256::fill(i.wrapping_add(100));
-            let floor = db.bounds().await.end;
+            let floor = db.bounds().end;
             db.apply_batch(db.new_batch().set(key, value).merkleize(&db, None, floor))
                 .await
                 .unwrap();
@@ -1013,7 +1002,7 @@ pub(super) mod test {
         }
 
         let root_before = db.root();
-        let bounds_before = db.bounds().await;
+        let bounds_before = db.bounds();
 
         let prune_loc = Location::new(*bounds_before.end - 5);
         db.prune(prune_loc).await.unwrap();
@@ -1108,7 +1097,7 @@ pub(super) mod test {
         let merkleized = batch.merkleize(&db, None, Location::new(0));
         db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
-        assert_eq!(db.bounds().await.end, 2_000 + 2);
+        assert_eq!(db.bounds().end, 2_000 + 2);
 
         // Drop & reopen the db, making sure it has exactly the same state.
         let root = db.root();
@@ -1116,7 +1105,7 @@ pub(super) mod test {
 
         let db = open_db(context.child("second")).await;
         assert_eq!(root, db.root());
-        assert_eq!(db.bounds().await.end, 2_000 + 2);
+        assert_eq!(db.bounds().end, 2_000 + 2);
         for i in 0u64..2_000 {
             let k = Sha256::hash(&i.to_be_bytes());
             let v = Sha256::fill(i as u8);
@@ -1126,7 +1115,7 @@ pub(super) mod test {
         // Make sure all ranges of 5 operations are provable, including truncated ranges at the
         // end.
         let max_ops = NZU64!(5);
-        for i in 0..*db.bounds().await.end {
+        for i in 0..*db.bounds().end {
             let (proof, log) = db.proof(Location::new(i), max_ops).await.unwrap();
             assert!(verify_proof(&hasher, &proof, Location::new(i), &log, &root));
         }
@@ -1158,7 +1147,7 @@ pub(super) mod test {
         let merkleized = batch.merkleize(&db, None, Location::new(0));
         db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
-        assert_eq!(db.bounds().await.end, ELEMENTS + 2);
+        assert_eq!(db.bounds().end, ELEMENTS + 2);
         db.sync().await.unwrap();
         let halfway_root = db.root();
 
@@ -1177,14 +1166,14 @@ pub(super) mod test {
         // Recovery should replay the log to regenerate the merkle structure.
         // op_count = 1002 (first batch + commit) + 1000 (second batch) + 1 (second commit) = 2003
         let db = open_db(context.child("second")).await;
-        assert_eq!(db.bounds().await.end, 2003);
+        assert_eq!(db.bounds().end, 2003);
         let root = db.root();
         assert_ne!(root, halfway_root);
 
         // Drop & reopen could preserve the final commit.
         drop(db);
         let db = open_db(context.child("third")).await;
-        assert_eq!(db.bounds().await.end, 2003);
+        assert_eq!(db.bounds().end, 2003);
         assert_eq!(db.root(), root);
 
         db.destroy().await.unwrap();
@@ -1222,7 +1211,7 @@ pub(super) mod test {
 
         // Recovery should back up to previous commit point.
         let db = open_db(context.child("second")).await;
-        assert_eq!(db.bounds().await.end, 3);
+        assert_eq!(db.bounds().end, 3);
         let root = db.root();
         assert_eq!(root, first_commit_root);
 
@@ -1265,11 +1254,11 @@ pub(super) mod test {
         let inactivity_floor = Location::new(ELEMENTS / 2 + ITEMS_PER_SECTION * 2 - 1);
         let merkleized = batch.merkleize(&db, None, inactivity_floor);
         db.apply_batch(merkleized).await.unwrap();
-        assert_eq!(db.bounds().await.end, ELEMENTS + 2);
+        assert_eq!(db.bounds().end, ELEMENTS + 2);
 
         // Prune the db to the first half of the operations.
         db.prune(Location::new((ELEMENTS + 2) / 2)).await.unwrap();
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         assert_eq!(bounds.end, ELEMENTS + 2);
 
         // items_per_section is 5, so half should be exactly at a blob boundary, in which case
@@ -1292,7 +1281,7 @@ pub(super) mod test {
 
         let mut db = open_db(context.child("second")).await;
         assert_eq!(root, db.root());
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         assert_eq!(bounds.end, ELEMENTS + 2);
         let oldest_retained_loc = bounds.start;
         assert_eq!(oldest_retained_loc, Location::new(ELEMENTS / 2));
@@ -1301,7 +1290,7 @@ pub(super) mod test {
         let loc = Location::new(ELEMENTS / 2 + (ITEMS_PER_SECTION * 2 - 1));
         db.prune(loc).await.unwrap();
         // Actual boundary should be a multiple of 5.
-        let oldest_retained_loc = db.bounds().await.start;
+        let oldest_retained_loc = db.bounds().start;
         assert_eq!(
             oldest_retained_loc,
             Location::new(ELEMENTS / 2 + ITEMS_PER_SECTION)
@@ -1311,7 +1300,7 @@ pub(super) mod test {
         db.sync().await.unwrap();
         drop(db);
         let db = open_db(context.child("third")).await;
-        let oldest_retained_loc = db.bounds().await.start;
+        let oldest_retained_loc = db.bounds().start;
         assert_eq!(
             oldest_retained_loc,
             Location::new(ELEMENTS / 2 + ITEMS_PER_SECTION)
@@ -1464,7 +1453,7 @@ pub(super) mod test {
         let metadata_a = Sha256::fill(44u8);
         let first_range =
             commit_sets(&mut db, [(key1, value1), (key2, value2)], Some(metadata_a)).await;
-        let size_before = db.bounds().await.end;
+        let size_before = db.bounds().end;
         let root_before = db.root();
         let last_commit_before = db.last_commit_loc;
         assert_eq!(size_before, first_range.end);
@@ -1480,7 +1469,7 @@ pub(super) mod test {
 
         db.rewind(size_before).await.unwrap();
         assert_eq!(db.root(), root_before);
-        assert_eq!(db.bounds().await.end, size_before);
+        assert_eq!(db.bounds().end, size_before);
         assert_eq!(db.last_commit_loc, last_commit_before);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_a));
         assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
@@ -1492,7 +1481,7 @@ pub(super) mod test {
         drop(db);
         let db = open_db(context.child("reopen")).await;
         assert_eq!(db.root(), root_before);
-        assert_eq!(db.bounds().await.end, size_before);
+        assert_eq!(db.bounds().end, size_before);
         assert_eq!(db.last_commit_loc, last_commit_before);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_a));
         assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
@@ -1534,7 +1523,7 @@ pub(super) mod test {
         let value2 = Sha256::fill(22u8);
 
         commit_sets(&mut db, [(key1, value1)], None).await;
-        let size_after_first = db.bounds().await.end;
+        let size_after_first = db.bounds().end;
         commit_sets(&mut db, [(key2, value2)], None).await;
         assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
         assert_eq!(db.get(&key2).await.unwrap(), Some(value2));
@@ -1580,7 +1569,7 @@ pub(super) mod test {
 
             // Floor must be >= last_commit_loc for prune to succeed.
             // With 16 sets, commit is at current end + 16.
-            let floor = Location::new(*db.bounds().await.end + 16);
+            let floor = Location::new(*db.bounds().end + 16);
             commit_sets_with_floor(
                 &mut db,
                 (0u64..16).map(|i| {
@@ -1593,12 +1582,12 @@ pub(super) mod test {
             .await;
             db.prune(db.last_commit_loc).await.unwrap();
 
-            if db.bounds().await.start > first_range.start {
+            if db.bounds().start > first_range.start {
                 break;
             }
         }
 
-        let oldest_retained = db.bounds().await.start;
+        let oldest_retained = db.bounds().start;
         let boundary_err = db.rewind(oldest_retained).await.unwrap_err();
         assert!(
             matches!(
@@ -1918,7 +1907,7 @@ pub(super) mod test {
 
         // Expected: 1 initial commit + BATCHES * (KEYS_PER_BATCH + 1 commit).
         let expected = 1 + BATCHES * (KEYS_PER_BATCH + 1);
-        assert_eq!(db.bounds().await.end, expected);
+        assert_eq!(db.bounds().end, expected);
 
         db.destroy().await.unwrap();
     }
@@ -1947,7 +1936,7 @@ pub(super) mod test {
         .await
         .unwrap();
         let root_before = db.root();
-        let size_before = db.bounds().await.end;
+        let size_before = db.bounds().end;
 
         // Empty batch with no mutations.
         let merkleized = db.new_batch().merkleize(&db, None, Location::new(0));
@@ -1958,7 +1947,7 @@ pub(super) mod test {
         assert_ne!(db.root(), root_before);
         assert_eq!(db.root(), speculative);
         // Size grew by exactly 1 (the Commit op).
-        assert_eq!(db.bounds().await.end, size_before + 1);
+        assert_eq!(db.bounds().end, size_before + 1);
 
         db.destroy().await.unwrap();
     }
@@ -2058,7 +2047,7 @@ pub(super) mod test {
         assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root));
 
         // Expected: 1 initial commit + N sets + 1 commit.
-        assert_eq!(db.bounds().await.end, 1 + N + 1);
+        assert_eq!(db.bounds().end, 1 + N + 1);
 
         db.destroy().await.unwrap();
     }
@@ -2229,7 +2218,7 @@ pub(super) mod test {
         // Apply the first -- should succeed.
         db.apply_batch(batch_a).await.unwrap();
         let expected_root = db.root();
-        let expected_bounds = db.bounds().await;
+        let expected_bounds = db.bounds();
         assert_eq!(db.get(&key1).await.unwrap(), Some(v1));
         assert_eq!(db.get(&key2).await.unwrap(), None);
         assert_eq!(db.get_metadata().await.unwrap(), None);
@@ -2241,7 +2230,7 @@ pub(super) mod test {
             "expected StaleBatch error, got {result:?}"
         );
         assert_eq!(db.root(), expected_root);
-        assert_eq!(db.bounds().await, expected_bounds);
+        assert_eq!(db.bounds(), expected_bounds);
         assert_eq!(db.get(&key1).await.unwrap(), Some(v1));
         assert_eq!(db.get(&key2).await.unwrap(), None);
         assert_eq!(db.get_metadata().await.unwrap(), None);
@@ -2696,7 +2685,7 @@ pub(super) mod test {
         .await
         .unwrap();
         db.commit().await.unwrap();
-        let first_size = db.bounds().await.end;
+        let first_size = db.bounds().end;
         assert_eq!(db.inactivity_floor_loc(), Location::new(2));
 
         // Apply second batch with floor=4 (the new commit's location).
@@ -2949,7 +2938,7 @@ pub(super) mod test {
 
         // Commit A: 3 keys with floor=0.
         commit_sets(&mut db, [(k1, v1), (k2, v2), (k3, v3)], None).await;
-        let first_size = db.bounds().await.end;
+        let first_size = db.bounds().end;
         let first_root = db.root();
 
         // Commit B: 3 more keys with floor=first_size (declares batch A inactive).
@@ -3006,14 +2995,14 @@ pub(super) mod test {
 
         // Commit A: 1 key, floor=0.
         commit_sets(&mut db, [(k1, v1)], None).await;
-        let first_size = db.bounds().await.end;
+        let first_size = db.bounds().end;
         let first_root = db.root();
 
         // Commit B: 1 key, floor=first_size.
         let k2 = Sha256::fill(2u8);
         let v2 = Sha256::fill(12u8);
         commit_sets_with_floor(&mut db, [(k2, v2)], None, first_size).await;
-        let second_size = db.bounds().await.end;
+        let second_size = db.bounds().end;
 
         // Commit C: 1 key, floor=second_size. This raises the floor
         // above commit B's keys, so reopen excludes both A and B keys.
@@ -3074,7 +3063,7 @@ pub(super) mod test {
 
         // Commit B: Set(key, v2) with floor=0. get() returns v1 (earliest).
         commit_sets(&mut db, [(key, v2)], None).await;
-        let second_size = db.bounds().await.end;
+        let second_size = db.bounds().end;
         assert_eq!(db.get(&key).await.unwrap(), Some(v1));
 
         // Commit C: raises floor above both earlier writes.
@@ -3118,11 +3107,11 @@ pub(super) mod test {
 
         // Commit A: Set(key, v1) at loc=0, floor=0.
         commit_sets(&mut db, [(key, v1)], None).await;
-        let first_size = db.bounds().await.end;
+        let first_size = db.bounds().end;
 
         // Commit B: Set(key, v2), floor=0. get() returns v1 (earliest).
         commit_sets(&mut db, [(key, v2)], None).await;
-        let second_size = db.bounds().await.end;
+        let second_size = db.bounds().end;
         assert_eq!(db.get(&key).await.unwrap(), Some(v1));
 
         // Commit C: raises floor to first_size, so loc=0 is below floor but
@@ -3200,7 +3189,7 @@ pub(super) mod test {
         // to `commit_loc`; what matters semantically is that the floor authorizes pruning
         // of everything below the commit and that any further prune is rejected.
         db.prune(commit_loc).await.unwrap();
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         assert!(
             bounds.start <= commit_loc,
             "prune must not advance bounds.start past the floor"

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -1,9 +1,6 @@
 use crate::{
     index::unordered::Index,
-    journal::{
-        authenticated,
-        contiguous::{Mutable, Reader as _},
-    },
+    journal::{authenticated, contiguous::Mutable},
     merkle::{
         full::{self, Merkle},
         Family, Location,
@@ -95,8 +92,7 @@ where
             Index::new(context.child("snapshot"), db_config.translator.clone());
 
         let (last_commit_loc, inactivity_floor_loc) = {
-            let reader = journal.journal.reader().await;
-            let bounds = reader.bounds();
+            let bounds = journal.journal.bounds();
             let last_commit_loc = Location::<F>::new(
                 bounds
                     .end
@@ -104,7 +100,7 @@ where
                     .ok_or(Error::HistoricalFloorPruned(Location::new(bounds.end)))?,
             );
             let inactivity_floor_loc = crate::qmdb::find_inactivity_floor_at::<F, _>(
-                &reader,
+                &journal.journal,
                 Location::new(bounds.end),
                 |op| op.has_floor(),
             )
@@ -113,7 +109,7 @@ where
             // Replay the log from the inactivity floor to build the snapshot.
             build_snapshot_from_log::<F, _, _, _>(
                 inactivity_floor_loc,
-                &reader,
+                &journal.journal,
                 &mut snapshot,
                 |_, _| {},
             )
@@ -136,7 +132,7 @@ where
             inactivity_floor_loc,
             metrics,
         };
-        db.update_metrics().await;
+        db.update_metrics();
 
         db.sync().await?;
         Ok(db)

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -87,9 +87,7 @@ pub(crate) trait SyncTestHarness: Sized + 'static {
     fn inactivity_floor_loc(db: &Self::Db) -> Location<Self::Family>;
     fn prune(db: &mut Self::Db, loc: Location<Self::Family>) -> impl Future<Output = ()> + Send;
 
-    fn bounds(
-        db: &Self::Db,
-    ) -> impl Future<Output = std::ops::Range<Location<Self::Family>>> + Send;
+    fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>>;
     fn db_root(db: &Self::Db) -> sha256::Digest;
     fn get_metadata(db: &Self::Db) -> impl Future<Output = Option<Self::Metadata>> + Send;
     fn op_kv(op: &OpOf<Self>) -> Option<(&Self::Key, &Self::Value)>;
@@ -109,7 +107,7 @@ where
         let target_ops = H::create_ops(target_db_ops);
         let target_db =
             H::apply_ops(target_db, target_ops.clone(), Some(H::sample_metadata())).await;
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let target_op_count = bounds.end;
         let target_oldest_retained_loc = bounds.start;
         let target_root = H::db_root(&target_db);
@@ -142,7 +140,7 @@ where
         };
         let got_db: DbOf<H> = sync::sync(config).await.unwrap();
 
-        let bounds = H::bounds(&got_db).await;
+        let bounds = H::bounds(&got_db);
         assert_eq!(bounds.end, target_op_count);
         assert_eq!(bounds.start, target_oldest_retained_loc);
         assert_eq!(H::db_root(&got_db), target_root);
@@ -179,7 +177,7 @@ where
         let target_db = H::init_db(context.child("target")).await;
         let target_db = H::apply_ops(target_db, vec![], Some(H::sample_metadata())).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let target_op_count = bounds.end;
         let target_oldest_retained_loc = bounds.start;
         let target_root = H::db_root(&target_db);
@@ -204,7 +202,7 @@ where
         };
         let got_db: DbOf<H> = sync::sync(config).await.unwrap();
 
-        let bounds = H::bounds(&got_db).await;
+        let bounds = H::bounds(&got_db);
         assert_eq!(bounds.end, target_op_count);
         assert_eq!(bounds.start, target_oldest_retained_loc);
         assert_eq!(H::db_root(&got_db), target_root);
@@ -230,7 +228,7 @@ where
             H::apply_ops(target_db, target_ops.clone(), Some(H::sample_metadata())).await;
 
         let target_root = H::db_root(&target_db);
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let op_count = bounds.end;
 
@@ -257,7 +255,7 @@ where
 
         assert_eq!(H::db_root(&synced_db), target_root);
         let expected_root = H::db_root(&synced_db);
-        let bounds = H::bounds(&synced_db).await;
+        let bounds = H::bounds(&synced_db);
         let expected_op_count = bounds.end;
         let expected_oldest_retained_loc = bounds.start;
 
@@ -266,7 +264,7 @@ where
         let reopened_db = H::init_db_with_config(context.child("reopened"), db_config).await;
 
         assert_eq!(H::db_root(&reopened_db), expected_root);
-        let bounds = H::bounds(&reopened_db).await;
+        let bounds = H::bounds(&reopened_db);
         assert_eq!(bounds.end, expected_op_count);
         assert_eq!(bounds.start, expected_oldest_retained_loc);
 
@@ -296,14 +294,14 @@ where
         let initial_ops = H::create_ops(50);
         let target_db = H::apply_ops(target_db, initial_ops.clone(), None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
         let initial_upper_bound = bounds.end;
         let initial_root = H::db_root(&target_db);
 
         let additional_ops = H::create_ops_seeded(25, 1);
         let target_db = H::apply_ops(target_db, additional_ops.clone(), None).await;
-        let final_upper_bound = H::bounds(&target_db).await.end;
+        let final_upper_bound = H::bounds(&target_db).end;
         let final_root = H::db_root(&target_db);
 
         let target_db = Arc::new(target_db);
@@ -332,7 +330,7 @@ where
                     NextStep::Continue(new_client) => new_client,
                     NextStep::Complete(_) => panic!("client should not be complete"),
                 };
-                let log_size = Contiguous::size(client.journal()).await;
+                let log_size = Contiguous::bounds(client.journal()).end;
                 if log_size > *initial_lower_bound {
                     break client;
                 }
@@ -353,8 +351,8 @@ where
         let target_db =
             Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("Failed to unwrap Arc"));
         {
-            let bounds = H::bounds(&synced_db).await;
-            let target_bounds = H::bounds(&target_db).await;
+            let bounds = H::bounds(&synced_db);
+            let target_bounds = H::bounds(&target_db);
             assert_eq!(bounds.end, target_bounds.end);
             assert_eq!(bounds.start, target_bounds.start);
             assert_eq!(H::db_root(&synced_db), H::db_root(&target_db));
@@ -385,7 +383,7 @@ where
         let target_db = H::apply_ops(target_db, target_ops[..29].to_vec(), None).await;
 
         let target_root = H::db_root(&target_db);
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let op_count = bounds.end;
 
@@ -411,7 +409,7 @@ where
         let synced_db: DbOf<H> = sync::sync(config).await.unwrap();
 
         assert_eq!(H::db_root(&synced_db), target_root);
-        assert_eq!(H::bounds(&synced_db).await.end, op_count);
+        assert_eq!(H::bounds(&synced_db).end, op_count);
 
         H::destroy(synced_db).await;
         let target_db =
@@ -442,7 +440,7 @@ where
         let last_op = H::create_ops_seeded(1, 1);
         let target_db = H::apply_ops(target_db, last_op, None).await;
         let root = H::db_root(&target_db);
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let upper_bound = bounds.end;
 
@@ -465,7 +463,7 @@ where
         };
         let sync_db: DbOf<H> = sync::sync(config).await.unwrap();
 
-        assert_eq!(H::bounds(&sync_db).await.end, upper_bound);
+        assert_eq!(H::bounds(&sync_db).end, upper_bound);
         assert_eq!(H::db_root(&sync_db), root);
 
         H::destroy(sync_db).await;
@@ -495,7 +493,7 @@ where
         drop(sync_db);
 
         let root = H::db_root(&target_db);
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let upper_bound = bounds.end;
 
@@ -518,7 +516,7 @@ where
         };
         let sync_db: DbOf<H> = sync::sync(config).await.unwrap();
 
-        assert_eq!(H::bounds(&sync_db).await.end, upper_bound);
+        assert_eq!(H::bounds(&sync_db).end, upper_bound);
         assert_eq!(H::db_root(&sync_db), root);
 
         H::destroy(sync_db).await;
@@ -541,7 +539,7 @@ where
 
         H::prune(&mut target_db, Location::new(10)).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
         let initial_upper_bound = bounds.end;
         let initial_root = H::db_root(&target_db);
@@ -602,7 +600,7 @@ where
         let target_ops = H::create_ops(50);
         let target_db = H::apply_ops(target_db, target_ops, None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
         let initial_upper_bound = bounds.end;
         let initial_root = H::db_root(&target_db);
@@ -660,7 +658,7 @@ where
         let target_ops = H::create_ops(100);
         let target_db = H::apply_ops(target_db, target_ops, None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
         let initial_upper_bound = bounds.end;
         let initial_root = H::db_root(&target_db);
@@ -671,7 +669,7 @@ where
         H::prune(&mut target_db, Location::new(10)).await;
         let target_db = H::apply_ops(target_db, vec![], None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let final_lower_bound = bounds.start;
         let final_upper_bound = bounds.end;
         let final_root = H::db_root(&target_db);
@@ -709,7 +707,7 @@ where
         let synced_db: DbOf<H> = sync::sync(config).await.unwrap();
 
         assert_eq!(H::db_root(&synced_db), final_root);
-        let bounds = H::bounds(&synced_db).await;
+        let bounds = H::bounds(&synced_db);
         assert_eq!(bounds.end, final_upper_bound);
         assert_eq!(bounds.start, final_lower_bound);
 
@@ -733,7 +731,7 @@ where
         let early_ops = H::create_ops(50);
         let mut target_db = H::apply_ops(target_db, early_ops.clone(), None).await;
         H::commit(&mut target_db).await;
-        let first_commit_end = H::bounds(&target_db).await.end;
+        let first_commit_end = H::bounds(&target_db).end;
 
         // Second batch with floor = first_commit_end, declaring the first batch inactive.
         let late_ops = H::create_ops_seeded(50, 1);
@@ -748,7 +746,7 @@ where
 
         assert_eq!(H::inactivity_floor_loc(&target_db), first_commit_end);
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let target_root = H::db_root(&target_db);
 
         let target_db = Arc::new(target_db);
@@ -809,7 +807,7 @@ where
         let target_ops = H::create_ops(10);
         let target_db = H::apply_ops(target_db, target_ops, None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let upper_bound = bounds.end;
         let root = H::db_root(&target_db);
@@ -843,7 +841,7 @@ where
             .await;
 
         assert_eq!(H::db_root(&synced_db), root);
-        let bounds = H::bounds(&synced_db).await;
+        let bounds = H::bounds(&synced_db);
         assert_eq!(bounds.end, upper_bound);
         assert_eq!(bounds.start, lower_bound);
 
@@ -1030,8 +1028,8 @@ pub(crate) mod harnesses {
             db.prune(loc).await.unwrap();
         }
 
-        async fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>> {
-            db.bounds().await
+        fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>> {
+            db.bounds()
         }
 
         fn db_root(db: &Self::Db) -> sha256::Digest {
@@ -1281,7 +1279,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1330,7 +1328,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1379,7 +1377,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1447,7 +1445,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1505,7 +1503,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1555,7 +1553,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
 
             let batch2 = source
@@ -1566,7 +1564,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
             let current_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
             assert_ne!(stale_target, current_target);
 
@@ -1752,7 +1750,7 @@ mod compact_variable_mmr {
                 .merkleize(&source, Some(metadata.clone()), Location::new(0));
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1810,7 +1808,7 @@ mod compact_variable_mmr {
                 .merkleize(&source, Some(vec![9]), Location::new(0));
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target_b = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1987,7 +1985,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -2036,7 +2034,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -2085,7 +2083,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -2153,7 +2151,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -2214,7 +2212,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -2264,7 +2262,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
 
             let batch2 = source
@@ -2275,7 +2273,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
             let current_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
             assert_ne!(stale_target, current_target);
 

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -972,7 +972,7 @@ mod test {
             target_db.apply_batch(merkleized).await.unwrap();
 
             let target_root = target_db.root();
-            let bounds = target_db.bounds().await;
+            let bounds = target_db.bounds();
             let lower_bound = bounds.start;
             let upper_bound = bounds.end;
 
@@ -997,7 +997,7 @@ mod test {
             let synced_db: TestDb<mmr::Family> = sync::sync(config).await.unwrap();
 
             assert_eq!(synced_db.root(), target_root);
-            let bounds = synced_db.bounds().await;
+            let bounds = synced_db.bounds();
             assert_eq!(bounds.end, upper_bound);
             assert_eq!(bounds.start, lower_bound);
 

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -46,7 +46,7 @@
 use crate::{
     journal::{
         authenticated,
-        contiguous::{Contiguous, Mutable, Reader},
+        contiguous::{Contiguous, Mutable},
     },
     merkle::{full::Config as MerkleConfig, Family, Location, Proof},
     qmdb::{
@@ -152,7 +152,7 @@ where
         context: E,
     ) -> Result<Self, Error<F>> {
         let metrics = Metrics::new(context);
-        if journal.size().await == 0 {
+        if journal.size() == 0 {
             warn!("no operations found in log, creating initial commit");
             journal
                 .append(&Operation::Commit(None, Location::new(0)))
@@ -161,15 +161,14 @@ where
         }
 
         let (last_commit_loc, inactivity_floor_loc) = {
-            let reader = journal.reader().await;
-            let bounds = reader.bounds();
+            let bounds = journal.bounds();
             let last_commit_loc = Location::new(
                 bounds
                     .end
                     .checked_sub(1)
                     .expect("at least one commit should exist"),
             );
-            let op = reader.read(*last_commit_loc).await?;
+            let op = journal.read(*last_commit_loc).await?;
             let inactivity_floor_loc = op
                 .has_floor()
                 .expect("last operation should be a commit with floor");
@@ -188,7 +187,7 @@ where
             inactivity_floor_loc,
             metrics,
         };
-        db.update_metrics().await;
+        db.update_metrics();
         Ok(db)
     }
 
@@ -197,17 +196,16 @@ where
     /// # Errors
     ///
     /// Returns [`Error::LocationOutOfBounds`] if `loc` >=
-    /// `self.bounds().await.end`.
+    /// `self.bounds().end`.
     pub async fn get(&self, loc: Location<F>) -> Result<Option<V::Value>, Error<F>> {
         let _timer = self.metrics.reads.get_timer();
         self.metrics.reads.get_calls.inc();
         self.metrics.reads.locations_requested.inc();
-        let reader = self.journal.reader().await;
-        let op_count = reader.bounds().end;
+        let op_count = self.journal.bounds().end;
         if loc >= op_count {
             return Err(Error::LocationOutOfBounds(loc, Location::new(op_count)));
         }
-        let op = reader.read(*loc).await?;
+        let op = self.journal.read(*loc).await?;
 
         let result = op.into_value();
         Ok(result)
@@ -236,15 +234,14 @@ where
             locs.windows(2).all(|w| w[0] < w[1]),
             "locations must be strictly increasing"
         );
-        let reader = self.journal.reader().await;
-        let op_count = reader.bounds().end;
+        let op_count = self.journal.bounds().end;
         for &loc in locs {
             if loc >= op_count {
                 return Err(Error::LocationOutOfBounds(loc, Location::new(op_count)));
             }
         }
         let positions: Vec<u64> = locs.iter().map(|loc| **loc).collect();
-        let ops = reader.read_many(&positions).await?;
+        let ops = self.journal.read_many(&positions).await?;
         let result = ops.into_iter().map(|op| op.into_value()).collect();
         Ok(result)
     }
@@ -261,14 +258,14 @@ where
 
     /// Return [start, end) where `start` and `end - 1` are the Locations of the oldest and newest
     /// retained operations respectively.
-    pub async fn bounds(&self) -> std::ops::Range<Location<F>> {
-        let bounds = self.journal.reader().await.bounds();
+    pub fn bounds(&self) -> std::ops::Range<Location<F>> {
+        let bounds = self.journal.bounds();
         Location::new(bounds.start)..Location::new(bounds.end)
     }
 
     /// Update state gauges from the current database state.
-    async fn update_metrics(&self) {
-        let bounds = self.journal.reader().await.bounds();
+    fn update_metrics(&self) {
+        let bounds = self.journal.bounds();
         self.metrics.state.set(
             bounds.end,
             bounds.start,
@@ -286,12 +283,7 @@ where
 
     /// Get the metadata associated with the last commit.
     pub async fn get_metadata(&self) -> Result<Option<V::Value>, Error<F>> {
-        let op = self
-            .journal
-            .reader()
-            .await
-            .read(*self.last_commit_loc)
-            .await?;
+        let op = self.journal.read(*self.last_commit_loc).await?;
         let Operation::Commit(metadata, _floor) = op else {
             return Ok(None);
         };
@@ -327,7 +319,7 @@ where
         start_loc: Location<F>,
         max_ops: NonZeroU64,
     ) -> Result<(Proof<F, H::Digest>, Vec<Operation<F, V>>), Error<F>> {
-        self.historical_proof(self.bounds().await.end, start_loc, max_ops)
+        self.historical_proof(self.bounds().end, start_loc, max_ops)
             .await
     }
 
@@ -361,13 +353,13 @@ where
         start_loc: Location<F>,
         max_ops: NonZeroU64,
     ) -> Result<(Proof<F, H::Digest>, Vec<Operation<F, V>>), Error<F>> {
-        if op_count > self.journal.size().await {
+        if op_count > self.journal.size() {
             return Err(crate::merkle::Error::RangeOutOfBounds(op_count).into());
         }
 
-        let reader = self.journal.reader().await;
         let inactive_peaks =
-            crate::qmdb::inactive_peaks_at::<F, _>(&reader, op_count, |op| op.has_floor()).await?;
+            crate::qmdb::inactive_peaks_at::<F, _>(&self.journal, op_count, |op| op.has_floor())
+                .await?;
 
         Ok(self
             .journal
@@ -401,7 +393,7 @@ where
             ));
         }
         self.journal.prune(loc).await?;
-        self.update_metrics().await;
+        self.update_metrics();
         Ok(())
     }
 
@@ -440,14 +432,13 @@ where
 
         let rewind_last_loc = Location::new(rewind_size - 1);
         let rewind_floor = {
-            let reader = self.journal.reader().await;
-            let bounds = reader.bounds();
+            let bounds = self.journal.bounds();
             if rewind_size <= bounds.start {
                 return Err(Error::Journal(crate::journal::Error::ItemPruned(
                     *rewind_last_loc,
                 )));
             }
-            let rewind_last_op = reader.read(*rewind_last_loc).await?;
+            let rewind_last_op = self.journal.read(*rewind_last_loc).await?;
             let Operation::Commit(_, floor) = rewind_last_op else {
                 return Err(Error::UnexpectedData(rewind_last_loc));
             };
@@ -461,7 +452,7 @@ where
         self.inactivity_floor_loc = rewind_floor;
         let inactive_peaks = F::inactive_peaks(F::location_to_position(size), rewind_floor);
         self.root = self.journal.root(inactive_peaks)?;
-        self.update_metrics().await;
+        self.update_metrics();
         Ok(())
     }
 
@@ -560,7 +551,7 @@ where
         let end_loc = Location::new(batch.bounds.total_size);
         debug!(size = ?end_loc, "applied batch");
         let range = start_loc..end_loc;
-        self.update_metrics().await;
+        self.update_metrics();
         self.metrics
             .operations
             .operations_applied
@@ -615,7 +606,7 @@ pub(crate) mod tests {
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         assert_eq!(bounds.end, 1); // initial commit should exist
         assert_eq!(bounds.start, Location::new(0));
         assert_eq!(db.get_metadata().await.unwrap(), None);
@@ -631,7 +622,7 @@ pub(crate) mod tests {
 
         let mut db = reopen(context.child("db").with_attribute("index", 2)).await;
         assert_eq!(db.root(), root);
-        assert_eq!(db.bounds().await.end, 1);
+        assert_eq!(db.bounds().end, 1);
         assert_eq!(db.get_metadata().await.unwrap(), None);
 
         // Test calling commit on an empty db which should make it (durably) non-empty.
@@ -641,7 +632,7 @@ pub(crate) mod tests {
                 .merkleize(&db, Some(metadata.clone()), db.inactivity_floor_loc());
         db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
-        assert_eq!(db.bounds().await.end, 2); // 2 commit ops
+        assert_eq!(db.bounds().end, 2); // 2 commit ops
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata.clone()));
         assert_eq!(
             db.get(Location::new(1)).await.unwrap(),
@@ -651,7 +642,7 @@ pub(crate) mod tests {
 
         // Commit op should remain after reopen even without clean shutdown.
         let db = reopen(context.child("db").with_attribute("index", 3)).await;
-        assert_eq!(db.bounds().await.end, 2); // commit op should remain after re-open.
+        assert_eq!(db.bounds().end, 2); // commit op should remain after re-open.
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
         assert_eq!(db.root(), root);
         assert_eq!(db.last_commit_loc(), Location::new(1));
@@ -690,19 +681,19 @@ pub(crate) mod tests {
         db.sync().await.unwrap();
 
         // Commit the next append without syncing; reopen must replay it from the journal.
-        let second_loc = db.bounds().await.end;
+        let second_loc = db.bounds().end;
         let merkleized =
             db.new_batch()
                 .append(value1.clone())
                 .merkleize(&db, None, db.inactivity_floor_loc());
         db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
-        let committed_bounds = db.bounds().await;
+        let committed_bounds = db.bounds();
         let committed_root = db.root();
         drop(db);
 
         let db = reopen(context.child("db").with_attribute("index", 2)).await;
-        assert_eq!(db.bounds().await, committed_bounds);
+        assert_eq!(db.bounds(), committed_bounds);
         assert_eq!(db.root(), committed_root);
         assert_eq!(db.get(first_loc).await.unwrap(), Some(value0));
         assert_eq!(db.get(second_loc).await.unwrap(), Some(value1));
@@ -739,7 +730,7 @@ pub(crate) mod tests {
         }
 
         // Make sure closing/reopening gets us back to the same state.
-        assert_eq!(db.bounds().await.end, 4); // 2 appends, 1 commit + 1 initial commit
+        assert_eq!(db.bounds().end, 4); // 2 appends, 1 commit + 1 initial commit
         assert_eq!(db.get_metadata().await.unwrap(), None);
         assert_eq!(db.get(Location::new(3)).await.unwrap(), None); // the commit op
         let root = db.root();
@@ -747,7 +738,7 @@ pub(crate) mod tests {
         drop(db);
 
         let db = reopen(context.child("db").with_attribute("index", 2)).await;
-        assert_eq!(db.bounds().await.end, 4);
+        assert_eq!(db.bounds().end, 4);
         assert_eq!(db.root(), root);
         assert_eq!(db.get(Location::new(1)).await.unwrap().unwrap(), v1);
         assert_eq!(db.get(Location::new(2)).await.unwrap().unwrap(), v2);
@@ -755,7 +746,7 @@ pub(crate) mod tests {
         // Make sure commit operation remains after drop/reopen.
         drop(db);
         let db = reopen(context.child("db").with_attribute("index", 3)).await;
-        assert_eq!(db.bounds().await.end, 4);
+        assert_eq!(db.bounds().end, 4);
         assert_eq!(db.root(), root);
 
         db.destroy().await.unwrap();
@@ -830,7 +821,7 @@ pub(crate) mod tests {
         // Make sure we can reopen and get back to the same state.
         drop(db);
         let db = reopen(context.child("db").with_attribute("index", 4)).await;
-        assert_eq!(db.bounds().await.end, 2 * ELEMENTS + 3);
+        assert_eq!(db.bounds().end, 2 * ELEMENTS + 3);
         assert_eq!(db.root(), root);
 
         db.destroy().await.unwrap();
@@ -971,7 +962,7 @@ pub(crate) mod tests {
 
         // Reopen DB without clean shutdown and make sure the state is the same.
         let db = reopen(context.child("db").with_attribute("index", 2)).await;
-        assert_eq!(db.bounds().await.end, 1); // initial commit should exist
+        assert_eq!(db.bounds().end, 1); // initial commit should exist
         assert_eq!(db.root(), root);
 
         // Simulate failure after inserting operations without a commit.
@@ -984,7 +975,7 @@ pub(crate) mod tests {
         }
         drop(db);
         let db = reopen(context.child("db").with_attribute("index", 3)).await;
-        assert_eq!(db.bounds().await.end, 1); // initial commit should exist
+        assert_eq!(db.bounds().end, 1); // initial commit should exist
         assert_eq!(db.root(), root);
 
         // Repeat: simulate failure after inserting operations without a commit.
@@ -997,7 +988,7 @@ pub(crate) mod tests {
         }
         drop(db);
         let db = reopen(context.child("db").with_attribute("index", 4)).await;
-        assert_eq!(db.bounds().await.end, 1); // initial commit should exist
+        assert_eq!(db.bounds().end, 1); // initial commit should exist
         assert_eq!(db.root(), root);
 
         // One last check: multiple batches of uncommitted appends.
@@ -1010,7 +1001,7 @@ pub(crate) mod tests {
         }
         drop(db);
         let mut db = reopen(context.child("db").with_attribute("index", 5)).await;
-        assert_eq!(db.bounds().await.end, 1); // initial commit should exist
+        assert_eq!(db.bounds().end, 1); // initial commit should exist
         assert_eq!(db.root(), root);
         assert_eq!(db.last_commit_loc(), Location::new(0));
 
@@ -1026,7 +1017,7 @@ pub(crate) mod tests {
         }
         db.commit().await.unwrap();
         let db = reopen(context.child("db").with_attribute("index", 6)).await;
-        assert!(db.bounds().await.end > 1);
+        assert!(db.bounds().end > 1);
         assert_ne!(db.root(), root);
 
         db.destroy().await.unwrap();
@@ -1061,7 +1052,7 @@ pub(crate) mod tests {
         }
         db.commit().await.unwrap();
         let committed_root = db.root();
-        let committed_size = db.bounds().await.end;
+        let committed_size = db.bounds().end;
 
         // Add exactly one more append (uncommitted).
         {
@@ -1073,7 +1064,7 @@ pub(crate) mod tests {
         // Reopen and verify correct recovery.
         let mut db = reopen(context.child("db").with_attribute("index", 2)).await;
         assert_eq!(
-            db.bounds().await.end,
+            db.bounds().end,
             committed_size,
             "Should rewind to last commit"
         );
@@ -1103,7 +1094,7 @@ pub(crate) mod tests {
         assert_eq!(db.get(committed_size).await.unwrap(), Some(new_value));
 
         let new_committed_root = db.root();
-        let new_committed_size = db.bounds().await.end;
+        let new_committed_size = db.bounds().end;
 
         // Add multiple uncommitted appends.
         {
@@ -1118,7 +1109,7 @@ pub(crate) mod tests {
         // Reopen and verify correct recovery.
         let db = reopen(context.child("db").with_attribute("index", 3)).await;
         assert_eq!(
-            db.bounds().await.end,
+            db.bounds().end,
             new_committed_size,
             "Should rewind to last commit with multiple trailing appends"
         );
@@ -1347,11 +1338,11 @@ pub(crate) mod tests {
         }
         db.commit().await.unwrap();
         let root = db.root();
-        let op_count = db.bounds().await.end;
+        let op_count = db.bounds().end;
 
         // Reopen DB without clean shutdown and make sure the state is the same.
         let db = reopen(context.child("db").with_attribute("index", 2)).await;
-        assert_eq!(db.bounds().await.end, op_count);
+        assert_eq!(db.bounds().end, op_count);
         assert_eq!(db.root(), root);
         assert_eq!(db.last_commit_loc(), op_count - 1);
         drop(db);
@@ -1367,14 +1358,14 @@ pub(crate) mod tests {
         }
         drop(db);
         let db = reopen(context.child("recovery_b")).await;
-        assert_eq!(db.bounds().await.end, op_count);
+        assert_eq!(db.bounds().end, op_count);
         assert_eq!(db.root(), root);
         drop(db);
 
         // Repeat after pruning to the last commit.
         let mut db = reopen(context.child("db").with_attribute("index", 3)).await;
         db.prune(db.last_commit_loc()).await.unwrap();
-        assert_eq!(db.bounds().await.end, op_count);
+        assert_eq!(db.bounds().end, op_count);
         assert_eq!(db.root(), root);
         db.sync().await.unwrap();
         drop(db);
@@ -1388,7 +1379,7 @@ pub(crate) mod tests {
         }
         drop(db);
         let db = reopen(context.child("recovery_d")).await;
-        assert_eq!(db.bounds().await.end, op_count);
+        assert_eq!(db.bounds().end, op_count);
         assert_eq!(db.root(), root);
         drop(db);
 
@@ -1405,7 +1396,7 @@ pub(crate) mod tests {
         }
         db.commit().await.unwrap();
         let db = reopen(context.child("db").with_attribute("index", 5)).await;
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         assert!(bounds.end > op_count);
         assert_ne!(db.root(), root);
         assert_eq!(db.last_commit_loc(), bounds.end - 1);
@@ -1437,7 +1428,7 @@ pub(crate) mod tests {
 
         // Test that historical proof fails with op_count > number of operations.
         assert!(matches!(
-            db.historical_proof(db.bounds().await.end + 1, Location::new(5), NZU64!(10))
+            db.historical_proof(db.bounds().end + 1, Location::new(5), NZU64!(10))
                 .await,
             Err(Error::<F>::Merkle(crate::merkle::Error::RangeOutOfBounds(
                 _
@@ -1463,7 +1454,7 @@ pub(crate) mod tests {
                 verify_proof(&hasher, &proof, Location::new(start_loc), &ops, &root,),
                 "Failed to verify proof for range starting at {start_loc} with max {max_ops} ops",
             );
-            let expected_ops = std::cmp::min(max_ops, *db.bounds().await.end - start_loc);
+            let expected_ops = std::cmp::min(max_ops, *db.bounds().end - start_loc);
             assert_eq!(ops.len() as u64, expected_ops);
 
             let wrong_root = Sha256::hash(&[0xFF; 32]);
@@ -1526,7 +1517,7 @@ pub(crate) mod tests {
 
         const PRUNE_LOC: u64 = 30;
         db.prune(Location::new(PRUNE_LOC)).await.unwrap();
-        let oldest_retained = db.bounds().await.start;
+        let oldest_retained = db.bounds().start;
         assert_eq!(db.root(), root);
 
         db.sync().await.unwrap();
@@ -1550,14 +1541,14 @@ pub(crate) mod tests {
         let aggressive_prune: Location<F> = Location::new(150);
         db.prune(aggressive_prune).await.unwrap();
 
-        let new_oldest = db.bounds().await.start;
+        let new_oldest = db.bounds().start;
         let (proof, ops) = db.proof(new_oldest, NZU64!(20)).await.unwrap();
         assert!(verify_proof(&hasher, &proof, new_oldest, &ops, &root,));
 
-        let almost_all = db.bounds().await.end - 5;
+        let almost_all = db.bounds().end - 5;
         db.prune(almost_all).await.unwrap();
-        let final_oldest = db.bounds().await.start;
-        if final_oldest < db.bounds().await.end {
+        let final_oldest = db.bounds().start;
+        if final_oldest < db.bounds().end {
             let (final_proof, final_ops) = db.proof(final_oldest, NZU64!(10)).await.unwrap();
             assert!(verify_proof(
                 &hasher,
@@ -1812,7 +1803,7 @@ pub(crate) mod tests {
         let root = db.root();
         let (proof, ops) = db.proof(Location::new(0), NZU64!(1000)).await.unwrap();
         assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root,));
-        assert_eq!(db.bounds().await.end, 1 + BATCHES * (APPENDS_PER_BATCH + 1));
+        assert_eq!(db.bounds().end, 1 + BATCHES * (APPENDS_PER_BATCH + 1));
 
         db.destroy().await.unwrap();
     }
@@ -1833,7 +1824,7 @@ pub(crate) mod tests {
         );
         db.apply_batch(merkleized).await.unwrap();
         let root_before = db.root();
-        let size_before = db.bounds().await.end;
+        let size_before = db.bounds().end;
 
         let merkleized = db
             .new_batch()
@@ -1843,7 +1834,7 @@ pub(crate) mod tests {
 
         assert_ne!(db.root(), root_before);
         assert_eq!(db.root(), speculative);
-        assert_eq!(db.bounds().await.end, size_before + 1);
+        assert_eq!(db.bounds().end, size_before + 1);
 
         db.destroy().await.unwrap();
     }
@@ -1920,7 +1911,7 @@ pub(crate) mod tests {
         let root = db.root();
         let (proof, ops) = db.proof(Location::new(0), NZU64!(1000)).await.unwrap();
         assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root,));
-        assert_eq!(db.bounds().await.end, 1 + N + 1);
+        assert_eq!(db.bounds().end, 1 + N + 1);
 
         db.destroy().await.unwrap();
     }
@@ -2093,7 +2084,7 @@ pub(crate) mod tests {
         Operation<F, V>: EncodeShared,
     {
         let initial_root = db.root();
-        let initial_size = db.bounds().await.end;
+        let initial_size = db.bounds().end;
 
         let value_a = V::Value::make(1);
         let value_b = V::Value::make(2);
@@ -2106,7 +2097,7 @@ pub(crate) mod tests {
         .await;
 
         let root_before = db.root();
-        let size_before = db.bounds().await.end;
+        let size_before = db.bounds().end;
         let commit_before = db.last_commit_loc();
         assert_eq!(size_before, first_range.end);
 
@@ -2120,7 +2111,7 @@ pub(crate) mod tests {
 
         db.rewind(size_before).await.unwrap();
         assert_eq!(db.root(), root_before);
-        assert_eq!(db.bounds().await.end, size_before);
+        assert_eq!(db.bounds().end, size_before);
         assert_eq!(db.last_commit_loc(), commit_before);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_a.clone()));
         assert_eq!(
@@ -2143,7 +2134,7 @@ pub(crate) mod tests {
         drop(db);
         let mut db = reopen(context.child("reopen")).await;
         assert_eq!(db.root(), root_before);
-        assert_eq!(db.bounds().await.end, size_before);
+        assert_eq!(db.bounds().end, size_before);
         assert_eq!(db.last_commit_loc(), commit_before);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_a));
         assert_eq!(
@@ -2161,7 +2152,7 @@ pub(crate) mod tests {
 
         db.rewind(initial_size).await.unwrap();
         assert_eq!(db.root(), initial_root);
-        assert_eq!(db.bounds().await.end, initial_size);
+        assert_eq!(db.bounds().end, initial_size);
         assert_eq!(db.get_metadata().await.unwrap(), None);
         assert!(matches!(
             db.get(Location::new(1)).await,
@@ -2172,7 +2163,7 @@ pub(crate) mod tests {
         drop(db);
         let db = reopen(context.child("reopen_initial_boundary")).await;
         assert_eq!(db.root(), initial_root);
-        assert_eq!(db.bounds().await.end, initial_size);
+        assert_eq!(db.bounds().end, initial_size);
         assert_eq!(db.get_metadata().await.unwrap(), None);
         assert!(matches!(
             db.get(Location::new(1)).await,
@@ -2215,12 +2206,12 @@ pub(crate) mod tests {
             .await;
             db.prune(db.last_commit_loc()).await.unwrap();
 
-            if db.bounds().await.start > first_range.start {
+            if db.bounds().start > first_range.start {
                 break;
             }
         }
 
-        let oldest_retained = db.bounds().await.start;
+        let oldest_retained = db.bounds().start;
         let boundary_err = db.rewind(oldest_retained).await.unwrap_err();
         assert!(
             matches!(
@@ -2680,7 +2671,7 @@ pub(crate) mod tests {
         // to `commit_loc`; what matters semantically is that the floor has authorized pruning
         // of everything below the commit and that any further prune is rejected.
         db.prune(commit_loc).await.unwrap();
-        let bounds = db.bounds().await;
+        let bounds = db.bounds();
         assert!(
             bounds.start <= commit_loc,
             "prune must not advance bounds.start past the floor"
@@ -2705,7 +2696,7 @@ pub(crate) mod tests {
         db.sync().await.unwrap();
         drop(db);
         let mut db = reopen(context.child("reopened")).await;
-        let reopened_bounds = db.bounds().await;
+        let reopened_bounds = db.bounds();
         assert_eq!(reopened_bounds.end, Location::new(*commit_loc + 1));
         assert_eq!(db.last_commit_loc(), commit_loc);
         assert_eq!(db.inactivity_floor_loc(), commit_loc);

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     journal::{
         authenticated,
-        contiguous::{Contiguous as _, Mutable, Reader as _},
+        contiguous::{Contiguous as _, Mutable},
     },
     merkle::{
         full::{self, Merkle},
@@ -83,8 +83,7 @@ where
         .await?;
 
         let (last_commit_loc, inactivity_floor_loc) = {
-            let reader = journal.reader().await;
-            let bounds = reader.bounds();
+            let bounds = journal.bounds();
             let loc = bounds
                 .end
                 .checked_sub(1)
@@ -92,7 +91,7 @@ where
                     bounds.end,
                 )))?;
             let floor =
-                qmdb::find_inactivity_floor_at::<F, _>(&reader, Location::new(bounds.end), |op| {
+                qmdb::find_inactivity_floor_at::<F, _>(&journal, Location::new(bounds.end), |op| {
                     op.has_floor()
                 })
                 .await?;
@@ -112,7 +111,7 @@ where
             inactivity_floor_loc,
             metrics,
         };
-        db.update_metrics().await;
+        db.update_metrics();
 
         db.sync().await?;
         Ok(db)

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -74,9 +74,7 @@ pub(crate) trait SyncTestHarness: Sized + 'static {
     ) -> impl Future<Output = Self::Db> + Send;
     fn prune(db: &mut Self::Db, loc: Location<Self::Family>) -> impl Future<Output = ()> + Send;
 
-    fn bounds(
-        db: &Self::Db,
-    ) -> impl Future<Output = std::ops::Range<Location<Self::Family>>> + Send;
+    fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>>;
     fn db_root(db: &Self::Db) -> sha256::Digest;
     fn get_metadata(db: &Self::Db) -> impl Future<Output = Option<Self::Value>> + Send;
     fn get_value(
@@ -129,7 +127,7 @@ where
         let target_ops = H::create_ops(target_db_ops);
         let target_db =
             H::apply_ops(target_db, target_ops.clone(), Some(H::sample_metadata())).await;
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let target_op_count = bounds.end;
         let target_oldest_retained_loc = bounds.start;
         let target_root = H::db_root(&target_db);
@@ -155,7 +153,7 @@ where
         };
         let got_db: DbOf<H> = sync::sync(config).await.unwrap();
 
-        let bounds = H::bounds(&got_db).await;
+        let bounds = H::bounds(&got_db);
         assert_eq!(bounds.end, target_op_count);
         assert_eq!(bounds.start, target_oldest_retained_loc);
         assert_eq!(H::db_root(&got_db), target_root);
@@ -191,7 +189,7 @@ where
         let target_db = H::init_db(context.child("target")).await;
         let target_db = H::apply_ops(target_db, vec![], Some(H::sample_metadata())).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let target_op_count = bounds.end;
         let target_oldest_retained_loc = bounds.start;
         let target_root = H::db_root(&target_db);
@@ -216,7 +214,7 @@ where
         };
         let got_db: DbOf<H> = sync::sync(config).await.unwrap();
 
-        let bounds = H::bounds(&got_db).await;
+        let bounds = H::bounds(&got_db);
         assert_eq!(bounds.end, target_op_count);
         assert_eq!(bounds.start, target_oldest_retained_loc);
         assert_eq!(H::db_root(&got_db), target_root);
@@ -242,7 +240,7 @@ where
             H::apply_ops(target_db, target_ops.clone(), Some(H::sample_metadata())).await;
 
         let target_root = H::db_root(&target_db);
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let op_count = bounds.end;
 
@@ -269,7 +267,7 @@ where
 
         assert_eq!(H::db_root(&synced_db), target_root);
         let expected_root = H::db_root(&synced_db);
-        let bounds = H::bounds(&synced_db).await;
+        let bounds = H::bounds(&synced_db);
         let expected_op_count = bounds.end;
         let expected_oldest_retained_loc = bounds.start;
 
@@ -278,7 +276,7 @@ where
         let reopened_db = H::init_db_with_config(context.child("reopened"), db_config).await;
 
         assert_eq!(H::db_root(&reopened_db), expected_root);
-        let bounds = H::bounds(&reopened_db).await;
+        let bounds = H::bounds(&reopened_db);
         assert_eq!(bounds.end, expected_op_count);
         assert_eq!(bounds.start, expected_oldest_retained_loc);
 
@@ -308,14 +306,14 @@ where
         let initial_ops = H::create_ops(50);
         let target_db = H::apply_ops(target_db, initial_ops, None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
         let initial_upper_bound = bounds.end;
         let initial_root = H::db_root(&target_db);
 
         let additional_ops = H::create_ops_seeded(25, 1);
         let target_db = H::apply_ops(target_db, additional_ops, None).await;
-        let final_upper_bound = H::bounds(&target_db).await.end;
+        let final_upper_bound = H::bounds(&target_db).end;
         let final_root = H::db_root(&target_db);
 
         let target_db = Arc::new(target_db);
@@ -344,7 +342,7 @@ where
                     NextStep::Continue(new_client) => new_client,
                     NextStep::Complete(_) => panic!("client should not be complete"),
                 };
-                let log_size = Contiguous::size(client.journal()).await;
+                let log_size = Contiguous::bounds(client.journal()).end;
                 if log_size > *initial_lower_bound {
                     break client;
                 }
@@ -365,8 +363,8 @@ where
         let target_db =
             Arc::try_unwrap(target_db).unwrap_or_else(|_| panic!("Failed to unwrap Arc"));
         {
-            let bounds = H::bounds(&synced_db).await;
-            let target_bounds = H::bounds(&target_db).await;
+            let bounds = H::bounds(&synced_db);
+            let target_bounds = H::bounds(&target_db);
             assert_eq!(bounds.end, target_bounds.end);
             assert_eq!(bounds.start, target_bounds.start);
             assert_eq!(H::db_root(&synced_db), H::db_root(&target_db));
@@ -389,7 +387,7 @@ where
         let target_db = H::apply_ops(target_db, target_ops[..29].to_vec(), None).await;
 
         let target_root = H::db_root(&target_db);
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let op_count = bounds.end;
 
@@ -415,7 +413,7 @@ where
         let synced_db: DbOf<H> = sync::sync(config).await.unwrap();
 
         assert_eq!(H::db_root(&synced_db), target_root);
-        assert_eq!(H::bounds(&synced_db).await.end, op_count);
+        assert_eq!(H::bounds(&synced_db).end, op_count);
 
         H::destroy(synced_db).await;
         let target_db =
@@ -446,7 +444,7 @@ where
         let last_op = H::create_ops_seeded(1, 1);
         let target_db = H::apply_ops(target_db, last_op, None).await;
         let root = H::db_root(&target_db);
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let upper_bound = bounds.end;
 
@@ -469,7 +467,7 @@ where
         };
         let sync_db: DbOf<H> = sync::sync(config).await.unwrap();
 
-        assert_eq!(H::bounds(&sync_db).await.end, upper_bound);
+        assert_eq!(H::bounds(&sync_db).end, upper_bound);
         assert_eq!(H::db_root(&sync_db), root);
 
         H::destroy(sync_db).await;
@@ -499,7 +497,7 @@ where
         drop(sync_db);
 
         let root = H::db_root(&target_db);
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let upper_bound = bounds.end;
 
@@ -522,7 +520,7 @@ where
         };
         let sync_db: DbOf<H> = sync::sync(config).await.unwrap();
 
-        assert_eq!(H::bounds(&sync_db).await.end, upper_bound);
+        assert_eq!(H::bounds(&sync_db).end, upper_bound);
         assert_eq!(H::db_root(&sync_db), root);
 
         H::destroy(sync_db).await;
@@ -545,7 +543,7 @@ where
 
         H::prune(&mut target_db, Location::new(10)).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
         let initial_upper_bound = bounds.end;
         let initial_root = H::db_root(&target_db);
@@ -606,7 +604,7 @@ where
         let target_ops = H::create_ops(50);
         let target_db = H::apply_ops(target_db, target_ops, None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
         let initial_upper_bound = bounds.end;
         let initial_root = H::db_root(&target_db);
@@ -664,7 +662,7 @@ where
         let target_ops = H::create_ops(100);
         let target_db = H::apply_ops(target_db, target_ops, None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
         let initial_upper_bound = bounds.end;
         let initial_root = H::db_root(&target_db);
@@ -675,7 +673,7 @@ where
         H::prune(&mut target_db, Location::new(10)).await;
         let target_db = H::apply_ops(target_db, vec![], None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let final_lower_bound = bounds.start;
         let final_upper_bound = bounds.end;
         let final_root = H::db_root(&target_db);
@@ -713,7 +711,7 @@ where
         let synced_db: DbOf<H> = sync::sync(config).await.unwrap();
 
         assert_eq!(H::db_root(&synced_db), final_root);
-        let bounds = H::bounds(&synced_db).await;
+        let bounds = H::bounds(&synced_db);
         assert_eq!(bounds.end, final_upper_bound);
         assert_eq!(bounds.start, final_lower_bound);
 
@@ -735,7 +733,7 @@ where
         let target_ops = H::create_ops(10);
         let target_db = H::apply_ops(target_db, target_ops, None).await;
 
-        let bounds = H::bounds(&target_db).await;
+        let bounds = H::bounds(&target_db);
         let lower_bound = bounds.start;
         let upper_bound = bounds.end;
         let root = H::db_root(&target_db);
@@ -769,7 +767,7 @@ where
             .await;
 
         assert_eq!(H::db_root(&synced_db), root);
-        let bounds = H::bounds(&synced_db).await;
+        let bounds = H::bounds(&synced_db);
         assert_eq!(bounds.end, upper_bound);
         assert_eq!(bounds.start, lower_bound);
 
@@ -911,8 +909,8 @@ pub(crate) mod harnesses {
             db.prune(loc).await.unwrap();
         }
 
-        async fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>> {
-            db.bounds().await
+        fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>> {
+            db.bounds()
         }
 
         fn db_root(db: &Self::Db) -> sha256::Digest {
@@ -1148,7 +1146,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1198,7 +1196,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1248,7 +1246,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1312,7 +1310,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1370,7 +1368,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1420,7 +1418,7 @@ mod compact_variable_mmr {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1492,7 +1490,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
 
             let batch2 = source.new_batch().append(vec![4, 5, 6]).merkleize(
@@ -1504,7 +1502,7 @@ mod compact_variable_mmr {
             source.commit().await.unwrap();
             let current_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
             assert_ne!(stale_target, current_target);
 
@@ -1698,7 +1696,7 @@ mod compact_variable_mmr {
             );
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1758,7 +1756,7 @@ mod compact_variable_mmr {
             );
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target_b = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1922,7 +1920,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -1972,7 +1970,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -2022,7 +2020,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -2086,7 +2084,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -2144,7 +2142,7 @@ mod compact_variable_mmb {
             source.apply_batch(batch).await.unwrap();
             source.commit().await.unwrap();
 
-            let bounds = source.bounds().await;
+            let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: bounds.end,
@@ -2195,7 +2193,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
 
             let batch2 = source.new_batch().append(vec![4, 5, 6]).merkleize(
@@ -2207,7 +2205,7 @@ mod compact_variable_mmb {
             source.commit().await.unwrap();
             let current_target = sync::compact::Target {
                 root: source.root(),
-                leaf_count: source.bounds().await.end,
+                leaf_count: source.bounds().end,
             };
             assert_ne!(stale_target, current_target);
 

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -273,7 +273,7 @@ mod test {
             // Prune to loc=8: blob 0 ([0,7)) end=7 <= 8 -> pruned. bounds.start = 7, first retained
             // commit is at 8.
             db.prune(Location::new(8)).await.unwrap();
-            let bounds = db.bounds().await;
+            let bounds = db.bounds();
             assert_eq!(*bounds.start, 7);
 
             // op_count = first retained commit (= state just before that commit). Expected:

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -44,7 +44,7 @@
 use crate::{
     index::{Cursor, Unordered as Index},
     journal::{
-        contiguous::{Mutable, Reader},
+        contiguous::{Contiguous, Mutable},
         Error as JournalError,
     },
     merkle::{hasher::Standard as StandardHasher, Bagging, Family, Location},
@@ -103,7 +103,7 @@ pub(crate) async fn find_inactivity_floor_at<F, R>(
 ) -> Result<Location<F>, Error<F>>
 where
     F: Family,
-    R: Reader,
+    R: Contiguous,
 {
     let Some(last_op) = op_count.checked_sub(1) else {
         return Err(Error::HistoricalFloorPruned(op_count));
@@ -132,7 +132,7 @@ pub(crate) async fn inactive_peaks_at<F, R>(
 ) -> Result<usize, Error<F>>
 where
     F: Family,
-    R: Reader,
+    R: Contiguous,
 {
     if op_count == Location::new(0) {
         return Ok(0);
@@ -238,7 +238,7 @@ pub(super) async fn build_snapshot_from_log<F, C, I, Fn>(
 ) -> Result<usize, Error<F>>
 where
     F: crate::merkle::Family,
-    C: Reader<Item: Operation<F>>,
+    C: Contiguous<Item: Operation<F>>,
     I: Index<Value = crate::merkle::Location<F>>,
     Fn: FnMut(bool, Option<crate::merkle::Location<F>>),
 {
@@ -284,7 +284,7 @@ async fn delete_key<F, I, R>(
 where
     F: Family,
     I: Index<Value = Location<F>>,
-    R: Reader,
+    R: Contiguous,
     R::Item: Operation<F>,
 {
     // If the translated key is in the snapshot, get a cursor to look for the key.
@@ -311,7 +311,7 @@ async fn update_key<F, I, R>(
 where
     F: Family,
     I: Index<Value = Location<F>>,
-    R: Reader,
+    R: Contiguous,
     R::Item: Operation<F>,
 {
     // If the translated key is not in the snapshot, insert the new location. Otherwise, get a
@@ -346,7 +346,7 @@ async fn find_update_op<F, R>(
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
-    R: Reader,
+    R: Contiguous,
     R::Item: Operation<F>,
 {
     while let Some(&loc) = cursor.next() {
@@ -438,7 +438,7 @@ where
             }
 
             // Update the operation's snapshot location to point to tip.
-            cursor.update(Location::<F>::new(self.log.size().await));
+            cursor.update(Location::<F>::new(self.log.bounds().end));
         }
 
         // Apply the operation at tip.
@@ -460,7 +460,7 @@ where
         &mut self,
         mut inactivity_floor_loc: Location<F>,
     ) -> Result<Location<F>, Error<F>> {
-        let tip_loc: Location<F> = Location::new(self.log.size().await);
+        let tip_loc: Location<F> = Location::new(self.log.bounds().end);
         loop {
             assert!(
                 *inactivity_floor_loc < tip_loc,
@@ -468,10 +468,7 @@ where
             );
             let old_loc = inactivity_floor_loc;
             inactivity_floor_loc += 1;
-            let op = {
-                let reader = self.log.reader().await;
-                reader.read(*old_loc).await?
-            };
+            let op = self.log.read(*old_loc).await?;
             if self.move_op_if_active(op, old_loc).await? {
                 return Ok(inactivity_floor_loc);
             }

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -77,7 +77,7 @@ use crate::{
     index::{unordered::Index, Unordered as _},
     journal::contiguous::{
         variable::{Config as JournalConfig, Journal},
-        Mutable as _, Reader,
+        Contiguous, Mutable as _,
     },
     merkle::mmr::Location,
     qmdb::{
@@ -269,9 +269,8 @@ where
     /// if the location precedes the oldest retained location. The location is otherwise assumed
     /// valid.
     async fn get_op(&self, loc: Location) -> Result<Operation<crate::mmr::Family, K, V>, Error> {
-        let reader = self.log.reader();
-        assert!(*loc < reader.bounds().end);
-        reader.read(*loc).await.map_err(|e| match e {
+        assert!(*loc < self.log.bounds().end);
+        self.log.read(*loc).await.map_err(|e| match e {
             crate::journal::Error::ItemPruned(_) => Error::OperationPruned(loc),
             e => Error::Journal(e),
         })
@@ -280,7 +279,7 @@ where
     /// Return [start, end) where `start` and `end - 1` are the Locations of the oldest and newest
     /// retained operations respectively.
     pub fn bounds(&self) -> std::ops::Range<Location> {
-        let bounds = self.log.reader().bounds();
+        let bounds = self.log.bounds();
         Location::new(bounds.start)..Location::new(bounds.end)
     }
 
@@ -297,8 +296,7 @@ where
 
     /// Get the metadata associated with the last commit.
     pub async fn get_metadata(&self) -> Result<Option<V>, Error> {
-        let Operation::CommitFloor(metadata, _) =
-            self.log.reader().read(*self.last_commit_loc).await?
+        let Operation::CommitFloor(metadata, _) = self.log.read(*self.last_commit_loc).await?
         else {
             unreachable!("last commit should be a commit floor operation");
         };
@@ -322,7 +320,7 @@ where
             return Ok(());
         }
 
-        let bounds = self.log.reader().bounds();
+        let bounds = self.log.bounds();
         let log_size = Location::new(bounds.end);
         let oldest_retained_loc = Location::new(bounds.start);
         debug!(
@@ -361,8 +359,7 @@ where
         // Build the snapshot.
         let mut snapshot = Index::new(context.child("snapshot"), cfg.translator);
         let (inactivity_floor_loc, active_keys) = {
-            let reader = log.reader();
-            let op = reader.read(*last_commit_loc).await?;
+            let op = log.read(*last_commit_loc).await?;
             let inactivity_floor_loc = op.has_floor().expect("last op should be a commit");
             if inactivity_floor_loc > last_commit_loc {
                 return Err(crate::qmdb::Error::DataCorrupted(
@@ -370,7 +367,7 @@ where
                 ));
             }
             let active_keys =
-                build_snapshot_from_log(inactivity_floor_loc, &reader, &mut snapshot, |_, _| {})
+                build_snapshot_from_log(inactivity_floor_loc, &log, &mut snapshot, |_, _| {})
                     .await?;
             (inactivity_floor_loc, active_keys)
         };
@@ -425,11 +422,10 @@ where
         for (key, value) in diff {
             if let Some(value) = value {
                 let updated = {
-                    let reader = self.log.reader();
-                    let new_loc = reader.bounds().end;
+                    let new_loc = self.log.bounds().end;
                     update_key::<crate::mmr::Family, _, _>(
                         &mut self.snapshot,
-                        &reader,
+                        &self.log,
                         &key,
                         Location::new(new_loc),
                     )
@@ -444,11 +440,9 @@ where
                     .append(&Operation::Update(Update(key, value)))
                     .await?;
             } else {
-                let deleted = {
-                    let reader = self.log.reader();
-                    delete_key::<crate::mmr::Family, _, _>(&mut self.snapshot, &reader, &key)
-                        .await?
-                };
+                let deleted =
+                    delete_key::<crate::mmr::Family, _, _>(&mut self.snapshot, &self.log, &key)
+                        .await?;
                 if deleted.is_some() {
                     self.log.append(&Operation::Delete(key)).await?;
                     self.steps += 1;

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -590,7 +590,7 @@ macro_rules! impl_compact_resolver_keyless {
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 fetch_state_from_full_source(
                     target,
-                    || async { Target::new(self.root(), self.bounds().await.end) },
+                    || async { Target::new(self.root(), self.bounds().end) },
                     |leaf_count, last_commit_loc| {
                         self.historical_proof(
                             leaf_count,
@@ -629,7 +629,7 @@ macro_rules! impl_compact_resolver_keyless {
                 let db = self.read().await;
                 fetch_state_from_full_source(
                     target,
-                    || async { Target::new(db.root(), db.bounds().await.end) },
+                    || async { Target::new(db.root(), db.bounds().end) },
                     |leaf_count, last_commit_loc| {
                         db.historical_proof(
                             leaf_count,
@@ -665,7 +665,7 @@ macro_rules! impl_compact_resolver_keyless {
                 let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
                 fetch_state_from_full_source(
                     target,
-                    || async { Target::new(db.root(), db.bounds().await.end) },
+                    || async { Target::new(db.root(), db.bounds().end) },
                     |leaf_count, last_commit_loc| {
                         db.historical_proof(
                             leaf_count,
@@ -708,7 +708,7 @@ macro_rules! impl_compact_resolver_immutable {
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 fetch_state_from_full_source(
                     target,
-                    || async { Target::new(self.root(), self.bounds().await.end) },
+                    || async { Target::new(self.root(), self.bounds().end) },
                     |leaf_count, last_commit_loc| {
                         self.historical_proof(
                             leaf_count,
@@ -750,7 +750,7 @@ macro_rules! impl_compact_resolver_immutable {
                 let db = self.read().await;
                 fetch_state_from_full_source(
                     target,
-                    || async { Target::new(db.root(), db.bounds().await.end) },
+                    || async { Target::new(db.root(), db.bounds().end) },
                     |leaf_count, last_commit_loc| {
                         db.historical_proof(
                             leaf_count,
@@ -789,7 +789,7 @@ macro_rules! impl_compact_resolver_immutable {
                 let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
                 fetch_state_from_full_source(
                     target,
-                    || async { Target::new(db.root(), db.bounds().await.end) },
+                    || async { Target::new(db.root(), db.bounds().end) },
                     |leaf_count, last_commit_loc| {
                         db.historical_proof(
                             leaf_count,

--- a/storage/src/qmdb/sync/journal.rs
+++ b/storage/src/qmdb/sync/journal.rs
@@ -1,5 +1,5 @@
 use crate::{
-    journal::contiguous::{Contiguous, Reader as _},
+    journal::contiguous::Contiguous,
     merkle::{Family, Location},
 };
 use commonware_utils::range::NonEmptyRange;
@@ -70,7 +70,7 @@ where
     }
 
     async fn resize(&mut self, start: Location<F>) -> Result<(), Self::Error> {
-        if Contiguous::size(self).await <= *start {
+        if Contiguous::bounds(self).end <= *start {
             self.clear_to_size(*start).await
         } else {
             self.prune(*start).await.map(|_| ())
@@ -82,7 +82,7 @@ where
     }
 
     async fn size(&self) -> u64 {
-        Contiguous::size(self).await
+        Contiguous::bounds(self).end
     }
 
     async fn append(&mut self, op: Self::Op) -> Result<(), Self::Error> {
@@ -107,7 +107,7 @@ where
         range: NonEmptyRange<Location<F>>,
     ) -> Result<Self, Self::Error> {
         let mut journal = Self::init(context, config).await?;
-        let size = Contiguous::size(&journal).await;
+        let size = Contiguous::bounds(&journal).end;
 
         // Fresh journal already aligned with the sync start - nothing to do.
         if size == 0 && *range.start() == 0 {
@@ -117,7 +117,7 @@ where
         // After a crash during a previous clear_to_size, the journal may recover empty at a stale
         // position ahead of the requested start (possibly even beyond range.end). Re-clear so the
         // sync engine starts from the correct location.
-        let bounds = journal.reader().bounds();
+        let bounds = journal.bounds();
         if bounds.is_empty() && bounds.start > *range.start() {
             journal.clear_to_size(*range.start()).await?;
             return Ok(journal);
@@ -137,7 +137,7 @@ where
     }
 
     async fn resize(&mut self, start: Location<F>) -> Result<(), Self::Error> {
-        if Contiguous::size(self).await <= *start {
+        if Contiguous::bounds(self).end <= *start {
             self.clear_to_size(*start).await
         } else {
             self.prune(*start).await.map(|_| ())
@@ -149,7 +149,7 @@ where
     }
 
     async fn size(&self) -> u64 {
-        Contiguous::size(self).await
+        Contiguous::bounds(self).end
     }
 
     async fn append(&mut self, op: Self::Op) -> Result<(), Self::Error> {
@@ -211,9 +211,9 @@ mod tests {
                 .await
                 .unwrap();
 
-            let size = Contiguous::size(&journal).await;
+            let size = Contiguous::bounds(&journal).end;
             assert_eq!(size, 7);
-            let bounds = journal.reader().bounds();
+            let bounds = journal.bounds();
             assert!(bounds.is_empty());
             assert_eq!(bounds.start, 7);
 
@@ -244,9 +244,9 @@ mod tests {
                 .await
                 .unwrap();
 
-            let size = Contiguous::size(&journal).await;
+            let size = Contiguous::bounds(&journal).end;
             assert_eq!(size, 7);
-            let bounds = journal.reader().bounds();
+            let bounds = journal.bounds();
             assert!(bounds.is_empty());
             assert_eq!(bounds.start, 7);
 

--- a/storage/src/queue/storage.rs
+++ b/storage/src/queue/storage.rs
@@ -2,7 +2,7 @@
 
 use super::{metrics, Error};
 use crate::{
-    journal::contiguous::{variable, Reader as _},
+    journal::contiguous::{variable, Contiguous as _},
     rmap::RMap,
     Context,
 };
@@ -126,7 +126,7 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
 
         // On restart, ack_floor is the pruning boundary (items below are deleted).
         // acked_above is empty (in-memory state lost on restart).
-        let bounds = journal.reader().bounds();
+        let bounds = journal.bounds();
         let acked_above = RMap::new();
 
         debug!(floor = bounds.start, size = bounds.end, "queue initialized");
@@ -184,8 +184,7 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
     ///
     /// Returns an error if the underlying storage operation fails.
     pub async fn dequeue(&mut self) -> Result<Option<(u64, V)>, Error> {
-        let reader = self.journal.reader();
-        let size = reader.bounds().end;
+        let size = self.journal.bounds().end;
 
         // Fast-forward above ack floor
         if self.read_pos < self.ack_floor {
@@ -203,7 +202,7 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
             return Ok(None);
         }
 
-        let item = reader.read(self.read_pos).await?;
+        let item = self.journal.read(self.read_pos).await?;
         let pos = self.read_pos;
         self.read_pos += 1;
         let _ = self.metrics.next.try_set(self.read_pos);


### PR DESCRIPTION
`Contiguous` handed out a `Reader` (an owned snapshot) per read. This drops that indirection: `Contiguous` carries the read methods itself, and reads use a cheap borrowed view instead of an owned snapshot.

## Trait
- Remove `Reader`; move `bounds`/`read`/`read_many`/`try_read_sync`/`replay` onto `Contiguous`.
- Remove `Contiguous::reader()` and `Contiguous::size()` (callers use `bounds().end`).

## Journal (fixed + variable)
- Implement `Contiguous` directly; reads go through an internal borrowed `reader()` (a live view over `Blobs::Writable`). The `&self` borrow blocks concurrent mutation, so no snapshot is captured.
- Keep `Journal::snapshot()` for reads that must outlive a borrow: a detached, owned reader (`Blobs::Snapshot`) with frozen bounds, readable across prunes; rewind refused (`BlobInUse`) while one is alive.
- `Reader` gains a lifetime (`Reader<'a>`) and a `Blobs<'a>` enum unifying the live and snapshot backings.
- `replay` runs through a shared helper that owns its handles (`use<E, V>`), letting `Journal::replay` return a stream without borrowing a function-local snapshot.
- Rename the rewind gate `readers` -> `snapshots`.

## Consumers (qmdb, queue, authenticated)
- `journal.reader().await.{read,bounds,...}` -> direct `journal.{...}`; `size().await` -> `bounds().end`.
- De-async `size`/`bounds`/`update_metrics` where their only `await` was the removed call.
- `R: Reader` trait bounds -> `R: Contiguous`.