### PR TITLE
[resolver] [consensus] Nits

### DIFF
--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -902,6 +902,7 @@ where
         join_all(
             produces
                 .into_iter()
+                .filter(|(_, response)| !response.is_closed()) // Ignore closed senders
                 .map(|(key, response)| self.handle_produce(key, response, buffer)),
         )
         .await;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -902,7 +902,7 @@ where
         join_all(
             produces
                 .into_iter()
-                .filter(|(_, response)| !response.is_closed()) // Ignore closed senders
+                .filter(|(_, response)| !response.is_closed())
                 .map(|(key, response)| self.handle_produce(key, response, buffer)),
         )
         .await;

--- a/resolver/src/delivery.rs
+++ b/resolver/src/delivery.rs
@@ -144,8 +144,7 @@ where
     /// Dropped entries abort in-progress deliveries. Returns the number of
     /// removed entries.
     pub fn retain<F: FnMut(&Con::Key) -> bool>(&mut self, mut predicate: F) -> usize {
-        let removed: Vec<_> = self.entries.extract_if(|key, _| !predicate(key)).collect();
-        removed.len()
+        self.entries.extract_if(|key, _| !predicate(key)).count()
     }
 
     /// Remove all entries and abort all in-progress deliveries.

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -407,10 +407,7 @@ where
             self.inflight.cancel(&key);
             return;
         };
-        let delivery = Delivery {
-            key: key.clone(),
-            subscribers,
-        };
+        let delivery = Delivery { key, subscribers };
 
         // The peer had the data, so deliver it to the consumer without blocking the engine.
         self.inflight.deliver(delivery, peer, response);


### PR DESCRIPTION
`consensus/src/marshal/core/actor.rs`: avoid handling message if sender channel is closed. This is checked above, but after the existing check we do non-trivial work

`resolver/src/delivery.rs`: avoid an allocation

`resolver/src/p2p/engine.rs`: remove unneeded clone