### PR TITLE
[runtime] [storage/journal] Release write buffers of sealed journal sections

### DIFF
--- a/runtime/src/utils/buffer/paged/append.rs
+++ b/runtime/src/utils/buffer/paged/append.rs
@@ -1235,6 +1235,21 @@ impl<B: Blob> Append<B> {
         blob_state.sync().await
     }
 
+    /// Releases the oversized write-buffer backing once this blob is no longer the active append
+    /// tip.
+    ///
+    /// Full pages are drained to the blob (without an extra sync) so only a sub-page remainder is
+    /// left buffered, then that remainder is copied into a right-sized allocation, freeing the
+    /// write-buffer-sized backing it would otherwise pin. The buffered bytes are preserved and are
+    /// still made durable by a later [Self::sync]; only surplus pooled capacity is reclaimed.
+    pub async fn seal(&self) -> Result<(), Error> {
+        let buf_guard = self.buffer.write().await;
+        self.flush_internal(buf_guard, false, false).await?;
+        let mut buffer = self.buffer.write().await;
+        buffer.compact();
+        Ok(())
+    }
+
     /// Resize the blob to the provided logical `size`.
     ///
     /// This truncates the blob to contain only `size` logical bytes. The physical blob size will
@@ -1472,6 +1487,45 @@ mod tests {
             let mut buf = vec![0u8; data.len()];
             assert!(append.try_read_sync(0, &mut buf));
             assert_eq!(buf, data);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_seal_preserves_data_across_pages() {
+        // Sealing a blob that is no longer the active tip must release its surplus backing while
+        // preserving every buffered byte: full pages already drained to the blob plus the trailing
+        // partial page kept in the (now compacted) tip.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context.open("test_partition", b"seal").await.unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let append = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            // More than two pages so the tip holds full pages plus a trailing partial page.
+            let data: Vec<u8> = (0..250u32).map(|i| i as u8).collect();
+            append.append(&data).await.unwrap();
+            let size = append.size().await;
+            assert_eq!(size, data.len() as u64);
+
+            // Sealing keeps the logical size and all bytes readable.
+            append.seal().await.unwrap();
+            assert_eq!(append.size().await, size);
+            let read = append.read_at(0, data.len()).await.unwrap();
+            assert_eq!(read.coalesce().as_ref(), &data[..]);
+
+            // Durability is unaffected: after a sync and reopen the data is intact on disk.
+            append.sync().await.unwrap();
+            drop(append);
+            let (blob, blob_size) = context.open("test_partition", b"seal").await.unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let reopened = Append::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size().await, size);
+            let read = reopened.read_at(0, data.len()).await.unwrap();
+            assert_eq!(read.coalesce().as_ref(), &data[..]);
         });
     }
 

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -263,6 +263,23 @@ impl Buffer {
     pub(super) const fn clear(&mut self) {
         self.len = 0;
     }
+
+    /// Releases an oversized backing allocation by copying the buffered bytes into a right-sized
+    /// pooled buffer.
+    ///
+    /// [Self::drop_prefix] leaves a trailing partial page as a view into the original
+    /// (write-buffer-sized) backing, which keeps the whole allocation alive. Once a blob is no
+    /// longer the active append tip its small remainder no longer needs that capacity, so copying
+    /// it into a fresh buffer lets the large backing be reclaimed.
+    pub(super) fn compact(&mut self) {
+        if self.len == 0 {
+            self.data = IoBuf::default();
+            return;
+        }
+        let mut fresh = self.pool.alloc(self.len);
+        fresh.put_slice(&self.data.as_ref()[..self.len]);
+        self.data = fresh.freeze();
+    }
 }
 
 impl AsRef<[u8]> for Buffer {

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -294,4 +294,17 @@ impl<B: Blob> Write<B> {
 
         state.sync().await
     }
+
+    /// Releases the buffer backing once this blob is no longer the active append tip.
+    ///
+    /// Buffered bytes are drained to the blob (without an extra sync); [`Buffer::take`] resets the
+    /// tip to a detached, empty state so no write-buffer backing is retained. The drained bytes are
+    /// still made durable by a later [`Self::sync`].
+    pub async fn seal(&self) -> Result<(), Error> {
+        let mut state = self.state.write().await;
+        if let Some((buf, offset)) = state.buffer.take() {
+            state.write_at(offset, buf).await?;
+        }
+        Ok(())
+    }
 }

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -27,6 +27,9 @@ pub trait SectionBuffer: Clone + Send + Sync {
 
     /// Resize the logical size of the buffer.
     fn resize(&self, len: u64) -> impl Future<Output = Result<(), RError>> + Send;
+
+    /// Release surplus write-buffer capacity once this section is no longer the active append tip.
+    fn seal(&self) -> impl Future<Output = Result<(), RError>> + Send;
 }
 
 impl<B: Blob> SectionBuffer for Append<B> {
@@ -41,6 +44,10 @@ impl<B: Blob> SectionBuffer for Append<B> {
     async fn resize(&self, len: u64) -> Result<(), RError> {
         Self::resize(self, len).await
     }
+
+    async fn seal(&self) -> Result<(), RError> {
+        Self::seal(self).await
+    }
 }
 
 impl<B: Blob> SectionBuffer for Write<B> {
@@ -54,6 +61,10 @@ impl<B: Blob> SectionBuffer for Write<B> {
 
     async fn resize(&self, len: u64) -> Result<(), RError> {
         Self::resize(self, len).await
+    }
+
+    async fn seal(&self) -> Result<(), RError> {
+        Self::seal(self).await
     }
 }
 
@@ -205,6 +216,15 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
         self.prune_guard(section)?;
 
         if !self.blobs.contains_key(&section) {
+            // Advancing past the current tip section: it will never be appended to again, so
+            // release its oversized write buffer (keeping only its partial-page remainder) instead
+            // of pinning a full write-buffer allocation per retained section until it is pruned.
+            if let Some((&prev, prev_buf)) = self.blobs.last_key_value() {
+                if section > prev {
+                    prev_buf.seal().await.map_err(Error::Runtime)?;
+                }
+            }
+
             let name = section.to_be_bytes();
             let (blob, size) = self.context.open(&self.partition, &name).await?;
             let buffer = self.factory.create(blob, size).await?;


### PR DESCRIPTION
## Problem

A segmented journal keeps one write buffer per section in `Manager::blobs`, each
holding a `write_buffer`-sized backing allocation (default 2 MiB), released only
by `prune()`. When a section fills and the journal advances to the next one, the
prior section's buffer keeps its full backing alive: a flush drains the full
pages but leaves the trailing partial page as a *slice* of the original
allocation (`tip::Buffer::drop_prefix`), so a sub-page remainder pins the whole
2 MiB. `commit()`/`sync()` flush the bytes to disk but never release this
backing.

Resident memory therefore grows ~2 MiB per `items_per_blob` operations -- for
**both** the operations log and the merkle node journal -- and is reclaimed only
at `prune()`. During a large QMDB build (which raises the inactivity floor but
does not prune), this dominates memory and OOMs at scale.

## Fix

Seal a section when the journal advances past it (`Manager::get_or_create`):
drain its full pages and copy the partial-page remainder into a right-sized
buffer (`tip::Buffer::compact`), releasing the oversized backing. The active tip
keeps its full write buffer for append reuse; sealed sections shrink from ~2 MiB
to one page. Durability is unchanged -- `seal` uses the existing un-synced flush
path, so nothing is durable until the next `commit`/`sync`, exactly as before.

## Impact (1M-key + 5M-update build)

|                      | before  | after                                   |
|----------------------|---------|-----------------------------------------|
| live heap at peak    | 1.48 GB | 236 MB                                  |
| live 2 MiB buffers   | 665     | 65 (bounded by pool cap, not # sections)|
| peak RSS             | 1.66 GB | 766 MB                                  |

At 50M keys this is the difference between ~66 GB of section-buffer overhead and
~0.5 GB.

## Tests

- New `test_seal_preserves_data_across_pages` (append spanning pages, seal,
  verify data is intact and survives a sync + reopen).
- `commonware-runtime` buffer tests, `commonware-storage` `journal::`
  (segmented/contiguous/authenticated), and `qmdb::any` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
