### PR TITLE
[storage/qmdb] Parallel snapshot init for the partitioned indexes

### DIFF
--- a/codec/src/util.rs
+++ b/codec/src/util.rs
@@ -1,6 +1,6 @@
 //! Codec utility functions
 
-use crate::{Error, extensions::ReadExt as _};
+use crate::Error;
 use bytes::Buf;
 
 /// Checks if the buffer has at least `len` bytes remaining. Returns an [Error::EndOfBuffer] if not.
@@ -17,10 +17,65 @@ pub fn at_least<B: Buf>(buf: &mut B, len: usize) -> Result<(), Error> {
 /// otherwise.
 #[inline]
 pub fn ensure_zeros<B: Buf>(buf: &mut B, size: usize) -> Result<(), Error> {
-    for _ in 0..size {
-        if u8::read(buf)? != 0 {
+    at_least(buf, size)?;
+    let mut remaining = size;
+    while remaining > 0 {
+        // Compare (and advance) a chunk at a time rather than a byte at a time. Padding regularly
+        // spans dozens of bytes, and a slice comparison vectorizes.
+        let chunk = buf.chunk();
+        let len = chunk.len().min(remaining);
+        if chunk[..len].iter().any(|&b| b != 0) {
             return Err(Error::Invalid("codec", "non-zero bytes"));
         }
+        buf.advance(len);
+        remaining -= len;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ensure_zeros() {
+        // Consumes exactly `size` bytes of an all-zero region.
+        let mut buf = &[0u8, 0, 0, 0, 7][..];
+        ensure_zeros(&mut buf, 4).unwrap();
+        assert_eq!(buf.remaining(), 1);
+
+        // A zero-length check consumes nothing, even on an empty buffer.
+        let mut buf = &[][..];
+        ensure_zeros(&mut buf, 0).unwrap();
+
+        // A short buffer fails without panicking.
+        let mut buf = &[0u8, 0][..];
+        assert!(matches!(ensure_zeros(&mut buf, 3), Err(Error::EndOfBuffer)));
+
+        // A non-zero byte anywhere in the region fails.
+        for i in 0..4 {
+            let mut bytes = [0u8; 4];
+            bytes[i] = 1;
+            let mut buf = &bytes[..];
+            assert!(matches!(
+                ensure_zeros(&mut buf, 4),
+                Err(Error::Invalid(_, _))
+            ));
+        }
+    }
+
+    #[test]
+    fn test_ensure_zeros_across_chunks() {
+        // A chained buffer exposes the region as multiple chunks, exercising the chunk loop.
+        let mut buf = (&[0u8, 0][..]).chain(&[0u8, 0, 0][..]);
+        ensure_zeros(&mut buf, 5).unwrap();
+        assert_eq!(buf.remaining(), 0);
+
+        // A non-zero byte in the second chunk still fails.
+        let mut buf = (&[0u8, 0][..]).chain(&[0u8, 2][..]);
+        assert!(matches!(
+            ensure_zeros(&mut buf, 4),
+            Err(Error::Invalid(_, _))
+        ));
+    }
 }

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -34,7 +34,6 @@ pub type Operation = FixedOperation<mmr::Family, Key, Value>;
 pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequential> {
     let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
     Config {
-        init_workers: None,
         merkle_config: MmrConfig {
             journal_partition: "mmr-journal".into(),
             metadata_partition: "mmr-metadata".into(),
@@ -51,6 +50,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
         },
         translator: Translator::default(),
         init_cache_size: Some(NZUsize!(1 << 16)),
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -50,7 +50,8 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
         },
         translator: Translator::default(),
         init_cache_size: Some(NZUsize!(1 << 16)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -9,7 +9,7 @@ use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     mmr::{self, Location, Proof, full::Config as MmrConfig},
     qmdb::{
-        self, InitParallelism,
+        self,
         any::{
             FixedConfig as Config,
             unordered::{
@@ -34,7 +34,7 @@ pub type Operation = FixedOperation<mmr::Family, Key, Value>;
 pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequential> {
     let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
     Config {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: MmrConfig {
             journal_partition: "mmr-journal".into(),
             metadata_partition: "mmr-metadata".into(),

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -9,7 +9,7 @@ use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     mmr::{self, Location, Proof, full::Config as MmrConfig},
     qmdb::{
-        self,
+        self, InitParallelism,
         any::{
             FixedConfig as Config,
             unordered::{
@@ -34,6 +34,7 @@ pub type Operation = FixedOperation<mmr::Family, Key, Value>;
 pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequential> {
     let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
     Config {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: MmrConfig {
             journal_partition: "mmr-journal".into(),
             metadata_partition: "mmr-metadata".into(),

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -73,7 +73,8 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
         grafted_metadata_partition: "grafted-mmr-metadata".into(),
         translator: Translator::default(),
         init_cache_size: Some(NZUsize!(1 << 16)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -24,7 +24,7 @@ use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     mmr::{self, Location, Proof, full::Config as MmrConfig},
     qmdb::{
-        self,
+        self, InitParallelism,
         any::unordered::{Update, fixed::Operation as FixedOperation},
         current::{self, FixedConfig as Config},
         operation::Committable,
@@ -56,6 +56,7 @@ pub type Operation = FixedOperation<mmr::Family, Key, Value>;
 pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequential> {
     let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
     Config {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: MmrConfig {
             journal_partition: "mmr-journal".into(),
             metadata_partition: "mmr-metadata".into(),

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -56,7 +56,6 @@ pub type Operation = FixedOperation<mmr::Family, Key, Value>;
 pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequential> {
     let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
     Config {
-        init_workers: None,
         merkle_config: MmrConfig {
             journal_partition: "mmr-journal".into(),
             metadata_partition: "mmr-metadata".into(),
@@ -74,6 +73,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
         grafted_metadata_partition: "grafted-mmr-metadata".into(),
         translator: Translator::default(),
         init_cache_size: Some(NZUsize!(1 << 16)),
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -24,7 +24,7 @@ use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     mmr::{self, Location, Proof, full::Config as MmrConfig},
     qmdb::{
-        self, InitParallelism,
+        self,
         any::unordered::{Update, fixed::Operation as FixedOperation},
         current::{self, FixedConfig as Config},
         operation::Committable,
@@ -56,7 +56,7 @@ pub type Operation = FixedOperation<mmr::Family, Key, Value>;
 pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequential> {
     let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
     Config {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: MmrConfig {
             journal_partition: "mmr-journal".into(),
             metadata_partition: "mmr-metadata".into(),

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -51,6 +51,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, FConfig,
         },
         translator: commonware_storage::translator::EightCap,
         init_cache_size: Some(NZUsize!(1 << 16)),
+        init_buffer: NZUsize!(1 << 21),
     }
 }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -1558,7 +1558,6 @@ mod tests {
     ) -> any::FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE);
         any::FixedConfig {
-            init_workers: None,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{prefix}_mmr_journal"),
                 metadata_partition: format!("{prefix}_mmr_metadata"),
@@ -1575,6 +1574,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -1574,7 +1574,8 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         }
     }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -946,7 +946,7 @@ mod tests {
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedLogConfig,
         mmr::{self, Location, full::Config as MmrJournalConfig},
-        qmdb::{InitParallelism, any, sync::Target},
+        qmdb::{any, sync::Target},
         translator::TwoCap,
     };
     use commonware_utils::{
@@ -1558,7 +1558,7 @@ mod tests {
     ) -> any::FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE);
         any::FixedConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{prefix}_mmr_journal"),
                 metadata_partition: format!("{prefix}_mmr_metadata"),

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -946,7 +946,7 @@ mod tests {
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedLogConfig,
         mmr::{self, Location, full::Config as MmrJournalConfig},
-        qmdb::{any, sync::Target},
+        qmdb::{InitParallelism, any, sync::Target},
         translator::TwoCap,
     };
     use commonware_utils::{
@@ -1558,6 +1558,7 @@ mod tests {
     ) -> any::FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE);
         any::FixedConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{prefix}_mmr_journal"),
                 metadata_partition: format!("{prefix}_mmr_metadata"),

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -816,7 +816,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_workers: None,
+            init_concurrency: NZUsize!(1),
         }
     }
 

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -816,7 +816,8 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         }
     }
 

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -816,7 +816,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_parallelism: Default::default(),
+            init_workers: None,
         }
     }
 

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -13,6 +13,7 @@ use crate::stateful::db::{
 use commonware_codec::{Codec, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_storage::{
     Context,
     index::{
@@ -475,7 +476,7 @@ impl<F, E, K, V, H, T, S> ManagedDb<E>
     >
 where
     F: Family,
-    E: Context,
+    E: Context + Spawner,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher + 'static,
@@ -574,7 +575,7 @@ impl<F, E, K, V, H, T, S> ManagedDb<E>
     >
 where
     F: Family,
-    E: Context,
+    E: Context + Spawner,
     K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -677,7 +678,7 @@ impl<F, E, K, V, H, T, S, R> StateSyncDb<E, R>
     >
 where
     F: Family,
-    E: Context,
+    E: Context + Spawner,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher,
@@ -731,7 +732,7 @@ impl<F, E, K, V, H, T, S, R> StateSyncDb<E, R>
     >
 where
     F: Family,
-    E: Context,
+    E: Context + Spawner,
     K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -815,6 +816,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_parallelism: Default::default(),
         }
     }
 

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1181,12 +1181,9 @@ mod tests {
             fixed::Config as FixedJournalConfig, variable::Config as VariableJournalConfig,
         },
         merkle::{full::Config as MerkleConfig, mmr},
-        qmdb::{
-            InitParallelism,
-            current::{
-                ordered::{fixed as ordered_fixed, variable as ordered_variable},
-                unordered::fixed,
-            },
+        qmdb::current::{
+            ordered::{fixed as ordered_fixed, variable as ordered_variable},
+            unordered::fixed,
         },
         translator::TwoCap,
     };
@@ -1237,7 +1234,7 @@ mod tests {
     fn fixed_config(suffix: &str, pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("stateful-current-journal-{suffix}"),
                 metadata_partition: format!("stateful-current-metadata-{suffix}"),
@@ -1264,7 +1261,7 @@ mod tests {
     ) -> VariableConfig<TwoCap, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("stateful-current-journal-{suffix}"),
                 metadata_partition: format!("stateful-current-metadata-{suffix}"),

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -13,6 +13,7 @@ use crate::stateful::db::{
 use commonware_codec::{Codec, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_storage::{
     Context,
     index::{
@@ -471,7 +472,7 @@ impl<F, E, K, V, H, T, const N: usize, S> ManagedDb<E>
     >
 where
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher + 'static,
@@ -572,7 +573,7 @@ impl<F, E, K, V, H, T, const N: usize, S> ManagedDb<E>
     >
 where
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher + 'static,
@@ -671,6 +672,7 @@ mod open {
     use commonware_codec::{Codec, Read};
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
+    use commonware_runtime::Spawner;
     use commonware_storage::{
         Context,
         merkle::Graftable,
@@ -702,7 +704,7 @@ mod open {
     ) -> Result<Db<F, E, K, V, H, T, N, S>, Error<F>>
     where
         F: Graftable,
-        E: Context,
+        E: Context + Spawner,
         K: Array,
         V: VariableValue + 'static,
         H: Hasher,
@@ -719,7 +721,7 @@ mod open {
     ) -> Result<OrderedVariableDb<F, E, K, V, H, T, N, S>, Error<F>>
     where
         F: Graftable,
-        E: Context,
+        E: Context + Spawner,
         K: commonware_storage::qmdb::operation::Key,
         V: VariableValue + 'static,
         H: Hasher,
@@ -745,7 +747,7 @@ impl<F, E, K, V, H, T, const N: usize, S> ManagedDb<E>
     >
 where
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Key + Array,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -851,7 +853,7 @@ impl<F, E, K, V, H, T, const N: usize, S> ManagedDb<E>
     >
 where
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -957,7 +959,7 @@ impl<F, E, K, V, H, T, R, const N: usize, S> StateSyncDb<E, R>
     >
 where
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher,
@@ -1012,7 +1014,7 @@ impl<F, E, K, V, H, T, R, const N: usize, S> StateSyncDb<E, R>
     >
 where
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher,
@@ -1067,7 +1069,7 @@ impl<F, E, K, V, H, T, R, const N: usize, S> StateSyncDb<E, R>
     >
 where
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Key + Array,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -1123,7 +1125,7 @@ impl<F, E, K, V, H, T, R, const N: usize, S> StateSyncDb<E, R>
     >
 where
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -1179,9 +1181,12 @@ mod tests {
             fixed::Config as FixedJournalConfig, variable::Config as VariableJournalConfig,
         },
         merkle::{full::Config as MerkleConfig, mmr},
-        qmdb::current::{
-            ordered::{fixed as ordered_fixed, variable as ordered_variable},
-            unordered::fixed,
+        qmdb::{
+            InitParallelism,
+            current::{
+                ordered::{fixed as ordered_fixed, variable as ordered_variable},
+                unordered::fixed,
+            },
         },
         translator::TwoCap,
     };
@@ -1232,6 +1237,7 @@ mod tests {
     fn fixed_config(suffix: &str, pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("stateful-current-journal-{suffix}"),
                 metadata_partition: format!("stateful-current-metadata-{suffix}"),
@@ -1258,6 +1264,7 @@ mod tests {
     ) -> VariableConfig<TwoCap, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("stateful-current-journal-{suffix}"),
                 metadata_partition: format!("stateful-current-metadata-{suffix}"),

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1251,7 +1251,8 @@ mod tests {
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         }
     }
 
@@ -1280,7 +1281,8 @@ mod tests {
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         }
     }
 

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1234,7 +1234,6 @@ mod tests {
     fn fixed_config(suffix: &str, pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("stateful-current-journal-{suffix}"),
                 metadata_partition: format!("stateful-current-metadata-{suffix}"),
@@ -1252,6 +1251,7 @@ mod tests {
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 
@@ -1261,7 +1261,6 @@ mod tests {
     ) -> VariableConfig<TwoCap, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("stateful-current-journal-{suffix}"),
                 metadata_partition: format!("stateful-current-metadata-{suffix}"),
@@ -1281,6 +1280,7 @@ mod tests {
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -479,6 +479,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_buffer: NZUsize!(1 << 21),
         }
     }
 

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1828,7 +1828,7 @@ mod tests {
                 journal_config: fixed_journal_config(context, suffix),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_workers: None,
+                init_concurrency: NZUsize!(1),
             }
         }
 
@@ -1841,7 +1841,7 @@ mod tests {
                 journal_config: variable_journal_config(context, suffix, ((), ())),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_workers: None,
+                init_concurrency: NZUsize!(1),
             }
         }
 
@@ -1855,7 +1855,7 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_workers: None,
+                init_concurrency: NZUsize!(1),
             }
         }
 
@@ -1869,7 +1869,7 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_workers: None,
+                init_concurrency: NZUsize!(1),
             }
         }
 

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1828,7 +1828,8 @@ mod tests {
                 journal_config: fixed_journal_config(context, suffix),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_concurrency: NZUsize!(1),
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             }
         }
 
@@ -1841,7 +1842,8 @@ mod tests {
                 journal_config: variable_journal_config(context, suffix, ((), ())),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_concurrency: NZUsize!(1),
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             }
         }
 
@@ -1855,7 +1857,8 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_concurrency: NZUsize!(1),
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             }
         }
 
@@ -1869,7 +1872,8 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_concurrency: NZUsize!(1),
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             }
         }
 
@@ -1882,6 +1886,7 @@ mod tests {
                 log: fixed_journal_config(context, suffix),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                init_buffer: NZUsize!(1 << 21),
             }
         }
 
@@ -1894,6 +1899,7 @@ mod tests {
                 log: variable_journal_config(context, suffix, ((), ())),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                init_buffer: NZUsize!(1 << 21),
             }
         }
 

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1664,8 +1664,8 @@ mod tests {
             },
             merkle::{full::Config as MerkleConfig, mmr},
             qmdb::{
-                InitParallelism, any as storage_any, current as storage_current,
-                immutable as storage_immutable, keyless as storage_keyless,
+                any as storage_any, current as storage_current, immutable as storage_immutable,
+                keyless as storage_keyless,
             },
             translator::TwoCap,
         };
@@ -1828,7 +1828,7 @@ mod tests {
                 journal_config: fixed_journal_config(context, suffix),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_parallelism: InitParallelism::Serial,
+                init_workers: None,
             }
         }
 
@@ -1841,7 +1841,7 @@ mod tests {
                 journal_config: variable_journal_config(context, suffix, ((), ())),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_parallelism: InitParallelism::Serial,
+                init_workers: None,
             }
         }
 
@@ -1855,7 +1855,7 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_parallelism: InitParallelism::Serial,
+                init_workers: None,
             }
         }
 
@@ -1869,7 +1869,7 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
-                init_parallelism: InitParallelism::Serial,
+                init_workers: None,
             }
         }
 

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1664,8 +1664,8 @@ mod tests {
             },
             merkle::{full::Config as MerkleConfig, mmr},
             qmdb::{
-                any as storage_any, current as storage_current, immutable as storage_immutable,
-                keyless as storage_keyless,
+                InitParallelism, any as storage_any, current as storage_current,
+                immutable as storage_immutable, keyless as storage_keyless,
             },
             translator::TwoCap,
         };
@@ -1828,6 +1828,7 @@ mod tests {
                 journal_config: fixed_journal_config(context, suffix),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                init_parallelism: InitParallelism::Serial,
             }
         }
 
@@ -1840,6 +1841,7 @@ mod tests {
                 journal_config: variable_journal_config(context, suffix, ((), ())),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                init_parallelism: InitParallelism::Serial,
             }
         }
 
@@ -1853,6 +1855,7 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                init_parallelism: InitParallelism::Serial,
             }
         }
 
@@ -1866,6 +1869,7 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                init_parallelism: InitParallelism::Serial,
             }
         }
 

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -395,7 +395,10 @@ mod tests {
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedLogConfig,
         mmr::{self, Location, Proof, full::Config as MmrJournalConfig},
-        qmdb::any::{FixedConfig, unordered::fixed},
+        qmdb::{
+            InitParallelism,
+            any::{FixedConfig, unordered::fixed},
+        },
         translator::TwoCap,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, channel::oneshot};
@@ -487,6 +490,7 @@ mod tests {
     fn db_config(suffix: &str, pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, NZU16!(101), NZUsize!(11));
         FixedConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{suffix}-mmr-journal"),
                 metadata_partition: format!("{suffix}-mmr-metadata"),

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -503,7 +503,8 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         }
     }
 

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -487,7 +487,6 @@ mod tests {
     fn db_config(suffix: &str, pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, NZU16!(101), NZUsize!(11));
         FixedConfig {
-            init_workers: None,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{suffix}-mmr-journal"),
                 metadata_partition: format!("{suffix}-mmr-metadata"),
@@ -504,6 +503,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -395,10 +395,7 @@ mod tests {
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedLogConfig,
         mmr::{self, Location, Proof, full::Config as MmrJournalConfig},
-        qmdb::{
-            InitParallelism,
-            any::{FixedConfig, unordered::fixed},
-        },
+        qmdb::any::{FixedConfig, unordered::fixed},
         translator::TwoCap,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, channel::oneshot};
@@ -490,7 +487,7 @@ mod tests {
     fn db_config(suffix: &str, pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, NZU16!(101), NZUsize!(11));
         FixedConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{suffix}-mmr-journal"),
                 metadata_partition: format!("{suffix}-mmr-metadata"),

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -49,7 +49,6 @@ use commonware_storage::{
     journal::contiguous::{fixed::Config as FixedLogConfig, variable::Config as VariableLogConfig},
     mmr::{self, Location, full::Config as MmrJournalConfig},
     qmdb::{
-        InitParallelism,
         any::{FixedConfig, unordered::fixed},
         immutable,
         sync::{Target, compact as compact_sync},
@@ -421,7 +420,7 @@ impl EngineDefinition for MultiDbEngine {
 
         // QMDB database configs (one per database)
         let db_config_a = FixedConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{partition_prefix}-qmdb-a-mmr-journal"),
                 metadata_partition: format!("{partition_prefix}-qmdb-a-mmr-metadata"),

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -49,6 +49,7 @@ use commonware_storage::{
     journal::contiguous::{fixed::Config as FixedLogConfig, variable::Config as VariableLogConfig},
     mmr::{self, Location, full::Config as MmrJournalConfig},
     qmdb::{
+        InitParallelism,
         any::{FixedConfig, unordered::fixed},
         immutable,
         sync::{Target, compact as compact_sync},
@@ -420,6 +421,7 @@ impl EngineDefinition for MultiDbEngine {
 
         // QMDB database configs (one per database)
         let db_config_a = FixedConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{partition_prefix}-qmdb-a-mmr-journal"),
                 metadata_partition: format!("{partition_prefix}-qmdb-a-mmr-metadata"),

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -420,7 +420,6 @@ impl EngineDefinition for MultiDbEngine {
 
         // QMDB database configs (one per database)
         let db_config_a = FixedConfig {
-            init_workers: None,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{partition_prefix}-qmdb-a-mmr-journal"),
                 metadata_partition: format!("{partition_prefix}-qmdb-a-mmr-metadata"),
@@ -437,6 +436,7 @@ impl EngineDefinition for MultiDbEngine {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         };
         // One witness entry per section so the periodic prune actually drops entries
         // (pruning is section-aligned).

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -436,7 +436,8 @@ impl EngineDefinition for MultiDbEngine {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         };
         // One witness entry per section so the periodic prune actually drops entries
         // (pruning is section-aligned).

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -361,7 +361,8 @@ impl EngineDefinition for SingleDbEngine {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         };
 
         // Destructure the 7 channels.

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -345,7 +345,6 @@ impl EngineDefinition for SingleDbEngine {
 
         // QMDB database config (created by Stateful::start)
         let db_config = FixedConfig {
-            init_workers: None,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{partition_prefix}-qmdb-mmr-journal"),
                 metadata_partition: format!("{partition_prefix}-qmdb-mmr-metadata"),
@@ -362,6 +361,7 @@ impl EngineDefinition for SingleDbEngine {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         };
 
         // Destructure the 7 channels.

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -48,7 +48,6 @@ use commonware_storage::{
     journal::contiguous::fixed::Config as FixedLogConfig,
     mmr::{self, Location, full::Config as MmrJournalConfig},
     qmdb::{
-        InitParallelism,
         any::{FixedConfig, unordered::fixed},
         sync::Target,
     },
@@ -346,7 +345,7 @@ impl EngineDefinition for SingleDbEngine {
 
         // QMDB database config (created by Stateful::start)
         let db_config = FixedConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{partition_prefix}-qmdb-mmr-journal"),
                 metadata_partition: format!("{partition_prefix}-qmdb-mmr-metadata"),

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -48,6 +48,7 @@ use commonware_storage::{
     journal::contiguous::fixed::Config as FixedLogConfig,
     mmr::{self, Location, full::Config as MmrJournalConfig},
     qmdb::{
+        InitParallelism,
         any::{FixedConfig, unordered::fixed},
         sync::Target,
     },
@@ -345,6 +346,7 @@ impl EngineDefinition for SingleDbEngine {
 
         // QMDB database config (created by Stateful::start)
         let db_config = FixedConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{partition_prefix}-qmdb-mmr-journal"),
                 metadata_partition: format!("{partition_prefix}-qmdb-mmr-metadata"),

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -118,7 +118,8 @@ fn make_config(
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -118,7 +118,7 @@ fn make_config(
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+        init_workers: None,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -118,6 +118,7 @@ fn make_config(
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -118,7 +118,7 @@ fn make_config(
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_workers: None,
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -165,6 +165,7 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -165,7 +165,7 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+        init_workers: None,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -165,7 +165,7 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_workers: None,
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -165,7 +165,8 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -157,7 +157,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
-            init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+            init_workers: None,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -157,7 +157,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -157,7 +157,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
-            init_workers: None,
+            init_concurrency: NZUsize!(1),
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -157,6 +157,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
+            init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -96,6 +96,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
+        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -96,7 +96,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_workers: None,
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -96,7 +96,8 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -96,7 +96,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+        init_workers: None,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -147,7 +147,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -147,7 +147,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
-            init_workers: None,
+            init_concurrency: NZUsize!(1),
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -147,7 +147,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
-            init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+            init_workers: None,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -147,6 +147,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
+            init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -112,6 +112,7 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -112,7 +112,7 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+        init_workers: None,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -112,7 +112,8 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -112,7 +112,7 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_workers: None,
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -160,6 +160,7 @@ fn test_config(
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -160,7 +160,7 @@ fn test_config(
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+        init_workers: None,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -160,7 +160,7 @@ fn test_config(
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_workers: None,
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -160,7 +160,8 @@ fn test_config(
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -120,6 +120,7 @@ fn db_config(
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        init_buffer: NZUsize!(1 << 21),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -109,7 +109,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_workers: None,
+                init_concurrency: NZUsize!(1),
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -109,7 +109,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+                init_workers: None,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -109,7 +109,8 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_concurrency: NZUsize!(1),
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -109,6 +109,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
+                init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -136,7 +136,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+                init_workers: None,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -136,7 +136,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_workers: None,
+                init_concurrency: NZUsize!(1),
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -136,6 +136,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
+                init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -136,7 +136,8 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_concurrency: NZUsize!(1),
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -95,6 +95,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
+        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -95,7 +95,8 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -95,7 +95,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_workers: None,
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -95,7 +95,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+        init_workers: None,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -111,6 +111,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
+                init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -111,7 +111,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
+                init_workers: None,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -111,7 +111,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_workers: None,
+                init_concurrency: NZUsize!(1),
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -111,7 +111,8 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_concurrency: NZUsize!(1),
+                init_buffer: NZUsize!(1 << 21),
+                init_concurrency: (),
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/store_operations.rs
+++ b/storage/fuzz/fuzz_targets/store_operations.rs
@@ -108,6 +108,7 @@ fn test_config(
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        init_buffer: NZUsize!(1 << 21),
     }
 }
 

--- a/storage/src/index/ordered.rs
+++ b/storage/src/index/ordered.rs
@@ -339,7 +339,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
 
     #[cfg(test)]
     fn keys(&self) -> usize {
-        self.map.len()
+        self.keys.get() as usize
     }
 
     #[cfg(test)]

--- a/storage/src/index/partitioned/mod.rs
+++ b/storage/src/index/partitioned/mod.rs
@@ -35,7 +35,7 @@ const INDEX_INT_SIZE: usize = 4;
 ///
 /// Partition order tracks lexicographic key order, which the [`ordered`] variant relies on to
 /// traverse keys in order.
-fn partition_index_and_sub_key<const P: usize>(key: &[u8]) -> (usize, &[u8]) {
+pub(crate) fn partition_index_and_sub_key<const P: usize>(key: &[u8]) -> (usize, &[u8]) {
     // TODO: Re-evaluate assertion placement after `generic_const_exprs` is stable.
     const {
         assert!(P > 0, "P must be greater than 0");

--- a/storage/src/index/partitioned/mod.rs
+++ b/storage/src/index/partitioned/mod.rs
@@ -26,9 +26,61 @@
 pub mod ordered;
 pub mod unordered;
 
+#[commonware_macros::stability(ALPHA)]
+use crate::index::{Cursor, Unordered};
+
 // Because the prefix length has a max of 3, we can safely use a 4-byte int for the index type
 // used by prefix conversion.
 const INDEX_INT_SIZE: usize = 4;
+
+/// An index whose snapshot build can be split across parallel workers, each owning a contiguous
+/// range of its partitions. A worker's [Self::Range] is created empty by [Self::new_range],
+/// populated through its cursor operations, and folded back into the full index by
+/// [Self::install_range].
+#[commonware_macros::stability(ALPHA)]
+pub(crate) trait Partitioned: Unordered {
+    /// A worker's restricted view over the contiguous partition range it owns.
+    type Range: PartitionRange<Value = Self::Value> + Send + 'static;
+
+    /// The number of partitions in the index.
+    fn partition_count(&self) -> usize;
+
+    /// The partition index that holds `key`.
+    fn partition_of(key: &[u8]) -> usize;
+
+    /// Create a [Self::Range] covering partitions `[offset, offset + count)`.
+    fn new_range(&self, offset: usize, count: usize) -> Self::Range;
+
+    /// Move a populated `range`'s contents into self at the global slot range it was created
+    /// with, which must be empty.
+    fn install_range(&mut self, range: Self::Range);
+
+    /// Visit every value held across all partitions, in unspecified order.
+    fn for_each_value(&self, f: impl FnMut(&Self::Value));
+}
+
+/// One [Partitioned] worker's restricted view of its partition range: only the cursor
+/// operations (addressed by full key), so the globally-addressed [Unordered] methods cannot be
+/// miscalled on a worker.
+#[commonware_macros::stability(ALPHA)]
+pub(crate) trait PartitionRange: Sized {
+    /// The value type held by the range.
+    type Value: Send + Sync;
+
+    /// The cursor over one key's values (see [Unordered::Cursor]).
+    type Cursor<'a>: Cursor<Value = Self::Value>
+    where
+        Self: 'a;
+
+    /// Mutable access to `key`'s values, if the key exists (see [Unordered::get_mut]). The key's
+    /// partition must fall within this range.
+    fn get_mut(&mut self, key: &[u8]) -> Option<Self::Cursor<'_>>;
+
+    /// Mutable access to `key`'s values if the key exists, otherwise insert `value` for it and
+    /// return `None` (see [Unordered::get_mut_or_insert]). The key's partition must fall within
+    /// this range.
+    fn get_mut_or_insert(&mut self, key: &[u8], value: Self::Value) -> Option<Self::Cursor<'_>>;
+}
 
 /// Get the partition index for the given key, along with the prefix-stripped key for probing
 /// the referenced partition. The returned index value is in the range `[0, 2^(P*8) - 1]`.

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -50,6 +50,8 @@ use crate::{
     },
     translator::Translator,
 };
+#[commonware_macros::stability(ALPHA)]
+use commonware_runtime::telemetry::metrics::{Registered, Registration};
 use commonware_runtime::{
     Metrics,
     telemetry::metrics::{Counter, Gauge, MetricsExt as _},
@@ -73,9 +75,15 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     /// Translates the prefix-stripped key bytes into a partition-local key.
     translator: T,
 
-    /// The `2^(8*P)` partitions, indexed by the `P`-byte key prefix. Each stores its translated
-    /// keys and values as sorted arrays (the inline representation); an emptied partition may
-    /// instead have spilled (see `spilled`).
+    /// Base partition index this instance addresses from: a key's global partition `p` maps to local
+    /// slot `p - offset`. A full index covers every partition and so has `offset == 0`. A parallel
+    /// snapshot-build worker (see [`Self::new_range`]) covers only `[offset, offset + len)`.
+    offset: usize,
+
+    /// The partitions this instance covers, indexed by `global_partition - offset`. A full index
+    /// holds all `2^(8*P)` (offset `0`) while a build worker holds only its range. Each stores its
+    /// translated keys and values as sorted arrays (the inline representation), though an emptied
+    /// partition may instead have spilled (see `spilled`).
     partitions: Box<[Partition<T::Key, V>]>,
 
     /// Partitions that have spilled out of their sorted arrays (reached `SPILL_THRESHOLD` entries),
@@ -95,6 +103,10 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
 
     /// Metric: cumulative values removed (via `remove`, cursor `delete`, or `retain`).
     pruned: Counter,
+
+    /// Metric: cumulative partitions spilled to the side-table. Emptied partitions that de-spill
+    /// (rare) are not subtracted. Detached on build workers and folded in at [`Self::install_range`].
+    spills: Counter,
 }
 
 impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
@@ -110,12 +122,14 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             .into_boxed_slice();
         Self {
             translator,
+            offset: 0,
             partitions,
             spilled: HashMap::new(),
             threshold: SPILL_THRESHOLD,
             keys: ctx.gauge("keys", "Number of translated keys in the index"),
             items: ctx.gauge("items", "Number of items in the index"),
             pruned: ctx.counter("pruned", "Number of items pruned"),
+            spills: ctx.counter("spills", "Number of partitions spilled to the side-table"),
         }
     }
 
@@ -137,6 +151,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         }
         let inner: BTreeMap<T::Key, Vec<V>> = self.partitions[i].drain_runs().into_iter().collect();
         self.spilled.insert(i, inner);
+        self.spills.inc();
     }
 
     /// The `BTreeMap` of spilled partition `i`, or `None` if `i` has not spilled. The empty-map
@@ -207,6 +222,92 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
     pub(crate) fn spilled_count(&self) -> usize {
         self.spilled.len()
     }
+
+    /// Cumulative value of the `spills` metric.
+    #[cfg(test)]
+    fn spills(&self) -> usize {
+        self.spills.get() as usize
+    }
+
+    /// The number of partitions (`2^(8*P)`).
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) fn partition_count(&self) -> usize {
+        self.partitions.len()
+    }
+
+    /// Create an index covering only partitions `[offset, offset + count)` for a parallel
+    /// snapshot-build worker, matching this index's translator and spill threshold. It allocates just
+    /// `count` partition slots but is still addressed by the global partition index (mapped to a local
+    /// slot in `get_mut`/`get_mut_or_insert`), so per-worker memory is the range, not the full
+    /// `2^(8*P)` -- which is what makes a large `P` affordable. Its metric handles are detached (never
+    /// registered): they only accumulate the counts that [`Self::install_range`] folds back into a
+    /// full index. Only `get_mut` and `get_mut_or_insert` (and their cursors) map the global
+    /// partition index to the local slot, so only those operations are valid on it. The other
+    /// `Unordered` methods index partitions globally and would touch the wrong slot.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) fn new_range(&self, offset: usize, count: usize) -> Self {
+        fn detached<M: Default>() -> Registered<M> {
+            Registered::with_registration(M::default(), Registration::from(()))
+        }
+        let partitions = (0..count)
+            .map(|_| Partition::default())
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            translator: self.translator.clone(),
+            offset,
+            partitions,
+            spilled: HashMap::new(),
+            threshold: self.threshold,
+            keys: detached(),
+            items: detached(),
+            pruned: detached(),
+            spills: detached(),
+        }
+    }
+
+    /// Move a build `worker`'s partitions and spilled entries into self (a full `offset == 0` index),
+    /// at the global slots `[worker.offset, worker.offset + worker.partitions.len())`, which must be
+    /// empty. Build workers are transient, so all of the worker's metric counts (`spills`, `pruned`,
+    /// `keys`, `items`) are folded into self's here. Returns the worker's item count so the caller
+    /// can total items across workers.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) fn install_range(&mut self, worker: &mut Self) -> i64 {
+        let lo = worker.offset;
+        for (local, partition) in worker.partitions.iter_mut().enumerate() {
+            self.partitions[lo + local] = std::mem::take(partition);
+        }
+        // Drain only the partitions that actually spilled (remapping local -> global), rather than
+        // probing every slot in the range.
+        for (local, inner) in worker.spilled.drain() {
+            self.spilled.insert(lo + local, inner);
+        }
+        // Fold in the worker's metric counts (a build worker's own handles are detached), matching
+        // what the serial replay records on the full index.
+        self.spills.inc_by(worker.spills.get());
+        self.pruned.inc_by(worker.pruned.get());
+        self.keys.inc_by(worker.keys.get());
+        let items = worker.items.get();
+        self.items.inc_by(items);
+        items
+    }
+
+    /// Visit every value held across all partitions (inline and spilled), in unspecified order.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) fn for_each_value(&self, mut f: impl FnMut(&V)) {
+        for (p, partition) in self.partitions.iter().enumerate() {
+            for v in partition.values_iter() {
+                f(v);
+            }
+            if let Some(inner) = self.spilled_partition(p) {
+                for vals in inner.values() {
+                    for v in vals {
+                        f(v);
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl<T: Translator, V: Send + Sync, const P: usize> Factory<T> for Index<T, V, P> {
@@ -255,7 +356,11 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
     }
 
     fn get_mut<'a>(&'a mut self, key: &[u8]) -> Option<Self::Cursor<'a>> {
+        // Map the global partition index to this instance's local slot. A full index has
+        // `offset == 0`, so this is a no-op there. A build worker covers only
+        // `[offset, offset + len)`.
         let (i, sub) = partition_index_and_sub_key::<P>(key);
+        let i = i - self.offset;
         let k = self.translator.transform(sub);
         self.maybe_spill(i);
         if !self.partitions[i].is_empty() {
@@ -298,6 +403,8 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         value: Self::Value,
     ) -> Option<Self::Cursor<'a>> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
+        // Map the global partition index to this instance's local slot (see `get_mut`).
+        let i = i - self.offset;
         let k = self.translator.transform(sub);
         self.maybe_spill(i);
         if !self.partitions[i].is_empty() {
@@ -559,7 +666,7 @@ mod tests {
     use crate::translator::OneCap;
     use commonware_formatting::hex;
     use commonware_macros::test_traced;
-    use commonware_runtime::{Runner, deterministic};
+    use commonware_runtime::{Runner, Supervisor as _, deterministic};
 
     fn new_index(context: deterministic::Context) -> Index<OneCap, u64, 1> {
         Index::new(context, OneCap)
@@ -838,6 +945,7 @@ mod tests {
             // Inline -> spilled: a second distinct key crosses the threshold.
             index.insert(&[0x10, 0x02], 2);
             assert_eq!(index.spilled_count(), 1);
+            assert_eq!(index.spills(), 1);
             assert_eq!(index.keys(), 2);
             assert_eq!(index.items(), 2);
 
@@ -855,6 +963,7 @@ mod tests {
                 cursor.delete();
             }
             assert_eq!(index.spilled_count(), 0); // de-spilled back to empty
+            assert_eq!(index.spills(), 1); // cumulative: a de-spill does not decrement it
             assert_eq!(index.keys(), 0);
             assert_eq!(index.items(), 0);
 
@@ -863,6 +972,7 @@ mod tests {
             assert_eq!(index.spilled_count(), 0);
             index.insert(&[0x10, 0x04], 4);
             assert_eq!(index.spilled_count(), 1);
+            assert_eq!(index.spills(), 2); // a fresh spill of the same partition counts again
             assert_eq!(
                 index.get(&[0x10, 0x03]).copied().collect::<Vec<_>>(),
                 vec![3]
@@ -877,11 +987,68 @@ mod tests {
             assert_eq!(index.spilled_count(), 1); // 0x04 still present
             index.remove(&[0x10, 0x04]);
             assert_eq!(index.spilled_count(), 0);
+            assert_eq!(index.spills(), 2); // still cumulative after a second spill + de-spill
             assert_eq!(index.keys(), 0);
             assert_eq!(index.items(), 0);
 
             // Every removed value was counted once: 2 via cursor delete + 2 via remove.
             assert_eq!(index.pruned(), 4);
+        });
+    }
+
+    #[test_traced]
+    fn test_spill_install_range_counts() {
+        deterministic::Runner::default().start(|context| async move {
+            // The full index that build workers fold into. It spills once a partition holds two
+            // entries.
+            let mut full = new_index_spilling(context.child("full"));
+            assert_eq!(full.spills(), 0);
+
+            // A build worker covering the whole partition range. Its detached counter records every
+            // spill event, including one whose partition later de-spills (fully drained via remove).
+            let mut worker = full.new_range(0, full.partition_count());
+            worker.get_mut_or_insert(&[0x10, 0x01], 1);
+            worker.get_mut_or_insert(&[0x10, 0x02], 2); // second key in partition 0x10 -> spills
+            worker.insert(&[0x20, 0x01], 3);
+            worker.insert(&[0x20, 0x02], 4); // partition 0x20 spills too...
+            worker.remove(&[0x20, 0x01]);
+            worker.remove(&[0x20, 0x02]); // ...then fully drains, de-spilling
+            assert_eq!(worker.spilled_count(), 1);
+            assert_eq!(worker.spills(), 2); // cumulative: the de-spilled partition still counts
+
+            // Folding the worker in carries its cumulative count into the full index's metric,
+            // matching what a serial build over the same operations would have recorded.
+            full.install_range(&mut worker);
+            assert_eq!(full.spilled_count(), 1);
+            assert_eq!(full.spills(), 2);
+        });
+    }
+
+    #[test_traced]
+    fn test_install_range_carries_pruned() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut full = new_index(context.child("full"));
+            assert_eq!(full.pruned(), 0);
+
+            // A worker covering the whole partition range. Give a key two values, then delete both
+            // through a cursor (the same path the parallel build's deletes take) so the worker
+            // records prunes that the full index never sees directly.
+            let mut worker = full.new_range(0, full.partition_count());
+            worker.insert(&[0x10, 0x01], 1);
+            worker.insert(&[0x10, 0x01], 2);
+            {
+                let mut cursor = worker.get_mut(&[0x10, 0x01]).unwrap();
+                while cursor.next().is_some() {
+                    cursor.delete();
+                }
+            }
+            assert_eq!(worker.pruned(), 2);
+            assert_eq!(full.pruned(), 0);
+
+            // Installing the worker folds its prune count into the full index (matching the serial
+            // build, which records prunes on the full index directly).
+            full.install_range(&mut worker);
+            assert_eq!(full.pruned(), 2);
         });
     }
 

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -419,10 +419,10 @@ pub(crate) struct RangeIndex<T: Translator, V: Send + Sync, const P: usize> {
     offset: usize,
 }
 
+#[commonware_macros::stability(ALPHA)]
 impl<T: Translator, V: Send + Sync, const P: usize> RangeIndex<T, V, P> {
     /// Provides mutable access to the values associated with a translated key, if the key exists.
     /// The key's global partition index must fall within this worker's range.
-    #[commonware_macros::stability(ALPHA)]
     pub(crate) fn get_mut(&mut self, key: &[u8]) -> Option<Cursor<'_, T::Key, V>> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         self.index.get_mut_slot(i - self.offset, sub)
@@ -431,7 +431,6 @@ impl<T: Translator, V: Send + Sync, const P: usize> RangeIndex<T, V, P> {
     /// Provides mutable access to the values associated with a translated key if the key exists,
     /// otherwise inserts `value` for it and returns `None`. The key's global partition index must
     /// fall within this worker's range.
-    #[commonware_macros::stability(ALPHA)]
     pub(crate) fn get_mut_or_insert(
         &mut self,
         key: &[u8],

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -75,15 +75,10 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     /// Translates the prefix-stripped key bytes into a partition-local key.
     translator: T,
 
-    /// Base partition index this instance addresses from: a key's global partition `p` maps to local
-    /// slot `p - offset`. A full index covers every partition and so has `offset == 0`. A parallel
-    /// snapshot-build worker (see [`Self::new_range`]) covers only `[offset, offset + len)`.
-    offset: usize,
-
-    /// The partitions this instance covers, indexed by `global_partition - offset`. A full index
-    /// holds all `2^(8*P)` (offset `0`) while a build worker holds only its range. Each stores its
-    /// translated keys and values as sorted arrays (the inline representation), though an emptied
-    /// partition may instead have spilled (see `spilled`).
+    /// The partitions, indexed by a key's partition index. A full index holds all `2^(8*P)`, while
+    /// the index inside a [RangeIndex] build worker holds only the worker's range (addressed by
+    /// local slot). Each stores its translated keys and values as sorted arrays (the inline
+    /// representation), though an emptied partition may instead have spilled (see `spilled`).
     partitions: Box<[Partition<T::Key, V>]>,
 
     /// Partitions that have spilled out of their sorted arrays (reached `SPILL_THRESHOLD` entries),
@@ -122,7 +117,6 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             .into_boxed_slice();
         Self {
             translator,
-            offset: 0,
             partitions,
             spilled: HashMap::new(),
             threshold: SPILL_THRESHOLD,
@@ -235,17 +229,111 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         self.partitions.len()
     }
 
-    /// Create an index covering only partitions `[offset, offset + count)` for a parallel
-    /// snapshot-build worker, matching this index's translator and spill threshold. It allocates just
-    /// `count` partition slots but is still addressed by the global partition index (mapped to a local
-    /// slot in `get_mut`/`get_mut_or_insert`), so per-worker memory is the range, not the full
-    /// `2^(8*P)` -- which is what makes a large `P` affordable. Its metric handles are detached (never
+    /// Mutable cursor over the values of sub-key `sub` in the partition at local slot `i`, if the
+    /// key exists (see [Unordered::get_mut]).
+    fn get_mut_slot(&mut self, i: usize, sub: &[u8]) -> Option<Cursor<'_, T::Key, V>> {
+        let k = self.translator.transform(sub);
+        self.maybe_spill(i);
+        if !self.partitions[i].is_empty() {
+            let run = self.partitions[i].run_range(&k);
+            if run.is_empty() {
+                return None;
+            }
+            return Some(Cursor::soa(
+                &mut self.partitions[i],
+                k,
+                run,
+                &self.keys,
+                &self.items,
+                &self.pruned,
+            ));
+        }
+
+        // Hand out a spilled cursor if the partition has spilled and holds `k`.
+        if self
+            .spilled_partition(i)
+            .is_some_and(|inner| inner.contains_key(&k))
+        {
+            return Some(Cursor::spilled(
+                &mut self.spilled,
+                i,
+                k,
+                &self.keys,
+                &self.items,
+                &self.pruned,
+            ));
+        }
+
+        // Partition is genuinely empty.
+        None
+    }
+
+    /// Mutable cursor over the values of sub-key `sub` in the partition at local slot `i` if the
+    /// key exists, otherwise inserts `value` for it and returns `None` (see
+    /// [Unordered::get_mut_or_insert]).
+    fn get_mut_or_insert_slot(
+        &mut self,
+        i: usize,
+        sub: &[u8],
+        value: V,
+    ) -> Option<Cursor<'_, T::Key, V>> {
+        let k = self.translator.transform(sub);
+        self.maybe_spill(i);
+        if !self.partitions[i].is_empty() {
+            let run = self.partitions[i].run_range(&k);
+            if !run.is_empty() {
+                return Some(Cursor::soa(
+                    &mut self.partitions[i],
+                    k,
+                    run,
+                    &self.keys,
+                    &self.items,
+                    &self.pruned,
+                ));
+            }
+            self.partitions[i].insert_at(run.end, k, value);
+            self.keys.inc();
+            self.items.inc();
+            self.maybe_spill(i);
+            return None;
+        }
+
+        // Partition i is empty. If it's because it has spilled, serve or create the key in its
+        // `BTreeMap`.
+        if let Some(inner) = self.spilled_partition(i) {
+            if inner.contains_key(&k) {
+                return Some(Cursor::spilled(
+                    &mut self.spilled,
+                    i,
+                    k,
+                    &self.keys,
+                    &self.items,
+                    &self.pruned,
+                ));
+            }
+            self.spilled.get_mut(&i).unwrap().insert(k, vec![value]);
+            self.keys.inc();
+            self.items.inc();
+            return None;
+        }
+
+        // Partition i is genuinely empty: start a fresh sorted array.
+        self.partitions[i].insert_at(0, k, value);
+        self.keys.inc();
+        self.items.inc();
+        self.maybe_spill(i);
+
+        None
+    }
+
+    /// Create a [RangeIndex] covering only partitions `[offset, offset + count)` for a parallel
+    /// snapshot-build worker, matching this index's translator and spill threshold. It allocates
+    /// just `count` partition slots, so per-worker memory is the range, not the full `2^(8*P)` --
+    /// which is what makes a large `P` affordable. Its metric handles are detached (never
     /// registered): they only accumulate the counts that [`Self::install_range`] folds back into a
-    /// full index. Only `get_mut` and `get_mut_or_insert` (and their cursors) map the global
-    /// partition index to the local slot, so only those operations are valid on it. The other
-    /// `Unordered` methods index partitions globally and would touch the wrong slot.
+    /// full index.
     #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn new_range(&self, offset: usize, count: usize) -> Self {
+    pub(crate) fn new_range(&self, offset: usize, count: usize) -> RangeIndex<T, V, P> {
         fn detached<M: Default>() -> Registered<M> {
             Registered::with_registration(M::default(), Registration::from(()))
         }
@@ -253,43 +341,50 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             .map(|_| Partition::default())
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        Self {
-            translator: self.translator.clone(),
+        RangeIndex {
+            index: Self {
+                translator: self.translator.clone(),
+                partitions,
+                spilled: HashMap::new(),
+                threshold: self.threshold,
+                keys: detached(),
+                items: detached(),
+                pruned: detached(),
+                spills: detached(),
+            },
             offset,
-            partitions,
-            spilled: HashMap::new(),
-            threshold: self.threshold,
-            keys: detached(),
-            items: detached(),
-            pruned: detached(),
-            spills: detached(),
         }
     }
 
-    /// Move a build `worker`'s partitions and spilled entries into self (a full `offset == 0` index),
-    /// at the global slots `[worker.offset, worker.offset + worker.partitions.len())`, which must be
-    /// empty. Build workers are transient, so all of the worker's metric counts (`spills`, `pruned`,
-    /// `keys`, `items`) are folded into self's here. Returns the worker's item count so the caller
-    /// can total items across workers.
+    /// Move a build `worker`'s partitions and spilled entries into self (a full index), at the
+    /// global slot range the worker was created with, which must be empty. Build workers
+    /// are transient, so all of the worker's metric counts (`spills`, `pruned`, `keys`, `items`)
+    /// are folded into self's here. Returns the worker's item count so the caller can total items
+    /// across workers.
     #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn install_range(&mut self, worker: &mut Self) -> i64 {
+    pub(crate) fn install_range(&mut self, mut worker: RangeIndex<T, V, P>) -> usize {
         let lo = worker.offset;
-        for (local, partition) in worker.partitions.iter_mut().enumerate() {
+        for (local, partition) in worker.index.partitions.iter_mut().enumerate() {
             self.partitions[lo + local] = std::mem::take(partition);
         }
+
         // Drain only the partitions that actually spilled (remapping local -> global), rather than
         // probing every slot in the range.
-        for (local, inner) in worker.spilled.drain() {
+        for (local, inner) in worker.index.spilled.drain() {
             self.spilled.insert(lo + local, inner);
         }
+
         // Fold in the worker's metric counts (a build worker's own handles are detached), matching
         // what the serial replay records on the full index.
-        self.spills.inc_by(worker.spills.get());
-        self.pruned.inc_by(worker.pruned.get());
-        self.keys.inc_by(worker.keys.get());
-        let items = worker.items.get();
+        self.spills.inc_by(worker.index.spills.get());
+        self.pruned.inc_by(worker.index.pruned.get());
+        self.keys.inc_by(worker.index.keys.get());
+        let items = worker.index.items.get();
         self.items.inc_by(items);
-        items
+
+        // A worker only ever holds in-memory entries, so its item gauge is non-negative and fits
+        // in a usize.
+        usize::try_from(items).expect("worker item count fits usize")
     }
 
     /// Visit every value held across all partitions (inline and spilled), in unspecified order.
@@ -307,6 +402,44 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
                 }
             }
         }
+    }
+}
+
+/// A restricted view of an [Index] covering only a contiguous range of partitions, held by one
+/// parallel snapshot-build worker (created by [Index::new_range], folded back into a full index by
+/// [Index::install_range]). It exposes only the cursor operations, which map a key's global
+/// partition index to the worker's local slot; the other [Unordered] operations index partitions
+/// globally and are deliberately unavailable so they cannot be miscalled on a worker.
+#[commonware_macros::stability(ALPHA)]
+pub(crate) struct RangeIndex<T: Translator, V: Send + Sync, const P: usize> {
+    /// The worker's partitions, addressed by local slot (`global partition - offset`).
+    index: Index<T, V, P>,
+
+    /// The first global partition index the worker covers.
+    offset: usize,
+}
+
+impl<T: Translator, V: Send + Sync, const P: usize> RangeIndex<T, V, P> {
+    /// Provides mutable access to the values associated with a translated key, if the key exists.
+    /// The key's global partition index must fall within this worker's range.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) fn get_mut(&mut self, key: &[u8]) -> Option<Cursor<'_, T::Key, V>> {
+        let (i, sub) = partition_index_and_sub_key::<P>(key);
+        self.index.get_mut_slot(i - self.offset, sub)
+    }
+
+    /// Provides mutable access to the values associated with a translated key if the key exists,
+    /// otherwise inserts `value` for it and returns `None`. The key's global partition index must
+    /// fall within this worker's range.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) fn get_mut_or_insert(
+        &mut self,
+        key: &[u8],
+        value: V,
+    ) -> Option<Cursor<'_, T::Key, V>> {
+        let (i, sub) = partition_index_and_sub_key::<P>(key);
+        self.index
+            .get_mut_or_insert_slot(i - self.offset, sub, value)
     }
 }
 
@@ -356,45 +489,8 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
     }
 
     fn get_mut<'a>(&'a mut self, key: &[u8]) -> Option<Self::Cursor<'a>> {
-        // Map the global partition index to this instance's local slot. A full index has
-        // `offset == 0`, so this is a no-op there. A build worker covers only
-        // `[offset, offset + len)`.
         let (i, sub) = partition_index_and_sub_key::<P>(key);
-        let i = i - self.offset;
-        let k = self.translator.transform(sub);
-        self.maybe_spill(i);
-        if !self.partitions[i].is_empty() {
-            let run = self.partitions[i].run_range(&k);
-            if run.is_empty() {
-                return None;
-            }
-            return Some(Cursor::soa(
-                &mut self.partitions[i],
-                k,
-                run,
-                &self.keys,
-                &self.items,
-                &self.pruned,
-            ));
-        }
-
-        // Hand out a spilled cursor if the partition has spilled and holds `k`.
-        if self
-            .spilled_partition(i)
-            .is_some_and(|inner| inner.contains_key(&k))
-        {
-            return Some(Cursor::spilled(
-                &mut self.spilled,
-                i,
-                k,
-                &self.keys,
-                &self.items,
-                &self.pruned,
-            ));
-        }
-
-        // Partition is genuinely empty.
-        None
+        self.get_mut_slot(i, sub)
     }
 
     fn get_mut_or_insert<'a>(
@@ -402,56 +498,8 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         key: &[u8],
         value: Self::Value,
     ) -> Option<Self::Cursor<'a>> {
-        // Map the global partition index to this instance's local slot (see `get_mut`).
         let (i, sub) = partition_index_and_sub_key::<P>(key);
-        let i = i - self.offset;
-        let k = self.translator.transform(sub);
-        self.maybe_spill(i);
-        if !self.partitions[i].is_empty() {
-            let run = self.partitions[i].run_range(&k);
-            if !run.is_empty() {
-                return Some(Cursor::soa(
-                    &mut self.partitions[i],
-                    k,
-                    run,
-                    &self.keys,
-                    &self.items,
-                    &self.pruned,
-                ));
-            }
-            self.partitions[i].insert_at(run.end, k, value);
-            self.keys.inc();
-            self.items.inc();
-            self.maybe_spill(i);
-            return None;
-        }
-
-        // Partition i is empty. If it's because it has spilled, serve or create the key in its
-        // `BTreeMap`.
-        if let Some(inner) = self.spilled_partition(i) {
-            if inner.contains_key(&k) {
-                return Some(Cursor::spilled(
-                    &mut self.spilled,
-                    i,
-                    k,
-                    &self.keys,
-                    &self.items,
-                    &self.pruned,
-                ));
-            }
-            self.spilled.get_mut(&i).unwrap().insert(k, vec![value]);
-            self.keys.inc();
-            self.items.inc();
-            return None;
-        }
-
-        // Partition i is genuinely empty: start a fresh sorted array.
-        self.partitions[i].insert_at(0, k, value);
-        self.keys.inc();
-        self.items.inc();
-        self.maybe_spill(i);
-
-        None
+        self.get_mut_or_insert_slot(i, sub, value)
     }
 
     fn insert(&mut self, key: &[u8], value: Self::Value) {
@@ -1004,21 +1052,22 @@ mod tests {
             let mut full = new_index_spilling(context.child("full"));
             assert_eq!(full.spills(), 0);
 
-            // A build worker covering the whole partition range. Its detached counter records every
+            // A build worker covering the whole partition range (offset 0, so the inner index's
+            // globally-addressed methods are usable directly). Its detached counter records every
             // spill event, including one whose partition later de-spills (fully drained via remove).
             let mut worker = full.new_range(0, full.partition_count());
             worker.get_mut_or_insert(&[0x10, 0x01], 1);
             worker.get_mut_or_insert(&[0x10, 0x02], 2); // second key in partition 0x10 -> spills
-            worker.insert(&[0x20, 0x01], 3);
-            worker.insert(&[0x20, 0x02], 4); // partition 0x20 spills too...
-            worker.remove(&[0x20, 0x01]);
-            worker.remove(&[0x20, 0x02]); // ...then fully drains, de-spilling
-            assert_eq!(worker.spilled_count(), 1);
-            assert_eq!(worker.spills(), 2); // cumulative: the de-spilled partition still counts
+            worker.index.insert(&[0x20, 0x01], 3);
+            worker.index.insert(&[0x20, 0x02], 4); // partition 0x20 spills too...
+            worker.index.remove(&[0x20, 0x01]);
+            worker.index.remove(&[0x20, 0x02]); // ...then fully drains, de-spilling
+            assert_eq!(worker.index.spilled_count(), 1);
+            assert_eq!(worker.index.spills(), 2); // cumulative: the de-spilled partition still counts
 
             // Folding the worker in carries its cumulative count into the full index's metric,
             // matching what a serial build over the same operations would have recorded.
-            full.install_range(&mut worker);
+            full.install_range(worker);
             assert_eq!(full.spilled_count(), 1);
             assert_eq!(full.spills(), 2);
         });
@@ -1030,24 +1079,25 @@ mod tests {
             let mut full = new_index(context.child("full"));
             assert_eq!(full.pruned(), 0);
 
-            // A worker covering the whole partition range. Give a key two values, then delete both
-            // through a cursor (the same path the parallel build's deletes take) so the worker
-            // records prunes that the full index never sees directly.
+            // A worker covering the whole partition range (offset 0, so the inner index's
+            // globally-addressed methods are usable directly). Give a key two values, then delete
+            // both through a cursor (the same path the parallel build's deletes take) so the
+            // worker records prunes that the full index never sees directly.
             let mut worker = full.new_range(0, full.partition_count());
-            worker.insert(&[0x10, 0x01], 1);
-            worker.insert(&[0x10, 0x01], 2);
+            worker.index.insert(&[0x10, 0x01], 1);
+            worker.index.insert(&[0x10, 0x01], 2);
             {
                 let mut cursor = worker.get_mut(&[0x10, 0x01]).unwrap();
                 while cursor.next().is_some() {
                     cursor.delete();
                 }
             }
-            assert_eq!(worker.pruned(), 2);
+            assert_eq!(worker.index.pruned(), 2);
             assert_eq!(full.pruned(), 0);
 
             // Installing the worker folds its prune count into the full index (matching the serial
             // build, which records prunes on the full index directly).
-            full.install_range(&mut worker);
+            full.install_range(worker);
             assert_eq!(full.pruned(), 2);
         });
     }
@@ -1063,19 +1113,18 @@ mod tests {
             // (`new_range` copies the threshold).
             let mut full = new_index_spilling(context.child("full"));
 
-            // A worker covering global partitions [0x80, 0x82). Only `get_mut_or_insert` (and
-            // `get_mut`) are offset-aware, so all writes go through it: two distinct keys spill
-            // partition 0x80, and a third key stays inline in partition 0x81.
+            // A worker covering global partitions [0x80, 0x82): two distinct keys spill partition
+            // 0x80, and a third key stays inline in partition 0x81.
             let mut worker = full.new_range(0x80, 2);
             worker.get_mut_or_insert(&[0x80, 0x01], 1);
             worker.get_mut_or_insert(&[0x80, 0x02], 2);
             worker.get_mut_or_insert(&[0x81, 0x07], 3);
-            assert_eq!(worker.spilled_count(), 1);
-            assert_eq!(worker.keys(), 3);
+            assert_eq!(worker.index.spilled_count(), 1);
+            assert_eq!(worker.index.keys(), 3);
 
             // Installing must remap both the inline partition and the spilled entry to the
             // worker's global range.
-            assert_eq!(full.install_range(&mut worker), 3);
+            assert_eq!(full.install_range(worker), 3);
             assert_eq!(full.spilled_count(), 1);
             assert_eq!(full.keys(), 3);
             assert_eq!(full.items(), 3);

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -43,6 +43,8 @@ mod partition;
 
 pub use self::cursor::Cursor;
 use self::partition::Partition;
+#[commonware_macros::stability(ALPHA)]
+use crate::index::partitioned::{PartitionRange, Partitioned};
 use crate::{
     index::{
         Cursor as CursorTrait, Factory, Ordered, Unordered,
@@ -50,8 +52,6 @@ use crate::{
     },
     translator::Translator,
 };
-#[commonware_macros::stability(ALPHA)]
-use commonware_runtime::telemetry::metrics::{Registered, Registration};
 use commonware_runtime::{
     Metrics,
     telemetry::metrics::{Counter, Gauge, MetricsExt as _},
@@ -100,7 +100,8 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     pruned: Counter,
 
     /// Metric: cumulative partitions spilled to the side-table. Emptied partitions that de-spill
-    /// (rare) are not subtracted. Detached on build workers and folded in at [`Self::install_range`].
+    /// (rare) are not subtracted. Build workers hold clones of the handle, so their spills count
+    /// here live.
     spills: Counter,
 }
 
@@ -223,12 +224,6 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         self.spills.get() as usize
     }
 
-    /// The number of partitions (`2^(8*P)`).
-    #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn partition_count(&self) -> usize {
-        self.partitions.len()
-    }
-
     /// Mutable cursor over the values of sub-key `sub` in the partition at local slot `i`, if the
     /// key exists (see [Unordered::get_mut]).
     fn get_mut_slot(&mut self, i: usize, sub: &[u8]) -> Option<Cursor<'_, T::Key, V>> {
@@ -325,18 +320,24 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
 
         None
     }
+}
 
-    /// Create a [RangeIndex] covering only partitions `[offset, offset + count)` for a parallel
-    /// snapshot-build worker, matching this index's translator and spill threshold. It allocates
-    /// just `count` partition slots, so per-worker memory is the range, not the full `2^(8*P)` --
-    /// which is what makes a large `P` affordable. Its metric handles are detached (never
-    /// registered): they only accumulate the counts that [`Self::install_range`] folds back into a
-    /// full index.
-    #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn new_range(&self, offset: usize, count: usize) -> RangeIndex<T, V, P> {
-        fn detached<M: Default>() -> Registered<M> {
-            Registered::with_registration(M::default(), Registration::from(()))
-        }
+#[commonware_macros::stability(ALPHA)]
+impl<T: Translator, V: Send + Sync + 'static, const P: usize> Partitioned for Index<T, V, P> {
+    type Range = RangeIndex<T, V, P>;
+
+    fn partition_count(&self) -> usize {
+        self.partitions.len()
+    }
+
+    fn partition_of(key: &[u8]) -> usize {
+        partition_index_and_sub_key::<P>(key).0
+    }
+
+    /// The range matches this index's translator and spill threshold. It allocates only `count`
+    /// partition slots, so per-worker memory is the range rather than the full `2^(8*P)`, which
+    /// is what makes a large `P` affordable.
+    fn new_range(&self, offset: usize, count: usize) -> RangeIndex<T, V, P> {
         let partitions = (0..count)
             .map(|_| Partition::default())
             .collect::<Vec<_>>()
@@ -347,25 +348,33 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
                 partitions,
                 spilled: HashMap::new(),
                 threshold: self.threshold,
-                keys: detached(),
-                items: detached(),
-                pruned: detached(),
-                spills: detached(),
+                keys: self.keys.clone(),
+                items: self.items.clone(),
+                pruned: self.pruned.clone(),
+                spills: self.spills.clone(),
             },
             offset,
         }
     }
 
-    /// Move a build `worker`'s partitions and spilled entries into self (a full index), at the
-    /// global slot range the worker was created with, which must be empty. Build workers
-    /// are transient, so all of the worker's metric counts (`spills`, `pruned`, `keys`, `items`)
-    /// are folded into self's here. Returns the worker's item count so the caller can total items
-    /// across workers.
-    #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn install_range(&mut self, mut worker: RangeIndex<T, V, P>) -> usize {
+    /// Moves the worker's partitions and spilled entries wholesale. Metrics need no adjustment,
+    /// since the worker updated this index's handles directly.
+    fn install_range(&mut self, mut worker: RangeIndex<T, V, P>) {
         let lo = worker.offset;
+        let len = worker.index.partitions.len();
+
+        // Probe the spilled side-table by its (usually empty) key set rather than once per slot.
+        assert!(
+            self.spilled.keys().all(|&p| p < lo || p >= lo + len),
+            "install target range must be empty"
+        );
         for (local, partition) in worker.index.partitions.iter_mut().enumerate() {
-            self.partitions[lo + local] = std::mem::take(partition);
+            let global = lo + local;
+            assert!(
+                self.partitions[global].is_empty(),
+                "install target range must be empty"
+            );
+            self.partitions[global] = std::mem::take(partition);
         }
 
         // Drain only the partitions that actually spilled (remapping local -> global), rather than
@@ -373,23 +382,10 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         for (local, inner) in worker.index.spilled.drain() {
             self.spilled.insert(lo + local, inner);
         }
-
-        // Fold in the worker's metric counts (a build worker's own handles are detached), matching
-        // what the serial replay records on the full index.
-        self.spills.inc_by(worker.index.spills.get());
-        self.pruned.inc_by(worker.index.pruned.get());
-        self.keys.inc_by(worker.index.keys.get());
-        let items = worker.index.items.get();
-        self.items.inc_by(items);
-
-        // A worker only ever holds in-memory entries, so its item gauge is non-negative and fits
-        // in a usize.
-        usize::try_from(items).expect("worker item count fits usize")
     }
 
-    /// Visit every value held across all partitions (inline and spilled), in unspecified order.
-    #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn for_each_value(&self, mut f: impl FnMut(&V)) {
+    /// Visits inline and spilled values.
+    fn for_each_value(&self, mut f: impl FnMut(&V)) {
         for (p, partition) in self.partitions.iter().enumerate() {
             for v in partition.values_iter() {
                 f(v);
@@ -408,8 +404,8 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
 /// A restricted view of an [Index] covering only a contiguous range of partitions, held by one
 /// parallel snapshot-build worker (created by [Index::new_range], folded back into a full index by
 /// [Index::install_range]). It exposes only the cursor operations, which map a key's global
-/// partition index to the worker's local slot; the other [Unordered] operations index partitions
-/// globally and are deliberately unavailable so they cannot be miscalled on a worker.
+/// partition index to the worker's local slot. The other [Unordered] operations index partitions
+/// globally and are deliberately unavailable, so they cannot be miscalled on a worker.
 #[commonware_macros::stability(ALPHA)]
 pub(crate) struct RangeIndex<T: Translator, V: Send + Sync, const P: usize> {
     /// The worker's partitions, addressed by local slot (`global partition - offset`).
@@ -420,22 +416,19 @@ pub(crate) struct RangeIndex<T: Translator, V: Send + Sync, const P: usize> {
 }
 
 #[commonware_macros::stability(ALPHA)]
-impl<T: Translator, V: Send + Sync, const P: usize> RangeIndex<T, V, P> {
-    /// Provides mutable access to the values associated with a translated key, if the key exists.
-    /// The key's global partition index must fall within this worker's range.
-    pub(crate) fn get_mut(&mut self, key: &[u8]) -> Option<Cursor<'_, T::Key, V>> {
+impl<T: Translator, V: Send + Sync, const P: usize> PartitionRange for RangeIndex<T, V, P> {
+    type Value = V;
+    type Cursor<'a>
+        = Cursor<'a, T::Key, V>
+    where
+        Self: 'a;
+
+    fn get_mut(&mut self, key: &[u8]) -> Option<Cursor<'_, T::Key, V>> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         self.index.get_mut_slot(i - self.offset, sub)
     }
 
-    /// Provides mutable access to the values associated with a translated key if the key exists,
-    /// otherwise inserts `value` for it and returns `None`. The key's global partition index must
-    /// fall within this worker's range.
-    pub(crate) fn get_mut_or_insert(
-        &mut self,
-        key: &[u8],
-        value: V,
-    ) -> Option<Cursor<'_, T::Key, V>> {
+    fn get_mut_or_insert(&mut self, key: &[u8], value: V) -> Option<Cursor<'_, T::Key, V>> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         self.index
             .get_mut_or_insert_slot(i - self.offset, sub, value)
@@ -1044,16 +1037,17 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_spill_install_range_counts() {
+    fn test_spill_counts_live() {
         deterministic::Runner::default().start(|context| async move {
-            // The full index that build workers fold into. It spills once a partition holds two
-            // entries.
+            // The full index that build workers install into. It spills once a partition holds
+            // two entries.
             let mut full = new_index_spilling(context.child("full"));
             assert_eq!(full.spills(), 0);
 
             // A build worker covering the whole partition range (offset 0, so the inner index's
-            // globally-addressed methods are usable directly). Its detached counter records every
-            // spill event, including one whose partition later de-spills (fully drained via remove).
+            // globally-addressed methods are usable directly). It holds clones of the full
+            // index's metric handles, so every spill event counts there as it happens, including
+            // one whose partition later de-spills (fully drained via remove).
             let mut worker = full.new_range(0, full.partition_count());
             worker.get_mut_or_insert(&[0x10, 0x01], 1);
             worker.get_mut_or_insert(&[0x10, 0x02], 2); // second key in partition 0x10 -> spills
@@ -1062,10 +1056,9 @@ mod tests {
             worker.index.remove(&[0x20, 0x01]);
             worker.index.remove(&[0x20, 0x02]); // ...then fully drains, de-spilling
             assert_eq!(worker.index.spilled_count(), 1);
-            assert_eq!(worker.index.spills(), 2); // cumulative: the de-spilled partition still counts
+            assert_eq!(full.spills(), 2); // cumulative: the de-spilled partition still counts
 
-            // Folding the worker in carries its cumulative count into the full index's metric,
-            // matching what a serial build over the same operations would have recorded.
+            // Installing moves the structures without touching the already-live counts.
             full.install_range(worker);
             assert_eq!(full.spilled_count(), 1);
             assert_eq!(full.spills(), 2);
@@ -1073,15 +1066,16 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_install_range_carries_pruned() {
+    fn test_worker_prunes_count_live() {
         deterministic::Runner::default().start(|context| async move {
             let mut full = new_index(context.child("full"));
             assert_eq!(full.pruned(), 0);
 
             // A worker covering the whole partition range (offset 0, so the inner index's
             // globally-addressed methods are usable directly). Give a key two values, then delete
-            // both through a cursor (the same path the parallel build's deletes take) so the
-            // worker records prunes that the full index never sees directly.
+            // both through a cursor (the same path the parallel build's deletes take). The worker
+            // holds clones of the full index's metric handles, so the prunes count there
+            // immediately, matching what the serial build records.
             let mut worker = full.new_range(0, full.partition_count());
             worker.index.insert(&[0x10, 0x01], 1);
             worker.index.insert(&[0x10, 0x01], 2);
@@ -1091,11 +1085,9 @@ mod tests {
                     cursor.delete();
                 }
             }
-            assert_eq!(worker.index.pruned(), 2);
-            assert_eq!(full.pruned(), 0);
+            assert_eq!(full.pruned(), 2);
 
-            // Installing the worker folds its prune count into the full index (matching the serial
-            // build, which records prunes on the full index directly).
+            // Installing moves the structures without touching the already-live counts.
             full.install_range(worker);
             assert_eq!(full.pruned(), 2);
         });
@@ -1123,7 +1115,7 @@ mod tests {
 
             // Installing must remap both the inline partition and the spilled entry to the
             // worker's global range.
-            assert_eq!(full.install_range(worker), 3);
+            full.install_range(worker);
             assert_eq!(full.spilled_count(), 1);
             assert_eq!(full.keys(), 3);
             assert_eq!(full.items(), 3);

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -402,8 +402,8 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         key: &[u8],
         value: Self::Value,
     ) -> Option<Self::Cursor<'a>> {
-        let (i, sub) = partition_index_and_sub_key::<P>(key);
         // Map the global partition index to this instance's local slot (see `get_mut`).
+        let (i, sub) = partition_index_and_sub_key::<P>(key);
         let i = i - self.offset;
         let k = self.translator.transform(sub);
         self.maybe_spill(i);
@@ -1049,6 +1049,53 @@ mod tests {
             // build, which records prunes on the full index directly).
             full.install_range(&mut worker);
             assert_eq!(full.pruned(), 2);
+        });
+    }
+
+    /// A worker with a nonzero offset must land its partitions AND its spilled entries at the
+    /// global slots `offset + local` when installed. The multi-worker equivalence tests never
+    /// spill inside a worker range (their per-partition load stays below the spill threshold), so
+    /// this is the only coverage of the spilled remap off offset zero.
+    #[test_traced]
+    fn test_install_range_nonzero_offset() {
+        deterministic::Runner::default().start(|context| async move {
+            // The full index spills once a partition holds two entries, as does the worker
+            // (`new_range` copies the threshold).
+            let mut full = new_index_spilling(context.child("full"));
+
+            // A worker covering global partitions [0x80, 0x82). Only `get_mut_or_insert` (and
+            // `get_mut`) are offset-aware, so all writes go through it: two distinct keys spill
+            // partition 0x80, and a third key stays inline in partition 0x81.
+            let mut worker = full.new_range(0x80, 2);
+            worker.get_mut_or_insert(&[0x80, 0x01], 1);
+            worker.get_mut_or_insert(&[0x80, 0x02], 2);
+            worker.get_mut_or_insert(&[0x81, 0x07], 3);
+            assert_eq!(worker.spilled_count(), 1);
+            assert_eq!(worker.keys(), 3);
+
+            // Installing must remap both the inline partition and the spilled entry to the
+            // worker's global range.
+            assert_eq!(full.install_range(&mut worker), 3);
+            assert_eq!(full.spilled_count(), 1);
+            assert_eq!(full.keys(), 3);
+            assert_eq!(full.items(), 3);
+            assert_eq!(
+                full.get(&[0x80, 0x01]).copied().collect::<Vec<_>>(),
+                vec![1]
+            );
+            assert_eq!(
+                full.get(&[0x80, 0x02]).copied().collect::<Vec<_>>(),
+                vec![2]
+            );
+            assert_eq!(
+                full.get(&[0x81, 0x07]).copied().collect::<Vec<_>>(),
+                vec![3]
+            );
+
+            // Nothing may land at the worker's local slots (global partitions 0x00 and 0x01),
+            // which is exactly where a remap that dropped the offset would file these entries.
+            assert!(full.get(&[0x00, 0x01]).next().is_none());
+            assert!(full.get(&[0x01, 0x07]).next().is_none());
         });
     }
 

--- a/storage/src/index/partitioned/ordered/partition.rs
+++ b/storage/src/index/partitioned/ordered/partition.rs
@@ -111,6 +111,12 @@ impl<K: Ord + Copy, V> Partition<K, V> {
         &self.vals[idx]
     }
 
+    /// Iterate every value held by the partition (in array order, all runs).
+    #[commonware_macros::stability(ALPHA)]
+    pub(super) fn values_iter(&self) -> std::slice::Iter<'_, V> {
+        self.vals.iter()
+    }
+
     /// Insert `(key, value)` at array index `idx`. The caller must pass an `idx` that keeps `keys`
     /// sorted (i.e. within or adjacent to `key`'s run).
     pub(super) fn insert_at(&mut self, idx: usize, key: K, value: V) {

--- a/storage/src/index/partitioned/unordered.rs
+++ b/storage/src/index/partitioned/unordered.rs
@@ -1,5 +1,7 @@
 //! The unordered variant of a partitioned index.
 
+#[commonware_macros::stability(ALPHA)]
+use crate::index::partitioned::{PartitionRange, Partitioned};
 use crate::{
     index::{
         Unordered as UnorderedTrait, partitioned::partition_index_and_sub_key,
@@ -45,6 +47,76 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         let (i, sub_key) = partition_index_and_sub_key::<P>(key);
 
         (&mut self.partitions[i], sub_key)
+    }
+}
+
+#[commonware_macros::stability(ALPHA)]
+impl<T: Translator, V: Send + Sync + 'static, const P: usize> Partitioned for Index<T, V, P> {
+    type Range = RangeIndex<T, V, P>;
+
+    fn partition_count(&self) -> usize {
+        self.partitions.len()
+    }
+
+    fn partition_of(key: &[u8]) -> usize {
+        partition_index_and_sub_key::<P>(key).0
+    }
+
+    /// The range allocates only `count` slots, so per-worker memory is the range rather than
+    /// the full `2^(8*P)`.
+    fn new_range(&self, offset: usize, count: usize) -> RangeIndex<T, V, P> {
+        let partitions = (0..count)
+            .map(|i| self.partitions[offset + i].empty())
+            .collect();
+        RangeIndex { partitions, offset }
+    }
+
+    /// Absorbs each slot's maps wholesale into the matching partition.
+    fn install_range(&mut self, worker: RangeIndex<T, V, P>) {
+        let lo = worker.offset;
+        for (local, slot) in worker.partitions.into_iter().enumerate() {
+            self.partitions[lo + local].absorb(slot);
+        }
+    }
+
+    /// Visits inline and overflow values.
+    fn for_each_value(&self, mut f: impl FnMut(&V)) {
+        for partition in &self.partitions {
+            partition.for_each_value(&mut f);
+        }
+    }
+}
+
+/// A restricted view of an [Index] covering only a contiguous range of partitions, held by one
+/// parallel snapshot-build worker (created by [Index::new_range], folded back into a full index by
+/// [Index::install_range]). It exposes only the cursor operations, which map a key's global
+/// partition index to the worker's local slot. The other [UnorderedTrait] operations index
+/// partitions globally and are deliberately unavailable, so they cannot be miscalled on a worker.
+#[commonware_macros::stability(ALPHA)]
+pub(crate) struct RangeIndex<T: Translator, V: Send + Sync, const P: usize> {
+    /// The worker's partition slots, addressed by local slot (`global partition - offset`).
+    partitions: Vec<UnorderedIndex<T, V>>,
+
+    /// The first global partition index the worker covers.
+    offset: usize,
+}
+
+#[commonware_macros::stability(ALPHA)]
+impl<T: Translator, V: Send + Sync, const P: usize> PartitionRange for RangeIndex<T, V, P> {
+    type Value = V;
+    type Cursor<'a>
+        = <UnorderedIndex<T, V> as UnorderedTrait>::Cursor<'a>
+    where
+        Self: 'a;
+
+    fn get_mut(&mut self, key: &[u8]) -> Option<Self::Cursor<'_>> {
+        let (i, sub) = partition_index_and_sub_key::<P>(key);
+        self.partitions[i - self.offset].get_mut(sub)
+    }
+
+    fn get_mut_or_insert(&mut self, key: &[u8], value: V) -> Option<Self::Cursor<'_>> {
+        let (i, sub) = partition_index_and_sub_key::<P>(key);
+        self.partitions[i - self.offset].get_mut_or_insert(sub, value)
     }
 }
 
@@ -140,5 +212,99 @@ impl<T: Translator, V: Send + Sync, const P: usize> UnorderedTrait for Index<T, 
         }
 
         pruned
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{index::Cursor as _, translator::OneCap};
+    use commonware_macros::test_traced;
+    use commonware_runtime::{Runner as _, Supervisor as _, deterministic};
+
+    /// A `P=1` index over `u64` values with a one-byte translator, so distinct keys sharing a
+    /// partition and translated sub-key collide into an overflow chain.
+    fn new_index(ctx: impl Metrics) -> Index<OneCap, u64, 1> {
+        Index::new(ctx, OneCap)
+    }
+
+    /// A worker with a nonzero offset must land its slots at the global partitions
+    /// `offset + local` when installed, carrying inline values and overflow chains (the
+    /// key/item counts are live through the shared handles, so the `get` asserts are what pin
+    /// the moved contents).
+    #[test_traced]
+    fn test_install_range_nonzero_offset() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut full = new_index(context.child("full"));
+
+            // A worker covering global partitions [0x80, 0x82): two keys in partition 0x80, one
+            // in 0x81.
+            let mut worker = full.new_range(0x80, 2);
+            assert!(worker.get_mut_or_insert(&[0x80, 0x01], 1).is_none());
+            assert!(worker.get_mut_or_insert(&[0x80, 0x02], 2).is_none());
+            assert!(worker.get_mut_or_insert(&[0x81, 0x07], 3).is_none());
+
+            // A colliding key (same partition and translated sub-key as the first) joins the
+            // first key's chain through the cursor, the same path the build worker's collision
+            // resolution takes.
+            {
+                let mut cursor = worker.get_mut_or_insert(&[0x80, 0x01, 0xFF], 4).unwrap();
+                while cursor.next().is_some() {}
+                cursor.insert(4);
+            }
+
+            // Installing must remap the slots to the worker's global range and preserve every
+            // value, including the chained one.
+            full.install_range(worker);
+            assert_eq!(full.keys(), 3);
+            assert_eq!(full.items(), 4);
+            assert_eq!(
+                full.get(&[0x80, 0x01]).copied().collect::<Vec<_>>(),
+                vec![1, 4]
+            );
+            assert_eq!(
+                full.get(&[0x80, 0x02]).copied().collect::<Vec<_>>(),
+                vec![2]
+            );
+            assert_eq!(
+                full.get(&[0x81, 0x07]).copied().collect::<Vec<_>>(),
+                vec![3]
+            );
+        });
+    }
+
+    /// A worker's cursor deletes (the parallel build's delete path) count on the covered
+    /// partition's shared `pruned` handle as they happen, matching what the serial build
+    /// records.
+    #[test_traced]
+    fn test_worker_prunes_count_live() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut full = new_index(context.child("full"));
+            assert_eq!(full.pruned(), 0);
+
+            // Give one translated key two values, then delete both through a cursor. The worker
+            // slots hold clones of their partitions' metric handles, so the prunes count on the
+            // full index immediately.
+            let mut worker = full.new_range(0, full.partition_count());
+            assert!(worker.get_mut_or_insert(&[0x10, 0x01], 1).is_none());
+            {
+                let mut cursor = worker.get_mut_or_insert(&[0x10, 0x01, 0xFF], 2).unwrap();
+                while cursor.next().is_some() {}
+                cursor.insert(2);
+            }
+            {
+                let mut cursor = worker.get_mut(&[0x10, 0x01]).unwrap();
+                while cursor.next().is_some() {
+                    cursor.delete();
+                }
+            }
+            assert_eq!(full.pruned(), 2);
+
+            // Installing moves the structures without touching the already-live counts.
+            full.install_range(worker);
+            assert_eq!(full.pruned(), 2);
+            assert_eq!(full.keys(), 0);
+            assert_eq!(full.items(), 0);
+        });
     }
 }

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -18,11 +18,6 @@ use std::collections::{
     hash_map::{Entry, OccupiedEntry, VacantEntry},
 };
 
-/// The initial capacity of the internal hashmap. This is a guess at the number of unique keys we
-/// will encounter. The hashmap will grow as needed, but this is a good starting point (covering the
-/// entire [crate::translator::OneCap] range).
-const INITIAL_CAPACITY: usize = 256;
-
 /// Implementation of [IndexEntry] for [OccupiedEntry].
 impl<K: Send + Sync, V: Send + Sync> IndexEntry<V> for OccupiedEntry<'_, K, V> {
     type Key = K;
@@ -67,12 +62,13 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
         vacant.insert(v);
     }
 
-    /// Create a new index with the given translator and metrics registry.
+    /// Create a new index with the given translator and metrics registry. The maps start without
+    /// capacity and grow as needed, so unused indices (e.g. empty partitions) cost no memory.
     pub fn new(ctx: impl Metrics, translator: T) -> Self {
         Self {
             translator: translator.clone(),
             overflow: HashMap::with_hasher(translator.clone()),
-            map: HashMap::with_capacity_and_hasher(INITIAL_CAPACITY, translator),
+            map: HashMap::with_hasher(translator),
             keys: ctx.gauge("keys", "Number of translated keys in the index"),
             items: ctx.gauge("items", "Number of items in the index"),
             pruned: ctx.counter("pruned", "Number of items pruned"),
@@ -80,8 +76,7 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
     }
 
     /// Create an empty index with this index's translator and metric handles. Parallel
-    /// snapshot-build workers use it for their partition slots. The maps start without
-    /// capacity, since a worker slot often receives nothing.
+    /// snapshot-build workers use it for their partition slots.
     #[commonware_macros::stability(ALPHA)]
     pub(crate) fn empty(&self) -> Self {
         Self {

--- a/storage/src/index/unordered.rs
+++ b/storage/src/index/unordered.rs
@@ -78,6 +78,51 @@ impl<T: Translator, V: Send + Sync> Index<T, V> {
             pruned: ctx.counter("pruned", "Number of items pruned"),
         }
     }
+
+    /// Create an empty index with this index's translator and metric handles. Parallel
+    /// snapshot-build workers use it for their partition slots. The maps start without
+    /// capacity, since a worker slot often receives nothing.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) fn empty(&self) -> Self {
+        Self {
+            translator: self.translator.clone(),
+            overflow: HashMap::with_hasher(self.translator.clone()),
+            map: HashMap::with_hasher(self.translator.clone()),
+            keys: self.keys.clone(),
+            items: self.items.clone(),
+            pruned: self.pruned.clone(),
+        }
+    }
+
+    /// Move `other`'s contents into self, which must be empty. Wholesale moves are what let
+    /// [`Self::empty`] build-worker slots install without re-inserting each entry.
+    /// Metrics need no adjustment, since `other` updated self's handles directly.
+    ///
+    /// # Panics
+    ///
+    /// Panics if self is not empty.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) fn absorb(&mut self, other: Self) {
+        assert!(
+            self.map.is_empty() && self.overflow.is_empty(),
+            "absorb target must be empty"
+        );
+        self.map = other.map;
+        self.overflow = other.overflow;
+    }
+
+    /// Visit every value held by the index (inline and overflow), in unspecified order.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) fn for_each_value(&self, mut f: impl FnMut(&V)) {
+        for v in self.map.values() {
+            f(v);
+        }
+        for chain in self.overflow.values() {
+            for v in chain {
+                f(v);
+            }
+        }
+    }
 }
 
 impl<T: Translator, V: Send + Sync> super::Factory<T> for Index<T, V> {
@@ -223,7 +268,7 @@ impl<T: Translator, V: Send + Sync> Unordered for Index<T, V> {
 
     #[cfg(test)]
     fn keys(&self) -> usize {
-        self.map.len()
+        self.keys.get() as usize
     }
 
     #[cfg(test)]

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -924,7 +924,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Readable for Merkle<F, E, D,
     }
 }
 
-impl<F: Family, E: Context + Sync, D: Digest, S: Strategy> crate::merkle::storage::Storage<F>
+impl<F: Family, E: Context, D: Digest, S: Strategy> crate::merkle::storage::Storage<F>
     for Merkle<F, E, D, S>
 {
     type Digest = D;

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -924,7 +924,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Readable for Merkle<F, E, D,
     }
 }
 
-impl<F: Family, E: Context, D: Digest, S: Strategy> crate::merkle::storage::Storage<F>
+impl<F: Family, E: Context + Sync, D: Digest, S: Strategy> crate::merkle::storage::Storage<F>
     for Merkle<F, E, D, S>
 {
     type Digest = D;

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -717,20 +717,22 @@ where
 {
     /// Returns a [Db] initialized from `log`. `shared_bitmap = None` allocates a fresh bitmap;
     /// `Some(b)` adopts a pre-allocated bitmap (used by `current::Db`, which sizes pruned chunks
-    /// from grafted metadata). `init_concurrency` bounds how many tasks the snapshot build
-    /// uses, including this one.
+    /// from grafted metadata). `init_concurrency` is the index's snapshot-build concurrency
+    /// (see [crate::qmdb::SnapshotBuild::Concurrency]).
     ///
     /// # Panics
     ///
     /// Panics if the last operation is not a commit floor operation. Empty logs are handled
     /// upstream by [`crate::qmdb::any::init_with_bitmap`].
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn init_from_log(
         context: E,
         mut index: I,
         log: AuthenticatedLog<F, E, C, H, S>,
         shared_bitmap: Option<Arc<Shared<N>>>,
+        init_concurrency: <I as crate::qmdb::SnapshotBuild<F>>::Concurrency,
+        init_buffer: NonZeroUsize,
         cache_size: Option<NonZeroUsize>,
-        init_concurrency: NonZeroUsize,
         metrics: Metrics<E>,
     ) -> Result<Self, crate::qmdb::Error<F>>
     where
@@ -763,6 +765,7 @@ where
                     inactivity_floor_loc,
                     &log,
                     init_concurrency,
+                    init_buffer,
                     cache_size,
                 )
                 .await?;

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -717,20 +717,19 @@ where
 {
     /// Returns a [Db] initialized from `log`. `shared_bitmap = None` allocates a fresh bitmap;
     /// `Some(b)` adopts a pre-allocated bitmap (used by `current::Db`, which sizes pruned chunks
-    /// from grafted metadata). `parallelism` selects how the snapshot build splits its work.
+    /// from grafted metadata). `workers` bounds how many tasks the snapshot build splits across.
     ///
     /// # Panics
     ///
     /// Panics if the last operation is not a commit floor operation. Empty logs are handled
     /// upstream by [`crate::qmdb::any::init_with_bitmap`].
-    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn init_from_log(
         context: E,
         mut index: I,
         log: AuthenticatedLog<F, E, C, H, S>,
         shared_bitmap: Option<Arc<Shared<N>>>,
         cache_size: Option<NonZeroUsize>,
-        parallelism: crate::qmdb::InitParallelism,
+        workers: Option<NonZeroUsize>,
         metrics: Metrics<E>,
     ) -> Result<Self, crate::qmdb::Error<F>>
     where
@@ -740,7 +739,6 @@ where
     {
         // Share the log so the snapshot build can hand each parallel worker its own reader. Sole
         // ownership is recovered (`Arc::into_inner`) once the build has dropped every worker clone.
-        let strategy = log.strategy().clone();
         let log = Arc::new(log);
         let (last_commit_loc, inactivity_floor_loc, active_keys, bitmap) = {
             let bounds = log.bounds();
@@ -757,9 +755,13 @@ where
             )
             .await?;
 
+            // Build the snapshot, collecting each replayed location's activity status.
+            let (active_keys, activity) = index
+                .build_snapshot(context, inactivity_floor_loc, &log, workers, cache_size)
+                .await?;
+
             // Seed the bitmap so its pruned prefix matches the retained log boundary. Bits in
-            // [pruned_bits, bounds.start) correspond to pruned operations and remain 0; replay
-            // appends bits from the inactivity floor onward.
+            // [pruned_bits, bounds.start) correspond to pruned operations and remain 0.
             let bitmap = shared_bitmap.unwrap_or_else(|| {
                 let pruned_chunks =
                     (bounds.start / bitmap::Prunable::<N>::CHUNK_SIZE_BITS) as usize;
@@ -768,11 +770,12 @@ where
                 Arc::new(Shared::new(bm))
             });
 
-            // Extend the bitmap up to the inactivity floor (zero-fill).
+            // Extend the bitmap up to the inactivity floor (zero-fill), then append the replayed
+            // suffix, all under a single lock acquisition.
             {
                 let mut guard = bitmap.write();
                 // A caller-supplied bitmap must be pruned to a chunk boundary at or below the
-                // inactivity floor; otherwise `extend_to` would silently leave gaps.
+                // inactivity floor. Anything past it would make `extend_to` silently leave gaps.
                 assert!(
                     guard.pruned_bits() <= *inactivity_floor_loc,
                     "shared_bitmap pruned_bits {} exceeds inactivity_floor_loc {}",
@@ -780,31 +783,10 @@ where
                     *inactivity_floor_loc,
                 );
                 guard.extend_to(*inactivity_floor_loc);
+                for is_active in activity.iter() {
+                    guard.push(is_active);
+                }
             }
-
-            // The closure takes a brief lock per call (holding it across the build's `.await`s is
-            // not `Send`). `old_loc`, when set, clears a superseded bit. The serial build supplies
-            // it per op while the parallel build pre-resolves and passes `None`.
-            let active_keys = {
-                let bitmap = &bitmap;
-                index
-                    .build_snapshot(
-                        context,
-                        inactivity_floor_loc,
-                        &log,
-                        strategy,
-                        parallelism,
-                        cache_size,
-                        |is_active, old_loc| {
-                            let mut guard = bitmap.write();
-                            guard.push(is_active);
-                            if let Some(loc) = old_loc {
-                                guard.set_bit(*loc, false);
-                            }
-                        },
-                    )
-                    .await?
-            };
 
             (last_commit_loc, inactivity_floor_loc, active_keys, bitmap)
         };

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -717,7 +717,8 @@ where
 {
     /// Returns a [Db] initialized from `log`. `shared_bitmap = None` allocates a fresh bitmap;
     /// `Some(b)` adopts a pre-allocated bitmap (used by `current::Db`, which sizes pruned chunks
-    /// from grafted metadata). `workers` bounds how many tasks the snapshot build splits across.
+    /// from grafted metadata). `init_concurrency` bounds how many tasks the snapshot build
+    /// uses, including this one.
     ///
     /// # Panics
     ///
@@ -729,7 +730,7 @@ where
         log: AuthenticatedLog<F, E, C, H, S>,
         shared_bitmap: Option<Arc<Shared<N>>>,
         cache_size: Option<NonZeroUsize>,
-        workers: Option<NonZeroUsize>,
+        init_concurrency: NonZeroUsize,
         metrics: Metrics<E>,
     ) -> Result<Self, crate::qmdb::Error<F>>
     where
@@ -757,7 +758,13 @@ where
 
             // Build the snapshot, collecting each replayed location's activity status.
             let (active_keys, activity) = index
-                .build_snapshot(context, inactivity_floor_loc, &log, workers, cache_size)
+                .build_snapshot(
+                    context,
+                    inactivity_floor_loc,
+                    &log,
+                    init_concurrency,
+                    cache_size,
+                )
                 .await?;
 
             // Seed the bitmap so its pruned prefix matches the retained log boundary. Bits in

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     merkle::{Family, Location, Proof},
     qmdb::{
-        Error, bitmap::Shared, build_snapshot_from_log, delete_known_loc, metrics::Metrics,
+        Error, bitmap::Shared, delete_known_loc, metrics::Metrics,
         operation::Operation as OperationTrait, update_known_loc,
     },
 };
@@ -20,6 +20,7 @@ use commonware_codec::{Codec, CodecShared};
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_utils::bitmap;
 use core::num::{NonZeroU64, NonZeroUsize};
 use std::{collections::HashMap, sync::Arc};
@@ -592,7 +593,7 @@ where
                 match op {
                     Operation::CommitFloor(_, _) => {}
                     Operation::Update(update) => {
-                        let key = update.key().clone();
+                        let key = update.into_key();
                         let previous_loc = prior_state_by_key.get(&key).copied().flatten();
 
                         if loc >= rewind_size {
@@ -716,19 +717,31 @@ where
 {
     /// Returns a [Db] initialized from `log`. `shared_bitmap = None` allocates a fresh bitmap;
     /// `Some(b)` adopts a pre-allocated bitmap (used by `current::Db`, which sizes pruned chunks
-    /// from grafted metadata).
+    /// from grafted metadata). `parallelism` selects how the snapshot build splits its work.
     ///
     /// # Panics
     ///
     /// Panics if the last operation is not a commit floor operation. Empty logs are handled
     /// upstream by [`crate::qmdb::any::init_with_bitmap`].
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn init_from_log(
+        context: E,
         mut index: I,
         log: AuthenticatedLog<F, E, C, H, S>,
         shared_bitmap: Option<Arc<Shared<N>>>,
         cache_size: Option<NonZeroUsize>,
+        parallelism: crate::qmdb::InitParallelism,
         metrics: Metrics<E>,
-    ) -> Result<Self, crate::qmdb::Error<F>> {
+    ) -> Result<Self, crate::qmdb::Error<F>>
+    where
+        E: Spawner,
+        I: crate::qmdb::SnapshotBuild<F>,
+        C: 'static,
+    {
+        // Share the log so the snapshot build can hand each parallel worker its own reader. Sole
+        // ownership is recovered (`Arc::into_inner`) once the build has dropped every worker clone.
+        let strategy = log.strategy().clone();
+        let log = Arc::new(log);
         let (last_commit_loc, inactivity_floor_loc, active_keys, bitmap) = {
             let bounds = log.bounds();
             let last_commit_loc = Location::new(
@@ -738,7 +751,7 @@ where
                     .ok_or(Error::HistoricalFloorPruned(Location::new(bounds.end)))?,
             );
             let inactivity_floor_loc = crate::qmdb::find_inactivity_floor_at::<F, _>(
-                &log,
+                &*log,
                 Location::new(bounds.end),
                 |op| op.has_floor(),
             )
@@ -769,34 +782,35 @@ where
                 guard.extend_to(*inactivity_floor_loc);
             }
 
-            // Replay through `build_snapshot_from_log`. The closure fires synchronously between
-            // the helper's awaits, so each invocation does its own brief lock-update-release.
-            // Holding the guard across `.await` would not be `Send`-safe.
+            // The closure takes a brief lock per call (holding it across the build's `.await`s is
+            // not `Send`). `old_loc`, when set, clears a superseded bit. The serial build supplies
+            // it per op while the parallel build pre-resolves and passes `None`.
             let active_keys = {
                 let bitmap = &bitmap;
-                build_snapshot_from_log(
-                    inactivity_floor_loc,
-                    &log,
-                    &mut index,
-                    cache_size,
-                    |is_active, old_loc| {
-                        let mut guard = bitmap.write();
-                        guard.push(is_active);
-                        if let Some(loc) = old_loc {
-                            guard.set_bit(*loc, false);
-                        }
-                    },
-                )
-                .await?
+                index
+                    .build_snapshot(
+                        context,
+                        inactivity_floor_loc,
+                        &log,
+                        strategy,
+                        parallelism,
+                        cache_size,
+                        |is_active, old_loc| {
+                            let mut guard = bitmap.write();
+                            guard.push(is_active);
+                            if let Some(loc) = old_loc {
+                                guard.set_bit(*loc, false);
+                            }
+                        },
+                    )
+                    .await?
             };
-
-            // CommitFloor convention: only the current `last_commit_loc` carries bit=1; earlier
-            // CommitFloors are 0. `build_snapshot_from_log` reports `is_active = (loc ==
-            // last_commit_loc)` for each CommitFloor op, so the per-op push above already
-            // encodes this.
 
             (last_commit_loc, inactivity_floor_loc, active_keys, bitmap)
         };
+
+        // The build has returned, so every worker clone of the log is dropped. Reclaim it.
+        let log = Arc::into_inner(log).expect("snapshot build retained a log reference");
 
         // The bitmap must have exactly one bit per retained log location.
         if bitmap::Readable::<N>::len(bitmap.as_ref()) != log.size() {

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -133,9 +133,12 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
 
-    /// How the snapshot build parallelizes during init. Note that only certain index types (such
-    /// as the ordered-partitioned index) support parallel construction.
-    pub init_parallelism: super::InitParallelism,
+    /// Number of worker tasks the init-time snapshot build may split across; `None` builds on the
+    /// init task. Only certain index types (such as the ordered-partitioned index) build in
+    /// parallel. Counts past a few waste tasks without speeding up the build, and each task is
+    /// spawned as blocking-friendly shared work, so on runtimes with a bounded blocking pool keep
+    /// counts well below that pool's size.
+    pub init_workers: Option<NonZeroUsize>,
 }
 
 /// Configuration for an `Any` authenticated db with fixed-size values.
@@ -207,7 +210,7 @@ where
         log,
         bitmap,
         cfg.init_cache_size,
-        cfg.init_parallelism,
+        cfg.init_workers,
         metrics,
     )
     .await
@@ -219,10 +222,7 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
-        qmdb::{
-            InitParallelism,
-            any::{FixedConfig, MerkleConfig, VariableConfig},
-        },
+        qmdb::any::{FixedConfig, MerkleConfig, VariableConfig},
         translator::OneCap,
     };
     use commonware_codec::{Codec, CodecShared};
@@ -265,7 +265,7 @@ pub(crate) mod test {
     ) -> FixedConfig<T, S> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),
@@ -291,7 +291,7 @@ pub(crate) mod test {
     ) -> VariableConfig<T, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -119,7 +119,7 @@ pub(crate) const BITMAP_CHUNK_BYTES: usize = 64;
 
 /// Configuration for an `Any` authenticated db.
 #[derive(Clone)]
-pub struct Config<T: Translator, J, S: Strategy> {
+pub struct Config<T: Translator, J, S: Strategy, B = ()> {
     /// Configuration for the Merkle structure backing the authenticated journal.
     pub merkle_config: MerkleConfig<S>,
 
@@ -133,22 +133,26 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
 
-    /// Number of tasks that build the init-time snapshot, including the init task itself
-    /// (which replays and routes the log); `1` builds entirely on the init task. Only certain
-    /// index types (such as the ordered-partitioned index) build in parallel.
-    pub init_concurrency: NonZeroUsize,
+    /// Size (in bytes) of the read buffer used to replay the log during init.
+    pub init_buffer: NonZeroUsize,
+
+    /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]):
+    /// `()` for index types that build serially, and the number of build tasks (including the
+    /// init task itself, which replays and routes the log, so `1` builds entirely on the init
+    /// task) for index types that build in parallel.
+    pub init_concurrency: B,
 }
 
 /// Configuration for an `Any` authenticated db with fixed-size values.
-pub type FixedConfig<T, S> = Config<T, FConfig, S>;
+pub type FixedConfig<T, S, B = ()> = Config<T, FConfig, S, B>;
 
 /// Configuration for an `Any` authenticated db with variable-sized values.
-pub type VariableConfig<T, C, S> = Config<T, VConfig<C>, S>;
+pub type VariableConfig<T, C, S, B = ()> = Config<T, VConfig<C>, S, B>;
 
 /// Initialize an `Any` authenticated db from the given config.
 pub async fn init<F, E, U, H, T, I, J, S>(
     context: E,
-    cfg: Config<T, J::Config, S>,
+    cfg: Config<T, J::Config, S, <I as crate::qmdb::SnapshotBuild<F>>::Concurrency>,
 ) -> Result<db::Db<F, E, J, I, H, U, BITMAP_CHUNK_BYTES, S>, crate::qmdb::Error<F>>
 where
     F: Family,
@@ -169,7 +173,7 @@ where
 #[boxed]
 pub(crate) async fn init_with_bitmap<F, E, U, H, T, I, J, S, const N: usize>(
     context: E,
-    cfg: Config<T, J::Config, S>,
+    cfg: Config<T, J::Config, S, <I as crate::qmdb::SnapshotBuild<F>>::Concurrency>,
     bitmap: Option<Arc<Shared<N>>>,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where
@@ -207,8 +211,9 @@ where
         index,
         log,
         bitmap,
-        cfg.init_cache_size,
         cfg.init_concurrency,
+        cfg.init_buffer,
+        cfg.init_cache_size,
         metrics,
     )
     .await
@@ -261,6 +266,21 @@ pub(crate) mod test {
         pooler: &impl BufferPooler,
         strategy: S,
     ) -> FixedConfig<T, S> {
+        fixed_db_config_full(suffix, pooler, strategy, ())
+    }
+
+    /// Shared config construction for every fixed-value flavor, generic over the strategy and
+    /// the index's snapshot-build concurrency.
+    pub(crate) fn fixed_db_config_full<
+        T: Translator + Default,
+        S: commonware_parallel::Strategy,
+        B,
+    >(
+        suffix: &str,
+        pooler: &impl BufferPooler,
+        strategy: S,
+        init_concurrency: B,
+    ) -> FixedConfig<T, S, B> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
             merkle_config: MerkleConfig {
@@ -279,14 +299,41 @@ pub(crate) mod test {
             },
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency,
         }
+    }
+
+    /// Like [fixed_db_config], typed for a partitioned index at the serial concurrency.
+    pub(crate) fn fixed_db_config_partitioned<T: Translator + Default>(
+        suffix: &str,
+        pooler: &impl BufferPooler,
+    ) -> FixedConfig<T, Sequential, NonZeroUsize> {
+        fixed_db_config_full(suffix, pooler, Sequential, NZUsize!(1))
+    }
+
+    /// Like [variable_db_config], typed for a partitioned index at the serial concurrency.
+    pub(crate) fn variable_db_config_partitioned<T: Translator + Default>(
+        suffix: &str,
+        pooler: &impl BufferPooler,
+    ) -> VariableConfig<T, ((), ()), Sequential, NonZeroUsize> {
+        variable_db_config_full(suffix, pooler, NZUsize!(1))
     }
 
     pub(crate) fn variable_db_config<T: Translator + Default>(
         suffix: &str,
         pooler: &impl BufferPooler,
     ) -> VariableConfig<T, ((), ()), Sequential> {
+        variable_db_config_full(suffix, pooler, ())
+    }
+
+    /// Shared config construction for every variable-value flavor, generic over the index's
+    /// snapshot-build concurrency.
+    pub(crate) fn variable_db_config_full<T: Translator + Default, B>(
+        suffix: &str,
+        pooler: &impl BufferPooler,
+        init_concurrency: B,
+    ) -> VariableConfig<T, ((), ()), Sequential, B> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
             merkle_config: MerkleConfig {
@@ -307,7 +354,8 @@ pub(crate) mod test {
             },
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency,
         }
     }
 
@@ -1408,14 +1456,14 @@ pub(crate) mod test {
             $cb!($($args)*, uv, UnorderedVariable, mmr::Family, variable_db_config);
             $cb!($($args)*, of, OrderedFixed, mmr::Family, fixed_db_config);
             $cb!($($args)*, ov, OrderedVariable, mmr::Family, variable_db_config);
-            $cb!($($args)*, ufp1, UnorderedFixedP1, mmr::Family, fixed_db_config);
-            $cb!($($args)*, uvp1, UnorderedVariableP1, mmr::Family, variable_db_config);
-            $cb!($($args)*, ofp1, OrderedFixedP1, mmr::Family, fixed_db_config);
-            $cb!($($args)*, ovp1, OrderedVariableP1, mmr::Family, variable_db_config);
-            $cb!($($args)*, ufp2, UnorderedFixedP2, mmr::Family, fixed_db_config);
-            $cb!($($args)*, uvp2, UnorderedVariableP2, mmr::Family, variable_db_config);
-            $cb!($($args)*, ofp2, OrderedFixedP2, mmr::Family, fixed_db_config);
-            $cb!($($args)*, ovp2, OrderedVariableP2, mmr::Family, variable_db_config);
+            $cb!($($args)*, ufp1, UnorderedFixedP1, mmr::Family, fixed_db_config_partitioned);
+            $cb!($($args)*, uvp1, UnorderedVariableP1, mmr::Family, variable_db_config_partitioned);
+            $cb!($($args)*, ofp1, OrderedFixedP1, mmr::Family, fixed_db_config_partitioned);
+            $cb!($($args)*, ovp1, OrderedVariableP1, mmr::Family, variable_db_config_partitioned);
+            $cb!($($args)*, ufp2, UnorderedFixedP2, mmr::Family, fixed_db_config_partitioned);
+            $cb!($($args)*, uvp2, UnorderedVariableP2, mmr::Family, variable_db_config_partitioned);
+            $cb!($($args)*, ofp2, OrderedFixedP2, mmr::Family, fixed_db_config_partitioned);
+            $cb!($($args)*, ovp2, OrderedVariableP2, mmr::Family, variable_db_config_partitioned);
         };
     }
 
@@ -1426,14 +1474,14 @@ pub(crate) mod test {
             $cb!($($args)*, uv, UnorderedVariable, mmr::Family, variable_db_config);
             $cb!($($args)*, of, OrderedFixed, mmr::Family, fixed_db_config);
             $cb!($($args)*, ov, OrderedVariable, mmr::Family, variable_db_config);
-            $cb!($($args)*, ufp1, UnorderedFixedP1, mmr::Family, fixed_db_config);
-            $cb!($($args)*, uvp1, UnorderedVariableP1, mmr::Family, variable_db_config);
-            $cb!($($args)*, ofp1, OrderedFixedP1, mmr::Family, fixed_db_config);
-            $cb!($($args)*, ovp1, OrderedVariableP1, mmr::Family, variable_db_config);
-            $cb!($($args)*, ufp2, UnorderedFixedP2, mmr::Family, fixed_db_config);
-            $cb!($($args)*, uvp2, UnorderedVariableP2, mmr::Family, variable_db_config);
-            $cb!($($args)*, ofp2, OrderedFixedP2, mmr::Family, fixed_db_config);
-            $cb!($($args)*, ovp2, OrderedVariableP2, mmr::Family, variable_db_config);
+            $cb!($($args)*, ufp1, UnorderedFixedP1, mmr::Family, fixed_db_config_partitioned);
+            $cb!($($args)*, uvp1, UnorderedVariableP1, mmr::Family, variable_db_config_partitioned);
+            $cb!($($args)*, ofp1, OrderedFixedP1, mmr::Family, fixed_db_config_partitioned);
+            $cb!($($args)*, ovp1, OrderedVariableP1, mmr::Family, variable_db_config_partitioned);
+            $cb!($($args)*, ufp2, UnorderedFixedP2, mmr::Family, fixed_db_config_partitioned);
+            $cb!($($args)*, uvp2, UnorderedVariableP2, mmr::Family, variable_db_config_partitioned);
+            $cb!($($args)*, ofp2, OrderedFixedP2, mmr::Family, fixed_db_config_partitioned);
+            $cb!($($args)*, ovp2, OrderedVariableP2, mmr::Family, variable_db_config_partitioned);
             $cb!($($args)*, uf_mmb, MmbUnorderedFixed, mmb::Family, fixed_db_config);
             $cb!($($args)*, uv_mmb, MmbUnorderedVariable, mmb::Family, variable_db_config);
             $cb!($($args)*, of_mmb, MmbOrderedFixed, mmb::Family, fixed_db_config);

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -85,6 +85,7 @@ use commonware_codec::{CodecShared, Encode};
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use core::num::NonZeroUsize;
 use std::sync::Arc;
 use tracing::warn;
@@ -131,6 +132,10 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
+
+    /// How the snapshot build parallelizes during init. Note that only certain index types (such
+    /// as the ordered-partitioned index) support parallel construction.
+    pub init_parallelism: super::InitParallelism,
 }
 
 /// Configuration for an `Any` authenticated db with fixed-size values.
@@ -146,12 +151,12 @@ pub async fn init<F, E, U, H, T, I, J, S>(
 ) -> Result<db::Db<F, E, J, I, H, U, BITMAP_CHUNK_BYTES, S>, crate::qmdb::Error<F>>
 where
     F: Family,
-    E: Context,
+    E: Context + Spawner,
     U: Update + Send + Sync,
     H: Hasher,
     T: Translator,
-    I: IndexFactory<T, Value = Location<F>>,
-    J: authenticated::Backing<E, Item = Operation<F, U>>,
+    I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
+    J: authenticated::Backing<E, Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
 {
@@ -168,12 +173,12 @@ pub(crate) async fn init_with_bitmap<F, E, U, H, T, I, J, S, const N: usize>(
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where
     F: Family,
-    E: Context,
+    E: Context + Spawner,
     U: Update + Send + Sync,
     H: Hasher,
     T: Translator,
-    I: IndexFactory<T, Value = Location<F>>,
-    J: authenticated::Backing<E, Item = Operation<F, U>>,
+    I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
+    J: authenticated::Backing<E, Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
 {
@@ -194,8 +199,18 @@ where
     }
 
     let index = I::new(context.child("index"), cfg.translator);
+    let snapshot_context = context.child("snapshot");
     let metrics = Metrics::new(context);
-    db::Db::init_from_log(index, log, bitmap, cfg.init_cache_size, metrics).await
+    db::Db::init_from_log(
+        snapshot_context,
+        index,
+        log,
+        bitmap,
+        cfg.init_cache_size,
+        cfg.init_parallelism,
+        metrics,
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -204,7 +219,10 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
-        qmdb::any::{FixedConfig, MerkleConfig, VariableConfig},
+        qmdb::{
+            InitParallelism,
+            any::{FixedConfig, MerkleConfig, VariableConfig},
+        },
         translator::OneCap,
     };
     use commonware_codec::{Codec, CodecShared};
@@ -247,6 +265,7 @@ pub(crate) mod test {
     ) -> FixedConfig<T, S> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),
@@ -272,6 +291,7 @@ pub(crate) mod test {
     ) -> VariableConfig<T, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -133,12 +133,13 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
 
-    /// Number of worker tasks the init-time snapshot build may split across; `None` builds on the
-    /// init task. Only certain index types (such as the ordered-partitioned index) build in
-    /// parallel. Counts past a few waste tasks without speeding up the build, and each task is
-    /// spawned as blocking-friendly shared work, so on runtimes with a bounded blocking pool keep
-    /// counts well below that pool's size.
-    pub init_workers: Option<NonZeroUsize>,
+    /// Number of tasks that build the init-time snapshot, including the init task itself
+    /// (which replays and routes the log); `1` builds entirely on the init task. Only certain
+    /// index types (such as the ordered-partitioned index) build in parallel. Counts past a few
+    /// waste tasks without speeding up the build, and each additional task is spawned as
+    /// blocking-friendly shared work, so on runtimes with a bounded blocking pool keep counts
+    /// well below that pool's size.
+    pub init_concurrency: NonZeroUsize,
 }
 
 /// Configuration for an `Any` authenticated db with fixed-size values.
@@ -210,7 +211,7 @@ where
         log,
         bitmap,
         cfg.init_cache_size,
-        cfg.init_workers,
+        cfg.init_concurrency,
         metrics,
     )
     .await
@@ -265,7 +266,6 @@ pub(crate) mod test {
     ) -> FixedConfig<T, S> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),
@@ -282,6 +282,7 @@ pub(crate) mod test {
             },
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 
@@ -291,7 +292,6 @@ pub(crate) mod test {
     ) -> VariableConfig<T, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),
@@ -310,6 +310,7 @@ pub(crate) mod test {
             },
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -135,10 +135,7 @@ pub struct Config<T: Translator, J, S: Strategy> {
 
     /// Number of tasks that build the init-time snapshot, including the init task itself
     /// (which replays and routes the log); `1` builds entirely on the init task. Only certain
-    /// index types (such as the ordered-partitioned index) build in parallel. Counts past a few
-    /// waste tasks without speeding up the build, and each additional task is spawned as
-    /// blocking-friendly shared work, so on runtimes with a bounded blocking pool keep counts
-    /// well below that pool's size.
+    /// index types (such as the ordered-partitioned index) build in parallel.
     pub init_concurrency: NonZeroUsize,
 }
 

--- a/storage/src/qmdb/any/operation/mod.rs
+++ b/storage/src/qmdb/any/operation/mod.rs
@@ -73,6 +73,14 @@ impl<F: Family, S: Update> crate::qmdb::operation::Operation<F> for Operation<F,
         }
     }
 
+    fn into_key(self) -> Option<Self::Key> {
+        match self {
+            Self::Delete(k) => Some(k),
+            Self::Update(p) => Some(p.into_key()),
+            Self::CommitFloor(_, _) => None,
+        }
+    }
+
     fn is_update(&self) -> bool {
         matches!(self, Self::Update(_))
     }

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -38,6 +38,9 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync + 'static {
     /// The updated key.
     fn key(&self) -> &Self::Key;
 
+    /// Consumes the update and returns its owned key.
+    fn into_key(self) -> Self::Key;
+
     /// The updated value.
     fn value(&self) -> &Self::Value;
 

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -56,6 +56,10 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
         &self.key
     }
 
+    fn into_key(self) -> K {
+        self.key
+    }
+
     fn value(&self) -> &V::Value {
         &self.value
     }

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -47,6 +47,10 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
         &self.0
     }
 
+    fn into_key(self) -> K {
+        self.0
+    }
+
     fn value(&self) -> &V::Value {
         &self.1
     }

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -156,7 +156,7 @@ pub(crate) mod test {
         translator::{OneCap, TwoCap},
     };
     use commonware_cryptography::{Sha256, sha256::Digest};
-    use commonware_macros::test_traced;
+    use commonware_macros::{boxed, test_traced};
     use commonware_math::algebra::Random;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
@@ -502,15 +502,17 @@ pub(crate) mod test {
         });
     }
 
-    /// Build a `P`-partitioned ordered db with churny ops, then assert that reopening it with a range
-    /// of worker counts (`0` for the serial path, `1` for the single-worker de-interleave, counts
-    /// that round down to fewer workers with wider ranges, and counts above the partition count
-    /// that clamp) all reconstruct the identical root and key-value state: the parallel build
-    /// replays the same immutable log, just split across workers owning disjoint partition ranges.
+    /// Build a `P`-partitioned ordered db with churny ops, then assert that reopening it with a
+    /// range of `init_concurrency` values (`1` for the serial path, `2` for the single-worker
+    /// de-interleave, counts that round down to fewer workers with wider ranges, and counts
+    /// above the partition count that clamp) all reconstruct the identical root and key-value
+    /// state: the parallel build replays the same immutable log, just split across workers
+    /// owning disjoint partition ranges.
+    #[boxed]
     async fn check_parallel_init_equivalence<const P: usize>(
         context: deterministic::Context,
         partition: &'static str,
-        worker_counts: &[usize],
+        concurrency_sweep: &[usize],
     ) {
         type PartDb<const P: usize, S> =
             partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, P, S>;
@@ -547,7 +549,7 @@ pub(crate) mod test {
         }
 
         let cfg = fixed_db_config::<OneCap>(partition, &context);
-        let mut db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
+        let db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
             .await
             .unwrap();
 
@@ -559,8 +561,8 @@ pub(crate) mod test {
             batch = batch.write(k, Some(v));
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Commit 2: update a third (inactivating their commit-1 ops) and delete a seventh.
         let mut batch = db.new_batch();
@@ -574,8 +576,8 @@ pub(crate) mod test {
             batch = batch.write(k, None);
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Commit 3: reinsert a third of the deleted keys, so the replayed log contains
         // delete-then-reinsert sequences for the parallel build to resolve.
@@ -586,20 +588,26 @@ pub(crate) mod test {
             batch = batch.write(k, Some(v));
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        db.sync().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        let db = db.sync().await.unwrap();
         let root = db.root();
         drop(db);
 
-        // Reopen with a range of worker counts. All rebuild from the same log and must match the
-        // original root and serve the expected value for every key.
-        for &workers in worker_counts {
+        // Reopen with a range of concurrency values. All rebuild from the same log and must
+        // match the original root and serve the expected value for every key.
+        for &concurrency in concurrency_sweep {
             let mut cfg = fixed_db_config::<OneCap>(partition, &context);
-            cfg.init_workers = core::num::NonZeroUsize::new(workers);
-            let ctx = context.child("reopen").with_attribute("workers", workers);
+            cfg.init_concurrency = core::num::NonZeroUsize::new(concurrency).unwrap();
+            let ctx = context
+                .child("reopen")
+                .with_attribute("concurrency", concurrency);
             let db = PartDb::<P, Sequential>::init(ctx, cfg).await.unwrap();
-            assert_eq!(db.root(), root, "root mismatch at P={P} workers={workers}");
+            assert_eq!(
+                db.root(),
+                root,
+                "root mismatch at P={P} concurrency={concurrency}"
+            );
             assert_expected_values(&db).await;
             drop(db);
         }
@@ -621,7 +629,7 @@ pub(crate) mod test {
             drop(db);
 
             let mut cfg = fixed_db_config::<OneCap>("parallel_fresh", &context);
-            cfg.init_workers = core::num::NonZeroUsize::new(3);
+            cfg.init_concurrency = NZUsize!(4);
             let db = FreshDb::<Sequential>::init(context.child("reopen"), cfg)
                 .await
                 .unwrap();
@@ -643,7 +651,7 @@ pub(crate) mod test {
 
             // Populate a db so the log has committed operations to replay.
             let cfg = fixed_db_config::<OneCap>("parallel_replay_fail", &context);
-            let mut db = FailDb::<Sequential>::init(context.child("populate"), cfg)
+            let db = FailDb::<Sequential>::init(context.child("populate"), cfg)
                 .await
                 .unwrap();
             let mut batch = db.new_batch();
@@ -653,9 +661,9 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db.sync().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
             drop(db);
 
             // Reopen the op log directly (init's reads run before faults are enabled) and build
@@ -681,7 +689,7 @@ pub(crate) mod test {
             // workers never read the log themselves.
             context.storage_fault_config().write().read_rate = Some(1.0);
             let result = index
-                .build_snapshot(context.child("build"), floor, &log, Some(NZUsize!(3)), None)
+                .build_snapshot(context.child("build"), floor, &log, NZUsize!(4), None)
                 .await;
             assert!(result.is_err(), "replay must fail under read faults");
 
@@ -695,13 +703,13 @@ pub(crate) mod test {
     #[test_traced("WARN")]
     fn test_ordered_partitioned_p1_parallel_init_equivalence() {
         deterministic::Runner::default().start(|context| async move {
-            // 200 rounds down to 128 equal two-partition ranges for P=1 (count=256) and 300
-            // exceeds the partition count and clamps. Both must reconstruct the same root
-            // without panicking.
+            // Concurrency 201 (200 workers) rounds down to 128 equal two-partition ranges for
+            // P=1 (count=256) and 301 exceeds the partition count and clamps. Both must
+            // reconstruct the same root without panicking.
             check_parallel_init_equivalence::<1>(
                 context,
                 "parallel_equiv_p1",
-                &[0, 1, 2, 4, 8, 200, 300],
+                &[1, 2, 3, 5, 9, 201, 301],
             )
             .await;
         });
@@ -713,7 +721,7 @@ pub(crate) mod test {
             check_parallel_init_equivalence::<2>(
                 context,
                 "parallel_equiv_p2",
-                &[0, 1, 2, 4, 8, 200],
+                &[1, 2, 3, 5, 9, 201],
             )
             .await;
         });
@@ -727,7 +735,7 @@ pub(crate) mod test {
     #[ignore]
     fn test_ordered_partitioned_p3_parallel_init_equivalence() {
         deterministic::Runner::default().start(|context| async move {
-            check_parallel_init_equivalence::<3>(context, "parallel_equiv_p3", &[0, 1, 2]).await;
+            check_parallel_init_equivalence::<3>(context, "parallel_equiv_p3", &[1, 2, 3]).await;
         });
     }
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -113,7 +113,10 @@ pub mod partitioned {
     {
         /// Returns a [Db] QMDB initialized from `cfg`. Uncommitted log operations will be
         /// discarded and the state of the db will be as of the last committed operation.
-        pub async fn init(context: E, cfg: Config<T, S>) -> Result<Self, Error<F>> {
+        pub async fn init(
+            context: E,
+            cfg: Config<T, S, core::num::NonZeroUsize>,
+        ) -> Result<Self, Error<F>> {
             crate::qmdb::any::init(context, cfg).await
         }
     }
@@ -149,7 +152,7 @@ pub(crate) mod test {
                         test_ordered_any_update_collision_edge_case,
                     },
                 },
-                test::fixed_db_config,
+                test::{fixed_db_config, fixed_db_config_partitioned},
             },
             verify_proof,
         },
@@ -548,7 +551,7 @@ pub(crate) mod test {
             }
         }
 
-        let cfg = fixed_db_config::<OneCap>(partition, &context);
+        let cfg = fixed_db_config_partitioned::<OneCap>(partition, &context);
         let db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
             .await
             .unwrap();
@@ -592,12 +595,15 @@ pub(crate) mod test {
         let db = db.commit().await.unwrap();
         let db = db.sync().await.unwrap();
         let root = db.root();
+        let active_keys = db.active_keys;
         drop(db);
 
         // Reopen with a range of concurrency values. All rebuild from the same log and must
-        // match the original root and serve the expected value for every key.
+        // match the original root, the original active-key count (counted per actual key, so
+        // translated-key collision chains contribute each of their members), and serve the
+        // expected value for every key.
         for &concurrency in concurrency_sweep {
-            let mut cfg = fixed_db_config::<OneCap>(partition, &context);
+            let mut cfg = fixed_db_config_partitioned::<OneCap>(partition, &context);
             cfg.init_concurrency = core::num::NonZeroUsize::new(concurrency).unwrap();
             let ctx = context
                 .child("reopen")
@@ -607,6 +613,10 @@ pub(crate) mod test {
                 db.root(),
                 root,
                 "root mismatch at P={P} concurrency={concurrency}"
+            );
+            assert_eq!(
+                db.active_keys, active_keys,
+                "active-key count mismatch at P={P} concurrency={concurrency}"
             );
             assert_expected_values(&db).await;
             drop(db);
@@ -621,14 +631,14 @@ pub(crate) mod test {
             type FreshDb<S> =
                 partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 1, S>;
 
-            let cfg = fixed_db_config::<OneCap>("parallel_fresh", &context);
+            let cfg = fixed_db_config_partitioned::<OneCap>("parallel_fresh", &context);
             let db = FreshDb::<Sequential>::init(context.child("create"), cfg)
                 .await
                 .unwrap();
             let root = db.root();
             drop(db);
 
-            let mut cfg = fixed_db_config::<OneCap>("parallel_fresh", &context);
+            let mut cfg = fixed_db_config_partitioned::<OneCap>("parallel_fresh", &context);
             cfg.init_concurrency = NZUsize!(4);
             let db = FreshDb::<Sequential>::init(context.child("reopen"), cfg)
                 .await
@@ -650,7 +660,7 @@ pub(crate) mod test {
                 partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 1, S>;
 
             // Populate a db so the log has committed operations to replay.
-            let cfg = fixed_db_config::<OneCap>("parallel_replay_fail", &context);
+            let cfg = fixed_db_config_partitioned::<OneCap>("parallel_replay_fail", &context);
             let db = FailDb::<Sequential>::init(context.child("populate"), cfg)
                 .await
                 .unwrap();
@@ -668,7 +678,7 @@ pub(crate) mod test {
 
             // Reopen the op log directly (init's reads run before faults are enabled) and build
             // against a fresh index, mirroring init's parallel snapshot build.
-            let cfg = fixed_db_config::<OneCap>("parallel_replay_fail", &context);
+            let cfg = fixed_db_config_partitioned::<OneCap>("parallel_replay_fail", &context);
             let log = Journal::<Context, Operation<mmr::Family, Digest, Digest>>::init(
                 context.child("log"),
                 cfg.journal_config,
@@ -689,7 +699,14 @@ pub(crate) mod test {
             // workers never read the log themselves.
             context.storage_fault_config().write().read_rate = Some(1.0);
             let result = index
-                .build_snapshot(context.child("build"), floor, &log, NZUsize!(4), None)
+                .build_snapshot(
+                    context.child("build"),
+                    floor,
+                    &log,
+                    NZUsize!(4),
+                    NZUsize!(1 << 21),
+                    None,
+                )
                 .await;
             assert!(result.is_err(), "replay must fail under read faults");
 
@@ -697,6 +714,53 @@ pub(crate) mod test {
             assert_eq!(Arc::strong_count(&log), 1);
 
             context.storage_fault_config().write().read_rate = None;
+        });
+    }
+
+    /// A multi-worker build of an empty log must return the serial build's result (zero active
+    /// keys, an empty bitmap) rather than panicking on the last-commit bit.
+    #[test_traced("WARN")]
+    fn test_ordered_partitioned_parallel_init_empty_log() {
+        deterministic::Runner::default().start(|context| async move {
+            use crate::qmdb::SnapshotBuild as _;
+            use std::sync::Arc;
+
+            let mut results = Vec::new();
+            for concurrency in [1usize, 4] {
+                let cfg = fixed_db_config_partitioned::<OneCap>("ordered_parallel_empty", &context);
+                let log = Journal::<Context, Operation<mmr::Family, Digest, Digest>>::init(
+                    context
+                        .child("log")
+                        .with_attribute("concurrency", concurrency),
+                    cfg.journal_config,
+                )
+                .await
+                .unwrap();
+                let log = Arc::new(log);
+                let mut index =
+                    crate::index::partitioned::ordered::Index::<OneCap, Location, 1>::new(
+                        context
+                            .child("index")
+                            .with_attribute("concurrency", concurrency),
+                        OneCap,
+                    );
+                let result = index
+                    .build_snapshot(
+                        context
+                            .child("build")
+                            .with_attribute("concurrency", concurrency),
+                        Location::new(0),
+                        &log,
+                        core::num::NonZeroUsize::new(concurrency).unwrap(),
+                        NZUsize!(1 << 21),
+                        None,
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(result.0, 0);
+                results.push(result);
+            }
+            assert_eq!(results[0], results[1]);
         });
     }
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 pub type Update<K, V> = ordered::Update<K, FixedEncoding<V>>;
@@ -35,8 +36,15 @@ pub type Db<F, E, K, V, H, T, S> = super::Db<
     S,
 >;
 
-impl<F: Family, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator, S: Strategy>
-    Db<F, E, K, V, H, T, S>
+impl<
+    F: Family,
+    E: Context + Spawner,
+    K: Array,
+    V: FixedValue,
+    H: Hasher,
+    T: Translator,
+    S: Strategy,
+> Db<F, E, K, V, H, T, S>
 {
     /// Returns a [Db] qmdb initialized from `cfg`. Any uncommitted log operations will be
     /// discarded and the state of the db will be as of the last committed operation.
@@ -69,6 +77,7 @@ pub mod partitioned {
     };
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
+    use commonware_runtime::Spawner;
     use commonware_utils::Array;
 
     /// An ordered key-value QMDB with a partitioned snapshot index.
@@ -93,7 +102,7 @@ pub mod partitioned {
 
     impl<
         F: Family,
-        E: Context,
+        E: Context + Spawner,
         K: Array,
         V: FixedValue,
         H: Hasher,
@@ -140,7 +149,7 @@ pub(crate) mod test {
                         test_ordered_any_update_collision_edge_case,
                     },
                 },
-                test::fixed_db_config,
+                test::{fixed_db_config, fixed_db_config_with_strategy},
             },
             verify_proof,
         },
@@ -149,12 +158,12 @@ pub(crate) mod test {
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
-    use commonware_parallel::Sequential;
+    use commonware_parallel::{Manual, Sequential};
     use commonware_runtime::{
         Runner as _, Supervisor as _,
         deterministic::{self, Context},
     };
-    use commonware_utils::{NZU64, TestRng, sequence::FixedBytes};
+    use commonware_utils::{NZU64, NZUsize, TestRng, sequence::FixedBytes};
     use futures::StreamExt as _;
     use rand::{Rng, seq::IteratorRandom};
     use std::collections::{BTreeMap, HashMap};
@@ -490,6 +499,266 @@ pub(crate) mod test {
             assert!(db.get_span(&key2).await.unwrap().is_none());
 
             db.destroy().await.unwrap();
+        });
+    }
+
+    /// Build a `P`-partitioned ordered db with churny ops, then assert that reopening it with a range
+    /// of worker counts (`0` for the serial path, `1` for the single-worker de-interleave, counts
+    /// that round down to fewer workers with wider ranges, and counts above the partition count
+    /// that clamp) all reconstruct the identical root and key-value state: the parallel build
+    /// replays the same immutable log, just split across workers owning disjoint partition ranges. A final reopen
+    /// uses [crate::qmdb::InitParallelism::Auto] with a [Manual] strategy hint to cover the
+    /// derived-count path.
+    async fn check_parallel_init_equivalence<const P: usize>(
+        context: deterministic::Context,
+        partition: &'static str,
+        worker_counts: &[usize],
+    ) {
+        type PartDb<const P: usize, S> =
+            partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, P, S>;
+
+        /// The value each key holds after the three commits below. Keys deleted in commit 2 and
+        /// reinserted in commit 3 hold the reinserted value. Keys deleted and not reinserted are
+        /// absent. Updated keys hold the commit-2 value. The rest hold their commit-1 value.
+        fn expected_value(i: u64) -> Option<Digest> {
+            if i % 21 == 1 {
+                Some(Sha256::hash(&(i * 13).to_be_bytes()))
+            } else if i % 7 == 1 {
+                None
+            } else if i.is_multiple_of(3) {
+                Some(Sha256::hash(&((i + 1) * 11).to_be_bytes()))
+            } else {
+                Some(Sha256::hash(&(i * 7).to_be_bytes()))
+            }
+        }
+
+        /// Assert every key resolves to its expected value, catching a location filed under the
+        /// wrong key (which the root comparison alone cannot detect since the `any` root is a pure
+        /// function of the log).
+        async fn assert_expected_values<const P: usize, S: commonware_parallel::Strategy>(
+            db: &PartDb<P, S>,
+        ) {
+            for i in 0u64..4000 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                assert_eq!(
+                    db.get(&k).await.unwrap(),
+                    expected_value(i),
+                    "value mismatch for key {i}"
+                );
+            }
+        }
+
+        let cfg = fixed_db_config::<OneCap>(partition, &context);
+        let mut db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
+            .await
+            .unwrap();
+
+        // Commit 1: insert every key.
+        let mut batch = db.new_batch();
+        for i in 0u64..4000 {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&(i * 7).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+
+        // Commit 2: update a third (inactivating their commit-1 ops) and delete a seventh.
+        let mut batch = db.new_batch();
+        for i in (0u64..4000).step_by(3) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&((i + 1) * 11).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        for i in (1u64..4000).step_by(7) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            batch = batch.write(k, None);
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+
+        // Commit 3: reinsert a third of the deleted keys, so the replayed log contains
+        // delete-then-reinsert sequences for the parallel build to resolve.
+        let mut batch = db.new_batch();
+        for i in (1u64..4000).step_by(21) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&(i * 13).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        db.sync().await.unwrap();
+        let root = db.root();
+        drop(db);
+
+        // Reopen with a range of worker counts. All rebuild from the same log and must match the
+        // original root and serve the expected value for every key.
+        for &workers in worker_counts {
+            let mut cfg = fixed_db_config::<OneCap>(partition, &context);
+            cfg.init_parallelism = match workers {
+                0 => crate::qmdb::InitParallelism::Serial,
+                n => {
+                    crate::qmdb::InitParallelism::Workers(core::num::NonZeroUsize::new(n).unwrap())
+                }
+            };
+            let ctx = context.child("reopen").with_attribute("workers", workers);
+            let db = PartDb::<P, Sequential>::init(ctx, cfg).await.unwrap();
+            assert_eq!(db.root(), root, "root mismatch at P={P} workers={workers}");
+            assert_expected_values(&db).await;
+            drop(db);
+        }
+
+        // One derived-count reopen: `Auto` with a hint of 4 reserves one core for routing and
+        // builds with the remaining workers.
+        let mut cfg = fixed_db_config_with_strategy::<OneCap, _>(
+            partition,
+            &context,
+            Manual::new(Sequential, NZUsize!(4)),
+        );
+        cfg.init_parallelism = crate::qmdb::InitParallelism::Auto;
+        let db = PartDb::<P, Manual<Sequential>>::init(context.child("reopen_auto"), cfg)
+            .await
+            .unwrap();
+        assert_eq!(db.root(), root, "root mismatch at P={P} auto");
+        assert_expected_values(&db).await;
+        drop(db);
+    }
+
+    /// A fresh db's log holds only the auto-appended CommitFloor. A multi-worker reopen must
+    /// handle the keyless single-op replay (every routed batch empty).
+    #[test_traced("WARN")]
+    fn test_ordered_partitioned_fresh_db_parallel_init() {
+        deterministic::Runner::default().start(|context| async move {
+            type FreshDb<S> =
+                partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 1, S>;
+
+            let cfg = fixed_db_config::<OneCap>("parallel_fresh", &context);
+            let db = FreshDb::<Sequential>::init(context.child("create"), cfg)
+                .await
+                .unwrap();
+            let root = db.root();
+            drop(db);
+
+            let mut cfg = fixed_db_config::<OneCap>("parallel_fresh", &context);
+            cfg.init_parallelism =
+                crate::qmdb::InitParallelism::Workers(core::num::NonZeroUsize::new(3).unwrap());
+            let db = FreshDb::<Sequential>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+        });
+    }
+
+    /// A replay failure during a parallel build must join every worker before surfacing the
+    /// error: no worker may outlive the failed build, retaining a clone of the log and its
+    /// partition-range allocation (the [crate::qmdb::SnapshotBuild] cleanup invariant).
+    #[test_traced("WARN")]
+    fn test_ordered_partitioned_parallel_init_replay_failure_drains_workers() {
+        deterministic::Runner::default().start(|context| async move {
+            use crate::{journal::contiguous::Contiguous as _, qmdb::SnapshotBuild as _};
+            use std::sync::Arc;
+
+            type FailDb<S> =
+                partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 1, S>;
+
+            // Populate a db so the log has committed operations to replay.
+            let cfg = fixed_db_config::<OneCap>("parallel_replay_fail", &context);
+            let mut db = FailDb::<Sequential>::init(context.child("populate"), cfg)
+                .await
+                .unwrap();
+            let mut batch = db.new_batch();
+            for i in 0u64..100 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                let v = Sha256::hash(&(i * 7).to_be_bytes());
+                batch = batch.write(k, Some(v));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap();
+            db.sync().await.unwrap();
+            drop(db);
+
+            // Reopen the op log directly (init's reads run before faults are enabled) and build
+            // against a fresh index, mirroring init's parallel snapshot build.
+            let cfg = fixed_db_config::<OneCap>("parallel_replay_fail", &context);
+            let log = Journal::<Context, Operation<mmr::Family, Digest, Digest>>::init(
+                context.child("log"),
+                cfg.journal_config,
+            )
+            .await
+            .unwrap();
+            let floor = Location::new(log.bounds().start);
+            let log = Arc::new(log);
+            let mut index = crate::index::partitioned::ordered::Index::<OneCap, Location, 1>::new(
+                context.child("index"),
+                OneCap,
+            );
+
+            // Every read now fails, and the failure necessarily surfaces through the replay
+            // stream: the reopened journal's page cache is fresh (only the buffer pool is shared
+            // across configs, never cached pages), so replay's first item forces a storage read,
+            // and with far fewer ops than the routing batch size no batch reaches a worker, so
+            // workers never read the log themselves.
+            context.storage_fault_config().write().read_rate = Some(1.0);
+            let result = index
+                .build_snapshot(
+                    context.child("build"),
+                    floor,
+                    &log,
+                    Sequential,
+                    crate::qmdb::InitParallelism::Workers(NZUsize!(3)),
+                    None,
+                    |_, _| {},
+                )
+                .await;
+            assert!(result.is_err(), "replay must fail under read faults");
+
+            // Every worker was joined before the error surfaced: nothing else may retain the log.
+            assert_eq!(Arc::strong_count(&log), 1);
+
+            context.storage_fault_config().write().read_rate = None;
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_ordered_partitioned_p1_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            // 200 rounds down to 128 equal two-partition ranges for P=1 (count=256) and 300
+            // exceeds the partition count and clamps. Both must reconstruct the same root
+            // without panicking.
+            check_parallel_init_equivalence::<1>(
+                context,
+                "parallel_equiv_p1",
+                &[0, 1, 2, 4, 8, 200, 300],
+            )
+            .await;
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_ordered_partitioned_p2_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            check_parallel_init_equivalence::<2>(
+                context,
+                "parallel_equiv_p2",
+                &[0, 1, 2, 4, 8, 200],
+            )
+            .await;
+        });
+    }
+
+    /// P=3 allocates `2^24` partition slots (~800 MB per index), so it is too memory-heavy for the
+    /// default suite. Run it explicitly with `--ignored` (and ideally `--release`). Only serial and
+    /// one offset-parallel reopen are checked -- enough to validate the offset-based range build and
+    /// merge at the largest prefix width without the full worker-count sweep.
+    #[test_traced("WARN")]
+    #[ignore]
+    fn test_ordered_partitioned_p3_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            check_parallel_init_equivalence::<3>(context, "parallel_equiv_p3", &[0, 1, 2]).await;
         });
     }
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -149,7 +149,7 @@ pub(crate) mod test {
                         test_ordered_any_update_collision_edge_case,
                     },
                 },
-                test::{fixed_db_config, fixed_db_config_with_strategy},
+                test::fixed_db_config,
             },
             verify_proof,
         },
@@ -158,7 +158,7 @@ pub(crate) mod test {
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
-    use commonware_parallel::{Manual, Sequential};
+    use commonware_parallel::Sequential;
     use commonware_runtime::{
         Runner as _, Supervisor as _,
         deterministic::{self, Context},
@@ -506,9 +506,7 @@ pub(crate) mod test {
     /// of worker counts (`0` for the serial path, `1` for the single-worker de-interleave, counts
     /// that round down to fewer workers with wider ranges, and counts above the partition count
     /// that clamp) all reconstruct the identical root and key-value state: the parallel build
-    /// replays the same immutable log, just split across workers owning disjoint partition ranges. A final reopen
-    /// uses [crate::qmdb::InitParallelism::Auto] with a [Manual] strategy hint to cover the
-    /// derived-count path.
+    /// replays the same immutable log, just split across workers owning disjoint partition ranges.
     async fn check_parallel_init_equivalence<const P: usize>(
         context: deterministic::Context,
         partition: &'static str,
@@ -598,33 +596,13 @@ pub(crate) mod test {
         // original root and serve the expected value for every key.
         for &workers in worker_counts {
             let mut cfg = fixed_db_config::<OneCap>(partition, &context);
-            cfg.init_parallelism = match workers {
-                0 => crate::qmdb::InitParallelism::Serial,
-                n => {
-                    crate::qmdb::InitParallelism::Workers(core::num::NonZeroUsize::new(n).unwrap())
-                }
-            };
+            cfg.init_workers = core::num::NonZeroUsize::new(workers);
             let ctx = context.child("reopen").with_attribute("workers", workers);
             let db = PartDb::<P, Sequential>::init(ctx, cfg).await.unwrap();
             assert_eq!(db.root(), root, "root mismatch at P={P} workers={workers}");
             assert_expected_values(&db).await;
             drop(db);
         }
-
-        // One derived-count reopen: `Auto` with a hint of 4 reserves one core for routing and
-        // builds with the remaining workers.
-        let mut cfg = fixed_db_config_with_strategy::<OneCap, _>(
-            partition,
-            &context,
-            Manual::new(Sequential, NZUsize!(4)),
-        );
-        cfg.init_parallelism = crate::qmdb::InitParallelism::Auto;
-        let db = PartDb::<P, Manual<Sequential>>::init(context.child("reopen_auto"), cfg)
-            .await
-            .unwrap();
-        assert_eq!(db.root(), root, "root mismatch at P={P} auto");
-        assert_expected_values(&db).await;
-        drop(db);
     }
 
     /// A fresh db's log holds only the auto-appended CommitFloor. A multi-worker reopen must
@@ -643,8 +621,7 @@ pub(crate) mod test {
             drop(db);
 
             let mut cfg = fixed_db_config::<OneCap>("parallel_fresh", &context);
-            cfg.init_parallelism =
-                crate::qmdb::InitParallelism::Workers(core::num::NonZeroUsize::new(3).unwrap());
+            cfg.init_workers = core::num::NonZeroUsize::new(3);
             let db = FreshDb::<Sequential>::init(context.child("reopen"), cfg)
                 .await
                 .unwrap();
@@ -704,15 +681,7 @@ pub(crate) mod test {
             // workers never read the log themselves.
             context.storage_fault_config().write().read_rate = Some(1.0);
             let result = index
-                .build_snapshot(
-                    context.child("build"),
-                    floor,
-                    &log,
-                    Sequential,
-                    crate::qmdb::InitParallelism::Workers(NZUsize!(3)),
-                    None,
-                    |_, _| {},
-                )
+                .build_snapshot(context.child("build"), floor, &log, Some(NZUsize!(3)), None)
                 .await;
             assert!(result.is_err(), "replay must fail under read faults");
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -184,7 +184,6 @@ pub(crate) mod test {
         let page_cache =
             CacheRef::from_pooler(pooler, NZU16!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE));
         VariableConfig {
-            init_workers: None,
             merkle_config: crate::mmr::full::Config {
                 journal_partition: format!("mmr-journal-{seed}"),
                 metadata_partition: format!("mmr-metadata-{seed}"),
@@ -203,6 +202,7 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 
@@ -243,7 +243,7 @@ pub(crate) mod test {
 
             // Commit 1: insert every key.
             let cfg = create_test_config(77, &context);
-            let mut db = PartDb::<Sequential>::init(context.child("populate"), cfg)
+            let db = PartDb::<Sequential>::init(context.child("populate"), cfg)
                 .await
                 .unwrap();
             let mut batch = db.new_batch();
@@ -253,8 +253,8 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Commit 2: update a third and delete a seventh so the replay carries churn.
             let mut batch = db.new_batch();
@@ -267,18 +267,24 @@ pub(crate) mod test {
                 batch = batch.write(k, None);
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db.sync().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
             let root = db.root();
             drop(db);
 
-            for workers in [0usize, 3] {
+            for concurrency in [1usize, 4] {
                 let mut cfg = create_test_config(77, &context);
-                cfg.init_workers = core::num::NonZeroUsize::new(workers);
-                let ctx = context.child("reopen").with_attribute("workers", workers);
+                cfg.init_concurrency = core::num::NonZeroUsize::new(concurrency).unwrap();
+                let ctx = context
+                    .child("reopen")
+                    .with_attribute("concurrency", concurrency);
                 let db = PartDb::<Sequential>::init(ctx, cfg).await.unwrap();
-                assert_eq!(db.root(), root, "root mismatch at workers={workers}");
+                assert_eq!(
+                    db.root(),
+                    root,
+                    "root mismatch at concurrency={concurrency}"
+                );
                 for i in 0u64..500 {
                     let k = Sha256::hash(&i.to_be_bytes());
                     assert_eq!(

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -125,7 +125,7 @@ pub mod partitioned {
         /// discarded and the state of the db will be as of the last committed operation.
         pub async fn init(
             context: E,
-            cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg, S>,
+            cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg, S, core::num::NonZeroUsize>,
         ) -> Result<Self, Error<F>> {
             crate::qmdb::any::init(context, cfg).await
         }
@@ -173,14 +173,18 @@ pub(crate) mod test {
     const PAGE_SIZE: u16 = 103;
     const PAGE_CACHE_SIZE: usize = 13;
 
-    pub(crate) type VarConfig =
-        VariableConfig<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ())), Sequential>;
+    pub(crate) type VarConfig<B = ()> =
+        VariableConfig<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ())), Sequential, B>;
 
     /// Type alias for the concrete [Db] type used in these unit tests.
     pub(crate) type AnyTest =
         Db<mmr::Family, deterministic::Context, Digest, Vec<u8>, Sha256, TwoCap, Sequential>;
 
-    pub(crate) fn create_test_config(seed: u64, pooler: &impl BufferPooler) -> VarConfig {
+    pub(crate) fn create_test_config<B>(
+        seed: u64,
+        pooler: &impl BufferPooler,
+        init_concurrency: B,
+    ) -> VarConfig<B> {
         let page_cache =
             CacheRef::from_pooler(pooler, NZU16!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE));
         VariableConfig {
@@ -202,14 +206,15 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency,
         }
     }
 
     /// Create a test database with unique partition names
     pub(crate) async fn create_test_db(mut context: Context) -> AnyTest {
         let seed = context.next_u64();
-        let config = create_test_config(seed, &context);
+        let config = create_test_config(seed, &context, ());
         AnyTest::init(context, config).await.unwrap()
     }
 
@@ -242,7 +247,7 @@ pub(crate) mod test {
             }
 
             // Commit 1: insert every key.
-            let cfg = create_test_config(77, &context);
+            let cfg = create_test_config(77, &context, NZUsize!(1));
             let db = PartDb::<Sequential>::init(context.child("populate"), cfg)
                 .await
                 .unwrap();
@@ -274,8 +279,11 @@ pub(crate) mod test {
             drop(db);
 
             for concurrency in [1usize, 4] {
-                let mut cfg = create_test_config(77, &context);
-                cfg.init_concurrency = core::num::NonZeroUsize::new(concurrency).unwrap();
+                let cfg = create_test_config(
+                    77,
+                    &context,
+                    core::num::NonZeroUsize::new(concurrency).unwrap(),
+                );
                 let ctx = context
                     .child("reopen")
                     .with_attribute("concurrency", concurrency);

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -20,6 +20,7 @@ use crate::{
 use commonware_codec::{Codec, Read};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 
 pub type Update<K, V> = ordered::Update<K, VariableEncoding<V>>;
 pub type Operation<F, K, V> = ordered::Operation<F, K, VariableEncoding<V>>;
@@ -37,8 +38,15 @@ pub type Db<F, E, K, V, H, T, S> = super::Db<
     S,
 >;
 
-impl<F: Family, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator, S: Strategy>
-    Db<F, E, K, V, H, T, S>
+impl<
+    F: Family,
+    E: Context + Spawner,
+    K: Key,
+    V: VariableValue,
+    H: Hasher,
+    T: Translator,
+    S: Strategy,
+> Db<F, E, K, V, H, T, S>
 where
     Operation<F, K, V>: Codec,
 {
@@ -78,6 +86,7 @@ pub mod partitioned {
     use commonware_codec::{Codec, Read};
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
+    use commonware_runtime::Spawner;
 
     /// An ordered key-value QMDB with a partitioned snapshot index and variable-size values.
     ///
@@ -101,7 +110,7 @@ pub mod partitioned {
 
     impl<
         F: Family,
-        E: Context,
+        E: Context + Spawner,
         K: Key,
         V: VariableValue,
         H: Hasher,
@@ -140,12 +149,15 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         mmr,
-        qmdb::any::{
-            ordered::test::{
-                test_ordered_any_db_basic, test_ordered_any_db_empty,
-                test_ordered_any_update_collision_edge_case,
+        qmdb::{
+            InitParallelism,
+            any::{
+                ordered::test::{
+                    test_ordered_any_db_basic, test_ordered_any_db_empty,
+                    test_ordered_any_update_collision_edge_case,
+                },
+                test::variable_db_config,
             },
-            test::variable_db_config,
         },
         translator::TwoCap,
     };
@@ -164,23 +176,32 @@ pub(crate) mod test {
     const PAGE_SIZE: u16 = 103;
     const PAGE_CACHE_SIZE: usize = 13;
 
-    pub(crate) type VarConfig =
-        VariableConfig<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ())), Sequential>;
+    pub(crate) type VarConfig<S = Sequential> =
+        VariableConfig<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ())), S>;
 
     /// Type alias for the concrete [Db] type used in these unit tests.
     pub(crate) type AnyTest =
         Db<mmr::Family, deterministic::Context, Digest, Vec<u8>, Sha256, TwoCap, Sequential>;
 
     pub(crate) fn create_test_config(seed: u64, pooler: &impl BufferPooler) -> VarConfig {
+        create_test_config_with_strategy(seed, pooler, Sequential)
+    }
+
+    pub(crate) fn create_test_config_with_strategy<S: Strategy>(
+        seed: u64,
+        pooler: &impl BufferPooler,
+        strategy: S,
+    ) -> VarConfig<S> {
         let page_cache =
             CacheRef::from_pooler(pooler, NZU16!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE));
         VariableConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: crate::mmr::full::Config {
                 journal_partition: format!("mmr-journal-{seed}"),
                 metadata_partition: format!("mmr-metadata-{seed}"),
                 items_per_blob: NZU64!(12), // intentionally small and janky size
                 write_buffer: NZUsize!(64),
-                strategy: Sequential,
+                strategy,
                 page_cache: page_cache.clone(),
             },
             journal_config: crate::journal::contiguous::variable::Config {
@@ -201,6 +222,88 @@ pub(crate) mod test {
         let seed = context.next_u64();
         let config = create_test_config(seed, &context);
         AnyTest::init(context, config).await.unwrap()
+    }
+
+    /// Serial-vs-parallel init equivalence for the variable-value partitioned db. The parallel
+    /// build streams variable-size ops through the shared log, which the fixed-value equivalence
+    /// tests cannot cover.
+    #[test_traced("WARN")]
+    fn test_ordered_partitioned_variable_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            type PartDb<S> = partitioned::Db<
+                mmr::Family,
+                deterministic::Context,
+                Digest,
+                Vec<u8>,
+                Sha256,
+                TwoCap,
+                1,
+                S,
+            >;
+
+            /// The value each key holds after the two commits below.
+            fn expected_value(i: u64) -> Option<Vec<u8>> {
+                if i % 7 == 1 {
+                    None
+                } else if i.is_multiple_of(3) {
+                    Some(vec![0xAB; (i % 17 + 1) as usize])
+                } else {
+                    Some(vec![(i % 251) as u8; (i % 40 + 1) as usize])
+                }
+            }
+
+            // Commit 1: insert every key.
+            let cfg = create_test_config(77, &context);
+            let mut db = PartDb::<Sequential>::init(context.child("populate"), cfg)
+                .await
+                .unwrap();
+            let mut batch = db.new_batch();
+            for i in 0u64..500 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                let v = vec![(i % 251) as u8; (i % 40 + 1) as usize];
+                batch = batch.write(k, Some(v));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap();
+
+            // Commit 2: update a third and delete a seventh so the replay carries churn.
+            let mut batch = db.new_batch();
+            for i in (0u64..500).step_by(3) {
+                let k = Sha256::hash(&i.to_be_bytes());
+                batch = batch.write(k, Some(vec![0xAB; (i % 17 + 1) as usize]));
+            }
+            for i in (1u64..500).step_by(7) {
+                let k = Sha256::hash(&i.to_be_bytes());
+                batch = batch.write(k, None);
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap();
+            db.sync().await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            for workers in [0usize, 3] {
+                let mut cfg = create_test_config(77, &context);
+                cfg.init_parallelism = match workers {
+                    0 => InitParallelism::Serial,
+                    n => InitParallelism::Workers(core::num::NonZeroUsize::new(n).unwrap()),
+                };
+                let ctx = context.child("reopen").with_attribute("workers", workers);
+                let db = PartDb::<Sequential>::init(ctx, cfg).await.unwrap();
+                assert_eq!(db.root(), root, "root mismatch at workers={workers}");
+                for i in 0u64..500 {
+                    let k = Sha256::hash(&i.to_be_bytes());
+                    assert_eq!(
+                        db.get(&k).await.unwrap(),
+                        expected_value(i),
+                        "value mismatch for key {i}"
+                    );
+                }
+                drop(db);
+            }
+        });
     }
 
     /// Deterministic byte vector generator for variable-value tests.

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -149,15 +149,12 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         mmr,
-        qmdb::{
-            InitParallelism,
-            any::{
-                ordered::test::{
-                    test_ordered_any_db_basic, test_ordered_any_db_empty,
-                    test_ordered_any_update_collision_edge_case,
-                },
-                test::variable_db_config,
+        qmdb::any::{
+            ordered::test::{
+                test_ordered_any_db_basic, test_ordered_any_db_empty,
+                test_ordered_any_update_collision_edge_case,
             },
+            test::variable_db_config,
         },
         translator::TwoCap,
     };
@@ -176,32 +173,24 @@ pub(crate) mod test {
     const PAGE_SIZE: u16 = 103;
     const PAGE_CACHE_SIZE: usize = 13;
 
-    pub(crate) type VarConfig<S = Sequential> =
-        VariableConfig<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ())), S>;
+    pub(crate) type VarConfig =
+        VariableConfig<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ())), Sequential>;
 
     /// Type alias for the concrete [Db] type used in these unit tests.
     pub(crate) type AnyTest =
         Db<mmr::Family, deterministic::Context, Digest, Vec<u8>, Sha256, TwoCap, Sequential>;
 
     pub(crate) fn create_test_config(seed: u64, pooler: &impl BufferPooler) -> VarConfig {
-        create_test_config_with_strategy(seed, pooler, Sequential)
-    }
-
-    pub(crate) fn create_test_config_with_strategy<S: Strategy>(
-        seed: u64,
-        pooler: &impl BufferPooler,
-        strategy: S,
-    ) -> VarConfig<S> {
         let page_cache =
             CacheRef::from_pooler(pooler, NZU16!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE));
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: crate::mmr::full::Config {
                 journal_partition: format!("mmr-journal-{seed}"),
                 metadata_partition: format!("mmr-metadata-{seed}"),
                 items_per_blob: NZU64!(12), // intentionally small and janky size
                 write_buffer: NZUsize!(64),
-                strategy,
+                strategy: Sequential,
                 page_cache: page_cache.clone(),
             },
             journal_config: crate::journal::contiguous::variable::Config {
@@ -286,10 +275,7 @@ pub(crate) mod test {
 
             for workers in [0usize, 3] {
                 let mut cfg = create_test_config(77, &context);
-                cfg.init_parallelism = match workers {
-                    0 => InitParallelism::Serial,
-                    n => InitParallelism::Workers(core::num::NonZeroUsize::new(n).unwrap()),
-                };
+                cfg.init_workers = core::num::NonZeroUsize::new(workers);
                 let ctx = context.child("reopen").with_attribute("workers", workers);
                 let db = PartDb::<Sequential>::init(ctx, cfg).await.unwrap();
                 assert_eq!(db.root(), root, "root mismatch at workers={workers}");

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -46,6 +46,7 @@ use crate::{
 use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_utils::{Array, range::NonEmptyRange};
 use core::num::NonZeroUsize;
 
@@ -63,15 +64,16 @@ async fn build_db<F, E, U, I, H, C, T, S>(
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
     cache_size: Option<NonZeroUsize>,
+    parallelism: qmdb::InitParallelism,
 ) -> Result<Db<F, E, C, I, H, U, { crate::qmdb::any::BITMAP_CHUNK_BYTES }, S>, qmdb::Error<F>>
 where
     F: merkle::Family,
-    E: Context,
+    E: Context + Spawner,
     U: Update + Send + Sync + 'static,
-    I: IndexFactory<T, Value = Location<F>>,
+    I: IndexFactory<T> + crate::qmdb::SnapshotBuild<F>,
     H: Hasher,
     T: Translator,
-    C: Mutable<Item = Operation<F, U>>,
+    C: Mutable<Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Codec + Committable + CodecShared,
 {
@@ -96,8 +98,18 @@ where
         apply_batch_size as u64,
     )
     .await?;
+    let snapshot_context = context.child("snapshot");
     let metrics = Metrics::new(context);
-    let db = Db::init_from_log(index, log, None, cache_size, metrics).await?;
+    let db = Db::init_from_log(
+        snapshot_context,
+        index,
+        log,
+        None,
+        cache_size,
+        parallelism,
+        metrics,
+    )
+    .await?;
 
     Ok(db)
 }
@@ -110,7 +122,7 @@ macro_rules! impl_sync_database {
         impl<F, E, K, V, H, T, S> qmdb::sync::Database for $db<F, E, K, V, H, T, S>
         where
             F: merkle::Family,
-            E: Context,
+            E: Context + Spawner,
             K: $key_bound,
             V: $value_bound + 'static,
             H: Hasher,
@@ -137,6 +149,7 @@ macro_rules! impl_sync_database {
                 let merkle_config = config.merkle_config.clone();
                 let translator = config.translator.clone();
                 let cache_size = config.init_cache_size;
+                let parallelism = config.init_parallelism;
                 build_db::<F, _, $update<K, V>, _, H, _, T, S>(
                     context,
                     merkle_config,
@@ -146,6 +159,7 @@ macro_rules! impl_sync_database {
                     range,
                     apply_batch_size,
                     cache_size,
+                    parallelism,
                 )
                 .await
             }

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -63,8 +63,9 @@ async fn build_db<F, E, U, I, H, C, T, S>(
     pinned_nodes: Option<Vec<H::Digest>>,
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
+    init_concurrency: <I as crate::qmdb::SnapshotBuild<F>>::Concurrency,
+    init_buffer: NonZeroUsize,
     cache_size: Option<NonZeroUsize>,
-    init_concurrency: NonZeroUsize,
 ) -> Result<Db<F, E, C, I, H, U, { crate::qmdb::any::BITMAP_CHUNK_BYTES }, S>, qmdb::Error<F>>
 where
     F: merkle::Family,
@@ -105,8 +106,9 @@ where
         index,
         log,
         None,
-        cache_size,
         init_concurrency,
+        init_buffer,
+        cache_size,
         metrics,
     )
     .await?;
@@ -149,6 +151,7 @@ macro_rules! impl_sync_database {
                 let merkle_config = config.merkle_config.clone();
                 let translator = config.translator.clone();
                 let cache_size = config.init_cache_size;
+                let init_buffer = config.init_buffer;
                 let init_concurrency = config.init_concurrency;
                 build_db::<F, _, $update<K, V>, _, H, _, T, S>(
                     context,
@@ -158,8 +161,9 @@ macro_rules! impl_sync_database {
                     pinned_nodes,
                     range,
                     apply_batch_size,
-                    cache_size,
                     init_concurrency,
+                    init_buffer,
+                    cache_size,
                 )
                 .await
             }

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -64,7 +64,7 @@ async fn build_db<F, E, U, I, H, C, T, S>(
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
     cache_size: Option<NonZeroUsize>,
-    workers: Option<NonZeroUsize>,
+    init_concurrency: NonZeroUsize,
 ) -> Result<Db<F, E, C, I, H, U, { crate::qmdb::any::BITMAP_CHUNK_BYTES }, S>, qmdb::Error<F>>
 where
     F: merkle::Family,
@@ -106,7 +106,7 @@ where
         log,
         None,
         cache_size,
-        workers,
+        init_concurrency,
         metrics,
     )
     .await?;
@@ -149,7 +149,7 @@ macro_rules! impl_sync_database {
                 let merkle_config = config.merkle_config.clone();
                 let translator = config.translator.clone();
                 let cache_size = config.init_cache_size;
-                let workers = config.init_workers;
+                let init_concurrency = config.init_concurrency;
                 build_db::<F, _, $update<K, V>, _, H, _, T, S>(
                     context,
                     merkle_config,
@@ -159,7 +159,7 @@ macro_rules! impl_sync_database {
                     range,
                     apply_batch_size,
                     cache_size,
-                    workers,
+                    init_concurrency,
                 )
                 .await
             }

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -64,7 +64,7 @@ async fn build_db<F, E, U, I, H, C, T, S>(
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
     cache_size: Option<NonZeroUsize>,
-    parallelism: qmdb::InitParallelism,
+    workers: Option<NonZeroUsize>,
 ) -> Result<Db<F, E, C, I, H, U, { crate::qmdb::any::BITMAP_CHUNK_BYTES }, S>, qmdb::Error<F>>
 where
     F: merkle::Family,
@@ -106,7 +106,7 @@ where
         log,
         None,
         cache_size,
-        parallelism,
+        workers,
         metrics,
     )
     .await?;
@@ -149,7 +149,7 @@ macro_rules! impl_sync_database {
                 let merkle_config = config.merkle_config.clone();
                 let translator = config.translator.clone();
                 let cache_size = config.init_cache_size;
-                let parallelism = config.init_parallelism;
+                let workers = config.init_workers;
                 build_db::<F, _, $update<K, V>, _, H, _, T, S>(
                     context,
                     merkle_config,
@@ -159,7 +159,7 @@ macro_rules! impl_sync_database {
                     range,
                     apply_batch_size,
                     cache_size,
-                    parallelism,
+                    workers,
                 )
                 .await
             }

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -6,10 +6,10 @@
 
 use crate::{
     journal::contiguous::Contiguous,
-    merkle::{self, Location},
+    merkle::{self, Location, mmr},
     qmdb::{
         self,
-        any::traits::DbAny,
+        any::{test::fixed_db_config_with_strategy, traits::DbAny},
         operation::Operation as OperationTrait,
         sync::{
             self, Engine, Target,
@@ -17,20 +17,22 @@ use crate::{
             resolver::{self, FetchResult, Resolver},
         },
     },
+    translator::TwoCap,
 };
 use commonware_codec::Encode;
-use commonware_cryptography::sha256::Digest;
-use commonware_macros::select;
+use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
+use commonware_macros::{select, test_traced};
+use commonware_parallel::{Manual, Sequential};
 use commonware_runtime::{
     BufferPooler, Clock, Metrics as _, Runner as _, Supervisor as _, deterministic,
 };
 use commonware_utils::{
-    NZU64,
+    NZU64, NZUsize,
     channel::{mpsc, oneshot},
     non_empty_range,
     sync::{AsyncRwLock, Mutex},
 };
-use futures::{FutureExt, pin_mut};
+use futures::{FutureExt, future::join_all, pin_mut};
 use rand::Rng as _;
 use std::{
     num::NonZeroU64,
@@ -2999,3 +3001,104 @@ sync_tests_for_harness!(
     harnesses::UnorderedVariableMmbHarness,
     unordered_variable_mmb
 );
+
+/// State-sync rebuilds must honor the configured `init_parallelism` rather than deriving a worker
+/// count from the strategy. The partitioned ordered index is the only index type with a parallel
+/// build, and no partitioned db implements [qmdb::sync::Database] yet, so this exercises the
+/// shared [super::build_db] helper directly: `Serial` must spawn no snapshot workers even though
+/// the strategy's hint allows them, `Workers(2)` must spawn them, and both must rebuild the
+/// source root.
+#[test_traced]
+fn test_sync_build_honors_init_parallelism() {
+    type PartDb = crate::qmdb::any::ordered::fixed::partitioned::Db<
+        mmr::Family,
+        deterministic::Context,
+        Digest,
+        Digest,
+        Sha256,
+        TwoCap,
+        1,
+        Manual<Sequential>,
+    >;
+
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        // A strategy whose hint permits workers: a rebuild that ignored the configured
+        // `init_parallelism` would derive a parallel build from it.
+        let strategy = Manual::new(Sequential, NZUsize!(4));
+        let cfg = fixed_db_config_with_strategy::<TwoCap, _>(
+            "sync_honors_init_parallelism",
+            &context,
+            strategy,
+        );
+
+        // Build a committed source db (the test config's `init_parallelism` is `Serial`).
+        let mut db = PartDb::init(context.child("source"), cfg.clone())
+            .await
+            .unwrap();
+        let mut batch = db.new_batch();
+        for i in 0u64..500 {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&(i * 7).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+        db.sync().await.unwrap();
+        let root = db.root();
+        let lower = db.sync_boundary();
+        let upper = db.bounds().end;
+        let pinned: Vec<Digest> = join_all(
+            <mmr::Family as merkle::Family>::nodes_to_pin(lower).map(|p| db.log.merkle.get_node(p)),
+        )
+        .await
+        .into_iter()
+        .map(|n| n.unwrap().unwrap())
+        .collect();
+        let journal = db.log.journal;
+
+        // A `Serial` rebuild must not spawn snapshot workers.
+        let synced: PartDb = super::build_db(
+            context.child("serial_rebuild"),
+            cfg.merkle_config.clone(),
+            journal,
+            cfg.translator.clone(),
+            Some(pinned.clone()),
+            non_empty_range!(lower, upper),
+            1024,
+            cfg.init_cache_size,
+            qmdb::InitParallelism::Serial,
+        )
+        .await
+        .unwrap();
+        assert_eq!(synced.root(), root);
+        assert!(
+            !context.encode().contains("snapshot_worker"),
+            "serial sync rebuild must not spawn snapshot workers"
+        );
+
+        // An explicit worker count must spawn workers and rebuild the same root.
+        let journal = synced.log.journal;
+        let synced: PartDb = super::build_db(
+            context.child("parallel_rebuild"),
+            cfg.merkle_config.clone(),
+            journal,
+            cfg.translator.clone(),
+            Some(pinned),
+            non_empty_range!(lower, upper),
+            1024,
+            cfg.init_cache_size,
+            qmdb::InitParallelism::Workers(NZUsize!(2)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(synced.root(), root);
+        assert!(
+            context.encode().contains("snapshot_worker"),
+            "explicit worker count must spawn snapshot workers"
+        );
+
+        synced.destroy().await.unwrap();
+    });
+}

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -9,7 +9,7 @@ use crate::{
     merkle::{self, Location, mmr},
     qmdb::{
         self,
-        any::{test::fixed_db_config_with_strategy, traits::DbAny},
+        any::{test::fixed_db_config, traits::DbAny},
         operation::Operation as OperationTrait,
         sync::{
             self, Engine, Target,
@@ -22,7 +22,7 @@ use crate::{
 use commonware_codec::Encode;
 use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
 use commonware_macros::{select, test_traced};
-use commonware_parallel::{Manual, Sequential};
+use commonware_parallel::Sequential;
 use commonware_runtime::{
     BufferPooler, Clock, Metrics as _, Runner as _, Supervisor as _, deterministic,
 };
@@ -3002,14 +3002,13 @@ sync_tests_for_harness!(
     unordered_variable_mmb
 );
 
-/// State-sync rebuilds must honor the configured `init_parallelism` rather than deriving a worker
-/// count from the strategy. The partitioned ordered index is the only index type with a parallel
-/// build, and no partitioned db implements [qmdb::sync::Database] yet, so this exercises the
-/// shared [super::build_db] helper directly: `Serial` must spawn no snapshot workers even though
-/// the strategy's hint allows them, `Workers(2)` must spawn them, and both must rebuild the
+/// State-sync rebuilds must honor the configured `init_workers`. The partitioned ordered
+/// index is the only index type with a parallel build, and no partitioned db implements
+/// [qmdb::sync::Database] yet, so this exercises the shared [super::build_db] helper directly:
+/// `None` must spawn no snapshot workers, `Some(2)` must spawn them, and both must rebuild the
 /// source root.
 #[test_traced]
-fn test_sync_build_honors_init_parallelism() {
+fn test_sync_build_honors_init_workers() {
     type PartDb = crate::qmdb::any::ordered::fixed::partitioned::Db<
         mmr::Family,
         deterministic::Context,
@@ -3018,21 +3017,14 @@ fn test_sync_build_honors_init_parallelism() {
         Sha256,
         TwoCap,
         1,
-        Manual<Sequential>,
+        Sequential,
     >;
 
     let executor = deterministic::Runner::default();
     executor.start(|context| async move {
-        // A strategy whose hint permits workers: a rebuild that ignored the configured
-        // `init_parallelism` would derive a parallel build from it.
-        let strategy = Manual::new(Sequential, NZUsize!(4));
-        let cfg = fixed_db_config_with_strategy::<TwoCap, _>(
-            "sync_honors_init_parallelism",
-            &context,
-            strategy,
-        );
+        let cfg = fixed_db_config::<TwoCap>("sync_honors_init_workers", &context);
 
-        // Build a committed source db (the test config's `init_parallelism` is `Serial`).
+        // Build a committed source db (the test config's `init_workers` is `None`).
         let mut db = PartDb::init(context.child("source"), cfg.clone())
             .await
             .unwrap();
@@ -3068,7 +3060,7 @@ fn test_sync_build_honors_init_parallelism() {
             non_empty_range!(lower, upper),
             1024,
             cfg.init_cache_size,
-            qmdb::InitParallelism::Serial,
+            None,
         )
         .await
         .unwrap();
@@ -3089,7 +3081,7 @@ fn test_sync_build_honors_init_parallelism() {
             non_empty_range!(lower, upper),
             1024,
             cfg.init_cache_size,
-            qmdb::InitParallelism::Workers(NZUsize!(2)),
+            Some(NZUsize!(2)),
         )
         .await
         .unwrap();

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -6,10 +6,10 @@
 
 use crate::{
     journal::contiguous::Contiguous,
-    merkle::{self, Location, mmr},
+    merkle::{self, Location},
     qmdb::{
         self,
-        any::{test::fixed_db_config, traits::DbAny},
+        any::traits::DbAny,
         operation::Operation as OperationTrait,
         sync::{
             self, Engine, Target,
@@ -17,22 +17,20 @@ use crate::{
             resolver::{self, FetchResult, Resolver},
         },
     },
-    translator::TwoCap,
 };
 use commonware_codec::Encode;
-use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
-use commonware_macros::{select, test_traced};
-use commonware_parallel::Sequential;
+use commonware_cryptography::sha256::Digest;
+use commonware_macros::select;
 use commonware_runtime::{
     BufferPooler, Clock, Metrics as _, Runner as _, Supervisor as _, deterministic,
 };
 use commonware_utils::{
-    NZU64, NZUsize,
+    NZU64,
     channel::{mpsc, oneshot},
     non_empty_range,
     sync::{AsyncRwLock, Mutex},
 };
-use futures::{FutureExt, future::join_all, pin_mut};
+use futures::{FutureExt, pin_mut};
 use rand::Rng as _;
 use std::{
     num::NonZeroU64,
@@ -2286,6 +2284,7 @@ mod harnesses {
             crate::qmdb::any::ordered::variable::test::create_test_config(
                 suffix.parse().unwrap_or(0),
                 pooler,
+                (),
             )
         }
 
@@ -2567,6 +2566,7 @@ mod harnesses {
             crate::qmdb::any::ordered::variable::test::create_test_config(
                 suffix.parse().unwrap_or(0),
                 pooler,
+                (),
             )
         }
 
@@ -2587,7 +2587,8 @@ mod harnesses {
 
         async fn init_db(mut ctx: Context) -> Self::Db {
             let seed = ctx.next_u64();
-            let config = crate::qmdb::any::ordered::variable::test::create_test_config(seed, &ctx);
+            let config =
+                crate::qmdb::any::ordered::variable::test::create_test_config(seed, &ctx, ());
             Self::Db::init(ctx, config).await.unwrap()
         }
 
@@ -3001,96 +3002,3 @@ sync_tests_for_harness!(
     harnesses::UnorderedVariableMmbHarness,
     unordered_variable_mmb
 );
-
-/// State-sync rebuilds must honor the configured `init_concurrency`. The partitioned ordered
-/// index is the only index type with a parallel build, and no partitioned db implements
-/// [qmdb::sync::Database] yet, so this exercises the shared [super::build_db] helper directly:
-/// concurrency `1` must spawn no snapshot workers, `3` must spawn them, and both must rebuild the
-/// source root.
-#[test_traced]
-fn test_sync_build_honors_init_concurrency() {
-    type PartDb = crate::qmdb::any::ordered::fixed::partitioned::Db<
-        mmr::Family,
-        deterministic::Context,
-        Digest,
-        Digest,
-        Sha256,
-        TwoCap,
-        1,
-        Sequential,
-    >;
-
-    let executor = deterministic::Runner::default();
-    executor.start(|context| async move {
-        let cfg = fixed_db_config::<TwoCap>("sync_honors_init_concurrency", &context);
-
-        // Build a committed source db (the test config's `init_concurrency` is `0`).
-        let db = PartDb::init(context.child("source"), cfg.clone())
-            .await
-            .unwrap();
-        let mut batch = db.new_batch();
-        for i in 0u64..500 {
-            let k = Sha256::hash(&i.to_be_bytes());
-            let v = Sha256::hash(&(i * 7).to_be_bytes());
-            batch = batch.write(k, Some(v));
-        }
-        let merkleized = batch.merkleize(&db, None).await.unwrap();
-        let (db, _) = db.apply_batch(merkleized).await.unwrap();
-        let db = db.commit().await.unwrap();
-        let db = db.sync().await.unwrap();
-        let root = db.root();
-        let lower = db.sync_boundary();
-        let upper = db.bounds().end;
-        let pinned: Vec<Digest> = join_all(
-            <mmr::Family as merkle::Family>::nodes_to_pin(lower).map(|p| db.log.merkle.get_node(p)),
-        )
-        .await
-        .into_iter()
-        .map(|n| n.unwrap().unwrap())
-        .collect();
-        let journal = db.log.journal;
-
-        // A `Serial` rebuild must not spawn snapshot workers.
-        let synced: PartDb = super::build_db(
-            context.child("serial_rebuild"),
-            cfg.merkle_config.clone(),
-            journal,
-            cfg.translator.clone(),
-            Some(pinned.clone()),
-            non_empty_range!(lower, upper),
-            1024,
-            cfg.init_cache_size,
-            NZUsize!(1),
-        )
-        .await
-        .unwrap();
-        assert_eq!(synced.root(), root);
-        assert!(
-            !context.encode().contains("snapshot_worker"),
-            "serial sync rebuild must not spawn snapshot workers"
-        );
-
-        // An explicit worker count must spawn workers and rebuild the same root.
-        let journal = synced.log.journal;
-        let synced: PartDb = super::build_db(
-            context.child("parallel_rebuild"),
-            cfg.merkle_config.clone(),
-            journal,
-            cfg.translator.clone(),
-            Some(pinned),
-            non_empty_range!(lower, upper),
-            1024,
-            cfg.init_cache_size,
-            NZUsize!(3),
-        )
-        .await
-        .unwrap();
-        assert_eq!(synced.root(), root);
-        assert!(
-            context.encode().contains("snapshot_worker"),
-            "explicit worker count must spawn snapshot workers"
-        );
-
-        synced.destroy().await.unwrap();
-    });
-}

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -3002,13 +3002,13 @@ sync_tests_for_harness!(
     unordered_variable_mmb
 );
 
-/// State-sync rebuilds must honor the configured `init_workers`. The partitioned ordered
+/// State-sync rebuilds must honor the configured `init_concurrency`. The partitioned ordered
 /// index is the only index type with a parallel build, and no partitioned db implements
 /// [qmdb::sync::Database] yet, so this exercises the shared [super::build_db] helper directly:
-/// `None` must spawn no snapshot workers, `Some(2)` must spawn them, and both must rebuild the
+/// concurrency `1` must spawn no snapshot workers, `3` must spawn them, and both must rebuild the
 /// source root.
 #[test_traced]
-fn test_sync_build_honors_init_workers() {
+fn test_sync_build_honors_init_concurrency() {
     type PartDb = crate::qmdb::any::ordered::fixed::partitioned::Db<
         mmr::Family,
         deterministic::Context,
@@ -3022,10 +3022,10 @@ fn test_sync_build_honors_init_workers() {
 
     let executor = deterministic::Runner::default();
     executor.start(|context| async move {
-        let cfg = fixed_db_config::<TwoCap>("sync_honors_init_workers", &context);
+        let cfg = fixed_db_config::<TwoCap>("sync_honors_init_concurrency", &context);
 
-        // Build a committed source db (the test config's `init_workers` is `None`).
-        let mut db = PartDb::init(context.child("source"), cfg.clone())
+        // Build a committed source db (the test config's `init_concurrency` is `0`).
+        let db = PartDb::init(context.child("source"), cfg.clone())
             .await
             .unwrap();
         let mut batch = db.new_batch();
@@ -3035,9 +3035,9 @@ fn test_sync_build_honors_init_workers() {
             batch = batch.write(k, Some(v));
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        db.sync().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        let db = db.sync().await.unwrap();
         let root = db.root();
         let lower = db.sync_boundary();
         let upper = db.bounds().end;
@@ -3060,7 +3060,7 @@ fn test_sync_build_honors_init_workers() {
             non_empty_range!(lower, upper),
             1024,
             cfg.init_cache_size,
-            None,
+            NZUsize!(1),
         )
         .await
         .unwrap();
@@ -3081,7 +3081,7 @@ fn test_sync_build_honors_init_workers() {
             non_empty_range!(lower, upper),
             1024,
             cfg.init_cache_size,
-            Some(NZUsize!(2)),
+            NZUsize!(3),
         )
         .await
         .unwrap();

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -105,7 +105,10 @@ pub mod partitioned {
     {
         /// Returns a [Db] QMDB initialized from `cfg`. Uncommitted log operations will be
         /// discarded and the state of the db will be as of the last committed operation.
-        pub async fn init(context: E, cfg: Config<T, S>) -> Result<Self, Error<F>> {
+        pub async fn init(
+            context: E,
+            cfg: Config<T, S, core::num::NonZeroUsize>,
+        ) -> Result<Self, Error<F>> {
             crate::qmdb::any::init(context, cfg).await
         }
     }
@@ -129,18 +132,23 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         index::Unordered as _,
+        journal::{Error as JournalError, contiguous::Contiguous},
         merkle::{
             Location as GenericLocation,
             mmr::{self, Location},
         },
         qmdb::{
+            SnapshotBuild as _,
             any::{
-                test::{fixed_db_config, fixed_db_config_with_strategy},
+                test::{
+                    colliding_digest, fixed_db_config, fixed_db_config_partitioned,
+                    fixed_db_config_with_strategy,
+                },
                 unordered::{Update, fixed::Operation},
             },
             verify_proof,
         },
-        translator::TwoCap,
+        translator::{OneCap, TwoCap},
     };
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::{select, test_traced};
@@ -152,9 +160,14 @@ pub(crate) mod test {
     };
     use commonware_utils::{NZU64, NZUsize, TestRng};
     use core::num::NonZeroUsize;
-    use futures::FutureExt as _;
+    use futures::{FutureExt as _, Stream};
     use rand::Rng;
-    use std::{collections::HashMap, time::Duration};
+    use std::{
+        collections::HashMap,
+        future::{Future, ready},
+        sync::Arc,
+        time::Duration,
+    };
 
     /// A generic type alias for an Any database parameterized by merkle family.
     type AnyTestGeneric<F> = crate::qmdb::any::db::Db<
@@ -436,6 +449,397 @@ pub(crate) mod test {
                 );
                 drop(db);
             }
+        });
+    }
+
+    /// Build a `P`-partitioned unordered db with churny ops, then assert that reopening it with a
+    /// range of `init_concurrency` values (`1` for the serial path, `2` for the single-worker
+    /// de-interleave, counts that round down to fewer workers with wider ranges, and counts
+    /// above the partition count that clamp) all reconstruct the identical root and key-value
+    /// state: the parallel build replays the same immutable log, just split across workers
+    /// owning disjoint partition ranges.
+    #[commonware_macros::boxed]
+    async fn check_parallel_init_equivalence<const P: usize>(
+        context: deterministic::Context,
+        partition: &'static str,
+        concurrency_sweep: &[usize],
+    ) {
+        type PartDb<const P: usize, S> =
+            partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, P, S>;
+
+        /// The value each key holds after the three commits below. Keys deleted in commit 2 and
+        /// reinserted in commit 3 hold the reinserted value. Keys deleted and not reinserted are
+        /// absent. Updated keys hold the commit-2 value. The rest hold their commit-1 value.
+        fn expected_value(i: u64) -> Option<Digest> {
+            if i % 21 == 1 {
+                Some(Sha256::hash(&(i * 13).to_be_bytes()))
+            } else if i % 7 == 1 {
+                None
+            } else if i.is_multiple_of(3) {
+                Some(Sha256::hash(&((i + 1) * 11).to_be_bytes()))
+            } else {
+                Some(Sha256::hash(&(i * 7).to_be_bytes()))
+            }
+        }
+
+        /// Assert every key resolves to its expected value, catching a location filed under the
+        /// wrong key (which the root comparison alone cannot detect since the `any` root is a pure
+        /// function of the log).
+        async fn assert_expected_values<const P: usize, S: commonware_parallel::Strategy>(
+            db: &PartDb<P, S>,
+        ) {
+            for i in 0u64..4000 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                assert_eq!(
+                    db.get(&k).await.unwrap(),
+                    expected_value(i),
+                    "value mismatch for key {i}"
+                );
+            }
+        }
+
+        let cfg = fixed_db_config_partitioned::<OneCap>(partition, &context);
+        let db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
+            .await
+            .unwrap();
+
+        // Commit 1: insert every key.
+        let mut batch = db.new_batch();
+        for i in 0u64..4000 {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&(i * 7).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+
+        // Commit 2: update a third (inactivating their commit-1 ops) and delete a seventh.
+        let mut batch = db.new_batch();
+        for i in (0u64..4000).step_by(3) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&((i + 1) * 11).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        for i in (1u64..4000).step_by(7) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            batch = batch.write(k, None);
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+
+        // Commit 3: reinsert a third of the deleted keys, so the replayed log contains
+        // delete-then-reinsert sequences for the parallel build to resolve.
+        let mut batch = db.new_batch();
+        for i in (1u64..4000).step_by(21) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&(i * 13).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        let db = db.sync().await.unwrap();
+        let root = db.root();
+        let active_keys = db.active_keys;
+        drop(db);
+
+        // Reopen with a range of concurrency values. All rebuild from the same log and must
+        // match the original root, the original active-key count (counted per actual key, so
+        // translated-key collision chains contribute each of their members), and serve the
+        // expected value for every key.
+        for &concurrency in concurrency_sweep {
+            let mut cfg = fixed_db_config_partitioned::<OneCap>(partition, &context);
+            cfg.init_concurrency = NonZeroUsize::new(concurrency).unwrap();
+            let ctx = context
+                .child("reopen")
+                .with_attribute("concurrency", concurrency);
+            let db = PartDb::<P, Sequential>::init(ctx, cfg).await.unwrap();
+            assert_eq!(
+                db.root(),
+                root,
+                "root mismatch at P={P} concurrency={concurrency}"
+            );
+            assert_eq!(
+                db.active_keys, active_keys,
+                "active-key count mismatch at P={P} concurrency={concurrency}"
+            );
+            assert_expected_values(&db).await;
+            drop(db);
+        }
+    }
+
+    /// `P=2` allocates 65,536 hash sub-indexes per index instance (each pre-sizing its map), which
+    /// is too memory-heavy for the default suite, and the range/offset arithmetic is shared with
+    /// the ordered variant's P=2 coverage -- so the unordered sweep runs at P=1 only.
+    #[test_traced("WARN")]
+    fn test_unordered_partitioned_p1_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            // Concurrency 201 (200 workers) rounds down to 128 equal two-partition ranges for
+            // P=1 (count=256) and 301 exceeds the partition count and clamps. Both must
+            // reconstruct the same root without panicking.
+            check_parallel_init_equivalence::<1>(
+                context,
+                "unordered_parallel_equiv_p1",
+                &[1, 2, 3, 5, 9, 201, 301],
+            )
+            .await;
+        });
+    }
+
+    /// A fresh db's log holds only the auto-appended CommitFloor. A multi-worker reopen must
+    /// handle the keyless single-op replay (every routed batch empty).
+    #[test_traced("WARN")]
+    fn test_unordered_partitioned_fresh_db_parallel_init() {
+        deterministic::Runner::default().start(|context| async move {
+            type FreshDb<S> =
+                partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 1, S>;
+
+            let cfg = fixed_db_config_partitioned::<OneCap>("unordered_parallel_fresh", &context);
+            let db = FreshDb::<Sequential>::init(context.child("create"), cfg)
+                .await
+                .unwrap();
+            let root = db.root();
+            drop(db);
+
+            let mut cfg =
+                fixed_db_config_partitioned::<OneCap>("unordered_parallel_fresh", &context);
+            cfg.init_concurrency = NZUsize!(4);
+            let db = FreshDb::<Sequential>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+        });
+    }
+
+    /// A replay failure during a parallel build must join every worker before surfacing the
+    /// error: no worker may outlive the failed build, retaining a clone of the log and its
+    /// partition-range allocation (the [crate::qmdb::SnapshotBuild] cleanup invariant).
+    #[test_traced("WARN")]
+    fn test_unordered_partitioned_parallel_init_replay_failure_drains_workers() {
+        deterministic::Runner::default().start(|context| async move {
+            type FailDb<S> =
+                partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 1, S>;
+
+            // Populate a db so the log has committed operations to replay.
+            let cfg =
+                fixed_db_config_partitioned::<OneCap>("unordered_parallel_replay_fail", &context);
+            let db = FailDb::<Sequential>::init(context.child("populate"), cfg)
+                .await
+                .unwrap();
+            let mut batch = db.new_batch();
+            for i in 0u64..100 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                let v = Sha256::hash(&(i * 7).to_be_bytes());
+                batch = batch.write(k, Some(v));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
+
+            // Reopen the op log directly (init's reads run before faults are enabled) and build
+            // against a fresh index, mirroring init's parallel snapshot build.
+            let cfg =
+                fixed_db_config_partitioned::<OneCap>("unordered_parallel_replay_fail", &context);
+            let log = Journal::<Context, Operation<mmr::Family, Digest, Digest>>::init(
+                context.child("log"),
+                cfg.journal_config,
+            )
+            .await
+            .unwrap();
+            let floor = Location::new(log.bounds().start);
+            let log = Arc::new(log);
+            let mut index = crate::index::partitioned::unordered::Index::<OneCap, Location, 1>::new(
+                context.child("index"),
+                OneCap,
+            );
+
+            // Every read now fails, and the failure necessarily surfaces through the replay
+            // stream: the reopened journal's page cache is fresh (only the buffer pool is shared
+            // across configs, never cached pages), so replay's first item forces a storage read,
+            // and with far fewer ops than the routing batch size no batch reaches a worker, so
+            // workers never read the log themselves.
+            context.storage_fault_config().write().read_rate = Some(1.0);
+            let result = index
+                .build_snapshot(
+                    context.child("build"),
+                    floor,
+                    &log,
+                    NZUsize!(4),
+                    NZUsize!(1 << 21),
+                    None,
+                )
+                .await;
+            assert!(result.is_err(), "replay must fail under read faults");
+
+            // Every worker was joined before the error surfaced: nothing else may retain the log.
+            assert_eq!(Arc::strong_count(&log), 1);
+
+            context.storage_fault_config().write().read_rate = None;
+        });
+    }
+
+    /// A read-only log view whose random-access reads always fail. During a parallel build only
+    /// the workers read the log directly (collision resolution, with the init cache disabled), so
+    /// this fails a worker's read while the router's replay stream succeeds.
+    struct FailingReads<C>(C);
+
+    impl<C: Contiguous<Item: Sync>> Contiguous for FailingReads<C> {
+        type Item = C::Item;
+
+        fn bounds(&self) -> std::ops::Range<u64> {
+            self.0.bounds()
+        }
+
+        fn read(
+            &self,
+            position: u64,
+        ) -> impl Future<Output = Result<Self::Item, JournalError>> + Send + Sync {
+            ready(Err(JournalError::ItemPruned(position)))
+        }
+
+        fn read_many(
+            &self,
+            positions: &[u64],
+        ) -> impl Future<Output = Result<Vec<Self::Item>, JournalError>> + Send {
+            ready(Err(JournalError::ItemPruned(
+                positions.first().copied().unwrap_or_default(),
+            )))
+        }
+
+        fn try_read_sync(&self, _position: u64) -> Option<Self::Item> {
+            None
+        }
+
+        fn try_read_many_sync(&self, positions: &[u64]) -> Vec<Option<Self::Item>> {
+            positions.iter().map(|_| None).collect()
+        }
+
+        fn replay(
+            &self,
+            start_pos: u64,
+            buffer: NonZeroUsize,
+        ) -> impl Future<
+            Output = Result<
+                impl Stream<Item = Result<(u64, Self::Item), JournalError>> + Send,
+                JournalError,
+            >,
+        > + Send {
+            self.0.replay(start_pos, buffer)
+        }
+    }
+
+    /// A worker failure during a parallel build must surface through the worker join and leave
+    /// no worker retaining the log: the failing worker's channel closes, routing stops, and the
+    /// join returns the worker's error. This is the counterpart of the replay-failure test,
+    /// which fails the router's stream before any worker reads.
+    #[test_traced("WARN")]
+    fn test_unordered_partitioned_parallel_init_worker_failure_drains_workers() {
+        deterministic::Runner::default().start(|context| async move {
+            type FailDb<S> =
+                partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 1, S>;
+
+            // Populate with two keys that share a partition and translated sub-key, so the
+            // second key's replay resolves a collision by reading the first key's operation
+            // from the log.
+            let cfg =
+                fixed_db_config_partitioned::<OneCap>("unordered_parallel_worker_fail", &context);
+            let db = FailDb::<Sequential>::init(context.child("populate"), cfg)
+                .await
+                .unwrap();
+            let merkleized = db
+                .new_batch()
+                .write(colliding_digest(0x10, 1), Some(Sha256::hash(b"v1")))
+                .write(colliding_digest(0x10, 2), Some(Sha256::hash(b"v2")))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
+
+            // Reopen the op log behind a wrapper that fails every random-access read, and build
+            // with the cache disabled so collision resolution must read the log.
+            let cfg =
+                fixed_db_config_partitioned::<OneCap>("unordered_parallel_worker_fail", &context);
+            let log = Journal::<Context, Operation<mmr::Family, Digest, Digest>>::init(
+                context.child("log"),
+                cfg.journal_config,
+            )
+            .await
+            .unwrap();
+            let floor = Location::new(log.bounds().start);
+            let log = Arc::new(FailingReads(log));
+            let mut index = crate::index::partitioned::unordered::Index::<OneCap, Location, 1>::new(
+                context.child("index"),
+                OneCap,
+            );
+            let result = index
+                .build_snapshot(
+                    context.child("build"),
+                    floor,
+                    &log,
+                    NZUsize!(4),
+                    NZUsize!(1 << 21),
+                    None,
+                )
+                .await;
+            assert!(
+                matches!(result, Err(Error::Journal(JournalError::ItemPruned(_)))),
+                "worker read failure must surface through the join, got {result:?}"
+            );
+
+            // Every worker was joined before the error surfaced: nothing else may retain the log.
+            assert_eq!(Arc::strong_count(&log), 1);
+        });
+    }
+
+    /// A multi-worker build of an empty log must return the serial build's result (zero active
+    /// keys, an empty bitmap) rather than panicking on the last-commit bit.
+    #[test_traced("WARN")]
+    fn test_unordered_partitioned_parallel_init_empty_log() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut results = Vec::new();
+            for concurrency in [1usize, 4] {
+                let cfg =
+                    fixed_db_config_partitioned::<OneCap>("unordered_parallel_empty", &context);
+                let log = Journal::<Context, Operation<mmr::Family, Digest, Digest>>::init(
+                    context
+                        .child("log")
+                        .with_attribute("concurrency", concurrency),
+                    cfg.journal_config,
+                )
+                .await
+                .unwrap();
+                let log = Arc::new(log);
+                let mut index =
+                    crate::index::partitioned::unordered::Index::<OneCap, Location, 1>::new(
+                        context
+                            .child("index")
+                            .with_attribute("concurrency", concurrency),
+                        OneCap,
+                    );
+                let result = index
+                    .build_snapshot(
+                        context
+                            .child("build")
+                            .with_attribute("concurrency", concurrency),
+                        Location::new(0),
+                        &log,
+                        NonZeroUsize::new(concurrency).unwrap(),
+                        NZUsize!(1 << 21),
+                        None,
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(result.0, 0);
+                results.push(result);
+            }
+            assert_eq!(results[0], results[1]);
         });
     }
 

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 pub type Update<K, V> = unordered::Update<K, FixedEncoding<V>>;
@@ -31,8 +32,15 @@ pub type Db<F, E, K, V, H, T, S> = super::Db<
     S,
 >;
 
-impl<F: Family, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator, S: Strategy>
-    Db<F, E, K, V, H, T, S>
+impl<
+    F: Family,
+    E: Context + Spawner,
+    K: Array,
+    V: FixedValue,
+    H: Hasher,
+    T: Translator,
+    S: Strategy,
+> Db<F, E, K, V, H, T, S>
 {
     /// Returns a [Db] QMDB initialized from `cfg`. Uncommitted log operations will be
     /// discarded and the state of the db will be as of the last committed operation.
@@ -61,6 +69,7 @@ pub mod partitioned {
     };
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
+    use commonware_runtime::Spawner;
     use commonware_utils::Array;
 
     /// A key-value QMDB with a partitioned snapshot index.
@@ -85,7 +94,7 @@ pub mod partitioned {
 
     impl<
         F: Family,
-        E: Context,
+        E: Context + Spawner,
         K: Array,
         V: FixedValue,
         H: Hasher,

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -165,7 +165,6 @@ pub(crate) mod test {
     pub(crate) fn create_test_config(seed: u64, pooler: &impl BufferPooler) -> VarConfig {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_workers: None,
             merkle_config: crate::mmr::full::Config {
                 journal_partition: format!("journal-{seed}"),
                 metadata_partition: format!("metadata-{seed}"),
@@ -184,6 +183,7 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -120,7 +120,7 @@ pub mod partitioned {
         /// discarded and the state of the db will be as of the last committed operation.
         pub async fn init(
             context: E,
-            cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg, S>,
+            cfg: VariableConfig<T, <Operation<F, K, V> as Read>::Cfg, S, core::num::NonZeroUsize>,
         ) -> Result<Self, Error<F>> {
             crate::qmdb::any::init(context, cfg).await
         }
@@ -183,7 +183,8 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency: (),
         }
     }
 

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -19,6 +19,7 @@ use crate::{
 use commonware_codec::{Codec, Read};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 
 pub type Update<K, V> = unordered::Update<K, VariableEncoding<V>>;
 pub type Operation<F, K, V> = unordered::Operation<F, K, VariableEncoding<V>>;
@@ -36,8 +37,15 @@ pub type Db<F, E, K, V, H, T, S> = super::Db<
     S,
 >;
 
-impl<F: Family, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator, S: Strategy>
-    Db<F, E, K, V, H, T, S>
+impl<
+    F: Family,
+    E: Context + Spawner,
+    K: Key,
+    V: VariableValue,
+    H: Hasher,
+    T: Translator,
+    S: Strategy,
+> Db<F, E, K, V, H, T, S>
 where
     Operation<F, K, V>: Codec,
 {
@@ -73,6 +81,7 @@ pub mod partitioned {
     use commonware_codec::{Codec, Read};
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
+    use commonware_runtime::Spawner;
 
     /// A key-value QMDB with a partitioned snapshot index and variable-size values.
     ///
@@ -96,7 +105,7 @@ pub mod partitioned {
 
     impl<
         F: Family,
-        E: Context,
+        E: Context + Spawner,
         K: Key,
         V: VariableValue,
         H: Hasher,
@@ -133,7 +142,7 @@ pub mod partitioned {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use crate::{index::Unordered as _, mmr, translator::TwoCap};
+    use crate::{index::Unordered as _, mmr, qmdb::InitParallelism, translator::TwoCap};
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
@@ -156,6 +165,7 @@ pub(crate) mod test {
     pub(crate) fn create_test_config(seed: u64, pooler: &impl BufferPooler) -> VarConfig {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: crate::mmr::full::Config {
                 journal_partition: format!("journal-{seed}"),
                 metadata_partition: format!("metadata-{seed}"),

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -142,7 +142,7 @@ pub mod partitioned {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use crate::{index::Unordered as _, mmr, qmdb::InitParallelism, translator::TwoCap};
+    use crate::{index::Unordered as _, mmr, translator::TwoCap};
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
@@ -165,7 +165,7 @@ pub(crate) mod test {
     pub(crate) fn create_test_config(seed: u64, pooler: &impl BufferPooler) -> VarConfig {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: crate::mmr::full::Config {
                 journal_partition: format!("journal-{seed}"),
                 metadata_partition: format!("metadata-{seed}"),

--- a/storage/src/qmdb/benches/apply_batch.rs
+++ b/storage/src/qmdb/benches/apply_batch.rs
@@ -1,8 +1,8 @@
 //! Benchmarks for applying already-merkleized QMDB batches.
 
 use crate::common::{
-    AnyOFixP256Db, AnyUFixDb, CHUNK_SIZE, Digest, ImmFixDb, PAGE_CACHE_SIZE, any_fix_cfg_with,
-    imm_fix_cfg_with, make_fixed_value, seed_db,
+    AnyOFixP256Db, AnyUFixDb, CHUNK_SIZE, Digest, ImmFixDb, PAGE_CACHE_SIZE, any_fix_cfg_full,
+    any_fix_cfg_with, imm_fix_cfg_with, make_fixed_value, seed_db,
 };
 use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_macros::boxed;
@@ -15,7 +15,7 @@ use commonware_storage::{
     merkle::mmb::Family as Mmb,
     qmdb::any::traits::{BatchableDb, UnmerkleizedBatch},
 };
-use commonware_utils::{NZU64, TestRng};
+use commonware_utils::{NZU64, NZUsize, TestRng};
 use criterion::{Criterion, criterion_group};
 use rand::Rng;
 use std::{
@@ -78,7 +78,7 @@ async fn bench_direct_apply(ctx: &Context, updates: u64) -> Duration {
 async fn open_ord_db(ctx: &Context) -> ODb {
     ODb::init(
         ctx.child("storage"),
-        any_fix_cfg_with(ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE),
+        any_fix_cfg_full(ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE, NZUsize!(1)),
     )
     .await
     .unwrap()

--- a/storage/src/qmdb/benches/chained_growth.rs
+++ b/storage/src/qmdb/benches/chained_growth.rs
@@ -81,12 +81,12 @@ fn cur_fix_cfg(
 ) -> commonware_storage::qmdb::current::FixedConfig<EightCap, Rayon> {
     let pc = pc(ctx);
     commonware_storage::qmdb::current::FixedConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/src/qmdb/benches/chained_growth.rs
+++ b/storage/src/qmdb/benches/chained_growth.rs
@@ -86,7 +86,8 @@ fn cur_fix_cfg(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/storage/src/qmdb/benches/chained_growth.rs
+++ b/storage/src/qmdb/benches/chained_growth.rs
@@ -19,6 +19,7 @@ use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{self, full, mmb::Family as Mmb},
     qmdb::{
+        InitParallelism,
         any::traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
         current::{ordered::fixed::Db as OCFixed, unordered::fixed::Db as UCFixed},
     },
@@ -81,6 +82,7 @@ fn cur_fix_cfg(
 ) -> commonware_storage::qmdb::current::FixedConfig<EightCap, Rayon> {
     let pc = pc(ctx);
     commonware_storage::qmdb::current::FixedConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),

--- a/storage/src/qmdb/benches/chained_growth.rs
+++ b/storage/src/qmdb/benches/chained_growth.rs
@@ -19,7 +19,6 @@ use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{self, full, mmb::Family as Mmb},
     qmdb::{
-        InitParallelism,
         any::traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
         current::{ordered::fixed::Db as OCFixed, unordered::fixed::Db as UCFixed},
     },
@@ -82,7 +81,7 @@ fn cur_fix_cfg(
 ) -> commonware_storage::qmdb::current::FixedConfig<EightCap, Rayon> {
     let pc = pc(ctx);
     commonware_storage::qmdb::current::FixedConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -18,7 +18,10 @@ use commonware_storage::{
                 variable::Db as OVariable,
             },
             traits::{DbAny, UnmerkleizedBatch},
-            unordered::{fixed::Db as UFixed, variable::Db as UVariable},
+            unordered::{
+                fixed::{Db as UFixed, partitioned::Db as UFixPart},
+                variable::Db as UVariable,
+            },
         },
         current::{
             FixedConfig as CurrentFixedConfig, VariableConfig as CurrentVariableConfig,
@@ -61,6 +64,10 @@ pub type AnyOFixP256Db<F> = OFixP256<F, Context, Digest, Digest, Sha256, EightCa
 /// for very large key sets (P=2 spills past ~33M entries), used by the `init_scale` bench.
 #[allow(dead_code)]
 pub type AnyOFixP3Db<F> = OFixPart<F, Context, Digest, Digest, Sha256, EightCap, 3, Rayon>;
+/// Unordered "any" DB with a partitioned snapshot index (65,536 partitions, P=2), used by the
+/// `init_scale` bench to exercise the unordered index's parallel snapshot build.
+#[allow(dead_code)]
+pub type AnyUFixP64kDb<F> = UFixPart<F, Context, Digest, Digest, Sha256, EightCap, 2, Rayon>;
 pub type CurUFixDb<F> = UCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE, Rayon>;
 pub type CurOFixDb<F> = OCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE, Rayon>;
 
@@ -154,13 +161,24 @@ pub fn any_fix_cfg_with(
     items_per_blob: NonZeroU64,
     page_cache_size: NonZeroUsize,
 ) -> AnyFixedConfig<EightCap, Rayon> {
+    any_fix_cfg_full(ctx, items_per_blob, page_cache_size, ())
+}
+
+/// Shared fixed-value config construction, generic over the index's snapshot-build concurrency.
+pub fn any_fix_cfg_full<B>(
+    ctx: &(impl BufferPooler + Strategizer),
+    items_per_blob: NonZeroU64,
+    page_cache_size: NonZeroUsize,
+    init_concurrency: B,
+) -> AnyFixedConfig<EightCap, Rayon, B> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, page_cache_size);
     AnyFixedConfig {
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency,
     }
 }
 
@@ -174,6 +192,7 @@ pub fn imm_fix_cfg_with(
         log: fix_log_cfg(PARTITION_IMM, page_cache, items_per_blob),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        init_buffer: NZUsize!(1 << 21),
     }
 }
 
@@ -192,7 +211,8 @@ pub fn cur_fix_cfg_with(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_FIX}"),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -212,7 +232,8 @@ pub fn any_var_digest_cfg_with(
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -233,7 +254,8 @@ pub fn cur_var_digest_cfg_with(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -261,7 +283,8 @@ pub fn any_var_vec_cfg_with(
         ),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -287,7 +310,8 @@ pub fn cur_var_vec_cfg_with(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -8,7 +8,6 @@ use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{self, Family, full::Config as MerkleConfig},
     qmdb::{
-        InitParallelism,
         any::{
             FixedConfig as AnyFixedConfig, VariableConfig as AnyVariableConfig,
             ordered::{
@@ -59,10 +58,9 @@ pub type AnyOFixDb<F> = OFixed<F, Context, Digest, Digest, Sha256, EightCap, Ray
 /// partitioned ordered index's cursor (get_mut/find/update) on apply.
 pub type AnyOFixP256Db<F> = OFixP256<F, Context, Digest, Digest, Sha256, EightCap, Rayon>;
 /// Ordered "any" DB with a partitioned snapshot index (~16.8M partitions, P=3). The inline-SoA config
-/// for very large key sets (P=2 spills past ~33M entries), used by the `init_scale` bench. Generic
-/// over the strategy so `init_scale` can pin the snapshot build's worker count with a manual hint.
+/// for very large key sets (P=2 spills past ~33M entries), used by the `init_scale` bench.
 #[allow(dead_code)]
-pub type AnyOFixP3Db<F, S = Rayon> = OFixPart<F, Context, Digest, Digest, Sha256, EightCap, 3, S>;
+pub type AnyOFixP3Db<F> = OFixPart<F, Context, Digest, Digest, Sha256, EightCap, 3, Rayon>;
 pub type CurUFixDb<F> = UCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE, Rayon>;
 pub type CurOFixDb<F> = OCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE, Rayon>;
 
@@ -158,7 +156,7 @@ pub fn any_fix_cfg_with(
 ) -> AnyFixedConfig<EightCap, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, page_cache_size);
     AnyFixedConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         translator: EightCap,
@@ -189,7 +187,7 @@ pub fn cur_fix_cfg_with(
 ) -> CurrentFixedConfig<EightCap, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentFixedConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_FIX}"),
@@ -210,7 +208,7 @@ pub fn any_var_digest_cfg_with(
 ) -> AnyVariableConfig<EightCap, ((), ()), Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         translator: EightCap,
@@ -230,7 +228,7 @@ pub fn cur_var_digest_cfg_with(
 ) -> CurrentVariableConfig<EightCap, ((), ()), Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
@@ -254,7 +252,7 @@ pub fn any_var_vec_cfg_with(
 ) -> AnyVariableConfig<EightCap, VarVecCfg, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(
             PARTITION_VAR,
@@ -279,7 +277,7 @@ pub fn cur_var_vec_cfg_with(
 ) -> CurrentVariableConfig<EightCap, VarVecCfg, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(
             PARTITION_VAR,

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -8,10 +8,14 @@ use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{self, Family, full::Config as MerkleConfig},
     qmdb::{
+        InitParallelism,
         any::{
             FixedConfig as AnyFixedConfig, VariableConfig as AnyVariableConfig,
             ordered::{
-                fixed::{Db as OFixed, partitioned::p256::Db as OFixP256},
+                fixed::{
+                    Db as OFixed,
+                    partitioned::{Db as OFixPart, p256::Db as OFixP256},
+                },
                 variable::Db as OVariable,
             },
             traits::{DbAny, UnmerkleizedBatch},
@@ -54,6 +58,11 @@ pub type AnyOFixDb<F> = OFixed<F, Context, Digest, Digest, Sha256, EightCap, Ray
 /// Ordered "any" DB with a partitioned snapshot index (256 partitions, P=1). Exercises the
 /// partitioned ordered index's cursor (get_mut/find/update) on apply.
 pub type AnyOFixP256Db<F> = OFixP256<F, Context, Digest, Digest, Sha256, EightCap, Rayon>;
+/// Ordered "any" DB with a partitioned snapshot index (~16.8M partitions, P=3). The inline-SoA config
+/// for very large key sets (P=2 spills past ~33M entries), used by the `init_scale` bench. Generic
+/// over the strategy so `init_scale` can pin the snapshot build's worker count with a manual hint.
+#[allow(dead_code)]
+pub type AnyOFixP3Db<F, S = Rayon> = OFixPart<F, Context, Digest, Digest, Sha256, EightCap, 3, S>;
 pub type CurUFixDb<F> = UCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE, Rayon>;
 pub type CurOFixDb<F> = OCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE, Rayon>;
 
@@ -149,6 +158,7 @@ pub fn any_fix_cfg_with(
 ) -> AnyFixedConfig<EightCap, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, page_cache_size);
     AnyFixedConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         translator: EightCap,
@@ -179,6 +189,7 @@ pub fn cur_fix_cfg_with(
 ) -> CurrentFixedConfig<EightCap, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentFixedConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_FIX}"),
@@ -199,6 +210,7 @@ pub fn any_var_digest_cfg_with(
 ) -> AnyVariableConfig<EightCap, ((), ()), Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         translator: EightCap,
@@ -218,6 +230,7 @@ pub fn cur_var_digest_cfg_with(
 ) -> CurrentVariableConfig<EightCap, ((), ()), Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
@@ -241,6 +254,7 @@ pub fn any_var_vec_cfg_with(
 ) -> AnyVariableConfig<EightCap, VarVecCfg, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(
             PARTITION_VAR,
@@ -265,6 +279,7 @@ pub fn cur_var_vec_cfg_with(
 ) -> CurrentVariableConfig<EightCap, VarVecCfg, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(
             PARTITION_VAR,

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -156,11 +156,11 @@ pub fn any_fix_cfg_with(
 ) -> AnyFixedConfig<EightCap, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, page_cache_size);
     AnyFixedConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -187,12 +187,12 @@ pub fn cur_fix_cfg_with(
 ) -> CurrentFixedConfig<EightCap, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentFixedConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_FIX}"),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -208,11 +208,11 @@ pub fn any_var_digest_cfg_with(
 ) -> AnyVariableConfig<EightCap, ((), ()), Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -228,12 +228,12 @@ pub fn cur_var_digest_cfg_with(
 ) -> CurrentVariableConfig<EightCap, ((), ()), Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -252,7 +252,6 @@ pub fn any_var_vec_cfg_with(
 ) -> AnyVariableConfig<EightCap, VarVecCfg, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(
             PARTITION_VAR,
@@ -262,6 +261,7 @@ pub fn any_var_vec_cfg_with(
         ),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -277,7 +277,6 @@ pub fn cur_var_vec_cfg_with(
 ) -> CurrentVariableConfig<EightCap, VarVecCfg, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(
             PARTITION_VAR,
@@ -288,6 +287,7 @@ pub fn cur_var_vec_cfg_with(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -358,12 +358,12 @@ fn main() {
         match db_kind.as_str() {
             "current::unordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
-                    init_workers: None,
                     merkle_config,
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    init_concurrency: NZUsize!(1),
                 };
                 let db = CurrentDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(
@@ -375,12 +375,12 @@ fn main() {
             }
             "current::ordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
-                    init_workers: None,
                     merkle_config,
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    init_concurrency: NZUsize!(1),
                 };
                 let db = CurrentOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(
@@ -392,18 +392,17 @@ fn main() {
             }
             "any::ordered::fixed::mmb" => {
                 let cfg = FixedConfig {
-                    init_workers: None,
                     merkle_config,
                     journal_config,
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    init_concurrency: NZUsize!(1),
                 };
                 let db = AnyOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::ordered::fixed::mmb", AnyOrderedMerkleized)
             }
             "any::unordered::variable::mmb" => {
                 let cfg = commonware_storage::qmdb::any::VariableConfig {
-                    init_workers: None,
                     merkle_config,
                     journal_config: VConfig {
                         partition: "constantinople-var-log".into(),
@@ -415,17 +414,18 @@ fn main() {
                     },
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    init_concurrency: NZUsize!(1),
                 };
                 let db = AnyVarDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::unordered::variable::mmb", AnyVarMerkleized)
             }
             _ => {
                 let cfg = FixedConfig {
-                    init_workers: None,
                     merkle_config,
                     journal_config,
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    init_concurrency: NZUsize!(1),
                 };
                 let db = AnyDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::unordered::fixed::mmb", AnyMerkleized)

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -34,7 +34,7 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{full, mmb},
-    qmdb::{InitParallelism, any::FixedConfig, current::FixedConfig as CurrentFixedConfig},
+    qmdb::{any::FixedConfig, current::FixedConfig as CurrentFixedConfig},
     translator::EightCap,
 };
 use commonware_utils::{NZU16, NZU64, NZUsize, TestRng};
@@ -358,7 +358,7 @@ fn main() {
         match db_kind.as_str() {
             "current::unordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
-                    init_parallelism: InitParallelism::Serial,
+                    init_workers: None,
                     merkle_config,
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
@@ -375,7 +375,7 @@ fn main() {
             }
             "current::ordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
-                    init_parallelism: InitParallelism::Serial,
+                    init_workers: None,
                     merkle_config,
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
@@ -392,7 +392,7 @@ fn main() {
             }
             "any::ordered::fixed::mmb" => {
                 let cfg = FixedConfig {
-                    init_parallelism: InitParallelism::Serial,
+                    init_workers: None,
                     merkle_config,
                     journal_config,
                     translator: EightCap,
@@ -403,7 +403,7 @@ fn main() {
             }
             "any::unordered::variable::mmb" => {
                 let cfg = commonware_storage::qmdb::any::VariableConfig {
-                    init_parallelism: InitParallelism::Serial,
+                    init_workers: None,
                     merkle_config,
                     journal_config: VConfig {
                         partition: "constantinople-var-log".into(),
@@ -421,7 +421,7 @@ fn main() {
             }
             _ => {
                 let cfg = FixedConfig {
-                    init_parallelism: InitParallelism::Serial,
+                    init_workers: None,
                     merkle_config,
                     journal_config,
                     translator: EightCap,

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -363,7 +363,8 @@ fn main() {
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
-                    init_concurrency: NZUsize!(1),
+                    init_buffer: NZUsize!(1 << 21),
+                    init_concurrency: (),
                 };
                 let db = CurrentDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(
@@ -380,7 +381,8 @@ fn main() {
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
-                    init_concurrency: NZUsize!(1),
+                    init_buffer: NZUsize!(1 << 21),
+                    init_concurrency: (),
                 };
                 let db = CurrentOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(
@@ -396,7 +398,8 @@ fn main() {
                     journal_config,
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
-                    init_concurrency: NZUsize!(1),
+                    init_buffer: NZUsize!(1 << 21),
+                    init_concurrency: (),
                 };
                 let db = AnyOrderedDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::ordered::fixed::mmb", AnyOrderedMerkleized)
@@ -414,7 +417,8 @@ fn main() {
                     },
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
-                    init_concurrency: NZUsize!(1),
+                    init_buffer: NZUsize!(1 << 21),
+                    init_concurrency: (),
                 };
                 let db = AnyVarDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::unordered::variable::mmb", AnyVarMerkleized)
@@ -425,7 +429,8 @@ fn main() {
                     journal_config,
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
-                    init_concurrency: NZUsize!(1),
+                    init_buffer: NZUsize!(1 << 21),
+                    init_concurrency: (),
                 };
                 let db = AnyDb::init(ctx.child("db"), cfg).await.unwrap();
                 run_pipeline!(db, args, "any::unordered::fixed::mmb", AnyMerkleized)

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -34,7 +34,7 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{full, mmb},
-    qmdb::{any::FixedConfig, current::FixedConfig as CurrentFixedConfig},
+    qmdb::{InitParallelism, any::FixedConfig, current::FixedConfig as CurrentFixedConfig},
     translator::EightCap,
 };
 use commonware_utils::{NZU16, NZU64, NZUsize, TestRng};
@@ -358,6 +358,7 @@ fn main() {
         match db_kind.as_str() {
             "current::unordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
+                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
@@ -374,6 +375,7 @@ fn main() {
             }
             "current::ordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
+                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
@@ -390,6 +392,7 @@ fn main() {
             }
             "any::ordered::fixed::mmb" => {
                 let cfg = FixedConfig {
+                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config,
                     translator: EightCap,
@@ -400,6 +403,7 @@ fn main() {
             }
             "any::unordered::variable::mmb" => {
                 let cfg = commonware_storage::qmdb::any::VariableConfig {
+                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config: VConfig {
                         partition: "constantinople-var-log".into(),
@@ -417,6 +421,7 @@ fn main() {
             }
             _ => {
                 let cfg = FixedConfig {
+                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config,
                     translator: EightCap,

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -26,8 +26,8 @@
 //! reporting the total build time.
 //!
 //! `bench` reopens it (read-only) and times one `init` at the given init cache size (`cache` entries,
-//! `0` = off) and `parallelism` (`0` = serial, `N` = N worker tasks, `auto` = derived from the
-//! strategy hint). It reports the replay-region size `R` (so a full-coverage cache is `cache = R`)
+//! `0` = off) and `parallelism` (`0` = serial, `N` = N worker tasks). It reports the
+//! replay-region size `R` (so a full-coverage cache is `cache = R`)
 //! and the elapsed time, and uses the P=3 partitioned ordered index (the inline-SoA config for large
 //! key sets) so the parallel `build_snapshot` override is exercised. Sweep cache/parallelism by
 //! driving the command from a shell loop.
@@ -45,10 +45,7 @@ use commonware_runtime::{
     Runner as _, Supervisor as _,
     tokio::{Config, Runner},
 };
-use commonware_storage::{
-    merkle::mmr::Family as Mmr,
-    qmdb::{InitParallelism, any::traits::DbAny as _},
-};
+use commonware_storage::{merkle::mmr::Family as Mmr, qmdb::any::traits::DbAny as _};
 use commonware_utils::{NZU64, NZUsize};
 use std::{
     num::{NonZeroU64, NonZeroUsize},
@@ -78,27 +75,15 @@ const PRUNE_FREQUENCY: u32 = 100;
 /// workloads. Higher = more skew; ~1.0 is classic Zipf (near YCSB's 0.99).
 const KEY_ZIPF_EXPONENT: f64 = 1.0;
 
-/// Map a worker count to an [InitParallelism]: `0` is the serial build, `n` spawns `n` worker tasks.
-const fn workers(n: usize) -> InitParallelism {
-    match n {
-        0 => InitParallelism::Serial,
-        n => InitParallelism::Workers(NonZeroUsize::new(n).unwrap()),
-    }
-}
-
-/// Parse a `parallelism` CLI argument: `auto` for [`InitParallelism::Auto`], otherwise a worker count
-/// (`0` = serial, `n` = `n` worker tasks).
-fn parse_parallelism(arg: &str) -> Option<InitParallelism> {
-    if arg == "auto" {
-        Some(InitParallelism::Auto)
-    } else {
-        arg.parse::<usize>().ok().map(workers)
-    }
+/// Parse a `parallelism` CLI argument into a snapshot-build worker count (`0` = serial, `n` = `n`
+/// worker tasks). The outer `Option` is parse success.
+fn parse_workers(arg: &str) -> Option<Option<NonZeroUsize>> {
+    arg.parse::<usize>().ok().map(NonZeroUsize::new)
 }
 
 fn usage() {
     eprintln!(
-        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <parallelism>   reopen + time one init (cache=entries, 0=off; parallelism=0 serial / N workers / auto)\n  destroy   <folder>                          delete the database"
+        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <parallelism>   reopen + time one init (cache=entries, 0=off; parallelism=0 serial / N workers)\n  destroy   <folder>                          delete the database"
     );
 }
 
@@ -129,9 +114,9 @@ fn main() {
         Some("bench") => match (
             argv.get(1),
             argv.get(2).and_then(|a| a.parse().ok()),
-            argv.get(3).and_then(|a| parse_parallelism(a)),
+            argv.get(3).and_then(|a| parse_workers(a)),
         ) {
-            (Some(folder), Some(cache), Some(parallelism)) => bench(folder, cache, parallelism),
+            (Some(folder), Some(cache), Some(workers)) => bench(folder, cache, workers),
             _ => usage(),
         },
         Some("destroy") => match argv.get(1) {
@@ -189,9 +174,9 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
 }
 
 /// Reopen the database at `folder` (read-only) and time one `init` of the P=3 partitioned ordered
-/// index at the given init cache size (`cache` entries; `0` = off) and `parallelism`. Reports the
+/// index at the given init cache size (`cache` entries; `0` = off) and worker count. Reports the
 /// replay-region size `R` (a full-coverage cache is `cache = R`) and the elapsed time.
-fn bench(folder: &str, cache: usize, parallelism: InitParallelism) {
+fn bench(folder: &str, cache: usize, workers: Option<NonZeroUsize>) {
     if !db_dir_nonempty(folder) {
         eprintln!(
             "no database at {folder}; run `generate {folder} <keyspace> <num_updates>` first"
@@ -199,7 +184,7 @@ fn bench(folder: &str, cache: usize, parallelism: InitParallelism) {
         return;
     }
     let cfg = Config::default().with_storage_directory(folder);
-    let (elapsed, region) = time_init(&cfg, NonZeroUsize::new(cache), parallelism);
+    let (elapsed, region) = time_init(&cfg, NonZeroUsize::new(cache), workers);
     if region == 0 {
         eprintln!(
             "database at {folder} is empty; run `generate {folder} <keyspace> <num_updates>` first"
@@ -207,7 +192,7 @@ fn bench(folder: &str, cache: usize, parallelism: InitParallelism) {
         return;
     }
     println!(
-        "init_scale (any::ordered::fixed::p3::mmr) {folder} cache={cache} parallelism={parallelism:?} region={region} time={elapsed:?}"
+        "init_scale (any::ordered::fixed::p3::mmr) {folder} cache={cache} workers={workers:?} region={region} time={elapsed:?}"
     );
 }
 
@@ -220,17 +205,17 @@ fn destroy(folder: &str) {
 }
 
 /// Time a single `init` of the database at `cfg`'s folder with the given cache size and
-/// `parallelism`, returning the elapsed time and the replay-region size (`0` if the database is
+/// worker count, returning the elapsed time and the replay-region size (`0` if the database is
 /// empty/absent).
 fn time_init(
     cfg: &Config,
     cache_size: Option<NonZeroUsize>,
-    parallelism: InitParallelism,
+    workers: Option<NonZeroUsize>,
 ) -> (Duration, u64) {
     Runner::new(cfg.clone()).start(|ctx| async move {
         let mut config = any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE);
         config.init_cache_size = cache_size;
-        config.init_parallelism = parallelism;
+        config.init_workers = workers;
         let start = Instant::now();
         let db = AnyOFixP3Db::<Mmr>::init(ctx.child("storage"), config)
             .await

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -13,8 +13,8 @@
 //! elapsed build time. A folder names the database's on-disk location:
 //!
 //! ```text
-//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db <keyspace> <num_updates> [zipf_exponent]
-//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db <cache> <concurrency>
+//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db <keyspace> <num_updates> [zipf_exponent] [ordered|unordered]
+//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db <cache> <concurrency> [ordered|unordered]
 //! cargo bench -p commonware-storage --bench init_scale --features test-traits -- destroy  /tmp/db
 //! ```
 //!
@@ -29,9 +29,13 @@
 //! `0` = off) and `concurrency` (`1` = serial, `N` = N total build tasks, so N-1 workers alongside
 //! the init task). It reports the
 //! replay-region size `R` (so a full-coverage cache is `cache = R`)
-//! and the elapsed time, and uses the P=3 partitioned ordered index (the inline-SoA config for large
-//! key sets) so the parallel `build_snapshot` override is exercised. Sweep cache/concurrency by
-//! driving the command from a shell loop.
+//! and the elapsed time. Sweep cache/concurrency by driving the command from a shell loop.
+//!
+//! The optional index flavor (default `ordered`) selects the snapshot index whose parallel
+//! `build_snapshot` override is exercised: `ordered` is the P=3 partitioned ordered index (the
+//! inline-SoA config for large key sets), `unordered` the P=2 (65,536 partition) hash index.
+//! Bench a database with the flavor it was generated with, since the two db variants write
+//! different operation logs.
 //!
 //! Each invocation does exactly one reopen, so numbers are warm only if the OS file cache is already
 //! warm. For the realistic cold-cache case (init at process start), have the driver drop the OS cache
@@ -41,12 +45,14 @@
 #[path = "common.rs"]
 mod common;
 
-use common::{AnyOFixP3Db, any_fix_cfg_with, gen_random_kv, make_fixed_value};
+use common::{
+    AnyOFixP3Db, AnyUFixP64kDb, Digest, any_fix_cfg_full, gen_random_kv, make_fixed_value,
+};
 use commonware_runtime::{
     Runner as _, Supervisor as _,
     tokio::{Config, Runner},
 };
-use commonware_storage::{merkle::mmr::Family as Mmr, qmdb::any::traits::DbAny as _};
+use commonware_storage::{merkle::mmr::Family as Mmr, qmdb::any::traits::DbAny};
 use commonware_utils::{NZU64, NZUsize};
 use std::{
     num::{NonZeroU64, NonZeroUsize},
@@ -76,6 +82,34 @@ const PRUNE_FREQUENCY: u32 = 100;
 /// workloads. Higher = more skew; ~1.0 is classic Zipf (near YCSB's 0.99).
 const KEY_ZIPF_EXPONENT: f64 = 1.0;
 
+/// The snapshot index flavor a database is generated and benched with (see the module docs).
+#[derive(Clone, Copy)]
+enum IndexKind {
+    /// The P=3 partitioned ordered index.
+    Ordered,
+    /// The P=2 (65,536 partition) unordered hash index.
+    Unordered,
+}
+
+impl IndexKind {
+    /// Parse an index-flavor CLI argument. `None` is a parse failure.
+    fn parse(arg: &str) -> Option<Self> {
+        match arg {
+            "ordered" => Some(Self::Ordered),
+            "unordered" => Some(Self::Unordered),
+            _ => None,
+        }
+    }
+
+    /// The flavor's report label (the db type alias it selects).
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Ordered => "any::ordered::fixed::p3::mmr",
+            Self::Unordered => "any::unordered::fixed::p64k::mmr",
+        }
+    }
+}
+
 /// Parse a `concurrency` CLI argument into a snapshot-build concurrency (`1` = serial on the
 /// init task, `n` = `n - 1` worker tasks in addition to it). `None` is a parse failure.
 fn parse_concurrency(arg: &str) -> Option<NonZeroUsize> {
@@ -84,7 +118,7 @@ fn parse_concurrency(arg: &str) -> Option<NonZeroUsize> {
 
 fn usage() {
     eprintln!(
-        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <concurrency>   reopen + time one init (cache=entries, 0=off; concurrency=1 serial / N total build tasks)\n  destroy   <folder>                          delete the database"
+        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent] [ordered|unordered]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <concurrency> [ordered|unordered]   reopen + time one init (cache=entries, 0=off; concurrency=1 serial / N total build tasks)\n  destroy   <folder>                          delete the database"
     );
 }
 
@@ -97,18 +131,22 @@ fn main() {
             argv.get(3).and_then(|a| a.parse().ok()),
         ) {
             (Some(folder), Some(keyspace), Some(num_updates)) => {
-                // Optional zipf exponent (5th arg): omitted => default skew (KEY_ZIPF_EXPONENT);
-                // `0` => uniform sampling (`None`).
-                let zipf_exponent = match argv.get(4).map(|a| a.parse::<f64>()) {
-                    None => Some(KEY_ZIPF_EXPONENT),
-                    Some(Ok(e)) if e > 0.0 => Some(e),
-                    Some(Ok(_)) => None,
-                    Some(Err(_)) => {
+                // Optional trailing args, in either order: an index flavor (default ordered) and
+                // a zipf exponent -- omitted => default skew (KEY_ZIPF_EXPONENT); `0` => uniform
+                // sampling (`None`).
+                let mut zipf_exponent = Some(KEY_ZIPF_EXPONENT);
+                let mut index = IndexKind::Ordered;
+                for arg in &argv[4..] {
+                    if let Some(kind) = IndexKind::parse(arg) {
+                        index = kind;
+                    } else if let Ok(e) = arg.parse::<f64>() {
+                        zipf_exponent = (e > 0.0).then_some(e);
+                    } else {
                         usage();
                         return;
                     }
-                };
-                generate(folder, keyspace, num_updates, zipf_exponent)
+                }
+                generate(folder, keyspace, num_updates, zipf_exponent, index)
             }
             _ => usage(),
         },
@@ -116,8 +154,12 @@ fn main() {
             argv.get(1),
             argv.get(2).and_then(|a| a.parse().ok()),
             argv.get(3).and_then(|a| parse_concurrency(a)),
+            argv.get(4)
+                .map_or(Some(IndexKind::Ordered), |a| IndexKind::parse(a)),
         ) {
-            (Some(folder), Some(cache), Some(concurrency)) => bench(folder, cache, concurrency),
+            (Some(folder), Some(cache), Some(concurrency), Some(index)) => {
+                bench(folder, cache, concurrency, index)
+            }
             _ => usage(),
         },
         Some("destroy") => match argv.get(1) {
@@ -134,7 +176,13 @@ fn main() {
 ///
 /// `zipf_exponent` sets the key distribution: `None` is uniform, `Some(e)` is Zipf with exponent `e`.
 /// The populated set fills organically as updates sample the keyspace (no separate seed phase).
-fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option<f64>) {
+fn generate(
+    folder: &str,
+    keyspace: u64,
+    num_updates: u64,
+    zipf_exponent: Option<f64>,
+    index: IndexKind,
+) {
     if keyspace == 0 {
         eprintln!("keyspace must be > 0");
         return;
@@ -143,16 +191,16 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
         eprintln!("{folder} already contains data; `destroy` it first or pick a new folder");
         return;
     }
-    let cfg = Config::default().with_storage_directory(folder);
-    let elapsed = Runner::new(cfg).start(|ctx| async move {
-        // Generate with the same P=3 index the bench reopens with.
-        let db = AnyOFixP3Db::<Mmr>::init(
-            ctx.child("storage"),
-            any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE),
-        )
-        .await
-        .unwrap();
-        // Time the build itself (updates + prune + sync); opening the empty db above is cheap.
+
+    /// Time the build itself (updates + prune + sync). Opening the empty db is done by the
+    /// caller and is cheap.
+    #[commonware_macros::boxed]
+    async fn populate<M: DbAny<Mmr, Key = Digest, Value = Digest>>(
+        db: M,
+        keyspace: u64,
+        num_updates: u64,
+        zipf_exponent: Option<f64>,
+    ) -> Duration {
         let start = Instant::now();
         let db = gen_random_kv::<Mmr, _>(
             db,
@@ -170,14 +218,35 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
         let db = db.prune(boundary).await.unwrap();
         let _db = db.sync().await.unwrap();
         start.elapsed()
+    }
+
+    let cfg = Config::default().with_storage_directory(folder);
+    let elapsed = Runner::new(cfg).start(|ctx| async move {
+        // Generate with the same index flavor the bench reopens with (concurrency 1: generation
+        // opens an empty db, so there is nothing to build in parallel).
+        let config = any_fix_cfg_full(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE, NZUsize!(1));
+        match index {
+            IndexKind::Ordered => {
+                let db = AnyOFixP3Db::<Mmr>::init(ctx.child("storage"), config)
+                    .await
+                    .unwrap();
+                populate(db, keyspace, num_updates, zipf_exponent).await
+            }
+            IndexKind::Unordered => {
+                let db = AnyUFixP64kDb::<Mmr>::init(ctx.child("storage"), config)
+                    .await
+                    .unwrap();
+                populate(db, keyspace, num_updates, zipf_exponent).await
+            }
+        }
     });
     println!("generated {num_updates} updates over keyspace {keyspace} at {folder} in {elapsed:?}");
 }
 
-/// Reopen the database at `folder` (read-only) and time one `init` of the P=3 partitioned ordered
-/// index at the given init cache size (`cache` entries; `0` = off) and worker count. Reports the
+/// Reopen the database at `folder` (read-only) and time one `init` of the selected index flavor
+/// at the given init cache size (`cache` entries; `0` = off) and worker count. Reports the
 /// replay-region size `R` (a full-coverage cache is `cache = R`) and the elapsed time.
-fn bench(folder: &str, cache: usize, concurrency: NonZeroUsize) {
+fn bench(folder: &str, cache: usize, concurrency: NonZeroUsize, index: IndexKind) {
     if !db_dir_nonempty(folder) {
         eprintln!(
             "no database at {folder}; run `generate {folder} <keyspace> <num_updates>` first"
@@ -185,15 +254,16 @@ fn bench(folder: &str, cache: usize, concurrency: NonZeroUsize) {
         return;
     }
     let cfg = Config::default().with_storage_directory(folder);
-    let (elapsed, region) = time_init(&cfg, NonZeroUsize::new(cache), concurrency);
+    let (elapsed, region) = time_init(&cfg, NonZeroUsize::new(cache), concurrency, index);
     if region == 0 {
         eprintln!(
             "database at {folder} is empty; run `generate {folder} <keyspace> <num_updates>` first"
         );
         return;
     }
+    let label = index.label();
     println!(
-        "init_scale (any::ordered::fixed::p3::mmr) {folder} cache={cache} concurrency={concurrency} region={region} time={elapsed:?}"
+        "init_scale ({label}) {folder} cache={cache} concurrency={concurrency} region={region} time={elapsed:?}"
     );
 }
 
@@ -205,26 +275,44 @@ fn destroy(folder: &str) {
     }
 }
 
-/// Time a single `init` of the database at `cfg`'s folder with the given cache size and
-/// worker count, returning the elapsed time and the replay-region size (`0` if the database is
-/// empty/absent).
+/// Time a single `init` of the database at `cfg`'s folder with the given cache size, worker
+/// count, and index flavor, returning the elapsed time and the replay-region size (`0` if the
+/// database is empty/absent).
 fn time_init(
     cfg: &Config,
     cache_size: Option<NonZeroUsize>,
     concurrency: NonZeroUsize,
+    index: IndexKind,
 ) -> (Duration, u64) {
-    Runner::new(cfg.clone()).start(|ctx| async move {
-        let mut config = any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE);
-        config.init_cache_size = cache_size;
-        config.init_concurrency = concurrency;
-        let start = Instant::now();
-        let db = AnyOFixP3Db::<Mmr>::init(ctx.child("storage"), config)
-            .await
-            .unwrap();
+    /// The elapsed time since `start` and the db's replay-region size.
+    fn measure<M: DbAny<Mmr, Key = Digest, Value = Digest>>(
+        db: &M,
+        start: Instant,
+    ) -> (Duration, u64) {
         let elapsed = start.elapsed();
         let end: u64 = *db.bounds().end;
         let floor: u64 = *db.inactivity_floor_loc();
         (elapsed, end.saturating_sub(floor))
+    }
+
+    Runner::new(cfg.clone()).start(|ctx| async move {
+        let mut config = any_fix_cfg_full(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE, concurrency);
+        config.init_cache_size = cache_size;
+        let start = Instant::now();
+        match index {
+            IndexKind::Ordered => {
+                let db = AnyOFixP3Db::<Mmr>::init(ctx.child("storage"), config)
+                    .await
+                    .unwrap();
+                measure(&db, start)
+            }
+            IndexKind::Unordered => {
+                let db = AnyUFixP64kDb::<Mmr>::init(ctx.child("storage"), config)
+                    .await
+                    .unwrap();
+                measure(&db, start)
+            }
+        }
     })
 }
 

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -1,11 +1,11 @@
 //! Standalone, opt-in large-scale measurement of two QMDB operations at multi-GB scale: building a
-//! database (`generate`) and reopening it, i.e. rebuilding the snapshot (`bench`), with the
-//! init-time `(location -> key)` cache off vs on.
+//! database (`generate`) and reopening it, i.e. rebuilding the snapshot (`bench`), at a chosen
+//! init-time `(location -> key)` cache size and build parallelism.
 //!
 //! The criterion init benchmark ([init](super::init)) can't reach these sizes: it resamples, and the
 //! database is multi-GB. This binary instead builds a *real* on-disk database once and then times a
-//! *real* reopen ([`Db::init`], i.e. `build_snapshot_from_log`) at several cache sizes, so the
-//! cache's effect on the redundant collision-resolution log reads shows at scale.
+//! *real* reopen ([`Db::init`]) so the cache's effect on the redundant collision-resolution log reads,
+//! and the parallel build's speedup, show at scale.
 //!
 //! Generation and benchmarking are split so the (multi-minute, multi-GB) database is built once and
 //! reused across many reopen runs -- but generation is itself an interesting benchmark: building a
@@ -13,8 +13,8 @@
 //! elapsed build time. A folder names the database's on-disk location:
 //!
 //! ```text
-//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db 50000000 250000000
-//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db
+//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db <keyspace> <num_updates> [zipf_exponent]
+//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db <cache> <parallelism>
 //! cargo bench -p commonware-storage --bench init_scale --features test-traits -- destroy  /tmp/db
 //! ```
 //!
@@ -23,23 +23,34 @@
 //! phase, so the populated set fills organically as keys are sampled. The optional `zipf_exponent`
 //! arg selects the distribution -- omitted is the default Zipf (`KEY_ZIPF_EXPONENT`), `0` is uniform
 //! -- so a uniform and a skewed database differ only in that distribution. It then prunes and syncs,
-//! reporting the total build time. `bench` reopens it (read-only) at cache off / a quarter of the
-//! replay region / the whole replay region, reporting each init time plus the replay-region size `R`
-//! (what the cache must cover to avoid eviction).
+//! reporting the total build time.
+//!
+//! `bench` reopens it (read-only) and times one `init` at the given init cache size (`cache` entries,
+//! `0` = off) and `parallelism` (`0` = serial, `N` = N worker tasks, `auto` = derived from the
+//! strategy hint). It reports the replay-region size `R` (so a full-coverage cache is `cache = R`)
+//! and the elapsed time, and uses the P=3 partitioned ordered index (the inline-SoA config for large
+//! key sets) so the parallel `build_snapshot` override is exercised. Sweep cache/parallelism by
+//! driving the command from a shell loop.
+//!
+//! Each invocation does exactly one reopen, so numbers are warm only if the OS file cache is already
+//! warm. For the realistic cold-cache case (init at process start), have the driver drop the OS cache
+//! (`sudo purge` on macOS) between invocations.
 
 #[allow(dead_code, unused_imports, unused_macros)]
 #[path = "common.rs"]
 mod common;
 
-use common::{AnyOFixDb, any_fix_cfg_with, gen_random_kv, make_fixed_value};
+use common::{AnyOFixP3Db, any_fix_cfg_with, gen_random_kv, make_fixed_value};
 use commonware_runtime::{
     Runner as _, Supervisor as _,
     tokio::{Config, Runner},
 };
-use commonware_storage::{merkle::mmr::Family as Mmr, qmdb::any::traits::DbAny as _};
+use commonware_storage::{
+    merkle::mmr::Family as Mmr,
+    qmdb::{InitParallelism, any::traits::DbAny as _},
+};
 use commonware_utils::{NZU64, NZUsize};
 use std::{
-    io::Write as _,
     num::{NonZeroU64, NonZeroUsize},
     time::{Duration, Instant},
 };
@@ -67,9 +78,27 @@ const PRUNE_FREQUENCY: u32 = 100;
 /// workloads. Higher = more skew; ~1.0 is classic Zipf (near YCSB's 0.99).
 const KEY_ZIPF_EXPONENT: f64 = 1.0;
 
+/// Map a worker count to an [InitParallelism]: `0` is the serial build, `n` spawns `n` worker tasks.
+const fn workers(n: usize) -> InitParallelism {
+    match n {
+        0 => InitParallelism::Serial,
+        n => InitParallelism::Workers(NonZeroUsize::new(n).unwrap()),
+    }
+}
+
+/// Parse a `parallelism` CLI argument: `auto` for [`InitParallelism::Auto`], otherwise a worker count
+/// (`0` = serial, `n` = `n` worker tasks).
+fn parse_parallelism(arg: &str) -> Option<InitParallelism> {
+    if arg == "auto" {
+        Some(InitParallelism::Auto)
+    } else {
+        arg.parse::<usize>().ok().map(workers)
+    }
+}
+
 fn usage() {
     eprintln!(
-        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench    <folder>              reopen + time init at cache off / R/4 / R\n  destroy  <folder>              delete the database"
+        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <parallelism>   reopen + time one init (cache=entries, 0=off; parallelism=0 serial / N workers / auto)\n  destroy   <folder>                          delete the database"
     );
 }
 
@@ -97,9 +126,13 @@ fn main() {
             }
             _ => usage(),
         },
-        Some("bench") => match argv.get(1) {
-            Some(folder) => bench(folder),
-            None => usage(),
+        Some("bench") => match (
+            argv.get(1),
+            argv.get(2).and_then(|a| a.parse().ok()),
+            argv.get(3).and_then(|a| parse_parallelism(a)),
+        ) {
+            (Some(folder), Some(cache), Some(parallelism)) => bench(folder, cache, parallelism),
+            _ => usage(),
         },
         Some("destroy") => match argv.get(1) {
             Some(folder) => destroy(folder),
@@ -126,7 +159,8 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
     }
     let cfg = Config::default().with_storage_directory(folder);
     let elapsed = Runner::new(cfg).start(|ctx| async move {
-        let db = AnyOFixDb::<Mmr>::init(
+        // Generate with the same P=3 index the bench reopens with.
+        let db = AnyOFixP3Db::<Mmr>::init(
             ctx.child("storage"),
             any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE),
         )
@@ -154,9 +188,10 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
     println!("generated {num_updates} updates over keyspace {keyspace} at {folder} in {elapsed:?}");
 }
 
-/// Reopen the database at `folder` (read-only) and time `init` at three cache regimes: off, a
-/// quarter of the replay region (fills + evicts), and the whole replay region (no eviction).
-fn bench(folder: &str) {
+/// Reopen the database at `folder` (read-only) and time one `init` of the P=3 partitioned ordered
+/// index at the given init cache size (`cache` entries; `0` = off) and `parallelism`. Reports the
+/// replay-region size `R` (a full-coverage cache is `cache = R`) and the elapsed time.
+fn bench(folder: &str, cache: usize, parallelism: InitParallelism) {
     if !db_dir_nonempty(folder) {
         eprintln!(
             "no database at {folder}; run `generate {folder} <keyspace> <num_updates>` first"
@@ -164,29 +199,16 @@ fn bench(folder: &str) {
         return;
     }
     let cfg = Config::default().with_storage_directory(folder);
-
-    // No-cache baseline; also learn the replay region R (ops above the inactivity floor) -- what the
-    // location cache must cover to avoid eviction (a key-cache would need only the key count).
-    let (baseline, region) = time_init(&cfg, None);
+    let (elapsed, region) = time_init(&cfg, NonZeroUsize::new(cache), parallelism);
     if region == 0 {
         eprintln!(
             "database at {folder} is empty; run `generate {folder} <keyspace> <num_updates>` first"
         );
         return;
     }
-    println!("init_scale: {folder}  (any::ordered::fixed::mmr)");
-    println!("  replay region R = {region} ops");
-    println!("  cache=off          : {baseline:?}");
-    let _ = std::io::stdout().flush();
-
-    for cache_size in [
-        NonZeroUsize::new((region / 4) as usize),
-        NonZeroUsize::new(region as usize),
-    ] {
-        let (elapsed, _) = time_init(&cfg, cache_size);
-        println!("  cache={cache_size:?}: {elapsed:?}");
-        let _ = std::io::stdout().flush();
-    }
+    println!(
+        "init_scale (any::ordered::fixed::p3::mmr) {folder} cache={cache} parallelism={parallelism:?} region={region} time={elapsed:?}"
+    );
 }
 
 /// Delete the database at `folder`.
@@ -197,14 +219,20 @@ fn destroy(folder: &str) {
     }
 }
 
-/// Time a single `init` of the database at `cfg`'s folder with the given cache size, returning the
-/// elapsed time and the replay-region size (`0` if the database is empty/absent).
-fn time_init(cfg: &Config, cache_size: Option<NonZeroUsize>) -> (Duration, u64) {
+/// Time a single `init` of the database at `cfg`'s folder with the given cache size and
+/// `parallelism`, returning the elapsed time and the replay-region size (`0` if the database is
+/// empty/absent).
+fn time_init(
+    cfg: &Config,
+    cache_size: Option<NonZeroUsize>,
+    parallelism: InitParallelism,
+) -> (Duration, u64) {
     Runner::new(cfg.clone()).start(|ctx| async move {
         let mut config = any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE);
         config.init_cache_size = cache_size;
+        config.init_parallelism = parallelism;
         let start = Instant::now();
-        let db = AnyOFixDb::<Mmr>::init(ctx.child("storage"), config)
+        let db = AnyOFixP3Db::<Mmr>::init(ctx.child("storage"), config)
             .await
             .unwrap();
         let elapsed = start.elapsed();

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -75,15 +75,15 @@ const PRUNE_FREQUENCY: u32 = 100;
 /// workloads. Higher = more skew; ~1.0 is classic Zipf (near YCSB's 0.99).
 const KEY_ZIPF_EXPONENT: f64 = 1.0;
 
-/// Parse a `parallelism` CLI argument into a snapshot-build worker count (`0` = serial, `n` = `n`
-/// worker tasks). The outer `Option` is parse success.
-fn parse_workers(arg: &str) -> Option<Option<NonZeroUsize>> {
-    arg.parse::<usize>().ok().map(NonZeroUsize::new)
+/// Parse a `parallelism` CLI argument into a snapshot-build concurrency (`1` = serial on the
+/// init task, `n` = `n - 1` worker tasks in addition to it). `None` is a parse failure.
+fn parse_concurrency(arg: &str) -> Option<NonZeroUsize> {
+    arg.parse::<usize>().ok().and_then(NonZeroUsize::new)
 }
 
 fn usage() {
     eprintln!(
-        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <parallelism>   reopen + time one init (cache=entries, 0=off; parallelism=0 serial / N workers)\n  destroy   <folder>                          delete the database"
+        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <parallelism>   reopen + time one init (cache=entries, 0=off; parallelism=1 serial / N total build tasks)\n  destroy   <folder>                          delete the database"
     );
 }
 
@@ -114,9 +114,9 @@ fn main() {
         Some("bench") => match (
             argv.get(1),
             argv.get(2).and_then(|a| a.parse().ok()),
-            argv.get(3).and_then(|a| parse_workers(a)),
+            argv.get(3).and_then(|a| parse_concurrency(a)),
         ) {
-            (Some(folder), Some(cache), Some(workers)) => bench(folder, cache, workers),
+            (Some(folder), Some(cache), Some(concurrency)) => bench(folder, cache, concurrency),
             _ => usage(),
         },
         Some("destroy") => match argv.get(1) {
@@ -176,7 +176,7 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
 /// Reopen the database at `folder` (read-only) and time one `init` of the P=3 partitioned ordered
 /// index at the given init cache size (`cache` entries; `0` = off) and worker count. Reports the
 /// replay-region size `R` (a full-coverage cache is `cache = R`) and the elapsed time.
-fn bench(folder: &str, cache: usize, workers: Option<NonZeroUsize>) {
+fn bench(folder: &str, cache: usize, concurrency: NonZeroUsize) {
     if !db_dir_nonempty(folder) {
         eprintln!(
             "no database at {folder}; run `generate {folder} <keyspace> <num_updates>` first"
@@ -184,7 +184,7 @@ fn bench(folder: &str, cache: usize, workers: Option<NonZeroUsize>) {
         return;
     }
     let cfg = Config::default().with_storage_directory(folder);
-    let (elapsed, region) = time_init(&cfg, NonZeroUsize::new(cache), workers);
+    let (elapsed, region) = time_init(&cfg, NonZeroUsize::new(cache), concurrency);
     if region == 0 {
         eprintln!(
             "database at {folder} is empty; run `generate {folder} <keyspace> <num_updates>` first"
@@ -192,7 +192,7 @@ fn bench(folder: &str, cache: usize, workers: Option<NonZeroUsize>) {
         return;
     }
     println!(
-        "init_scale (any::ordered::fixed::p3::mmr) {folder} cache={cache} workers={workers:?} region={region} time={elapsed:?}"
+        "init_scale (any::ordered::fixed::p3::mmr) {folder} cache={cache} concurrency={concurrency} region={region} time={elapsed:?}"
     );
 }
 
@@ -210,12 +210,12 @@ fn destroy(folder: &str) {
 fn time_init(
     cfg: &Config,
     cache_size: Option<NonZeroUsize>,
-    workers: Option<NonZeroUsize>,
+    concurrency: NonZeroUsize,
 ) -> (Duration, u64) {
     Runner::new(cfg.clone()).start(|ctx| async move {
         let mut config = any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE);
         config.init_cache_size = cache_size;
-        config.init_workers = workers;
+        config.init_concurrency = concurrency;
         let start = Instant::now();
         let db = AnyOFixP3Db::<Mmr>::init(ctx.child("storage"), config)
             .await

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -1,6 +1,6 @@
 //! Standalone, opt-in large-scale measurement of two QMDB operations at multi-GB scale: building a
 //! database (`generate`) and reopening it, i.e. rebuilding the snapshot (`bench`), at a chosen
-//! init-time `(location -> key)` cache size and build parallelism.
+//! init-time `(location -> key)` cache size and build concurrency.
 //!
 //! The criterion init benchmark ([init](super::init)) can't reach these sizes: it resamples, and the
 //! database is multi-GB. This binary instead builds a *real* on-disk database once and then times a
@@ -14,7 +14,7 @@
 //!
 //! ```text
 //! cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db <keyspace> <num_updates> [zipf_exponent]
-//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db <cache> <parallelism>
+//! cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db <cache> <concurrency>
 //! cargo bench -p commonware-storage --bench init_scale --features test-traits -- destroy  /tmp/db
 //! ```
 //!
@@ -26,10 +26,11 @@
 //! reporting the total build time.
 //!
 //! `bench` reopens it (read-only) and times one `init` at the given init cache size (`cache` entries,
-//! `0` = off) and `parallelism` (`0` = serial, `N` = N worker tasks). It reports the
+//! `0` = off) and `concurrency` (`1` = serial, `N` = N total build tasks, so N-1 workers alongside
+//! the init task). It reports the
 //! replay-region size `R` (so a full-coverage cache is `cache = R`)
 //! and the elapsed time, and uses the P=3 partitioned ordered index (the inline-SoA config for large
-//! key sets) so the parallel `build_snapshot` override is exercised. Sweep cache/parallelism by
+//! key sets) so the parallel `build_snapshot` override is exercised. Sweep cache/concurrency by
 //! driving the command from a shell loop.
 //!
 //! Each invocation does exactly one reopen, so numbers are warm only if the OS file cache is already
@@ -75,7 +76,7 @@ const PRUNE_FREQUENCY: u32 = 100;
 /// workloads. Higher = more skew; ~1.0 is classic Zipf (near YCSB's 0.99).
 const KEY_ZIPF_EXPONENT: f64 = 1.0;
 
-/// Parse a `parallelism` CLI argument into a snapshot-build concurrency (`1` = serial on the
+/// Parse a `concurrency` CLI argument into a snapshot-build concurrency (`1` = serial on the
 /// init task, `n` = `n - 1` worker tasks in addition to it). `None` is a parse failure.
 fn parse_concurrency(arg: &str) -> Option<NonZeroUsize> {
     arg.parse::<usize>().ok().and_then(NonZeroUsize::new)
@@ -83,7 +84,7 @@ fn parse_concurrency(arg: &str) -> Option<NonZeroUsize> {
 
 fn usage() {
     eprintln!(
-        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <parallelism>   reopen + time one init (cache=entries, 0=off; parallelism=1 serial / N total build tasks)\n  destroy   <folder>                          delete the database"
+        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <concurrency>   reopen + time one init (cache=entries, 0=off; concurrency=1 serial / N total build tasks)\n  destroy   <folder>                          delete the database"
     );
 }
 

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -329,7 +329,8 @@ pub(crate) fn any_fix_cfg_with_cache(
         journal_config: fix_log_cfg(pc),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -342,7 +343,8 @@ fn any_var_cfg_with_cache(
         journal_config: var_log_cfg(pc),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -356,7 +358,8 @@ pub(crate) fn cur_fix_cfg_with_cache(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -370,7 +373,8 @@ fn cur_var_cfg_with_cache(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -23,7 +23,10 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{self, full},
-    qmdb::any::traits::{DbAny, MerkleizedBatch, UnmerkleizedBatch as _},
+    qmdb::{
+        InitParallelism,
+        any::traits::{DbAny, MerkleizedBatch, UnmerkleizedBatch as _},
+    },
     translator::EightCap,
 };
 use commonware_utils::{NZU16, NZU64, NZUsize, TestRng};
@@ -325,6 +328,7 @@ pub(crate) fn any_fix_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::any::FixedConfig<EightCap, Rayon> {
     commonware_storage::qmdb::any::FixedConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         translator: EightCap,
@@ -337,6 +341,7 @@ fn any_var_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::any::VariableConfig<EightCap, ((), ()), Rayon> {
     commonware_storage::qmdb::any::VariableConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         translator: EightCap,
@@ -349,6 +354,7 @@ pub(crate) fn cur_fix_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::current::FixedConfig<EightCap, Rayon> {
     commonware_storage::qmdb::current::FixedConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
@@ -362,6 +368,7 @@ fn cur_var_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::current::VariableConfig<EightCap, ((), ()), Rayon> {
     commonware_storage::qmdb::current::VariableConfig {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -23,10 +23,7 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{self, full},
-    qmdb::{
-        InitParallelism,
-        any::traits::{DbAny, MerkleizedBatch, UnmerkleizedBatch as _},
-    },
+    qmdb::any::traits::{DbAny, MerkleizedBatch, UnmerkleizedBatch as _},
     translator::EightCap,
 };
 use commonware_utils::{NZU16, NZU64, NZUsize, TestRng};
@@ -328,7 +325,7 @@ pub(crate) fn any_fix_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::any::FixedConfig<EightCap, Rayon> {
     commonware_storage::qmdb::any::FixedConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         translator: EightCap,
@@ -341,7 +338,7 @@ fn any_var_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::any::VariableConfig<EightCap, ((), ()), Rayon> {
     commonware_storage::qmdb::any::VariableConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         translator: EightCap,
@@ -354,7 +351,7 @@ pub(crate) fn cur_fix_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::current::FixedConfig<EightCap, Rayon> {
     commonware_storage::qmdb::current::FixedConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
@@ -368,7 +365,7 @@ fn cur_var_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::current::VariableConfig<EightCap, ((), ()), Rayon> {
     commonware_storage::qmdb::current::VariableConfig {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -325,11 +325,11 @@ pub(crate) fn any_fix_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::any::FixedConfig<EightCap, Rayon> {
     commonware_storage::qmdb::any::FixedConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -338,11 +338,11 @@ fn any_var_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::any::VariableConfig<EightCap, ((), ()), Rayon> {
     commonware_storage::qmdb::any::VariableConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -351,12 +351,12 @@ pub(crate) fn cur_fix_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::current::FixedConfig<EightCap, Rayon> {
     commonware_storage::qmdb::current::FixedConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -365,12 +365,12 @@ fn cur_var_cfg_with_cache(
     pc: CacheRef,
 ) -> commonware_storage::qmdb::current::VariableConfig<EightCap, ((), ()), Rayon> {
     commonware_storage::qmdb::current::VariableConfig {
-        init_workers: None,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -11,6 +11,7 @@ use crate::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{Family, full::Config as MerkleConfig, mmb, mmr},
     qmdb::{
+        InitParallelism,
         any::{
             self,
             traits::{DbAny, UnmerkleizedBatch as _},
@@ -160,6 +161,7 @@ fn any_fixed_config(
 ) -> any::FixedConfig<OneCap, Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     any::Config {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
@@ -173,6 +175,7 @@ fn any_variable_config(
 ) -> any::VariableConfig<OneCap, ((), ()), Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     any::Config {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
@@ -186,6 +189,7 @@ fn current_fixed_config(
 ) -> current::FixedConfig<OneCap, Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     current::Config {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         grafted_metadata_partition: format!("{suffix}-graft"),
@@ -200,6 +204,7 @@ fn current_variable_config(
 ) -> current::VariableConfig<OneCap, ((), ()), Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     current::Config {
+        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         grafted_metadata_partition: format!("{suffix}-graft"),

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -164,7 +164,8 @@ fn any_fixed_config(
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -178,7 +179,8 @@ fn any_variable_config(
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -193,7 +195,8 @@ fn current_fixed_config(
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -208,7 +211,8 @@ fn current_variable_config(
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
-        init_concurrency: NZUsize!(1),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
     }
 }
 
@@ -222,6 +226,7 @@ fn immutable_fixed_config(
         log: fixed_log_config(suffix, pc),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(1024)),
+        init_buffer: NZUsize!(1 << 21),
     }
 }
 
@@ -235,6 +240,7 @@ fn immutable_variable_config(
         log: variable_log_config(suffix, pc, ((), ())),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(1024)),
+        init_buffer: NZUsize!(1 << 21),
     }
 }
 

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -160,11 +160,11 @@ fn any_fixed_config(
 ) -> any::FixedConfig<OneCap, Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     any::Config {
-        init_workers: None,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -174,11 +174,11 @@ fn any_variable_config(
 ) -> any::VariableConfig<OneCap, ((), ()), Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     any::Config {
-        init_workers: None,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -188,12 +188,12 @@ fn current_fixed_config(
 ) -> current::FixedConfig<OneCap, Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     current::Config {
-        init_workers: None,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
+        init_concurrency: NZUsize!(1),
     }
 }
 
@@ -203,12 +203,12 @@ fn current_variable_config(
 ) -> current::VariableConfig<OneCap, ((), ()), Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     current::Config {
-        init_workers: None,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
+        init_concurrency: NZUsize!(1),
     }
 }
 

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -11,7 +11,6 @@ use crate::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{Family, full::Config as MerkleConfig, mmb, mmr},
     qmdb::{
-        InitParallelism,
         any::{
             self,
             traits::{DbAny, UnmerkleizedBatch as _},
@@ -161,7 +160,7 @@ fn any_fixed_config(
 ) -> any::FixedConfig<OneCap, Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     any::Config {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
@@ -175,7 +174,7 @@ fn any_variable_config(
 ) -> any::VariableConfig<OneCap, ((), ()), Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     any::Config {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
@@ -189,7 +188,7 @@ fn current_fixed_config(
 ) -> current::FixedConfig<OneCap, Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     current::Config {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         grafted_metadata_partition: format!("{suffix}-graft"),
@@ -204,7 +203,7 @@ fn current_variable_config(
 ) -> current::VariableConfig<OneCap, ((), ()), Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     current::Config {
-        init_parallelism: InitParallelism::Serial,
+        init_workers: None,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         grafted_metadata_partition: format!("{suffix}-graft"),

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -331,7 +331,7 @@ use crate::{
         authenticated,
         contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     },
-    merkle::{self, full::Config as MerkleConfig},
+    merkle::{self, Location, full::Config as MerkleConfig},
     qmdb::{
         any::{
             self, Config as AnyConfig,
@@ -381,12 +381,13 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
 
-    /// Number of worker tasks the init-time snapshot build may split across; `None` builds on the
-    /// init task. Only certain index types (such as the ordered-partitioned index) build in
-    /// parallel. Counts past a few waste tasks without speeding up the build, and each task is
-    /// spawned as blocking-friendly shared work, so on runtimes with a bounded blocking pool keep
-    /// counts well below that pool's size.
-    pub init_workers: Option<NonZeroUsize>,
+    /// Number of tasks that build the init-time snapshot, including the init task itself
+    /// (which replays and routes the log); `1` builds entirely on the init task. Only certain
+    /// index types (such as the ordered-partitioned index) build in parallel. Counts past a few
+    /// waste tasks without speeding up the build, and each additional task is spawned as
+    /// blocking-friendly shared work, so on runtimes with a bounded blocking pool keep counts
+    /// well below that pool's size.
+    pub init_concurrency: NonZeroUsize,
 }
 
 impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S> {
@@ -396,7 +397,7 @@ impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S>
             journal_config: cfg.journal_config,
             translator: cfg.translator,
             init_cache_size: cfg.init_cache_size,
-            init_workers: cfg.init_workers,
+            init_concurrency: cfg.init_concurrency,
         }
     }
 }
@@ -762,7 +763,6 @@ pub mod tests {
     ) -> FixedConfig<T, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
@@ -780,6 +780,7 @@ pub mod tests {
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 
@@ -790,7 +791,6 @@ pub mod tests {
     ) -> VariableConfig<T, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
@@ -810,6 +810,7 @@ pub mod tests {
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
+            init_concurrency: NZUsize!(1),
         }
     }
 
@@ -1602,7 +1603,6 @@ pub mod tests {
         executor.start(|context| async move {
             let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
             let cfg = VariableConfig {
-                init_workers: None,
                 merkle_config: MerkleConfig {
                     journal_partition: "forged-exclusion-journal".to_string(),
                     metadata_partition: "forged-exclusion-metadata".to_string(),
@@ -1622,6 +1622,7 @@ pub mod tests {
                 grafted_metadata_partition: "forged-exclusion-grafted".to_string(),
                 translator: OneCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                init_concurrency: NZUsize!(1),
             };
             let db = ForgedExclusionDb::init(context.child("db"), cfg)
                 .await

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -381,9 +381,12 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
 
-    /// How the snapshot build parallelizes during init. Note that only certain index types (such
-    /// as the ordered-partitioned index) support parallel construction.
-    pub init_parallelism: super::InitParallelism,
+    /// Number of worker tasks the init-time snapshot build may split across; `None` builds on the
+    /// init task. Only certain index types (such as the ordered-partitioned index) build in
+    /// parallel. Counts past a few waste tasks without speeding up the build, and each task is
+    /// spawned as blocking-friendly shared work, so on runtimes with a bounded blocking pool keep
+    /// counts well below that pool's size.
+    pub init_workers: Option<NonZeroUsize>,
 }
 
 impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S> {
@@ -393,7 +396,7 @@ impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S>
             journal_config: cfg.journal_config,
             translator: cfg.translator,
             init_cache_size: cfg.init_cache_size,
-            init_parallelism: cfg.init_parallelism,
+            init_workers: cfg.init_workers,
         }
     }
 }
@@ -518,7 +521,6 @@ pub mod tests {
     use crate::{
         merkle::{self, mmb, mmr},
         qmdb::{
-            InitParallelism,
             any::{
                 test::colliding_digest,
                 traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
@@ -528,7 +530,7 @@ pub mod tests {
         },
         translator::Translator,
     };
-    use commonware_parallel::{Sequential, Strategy};
+    use commonware_parallel::Sequential;
     use commonware_runtime::{
         BufferPooler, Runner as _, Supervisor as _,
         buffer::paged::CacheRef,
@@ -758,23 +760,15 @@ pub mod tests {
         partition_prefix: &str,
         pooler: &impl BufferPooler,
     ) -> FixedConfig<T, Sequential> {
-        fixed_config_with_strategy(partition_prefix, pooler, Sequential)
-    }
-
-    pub(crate) fn fixed_config_with_strategy<T: Translator + Default, S: Strategy>(
-        partition_prefix: &str,
-        pooler: &impl BufferPooler,
-        strategy: S,
-    ) -> FixedConfig<T, S> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
                 items_per_blob: NZU64!(11),
                 write_buffer: NZUsize!(1024),
-                strategy,
+                strategy: Sequential,
                 page_cache: page_cache.clone(),
             },
             journal_config: FConfig {
@@ -796,7 +790,7 @@ pub mod tests {
     ) -> VariableConfig<T, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
+            init_workers: None,
             merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
@@ -1608,7 +1602,7 @@ pub mod tests {
         executor.start(|context| async move {
             let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
             let cfg = VariableConfig {
-                init_parallelism: InitParallelism::Serial,
+                init_workers: None,
                 merkle_config: MerkleConfig {
                     journal_partition: "forged-exclusion-journal".to_string(),
                     metadata_partition: "forged-exclusion-metadata".to_string(),

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -383,10 +383,7 @@ pub struct Config<T: Translator, J, S: Strategy> {
 
     /// Number of tasks that build the init-time snapshot, including the init task itself
     /// (which replays and routes the log); `1` builds entirely on the init task. Only certain
-    /// index types (such as the ordered-partitioned index) build in parallel. Counts past a few
-    /// waste tasks without speeding up the build, and each additional task is spawned as
-    /// blocking-friendly shared work, so on runtimes with a bounded blocking pool keep counts
-    /// well below that pool's size.
+    /// index types (such as the ordered-partitioned index) build in parallel.
     pub init_concurrency: NonZeroUsize,
 }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -364,7 +364,7 @@ use self::db::Metrics;
 
 /// Configuration for a `Current` authenticated db.
 #[derive(Clone)]
-pub struct Config<T: Translator, J, S: Strategy> {
+pub struct Config<T: Translator, J, S: Strategy, B = ()> {
     /// Configuration for the Merkle structure backing the authenticated journal.
     pub merkle_config: MerkleConfig<S>,
 
@@ -381,35 +381,40 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
 
-    /// Number of tasks that build the init-time snapshot, including the init task itself
-    /// (which replays and routes the log); `1` builds entirely on the init task. Only certain
-    /// index types (such as the ordered-partitioned index) build in parallel.
-    pub init_concurrency: NonZeroUsize,
+    /// Size (in bytes) of the read buffer used to replay the log during init.
+    pub init_buffer: NonZeroUsize,
+
+    /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]):
+    /// `()` for index types that build serially, and the number of build tasks (including the
+    /// init task itself, which replays and routes the log, so `1` builds entirely on the init
+    /// task) for index types that build in parallel.
+    pub init_concurrency: B,
 }
 
-impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S> {
-    fn from(cfg: Config<T, J, S>) -> Self {
+impl<T: Translator, J, S: Strategy, B> From<Config<T, J, S, B>> for AnyConfig<T, J, S, B> {
+    fn from(cfg: Config<T, J, S, B>) -> Self {
         Self {
             merkle_config: cfg.merkle_config,
             journal_config: cfg.journal_config,
             translator: cfg.translator,
             init_cache_size: cfg.init_cache_size,
+            init_buffer: cfg.init_buffer,
             init_concurrency: cfg.init_concurrency,
         }
     }
 }
 
 /// Configuration for a `Current` authenticated db with fixed-size values.
-pub type FixedConfig<T, S> = Config<T, FConfig, S>;
+pub type FixedConfig<T, S, B = ()> = Config<T, FConfig, S, B>;
 
 /// Configuration for a `Current` authenticated db with variable-sized values.
-pub type VariableConfig<T, C, S> = Config<T, VConfig<C>, S>;
+pub type VariableConfig<T, C, S, B = ()> = Config<T, VConfig<C>, S, B>;
 
 /// Initialize a `Current` authenticated db from the given config.
 #[boxed]
 pub(super) async fn init<F, E, U, H, T, I, J, const N: usize, S>(
     context: E,
-    config: Config<T, J::Config, S>,
+    config: Config<T, J::Config, S, <I as crate::qmdb::SnapshotBuild<F>>::Concurrency>,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where
     F: merkle::Graftable,
@@ -758,6 +763,16 @@ pub mod tests {
         partition_prefix: &str,
         pooler: &impl BufferPooler,
     ) -> FixedConfig<T, Sequential> {
+        fixed_config_full(partition_prefix, pooler, ())
+    }
+
+    /// Shared config construction for every fixed-value flavor, generic over the index's
+    /// snapshot-build concurrency.
+    pub(crate) fn fixed_config_full<T: Translator + Default, B>(
+        partition_prefix: &str,
+        pooler: &impl BufferPooler,
+        init_concurrency: B,
+    ) -> FixedConfig<T, Sequential, B> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
             merkle_config: MerkleConfig {
@@ -777,7 +792,8 @@ pub mod tests {
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency,
         }
     }
 
@@ -786,6 +802,16 @@ pub mod tests {
         partition_prefix: &str,
         pooler: &impl BufferPooler,
     ) -> VariableConfig<T, ((), ()), Sequential> {
+        variable_config_full(partition_prefix, pooler, ())
+    }
+
+    /// Shared config construction for every variable-value flavor, generic over the index's
+    /// snapshot-build concurrency.
+    pub(crate) fn variable_config_full<T: Translator + Default, B>(
+        partition_prefix: &str,
+        pooler: &impl BufferPooler,
+        init_concurrency: B,
+    ) -> VariableConfig<T, ((), ()), Sequential, B> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
             merkle_config: MerkleConfig {
@@ -807,8 +833,25 @@ pub mod tests {
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
-            init_concurrency: NZUsize!(1),
+            init_buffer: NZUsize!(1 << 21),
+            init_concurrency,
         }
+    }
+
+    /// Like [fixed_config], typed for a partitioned index at the serial concurrency.
+    pub(crate) fn fixed_config_partitioned<T: Translator + Default>(
+        partition_prefix: &str,
+        pooler: &impl BufferPooler,
+    ) -> FixedConfig<T, Sequential, NonZeroUsize> {
+        fixed_config_full(partition_prefix, pooler, NZUsize!(1))
+    }
+
+    /// Like [variable_config], typed for a partitioned index at the serial concurrency.
+    pub(crate) fn variable_config_partitioned<T: Translator + Default>(
+        partition_prefix: &str,
+        pooler: &impl BufferPooler,
+    ) -> VariableConfig<T, ((), ()), Sequential, NonZeroUsize> {
+        variable_config_full(partition_prefix, pooler, NZUsize!(1))
     }
 
     /// Commit a set of writes as a single batch.
@@ -1619,6 +1662,7 @@ pub mod tests {
                 grafted_metadata_partition: "forged-exclusion-grafted".to_string(),
                 translator: OneCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                init_buffer: NZUsize!(1 << 21),
                 init_concurrency: NZUsize!(1),
             };
             let db = ForgedExclusionDb::init(context.child("db"), cfg)
@@ -1701,26 +1745,26 @@ pub mod tests {
             $cb!($($args)*, ov, OrderedVariableDb, variable_config);
             $cb!($($args)*, uf, UnorderedFixedDb, fixed_config);
             $cb!($($args)*, uv, UnorderedVariableDb, variable_config);
-            $cb!($($args)*, ofp1, OrderedFixedP1Db, fixed_config);
-            $cb!($($args)*, ovp1, OrderedVariableP1Db, variable_config);
-            $cb!($($args)*, ufp1, UnorderedFixedP1Db, fixed_config);
-            $cb!($($args)*, uvp1, UnorderedVariableP1Db, variable_config);
-            $cb!($($args)*, ofp2, OrderedFixedP2Db, fixed_config);
-            $cb!($($args)*, ovp2, OrderedVariableP2Db, variable_config);
-            $cb!($($args)*, ufp2, UnorderedFixedP2Db, fixed_config);
-            $cb!($($args)*, uvp2, UnorderedVariableP2Db, variable_config);
+            $cb!($($args)*, ofp1, OrderedFixedP1Db, fixed_config_partitioned);
+            $cb!($($args)*, ovp1, OrderedVariableP1Db, variable_config_partitioned);
+            $cb!($($args)*, ufp1, UnorderedFixedP1Db, fixed_config_partitioned);
+            $cb!($($args)*, uvp1, UnorderedVariableP1Db, variable_config_partitioned);
+            $cb!($($args)*, ofp2, OrderedFixedP2Db, fixed_config_partitioned);
+            $cb!($($args)*, ovp2, OrderedVariableP2Db, variable_config_partitioned);
+            $cb!($($args)*, ufp2, UnorderedFixedP2Db, fixed_config_partitioned);
+            $cb!($($args)*, uvp2, UnorderedVariableP2Db, variable_config_partitioned);
             $cb!($($args)*, of_mmb, OrderedFixedMmbDb, fixed_config);
             $cb!($($args)*, ov_mmb, OrderedVariableMmbDb, variable_config);
             $cb!($($args)*, uf_mmb, UnorderedFixedMmbDb, fixed_config);
             $cb!($($args)*, uv_mmb, UnorderedVariableMmbDb, variable_config);
-            $cb!($($args)*, ofp1_mmb, OrderedFixedMmbP1Db, fixed_config);
-            $cb!($($args)*, ovp1_mmb, OrderedVariableMmbP1Db, variable_config);
-            $cb!($($args)*, ufp1_mmb, UnorderedFixedMmbP1Db, fixed_config);
-            $cb!($($args)*, uvp1_mmb, UnorderedVariableMmbP1Db, variable_config);
-            $cb!($($args)*, ofp2_mmb, OrderedFixedMmbP2Db, fixed_config);
-            $cb!($($args)*, ovp2_mmb, OrderedVariableMmbP2Db, variable_config);
-            $cb!($($args)*, ufp2_mmb, UnorderedFixedMmbP2Db, fixed_config);
-            $cb!($($args)*, uvp2_mmb, UnorderedVariableMmbP2Db, variable_config);
+            $cb!($($args)*, ofp1_mmb, OrderedFixedMmbP1Db, fixed_config_partitioned);
+            $cb!($($args)*, ovp1_mmb, OrderedVariableMmbP1Db, variable_config_partitioned);
+            $cb!($($args)*, ufp1_mmb, UnorderedFixedMmbP1Db, fixed_config_partitioned);
+            $cb!($($args)*, uvp1_mmb, UnorderedVariableMmbP1Db, variable_config_partitioned);
+            $cb!($($args)*, ofp2_mmb, OrderedFixedMmbP2Db, fixed_config_partitioned);
+            $cb!($($args)*, ovp2_mmb, OrderedVariableMmbP2Db, variable_config_partitioned);
+            $cb!($($args)*, ufp2_mmb, UnorderedFixedMmbP2Db, fixed_config_partitioned);
+            $cb!($($args)*, uvp2_mmb, UnorderedVariableMmbP2Db, variable_config_partitioned);
         };
     }
 
@@ -1729,16 +1773,16 @@ pub mod tests {
         ($cb:ident!($($args:tt)*)) => {
             $cb!($($args)*, of, OrderedFixedDb, fixed_config);
             $cb!($($args)*, ov, OrderedVariableDb, variable_config);
-            $cb!($($args)*, ofp1, OrderedFixedP1Db, fixed_config);
-            $cb!($($args)*, ovp1, OrderedVariableP1Db, variable_config);
-            $cb!($($args)*, ofp2, OrderedFixedP2Db, fixed_config);
-            $cb!($($args)*, ovp2, OrderedVariableP2Db, variable_config);
+            $cb!($($args)*, ofp1, OrderedFixedP1Db, fixed_config_partitioned);
+            $cb!($($args)*, ovp1, OrderedVariableP1Db, variable_config_partitioned);
+            $cb!($($args)*, ofp2, OrderedFixedP2Db, fixed_config_partitioned);
+            $cb!($($args)*, ovp2, OrderedVariableP2Db, variable_config_partitioned);
             $cb!($($args)*, of_mmb, OrderedFixedMmbDb, fixed_config);
             $cb!($($args)*, ov_mmb, OrderedVariableMmbDb, variable_config);
-            $cb!($($args)*, ofp1_mmb, OrderedFixedMmbP1Db, fixed_config);
-            $cb!($($args)*, ovp1_mmb, OrderedVariableMmbP1Db, variable_config);
-            $cb!($($args)*, ofp2_mmb, OrderedFixedMmbP2Db, fixed_config);
-            $cb!($($args)*, ovp2_mmb, OrderedVariableMmbP2Db, variable_config);
+            $cb!($($args)*, ofp1_mmb, OrderedFixedMmbP1Db, fixed_config_partitioned);
+            $cb!($($args)*, ovp1_mmb, OrderedVariableMmbP1Db, variable_config_partitioned);
+            $cb!($($args)*, ofp2_mmb, OrderedFixedMmbP2Db, fixed_config_partitioned);
+            $cb!($($args)*, ovp2_mmb, OrderedVariableMmbP2Db, variable_config_partitioned);
         };
     }
 
@@ -1747,16 +1791,16 @@ pub mod tests {
         ($cb:ident!($($args:tt)*)) => {
             $cb!($($args)*, uf, UnorderedFixedDb, fixed_config);
             $cb!($($args)*, uv, UnorderedVariableDb, variable_config);
-            $cb!($($args)*, ufp1, UnorderedFixedP1Db, fixed_config);
-            $cb!($($args)*, uvp1, UnorderedVariableP1Db, variable_config);
-            $cb!($($args)*, ufp2, UnorderedFixedP2Db, fixed_config);
-            $cb!($($args)*, uvp2, UnorderedVariableP2Db, variable_config);
+            $cb!($($args)*, ufp1, UnorderedFixedP1Db, fixed_config_partitioned);
+            $cb!($($args)*, uvp1, UnorderedVariableP1Db, variable_config_partitioned);
+            $cb!($($args)*, ufp2, UnorderedFixedP2Db, fixed_config_partitioned);
+            $cb!($($args)*, uvp2, UnorderedVariableP2Db, variable_config_partitioned);
             $cb!($($args)*, uf_mmb, UnorderedFixedMmbDb, fixed_config);
             $cb!($($args)*, uv_mmb, UnorderedVariableMmbDb, variable_config);
-            $cb!($($args)*, ufp1_mmb, UnorderedFixedMmbP1Db, fixed_config);
-            $cb!($($args)*, uvp1_mmb, UnorderedVariableMmbP1Db, variable_config);
-            $cb!($($args)*, ufp2_mmb, UnorderedFixedMmbP2Db, fixed_config);
-            $cb!($($args)*, uvp2_mmb, UnorderedVariableMmbP2Db, variable_config);
+            $cb!($($args)*, ufp1_mmb, UnorderedFixedMmbP1Db, fixed_config_partitioned);
+            $cb!($($args)*, uvp1_mmb, UnorderedVariableMmbP1Db, variable_config_partitioned);
+            $cb!($($args)*, ufp2_mmb, UnorderedFixedMmbP2Db, fixed_config_partitioned);
+            $cb!($($args)*, uvp2_mmb, UnorderedVariableMmbP2Db, variable_config_partitioned);
         };
     }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -331,7 +331,7 @@ use crate::{
         authenticated,
         contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     },
-    merkle::{self, Location, full::Config as MerkleConfig},
+    merkle::{self, full::Config as MerkleConfig},
     qmdb::{
         any::{
             self, Config as AnyConfig,
@@ -346,6 +346,7 @@ use commonware_codec::{CodecShared, FixedSize};
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_utils::bitmap::Prunable as BitMap;
 use core::num::NonZeroUsize;
 use std::sync::Arc;
@@ -379,6 +380,10 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
+
+    /// How the snapshot build parallelizes during init. Note that only certain index types (such
+    /// as the ordered-partitioned index) support parallel construction.
+    pub init_parallelism: super::InitParallelism,
 }
 
 impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S> {
@@ -388,6 +393,7 @@ impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S>
             journal_config: cfg.journal_config,
             translator: cfg.translator,
             init_cache_size: cfg.init_cache_size,
+            init_parallelism: cfg.init_parallelism,
         }
     }
 }
@@ -406,12 +412,12 @@ pub(super) async fn init<F, E, U, H, T, I, J, const N: usize, S>(
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where
     F: merkle::Graftable,
-    E: Context,
+    E: Context + Spawner,
     U: Update + Send + Sync,
     H: Hasher,
     T: Translator,
-    I: IndexFactory<T, Value = Location<F>>,
-    J: authenticated::Backing<E, Item = Operation<F, U>>,
+    I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
+    J: authenticated::Backing<E, Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
 {
@@ -512,6 +518,7 @@ pub mod tests {
     use crate::{
         merkle::{self, mmb, mmr},
         qmdb::{
+            InitParallelism,
             any::{
                 test::colliding_digest,
                 traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
@@ -521,7 +528,7 @@ pub mod tests {
         },
         translator::Translator,
     };
-    use commonware_parallel::Sequential;
+    use commonware_parallel::{Sequential, Strategy};
     use commonware_runtime::{
         BufferPooler, Runner as _, Supervisor as _,
         buffer::paged::CacheRef,
@@ -751,14 +758,23 @@ pub mod tests {
         partition_prefix: &str,
         pooler: &impl BufferPooler,
     ) -> FixedConfig<T, Sequential> {
+        fixed_config_with_strategy(partition_prefix, pooler, Sequential)
+    }
+
+    pub(crate) fn fixed_config_with_strategy<T: Translator + Default, S: Strategy>(
+        partition_prefix: &str,
+        pooler: &impl BufferPooler,
+        strategy: S,
+    ) -> FixedConfig<T, S> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
                 items_per_blob: NZU64!(11),
                 write_buffer: NZUsize!(1024),
-                strategy: Sequential,
+                strategy,
                 page_cache: page_cache.clone(),
             },
             journal_config: FConfig {
@@ -780,6 +796,7 @@ pub mod tests {
     ) -> VariableConfig<T, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
+            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
@@ -1591,6 +1608,7 @@ pub mod tests {
         executor.start(|context| async move {
             let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
             let cfg = VariableConfig {
+                init_parallelism: InitParallelism::Serial,
                 merkle_config: MerkleConfig {
                     journal_partition: "forged-exclusion-journal".to_string(),
                     metadata_partition: "forged-exclusion-metadata".to_string(),

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
@@ -38,7 +39,7 @@ pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
 
 impl<
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Array,
     V: FixedValue,
     H: Hasher,
@@ -81,7 +82,7 @@ pub mod partitioned {
 
     impl<
         F: Graftable,
-        E: Context,
+        E: Context + Spawner,
         K: Array,
         V: FixedValue,
         H: Hasher,
@@ -92,7 +93,8 @@ pub mod partitioned {
     > Db<F, E, K, V, H, T, P, N, S>
     {
         /// Initializes a [Db] authenticated database from the given `config`.
-        /// The configured [`Strategy`] is used to parallelize merkleization.
+        /// The configured [`Strategy`] is used to parallelize merkleization and the snapshot
+        /// build during init.
         pub async fn init(context: E, config: Config<T, S>) -> Result<Self, Error<F>> {
             crate::qmdb::current::init(context, config).await
         }
@@ -106,29 +108,25 @@ pub mod test {
         mmr,
         qmdb::{
             Error,
-            current::{ordered::tests as shared, tests::fixed_config},
+            current::{
+                ordered::tests as shared,
+                tests::{fixed_config, fixed_config_with_strategy},
+            },
         },
         translator::OneCap,
     };
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
+    use commonware_parallel::{Manual, Sequential};
     use commonware_runtime::{Runner as _, Supervisor as _, deterministic};
     use commonware_utils::{
-        NZU64,
+        NZU64, NZUsize,
         bitmap::{Prunable as BitMap, Readable as _},
     };
 
     /// A type alias for the concrete [Db] type used in these unit tests.
-    type CurrentTest = Db<
-        mmr::Family,
-        deterministic::Context,
-        Digest,
-        Digest,
-        Sha256,
-        OneCap,
-        32,
-        commonware_parallel::Sequential,
-    >;
+    type CurrentTest =
+        Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, OneCap, 32, Sequential>;
 
     /// Return an [Db] database initialized with a fixed config.
     async fn open_db(context: deterministic::Context, partition_prefix: String) -> CurrentTest {
@@ -211,4 +209,168 @@ pub mod test {
         test_current_ordered_fixed_staged_merkleize_parity,
         open_db
     );
+
+    /// Build a `P`-partitioned current db with churny ops across two commits (so the second commit's
+    /// updates and deletes inactivate locations from the first), prune it, then assert that
+    /// reopening it at a range of worker counts reconstructs the identical root and key-value
+    /// state. Unlike the `any` equivalence tests, the current root commits to the activity bitmap,
+    /// so this exercises the parallel build's bitmap reconstruction (`for_each_value` +
+    /// last-commit) over a pruned prefix, not just the snapshot index and MMR. A final reopen uses
+    /// [crate::qmdb::InitParallelism::Auto] with a [Manual] strategy hint to cover the
+    /// derived-count path.
+    async fn check_current_parallel_init_equivalence<const P: usize>(
+        context: deterministic::Context,
+        partition: &'static str,
+        worker_counts: &[usize],
+    ) {
+        type PartDb<const P: usize, S> = partitioned::Db<
+            mmr::Family,
+            deterministic::Context,
+            Digest,
+            Digest,
+            Sha256,
+            OneCap,
+            P,
+            32,
+            S,
+        >;
+
+        /// The value each key holds after the two commits below.
+        fn expected_value(i: u64) -> Option<Digest> {
+            if i % 7 == 1 {
+                None
+            } else if i.is_multiple_of(3) {
+                Some(Sha256::hash(&((i + 1) * 11).to_be_bytes()))
+            } else {
+                Some(Sha256::hash(&(i * 7).to_be_bytes()))
+            }
+        }
+
+        let cfg = fixed_config::<OneCap>(partition, &context);
+        let mut db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
+            .await
+            .unwrap();
+
+        // Commit 1: insert.
+        let mut batch = db.new_batch();
+        for i in 0u64..2000 {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&(i * 7).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+
+        // Commit 2: update a third (inactivating their commit-1 ops) and delete a seventh.
+        let mut batch = db.new_batch();
+        for i in (0u64..2000).step_by(3) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&((i + 1) * 11).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        for i in (1u64..2000).step_by(7) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            batch = batch.write(k, None);
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+
+        // Prune so the reopens rebuild the grafted root over a bitmap with a pruned prefix.
+        db.prune(db.sync_boundary()).await.unwrap();
+        db.sync().await.unwrap();
+        let root = db.root();
+        drop(db);
+
+        // Reopen at each worker count. All rebuild (snapshot + bitmap) from the same log and must
+        // match the original root and serve the expected value for every key.
+        for &workers in worker_counts {
+            let mut cfg = fixed_config::<OneCap>(partition, &context);
+            cfg.init_parallelism = match workers {
+                0 => crate::qmdb::InitParallelism::Serial,
+                n => {
+                    crate::qmdb::InitParallelism::Workers(core::num::NonZeroUsize::new(n).unwrap())
+                }
+            };
+            let ctx = context.child("reopen").with_attribute("workers", workers);
+            let db = PartDb::<P, Sequential>::init(ctx, cfg).await.unwrap();
+            assert_eq!(
+                db.root(),
+                root,
+                "current root mismatch at P={P} workers={workers}"
+            );
+            for i in 0u64..2000 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                assert_eq!(
+                    db.get(&k).await.unwrap(),
+                    expected_value(i),
+                    "value mismatch for key {i}"
+                );
+            }
+            drop(db);
+        }
+
+        // One derived-count reopen: `Auto` with a hint of 4 reserves one core for routing and
+        // builds with the remaining workers.
+        let mut cfg = fixed_config_with_strategy::<OneCap, _>(
+            partition,
+            &context,
+            Manual::new(Sequential, NZUsize!(4)),
+        );
+        cfg.init_parallelism = crate::qmdb::InitParallelism::Auto;
+        let db = PartDb::<P, Manual<Sequential>>::init(context.child("reopen_auto"), cfg)
+            .await
+            .unwrap();
+        assert_eq!(db.root(), root, "current root mismatch at P={P} auto");
+        for i in 0u64..2000 {
+            let k = Sha256::hash(&i.to_be_bytes());
+            assert_eq!(
+                db.get(&k).await.unwrap(),
+                expected_value(i),
+                "value mismatch for key {i}"
+            );
+        }
+        drop(db);
+    }
+
+    #[test_traced("WARN")]
+    fn test_current_ordered_partitioned_p1_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            check_current_parallel_init_equivalence::<1>(
+                context,
+                "current_parallel_equiv_p1",
+                &[0, 1, 2, 4],
+            )
+            .await;
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_current_ordered_partitioned_p2_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            check_current_parallel_init_equivalence::<2>(
+                context,
+                "current_parallel_equiv_p2",
+                &[0, 1, 2, 4],
+            )
+            .await;
+        });
+    }
+
+    /// P=3 allocates `2^24` partition slots per index, so it is too memory-heavy for the default
+    /// suite. Run it explicitly with `--ignored` (and ideally `--release`). Only serial and one
+    /// offset-parallel reopen are checked.
+    #[test_traced("WARN")]
+    #[ignore]
+    fn test_current_ordered_partitioned_p3_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            check_current_parallel_init_equivalence::<3>(
+                context,
+                "current_parallel_equiv_p3",
+                &[0, 2],
+            )
+            .await;
+        });
+    }
 }

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -93,8 +93,9 @@ pub mod partitioned {
     > Db<F, E, K, V, H, T, P, N, S>
     {
         /// Initializes a [Db] authenticated database from the given `config`.
-        /// The configured [`Strategy`] is used to parallelize merkleization and the snapshot
-        /// build during init.
+        /// The configured [`Strategy`] is used to parallelize merkleization, and
+        /// `config.init_workers` bounds how many tasks the snapshot build splits across during
+        /// init.
         pub async fn init(context: E, config: Config<T, S>) -> Result<Self, Error<F>> {
             crate::qmdb::current::init(context, config).await
         }
@@ -108,19 +109,16 @@ pub mod test {
         mmr,
         qmdb::{
             Error,
-            current::{
-                ordered::tests as shared,
-                tests::{fixed_config, fixed_config_with_strategy},
-            },
+            current::{ordered::tests as shared, tests::fixed_config},
         },
         translator::OneCap,
     };
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
-    use commonware_parallel::{Manual, Sequential};
+    use commonware_parallel::Sequential;
     use commonware_runtime::{Runner as _, Supervisor as _, deterministic};
     use commonware_utils::{
-        NZU64, NZUsize,
+        NZU64,
         bitmap::{Prunable as BitMap, Readable as _},
     };
 
@@ -215,9 +213,7 @@ pub mod test {
     /// reopening it at a range of worker counts reconstructs the identical root and key-value
     /// state. Unlike the `any` equivalence tests, the current root commits to the activity bitmap,
     /// so this exercises the parallel build's bitmap reconstruction (`for_each_value` +
-    /// last-commit) over a pruned prefix, not just the snapshot index and MMR. A final reopen uses
-    /// [crate::qmdb::InitParallelism::Auto] with a [Manual] strategy hint to cover the
-    /// derived-count path.
+    /// last-commit) over a pruned prefix, not just the snapshot index and MMR.
     async fn check_current_parallel_init_equivalence<const P: usize>(
         context: deterministic::Context,
         partition: &'static str,
@@ -287,12 +283,7 @@ pub mod test {
         // match the original root and serve the expected value for every key.
         for &workers in worker_counts {
             let mut cfg = fixed_config::<OneCap>(partition, &context);
-            cfg.init_parallelism = match workers {
-                0 => crate::qmdb::InitParallelism::Serial,
-                n => {
-                    crate::qmdb::InitParallelism::Workers(core::num::NonZeroUsize::new(n).unwrap())
-                }
-            };
+            cfg.init_workers = core::num::NonZeroUsize::new(workers);
             let ctx = context.child("reopen").with_attribute("workers", workers);
             let db = PartDb::<P, Sequential>::init(ctx, cfg).await.unwrap();
             assert_eq!(
@@ -310,28 +301,6 @@ pub mod test {
             }
             drop(db);
         }
-
-        // One derived-count reopen: `Auto` with a hint of 4 reserves one core for routing and
-        // builds with the remaining workers.
-        let mut cfg = fixed_config_with_strategy::<OneCap, _>(
-            partition,
-            &context,
-            Manual::new(Sequential, NZUsize!(4)),
-        );
-        cfg.init_parallelism = crate::qmdb::InitParallelism::Auto;
-        let db = PartDb::<P, Manual<Sequential>>::init(context.child("reopen_auto"), cfg)
-            .await
-            .unwrap();
-        assert_eq!(db.root(), root, "current root mismatch at P={P} auto");
-        for i in 0u64..2000 {
-            let k = Sha256::hash(&i.to_be_bytes());
-            assert_eq!(
-                db.get(&k).await.unwrap(),
-                expected_value(i),
-                "value mismatch for key {i}"
-            );
-        }
-        drop(db);
     }
 
     #[test_traced("WARN")]

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -93,9 +93,6 @@ pub mod partitioned {
     > Db<F, E, K, V, H, T, P, N, S>
     {
         /// Initializes a [Db] authenticated database from the given `config`.
-        /// The configured [`Strategy`] is used to parallelize merkleization, and
-        /// `config.init_concurrency` bounds how many tasks the snapshot build splits across during
-        /// init.
         pub async fn init(context: E, config: Config<T, S>) -> Result<Self, Error<F>> {
             crate::qmdb::current::init(context, config).await
         }

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -93,7 +93,10 @@ pub mod partitioned {
     > Db<F, E, K, V, H, T, P, N, S>
     {
         /// Initializes a [Db] authenticated database from the given `config`.
-        pub async fn init(context: E, config: Config<T, S>) -> Result<Self, Error<F>> {
+        pub async fn init(
+            context: E,
+            config: Config<T, S, core::num::NonZeroUsize>,
+        ) -> Result<Self, Error<F>> {
             crate::qmdb::current::init(context, config).await
         }
     }
@@ -106,7 +109,10 @@ pub mod test {
         mmr,
         qmdb::{
             Error,
-            current::{ordered::tests as shared, tests::fixed_config},
+            current::{
+                ordered::tests as shared,
+                tests::{fixed_config, fixed_config_partitioned},
+            },
         },
         translator::OneCap,
     };
@@ -240,7 +246,7 @@ pub mod test {
             }
         }
 
-        let cfg = fixed_config::<OneCap>(partition, &context);
+        let cfg = fixed_config_partitioned::<OneCap>(partition, &context);
         let db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
             .await
             .unwrap();
@@ -281,7 +287,7 @@ pub mod test {
         // Reopen at each concurrency. All rebuild (snapshot + bitmap) from the same log and must
         // match the original root and serve the expected value for every key.
         for &concurrency in concurrency_sweep {
-            let mut cfg = fixed_config::<OneCap>(partition, &context);
+            let mut cfg = fixed_config_partitioned::<OneCap>(partition, &context);
             cfg.init_concurrency = core::num::NonZeroUsize::new(concurrency).unwrap();
             let ctx = context
                 .child("reopen")

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -94,7 +94,7 @@ pub mod partitioned {
     {
         /// Initializes a [Db] authenticated database from the given `config`.
         /// The configured [`Strategy`] is used to parallelize merkleization, and
-        /// `config.init_workers` bounds how many tasks the snapshot build splits across during
+        /// `config.init_concurrency` bounds how many tasks the snapshot build splits across during
         /// init.
         pub async fn init(context: E, config: Config<T, S>) -> Result<Self, Error<F>> {
             crate::qmdb::current::init(context, config).await
@@ -114,7 +114,7 @@ pub mod test {
         translator::OneCap,
     };
     use commonware_cryptography::{Sha256, sha256::Digest};
-    use commonware_macros::test_traced;
+    use commonware_macros::{boxed, test_traced};
     use commonware_parallel::Sequential;
     use commonware_runtime::{Runner as _, Supervisor as _, deterministic};
     use commonware_utils::{
@@ -214,10 +214,11 @@ pub mod test {
     /// state. Unlike the `any` equivalence tests, the current root commits to the activity bitmap,
     /// so this exercises the parallel build's bitmap reconstruction (`for_each_value` +
     /// last-commit) over a pruned prefix, not just the snapshot index and MMR.
+    #[boxed]
     async fn check_current_parallel_init_equivalence<const P: usize>(
         context: deterministic::Context,
         partition: &'static str,
-        worker_counts: &[usize],
+        concurrency_sweep: &[usize],
     ) {
         type PartDb<const P: usize, S> = partitioned::Db<
             mmr::Family,
@@ -243,7 +244,7 @@ pub mod test {
         }
 
         let cfg = fixed_config::<OneCap>(partition, &context);
-        let mut db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
+        let db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
             .await
             .unwrap();
 
@@ -255,8 +256,8 @@ pub mod test {
             batch = batch.write(k, Some(v));
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Commit 2: update a third (inactivating their commit-1 ops) and delete a seventh.
         let mut batch = db.new_batch();
@@ -270,26 +271,29 @@ pub mod test {
             batch = batch.write(k, None);
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Prune so the reopens rebuild the grafted root over a bitmap with a pruned prefix.
-        db.prune(db.sync_boundary()).await.unwrap();
-        db.sync().await.unwrap();
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
+        let db = db.sync().await.unwrap();
         let root = db.root();
         drop(db);
 
-        // Reopen at each worker count. All rebuild (snapshot + bitmap) from the same log and must
+        // Reopen at each concurrency. All rebuild (snapshot + bitmap) from the same log and must
         // match the original root and serve the expected value for every key.
-        for &workers in worker_counts {
+        for &concurrency in concurrency_sweep {
             let mut cfg = fixed_config::<OneCap>(partition, &context);
-            cfg.init_workers = core::num::NonZeroUsize::new(workers);
-            let ctx = context.child("reopen").with_attribute("workers", workers);
+            cfg.init_concurrency = core::num::NonZeroUsize::new(concurrency).unwrap();
+            let ctx = context
+                .child("reopen")
+                .with_attribute("concurrency", concurrency);
             let db = PartDb::<P, Sequential>::init(ctx, cfg).await.unwrap();
             assert_eq!(
                 db.root(),
                 root,
-                "current root mismatch at P={P} workers={workers}"
+                "current root mismatch at P={P} concurrency={concurrency}"
             );
             for i in 0u64..2000 {
                 let k = Sha256::hash(&i.to_be_bytes());
@@ -309,7 +313,7 @@ pub mod test {
             check_current_parallel_init_equivalence::<1>(
                 context,
                 "current_parallel_equiv_p1",
-                &[0, 1, 2, 4],
+                &[1, 2, 3, 5],
             )
             .await;
         });
@@ -321,7 +325,7 @@ pub mod test {
             check_current_parallel_init_equivalence::<2>(
                 context,
                 "current_parallel_equiv_p2",
-                &[0, 1, 2, 4],
+                &[1, 2, 3, 5],
             )
             .await;
         });
@@ -337,7 +341,7 @@ pub mod test {
             check_current_parallel_init_equivalence::<3>(
                 context,
                 "current_parallel_equiv_p3",
-                &[0, 2],
+                &[1, 3],
             )
             .await;
         });

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -101,7 +101,7 @@ pub mod partitioned {
     {
         /// Initializes a [Db] from the given `config`.
         /// The configured [`Strategy`] is used to parallelize merkleization, and
-        /// `config.init_workers` bounds how many tasks the snapshot build splits across during
+        /// `config.init_concurrency` bounds how many tasks the snapshot build splits across during
         /// init.
         pub async fn init(
             context: E,

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -102,7 +102,7 @@ pub mod partitioned {
         /// Initializes a [Db] from the given `config`.
         pub async fn init(
             context: E,
-            config: Config<T, <Operation<F, K, V> as Read>::Cfg, S>,
+            config: Config<T, <Operation<F, K, V> as Read>::Cfg, S, core::num::NonZeroUsize>,
         ) -> Result<Self, Error<F>> {
             crate::qmdb::current::init(context, config).await
         }

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -100,9 +100,6 @@ pub mod partitioned {
         Operation<F, K, V>: Codec,
     {
         /// Initializes a [Db] from the given `config`.
-        /// The configured [`Strategy`] is used to parallelize merkleization, and
-        /// `config.init_concurrency` bounds how many tasks the snapshot build splits across during
-        /// init.
         pub async fn init(
             context: E,
             config: Config<T, <Operation<F, K, V> as Read>::Cfg, S>,

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -100,7 +100,9 @@ pub mod partitioned {
         Operation<F, K, V>: Codec,
     {
         /// Initializes a [Db] from the given `config`.
-        /// The configured [`Strategy`] is used to parallelize merkleization.
+        /// The configured [`Strategy`] is used to parallelize merkleization, and
+        /// `config.init_workers` bounds how many tasks the snapshot build splits across during
+        /// init.
         pub async fn init(
             context: E,
             config: Config<T, <Operation<F, K, V> as Read>::Cfg, S>,

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -23,6 +23,7 @@ use crate::{
 use commonware_codec::{Codec, Read};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 
 pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
     F,
@@ -38,7 +39,7 @@ pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
 
 impl<
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Key,
     V: VariableValue,
     H: Hasher,
@@ -86,7 +87,7 @@ pub mod partitioned {
 
     impl<
         F: Graftable,
-        E: Context,
+        E: Context + Spawner,
         K: Key,
         V: VariableValue,
         H: Hasher,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -72,6 +72,7 @@ use crate::{
 use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_utils::{Array, bitmap::Prunable as BitMap, channel::oneshot, range::NonEmptyRange};
 use core::num::NonZeroUsize;
 use std::sync::Arc;
@@ -104,17 +105,18 @@ async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
     cache_size: Option<NonZeroUsize>,
+    parallelism: qmdb::InitParallelism,
     metadata_partition: String,
     strategy: S,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, qmdb::Error<F>>
 where
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     U: Update + Send + Sync + 'static,
-    I: IndexFactory<T, Value = Location<F>>,
+    I: IndexFactory<T> + crate::qmdb::SnapshotBuild<F>,
     H: Hasher,
     T: Translator,
-    J: Mutable<Item = Operation<F, U>>,
+    J: Mutable<Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Codec + Committable + CodecShared,
 {
@@ -150,9 +152,18 @@ where
 
     // Build any::Db, handing it the pre-allocated bitmap. `init_from_log` populates the bitmap
     // during replay.
+    let snapshot_context = context.child("any_snapshot");
     let any_metrics = AnyMetrics::new(context.child("any"));
-    let any: AnyDb<F, E, J, I, H, U, N, S> =
-        AnyDb::init_from_log(index, log, Some(bitmap), cache_size, any_metrics).await?;
+    let any: AnyDb<F, E, J, I, H, U, N, S> = AnyDb::init_from_log(
+        snapshot_context,
+        index,
+        log,
+        Some(bitmap),
+        cache_size,
+        parallelism,
+        any_metrics,
+    )
+    .await?;
 
     // Fetch grafted pinned nodes from the ops tree. For each position the grafted family
     // needs at its pruning boundary, source the digest from the ops tree via the zero-chunk
@@ -244,7 +255,7 @@ macro_rules! impl_current_sync_database {
         impl<F, E, K, V, H, T, const N: usize, S> Database for $db<F, E, K, V, H, T, N, S>
         where
             F: Graftable,
-            E: Context,
+            E: Context + Spawner,
             K: $key_bound,
             V: $value_bound + 'static,
             H: Hasher,
@@ -273,6 +284,7 @@ macro_rules! impl_current_sync_database {
                 let strategy = config.merkle_config.strategy.clone();
                 let translator = config.translator.clone();
                 let cache_size = config.init_cache_size;
+                let parallelism = config.init_parallelism;
                 build_db::<F, _, $update<K, V>, _, H, _, T, N, _>(
                     context,
                     merkle_config,
@@ -282,6 +294,7 @@ macro_rules! impl_current_sync_database {
                     range,
                     apply_batch_size,
                     cache_size,
+                    parallelism,
                     metadata_partition,
                     strategy,
                 )

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -105,7 +105,7 @@ async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
     cache_size: Option<NonZeroUsize>,
-    parallelism: qmdb::InitParallelism,
+    workers: Option<NonZeroUsize>,
     metadata_partition: String,
     strategy: S,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, qmdb::Error<F>>
@@ -160,7 +160,7 @@ where
         log,
         Some(bitmap),
         cache_size,
-        parallelism,
+        workers,
         any_metrics,
     )
     .await?;
@@ -284,7 +284,7 @@ macro_rules! impl_current_sync_database {
                 let strategy = config.merkle_config.strategy.clone();
                 let translator = config.translator.clone();
                 let cache_size = config.init_cache_size;
-                let parallelism = config.init_parallelism;
+                let workers = config.init_workers;
                 build_db::<F, _, $update<K, V>, _, H, _, T, N, _>(
                     context,
                     merkle_config,
@@ -294,7 +294,7 @@ macro_rules! impl_current_sync_database {
                     range,
                     apply_batch_size,
                     cache_size,
-                    parallelism,
+                    workers,
                     metadata_partition,
                     strategy,
                 )

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -104,8 +104,9 @@ async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
     pinned_nodes: Option<Vec<H::Digest>>,
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
+    init_concurrency: <I as crate::qmdb::SnapshotBuild<F>>::Concurrency,
+    init_buffer: NonZeroUsize,
     cache_size: Option<NonZeroUsize>,
-    init_concurrency: NonZeroUsize,
     metadata_partition: String,
     strategy: S,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, qmdb::Error<F>>
@@ -159,8 +160,9 @@ where
         index,
         log,
         Some(bitmap),
-        cache_size,
         init_concurrency,
+        init_buffer,
+        cache_size,
         any_metrics,
     )
     .await?;
@@ -284,6 +286,7 @@ macro_rules! impl_current_sync_database {
                 let strategy = config.merkle_config.strategy.clone();
                 let translator = config.translator.clone();
                 let cache_size = config.init_cache_size;
+                let init_buffer = config.init_buffer;
                 let init_concurrency = config.init_concurrency;
                 build_db::<F, _, $update<K, V>, _, H, _, T, N, _>(
                     context,
@@ -293,8 +296,9 @@ macro_rules! impl_current_sync_database {
                     pinned_nodes,
                     range,
                     apply_batch_size,
-                    cache_size,
                     init_concurrency,
+                    init_buffer,
+                    cache_size,
                     metadata_partition,
                     strategy,
                 )

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -105,7 +105,7 @@ async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
     range: NonEmptyRange<Location<F>>,
     apply_batch_size: usize,
     cache_size: Option<NonZeroUsize>,
-    workers: Option<NonZeroUsize>,
+    init_concurrency: NonZeroUsize,
     metadata_partition: String,
     strategy: S,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, qmdb::Error<F>>
@@ -160,7 +160,7 @@ where
         log,
         Some(bitmap),
         cache_size,
-        workers,
+        init_concurrency,
         any_metrics,
     )
     .await?;
@@ -284,7 +284,7 @@ macro_rules! impl_current_sync_database {
                 let strategy = config.merkle_config.strategy.clone();
                 let translator = config.translator.clone();
                 let cache_size = config.init_cache_size;
-                let workers = config.init_workers;
+                let init_concurrency = config.init_concurrency;
                 build_db::<F, _, $update<K, V>, _, H, _, T, N, _>(
                     context,
                     merkle_config,
@@ -294,7 +294,7 @@ macro_rules! impl_current_sync_database {
                     range,
                     apply_batch_size,
                     cache_size,
-                    workers,
+                    init_concurrency,
                     metadata_partition,
                     strategy,
                 )

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -97,7 +97,10 @@ pub mod partitioned {
     {
         /// Initializes a [Db] authenticated database from the given `config`.
         /// The configured [`Strategy`] is used to parallelize merkleization.
-        pub async fn init(context: E, config: Config<T, S>) -> Result<Self, Error<F>> {
+        pub async fn init(
+            context: E,
+            config: Config<T, S, core::num::NonZeroUsize>,
+        ) -> Result<Self, Error<F>> {
             crate::qmdb::current::init(context, config).await
         }
     }
@@ -108,11 +111,15 @@ pub mod test {
     use super::*;
     use crate::{
         mmr,
-        qmdb::current::{tests::fixed_config, unordered::tests as shared},
-        translator::TwoCap,
+        qmdb::current::{
+            tests::{fixed_config, fixed_config_partitioned},
+            unordered::tests as shared,
+        },
+        translator::{OneCap, TwoCap},
     };
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
+    use commonware_parallel::Sequential;
     use commonware_runtime::{Metrics, Runner as _, Supervisor as _, deterministic};
     use commonware_utils::TestRng;
     use rand::Rng as _;
@@ -413,5 +420,119 @@ pub mod test {
     #[test_traced("WARN")]
     pub fn test_current_db_proving_repeated_updates() {
         shared::test_proving_repeated_updates(open_db);
+    }
+
+    /// Build a `P`-partitioned current db with churny ops across two commits (so the second commit's
+    /// updates and deletes inactivate locations from the first), prune it, then assert that
+    /// reopening it at a range of worker counts reconstructs the identical root and key-value
+    /// state. Unlike the `any` equivalence tests, the current root commits to the activity bitmap,
+    /// so this exercises the parallel build's bitmap reconstruction (`for_each_value` +
+    /// last-commit) over a pruned prefix, not just the snapshot index and MMR.
+    #[commonware_macros::boxed]
+    async fn check_current_parallel_init_equivalence<const P: usize>(
+        context: deterministic::Context,
+        partition: &'static str,
+        concurrency_sweep: &[usize],
+    ) {
+        type PartDb<const P: usize, S> = partitioned::Db<
+            mmr::Family,
+            deterministic::Context,
+            Digest,
+            Digest,
+            Sha256,
+            OneCap,
+            P,
+            32,
+            S,
+        >;
+
+        /// The value each key holds after the two commits below.
+        fn expected_value(i: u64) -> Option<Digest> {
+            if i % 7 == 1 {
+                None
+            } else if i.is_multiple_of(3) {
+                Some(Sha256::hash(&((i + 1) * 11).to_be_bytes()))
+            } else {
+                Some(Sha256::hash(&(i * 7).to_be_bytes()))
+            }
+        }
+
+        let cfg = fixed_config_partitioned::<OneCap>(partition, &context);
+        let db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
+            .await
+            .unwrap();
+
+        // Commit 1: insert.
+        let mut batch = db.new_batch();
+        for i in 0u64..2000 {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&(i * 7).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+
+        // Commit 2: update a third (inactivating their commit-1 ops) and delete a seventh.
+        let mut batch = db.new_batch();
+        for i in (0u64..2000).step_by(3) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&((i + 1) * 11).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        for i in (1u64..2000).step_by(7) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            batch = batch.write(k, None);
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+
+        // Prune so the reopens rebuild the grafted root over a bitmap with a pruned prefix.
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
+        let db = db.sync().await.unwrap();
+        let root = db.root();
+        drop(db);
+
+        // Reopen at each concurrency. All rebuild (snapshot + bitmap) from the same log and must
+        // match the original root and serve the expected value for every key.
+        for &concurrency in concurrency_sweep {
+            let mut cfg = fixed_config_partitioned::<OneCap>(partition, &context);
+            cfg.init_concurrency = core::num::NonZeroUsize::new(concurrency).unwrap();
+            let ctx = context
+                .child("reopen")
+                .with_attribute("concurrency", concurrency);
+            let db = PartDb::<P, Sequential>::init(ctx, cfg).await.unwrap();
+            assert_eq!(
+                db.root(),
+                root,
+                "current root mismatch at P={P} concurrency={concurrency}"
+            );
+            for i in 0u64..2000 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                assert_eq!(
+                    db.get(&k).await.unwrap(),
+                    expected_value(i),
+                    "value mismatch for key {i}"
+                );
+            }
+            drop(db);
+        }
+    }
+
+    /// The unordered sweep runs at P=1 only: `P=2` allocates 65,536 hash sub-indexes per index
+    /// instance, which is too memory-heavy for the default suite, and the range/offset arithmetic
+    /// is shared with the ordered variant's P=2 coverage.
+    #[test_traced("WARN")]
+    fn test_current_unordered_partitioned_p1_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            check_current_parallel_init_equivalence::<1>(
+                context,
+                "current_unordered_parallel_equiv_p1",
+                &[1, 2, 3, 5],
+            )
+            .await;
+        });
     }
 }

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 /// A specialization of [super::db::Db] for unordered key spaces and fixed-size values.
@@ -38,7 +39,7 @@ pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
 
 impl<
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Array,
     V: FixedValue,
     H: Hasher,
@@ -84,7 +85,7 @@ pub mod partitioned {
 
     impl<
         F: Graftable,
-        E: Context,
+        E: Context + Spawner,
         K: Array,
         V: FixedValue,
         H: Hasher,

--- a/storage/src/qmdb/current/unordered/variable.rs
+++ b/storage/src/qmdb/current/unordered/variable.rs
@@ -22,6 +22,7 @@ use crate::{
 use commonware_codec::Read;
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
@@ -38,7 +39,7 @@ pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
 
 impl<
     F: Graftable,
-    E: Context,
+    E: Context + Spawner,
     K: Array,
     V: VariableValue,
     H: Hasher,
@@ -86,7 +87,7 @@ pub mod partitioned {
 
     impl<
         F: Graftable,
-        E: Context,
+        E: Context + Spawner,
         K: Array,
         V: VariableValue,
         H: Hasher,

--- a/storage/src/qmdb/current/unordered/variable.rs
+++ b/storage/src/qmdb/current/unordered/variable.rs
@@ -103,7 +103,7 @@ pub mod partitioned {
         /// The configured [`Strategy`] is used to parallelize merkleization.
         pub async fn init(
             context: E,
-            config: Config<T, <Operation<F, K, V> as Read>::Cfg, S>,
+            config: Config<T, <Operation<F, K, V> as Read>::Cfg, S, core::num::NonZeroUsize>,
         ) -> Result<Self, Error<F>> {
             crate::qmdb::current::init(context, config).await
         }

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -53,7 +53,14 @@ impl<F: Family, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator, S
             ROOT_BAGGING,
         )
         .await?;
-        Self::init_from_journal(journal, context, cfg.translator, cfg.init_cache_size).await
+        Self::init_from_journal(
+            journal,
+            context,
+            cfg.translator,
+            cfg.init_buffer,
+            cfg.init_cache_size,
+        )
+        .await
     }
 }
 
@@ -107,6 +114,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_buffer: NZUsize!(1 << 21),
         }
     }
 

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -136,6 +136,9 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
+
+    /// Size (in bytes) of the read buffer used to replay the log during init.
+    pub init_buffer: NonZeroUsize,
 }
 
 /// An authenticated database that only supports adding new keyed values (no updates or
@@ -225,6 +228,7 @@ where
         mut journal: authenticated::Journal<F, E, C, H, S>,
         context: E,
         translator: T,
+        init_buffer: NonZeroUsize,
         cache_size: Option<NonZeroUsize>,
     ) -> Result<Self, Error<F>> {
         if journal.size() == 0 {
@@ -256,6 +260,7 @@ where
                 inactivity_floor_loc,
                 &journal.journal,
                 &mut snapshot,
+                init_buffer,
                 cache_size,
                 |_, _| {},
             )

--- a/storage/src/qmdb/immutable/operation/mod.rs
+++ b/storage/src/qmdb/immutable/operation/mod.rs
@@ -68,6 +68,13 @@ impl<F: Family, K: Key, V: ValueEncoding> OperationTrait<F> for Operation<F, K, 
         self.key()
     }
 
+    fn into_key(self) -> Option<Self::Key> {
+        match self {
+            Self::Set(key, _) => Some(key),
+            Self::Commit(_, _) => None,
+        }
+    }
+
     fn is_delete(&self) -> bool {
         // Immutable databases don't support deletion
         false

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -110,6 +110,7 @@ where
                 inactivity_floor_loc,
                 &journal.journal,
                 &mut snapshot,
+                db_config.init_buffer,
                 db_config.init_cache_size,
                 |_, _| {},
             )

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -898,6 +898,7 @@ pub(crate) mod harnesses {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_buffer: NZUsize!(1 << 21),
         }
     }
 
@@ -1255,6 +1256,7 @@ mod compact_variable_mmr {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_buffer: NZUsize!(1 << 21),
         }
     }
 
@@ -2011,6 +2013,7 @@ mod compact_variable_mmb {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_buffer: NZUsize!(1 << 21),
         }
     }
 

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -57,7 +57,14 @@ impl<F: Family, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator, 
             ROOT_BAGGING,
         )
         .await?;
-        Self::init_from_journal(journal, context, cfg.translator, cfg.init_cache_size).await
+        Self::init_from_journal(
+            journal,
+            context,
+            cfg.translator,
+            cfg.init_buffer,
+            cfg.init_cache_size,
+        )
+        .await
     }
 }
 
@@ -129,6 +136,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_buffer: NZUsize!(1 << 21),
         }
     }
 

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -338,10 +338,26 @@ where
     R::Item: Operation<F>,
 {
     // If the translated key is in the snapshot, get a cursor to look for the key.
-    let Some(mut cursor) = snapshot.get_mut(key) else {
+    let Some(cursor) = snapshot.get_mut(key) else {
         return Ok(None);
     };
+    delete_at_cursor::<F, _, _>(cursor, reader, key, cache).await
+}
 
+/// Delete `key` at `cursor` (obtained from a `get_mut` lookup of `key`), returning its location if
+/// it was present among the cursor's conflicts.
+async fn delete_at_cursor<F, C, R>(
+    mut cursor: C,
+    reader: &R,
+    key: &<R::Item as Operation<F>>::Key,
+    cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
+) -> Result<Option<Location<F>>, Error<F>>
+where
+    F: Family,
+    C: Cursor<Value = Location<F>>,
+    R: Contiguous,
+    R::Item: Operation<F>,
+{
     // Find the matching key among all conflicts, then delete it.
     let Some(loc) = find_update_op::<F, _>(reader, &mut cursor, key, cache).await? else {
         return Ok(None);
@@ -367,10 +383,28 @@ where
 {
     // If the translated key is not in the snapshot, insert the new location. Otherwise, get a
     // cursor to look for the key.
-    let Some(mut cursor) = snapshot.get_mut_or_insert(key, new_loc) else {
+    let Some(cursor) = snapshot.get_mut_or_insert(key, new_loc) else {
         return Ok(None);
     };
+    update_at_cursor::<F, _, _>(cursor, reader, key, new_loc, cache).await
+}
 
+/// Update `key` to `new_loc` at `cursor` (obtained from a `get_mut_or_insert` lookup of `key`),
+/// returning its old location if it was present among the cursor's conflicts; otherwise `new_loc`
+/// is inserted at the cursor.
+async fn update_at_cursor<F, C, R>(
+    mut cursor: C,
+    reader: &R,
+    key: &<R::Item as Operation<F>>::Key,
+    new_loc: Location<F>,
+    cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
+) -> Result<Option<Location<F>>, Error<F>>
+where
+    F: Family,
+    C: Cursor<Value = Location<F>>,
+    R: Contiguous,
+    R::Item: Operation<F>,
+{
     // Find the matching key among all conflicts, then update its location.
     if let Some(loc) = find_update_op::<F, _>(reader, &mut cursor, key, cache).await? {
         assert!(new_loc > loc);
@@ -435,9 +469,9 @@ type RoutedBatch<K> = Vec<(K, u64, bool)>;
 async fn build_snapshot_worker<F, C, T, const P: usize>(
     log: Arc<C>,
     mut rx: mpsc::Receiver<RoutedBatch<<C::Item as Operation<F>>::Key>>,
-    mut index: crate::index::partitioned::ordered::Index<T, Location<F>, P>,
+    mut index: crate::index::partitioned::ordered::RangeIndex<T, Location<F>, P>,
     cache_size: Option<NonZeroUsize>,
-) -> Result<crate::index::partitioned::ordered::Index<T, Location<F>, P>, Error<F>>
+) -> Result<crate::index::partitioned::ordered::RangeIndex<T, Location<F>, P>, Error<F>>
 where
     F: Family,
     C: Contiguous<Item: Operation<F>>,
@@ -447,13 +481,18 @@ where
     while let Some(batch) = rx.recv().await {
         for (key, loc, is_delete) in batch {
             if is_delete {
-                delete_key::<F, _, _>(&mut index, &*log, &key, cache.as_mut()).await?;
+                if let Some(cursor) = index.get_mut(&key) {
+                    delete_at_cursor::<F, _, _>(cursor, &*log, &key, cache.as_mut()).await?;
+                }
             } else {
                 let new_loc = Location::new(loc);
-                update_key::<F, _, _>(&mut index, &*log, &key, new_loc, cache.as_mut()).await?;
+                if let Some(cursor) = index.get_mut_or_insert(&key, new_loc) {
+                    update_at_cursor::<F, _, _>(cursor, &*log, &key, new_loc, cache.as_mut())
+                        .await?;
+                }
 
                 // This update op is now a `find_update_op` candidate for later ops of its key.
-                // `key` is owned by this batch and unused after `update_key`, so move it in.
+                // `key` is owned by this batch and unused after the update, so move it in.
                 if let Some(cache) = cache.as_mut() {
                     cache.put(loc, key);
                 }
@@ -676,10 +715,10 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
 
         // Install each worker's partition range into self. Each worker carries its own
         // partition offset, so installation needs no range arguments.
-        let mut total_items = 0i64;
+        let mut total_items = 0;
         for handle in joined {
-            let mut worker_index = handle??;
-            total_items += self.install_range(&mut worker_index);
+            let worker_index = handle??;
+            total_items += self.install_range(worker_index);
         }
 
         // Reconstruct the activity bitmap in location order: a location is active iff it is the
@@ -693,7 +732,7 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
             active.set(last_commit - floor, true);
         }
 
-        Ok((total_items as usize, active))
+        Ok((total_items, active))
     }
 }
 

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -512,9 +512,10 @@ pub trait SnapshotBuild<F: Family>:
     /// keys and the activity status of every replayed location, in location order: a location's
     /// bit is set iff it holds the current operation of an active key or is the last commit.
     ///
-    /// `workers` bounds how many tasks an index type that builds in parallel splits the work
-    /// across (`None` builds on the calling task). Index types that build serially ignore it.
-    /// `cache_size` bounds each build's `(location -> key)` cache (`None` disables it).
+    /// `init_concurrency` bounds how many tasks an index type that builds in parallel uses,
+    /// including the calling task (`1` builds entirely on the calling task). Index types that
+    /// build serially ignore it. `cache_size` bounds each build's `(location -> key)` cache
+    /// (`None` disables it).
     // In-crate callers await this future at concrete index types, so the flexibility an explicit
     // `Send` bound on the returned future would add is unused.
     #[allow(async_fn_in_trait)]
@@ -523,19 +524,19 @@ pub trait SnapshotBuild<F: Family>:
         _context: E,
         inactivity_floor_loc: Location<F>,
         log: &Arc<C>,
-        workers: Option<NonZeroUsize>,
+        init_concurrency: NonZeroUsize,
         cache_size: Option<NonZeroUsize>,
     ) -> Result<(usize, BitMap), Error<F>>
     where
         E: Spawner,
         C: Contiguous<Item: Operation<F>> + 'static,
     {
-        // This index type builds serially, so `workers` has no effect. Warn on an explicit
-        // worker count rather than silently ignore it.
-        if workers.is_some() {
+        // This index type builds serially, so `init_concurrency` has no effect. Warn on an
+        // explicit concurrency rather than silently ignore it.
+        if init_concurrency.get() > 1 {
             tracing::warn!(
-                ?workers,
-                "init_workers configured but this index builds serially; ignoring"
+                init_concurrency,
+                "init_concurrency configured but this index builds serially; ignoring"
             );
         }
         build_snapshot_serial(inactivity_floor_loc, &**log, self, cache_size).await
@@ -573,7 +574,7 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
         context: E,
         inactivity_floor_loc: Location<F>,
         log: &Arc<C>,
-        workers: Option<NonZeroUsize>,
+        init_concurrency: NonZeroUsize,
         cache_size: Option<NonZeroUsize>,
     ) -> Result<(usize, BitMap), Error<F>>
     where
@@ -581,7 +582,7 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
         C: Contiguous<Item: Operation<F>> + 'static,
     {
         let count = self.partition_count();
-        let workers = workers.map_or(0, |n| n.get().min(count));
+        let workers = (init_concurrency.get() - 1).min(count);
 
         // No workers: build on this task.
         if workers == 0 {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -50,7 +50,7 @@
 //!   Ranges](https://github.com/opentimestamps/opentimestamps-server/blob/master/doc/merkle-mountain-range.md)
 
 use crate::{
-    index::{Cursor, Unordered as Index},
+    index::{Cursor, Unordered as Index, partitioned::partition_index_and_sub_key},
     journal::{
         Error as JournalError,
         contiguous::{Contiguous, Mutable},
@@ -60,12 +60,20 @@ use crate::{
         hasher::{Hasher as MerkleHasher, Standard as StandardHasher},
     },
     qmdb::operation::Operation,
+    translator::Translator,
 };
 use commonware_codec::Encode;
 use commonware_cryptography::Hasher;
-use commonware_utils::{NZUsize, cache::Clock};
+use commonware_parallel::Strategy;
+use commonware_runtime::Spawner;
+use commonware_utils::{NZUsize, bitmap::BitMap, cache::Clock, channel::mpsc};
 use core::num::NonZeroUsize;
-use futures::{StreamExt as _, pin_mut};
+use futures::{
+    StreamExt as _,
+    future::{BoxFuture, join_all},
+    pin_mut,
+};
+use std::sync::Arc;
 use thiserror::Error;
 
 pub mod any;
@@ -411,6 +419,314 @@ where
     }
 
     Ok(None)
+}
+
+/// Number of operations the snapshot replay batches per worker-channel send during a parallel build.
+const SNAPSHOT_ROUTE_BATCH: usize = 4096;
+
+/// Bounded depth (in batches) of each per-worker channel during a parallel build. Backpressure keeps
+/// the main replay from running arbitrarily far ahead of a slow worker.
+const SNAPSHOT_CHANNEL_DEPTH: usize = 4;
+
+/// Maximum worker tasks an [InitParallelism::Auto] build derives from the strategy's parallelism
+/// hint. The replay/routing task becomes the bottleneck past a few workers, so a larger count only
+/// splits the per-worker `(location -> key)` cache without speeding up the build.
+const SNAPSHOT_AUTO_MAX_WORKERS: usize = 4;
+
+/// A batch of keyed operations routed to a snapshot-build worker: each entry is the op's key, its
+/// location, and whether it is a delete.
+type RoutedBatch<K> = Vec<(K, u64, bool)>;
+
+/// How `init` builds the snapshot index, for index types that support parallel construction
+/// (currently only the ordered partitioned index; every other index type builds serially regardless).
+///
+/// This is an independent knob from the database's [Strategy]: the strategy sizes and executes
+/// synchronous CPU work (e.g. batch resolution), while init workers are spawned runtime tasks that
+/// interleave index building with log reads.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum InitParallelism {
+    /// Build serially on the calling task (no worker tasks).
+    #[default]
+    Serial,
+    /// Build with up to this many worker tasks, plus the task that replays and routes the log.
+    /// Partition ranges are fixed-width (except possibly the final range), so the effective count
+    /// can be lower than requested (e.g. 256 partitions with `Workers(200)` build with 128 workers
+    /// of two partitions each), and never exceeds the partition count. `Workers(1)` still
+    /// de-interleaves replay from the build onto a separate task.
+    Workers(NonZeroUsize),
+    /// Build with worker tasks derived from the strategy's parallelism hint, reserving one core for
+    /// the replay/routing task and capping at a few workers (past that, routing is the bottleneck).
+    /// Falls back to a serial build when the hint leaves no spare core.
+    Auto,
+}
+
+/// Build one parallel-init worker's partial snapshot: apply the routed operations (streamed in log
+/// order over `rx`) to `index`, resolving translated-key collisions with the worker's own log
+/// `reader` and `(location -> key)` cache. Returns the populated worker index.
+async fn build_snapshot_worker<F, C, T, const P: usize>(
+    log: Arc<C>,
+    mut rx: mpsc::Receiver<RoutedBatch<<C::Item as Operation<F>>::Key>>,
+    mut index: crate::index::partitioned::ordered::Index<T, Location<F>, P>,
+    cache_size: Option<NonZeroUsize>,
+) -> Result<crate::index::partitioned::ordered::Index<T, Location<F>, P>, Error<F>>
+where
+    F: Family,
+    C: Contiguous<Item: Operation<F>>,
+    T: Translator,
+{
+    let mut cache = cache_size.map(Clock::<u64, <C::Item as Operation<F>>::Key>::new);
+    while let Some(batch) = rx.recv().await {
+        for (key, loc, is_delete) in batch {
+            if is_delete {
+                delete_key::<F, _, _>(&mut index, &*log, &key, cache.as_mut()).await?;
+            } else {
+                let new_loc = Location::new(loc);
+                update_key::<F, _, _>(&mut index, &*log, &key, new_loc, cache.as_mut()).await?;
+
+                // This update op is now a `find_update_op` candidate for later ops of its key.
+                // `key` is owned by this batch and unused after `update_key`, so move it in.
+                if let Some(cache) = cache.as_mut() {
+                    cache.put(loc, key);
+                }
+            }
+        }
+    }
+    Ok(index)
+}
+
+/// Builds a database's snapshot index from the operations log.
+///
+/// Generic over the `Index` type so each index controls how it builds: serially with the default
+/// method body, or split across parallel workers with an override.
+///
+/// Sealed: only in-crate index types implement this, so internal invariants (e.g. builds must
+/// drop every clone of the shared log before returning) are enforced by the implementations
+/// rather than the public contract.
+pub trait SnapshotBuild<F: Family>:
+    sealed::SnapshotBuildSealed + Index<Value = Location<F>> + Sized + 'static
+{
+    /// Replay `log` from `inactivity_floor_loc`, populating `self` and invoking `callback` once per
+    /// replayed location, in location order. Each call carries an activity status to append and,
+    /// optionally, an earlier location whose status it clears. Implementations may report per-op
+    /// transitions (a status that a later call clears) or pre-resolved final statuses (never
+    /// clearing), but the state after the last call is identical either way. Returns the number of
+    /// active keys.
+    ///
+    /// `parallelism` selects how index types that build in parallel split the work; extra workers
+    /// have diminishing returns once the replay/routing task becomes the bottleneck. Index types
+    /// that build serially ignore it. `cache_size` bounds each build's `(location -> key)` cache
+    /// (`None` disables it).
+    #[allow(clippy::too_many_arguments)]
+    fn build_snapshot<'a, E, C, S, Fn>(
+        &'a mut self,
+        _context: E,
+        inactivity_floor_loc: Location<F>,
+        log: &'a Arc<C>,
+        _strategy: S,
+        parallelism: InitParallelism,
+        cache_size: Option<NonZeroUsize>,
+        callback: Fn,
+    ) -> BoxFuture<'a, Result<usize, Error<F>>>
+    where
+        E: Spawner,
+        C: Contiguous<Item: Operation<F>> + 'static,
+        S: Strategy,
+        Fn: FnMut(bool, Option<Location<F>>) + Send + 'a,
+    {
+        // This index type builds serially, so `parallelism` has no effect; warn on an explicit
+        // worker count rather than silently ignore it (`Auto` is best-effort and stays quiet).
+        if matches!(parallelism, InitParallelism::Workers(_)) {
+            tracing::warn!(
+                ?parallelism,
+                "init_parallelism configured but this index builds serially; ignoring"
+            );
+        }
+        Box::pin(async move {
+            build_snapshot_from_log(inactivity_floor_loc, &**log, self, cache_size, callback).await
+        })
+    }
+}
+
+mod sealed {
+    use crate::translator::Translator;
+
+    pub trait SnapshotBuildSealed {}
+    impl<T: Translator, V: Send + Sync> SnapshotBuildSealed for crate::index::unordered::Index<T, V> {}
+    impl<T: Translator, V: Send + Sync> SnapshotBuildSealed for crate::index::ordered::Index<T, V> {}
+    impl<T: Translator, V: Send + Sync, const P: usize> SnapshotBuildSealed
+        for crate::index::partitioned::unordered::Index<T, V, P>
+    {
+    }
+    impl<T: Translator, V: Send + Sync, const P: usize> SnapshotBuildSealed
+        for crate::index::partitioned::ordered::Index<T, V, P>
+    {
+    }
+}
+
+impl<F: Family, T: Translator> SnapshotBuild<F> for crate::index::unordered::Index<T, Location<F>> {}
+impl<F: Family, T: Translator> SnapshotBuild<F> for crate::index::ordered::Index<T, Location<F>> {}
+impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
+    for crate::index::partitioned::unordered::Index<T, Location<F>, P>
+{
+}
+
+impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
+    for crate::index::partitioned::ordered::Index<T, Location<F>, P>
+{
+    fn build_snapshot<'a, E, C, S, Fn>(
+        &'a mut self,
+        context: E,
+        inactivity_floor_loc: Location<F>,
+        log: &'a Arc<C>,
+        strategy: S,
+        parallelism: InitParallelism,
+        cache_size: Option<NonZeroUsize>,
+        mut callback: Fn,
+    ) -> BoxFuture<'a, Result<usize, Error<F>>>
+    where
+        E: Spawner,
+        C: Contiguous<Item: Operation<F>> + 'static,
+        S: Strategy,
+        Fn: FnMut(bool, Option<Location<F>>) + Send + 'a,
+    {
+        Box::pin(async move {
+            let count = self.partition_count();
+            let workers = match parallelism {
+                InitParallelism::Serial => 0,
+                InitParallelism::Workers(n) => n.get().min(count),
+                // Reserve one core for the replay/routing task and cap the rest: routing becomes
+                // the bottleneck past a few workers, and extra workers only split the per-worker
+                // cache.
+                InitParallelism::Auto => strategy
+                    .manual()
+                    .parallelism()
+                    .saturating_sub(1)
+                    .min(SNAPSHOT_AUTO_MAX_WORKERS)
+                    .min(count),
+            };
+
+            // Serial, or Auto where the hint left no spare core: build on this task.
+            if workers == 0 {
+                return build_snapshot_from_log(
+                    inactivity_floor_loc,
+                    &**log,
+                    self,
+                    cache_size,
+                    callback,
+                )
+                .await;
+            }
+
+            let floor = *inactivity_floor_loc;
+            let range_size = count.div_ceil(workers);
+
+            // `range_size` rounds up, so `range_size * workers` can exceed `count`, leaving trailing
+            // ranges empty (and a naive `count - lo` would underflow). Reduce to the number of
+            // non-empty ranges so routing (`p / range_size`) stays in `[0, workers)`.
+            let workers = count.div_ceil(range_size);
+            let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
+
+            // Spawn one worker per contiguous partition range, each owning its own reader and cache.
+            let mut senders = Vec::with_capacity(workers);
+            let mut handles = Vec::with_capacity(workers);
+            for w in 0..workers {
+                let (tx, rx) = mpsc::channel(SNAPSHOT_CHANNEL_DEPTH);
+                senders.push(tx);
+                let log = log.clone();
+
+                // This worker owns the contiguous partition range [lo, lo + range_len). It allocates
+                // only that many slots, so per-worker memory is the range, not the full partition set.
+                let lo = w * range_size;
+                let range_len = range_size.min(count - lo);
+                let worker_index = self.new_range(lo, range_len);
+                let handle = context
+                    .child("snapshot_worker")
+                    .with_attribute("worker", w)
+                    .shared(true)
+                    .spawn(move |_| {
+                        build_snapshot_worker::<F, C, T, P>(log, rx, worker_index, per_worker_cache)
+                    });
+                handles.push(handle);
+            }
+
+            // Replay the log once and route each keyed op to the worker owning its partition.
+            // Routing runs in an inner future so any replay failure is captured rather than
+            // returned immediately: returning while the worker handles are merely dropped would
+            // leave the workers running detached, retaining the log and their range allocations
+            // after init has already failed. The stream is also released before the join.
+            let end = log.bounds().end;
+            let last_commit = end.saturating_sub(1);
+            let routing_result: Result<(), Error<F>> = async {
+                let stream = log.replay(floor, SNAPSHOT_READ_BUFFER_SIZE).await?;
+                pin_mut!(stream);
+                let mut batches: Vec<RoutedBatch<_>> = (0..workers)
+                    .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
+                    .collect();
+
+                // A closed channel means a worker terminated early (e.g. returned an `Error<F>`
+                // while resolving a collision). Stop routing on the first such send failure and
+                // let the join below surface that worker's error, rather than panicking on the
+                // send.
+                while let Some(result) = stream.next().await {
+                    let (loc, op) = result?;
+                    let is_delete = op.is_delete();
+                    let Some(key) = op.into_key() else { continue };
+                    let (p, _) = partition_index_and_sub_key::<P>(key.as_ref());
+                    let w = p / range_size;
+                    batches[w].push((key, loc, is_delete));
+                    if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
+                        let batch = std::mem::replace(
+                            &mut batches[w],
+                            Vec::with_capacity(SNAPSHOT_ROUTE_BATCH),
+                        );
+                        if senders[w].send(batch).await.is_err() {
+                            return Ok(());
+                        }
+                    }
+                }
+
+                // Flush remaining batches before the channels close.
+                for (w, batch) in batches.into_iter().enumerate() {
+                    if !batch.is_empty() && senders[w].send(batch).await.is_err() {
+                        break;
+                    }
+                }
+                Ok(())
+            }
+            .await;
+
+            // Close the channels so each worker's stream terminates and it returns its index.
+            drop(senders);
+
+            // Join workers before surfacing any replay failure, so none outlive a failed init.
+            let joined = join_all(handles).await;
+            routing_result?;
+
+            // Install each worker's partition range into self. Each worker carries its own
+            // partition offset, so installation needs no range arguments.
+            let mut total_items = 0i64;
+            for handle in joined {
+                let mut worker_index = handle??;
+                total_items += self.install_range(&mut worker_index);
+            }
+
+            // Reconstruct the activity bitmap in location order: a location is active iff it is the
+            // current location of an active key, or it is the last commit. This matches the serial
+            // build's per-op push-then-clear, which leaves exactly those bits set.
+            let mut active: BitMap = BitMap::zeroes(end - floor);
+            self.for_each_value(|loc| {
+                active.set(**loc - floor, true);
+            });
+            if last_commit >= floor {
+                active.set(last_commit - floor, true);
+            }
+            for is_active in active.iter() {
+                callback(is_active, None);
+            }
+
+            Ok(total_items as usize)
+        })
+    }
 }
 
 /// For the given `key` which is known to exist in the snapshot with location `old_loc`, update

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -64,15 +64,10 @@ use crate::{
 };
 use commonware_codec::Encode;
 use commonware_cryptography::Hasher;
-use commonware_parallel::Strategy;
 use commonware_runtime::Spawner;
 use commonware_utils::{NZUsize, bitmap::BitMap, cache::Clock, channel::mpsc};
 use core::num::NonZeroUsize;
-use futures::{
-    StreamExt as _,
-    future::{BoxFuture, join_all},
-    pin_mut,
-};
+use futures::{StreamExt as _, future::join_all, pin_mut};
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -259,8 +254,10 @@ impl<F: Family> From<crate::journal::authenticated::Error<F>> for Error<F> {
 }
 
 /// The size of the read buffer to use for replaying the operations log when rebuilding the
-/// snapshot.
-const SNAPSHOT_READ_BUFFER_SIZE: NonZeroUsize = NZUsize!(1 << 16);
+/// snapshot. Each buffer fill pays a thread hand-off to the storage layer, so the buffer is sized
+/// to amortize that hand-off across tens of thousands of operations (at the cost of this much
+/// memory per replay).
+const SNAPSHOT_READ_BUFFER_SIZE: NonZeroUsize = NZUsize!(1 << 21);
 
 /// Builds the database's snapshot by replaying the log starting at the inactivity floor. Assumes
 /// the log is not pruned beyond the inactivity floor. The callback is invoked for each replayed
@@ -425,40 +422,12 @@ where
 const SNAPSHOT_ROUTE_BATCH: usize = 4096;
 
 /// Bounded depth (in batches) of each per-worker channel during a parallel build. Backpressure keeps
-/// the main replay from running arbitrarily far ahead of a slow worker.
+/// the replay from running arbitrarily far ahead of a slow worker.
 const SNAPSHOT_CHANNEL_DEPTH: usize = 4;
-
-/// Maximum worker tasks an [InitParallelism::Auto] build derives from the strategy's parallelism
-/// hint. The replay/routing task becomes the bottleneck past a few workers, so a larger count only
-/// splits the per-worker `(location -> key)` cache without speeding up the build.
-const SNAPSHOT_AUTO_MAX_WORKERS: usize = 4;
 
 /// A batch of keyed operations routed to a snapshot-build worker: each entry is the op's key, its
 /// location, and whether it is a delete.
 type RoutedBatch<K> = Vec<(K, u64, bool)>;
-
-/// How `init` builds the snapshot index, for index types that support parallel construction
-/// (currently only the ordered partitioned index; every other index type builds serially regardless).
-///
-/// This is an independent knob from the database's [Strategy]: the strategy sizes and executes
-/// synchronous CPU work (e.g. batch resolution), while init workers are spawned runtime tasks that
-/// interleave index building with log reads.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum InitParallelism {
-    /// Build serially on the calling task (no worker tasks).
-    #[default]
-    Serial,
-    /// Build with up to this many worker tasks, plus the task that replays and routes the log.
-    /// Partition ranges are fixed-width (except possibly the final range), so the effective count
-    /// can be lower than requested (e.g. 256 partitions with `Workers(200)` build with 128 workers
-    /// of two partitions each), and never exceeds the partition count. `Workers(1)` still
-    /// de-interleaves replay from the build onto a separate task.
-    Workers(NonZeroUsize),
-    /// Build with worker tasks derived from the strategy's parallelism hint, reserving one core for
-    /// the replay/routing task and capping at a few workers (past that, routing is the bottleneck).
-    /// Falls back to a serial build when the hint leaves no spare core.
-    Auto,
-}
 
 /// Build one parallel-init worker's partial snapshot: apply the routed operations (streamed in log
 /// order over `rx`) to `index`, resolving translated-key collisions with the worker's own log
@@ -494,6 +463,40 @@ where
     Ok(index)
 }
 
+/// Build a snapshot serially on the calling task via [build_snapshot_from_log], collecting each
+/// replayed location's activity status into a [BitMap]. Returns the number of active keys and the
+/// activity bitmap (see [SnapshotBuild::build_snapshot]).
+async fn build_snapshot_serial<F, C, I>(
+    inactivity_floor_loc: Location<F>,
+    reader: &C,
+    snapshot: &mut I,
+    cache_size: Option<NonZeroUsize>,
+) -> Result<(usize, BitMap), Error<F>>
+where
+    F: Family,
+    C: Contiguous<Item: Operation<F>>,
+    I: Index<Value = Location<F>>,
+{
+    // Track per-op transitions locally: push each op's status and clear the bit of any location it
+    // supersedes. The state after the last op is each location's final status.
+    let mut activity = BitMap::new();
+    let floor = *inactivity_floor_loc;
+    let active_keys = build_snapshot_from_log(
+        inactivity_floor_loc,
+        reader,
+        snapshot,
+        cache_size,
+        |is_active, old_loc| {
+            activity.push(is_active);
+            if let Some(loc) = old_loc {
+                activity.set(*loc - floor, false);
+            }
+        },
+    )
+    .await?;
+    Ok((active_keys, activity))
+}
+
 /// Builds a database's snapshot index from the operations log.
 ///
 /// Generic over the `Index` type so each index controls how it builds: serially with the default
@@ -505,45 +508,37 @@ where
 pub trait SnapshotBuild<F: Family>:
     sealed::SnapshotBuildSealed + Index<Value = Location<F>> + Sized + 'static
 {
-    /// Replay `log` from `inactivity_floor_loc`, populating `self` and invoking `callback` once per
-    /// replayed location, in location order. Each call carries an activity status to append and,
-    /// optionally, an earlier location whose status it clears. Implementations may report per-op
-    /// transitions (a status that a later call clears) or pre-resolved final statuses (never
-    /// clearing), but the state after the last call is identical either way. Returns the number of
-    /// active keys.
+    /// Replay `log` from `inactivity_floor_loc`, populating `self`. Returns the number of active
+    /// keys and the activity status of every replayed location, in location order: a location's
+    /// bit is set iff it holds the current operation of an active key or is the last commit.
     ///
-    /// `parallelism` selects how index types that build in parallel split the work; extra workers
-    /// have diminishing returns once the replay/routing task becomes the bottleneck. Index types
-    /// that build serially ignore it. `cache_size` bounds each build's `(location -> key)` cache
-    /// (`None` disables it).
-    #[allow(clippy::too_many_arguments)]
-    fn build_snapshot<'a, E, C, S, Fn>(
-        &'a mut self,
+    /// `workers` bounds how many tasks an index type that builds in parallel splits the work
+    /// across (`None` builds on the calling task). Index types that build serially ignore it.
+    /// `cache_size` bounds each build's `(location -> key)` cache (`None` disables it).
+    // In-crate callers await this future at concrete index types, so the flexibility an explicit
+    // `Send` bound on the returned future would add is unused.
+    #[allow(async_fn_in_trait)]
+    async fn build_snapshot<E, C>(
+        &mut self,
         _context: E,
         inactivity_floor_loc: Location<F>,
-        log: &'a Arc<C>,
-        _strategy: S,
-        parallelism: InitParallelism,
+        log: &Arc<C>,
+        workers: Option<NonZeroUsize>,
         cache_size: Option<NonZeroUsize>,
-        callback: Fn,
-    ) -> BoxFuture<'a, Result<usize, Error<F>>>
+    ) -> Result<(usize, BitMap), Error<F>>
     where
         E: Spawner,
         C: Contiguous<Item: Operation<F>> + 'static,
-        S: Strategy,
-        Fn: FnMut(bool, Option<Location<F>>) + Send + 'a,
     {
-        // This index type builds serially, so `parallelism` has no effect; warn on an explicit
-        // worker count rather than silently ignore it (`Auto` is best-effort and stays quiet).
-        if matches!(parallelism, InitParallelism::Workers(_)) {
+        // This index type builds serially, so `workers` has no effect. Warn on an explicit
+        // worker count rather than silently ignore it.
+        if workers.is_some() {
             tracing::warn!(
-                ?parallelism,
-                "init_parallelism configured but this index builds serially; ignoring"
+                ?workers,
+                "init_workers configured but this index builds serially; ignoring"
             );
         }
-        Box::pin(async move {
-            build_snapshot_from_log(inactivity_floor_loc, &**log, self, cache_size, callback).await
-        })
+        build_snapshot_serial(inactivity_floor_loc, &**log, self, cache_size).await
     }
 }
 
@@ -573,159 +568,131 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
 impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
     for crate::index::partitioned::ordered::Index<T, Location<F>, P>
 {
-    fn build_snapshot<'a, E, C, S, Fn>(
-        &'a mut self,
+    async fn build_snapshot<E, C>(
+        &mut self,
         context: E,
         inactivity_floor_loc: Location<F>,
-        log: &'a Arc<C>,
-        strategy: S,
-        parallelism: InitParallelism,
+        log: &Arc<C>,
+        workers: Option<NonZeroUsize>,
         cache_size: Option<NonZeroUsize>,
-        mut callback: Fn,
-    ) -> BoxFuture<'a, Result<usize, Error<F>>>
+    ) -> Result<(usize, BitMap), Error<F>>
     where
         E: Spawner,
         C: Contiguous<Item: Operation<F>> + 'static,
-        S: Strategy,
-        Fn: FnMut(bool, Option<Location<F>>) + Send + 'a,
     {
-        Box::pin(async move {
-            let count = self.partition_count();
-            let workers = match parallelism {
-                InitParallelism::Serial => 0,
-                InitParallelism::Workers(n) => n.get().min(count),
-                // Reserve one core for the replay/routing task and cap the rest: routing becomes
-                // the bottleneck past a few workers, and extra workers only split the per-worker
-                // cache.
-                InitParallelism::Auto => strategy
-                    .manual()
-                    .parallelism()
-                    .saturating_sub(1)
-                    .min(SNAPSHOT_AUTO_MAX_WORKERS)
-                    .min(count),
-            };
+        let count = self.partition_count();
+        let workers = workers.map_or(0, |n| n.get().min(count));
 
-            // Serial, or Auto where the hint left no spare core: build on this task.
-            if workers == 0 {
-                return build_snapshot_from_log(
-                    inactivity_floor_loc,
-                    &**log,
-                    self,
-                    cache_size,
-                    callback,
-                )
-                .await;
-            }
+        // No workers: build on this task.
+        if workers == 0 {
+            return build_snapshot_serial(inactivity_floor_loc, &**log, self, cache_size).await;
+        }
 
-            let floor = *inactivity_floor_loc;
-            let range_size = count.div_ceil(workers);
+        let floor = *inactivity_floor_loc;
+        let range_size = count.div_ceil(workers);
 
-            // `range_size` rounds up, so `range_size * workers` can exceed `count`, leaving trailing
-            // ranges empty (and a naive `count - lo` would underflow). Reduce to the number of
-            // non-empty ranges so routing (`p / range_size`) stays in `[0, workers)`.
-            let workers = count.div_ceil(range_size);
-            let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
+        // `range_size` rounds up, so `range_size * workers` can exceed `count`, leaving trailing
+        // ranges empty (and a naive `count - lo` would underflow). Reduce to the number of
+        // non-empty ranges so routing (`p / range_size`) stays in `[0, workers)`.
+        let workers = count.div_ceil(range_size);
+        let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
 
-            // Spawn one worker per contiguous partition range, each owning its own reader and cache.
-            let mut senders = Vec::with_capacity(workers);
-            let mut handles = Vec::with_capacity(workers);
-            for w in 0..workers {
-                let (tx, rx) = mpsc::channel(SNAPSHOT_CHANNEL_DEPTH);
-                senders.push(tx);
-                let log = log.clone();
+        // Spawn one worker per contiguous partition range, each owning its own reader and cache.
+        let mut senders = Vec::with_capacity(workers);
+        let mut handles = Vec::with_capacity(workers);
+        for w in 0..workers {
+            let (tx, rx) = mpsc::channel(SNAPSHOT_CHANNEL_DEPTH);
+            senders.push(tx);
+            let log = log.clone();
 
-                // This worker owns the contiguous partition range [lo, lo + range_len). It allocates
-                // only that many slots, so per-worker memory is the range, not the full partition set.
-                let lo = w * range_size;
-                let range_len = range_size.min(count - lo);
-                let worker_index = self.new_range(lo, range_len);
-                let handle = context
-                    .child("snapshot_worker")
-                    .with_attribute("worker", w)
-                    .shared(true)
-                    .spawn(move |_| {
-                        build_snapshot_worker::<F, C, T, P>(log, rx, worker_index, per_worker_cache)
-                    });
-                handles.push(handle);
-            }
+            // This worker owns the contiguous partition range [lo, lo + range_len). It allocates
+            // only that many slots, so per-worker memory is the range, not the full partition set.
+            let lo = w * range_size;
+            let range_len = range_size.min(count - lo);
+            let worker_index = self.new_range(lo, range_len);
+            let handle = context
+                .child("snapshot_worker")
+                .with_attribute("worker", w)
+                .shared(true)
+                .spawn(move |_| {
+                    build_snapshot_worker::<F, C, T, P>(log, rx, worker_index, per_worker_cache)
+                });
+            handles.push(handle);
+        }
 
-            // Replay the log once and route each keyed op to the worker owning its partition.
-            // Routing runs in an inner future so any replay failure is captured rather than
-            // returned immediately: returning while the worker handles are merely dropped would
-            // leave the workers running detached, retaining the log and their range allocations
-            // after init has already failed. The stream is also released before the join.
-            let end = log.bounds().end;
-            let last_commit = end.saturating_sub(1);
-            let routing_result: Result<(), Error<F>> = async {
-                let stream = log.replay(floor, SNAPSHOT_READ_BUFFER_SIZE).await?;
-                pin_mut!(stream);
-                let mut batches: Vec<RoutedBatch<_>> = (0..workers)
-                    .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
-                    .collect();
+        // Replay the log once and route each keyed op to the worker owning its partition.
+        // Routing runs in an inner future so any replay failure is captured rather than
+        // returned immediately: returning while the worker handles are merely dropped would
+        // leave the workers running detached, retaining the log and their range allocations
+        // after init has already failed. The stream is also released before the join.
+        let end = log.bounds().end;
+        let last_commit = end.saturating_sub(1);
+        let routing_result: Result<(), Error<F>> = async {
+            let stream = log.replay(floor, SNAPSHOT_READ_BUFFER_SIZE).await?;
+            pin_mut!(stream);
+            let mut batches: Vec<RoutedBatch<_>> = (0..workers)
+                .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
+                .collect();
 
-                // A closed channel means a worker terminated early (e.g. returned an `Error<F>`
-                // while resolving a collision). Stop routing on the first such send failure and
-                // let the join below surface that worker's error, rather than panicking on the
-                // send.
-                while let Some(result) = stream.next().await {
-                    let (loc, op) = result?;
-                    let is_delete = op.is_delete();
-                    let Some(key) = op.into_key() else { continue };
-                    let (p, _) = partition_index_and_sub_key::<P>(key.as_ref());
-                    let w = p / range_size;
-                    batches[w].push((key, loc, is_delete));
-                    if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
-                        let batch = std::mem::replace(
-                            &mut batches[w],
-                            Vec::with_capacity(SNAPSHOT_ROUTE_BATCH),
-                        );
-                        if senders[w].send(batch).await.is_err() {
-                            return Ok(());
-                        }
+            // A closed channel means a worker terminated early (e.g. returned an `Error<F>`
+            // while resolving a collision). Stop routing on the first such send failure and
+            // let the join below surface that worker's error, rather than panicking on the
+            // send.
+            while let Some(result) = stream.next().await {
+                let (loc, op) = result?;
+                let is_delete = op.is_delete();
+                let Some(key) = op.into_key() else { continue };
+                let (p, _) = partition_index_and_sub_key::<P>(key.as_ref());
+                let w = p / range_size;
+                batches[w].push((key, loc, is_delete));
+                if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
+                    let batch = std::mem::replace(
+                        &mut batches[w],
+                        Vec::with_capacity(SNAPSHOT_ROUTE_BATCH),
+                    );
+                    if senders[w].send(batch).await.is_err() {
+                        return Ok(());
                     }
                 }
+            }
 
-                // Flush remaining batches before the channels close.
-                for (w, batch) in batches.into_iter().enumerate() {
-                    if !batch.is_empty() && senders[w].send(batch).await.is_err() {
-                        break;
-                    }
+            // Flush remaining batches before the channels close.
+            for (w, batch) in batches.into_iter().enumerate() {
+                if !batch.is_empty() && senders[w].send(batch).await.is_err() {
+                    break;
                 }
-                Ok(())
             }
-            .await;
+            Ok(())
+        }
+        .await;
 
-            // Close the channels so each worker's stream terminates and it returns its index.
-            drop(senders);
+        // Close the channels so each worker's stream terminates and it returns its index.
+        drop(senders);
 
-            // Join workers before surfacing any replay failure, so none outlive a failed init.
-            let joined = join_all(handles).await;
-            routing_result?;
+        // Join workers before surfacing any replay failure, so none outlive a failed init.
+        let joined = join_all(handles).await;
+        routing_result?;
 
-            // Install each worker's partition range into self. Each worker carries its own
-            // partition offset, so installation needs no range arguments.
-            let mut total_items = 0i64;
-            for handle in joined {
-                let mut worker_index = handle??;
-                total_items += self.install_range(&mut worker_index);
-            }
+        // Install each worker's partition range into self. Each worker carries its own
+        // partition offset, so installation needs no range arguments.
+        let mut total_items = 0i64;
+        for handle in joined {
+            let mut worker_index = handle??;
+            total_items += self.install_range(&mut worker_index);
+        }
 
-            // Reconstruct the activity bitmap in location order: a location is active iff it is the
-            // current location of an active key, or it is the last commit. This matches the serial
-            // build's per-op push-then-clear, which leaves exactly those bits set.
-            let mut active: BitMap = BitMap::zeroes(end - floor);
-            self.for_each_value(|loc| {
-                active.set(**loc - floor, true);
-            });
-            if last_commit >= floor {
-                active.set(last_commit - floor, true);
-            }
-            for is_active in active.iter() {
-                callback(is_active, None);
-            }
+        // Reconstruct the activity bitmap in location order: a location is active iff it is the
+        // current location of an active key, or it is the last commit. This matches the serial
+        // build's per-op push-then-clear, which leaves exactly those bits set.
+        let mut active: BitMap = BitMap::zeroes(end - floor);
+        self.for_each_value(|loc| {
+            active.set(**loc - floor, true);
+        });
+        if last_commit >= floor {
+            active.set(last_commit - floor, true);
+        }
 
-            Ok(total_items as usize)
-        })
+        Ok((total_items as usize, active))
     }
 }
 

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -50,7 +50,10 @@
 //!   Ranges](https://github.com/opentimestamps/opentimestamps-server/blob/master/doc/merkle-mountain-range.md)
 
 use crate::{
-    index::{Cursor, Unordered as Index, partitioned::partition_index_and_sub_key},
+    index::{
+        Cursor, Unordered as Index,
+        partitioned::{PartitionRange, Partitioned},
+    },
     journal::{
         Error as JournalError,
         contiguous::{Contiguous, Mutable},
@@ -65,7 +68,7 @@ use crate::{
 use commonware_codec::Encode;
 use commonware_cryptography::Hasher;
 use commonware_runtime::Spawner;
-use commonware_utils::{NZUsize, bitmap::BitMap, cache::Clock, channel::mpsc};
+use commonware_utils::{bitmap::BitMap, cache::Clock, channel::mpsc};
 use core::num::NonZeroUsize;
 use futures::{StreamExt as _, future::join_all, pin_mut};
 use std::sync::Arc;
@@ -253,24 +256,20 @@ impl<F: Family> From<crate::journal::authenticated::Error<F>> for Error<F> {
     }
 }
 
-/// The size of the read buffer to use for replaying the operations log when rebuilding the
-/// snapshot. Each buffer fill pays a thread hand-off to the storage layer, so the buffer is sized
-/// to amortize that hand-off across tens of thousands of operations (at the cost of this much
-/// memory per replay).
-const SNAPSHOT_READ_BUFFER_SIZE: NonZeroUsize = NZUsize!(1 << 21);
-
 /// Builds the database's snapshot by replaying the log starting at the inactivity floor. Assumes
 /// the log is not pruned beyond the inactivity floor. The callback is invoked for each replayed
 /// operation, indicating activity status updates. The first argument of the callback is the
 /// activity status of the operation, and the second argument is the location of the operation it
 /// inactivates (if any). Returns the number of active keys in the db.
 ///
-/// `cache_size` bounds a `(location -> key)` cache that lets collision resolution resolve
-/// candidates from memory instead of re-reading the log; `None` disables it.
+/// `init_buffer` sizes the replay read buffer (in bytes). `cache_size` bounds a
+/// `(location -> key)` cache that lets collision resolution resolve candidates from memory
+/// instead of re-reading the log; `None` disables it.
 pub(super) async fn build_snapshot_from_log<F, C, I, Fn>(
     inactivity_floor_loc: crate::merkle::Location<F>,
     reader: &C,
     snapshot: &mut I,
+    init_buffer: NonZeroUsize,
     cache_size: Option<NonZeroUsize>,
     mut callback: Fn,
 ) -> Result<usize, Error<F>>
@@ -281,9 +280,7 @@ where
     Fn: FnMut(bool, Option<crate::merkle::Location<F>>),
 {
     let bounds = reader.bounds();
-    let stream = reader
-        .replay(*inactivity_floor_loc, SNAPSHOT_READ_BUFFER_SIZE)
-        .await?;
+    let stream = reader.replay(*inactivity_floor_loc, init_buffer).await?;
     pin_mut!(stream);
     let last_commit_loc = bounds.end.saturating_sub(1);
 
@@ -466,16 +463,16 @@ type RoutedBatch<K> = Vec<(K, u64, bool)>;
 /// Build one parallel-init worker's partial snapshot: apply the routed operations (streamed in log
 /// order over `rx`) to `index`, resolving translated-key collisions with the worker's own log
 /// `reader` and `(location -> key)` cache. Returns the populated worker index.
-async fn build_snapshot_worker<F, C, T, const P: usize>(
+async fn build_snapshot_worker<F, C, R>(
     log: Arc<C>,
     mut rx: mpsc::Receiver<RoutedBatch<<C::Item as Operation<F>>::Key>>,
-    mut index: crate::index::partitioned::ordered::RangeIndex<T, Location<F>, P>,
+    mut index: R,
     cache_size: Option<NonZeroUsize>,
-) -> Result<crate::index::partitioned::ordered::RangeIndex<T, Location<F>, P>, Error<F>>
+) -> Result<R, Error<F>>
 where
     F: Family,
     C: Contiguous<Item: Operation<F>>,
-    T: Translator,
+    R: PartitionRange<Value = Location<F>>,
 {
     let mut cache = cache_size.map(Clock::<u64, <C::Item as Operation<F>>::Key>::new);
     while let Some(batch) = rx.recv().await {
@@ -509,6 +506,7 @@ async fn build_snapshot_serial<F, C, I>(
     inactivity_floor_loc: Location<F>,
     reader: &C,
     snapshot: &mut I,
+    init_buffer: NonZeroUsize,
     cache_size: Option<NonZeroUsize>,
 ) -> Result<(usize, BitMap), Error<F>>
 where
@@ -524,6 +522,7 @@ where
         inactivity_floor_loc,
         reader,
         snapshot,
+        init_buffer,
         cache_size,
         |is_active, old_loc| {
             activity.push(is_active);
@@ -534,6 +533,149 @@ where
     )
     .await?;
     Ok((active_keys, activity))
+}
+
+/// Build a snapshot by splitting the log replay across parallel workers, each owning a contiguous
+/// range of the index's partitions (see [Partitioned]). Returns the number of active keys and
+/// the activity bitmap (see [SnapshotBuild::build_snapshot]).
+async fn build_snapshot_parallel<F, E, C, I>(
+    snapshot: &mut I,
+    context: E,
+    inactivity_floor_loc: Location<F>,
+    log: &Arc<C>,
+    init_concurrency: NonZeroUsize,
+    init_buffer: NonZeroUsize,
+    cache_size: Option<NonZeroUsize>,
+) -> Result<(usize, BitMap), Error<F>>
+where
+    F: Family,
+    E: Spawner,
+    C: Contiguous<Item: Operation<F>> + 'static,
+    I: Partitioned + Index<Value = Location<F>>,
+{
+    let count = snapshot.partition_count();
+    let workers = (init_concurrency.get() - 1).min(count);
+
+    // No workers: build on this task.
+    if workers == 0 {
+        return build_snapshot_serial(
+            inactivity_floor_loc,
+            &**log,
+            snapshot,
+            init_buffer,
+            cache_size,
+        )
+        .await;
+    }
+
+    let floor = *inactivity_floor_loc;
+    let range_size = count.div_ceil(workers);
+
+    // `range_size` rounds up, so `range_size * workers` can exceed `count`, leaving trailing
+    // ranges empty (and a naive `count - lo` would underflow). Reduce to the number of
+    // non-empty ranges so routing (`p / range_size`) stays in `[0, workers)`.
+    let workers = count.div_ceil(range_size);
+    let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
+
+    // Spawn one worker per contiguous partition range, each owning its own reader and cache.
+    let mut senders = Vec::with_capacity(workers);
+    let mut handles = Vec::with_capacity(workers);
+    for w in 0..workers {
+        let (tx, rx) = mpsc::channel(SNAPSHOT_CHANNEL_DEPTH);
+        senders.push(tx);
+        let log = log.clone();
+
+        // This worker owns the contiguous partition range [lo, lo + range_len). It allocates
+        // only that many slots, so per-worker memory is the range, not the full partition set.
+        let lo = w * range_size;
+        let range_len = range_size.min(count - lo);
+        let worker_index = snapshot.new_range(lo, range_len);
+        let handle = context
+            .child("snapshot_worker")
+            .with_attribute("worker", w)
+            .dedicated()
+            .spawn(move |_| {
+                build_snapshot_worker::<F, C, I::Range>(log, rx, worker_index, per_worker_cache)
+            });
+        handles.push(handle);
+    }
+
+    // Replay the log once and route each keyed op to the worker owning its partition.
+    // Routing runs in an inner future so any replay failure is captured rather than
+    // returned immediately: returning while the worker handles are merely dropped would
+    // leave the workers running detached, retaining the log and their range allocations
+    // after init has already failed. The stream is also released before the join.
+    let end = log.bounds().end;
+    let routing_result: Result<(), Error<F>> = async {
+        let stream = log.replay(floor, init_buffer).await?;
+        pin_mut!(stream);
+        let mut batches: Vec<RoutedBatch<_>> = (0..workers)
+            .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
+            .collect();
+
+        // A closed channel means a worker terminated early (e.g. returned an `Error<F>`
+        // while resolving a collision). Stop routing on the first such send failure and
+        // let the join below surface that worker's error, rather than panicking on the
+        // send.
+        while let Some(result) = stream.next().await {
+            let (loc, op) = result?;
+            let is_delete = op.is_delete();
+            let Some(key) = op.into_key() else { continue };
+            let w = I::partition_of(key.as_ref()) / range_size;
+            batches[w].push((key, loc, is_delete));
+            if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
+                let batch =
+                    std::mem::replace(&mut batches[w], Vec::with_capacity(SNAPSHOT_ROUTE_BATCH));
+                if senders[w].send(batch).await.is_err() {
+                    return Ok(());
+                }
+            }
+        }
+
+        // Flush remaining batches before the channels close.
+        for (w, batch) in batches.into_iter().enumerate() {
+            if !batch.is_empty() && senders[w].send(batch).await.is_err() {
+                break;
+            }
+        }
+        Ok(())
+    }
+    .await;
+
+    // Close the channels so each worker's stream terminates and it returns its index.
+    drop(senders);
+
+    // Join workers before surfacing any replay failure, so none outlive a failed init.
+    let joined = join_all(handles).await;
+    routing_result?;
+
+    // Install each worker's partition range into the snapshot. Each worker carries its own
+    // partition offset, so installation needs no range arguments.
+    for handle in joined {
+        let worker_index = handle??;
+        snapshot.install_range(worker_index);
+    }
+
+    // Reconstruct the activity bitmap in location order: a location is active iff it is the
+    // current location of an active key, or it is the last commit. This matches the serial
+    // build's per-op push-then-clear, which leaves exactly those bits set. Each active key
+    // holds exactly one location in the snapshot, so the same walk counts the active keys.
+    let mut total_items = 0;
+    let mut active: BitMap = BitMap::zeroes(end - floor);
+    snapshot.for_each_value(|loc| {
+        active.set(**loc - floor, true);
+        total_items += 1;
+    });
+
+    // The last operation is the final commit (a log always ends with one), which stays active.
+    // An empty log has none.
+    if let Some(last_commit) = end.checked_sub(1)
+        && last_commit >= floor
+    {
+        active.set(last_commit - floor, true);
+    }
+
+    Ok((total_items, active))
 }
 
 /// Builds a database's snapshot index from the operations log.
@@ -547,14 +689,17 @@ where
 pub trait SnapshotBuild<F: Family>:
     sealed::SnapshotBuildSealed + Index<Value = Location<F>> + Sized + 'static
 {
+    /// The build's concurrency knob: `()` for index types that build serially, and a task count
+    /// for index types that build in parallel (including the calling task, so `1` builds
+    /// entirely on the calling task).
+    type Concurrency: Copy + Send + 'static;
+
     /// Replay `log` from `inactivity_floor_loc`, populating `self`. Returns the number of active
     /// keys and the activity status of every replayed location, in location order: a location's
     /// bit is set iff it holds the current operation of an active key or is the last commit.
     ///
-    /// `init_concurrency` bounds how many tasks an index type that builds in parallel uses,
-    /// including the calling task (`1` builds entirely on the calling task). Index types that
-    /// build serially ignore it. `cache_size` bounds each build's `(location -> key)` cache
-    /// (`None` disables it).
+    /// `init_buffer` sizes the replay read buffer (in bytes), and `cache_size` bounds each
+    /// build's `(location -> key)` cache (`None` disables it).
     // In-crate callers await this future at concrete index types, so the flexibility an explicit
     // `Send` bound on the returned future would add is unused.
     #[allow(async_fn_in_trait)]
@@ -563,22 +708,15 @@ pub trait SnapshotBuild<F: Family>:
         _context: E,
         inactivity_floor_loc: Location<F>,
         log: &Arc<C>,
-        init_concurrency: NonZeroUsize,
+        _init_concurrency: Self::Concurrency,
+        init_buffer: NonZeroUsize,
         cache_size: Option<NonZeroUsize>,
     ) -> Result<(usize, BitMap), Error<F>>
     where
         E: Spawner,
         C: Contiguous<Item: Operation<F>> + 'static,
     {
-        // This index type builds serially, so `init_concurrency` has no effect. Warn on an
-        // explicit concurrency rather than silently ignore it.
-        if init_concurrency.get() > 1 {
-            tracing::warn!(
-                init_concurrency,
-                "init_concurrency configured but this index builds serially; ignoring"
-            );
-        }
-        build_snapshot_serial(inactivity_floor_loc, &**log, self, cache_size).await
+        build_snapshot_serial(inactivity_floor_loc, &**log, self, init_buffer, cache_size).await
     }
 }
 
@@ -598,141 +736,72 @@ mod sealed {
     }
 }
 
-impl<F: Family, T: Translator> SnapshotBuild<F> for crate::index::unordered::Index<T, Location<F>> {}
-impl<F: Family, T: Translator> SnapshotBuild<F> for crate::index::ordered::Index<T, Location<F>> {}
-impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
-    for crate::index::partitioned::unordered::Index<T, Location<F>, P>
-{
+impl<F: Family, T: Translator> SnapshotBuild<F> for crate::index::unordered::Index<T, Location<F>> {
+    type Concurrency = ();
+}
+impl<F: Family, T: Translator> SnapshotBuild<F> for crate::index::ordered::Index<T, Location<F>> {
+    type Concurrency = ();
 }
 
 impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
-    for crate::index::partitioned::ordered::Index<T, Location<F>, P>
+    for crate::index::partitioned::unordered::Index<T, Location<F>, P>
 {
+    type Concurrency = NonZeroUsize;
+
     async fn build_snapshot<E, C>(
         &mut self,
         context: E,
         inactivity_floor_loc: Location<F>,
         log: &Arc<C>,
         init_concurrency: NonZeroUsize,
+        init_buffer: NonZeroUsize,
         cache_size: Option<NonZeroUsize>,
     ) -> Result<(usize, BitMap), Error<F>>
     where
         E: Spawner,
         C: Contiguous<Item: Operation<F>> + 'static,
     {
-        let count = self.partition_count();
-        let workers = (init_concurrency.get() - 1).min(count);
+        build_snapshot_parallel(
+            self,
+            context,
+            inactivity_floor_loc,
+            log,
+            init_concurrency,
+            init_buffer,
+            cache_size,
+        )
+        .await
+    }
+}
 
-        // No workers: build on this task.
-        if workers == 0 {
-            return build_snapshot_serial(inactivity_floor_loc, &**log, self, cache_size).await;
-        }
+impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
+    for crate::index::partitioned::ordered::Index<T, Location<F>, P>
+{
+    type Concurrency = NonZeroUsize;
 
-        let floor = *inactivity_floor_loc;
-        let range_size = count.div_ceil(workers);
-
-        // `range_size` rounds up, so `range_size * workers` can exceed `count`, leaving trailing
-        // ranges empty (and a naive `count - lo` would underflow). Reduce to the number of
-        // non-empty ranges so routing (`p / range_size`) stays in `[0, workers)`.
-        let workers = count.div_ceil(range_size);
-        let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
-
-        // Spawn one worker per contiguous partition range, each owning its own reader and cache.
-        let mut senders = Vec::with_capacity(workers);
-        let mut handles = Vec::with_capacity(workers);
-        for w in 0..workers {
-            let (tx, rx) = mpsc::channel(SNAPSHOT_CHANNEL_DEPTH);
-            senders.push(tx);
-            let log = log.clone();
-
-            // This worker owns the contiguous partition range [lo, lo + range_len). It allocates
-            // only that many slots, so per-worker memory is the range, not the full partition set.
-            let lo = w * range_size;
-            let range_len = range_size.min(count - lo);
-            let worker_index = self.new_range(lo, range_len);
-            let handle = context
-                .child("snapshot_worker")
-                .with_attribute("worker", w)
-                .shared(true)
-                .spawn(move |_| {
-                    build_snapshot_worker::<F, C, T, P>(log, rx, worker_index, per_worker_cache)
-                });
-            handles.push(handle);
-        }
-
-        // Replay the log once and route each keyed op to the worker owning its partition.
-        // Routing runs in an inner future so any replay failure is captured rather than
-        // returned immediately: returning while the worker handles are merely dropped would
-        // leave the workers running detached, retaining the log and their range allocations
-        // after init has already failed. The stream is also released before the join.
-        let end = log.bounds().end;
-        let last_commit = end.saturating_sub(1);
-        let routing_result: Result<(), Error<F>> = async {
-            let stream = log.replay(floor, SNAPSHOT_READ_BUFFER_SIZE).await?;
-            pin_mut!(stream);
-            let mut batches: Vec<RoutedBatch<_>> = (0..workers)
-                .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
-                .collect();
-
-            // A closed channel means a worker terminated early (e.g. returned an `Error<F>`
-            // while resolving a collision). Stop routing on the first such send failure and
-            // let the join below surface that worker's error, rather than panicking on the
-            // send.
-            while let Some(result) = stream.next().await {
-                let (loc, op) = result?;
-                let is_delete = op.is_delete();
-                let Some(key) = op.into_key() else { continue };
-                let (p, _) = partition_index_and_sub_key::<P>(key.as_ref());
-                let w = p / range_size;
-                batches[w].push((key, loc, is_delete));
-                if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
-                    let batch = std::mem::replace(
-                        &mut batches[w],
-                        Vec::with_capacity(SNAPSHOT_ROUTE_BATCH),
-                    );
-                    if senders[w].send(batch).await.is_err() {
-                        return Ok(());
-                    }
-                }
-            }
-
-            // Flush remaining batches before the channels close.
-            for (w, batch) in batches.into_iter().enumerate() {
-                if !batch.is_empty() && senders[w].send(batch).await.is_err() {
-                    break;
-                }
-            }
-            Ok(())
-        }
-        .await;
-
-        // Close the channels so each worker's stream terminates and it returns its index.
-        drop(senders);
-
-        // Join workers before surfacing any replay failure, so none outlive a failed init.
-        let joined = join_all(handles).await;
-        routing_result?;
-
-        // Install each worker's partition range into self. Each worker carries its own
-        // partition offset, so installation needs no range arguments.
-        let mut total_items = 0;
-        for handle in joined {
-            let worker_index = handle??;
-            total_items += self.install_range(worker_index);
-        }
-
-        // Reconstruct the activity bitmap in location order: a location is active iff it is the
-        // current location of an active key, or it is the last commit. This matches the serial
-        // build's per-op push-then-clear, which leaves exactly those bits set.
-        let mut active: BitMap = BitMap::zeroes(end - floor);
-        self.for_each_value(|loc| {
-            active.set(**loc - floor, true);
-        });
-        if last_commit >= floor {
-            active.set(last_commit - floor, true);
-        }
-
-        Ok((total_items, active))
+    async fn build_snapshot<E, C>(
+        &mut self,
+        context: E,
+        inactivity_floor_loc: Location<F>,
+        log: &Arc<C>,
+        init_concurrency: NonZeroUsize,
+        init_buffer: NonZeroUsize,
+        cache_size: Option<NonZeroUsize>,
+    ) -> Result<(usize, BitMap), Error<F>>
+    where
+        E: Spawner,
+        C: Contiguous<Item: Operation<F>> + 'static,
+    {
+        build_snapshot_parallel(
+            self,
+            context,
+            inactivity_floor_loc,
+            log,
+            init_concurrency,
+            init_buffer,
+            cache_size,
+        )
+        .await
     }
 }
 

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -689,9 +689,8 @@ where
 pub trait SnapshotBuild<F: Family>:
     sealed::SnapshotBuildSealed + Index<Value = Location<F>> + Sized + 'static
 {
-    /// The build's concurrency knob: `()` for index types that build serially, and a task count
-    /// for index types that build in parallel (including the calling task, so `1` builds
-    /// entirely on the calling task).
+    /// The concurrency configuration the build consumes. Index types that always build serially
+    /// declare `()`, so a setting they cannot use is unrepresentable.
     type Concurrency: Copy + Send + 'static;
 
     /// Replay `log` from `inactivity_floor_loc`, populating `self`. Returns the number of active

--- a/storage/src/qmdb/operation.rs
+++ b/storage/src/qmdb/operation.rs
@@ -22,6 +22,9 @@ pub trait Operation<F: Family> {
     /// Returns the key if this operation involves a key, None otherwise.
     fn key(&self) -> Option<&Self::Key>;
 
+    /// Consumes the operation and returns its owned key, if any.
+    fn into_key(self) -> Option<Self::Key>;
+
     /// If this operation updates its key's value.
     fn is_update(&self) -> bool;
 

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -32,6 +32,7 @@
 //!         },
 //!         translator: TwoCap,
 //!         init_cache_size: Some(NZUsize!(1 << 16)),
+//!         init_buffer: NZUsize!(1 << 21),
 //!     };
 //!     let db =
 //!         Db::<_, Digest, Digest, TwoCap>::init(ctx.child("store"), config)
@@ -118,6 +119,9 @@ pub struct Config<T: Translator, C> {
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
+
+    /// Size (in bytes) of the read buffer used to replay the log during init.
+    pub init_buffer: NonZeroUsize,
 }
 
 /// A finalized batch of writes and deletes ready to be applied to the store.
@@ -395,6 +399,7 @@ where
 
         // Build the snapshot.
         let cache_size = cfg.init_cache_size;
+        let init_buffer = cfg.init_buffer;
         let mut snapshot = Index::new(context.child("snapshot"), cfg.translator);
         let (inactivity_floor_loc, active_keys) = {
             let op = log.read(*last_commit_loc).await?;
@@ -408,6 +413,7 @@ where
                 inactivity_floor_loc,
                 &log,
                 &mut snapshot,
+                init_buffer,
                 cache_size,
                 |_, _| {},
             )
@@ -564,6 +570,7 @@ mod test {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            init_buffer: NZUsize!(1 << 21),
         };
         TestStore::init(context, cfg).await.unwrap()
     }


### PR DESCRIPTION
## Summary

Parallelizes QMDB snapshot reconstruction (`init`) for the partitioned indexes (both the ordered and unordered variants). The main task replays the operations log once and routes each operation to one of N worker tasks by partition; workers read through a shared `Arc` of the log, and each owns its own `(location -> key)` cache and builds a disjoint partition range. The main task then merges the ranges and rebuilds the activity bitmap.

Builds on the init read cache (#4098, now merged into main): each worker gets its own conflict-free key cache, so init parallelizes with no lock contention and no cross-worker eviction (see #4098's "Why not just cache the replayed pages?").

## Design

- **Routing.** `partition_index_and_sub_key::<P>` maps each key to a partition; worker `w` owns a contiguous partition range. Two keys that can collide in the index share the partition prefix and capped sub-key, so all colliding ops route to the same worker; each worker resolves its own collisions in isolation, identically to the serial walk.
- **Per-worker state.** Workers read through a shared `Arc` of the log (concurrent reads, nothing writes the log during init; sole ownership is reclaimed after the build), and each holds its own `Clock<u64, Key>` cache (`init_cache_size / workers` each). The `(location -> key)` mapping is immutable, so caches never go stale and are conflict-free across workers (disjoint key sets).
- **Range-only workers.** A worker allocates only its partition range (`Index::new_range`), addressed by the global partition index via an `offset`, so P=3 (2^24 partitions) is affordable: per-worker memory is its range, not the full partition set.
- **Merge.** Main joins the workers, installs each range into `self`, and rebuilds the activity bitmap in location order. The result is independent of worker join order (deterministic).
- **Pump throughput.** The init task is the pump: replay reads through a 2 MiB buffer (amortizing the per-refill thread hand-off to the storage layer), op decode validates zero padding a chunk at a time, and the activity bitmap installs into the shared bitmap under a single lock acquisition after the build.
- **Failure drain.** If replay fails mid-route, the error is captured, the channels are closed, and every worker is joined before the error is returned, so no worker outlives a failed init or retains the log after it. A regression injects a read fault into the replay stream and asserts the log has a single owner when the build returns.

## Configurable

`init_concurrency` on the `any`/`current` configs counts the tasks that build the snapshot, including the init task, which always replays and routes the log (`NonZeroUsize`: the init task always participates):

- `1`: build entirely on the init task, no worker tasks.
- `n`: spawn `n - 1` worker tasks. The effective worker count never exceeds the partition count, and because partition ranges are fixed-width (except possibly the final range) it can round down (256 partitions at `init_concurrency = 201` build with 128 workers of two partitions each). `2` still de-interleaves the build from the replay onto its own task.

No derived/automatic count is offered: the plateau below makes a fixed small count the right choice everywhere, which keeps the snapshot build decoupled from the `Strategy` entirely.

Both partitioned index variants (ordered and unordered) consume it; the non-partitioned indexes build serially regardless. State-sync rebuilds honor the configured `init_concurrency`.

## Correctness

Equivalence tests (`any/ordered/fixed.rs`) populate a churny database and reopen it across a range of `init_concurrency` settings (`1`, single- and multi-worker counts, counts that round down to fewer workers, and counts above the partition count that clamp), asserting identical roots in every case (serial == parallel). `_p1`/`_p2` run in CI; `_p3` is `#[ignore]` (large allocation). The unordered partitioned index has matching equivalence coverage at P1 (`any/unordered/fixed.rs` and the `current` variant); its P2 (65,536 sub-indexes) is too memory-heavy for the suite. A matching test on the `current` variant covers the activity-bitmap reconstruction specifically: the current root commits to the bitmap, so it verifies the parallel build's `for_each_value` + last-commit recompute against the serial path. Determinism holds across runs with the same seed.

## Benchmarks (warm OS cache, P=3, full-coverage init cache)

Reopen time vs `init_concurrency` on two 50M-keyspace / 250M-update DBs (Linux x86_64, AMD EPYC 9354P). Each datapoint is one `init` in a fresh process (what a restart actually pays) with the OS file cache warm; values are the mean of two interleaved rounds:

| init_concurrency | uniform (R=64.6M) | zipf (R=38.2M) |
|---|---|---|
| `1` (serial) | 47.7 s | 28.7 s |
| `2` | 36.0 s (**1.3x**) | 22.1 s (**1.3x**) |
| `3` | 18.4 s (**2.6x**) | 11.1 s (**2.6x**) |
| `5` | 15.2 s (**3.1x**) | 9.9 s (**2.9x**) |
| `8` | 14.8 s (**3.2x**) | 8.7 s (**3.3x**) |

One additional worker alone (`init_concurrency = 2`) beats serial: moving the index build off the init task de-interleaves two dissimilar workloads (op decode vs index build) that otherwise thrash a single core. Returns then diminish past ~2 workers and flatten by ~4 (`init_concurrency` ~3-5): the floor is the init task's serial replay + per-op routing (decode-dominated), which the workers hide under once there are enough of them; further workers mostly idle. The unordered partitioned index is apply-bound the same way and parallelizes comparably (measured post-merge, same 50M/250M scale, `any::unordered::fixed` P=2): ~1.4x at `init_concurrency = 2`, ~3x at `3`, and ~3.9x (uniform) / ~4.2x (zipf) at `8`.

```
cargo bench -p commonware-storage --bench init_scale --features test-traits -- generate /tmp/db 50000000 250000000 0   # uniform (omit the 0 for Zipf)
cargo bench -p commonware-storage --bench init_scale --features test-traits -- bench    /tmp/db <cache> <parallelism>  # one reopen per invocation
```

## Notes

- Profiling reveals we could get better performance with a replay mode that decoded only keys; values provided by replay are not required by the init replay task.

---

_Edited post-merge to correct the scope: the parallel build covers both partitioned index variants (ordered and unordered), not the ordered variant alone. The merge commit message on `main` is unchanged._
