### PR TITLE
[cryptography] Improve parallelism in Bulletproofs prover

### DIFF
--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -161,3 +161,8 @@ path = "src/handshake/benches/bench.rs"
 name = "bloomfilter"
 harness = false
 path = "src/bloomfilter/benches/bench.rs"
+
+[[bench]]
+name = "ipa"
+harness = false
+path = "src/zk/bulletproofs/benches/bench.rs"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -163,6 +163,6 @@ harness = false
 path = "src/bloomfilter/benches/bench.rs"
 
 [[bench]]
-name = "ipa"
+name = "bulletproofs"
 harness = false
 path = "src/zk/bulletproofs/benches/bench.rs"

--- a/cryptography/src/zk/bulletproofs/benches/bench.rs
+++ b/cryptography/src/zk/bulletproofs/benches/bench.rs
@@ -1,0 +1,5 @@
+use criterion::criterion_main;
+
+mod ipa;
+
+criterion_main!(ipa::benches);

--- a/cryptography/src/zk/bulletproofs/benches/ipa.rs
+++ b/cryptography/src/zk/bulletproofs/benches/ipa.rs
@@ -1,0 +1,135 @@
+use commonware_cryptography::{
+    bls12381::primitives::group::{Scalar, G1},
+    transcript::Transcript,
+    zk::bulletproofs::ipa::{self, Proof, Setup, Witness},
+};
+use commonware_math::algebra::{CryptoGroup, Random};
+use commonware_parallel::{Rayon, Sequential};
+use criterion::{criterion_group, BatchSize, Criterion};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{hint::black_box, num::NonZeroUsize};
+
+fn make_setup(len: usize) -> Setup<G1> {
+    let generators: Vec<_> = (0..(2 * len + 1))
+        .map(|i| G1::generator() * &Scalar::from(i as u64 + 1))
+        .collect();
+    Setup::new(
+        generators[0],
+        generators[1..]
+            .chunks_exact(2)
+            .map(|chunk| (chunk[0], chunk[1])),
+    )
+}
+
+fn make_elements(rng: &mut StdRng, len: usize) -> Vec<(Scalar, Scalar)> {
+    let mut elements = Vec::with_capacity(len);
+    for _ in 0..len {
+        elements.push((Scalar::random(&mut *rng), Scalar::random(&mut *rng)));
+    }
+    elements
+}
+
+fn make_proof(setup: &Setup<G1>, len: usize) -> (ipa::Claim<Scalar, G1>, Proof<Scalar, G1>) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let y = Scalar::random(&mut rng);
+    let (witness, claim) =
+        Witness::new_with_claim(setup, y, make_elements(&mut rng, len)).expect("valid witness");
+    let mut transcript = Transcript::new(b"ipa-bench");
+    transcript.commit(&b"context"[..]);
+    let proof = ipa::prove(&mut transcript, setup, &claim, witness, &Sequential)
+        .expect("proof should succeed");
+    (claim, proof)
+}
+
+fn bench_prove(c: &mut Criterion) {
+    let par = Rayon::new(NonZeroUsize::new(8).unwrap()).unwrap();
+
+    for len in [8usize, 16, 32, 64, 128] {
+        let setup = make_setup(len);
+        c.bench_function(&format!("{}::prove/n={len} conc=1", module_path!()), |b| {
+            b.iter_batched(
+                || {
+                    let mut rng = StdRng::seed_from_u64(0);
+                    let y = Scalar::random(&mut rng);
+                    let elements = make_elements(&mut rng, len);
+                    let (witness, claim) =
+                        Witness::new_with_claim(&setup, y, elements).expect("valid witness");
+                    (claim, witness)
+                },
+                |(claim, witness)| {
+                    let mut transcript = Transcript::new(b"ipa-bench");
+                    transcript.commit(&b"context"[..]);
+                    black_box(ipa::prove(
+                        &mut transcript,
+                        &setup,
+                        &claim,
+                        witness,
+                        &Sequential,
+                    ));
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        c.bench_function(&format!("{}::prove/n={len} conc=8", module_path!()), |b| {
+            b.iter_batched(
+                || {
+                    let mut rng = StdRng::seed_from_u64(0);
+                    let y = Scalar::random(&mut rng);
+                    let elements = make_elements(&mut rng, len);
+                    let (witness, claim) =
+                        Witness::new_with_claim(&setup, y, elements).expect("valid witness");
+                    (claim, witness)
+                },
+                |(claim, witness)| {
+                    let mut transcript = Transcript::new(b"ipa-bench");
+                    transcript.commit(&b"context"[..]);
+                    black_box(ipa::prove(&mut transcript, &setup, &claim, witness, &par));
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+fn bench_verify(c: &mut Criterion) {
+    let par = Rayon::new(NonZeroUsize::new(8).unwrap()).unwrap();
+
+    for len in [8usize, 16, 32, 64, 128] {
+        let setup = make_setup(len);
+        c.bench_function(&format!("{}::verify/n={len} conc=1", module_path!()), |b| {
+            b.iter_batched(
+                || make_proof(&setup, len),
+                |(claim, proof)| {
+                    let mut transcript = Transcript::new(b"ipa-bench");
+                    transcript.commit(&b"context"[..]);
+                    black_box(setup.eval(
+                        |vs| ipa::verify(&mut transcript, vs, &claim, proof),
+                        &Sequential,
+                    ));
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        c.bench_function(&format!("{}::verify/n={len} conc=8", module_path!()), |b| {
+            b.iter_batched(
+                || make_proof(&setup, len),
+                |(claim, proof)| {
+                    let mut transcript = Transcript::new(b"ipa-bench");
+                    transcript.commit(&b"context"[..]);
+                    black_box(
+                        setup.eval(|vs| ipa::verify(&mut transcript, vs, &claim, proof), &par),
+                    );
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_prove, bench_verify
+}

--- a/cryptography/src/zk/bulletproofs/ipa.rs
+++ b/cryptography/src/zk/bulletproofs/ipa.rs
@@ -605,8 +605,8 @@ where
         let mid = a.len() / 2;
         let (a_lo, a_hi) = a.split_at_mut(mid);
         let (b_lo, b_hi) = b.split_at_mut(mid);
-        let (g_lo, g_hi) = g.split_at_mut(mid);
-        let (h_lo, h_hi) = h.split_at_mut(mid);
+        let (g_lo, g_hi) = g.split_at(mid);
+        let (h_lo, h_hi) = h.split_at(mid);
         let l = G::msm(g_hi, a_lo, strategy)
             + &G::msm(h_lo, b_hi, strategy)
             + &(w_q.clone() * &F::msm(a_lo, b_hi, strategy));
@@ -631,17 +631,21 @@ where
         }
         b.truncate(mid);
 
-        for (g_lo_i, g_hi_i) in g_lo.iter_mut().zip(g_hi.iter_mut()) {
-            *g_lo_i *= &u_inv;
-            *g_lo_i += &(g_hi_i.clone() * &u);
-        }
-        g.truncate(mid);
-
-        for (h_lo_i, h_hi_i) in h_lo.iter_mut().zip(h_hi.iter_mut()) {
-            *h_lo_i *= &u;
-            *h_lo_i += &(h_hi_i.clone() * &u_inv);
-        }
-        h.truncate(mid);
+        let u_u_inv = [u.clone(), u_inv.clone()];
+        let (new_g, new_h) = strategy.join(
+            || {
+                strategy.map_collect_vec(g_lo.iter().zip(g_hi), |(g_lo_i, g_hi_i)| {
+                    G::msm(&[g_hi_i.clone(), g_lo_i.clone()], &u_u_inv, strategy)
+                })
+            },
+            || {
+                strategy.map_collect_vec(h_lo.iter().zip(h_hi), |(h_lo_i, h_hi_i)| {
+                    G::msm(&[h_lo_i.clone(), h_hi_i.clone()], &u_u_inv, strategy)
+                })
+            },
+        );
+        g = new_g;
+        h = new_h;
     }
     let a_final = a.pop().expect("a should not be empty");
     let b_final = b.pop().expect("b should not be empty");


### PR DESCRIPTION
Not quite linear scaling, but without this the prover doesn't scale at all with parallelism, so this is a good change.

Also added benchmarks for just the IPA.