### PR TITLE
[storage/merkle] Positionless node hashing with domain-separated merge

### DIFF
--- a/cryptography/src/blake3/mod.rs
+++ b/cryptography/src/blake3/mod.rs
@@ -39,6 +39,10 @@ pub type CoreBlake3 = blake3::Hasher;
 
 const DIGEST_LENGTH: usize = blake3::OUT_LEN;
 
+/// Context string for [`Blake3::merge_digest_pair`]'s key-derivation mode, domain-separating
+/// digest-pair hashing from standard hashing.
+const MERGE_CONTEXT: &str = "_COMMONWARE_CRYPTOGRAPHY_MERGE_DIGEST_PAIR";
+
 /// BLAKE3 hasher.
 #[cfg_attr(
     feature = "blake3-parallel",
@@ -87,6 +91,17 @@ impl Hasher for Blake3 {
     fn reset(&mut self) -> &mut Self {
         self.hasher = CoreBlake3::new();
         self
+    }
+
+    fn merge_digest_pair(&mut self, left: &Self::Digest, right: &Self::Digest) -> Self::Digest {
+        // Domain-separate digest-pair hashing from standard hashing via BLAKE3's key-derivation
+        // mode. Its finalization flags differ from a plain `hash`, so a merge output cannot equal a
+        // `hash` output except by a generic collision, uniformly for any input length.
+        let mut hasher = CoreBlake3::new_derive_key(MERGE_CONTEXT);
+        hasher.update(left.as_ref());
+        hasher.update(right.as_ref());
+        let array: [u8; DIGEST_LENGTH] = hasher.finalize().into();
+        Self::Digest::from(array)
     }
 }
 
@@ -210,6 +225,29 @@ mod tests {
     #[test]
     fn test_blake3_len() {
         assert_eq!(Digest::SIZE, DIGEST_LENGTH);
+    }
+
+    #[test]
+    fn merge_digest_pair_domain_separated() {
+        let mut hasher = Blake3::new();
+        let left = Blake3::hash(b"left");
+        let right = Blake3::hash(b"right");
+
+        let merged = hasher.merge_digest_pair(&left, &right);
+
+        // Deterministic and order-sensitive.
+        assert_eq!(merged, hasher.merge_digest_pair(&left, &right));
+        assert_ne!(merged, hasher.merge_digest_pair(&right, &left));
+
+        // Domain-separated from standard hashing: the plain hash of `left || right` must differ.
+        assert_ne!(merged, hasher.hash_digest_pair(&left, &right));
+
+        // Pins the key-derivation construction (and thus the domain context).
+        let mut kd = CoreBlake3::new_derive_key(MERGE_CONTEXT);
+        kd.update(left.as_ref());
+        kd.update(right.as_ref());
+        let expected: [u8; DIGEST_LENGTH] = kd.finalize().into();
+        assert_eq!(merged.as_ref(), expected);
     }
 
     #[test]

--- a/cryptography/src/crc32/mod.rs
+++ b/cryptography/src/crc32/mod.rs
@@ -92,6 +92,13 @@ impl Hasher for Crc32 {
         self.inner = crc_fast::Digest::new(ALGORITHM);
         self
     }
+
+    /// CRC32 is a non-cryptographic checksum and cannot provide the domain separation
+    /// [`Hasher::merge_digest_pair`] requires; this delegates to [`Hasher::hash_digest_pair`] and
+    /// must not be relied upon for authenticated structures.
+    fn merge_digest_pair(&mut self, left: &Self::Digest, right: &Self::Digest) -> Self::Digest {
+        self.hash_digest_pair(left, right)
+    }
 }
 
 /// Digest of a CRC32 hashing operation (4 bytes).

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -396,11 +396,13 @@ commonware_macros::stability_scope!(BETA {
         /// without an explicit domain tag.
         ///
         /// Implementations MUST achieve this via a construction `hash` cannot reproduce. SHA-256
-        /// compresses the 64-byte `l || r` block from a distinct initial state, so its output cannot
-        /// coincide with a finalized `hash` (which starts from the standard initial state) except by
-        /// a generic collision, uniformly for any input length. The default below delegates to
-        /// [`Hasher::hash_digest_pair`] and does NOT provide this separation; a hasher that relies on
-        /// the default must not be used where this property is required.
+        /// compresses the 64-byte `l || r` block from a distinct initial state, and BLAKE3 uses its
+        /// key-derivation mode; either output cannot coincide with a finalized `hash` except by a
+        /// generic collision, uniformly for any input length. The default below delegates to
+        /// [`Hasher::hash_digest_pair`] and does NOT provide this separation; it exists only for
+        /// non-cryptographic hashers (e.g. checksums) that make no such guarantee, and a hasher that
+        /// relies on it must not be used where this property is required. Any cryptographic hasher
+        /// intended for use in authenticated structures must override it.
         #[doc(hidden)]
         #[inline]
         fn merge_digest_pair(

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -395,23 +395,20 @@ commonware_macros::stability_scope!(BETA {
         /// caller use digest-pair hashing and standard hashing for distinct roles in one structure
         /// without an explicit domain tag.
         ///
-        /// Implementations MUST achieve this via a construction `hash` cannot reproduce. SHA-256
-        /// compresses the 64-byte `l || r` block from a distinct initial state, and BLAKE3 uses its
-        /// key-derivation mode; either output cannot coincide with a finalized `hash` except by a
-        /// generic collision, uniformly for any input length. The default below delegates to
-        /// [`Hasher::hash_digest_pair`] and does NOT provide this separation; it exists only for
-        /// non-cryptographic hashers (e.g. checksums) that make no such guarantee, and a hasher that
-        /// relies on it must not be used where this property is required. Any cryptographic hasher
-        /// intended for use in authenticated structures must override it.
+        /// Cryptographic implementations MUST achieve this via a construction `hash` cannot
+        /// reproduce: SHA-256 compresses the 64-byte `l || r` block from a distinct initial state,
+        /// and BLAKE3 uses its key-derivation mode; either output cannot coincide with a finalized
+        /// `hash` except by a generic collision, uniformly for any input length. Non-cryptographic
+        /// hashers (e.g. checksums) cannot offer this separation and may delegate to
+        /// [`Hasher::hash_digest_pair`], but must not be used where it is required (e.g.
+        /// authenticated structures). There is intentionally no default: every hasher states this
+        /// choice explicitly.
         #[doc(hidden)]
-        #[inline]
         fn merge_digest_pair(
             &mut self,
             left: &Self::Digest,
             right: &Self::Digest,
-        ) -> Self::Digest {
-            self.hash_digest_pair(left, right)
-        }
+        ) -> Self::Digest;
     }
 });
 

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -387,7 +387,20 @@ commonware_macros::stability_scope!(BETA {
             self.hash_parts([left.as_ref(), right.as_ref()])
         }
 
-        /// Merge two Merkle child digests.
+        /// Hash a pair of digests, domain-separated from [`Hasher::hash`].
+        ///
+        /// Unlike [`Hasher::hash_digest_pair`], this carries a security contract: its output must be
+        /// domain-separated from standard hashing, i.e. it must be infeasible to find a byte string
+        /// `x` and digests `(l, r)` such that `hash(x) == merge_digest_pair(l, r)`. This lets a
+        /// caller use digest-pair hashing and standard hashing for distinct roles in one structure
+        /// without an explicit domain tag.
+        ///
+        /// Implementations MUST achieve this via a construction `hash` cannot reproduce. SHA-256
+        /// compresses the 64-byte `l || r` block from a distinct initial state, so its output cannot
+        /// coincide with a finalized `hash` (which starts from the standard initial state) except by
+        /// a generic collision, uniformly for any input length. The default below delegates to
+        /// [`Hasher::hash_digest_pair`] and does NOT provide this separation; a hasher that relies on
+        /// the default must not be used where this property is required.
         #[doc(hidden)]
         #[inline]
         fn merge_digest_pair(
@@ -396,18 +409,6 @@ commonware_macros::stability_scope!(BETA {
             right: &Self::Digest,
         ) -> Self::Digest {
             self.hash_digest_pair(left, right)
-        }
-
-        /// Hash a `u64` followed by two digests.
-        #[doc(hidden)]
-        #[inline]
-        fn hash_u64_digest_pair(
-            &mut self,
-            prefix: u64,
-            left: &Self::Digest,
-            right: &Self::Digest,
-        ) -> Self::Digest {
-            self.hash_parts([prefix.to_be_bytes().as_slice(), left.as_ref(), right.as_ref()])
         }
     }
 });

--- a/cryptography/src/sha256/benches/bench.rs
+++ b/cryptography/src/sha256/benches/bench.rs
@@ -1,5 +1,6 @@
 use criterion::criterion_main;
 
+mod digest_pair;
 mod hash_message;
 
-criterion_main!(hash_message::benches);
+criterion_main!(digest_pair::benches, hash_message::benches);

--- a/cryptography/src/sha256/benches/digest_pair.rs
+++ b/cryptography/src/sha256/benches/digest_pair.rs
@@ -1,0 +1,23 @@
+use commonware_cryptography::{Hasher, Sha256};
+use criterion::{criterion_group, Criterion};
+use std::hint::black_box;
+
+/// Compares the per-call cost of the digest-pair primitives. `merge_digest_pair` (the Merkle node
+/// hash) is a single compression block, whereas `hash_digest_pair` (a full hash of `left || right`)
+/// spans two.
+fn bench_digest_pair(c: &mut Criterion) {
+    let left = Sha256::hash(b"left");
+    let right = Sha256::hash(b"right");
+
+    c.bench_function(&format!("{}/op=merge_digest_pair", module_path!()), |b| {
+        let mut hasher = Sha256::new();
+        b.iter(|| black_box(hasher.merge_digest_pair(black_box(&left), black_box(&right))));
+    });
+
+    c.bench_function(&format!("{}/op=hash_digest_pair", module_path!()), |b| {
+        let mut hasher = Sha256::new();
+        b.iter(|| black_box(hasher.hash_digest_pair(black_box(&left), black_box(&right))));
+    });
+}
+
+criterion_group!(benches, bench_digest_pair);

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -49,6 +49,17 @@ const INITIAL_STATE: [u32; 8] = [
     0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
 ];
 
+/// Initial compression state for [`Sha256::merge_digest_pair`], distinct from [`INITIAL_STATE`] so
+/// that digest-pair hashing is domain-separated from standard hashing. Because the compression
+/// starts from a different state, a `merge_digest_pair` output cannot equal a `hash` output even
+/// when their 64-byte input blocks coincide, so the two digest spaces are separated uniformly
+/// (independent of the hashed input's length). Equals
+/// `SHA256("_COMMONWARE_CRYPTOGRAPHY_MERGE_DIGEST_PAIR")` read as eight big-endian words; the
+/// `merge_iv_matches_domain` test pins this derivation.
+const MERGE_IV: [u32; 8] = [
+    0xcbe2f185, 0x094bef84, 0xdeaef739, 0xee6a5c3d, 0xd66c3491, 0x3734e4f4, 0xc80b471d, 0xfd7501a6,
+];
+
 /// SHA-256 hasher.
 #[derive(Debug)]
 pub struct Sha256 {
@@ -182,24 +193,13 @@ impl Hasher for Sha256 {
         write_scratch(&mut self.scratch[..32], left.as_ref());
         write_scratch(&mut self.scratch[32..64], right.as_ref());
 
-        let mut state = INITIAL_STATE;
+        // Start from MERGE_IV (not INITIAL_STATE) to domain-separate digest-pair hashing from
+        // standard hashing.
+        let mut state = MERGE_IV;
         let (blocks, remainder) = self.scratch[..BLOCK_LENGTH].as_chunks::<BLOCK_LENGTH>();
         debug_assert!(remainder.is_empty());
         compress256(&mut state, blocks);
         digest_from_state(state)
-    }
-
-    #[inline]
-    fn hash_u64_digest_pair(
-        &mut self,
-        prefix: u64,
-        left: &Self::Digest,
-        right: &Self::Digest,
-    ) -> Self::Digest {
-        write_scratch(&mut self.scratch[..8], &prefix.to_be_bytes());
-        write_scratch(&mut self.scratch[8..40], left.as_ref());
-        write_scratch(&mut self.scratch[40..72], right.as_ref());
-        finalize_fixed_72(&mut self.scratch)
     }
 }
 
@@ -221,19 +221,6 @@ fn finalize_fixed_64(scratch: &mut [u8; SCRATCH_LEN]) -> Digest {
     scratch[64] = 0x80;
     scratch[65..120].fill(0);
     write_scratch(&mut scratch[120..128], &[0, 0, 0, 0, 0, 0, 0x02, 0x00]);
-
-    let mut state = INITIAL_STATE;
-    let (blocks, remainder) = scratch[..SCRATCH_LEN].as_chunks::<BLOCK_LENGTH>();
-    debug_assert!(remainder.is_empty());
-    compress256(&mut state, blocks);
-    digest_from_state(state)
-}
-
-#[inline]
-fn finalize_fixed_72(scratch: &mut [u8; SCRATCH_LEN]) -> Digest {
-    scratch[72] = 0x80;
-    scratch[73..120].fill(0);
-    write_scratch(&mut scratch[120..128], &[0, 0, 0, 0, 0, 0, 0x02, 0x40]);
 
     let mut state = INITIAL_STATE;
     let (blocks, remainder) = scratch[..SCRATCH_LEN].as_chunks::<BLOCK_LENGTH>();
@@ -374,6 +361,17 @@ mod tests {
     const HELLO_DIGEST: [u8; DIGEST_LENGTH] = commonware_formatting::hex!(
         "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
     );
+
+    #[test]
+    fn merge_iv_matches_domain() {
+        // MERGE_IV is the domain string's digest read as eight big-endian words.
+        let digest = Sha256::hash(b"_COMMONWARE_CRYPTOGRAPHY_MERGE_DIGEST_PAIR");
+        let mut expected = [0u32; 8];
+        for (word, chunk) in expected.iter_mut().zip(digest.as_ref().chunks_exact(4)) {
+            *word = u32::from_be_bytes(chunk.try_into().unwrap());
+        }
+        assert_eq!(MERGE_IV, expected);
+    }
 
     #[test]
     fn test_sha256() {

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1154,7 +1154,6 @@ mod tests {
             let hasher = commonware_storage::qmdb::hasher::<Sha256>();
             let proof = guard.exclusion_proof(&hasher, &missing).await.unwrap();
             assert!(OrderedFixedDb::verify_exclusion_proof(
-                &hasher,
                 &missing,
                 &proof,
                 &guard.root(),
@@ -1198,7 +1197,6 @@ mod tests {
             let hasher = commonware_storage::qmdb::hasher::<Sha256>();
             let proof = guard.exclusion_proof(&hasher, &missing).await.unwrap();
             assert!(OrderedVariableDb::verify_exclusion_proof(
-                &hasher,
                 &missing,
                 &proof,
                 &guard.root(),

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -20,7 +20,7 @@ hash = "6d6382956289a2f706581a4b1afa08c5cd8e8a4f55b11d454425333b6537cc17"
 
 ["commonware_storage::bmt::tests::conformance::RootConformance"]
 n_cases = 200
-hash = "d69c21fb12b6510115afc547263eabe543cfdae6bb7952b43df57b41337339a4"
+hash = "39f3dbed2a1b56e8b8c03e31aa151d85466686ede2de954da00c48f3bc835b96"
 
 ["commonware_storage::cache::storage::conformance::CodecConformance<Record<u64>>"]
 n_cases = 65536
@@ -72,11 +72,11 @@ hash = "506b5a02d1a7c3e249f514b889e6099c27bb0723ebc711514263f0c71f0676ef"
 
 ["commonware_storage::merkle::conformance::MmbRootStability"]
 n_cases = 200
-hash = "7db87b0f0b2d10f3571bfc38a9bb0aa0045b8ef884da5a10dd2e758f9b3399a5"
+hash = "483498d14668b3f3a3bd51f431151b2fb1e4d433f0560ac1514c471e79bc429e"
 
 ["commonware_storage::merkle::conformance::MmrRootStability"]
 n_cases = 200
-hash = "4078ce1f5e242f8edb1d41575d51e166af620404036124f8094fc74d4b401047"
+hash = "5b4154bbf2ecf52499f0cd8d8f0a5e7f816bd3bc81c8a2ee585351ef290e8266"
 
 ["commonware_storage::merkle::mmr::proof::tests::conformance::CodecConformance<Proof<Family,Sha256Digest>>"]
 n_cases = 65536
@@ -144,131 +144,131 @@ hash = "75d4969d0ba96bbfaac96c59464f1cadbb779b4ed6e85b1984f4ff8eee544cfc"
 
 ["commonware_storage::qmdb::conformance::AnyMmbOrderedFixedConf"]
 n_cases = 200
-hash = "b3c1e2f17435b89294b6fc2f9b779574dc3fe9cc1d9e86a0ba76f3bd3f9361a0"
+hash = "bc79fba4bdda2dff8eae64fd509cec9bf8235889f85243971101da28c57bf4f0"
 
 ["commonware_storage::qmdb::conformance::AnyMmbOrderedVariableConf"]
 n_cases = 200
-hash = "bf14ce04fbb2fe8b4ff0865664d1b1fe1386645f3fdb43ea00efdc739eb17a42"
+hash = "5b21cf2ea2820024da561f91923edc046301409f11b1bc23ab100642180474c7"
 
 ["commonware_storage::qmdb::conformance::AnyMmbUnorderedFixedConf"]
 n_cases = 200
-hash = "8b42c684f9b0057ce941ec49ddf91e9cf6243bef26bac30c3976180903b4659f"
+hash = "8d1950a2bcd1e1b15fa28807b5b7ddd0271f3886a12560596ded7f1b21b58e21"
 
 ["commonware_storage::qmdb::conformance::AnyMmbUnorderedVariableConf"]
 n_cases = 200
-hash = "c681dc3a211feab68a0ee817d163767cbea302f883505b64668fa4398167b7fc"
+hash = "bfe3e4441d87b45591bee63e6db466148b0de2b882e390bf7604baee3bca6082"
 
 ["commonware_storage::qmdb::conformance::AnyMmrOrderedFixedConf"]
 n_cases = 200
-hash = "2c82870cf341bd0a55cdec3114d8dee0b8033a4cc552dd1d5ab421f092496b55"
+hash = "b268a7506f433c67f5f909fa117ec0ed6ad441eb07c6a01d76f9d0f354d5ca78"
 
 ["commonware_storage::qmdb::conformance::AnyMmrOrderedVariableConf"]
 n_cases = 200
-hash = "e42304d395e9fa591637a5559c76086f86b9d2af9245ff45d31cacb2db1d65cf"
+hash = "1a10a27073d0bd51794dc211f0eebc09000d49227d3856dde7cec4a1547bc26d"
 
 ["commonware_storage::qmdb::conformance::AnyMmrUnorderedFixedConf"]
 n_cases = 200
-hash = "79c5de9509b38d619ea082cdee833f80eadfa0ef21211f69039ee2d37de07bad"
+hash = "e0ff1ed6521c0fd9e6c8686fe0a24df279ae3623e295b8ea682cc1aa760f3771"
 
 ["commonware_storage::qmdb::conformance::AnyMmrUnorderedVariableConf"]
 n_cases = 200
-hash = "22374a7cbdfa0bdac17e2e285422a54375fec27017942ef7abea2cf8da298c70"
+hash = "c1e29449602c6f9ae26440d5eb9c044d7c6c322225878b7891c93d943a1918b9"
 
 ["commonware_storage::qmdb::conformance::CurrentMmbOrderedFixedConf"]
 n_cases = 200
-hash = "f6b8828f933b6ed2db8c4ac77c9c3d88e1320274748fce5494a28c96d05aa473"
+hash = "895641a5e788939f25d32a98b7954a488092a4b571487012506369408682d7d5"
 
 ["commonware_storage::qmdb::conformance::CurrentMmbOrderedVariableConf"]
 n_cases = 200
-hash = "4c9dcee11720117c8200081712cc10e94f646117185f10d675e07a0aa91ed04c"
+hash = "5fe2d117fb439753930c670fc2b692c8b919dc17f38ee2a5e46e1b9739c753fa"
 
 ["commonware_storage::qmdb::conformance::CurrentMmbUnorderedFixedConf"]
 n_cases = 200
-hash = "84a912ffcf79d324ae07a6f12090f5b26b5618f8ebeca30b7220b045a97812cc"
+hash = "9229dfcf5962b2bb61473c77c5ddf7d56d83cf79120c03ae7fb96550349dbf3f"
 
 ["commonware_storage::qmdb::conformance::CurrentMmbUnorderedVariableConf"]
 n_cases = 200
-hash = "12160d3dc3e5ae7b0a98fcb84c7e328eab148111940fe5c3e4e1691c046e2687"
+hash = "eb796ceae11d1835b4a350507b3857fe2a5d4c262ace2386368d874959adac87"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrOrderedFixedConf"]
 n_cases = 200
-hash = "0e5264ac6a0c0d56ace9ebc986635b128f9d7a118471875ad874b08e80f66ebb"
+hash = "91119a7472b96ae9cbf895be426d0db3dd0e760c385a57a6695ca02cdd3c8849"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrOrderedVariableConf"]
 n_cases = 200
-hash = "66cd3cc0299ef062e23d4f9812d5d45896cd808ee0bc65d9745a4265895ae8b5"
+hash = "27e91685b60eddbe173df8e48c98f7eccf085220aeed54cf59cefc161245567b"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrUnorderedFixedConf"]
 n_cases = 200
-hash = "8ce052fef8ce8e4d817a2961144cf3a28aec4bd6eb75d32b013499116a6981da"
+hash = "0e4541bec5552a1ceb27a4af85aafa1e1266f873dc5cd63731285501d137f792"
 
 ["commonware_storage::qmdb::conformance::CurrentMmrUnorderedVariableConf"]
 n_cases = 200
-hash = "0d0591823b7d5ed8dcb940d086ec214062eb3cfffd018e9fbadf9e16ce8da0f7"
+hash = "57833bb2682bfdc8f6c06d1a8bca3d419abc18c59ecb4fc3a1c9d36db02d70f8"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmbCompactFixedConf"]
 n_cases = 200
-hash = "4f247819136cb0a077007db74e385fd9a0935275bb23e3fe4647b32feb6c9456"
+hash = "bc421f87c90ca77ab6a6fb29c51a4a80b48b8efb0fb2dcddf8540dec66c8c67a"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmbCompactVariableConf"]
 n_cases = 200
-hash = "612fc203d1f94a4c66a271d33b3e20aba244def32a37f2e6cba19591b6cbb9bf"
+hash = "19be1f3f093aa0e7c7aa1a7db0604efa92ab171a6b9c121f21c84057f52a6211"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmbFixedConf"]
 n_cases = 200
-hash = "4f247819136cb0a077007db74e385fd9a0935275bb23e3fe4647b32feb6c9456"
+hash = "bc421f87c90ca77ab6a6fb29c51a4a80b48b8efb0fb2dcddf8540dec66c8c67a"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmbVariableConf"]
 n_cases = 200
-hash = "612fc203d1f94a4c66a271d33b3e20aba244def32a37f2e6cba19591b6cbb9bf"
+hash = "19be1f3f093aa0e7c7aa1a7db0604efa92ab171a6b9c121f21c84057f52a6211"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmrCompactFixedConf"]
 n_cases = 200
-hash = "e7917ffa234b8a156ac3d556ae4056bf307be259b1d6afe50256adc06e4ba133"
+hash = "b8062feeafbb8a98b15b97087c11ec9e84612e9e38d9b693b920159c9235e480"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmrCompactVariableConf"]
 n_cases = 200
-hash = "e4e85deaf4b968ee4074a3e7d82edc4fe244feec4361a6c17c085302febfb6d3"
+hash = "33949200c90edd4f1324b28d145a9a2bf6073febc7ed3f5b16c7f5af1a640993"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmrFixedConf"]
 n_cases = 200
-hash = "e7917ffa234b8a156ac3d556ae4056bf307be259b1d6afe50256adc06e4ba133"
+hash = "b8062feeafbb8a98b15b97087c11ec9e84612e9e38d9b693b920159c9235e480"
 
 ["commonware_storage::qmdb::conformance::ImmutableMmrVariableConf"]
 n_cases = 200
-hash = "e4e85deaf4b968ee4074a3e7d82edc4fe244feec4361a6c17c085302febfb6d3"
+hash = "33949200c90edd4f1324b28d145a9a2bf6073febc7ed3f5b16c7f5af1a640993"
 
 ["commonware_storage::qmdb::conformance::KeylessMmbCompactFixedConf"]
 n_cases = 200
-hash = "1bd0005c478a1feeea63b709ecafadb03d67f69ce2c14cfdf9c294f51d2839c5"
+hash = "5ab6ed680f7ace732316f2408b5ed0e9a02374d270b6d5c3cd18c4b41be341e0"
 
 ["commonware_storage::qmdb::conformance::KeylessMmbCompactVariableConf"]
 n_cases = 200
-hash = "37b13e76d7bd5e2fad9d0428e3c2f04de48746d87d77c8a30c95b5a77f4db453"
+hash = "10d6b7b1a8bac24abb0c9da8ee4b9703a5156df25e5d1a415db2d493f218af29"
 
 ["commonware_storage::qmdb::conformance::KeylessMmbFixedConf"]
 n_cases = 200
-hash = "1bd0005c478a1feeea63b709ecafadb03d67f69ce2c14cfdf9c294f51d2839c5"
+hash = "5ab6ed680f7ace732316f2408b5ed0e9a02374d270b6d5c3cd18c4b41be341e0"
 
 ["commonware_storage::qmdb::conformance::KeylessMmbVariableConf"]
 n_cases = 200
-hash = "37b13e76d7bd5e2fad9d0428e3c2f04de48746d87d77c8a30c95b5a77f4db453"
+hash = "10d6b7b1a8bac24abb0c9da8ee4b9703a5156df25e5d1a415db2d493f218af29"
 
 ["commonware_storage::qmdb::conformance::KeylessMmrCompactFixedConf"]
 n_cases = 200
-hash = "311e78baa8209313a49f2d788d96aa880ba4b3c1c5c88f3151b665f25160fad8"
+hash = "f43bb614619dd99c53199920fd68cc7709737579f8b7c19e7e1e84c91e912ca9"
 
 ["commonware_storage::qmdb::conformance::KeylessMmrCompactVariableConf"]
 n_cases = 200
-hash = "d6b0f89534be60d85f5754c16574536d84899fce930dfc182ef973475d3078e4"
+hash = "30a09fb34906027dcd6617e7b0eef3ab742fe27f23eeee840a21f7d6c96ec3f0"
 
 ["commonware_storage::qmdb::conformance::KeylessMmrFixedConf"]
 n_cases = 200
-hash = "311e78baa8209313a49f2d788d96aa880ba4b3c1c5c88f3151b665f25160fad8"
+hash = "f43bb614619dd99c53199920fd68cc7709737579f8b7c19e7e1e84c91e912ca9"
 
 ["commonware_storage::qmdb::conformance::KeylessMmrVariableConf"]
 n_cases = 200
-hash = "d6b0f89534be60d85f5754c16574536d84899fce930dfc182ef973475d3078e4"
+hash = "30a09fb34906027dcd6617e7b0eef3ab742fe27f23eeee840a21f7d6c96ec3f0"
 
 ["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmb::Family,U64,FixedEncoding<U64>\n,Sha256Digest,32>>"]
 n_cases = 65536

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -322,7 +322,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                     .await
                     .expect("proof generation should not fail for committed key");
                 assert!(
-                    Db::<F>::verify_key_value_proof(&hasher, k, v, &proof, &root),
+                    Db::<F>::verify_key_value_proof(k, v, &proof, &root),
                     "key value proof failed to verify after crash recovery"
                 );
             }
@@ -337,7 +337,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                     .await
                     .expect("range proof should not fail after recovery");
                 assert!(
-                    Db::<F>::verify_range_proof(&hasher, &proof, loc, &ops, &chunks, &root),
+                    Db::<F>::verify_range_proof(&proof, loc, &ops, &chunks, &root),
                     "range proof failed to verify after crash recovery at loc {loc}"
                 );
             }

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -297,7 +297,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
 
                         assert!(
                             Db::<F>::verify_range_proof(
-                                &hasher,
                                 &proof,
                                 start_loc,
                                 &ops,
@@ -340,7 +339,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_digest_proof = range_proof.clone();
                             bad_digest_proof.proof.digests = bad_digests;
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &bad_digest_proof,
                                 start_loc,
                                 &ops,
@@ -355,7 +353,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                                 let mut bad_pending_proof = range_proof.clone();
                                 bad_pending_proof.pending_chunk_digest = bad_pending;
                                 assert!(!Db::<F>::verify_range_proof(
-                                    &hasher,
                                     &bad_pending_proof,
                                     start_loc,
                                     &ops,
@@ -370,7 +367,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_partial_proof = range_proof.clone();
                             bad_partial_proof.partial_chunk_digest = bad_partial_digest;
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &bad_partial_proof,
                                 start_loc,
                                 &ops,
@@ -389,7 +385,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         }).collect();
                         if chunks != bad_chunks {
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &range_proof,
                                 start_loc,
                                 &ops,
@@ -415,7 +410,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         Ok(proof) => {
                             let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
                             let verification_result = Db::<F>::verify_key_value_proof(
-                                &hasher,
                                 k,
                                 value,
                                 &proof,
@@ -445,7 +439,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     match db.exclusion_proof(&hasher, &k).await {
                         Ok(proof) => {
                             let verification_result = Db::<F>::verify_exclusion_proof(
-                                &hasher,
                                 &k,
                                 &proof,
                                 &current_root,

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -271,7 +271,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
 
                         assert!(
                             Db::<F>::verify_range_proof(
-                                &hasher,
                                 &proof,
                                 start_loc,
                                 &ops,
@@ -311,7 +310,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_digest_proof = range_proof.clone();
                             bad_digest_proof.proof.digests = bad_digests;
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &bad_digest_proof,
                                 start_loc,
                                 &ops,
@@ -326,7 +324,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                                 let mut bad_pending_proof = range_proof.clone();
                                 bad_pending_proof.pending_chunk_digest = bad_pending;
                                 assert!(!Db::<F>::verify_range_proof(
-                                    &hasher,
                                     &bad_pending_proof,
                                     start_loc,
                                     &ops,
@@ -341,7 +338,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_partial_proof = range_proof.clone();
                             bad_partial_proof.partial_chunk_digest = bad_partial_digest;
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &bad_partial_proof,
                                 start_loc,
                                 &ops,
@@ -360,7 +356,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         }).collect();
                         if chunks != bad_chunks {
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &range_proof,
                                 start_loc,
                                 &ops,
@@ -383,7 +378,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         Ok(proof) => {
                             let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
                             let verification_result = Db::<F>::verify_key_value_proof(
-                                &hasher,
                                 k,
                                 value,
                                 &proof,

--- a/storage/src/bitmap/authenticated.rs
+++ b/storage/src/bitmap/authenticated.rs
@@ -588,10 +588,7 @@ impl<E: Context, D: Digest, const N: usize, S: Strategy> UnmerkleizedBitMap<E, D
         let dirty: Vec<(Location, D)> = self.strategy.map_init_collect_vec(
             &updates,
             || hasher.clone(),
-            |h, &(loc, chunk)| {
-                let pos = Position::try_from(loc).unwrap();
-                (loc, h.leaf_digest(pos, chunk.as_ref()))
-            },
+            |h, &(loc, chunk)| (loc, h.leaf_digest(loc, chunk.as_ref())),
         );
         batch = batch.update_leaf_batched(&dirty)?;
 

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -64,7 +64,7 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
     #[allow(clippy::should_implement_trait)]
     pub fn add(mut self, item: Item) -> Self {
         let mut state = self.hasher.state();
-        let digest = state.leaf_encoded(self.inner.size(), &item);
+        let digest = state.leaf_encoded(self.inner.leaves(), &item);
         self.inner = self.inner.add_leaf_digest(digest);
         self.items.push(item);
         self
@@ -129,10 +129,7 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         let digests = self.inner.strategy().map_init_collect_vec(
             items.iter().enumerate(),
             || self.hasher.state(),
-            |state, (i, item)| {
-                let pos = Position::try_from(first + i as u64).expect("valid leaf location");
-                state.leaf_encoded(pos, item)
-            },
+            |state, (i, item)| state.leaf_encoded(first + i as u64, item),
         );
 
         self.inner = self.inner.add_leaf_digests(digests);

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -248,9 +248,12 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         size
     }
 
-    /// Add a run of pre-computed leaf digests, in order.
+    /// Append a run of pre-computed leaf digests, in order.
+    ///
+    /// Bulk counterpart to [`Self::add_leaf_digest`]: reserves capacity once and advances the leaf
+    /// count incrementally, so it is the efficient path for building a structure from many leaves.
     #[cfg(feature = "std")]
-    pub(crate) fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
+    pub fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
         // Each leaf also appends its parent placeholders, so reserve for the full node count.
         let digests = digests.into_iter();
         let n = digests.size_hint().0 as u64;
@@ -269,7 +272,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 
     /// Hash `element` and add it as a leaf.
     pub fn add(self, hasher: &impl Hasher<F, Digest = D>, element: &[u8]) -> Self {
-        let digest = hasher.leaf_digest(self.size(), element);
+        let digest = hasher.leaf_digest(self.leaves(), element);
         self.add_leaf_digest(digest)
     }
 
@@ -302,7 +305,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         element: &[u8],
     ) -> Result<Self, Error<F>> {
         let pos = self.validate_loc(loc)?;
-        let digest = hasher.leaf_digest(pos, element);
+        let digest = hasher.leaf_digest(loc, element);
         self.store_node(pos, digest);
         self.mark_dirty(loc);
         Ok(self)
@@ -353,29 +356,15 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     /// Consume this batch and produce an immutable [`MerkleizedBatch`] using reusable hash state.
     #[cfg(feature = "std")]
     pub(crate) fn merkleize_reusing<H: CHasher<Digest = D>>(
-        self,
-        base: &Mem<F, D>,
-    ) -> Arc<MerkleizedBatch<F, D, S>> {
-        self.merkleize_reusing_with::<H, _>(base, |pos| pos)
-    }
-
-    /// Consume this batch using reusable hash state and a hash-position mapper.
-    #[cfg(feature = "std")]
-    pub(crate) fn merkleize_reusing_with<H, M>(
         mut self,
         base: &Mem<F, D>,
-        map_pos: M,
-    ) -> Arc<MerkleizedBatch<F, D, S>>
-    where
-        H: CHasher<Digest = D>,
-        M: Fn(Position<F>) -> Position<F> + Copy + Send + Sync,
-    {
+    ) -> Arc<MerkleizedBatch<F, D, S>> {
         let buckets = self.prepare_dirty_buckets();
         for (height, positions) in buckets.iter().enumerate() {
             if positions.is_empty() {
                 continue;
             }
-            self.merkleize_bucket_reusing::<H, M>(base, positions, height as u32, map_pos);
+            self.merkleize_bucket_reusing::<H>(base, positions, height as u32);
         }
 
         self.finish_merkleize()
@@ -424,7 +413,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
                 let (left, right) = F::children(pos, height);
                 let left_d = self.get_node(base, left).expect("left child missing");
                 let right_d = self.get_node(base, right).expect("right child missing");
-                let digest = hasher.node_digest(pos, &left_d, &right_d);
+                let digest = hasher.node_digest(&left_d, &right_d);
                 self.store_node(pos, digest);
             }
             return;
@@ -437,7 +426,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
                 let (left, right) = F::children(pos, height);
                 let left_d = self.get_node(base, left).expect("left child missing");
                 let right_d = self.get_node(base, right).expect("right child missing");
-                let digest = hasher.node_digest(pos, &left_d, &right_d);
+                let digest = hasher.node_digest(&left_d, &right_d);
                 (pos, digest)
             },
         );
@@ -447,15 +436,13 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     }
 
     #[cfg(feature = "std")]
-    fn merkleize_bucket_reusing<H, M>(
+    fn merkleize_bucket_reusing<H>(
         &mut self,
         base: &Mem<F, D>,
         positions: &[Position<F>],
         height: u32,
-        map_pos: M,
     ) where
         H: CHasher<Digest = D>,
-        M: Fn(Position<F>) -> Position<F> + Copy + Send + Sync,
     {
         if positions.len() < SEQUENTIAL_BUCKET_THRESHOLD {
             let mut state = Standard::<H>::new(Bagging::ForwardFold).state();
@@ -463,7 +450,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
                 let (left, right) = F::children(pos, height);
                 let left_d = self.get_node(base, left).expect("left child missing");
                 let right_d = self.get_node(base, right).expect("right child missing");
-                let digest = state.node_digest(map_pos(pos), &left_d, &right_d);
+                let digest = state.node_digest(&left_d, &right_d);
                 self.store_node(pos, digest);
             }
             return;
@@ -476,7 +463,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
                 let (left, right) = F::children(pos, height);
                 let left_d = self.get_node(base, left).expect("left child missing");
                 let right_d = self.get_node(base, right).expect("right child missing");
-                let digest = state.node_digest(map_pos(pos), &left_d, &right_d);
+                let digest = state.node_digest(&left_d, &right_d);
                 (pos, digest)
             },
         );

--- a/storage/src/merkle/benches/bench.rs
+++ b/storage/src/merkle/benches/bench.rs
@@ -2,6 +2,7 @@ use criterion::criterion_main;
 
 mod append;
 mod append_additional;
+mod build;
 mod flush;
 mod position_to_location;
 mod prove_many_elements;
@@ -11,6 +12,7 @@ mod update;
 criterion_main!(
     append::benches,
     append_additional::benches,
+    build::benches,
     flush::benches,
     position_to_location::benches,
     prove_many_elements::benches,

--- a/storage/src/merkle/benches/build.rs
+++ b/storage/src/merkle/benches/build.rs
@@ -1,0 +1,110 @@
+//! Benchmark for building a large in-memory MMR/MMB from a batch of leaves.
+//!
+//! Mirrors how databases actually build the structure (e.g. `qmdb`): leaf digests are computed
+//! (optionally in parallel via the strategy), appended in bulk with `add_leaf_digests`, merkleized
+//! (node hashing parallelized by the strategy), and applied. The timed region is the full build;
+//! one-time element generation is setup. Contrast with `append`, which builds via per-leaf `add`.
+
+use commonware_cryptography::{sha256, Sha256};
+use commonware_math::algebra::Random as _;
+use commonware_parallel::{Rayon, Sequential, Strategy};
+use commonware_runtime::{
+    benchmarks::{context, tokio},
+    tokio::{Config, Context},
+    ThreadPooler,
+};
+use commonware_storage::merkle::{
+    self, hasher::Hasher as _, mem::Mem, Bagging::ForwardFold, Family, Location,
+};
+use commonware_utils::NZUsize;
+use criterion::{criterion_group, Criterion};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{
+    hint::black_box,
+    num::NonZeroUsize,
+    time::{Duration, Instant},
+};
+
+type StandardHasher<H> = merkle::hasher::Standard<H>;
+
+const THREADS: NonZeroUsize = NZUsize!(8);
+
+#[cfg(not(full_bench))]
+const N_LEAVES: [usize; 2] = [100_000, 1_000_000];
+#[cfg(full_bench)]
+const N_LEAVES: [usize; 4] = [100_000, 1_000_000, 5_000_000, 10_000_000];
+
+fn make_elements(n: usize) -> Vec<sha256::Digest> {
+    let mut sampler = StdRng::seed_from_u64(0);
+    (0..n)
+        .map(|_| sha256::Digest::random(&mut sampler))
+        .collect()
+}
+
+/// Full build: (strategy-parallel) leaf hashing, bulk append, merkleize, apply.
+fn build<F: Family, S: Strategy>(
+    h: &StandardHasher<Sha256>,
+    elements: &[sha256::Digest],
+    strategy: S,
+) -> sha256::Digest {
+    let leaf_digests: Vec<sha256::Digest> = strategy.map_init_collect_vec(
+        elements.iter().enumerate(),
+        || (),
+        |_, (i, e)| h.leaf_digest(Location::<F>::new(i as u64), e.as_ref()),
+    );
+    let mut mem = Mem::<F, sha256::Digest>::new();
+    let batch = mem
+        .new_batch_with_strategy(strategy)
+        .add_leaf_digests(leaf_digests);
+    let merkleized = batch.merkleize(&mem, h);
+    mem.apply_batch(&merkleized).unwrap();
+    mem.root(h, 0).unwrap()
+}
+
+fn bench_build_family<F: Family>(c: &mut Criterion, runner: &tokio::Runner, family: &str) {
+    for &n in N_LEAVES.iter() {
+        for parallel in [false, true] {
+            c.bench_function(
+                &format!(
+                    "{}/n={n} family={family} parallel={parallel}",
+                    module_path!()
+                ),
+                |b| {
+                    b.to_async(runner).iter_custom(move |iters| async move {
+                        let ctx = context::get::<Context>();
+                        let h = StandardHasher::<Sha256>::new(ForwardFold);
+                        let elements = make_elements(n);
+                        let strategy: Option<Rayon> = if parallel {
+                            Some(ctx.create_strategy(THREADS).unwrap())
+                        } else {
+                            None
+                        };
+                        let mut total = Duration::ZERO;
+                        for _ in 0..iters {
+                            let start = Instant::now();
+                            let root = match &strategy {
+                                Some(s) => build::<F, _>(&h, &elements, s.clone()),
+                                None => build::<F, _>(&h, &elements, Sequential),
+                            };
+                            total += start.elapsed();
+                            black_box(root);
+                        }
+                        total
+                    });
+                },
+            );
+        }
+    }
+}
+
+fn bench_build(c: &mut Criterion) {
+    let runner = tokio::Runner::new(Config::default());
+    bench_build_family::<commonware_storage::mmr::Family>(c, &runner, "mmr");
+    bench_build_family::<commonware_storage::mmb::Family>(c, &runner, "mmb");
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_build
+}

--- a/storage/src/merkle/benches/build.rs
+++ b/storage/src/merkle/benches/build.rs
@@ -82,10 +82,10 @@ fn bench_build_family<F: Family>(c: &mut Criterion, runner: &tokio::Runner, fami
                         let mut total = Duration::ZERO;
                         for _ in 0..iters {
                             let start = Instant::now();
-                            let root = match &strategy {
-                                Some(s) => build::<F, _>(&h, &elements, s.clone()),
-                                None => build::<F, _>(&h, &elements, Sequential),
-                            };
+                            let root = strategy.as_ref().map_or_else(
+                                || build::<F, _>(&h, &elements, Sequential),
+                                |s| build::<F, _>(&h, &elements, s.clone()),
+                            );
                             total += start.elapsed();
                             black_box(root);
                         }

--- a/storage/src/merkle/hasher.rs
+++ b/storage/src/merkle/hasher.rs
@@ -1,6 +1,6 @@
 //! Shared hasher trait and standard implementation for Merkle-family data structures.
 
-use crate::merkle::{Bagging, Error, Family, Location, Position};
+use crate::merkle::{Bagging, Error, Family, Location};
 use alloc::vec::Vec;
 use commonware_codec::Encode;
 use commonware_cryptography::{Digest, Hasher as CHasher};
@@ -32,21 +32,6 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
     /// underlying hasher's `merge_digest_pair` contract (its output is domain-separated from
     /// `hash`), which is what lets leaves hash a variable-length element directly.
     fn node_digest(&self, left: &Self::Digest, right: &Self::Digest) -> Self::Digest;
-
-    /// Computes the digest for an internal node at structural position `pos`.
-    ///
-    /// The node digest itself does not depend on `pos`; this hook exists so that hashers which fuse
-    /// in external data keyed by tree position (e.g. the grafting verifier, which combines a bitmap
-    /// chunk at the grafting height) can act during proof reconstruction. The default ignores `pos`
-    /// and is identical to [`Hasher::node_digest`].
-    fn node_digest_at(
-        &self,
-        _pos: Position<F>,
-        left: &Self::Digest,
-        right: &Self::Digest,
-    ) -> Self::Digest {
-        self.node_digest(left, right)
-    }
 
     /// Computes the digest for a leaf given its location and the element it represents.
     fn leaf_digest(&self, loc: Location<F>, element: &[u8]) -> Self::Digest {

--- a/storage/src/merkle/hasher.rs
+++ b/storage/src/merkle/hasher.rs
@@ -9,8 +9,8 @@ use core::marker::PhantomData;
 /// A trait for computing the various digests of a Merkle-family structure.
 ///
 /// The type parameter `F` determines which Merkle family (MMR, MMB, etc.) this hasher targets, and
-/// consequently which `Position` and `Location` types appear in method signatures. Default
-/// implementations are provided for all methods except `hash()`.
+/// consequently which `Location` type appears in method signatures. Default implementations are
+/// provided for all methods except `hash()` and `node_digest()`.
 pub trait Hasher<F: Family>: Clone + Send + Sync {
     type Digest: Digest;
 
@@ -24,23 +24,33 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
     /// aggregation; `hash`, `leaf_digest`, and `node_digest` are unaffected.
     fn root_bagging(&self) -> Bagging;
 
-    /// Computes the digest for a node given its position and the digests of its children.
-    fn node_digest(
+    /// Computes the digest for an internal node from the digests of its children.
+    ///
+    /// Has no default because it cannot be expressed via [`Hasher::hash`]: a node digest must be
+    /// domain-separated from a leaf digest ([`Hasher::leaf_digest`]) so the two can never collide
+    /// even though neither carries an explicit tag. [`Standard`] inherits this separation from the
+    /// underlying hasher's `merge_digest_pair` contract (its output is domain-separated from
+    /// `hash`), which is what lets leaves hash a variable-length element directly.
+    fn node_digest(&self, left: &Self::Digest, right: &Self::Digest) -> Self::Digest;
+
+    /// Computes the digest for an internal node at structural position `pos`.
+    ///
+    /// The node digest itself does not depend on `pos`; this hook exists so that hashers which fuse
+    /// in external data keyed by tree position (e.g. the grafting verifier, which combines a bitmap
+    /// chunk at the grafting height) can act during proof reconstruction. The default ignores `pos`
+    /// and is identical to [`Hasher::node_digest`].
+    fn node_digest_at(
         &self,
-        pos: Position<F>,
+        _pos: Position<F>,
         left: &Self::Digest,
         right: &Self::Digest,
     ) -> Self::Digest {
-        self.hash([
-            (*pos).to_be_bytes().as_slice(),
-            left.as_ref(),
-            right.as_ref(),
-        ])
+        self.node_digest(left, right)
     }
 
-    /// Computes the digest for a leaf given its position and the element it represents.
-    fn leaf_digest(&self, pos: Position<F>, element: &[u8]) -> Self::Digest {
-        self.hash([(*pos).to_be_bytes().as_slice(), element])
+    /// Computes the digest for a leaf given its location and the element it represents.
+    fn leaf_digest(&self, loc: Location<F>, element: &[u8]) -> Self::Digest {
+        self.hash([(*loc).to_be_bytes().as_slice(), element])
     }
 
     /// Compute the digest of a byte slice.
@@ -179,6 +189,19 @@ impl<H: CHasher> Standard<H> {
         self.hash(core::iter::once(data))
     }
 
+    /// Compute the digest of an internal node from the digests of its children.
+    ///
+    /// Independent of the node's position, and with no explicit leaf/node domain separator. Omitting
+    /// the separator is safe because of the underlying hasher's `merge_digest_pair` contract: its
+    /// output must be unreachable by the finalized [`Self::hash`] used to compute leaves (SHA-256
+    /// gets this by compressing from a distinct initial state, which a finalized `hash` never
+    /// reaches), so a leaf digest can never equal a node digest absent a collision. A tag byte would
+    /// otherwise be needed here, and would cost the single-block fast path.
+    pub fn node_digest(&self, left: &H::Digest, right: &H::Digest) -> H::Digest {
+        let mut hasher = H::new();
+        hasher.merge_digest_pair(left, right)
+    }
+
     /// Create reusable hashing state for a local batch of Merkle operations.
     pub(crate) fn state(&self) -> StandardState<H> {
         StandardState { hasher: H::new() }
@@ -191,24 +214,22 @@ pub(crate) struct StandardState<H: CHasher> {
 }
 
 impl<H: CHasher> StandardState<H> {
-    /// Hash a fixed-position Merkle node.
-    pub(crate) fn node_digest<F: Family>(
-        &mut self,
-        pos: Position<F>,
-        left: &H::Digest,
-        right: &H::Digest,
-    ) -> H::Digest {
-        self.hasher.hash_u64_digest_pair(*pos, left, right)
+    /// Hash an internal Merkle node from the digests of its children.
+    ///
+    /// Position-free and tag-free; see [`Standard::node_digest`] for why omitting a leaf/node
+    /// domain separator is safe.
+    pub(crate) fn node_digest(&mut self, left: &H::Digest, right: &H::Digest) -> H::Digest {
+        self.hasher.merge_digest_pair(left, right)
     }
 
-    /// Hash a fixed-position leaf from an encoded value.
+    /// Hash a leaf at `loc` from an encoded value.
     pub(crate) fn leaf_encoded<F: Family, E: Encode>(
         &mut self,
-        pos: Position<F>,
+        loc: Location<F>,
         value: &E,
     ) -> H::Digest {
-        let pos = (*pos).to_be_bytes();
-        self.hasher.hash_prefixed(pos.as_slice(), value)
+        let loc = (*loc).to_be_bytes();
+        self.hasher.hash_prefixed(loc.as_slice(), value)
     }
 }
 
@@ -223,14 +244,8 @@ impl<F: Family, H: CHasher> Hasher<F> for Standard<H> {
         Self::root_bagging(self)
     }
 
-    fn node_digest(
-        &self,
-        pos: Position<F>,
-        left: &Self::Digest,
-        right: &Self::Digest,
-    ) -> Self::Digest {
-        let mut hasher = H::new();
-        hasher.hash_u64_digest_pair(*pos, left, right)
+    fn node_digest(&self, left: &Self::Digest, right: &Self::Digest) -> Self::Digest {
+        Self::node_digest(self, left, right)
     }
 
     fn fold(&self, acc: &Self::Digest, peak: &Self::Digest) -> Self::Digest {
@@ -249,13 +264,17 @@ impl<F: Family, T: Hasher<F>> Hasher<F> for &T {
     fn root_bagging(&self) -> Bagging {
         (**self).root_bagging()
     }
+
+    fn node_digest(&self, left: &Self::Digest, right: &Self::Digest) -> Self::Digest {
+        (**self).node_digest(left, right)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::merkle::{
-        mmr::{Location, Position, StandardHasher as Standard},
+        mmr::{Location, StandardHasher as Standard},
         Bagging::{BackwardFold, ForwardFold},
     };
     use alloc::vec::Vec;
@@ -328,16 +347,16 @@ mod tests {
         let digest1 = test_digest::<H>(1);
         let digest2 = test_digest::<H>(2);
 
-        let out = mmr_hasher.leaf_digest(Position::new(0), &digest1);
+        let out = mmr_hasher.leaf_digest(Location::new(0), &digest1);
         assert_ne!(out, test_digest::<H>(0), "hash should be non-zero");
 
-        let mut out2 = mmr_hasher.leaf_digest(Position::new(0), &digest1);
+        let mut out2 = mmr_hasher.leaf_digest(Location::new(0), &digest1);
         assert_eq!(out, out2, "hash should be re-computed consistently");
 
-        out2 = mmr_hasher.leaf_digest(Position::new(1), &digest1);
-        assert_ne!(out, out2, "hash should change with different pos");
+        out2 = mmr_hasher.leaf_digest(Location::new(1), &digest1);
+        assert_ne!(out, out2, "hash should change with different location");
 
-        out2 = mmr_hasher.leaf_digest(Position::new(0), &digest2);
+        out2 = mmr_hasher.leaf_digest(Location::new(0), &digest2);
         assert_ne!(out, out2, "hash should change with different input digest");
     }
 
@@ -348,28 +367,25 @@ mod tests {
         let d2 = test_digest::<H>(2);
         let d3 = test_digest::<H>(3);
 
-        let out = mmr_hasher.node_digest(Position::new(0), &d1, &d2);
+        let out = mmr_hasher.node_digest(&d1, &d2);
         assert_ne!(out, test_digest::<H>(0), "hash should be non-zero");
 
-        let mut out2 = mmr_hasher.node_digest(Position::new(0), &d1, &d2);
+        let mut out2 = mmr_hasher.node_digest(&d1, &d2);
         assert_eq!(out, out2, "hash should be re-computed consistently");
 
-        out2 = mmr_hasher.node_digest(Position::new(1), &d1, &d2);
-        assert_ne!(out, out2, "hash should change with different pos");
-
-        out2 = mmr_hasher.node_digest(Position::new(0), &d3, &d2);
+        out2 = mmr_hasher.node_digest(&d3, &d2);
         assert_ne!(
             out, out2,
             "hash should change with different first input hash"
         );
 
-        out2 = mmr_hasher.node_digest(Position::new(0), &d1, &d3);
+        out2 = mmr_hasher.node_digest(&d1, &d3);
         assert_ne!(
             out, out2,
             "hash should change with different second input hash"
         );
 
-        out2 = mmr_hasher.node_digest(Position::new(0), &d2, &d1);
+        out2 = mmr_hasher.node_digest(&d2, &d1);
         assert_ne!(
             out, out2,
             "hash should change when swapping order of inputs"

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -1164,7 +1164,7 @@ mod tests {
         mem.apply_batch(&c).unwrap();
 
         // B's overwrite must have been applied.
-        let updated = hasher.leaf_digest(pos0, b"updated-0");
+        let updated = hasher.leaf_digest(Location::<F>::new(0), b"updated-0");
         assert_eq!(
             mem.get_node(pos0),
             Some(updated),

--- a/storage/src/merkle/mmb/mem.rs
+++ b/storage/src/merkle/mmb/mem.rs
@@ -73,7 +73,7 @@ mod tests {
 
         let leaf_positions = [0u64, 1, 3, 4, 6, 8, 10, 11];
         for (i, pos) in leaf_positions.into_iter().enumerate() {
-            let expected = hasher.leaf_digest(Position::new(pos), &(i as u64).to_be_bytes());
+            let expected = hasher.leaf_digest(Location::new(i as u64), &(i as u64).to_be_bytes());
             assert_eq!(
                 mmb.get_node(Position::new(pos)).unwrap(),
                 expected,
@@ -82,31 +82,27 @@ mod tests {
         }
 
         let digest2 = hasher.node_digest(
-            Position::new(2),
             &mmb.get_node(Position::new(0)).unwrap(),
             &mmb.get_node(Position::new(1)).unwrap(),
         );
         assert_eq!(mmb.get_node(Position::new(2)).unwrap(), digest2);
 
         let digest5 = hasher.node_digest(
-            Position::new(5),
             &mmb.get_node(Position::new(3)).unwrap(),
             &mmb.get_node(Position::new(4)).unwrap(),
         );
         assert_eq!(mmb.get_node(Position::new(5)).unwrap(), digest5);
 
-        let digest7 = hasher.node_digest(Position::new(7), &digest2, &digest5);
+        let digest7 = hasher.node_digest(&digest2, &digest5);
         assert_eq!(mmb.get_node(Position::new(7)).unwrap(), digest7);
 
         let digest9 = hasher.node_digest(
-            Position::new(9),
             &mmb.get_node(Position::new(6)).unwrap(),
             &mmb.get_node(Position::new(8)).unwrap(),
         );
         assert_eq!(mmb.get_node(Position::new(9)).unwrap(), digest9);
 
         let digest12 = hasher.node_digest(
-            Position::new(12),
             &mmb.get_node(Position::new(10)).unwrap(),
             &mmb.get_node(Position::new(11)).unwrap(),
         );

--- a/storage/src/merkle/mmr/mem.rs
+++ b/storage/src/merkle/mmr/mem.rs
@@ -65,7 +65,7 @@ mod tests {
 
             for leaf in leaves.iter().by_ref() {
                 let pos = Position::try_from(*leaf).unwrap();
-                let digest = hasher.leaf_digest(pos, &element);
+                let digest = hasher.leaf_digest(*leaf, &element);
                 assert_eq!(mmr.get_node(pos).unwrap(), digest);
             }
 

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -483,8 +483,9 @@ impl<F: Family, D: Digest> Proof<F, D> {
 
     /// Reconstruct a root from range-proof digests and optionally collect authenticated nodes.
     ///
-    /// Reads the bagging policy from `hasher`. When `collected` is supplied, the verifier records
-    /// the intermediate node digests it authenticates while reconstructing the range.
+    /// Internal nodes are combined with [`Hasher::node_digest`]. Reads the bagging policy from
+    /// `hasher`. When `collected` is supplied, the verifier records the intermediate node digests it
+    /// authenticates while reconstructing the range.
     pub(crate) fn reconstruct_root_inner<H, E>(
         &self,
         hasher: &H,
@@ -495,6 +496,35 @@ impl<F: Family, D: Digest> Proof<F, D> {
     where
         H: Hasher<F, Digest = D>,
         E: AsRef<[u8]>,
+    {
+        self.reconstruct_root_with(
+            hasher,
+            &|_, left, right| hasher.node_digest(left, right),
+            elements,
+            start_loc,
+            collected,
+        )
+    }
+
+    /// Reconstruct a root from range-proof digests, combining internal nodes with a caller-supplied
+    /// `combine` function.
+    ///
+    /// `combine(pos, left, right)` yields the digest of the internal node at `pos`. Plain callers
+    /// use [`Self::reconstruct_root_inner`], which passes [`Hasher::node_digest`]; the grafting
+    /// verifier passes a combiner that fuses a bitmap chunk at the grafting height. `hasher` still
+    /// supplies leaf digests, peak folding, and the root bagging policy.
+    pub(crate) fn reconstruct_root_with<H, E, C>(
+        &self,
+        hasher: &H,
+        combine: &C,
+        elements: &[E],
+        start_loc: Location<F>,
+        collected: Option<&mut Vec<(Position<F>, D)>>,
+    ) -> Result<D, ReconstructionError>
+    where
+        H: Hasher<F, Digest = D>,
+        E: AsRef<[u8]>,
+        C: Fn(Position<F>, &D, &D) -> D,
     {
         let bagging = hasher.root_bagging();
         let mut collected = collected;
@@ -551,6 +581,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
         for peak in &bp.range_peaks {
             let peak_digest = peak.reconstruct_digest(
                 hasher,
+                combine,
                 &bp.range,
                 &mut elements_iter,
                 proof_digests.siblings,
@@ -710,7 +741,7 @@ impl<F: Family> Subtree<F> {
         let (left, right) = self.children();
         let left_d = left.reconstruct_from_pins(hasher, pinned_map)?;
         let right_d = right.reconstruct_from_pins(hasher, pinned_map)?;
-        Some(hasher.node_digest_at(self.pos, &left_d, &right_d))
+        Some(hasher.node_digest(&left_d, &right_d))
     }
 
     /// Reconstruct the digest of this subtree from a range of elements and sibling digests,
@@ -719,13 +750,20 @@ impl<F: Family> Subtree<F> {
     /// At each node:
     /// - If the subtree is entirely outside the range: consume a sibling digest.
     /// - If it's a leaf in the range: hash the next element.
-    /// - Otherwise: recurse into children via [`Family::children`] and compute the node digest.
+    /// - Otherwise: recurse into children via [`Family::children`] and compute the node digest via
+    ///   `combine`.
+    ///
+    /// `combine(pos, left, right)` yields the digest of the internal node at `pos`. Plain
+    /// reconstruction passes [`Hasher::node_digest`]; the grafting verifier passes a combiner that
+    /// fuses a bitmap chunk at the grafting height.
     ///
     /// If `collected` is `Some`, every child `(position, digest)` pair encountered during
     /// reconstruction is appended to the vector.
-    fn reconstruct_digest<D, H, E>(
+    #[allow(clippy::too_many_arguments)]
+    fn reconstruct_digest<D, H, E, C>(
         &self,
         hasher: &H,
+        combine: &C,
         range: &Range<Location<F>>,
         elements: &mut E,
         siblings: &[D],
@@ -736,6 +774,7 @@ impl<F: Family> Subtree<F> {
         D: Digest,
         H: Hasher<F, Digest = D>,
         E: Iterator<Item: AsRef<[u8]>>,
+        C: Fn(Position<F>, &D, &D) -> D,
     {
         // Entirely outside the range: consume a sibling digest.
         if self.is_outside(range) {
@@ -758,6 +797,7 @@ impl<F: Family> Subtree<F> {
         let (left, right) = self.children();
         let left_d = left.reconstruct_digest(
             hasher,
+            combine,
             range,
             elements,
             siblings,
@@ -766,6 +806,7 @@ impl<F: Family> Subtree<F> {
         )?;
         let right_d = right.reconstruct_digest(
             hasher,
+            combine,
             range,
             elements,
             siblings,
@@ -778,7 +819,7 @@ impl<F: Family> Subtree<F> {
             cd.push((right.pos, right_d));
         }
 
-        Ok(hasher.node_digest_at(self.pos, &left_d, &right_d))
+        Ok(combine(self.pos, &left_d, &right_d))
     }
 }
 

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -370,7 +370,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
     /// ```
     ///
     /// The verifier walks down from `p7` via `F::children`, pulls the pins for `p2` and `p5`, and
-    /// hashes them back up (`node_digest(p7, pin[p2], pin[p5])`) to compare against the `p7`
+    /// hashes them back up (`node_digest(pin[p2], pin[p5])`) to compare against the `p7`
     /// digest the proof authenticates.
     ///
     /// Returns `true` only if the proof reconstructs to `root` and every pinned node digest is
@@ -688,8 +688,7 @@ impl<F: Family> Subtree<F> {
     /// each pin as it is used.
     ///
     /// Walks down via [`Self::children`] until each recursion hits a pin, then hashes back up with
-    /// [`Hasher::node_digest`] for position-keyed domain separation. Returns `None` if any required
-    /// pin is missing.
+    /// [`Hasher::node_digest`]. Returns `None` if any required pin is missing.
     ///
     /// On failure, `pinned_map` may have been partially consumed. Callers are expected to return
     /// immediately without inspecting it further.
@@ -711,7 +710,7 @@ impl<F: Family> Subtree<F> {
         let (left, right) = self.children();
         let left_d = left.reconstruct_from_pins(hasher, pinned_map)?;
         let right_d = right.reconstruct_from_pins(hasher, pinned_map)?;
-        Some(hasher.node_digest(self.pos, &left_d, &right_d))
+        Some(hasher.node_digest_at(self.pos, &left_d, &right_d))
     }
 
     /// Reconstruct the digest of this subtree from a range of elements and sibling digests,
@@ -752,7 +751,7 @@ impl<F: Family> Subtree<F> {
             let elem = elements
                 .next()
                 .ok_or(ReconstructionError::MissingElements)?;
-            return Ok(hasher.leaf_digest(self.pos, elem.as_ref()));
+            return Ok(hasher.leaf_digest(self.leaf_start, elem.as_ref()));
         }
 
         // Recurse into children.
@@ -779,7 +778,7 @@ impl<F: Family> Subtree<F> {
             cd.push((right.pos, right_d));
         }
 
-        Ok(hasher.node_digest(self.pos, &left_d, &right_d))
+        Ok(hasher.node_digest_at(self.pos, &left_d, &right_d))
     }
 }
 

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -27,8 +27,7 @@ where
         || hasher.state(),
         |state, (i, op)| {
             let offset = u64::try_from(i).expect("operation offset exceeds u64");
-            let pos = F::location_to_position(first_leaf + offset);
-            state.leaf_encoded(pos, op)
+            state.leaf_encoded(first_leaf + offset, op)
         },
     );
 

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -671,9 +671,7 @@ where
                 grafted_batch = grafted_batch.add_leaf_digest(digest);
             }
         }
-        grafted_batch.merkleize_reusing_with::<H, _>(&current_db.grafted_tree, |pos| {
-            grafting::grafted_to_ops_pos::<F>(pos, grafting_height)
-        })
+        grafted_batch.merkleize_reusing::<H>(&current_db.grafted_tree)
     };
 
     // Build the layered bitmap (parent + overlay) before computing the canonical root, so that

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1146,9 +1146,7 @@ pub(super) async fn build_grafted_tree<
         let batch = {
             let batch = grafted_tree.new_batch_with_strategy(strategy.clone());
             let batch = batch.add_leaf_digests(leaves.iter().map(|&(_, digest)| digest));
-            batch.merkleize_reusing_with::<H, _>(&grafted_tree, |pos| {
-                grafting::grafted_to_ops_pos::<F>(pos, grafting_height)
-            })
+            batch.merkleize_reusing::<H>(&grafted_tree)
         };
         grafted_tree.apply_batch(&batch)?;
     }

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -6,8 +6,9 @@
 //! status of each operation. To authenticate both structures efficiently, we combine them: each
 //! _graftable_ chunk of the bitmap is hashed together with the corresponding subtree root from the
 //! ops tree to produce a single "grafted leaf" digest. These digests, along with their ancestor
-//! nodes, are stored in an in-memory Merkle structure (using grafted-space positions internally,
-//! with ops-space positions in hash pre-images).
+//! nodes, are stored in an in-memory Merkle structure keyed by grafted-space positions. Node
+//! digests do not depend on position, so a grafted ancestor and its corresponding ops node share
+//! the same digest whenever their children match.
 //!
 //! A chunk is _graftable_ once its height-`G` ancestor exists in the ops tree as a single node. In
 //! MMR every complete chunk is immediately graftable. MMB's delayed merges allow at most one chunk
@@ -56,7 +57,7 @@
 //!
 //! Nodes at the grafting height (positions 6 and 13) are "grafted leaves" whose digests combine the
 //! bitmap chunk with the ops subtree root: `hash(chunk || ops_subtree_root)`. Nodes above the
-//! grafting height (position 14) use standard hashing with ops-space positions.
+//! grafting height (position 14) use standard node hashing.
 //!
 //! The grafted tree is incrementally maintained when grafted leaves change.
 
@@ -174,52 +175,6 @@ pub fn grafted_to_ops_pos<F: Graftable>(
     F::subtree_root_position(ops_leaf_start, ops_height)
 }
 
-/// A hasher adapter that maps grafted-structure positions to ops-structure positions.
-///
-/// Both the grafted structure and ops structure use the same family `F`. The grafted
-/// structure's leaves correspond 1:1 with bitmap chunks. This adapter intercepts
-/// [`HasherTrait::node_digest`] to convert each grafted position to the corresponding
-/// ops-space position via [`Graftable::leftmost_leaf`] and [`Graftable::subtree_root_position`],
-/// ensuring hash pre-images use ops-space positions for domain separation.
-#[derive(Clone)]
-pub(super) struct GraftedHasher<F: Graftable, H: HasherTrait<F>> {
-    inner: H,
-    grafting_height: u32,
-    _family: PhantomData<F>,
-}
-
-impl<F: Graftable, H: HasherTrait<F>> GraftedHasher<F, H> {
-    pub(super) const fn new(inner: H, grafting_height: u32) -> Self {
-        Self {
-            inner,
-            grafting_height,
-            _family: PhantomData,
-        }
-    }
-}
-
-impl<F: Graftable, H: HasherTrait<F>> HasherTrait<F> for GraftedHasher<F, H> {
-    type Digest = H::Digest;
-
-    fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> Self::Digest {
-        self.inner.hash(parts)
-    }
-
-    fn root_bagging(&self) -> merkle::Bagging {
-        self.inner.root_bagging()
-    }
-
-    fn node_digest(
-        &self,
-        pos: Position<F>,
-        left: &Self::Digest,
-        right: &Self::Digest,
-    ) -> Self::Digest {
-        let ops_pos = grafted_to_ops_pos::<F>(pos, self.grafting_height);
-        self.inner.node_digest(ops_pos, left, right)
-    }
-}
-
 /// A [`merkle::hasher::Hasher`] implementation used for verifying proofs over grafted storage.
 ///
 /// The ops structure uses family `F`, so this implements [`merkle::hasher::Hasher`] for that
@@ -285,7 +240,11 @@ impl<F: Graftable, H: CHasher> HasherTrait<F> for Verifier<'_, F, H> {
         <merkle::hasher::Standard<H> as HasherTrait<F>>::root_bagging(&self.hasher)
     }
 
-    fn node_digest(
+    fn node_digest(&self, left: &H::Digest, right: &H::Digest) -> H::Digest {
+        <merkle::hasher::Standard<H> as HasherTrait<F>>::node_digest(&self.hasher, left, right)
+    }
+
+    fn node_digest_at(
         &self,
         pos: merkle::Position<F>,
         left_digest: &H::Digest,
@@ -293,12 +252,20 @@ impl<F: Graftable, H: CHasher> HasherTrait<F> for Verifier<'_, F, H> {
     ) -> H::Digest {
         match F::pos_to_height(pos).cmp(&self.grafting_height) {
             Ordering::Less | Ordering::Greater => {
-                // Below or above grafting height: standard hash with ops-space position.
-                self.hasher.node_digest(pos, left_digest, right_digest)
+                // Below or above grafting height: plain node digest.
+                <merkle::hasher::Standard<H> as HasherTrait<F>>::node_digest(
+                    &self.hasher,
+                    left_digest,
+                    right_digest,
+                )
             }
             Ordering::Equal => {
                 // At grafting height: compute ops subtree root, then combine with bitmap chunk.
-                let ops_subtree_root = self.hasher.node_digest(pos, left_digest, right_digest);
+                let ops_subtree_root = <merkle::hasher::Standard<H> as HasherTrait<F>>::node_digest(
+                    &self.hasher,
+                    left_digest,
+                    right_digest,
+                );
 
                 // Convert the F-family position to a chunk index using F's leftmost_leaf.
                 let loc = F::leftmost_leaf(pos, self.grafting_height);
@@ -353,7 +320,7 @@ pub(super) struct Storage<
     grafted_tree: &'a G,
     grafting_height: u32,
     ops_tree: &'a S,
-    grafted_hasher: GraftedHasher<F, H>,
+    hasher: H,
     _phantom: PhantomData<(F, D)>,
 }
 
@@ -377,7 +344,7 @@ impl<
             grafted_tree,
             grafting_height,
             ops_tree,
-            grafted_hasher: GraftedHasher::new(hasher, grafting_height),
+            hasher,
             _phantom: PhantomData,
         }
     }
@@ -410,10 +377,7 @@ impl<
         let (left, right) = F::children(pos, height);
         let left_digest = self.reconstruct_grafted_node(left)?;
         let right_digest = self.reconstruct_grafted_node(right)?;
-        Some(
-            self.grafted_hasher
-                .node_digest(pos, &left_digest, &right_digest),
-        )
+        Some(self.hasher.node_digest(&left_digest, &right_digest))
     }
 }
 
@@ -576,12 +540,10 @@ mod tests {
         let pos_at_g = mmr::Family::subtree_root_position(Location::new(0), GH);
 
         let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
-        let expected_no_combine = <StandardHasher<Sha256> as HasherTrait<mmr::Family>>::node_digest(
-            &standard, pos_at_g, &left, &right,
-        );
+        let expected_no_combine = standard.node_digest(&left, &right);
 
         let v = Verifier::<mmr::Family, Sha256>::new(GH, 0, vec![&chunk], 0, ForwardFold);
-        let got = <Verifier<'_, mmr::Family, Sha256> as HasherTrait<mmr::Family>>::node_digest(
+        let got = <Verifier<'_, mmr::Family, Sha256> as HasherTrait<mmr::Family>>::node_digest_at(
             &v, pos_at_g, &left, &right,
         );
         assert_eq!(
@@ -592,7 +554,7 @@ mod tests {
         // Sanity: with graftable_chunks=1 the chunk IS combined, so the digest differs.
         let v_graftable = Verifier::<mmr::Family, Sha256>::new(GH, 0, vec![&chunk], 1, ForwardFold);
         let got_graftable =
-            <Verifier<'_, mmr::Family, Sha256> as HasherTrait<mmr::Family>>::node_digest(
+            <Verifier<'_, mmr::Family, Sha256> as HasherTrait<mmr::Family>>::node_digest_at(
                 &v_graftable,
                 pos_at_g,
                 &left,
@@ -623,13 +585,8 @@ mod tests {
         chunks: &[sha256::Digest],
         grafting_height: u32,
     ) -> Mmr<sha256::Digest> {
-        let grafted_hasher =
-            GraftedHasher::<mmr::Family, _>::new(standard.clone(), grafting_height);
         let mut grafted_mmr = Mmr::new();
         if !chunks.is_empty() {
-            // Use a separate hasher for leaf digest computation to avoid borrow conflict
-            // with grafted_hasher (which borrows standard via fork()).
-            let leaf_hasher = StandardHasher::<Sha256>::new(ForwardFold);
             let batch = {
                 let mut batch = grafted_mmr.new_batch();
                 for (i, chunk) in chunks.iter().enumerate() {
@@ -638,10 +595,10 @@ mod tests {
                         .get_node(ops_pos)
                         .expect("ops tree missing node at mapped position");
                     batch = batch.add_leaf_digest(
-                        leaf_hasher.hash([chunk.as_ref(), ops_subtree_root.as_ref()]),
+                        standard.hash([chunk.as_ref(), ops_subtree_root.as_ref()]),
                     );
                 }
-                batch.merkleize(&grafted_mmr, &grafted_hasher)
+                batch.merkleize(&grafted_mmr, standard)
             };
             grafted_mmr.apply_batch(&batch).unwrap();
         }
@@ -800,7 +757,7 @@ mod tests {
         let c2 = Sha256::fill(0xF2);
 
         // Build grafted MMR with 2 leaves.
-        let grafted_hasher = GraftedHasher::<mmr::Family, _>::new(standard, grafting_height);
+        let grafted_hasher = standard;
         let mut grafted = Mmr::new();
         let pos0 = chunk_idx_to_ops_pos(0, grafting_height);
         let pos1 = chunk_idx_to_ops_pos(1, grafting_height);
@@ -1091,7 +1048,7 @@ mod tests {
         // Build a grafted MMR with 2 leaves.
         let d0 = Sha256::fill(0x01);
         let d1 = Sha256::fill(0x02);
-        let grafted_hasher = GraftedHasher::<mmr::Family, _>::new(standard, grafting_height);
+        let grafted_hasher = standard;
         let mut grafted = Mmr::new();
         let batch = grafted
             .new_batch()
@@ -1130,7 +1087,7 @@ mod tests {
 
         // Build a grafted MMR from pruned components + one new leaf.
         let d4 = Sha256::fill(0xBB);
-        let grafted_hasher = GraftedHasher::<mmr::Family, _>::new(standard, grafting_height);
+        let grafted_hasher = standard;
         let mut grafted =
             Mmr::from_components(Vec::new(), grafted_pruning_boundary, vec![pinned_digest])
                 .unwrap();

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -175,20 +175,20 @@ pub fn grafted_to_ops_pos<F: Graftable>(
     F::subtree_root_position(ops_leaf_start, ops_height)
 }
 
-/// A [`merkle::hasher::Hasher`] implementation used for verifying proofs over grafted storage.
+/// Node combiner used for verifying proofs over grafted storage.
 ///
-/// The ops structure uses family `F`, so this implements [`merkle::hasher::Hasher`] for that
-/// family to match the proof.
-/// Proof verification walks the tree from leaves to root, recomputing digests at each node.
-/// Since a proof path crosses the grafting boundary (from ops leaves up through grafted peaks),
-/// two different hashing behaviors are needed depending on the node's height relative to the
-/// grafting height:
+/// Proof reconstruction walks the ops tree (family `F`) from leaves to root. Because a proof path
+/// crosses the grafting boundary (from ops leaves up through grafted peaks), [`Self::combine`]
+/// applies two behaviors depending on the node's height relative to the grafting height:
 ///
-/// - **Below or above**: standard hash using ops-space positions (`F`).
-/// - **At**: the children form an ops subtree root, which is combined with a bitmap chunk element
+/// - **Below or above**: a plain node digest.
+/// - **At**: the children form an ops subtree root, which is combined with the node's bitmap chunk
 ///   to reconstruct the grafted leaf digest.
+///
+/// [`Self::combine`] is paired with [`Self::hasher`] (which supplies leaf digests, peak folding, and
+/// the root bagging policy) when reconstructing a grafted proof's root.
 #[derive(Clone)]
-pub struct Verifier<'a, F: Graftable, H: CHasher> {
+pub(crate) struct Verifier<'a, F: Graftable, H: CHasher> {
     hasher: merkle::hasher::Standard<H>,
     grafting_height: u32,
 
@@ -211,7 +211,7 @@ impl<'a, F: Graftable, H: CHasher> Verifier<'a, F, H> {
     /// `graftable_chunks` is the number of chunks committed by the grafted tree; any chunk index
     /// in `chunks` at or beyond this boundary is treated as pending and **not** combined with
     /// the ops subtree root at the grafting height.
-    pub const fn new(
+    pub(crate) const fn new(
         grafting_height: u32,
         start_chunk_index: u64,
         chunks: Vec<&'a [u8]>,
@@ -227,24 +227,25 @@ impl<'a, F: Graftable, H: CHasher> Verifier<'a, F, H> {
             _ops_family: PhantomData,
         }
     }
-}
 
-impl<F: Graftable, H: CHasher> HasherTrait<F> for Verifier<'_, F, H> {
-    type Digest = H::Digest;
-
-    fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> H::Digest {
-        self.hasher.hash(parts)
+    /// The plain hasher used for leaf digests, peak folding, and the root bagging policy during
+    /// reconstruction. Pair it with [`Self::combine`] when calling the proof reconstruction.
+    pub(crate) const fn hasher(&self) -> &merkle::hasher::Standard<H> {
+        &self.hasher
     }
 
-    fn root_bagging(&self) -> merkle::Bagging {
-        <merkle::hasher::Standard<H> as HasherTrait<F>>::root_bagging(&self.hasher)
+    /// Hash a bitmap chunk, used to validate supplied chunk bytes against a digest in the proof.
+    pub(crate) fn digest(&self, data: &[u8]) -> H::Digest {
+        self.hasher.digest(data)
     }
 
-    fn node_digest(&self, left: &H::Digest, right: &H::Digest) -> H::Digest {
-        <merkle::hasher::Standard<H> as HasherTrait<F>>::node_digest(&self.hasher, left, right)
-    }
-
-    fn node_digest_at(
+    /// Combine two child digests for the ops-tree node at `pos`, fusing the node's bitmap chunk when
+    /// `pos` sits at the grafting height.
+    ///
+    /// Below or above the grafting height this is a plain node digest. At the grafting height the
+    /// children form an ops subtree root, which is combined with the node's bitmap chunk to
+    /// reconstruct the grafted leaf digest.
+    pub(crate) fn combine(
         &self,
         pos: merkle::Position<F>,
         left_digest: &H::Digest,
@@ -253,19 +254,11 @@ impl<F: Graftable, H: CHasher> HasherTrait<F> for Verifier<'_, F, H> {
         match F::pos_to_height(pos).cmp(&self.grafting_height) {
             Ordering::Less | Ordering::Greater => {
                 // Below or above grafting height: plain node digest.
-                <merkle::hasher::Standard<H> as HasherTrait<F>>::node_digest(
-                    &self.hasher,
-                    left_digest,
-                    right_digest,
-                )
+                self.hasher.node_digest(left_digest, right_digest)
             }
             Ordering::Equal => {
                 // At grafting height: compute ops subtree root, then combine with bitmap chunk.
-                let ops_subtree_root = <merkle::hasher::Standard<H> as HasherTrait<F>>::node_digest(
-                    &self.hasher,
-                    left_digest,
-                    right_digest,
-                );
+                let ops_subtree_root = self.hasher.node_digest(left_digest, right_digest);
 
                 // Convert the F-family position to a chunk index using F's leftmost_leaf.
                 let loc = F::leftmost_leaf(pos, self.grafting_height);
@@ -293,7 +286,7 @@ impl<F: Graftable, H: CHasher> HasherTrait<F> for Verifier<'_, F, H> {
                 if chunk.iter().all(|&b| b == 0) {
                     ops_subtree_root
                 } else {
-                    self.hash([chunk, ops_subtree_root.as_ref()])
+                    self.hasher.hash([chunk, ops_subtree_root.as_ref()])
                 }
             }
         }
@@ -426,6 +419,40 @@ mod tests {
     /// every call site.
     const ALL_CHUNKS_GRAFTABLE: u64 = u64::MAX;
 
+    /// Verify a grafted range proof by reconstructing the root with the verifier's combiner and its
+    /// plain hasher, then comparing against `root`. The grafting [`Verifier`] is a node combiner
+    /// rather than a [`merkle::hasher::Hasher`], so it cannot be passed to `verify_range_inclusion`
+    /// directly.
+    fn verify_grafted_range<E: AsRef<[u8]>>(
+        proof: &merkle::Proof<mmr::Family, sha256::Digest>,
+        verifier: &Verifier<'_, mmr::Family, Sha256>,
+        elements: &[E],
+        start_loc: Location,
+        root: &sha256::Digest,
+    ) -> bool {
+        matches!(
+            proof.reconstruct_root_with(
+                verifier.hasher(),
+                &|pos, left, right| verifier.combine(pos, left, right),
+                elements,
+                start_loc,
+                None,
+            ),
+            Ok(reconstructed) if reconstructed == *root
+        )
+    }
+
+    /// Single-element convenience wrapper around [`verify_grafted_range`].
+    fn verify_grafted_element(
+        proof: &merkle::Proof<mmr::Family, sha256::Digest>,
+        verifier: &Verifier<'_, mmr::Family, Sha256>,
+        element: &[u8],
+        loc: Location,
+        root: &sha256::Digest,
+    ) -> bool {
+        verify_grafted_range(proof, verifier, &[element], loc, root)
+    }
+
     /// Count chunks of `2^G` leaves in `0..ops_leaves` that have a single covering peak at height G.
     ///
     /// Used as the oracle for `graftable_chunks` property tests.
@@ -543,9 +570,7 @@ mod tests {
         let expected_no_combine = standard.node_digest(&left, &right);
 
         let v = Verifier::<mmr::Family, Sha256>::new(GH, 0, vec![&chunk], 0, ForwardFold);
-        let got = <Verifier<'_, mmr::Family, Sha256> as HasherTrait<mmr::Family>>::node_digest_at(
-            &v, pos_at_g, &left, &right,
-        );
+        let got = v.combine(pos_at_g, &left, &right);
         assert_eq!(
             got, expected_no_combine,
             "graftable_chunks=0 must skip chunk combination at the grafting height"
@@ -553,13 +578,7 @@ mod tests {
 
         // Sanity: with graftable_chunks=1 the chunk IS combined, so the digest differs.
         let v_graftable = Verifier::<mmr::Family, Sha256>::new(GH, 0, vec![&chunk], 1, ForwardFold);
-        let got_graftable =
-            <Verifier<'_, mmr::Family, Sha256> as HasherTrait<mmr::Family>>::node_digest_at(
-                &v_graftable,
-                pos_at_g,
-                &left,
-                &right,
-            );
+        let got_graftable = v_graftable.combine(pos_at_g, &left, &right);
         assert_ne!(got, got_graftable);
     }
 
@@ -858,13 +877,25 @@ mod tests {
                         ALL_CHUNKS_GRAFTABLE,
                         ForwardFold,
                     );
-                    assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root));
+                    assert!(verify_grafted_element(
+                        &proof,
+                        &verifier,
+                        &b1,
+                        loc,
+                        &grafted_root
+                    ));
 
                     let loc = Location::new(1);
                     let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
                         .await
                         .unwrap();
-                    assert!(proof.verify_element_inclusion(&verifier, &b2, loc, &grafted_root));
+                    assert!(verify_grafted_element(
+                        &proof,
+                        &verifier,
+                        &b2,
+                        loc,
+                        &grafted_root
+                    ));
 
                     let loc = Location::new(2);
                     let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
@@ -877,13 +908,25 @@ mod tests {
                         ALL_CHUNKS_GRAFTABLE,
                         ForwardFold,
                     );
-                    assert!(proof.verify_element_inclusion(&verifier, &b3, loc, &grafted_root));
+                    assert!(verify_grafted_element(
+                        &proof,
+                        &verifier,
+                        &b3,
+                        loc,
+                        &grafted_root
+                    ));
 
                     let loc = Location::new(3);
                     let proof = verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
                         .await
                         .unwrap();
-                    assert!(proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
+                    assert!(verify_grafted_element(
+                        &proof,
+                        &verifier,
+                        &b4,
+                        loc,
+                        &grafted_root
+                    ));
                 }
 
                 // Verify that manipulated inputs cause proof verification to fail.
@@ -899,16 +942,31 @@ mod tests {
                         ALL_CHUNKS_GRAFTABLE,
                         ForwardFold,
                     );
-                    assert!(proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
+                    assert!(verify_grafted_element(
+                        &proof,
+                        &verifier,
+                        &b4,
+                        loc,
+                        &grafted_root
+                    ));
 
                     // Wrong leaf element.
-                    assert!(!proof.verify_element_inclusion(&verifier, &b3, loc, &grafted_root));
+                    assert!(!verify_grafted_element(
+                        &proof,
+                        &verifier,
+                        &b3,
+                        loc,
+                        &grafted_root
+                    ));
 
                     // Wrong root.
-                    assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &ops_root));
+                    assert!(!verify_grafted_element(
+                        &proof, &verifier, &b4, loc, &ops_root
+                    ));
 
                     // Wrong position.
-                    assert!(!proof.verify_element_inclusion(
+                    assert!(!verify_grafted_element(
+                        &proof,
                         &verifier,
                         &b4,
                         loc + 1,
@@ -923,7 +981,13 @@ mod tests {
                         ALL_CHUNKS_GRAFTABLE,
                         ForwardFold,
                     );
-                    assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
+                    assert!(!verify_grafted_element(
+                        &proof,
+                        &verifier,
+                        &b4,
+                        loc,
+                        &grafted_root
+                    ));
 
                     // Wrong chunk index in the verifier.
                     let verifier = Verifier::<mmr::Family, Sha256>::new(
@@ -933,7 +997,13 @@ mod tests {
                         ALL_CHUNKS_GRAFTABLE,
                         ForwardFold,
                     );
-                    assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
+                    assert!(!verify_grafted_element(
+                        &proof,
+                        &verifier,
+                        &b4,
+                        loc,
+                        &grafted_root
+                    ));
                 }
 
                 // Verify range proofs.
@@ -954,7 +1024,8 @@ mod tests {
                         ALL_CHUNKS_GRAFTABLE,
                         ForwardFold,
                     );
-                    assert!(proof.verify_range_inclusion(
+                    assert!(verify_grafted_range(
+                        &proof,
                         &verifier,
                         &range,
                         Location::new(0),
@@ -969,7 +1040,8 @@ mod tests {
                         ALL_CHUNKS_GRAFTABLE,
                         ForwardFold,
                     );
-                    assert!(!proof.verify_range_inclusion(
+                    assert!(!verify_grafted_range(
+                        &proof,
                         &verifier,
                         &range,
                         Location::new(0),
@@ -1023,7 +1095,13 @@ mod tests {
                 ALL_CHUNKS_GRAFTABLE,
                 ForwardFold,
             );
-            assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root));
+            assert!(verify_grafted_element(
+                &proof,
+                &verifier,
+                &b1,
+                loc,
+                &grafted_root
+            ));
 
             let verifier = Verifier::<mmr::Family, Sha256>::new(
                 GRAFTING_HEIGHT,
@@ -1036,7 +1114,13 @@ mod tests {
             let proof = merkle::verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
                 .await
                 .unwrap();
-            assert!(proof.verify_element_inclusion(&verifier, &b5, loc, &grafted_root));
+            assert!(verify_grafted_element(
+                &proof,
+                &verifier,
+                &b5,
+                loc,
+                &grafted_root
+            ));
         });
     }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -142,7 +142,7 @@
 //! height, it uses standard hashing. At the grafting height, it detects the boundary and
 //! reconstructs the grafted leaf from the chunk and the ops subtree root. For non-zero chunks the
 //! grafted leaf is `hash(chunk || ops_subtree_root)`; for all-zero chunks the grafted leaf is the
-//! ops subtree root itself (identity optimization -- see `grafting::Verifier::node`). Above the
+//! ops subtree root itself (identity optimization -- see `grafting::Verifier::combine`). Above the
 //! grafting height, it resumes standard hashing. If the reconstructed root matches the expected
 //! root and bit _i_ is set in the chunk, the operation is proven active.
 //!

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -30,10 +30,8 @@
 use crate::{
     journal::contiguous::{Contiguous, Reader as _},
     merkle::{
-        self,
-        hasher::{Hasher, Standard as StandardHasher},
-        storage::Storage,
-        Family, Graftable, Location, PendingChunk, Position, Proof,
+        self, hasher::Standard as StandardHasher, storage::Storage, Family, Graftable, Location,
+        PendingChunk, Position, Proof,
     },
     qmdb::{
         self,
@@ -417,8 +415,9 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             }
         }
 
-        let merkle_root = match self.proof.reconstruct_root_inner(
-            &grafting_verifier,
+        let merkle_root = match self.proof.reconstruct_root_with(
+            grafting_verifier.hasher(),
+            &|pos, left, right| grafting_verifier.combine(pos, left, right),
             &elements,
             start_loc,
             collected,

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -928,7 +928,7 @@ mod tests {
                 .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
-        let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+        let grafted_hasher = hasher.clone();
         let mut grafted = Mem::<F, sha256::Digest>::new();
         let merkleized = {
             let mut batch = grafted.new_batch();
@@ -1022,7 +1022,7 @@ mod tests {
                 .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
-        let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+        let grafted_hasher = hasher.clone();
         let mut grafted = Mem::<F, sha256::Digest>::new();
         let merkleized = {
             let mut batch = grafted.new_batch();
@@ -1125,7 +1125,7 @@ mod tests {
                 .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
-        let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+        let grafted_hasher = hasher.clone();
         let mut grafted = Mem::<F, sha256::Digest>::new();
         let merkleized = {
             let mut batch = grafted.new_batch();
@@ -1222,7 +1222,7 @@ mod tests {
                 .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
-        let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+        let grafted_hasher = hasher.clone();
         let mut grafted = Mem::<F, sha256::Digest>::new();
         let merkleized = {
             let mut batch = grafted.new_batch();
@@ -1312,7 +1312,7 @@ mod tests {
                 .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
-        let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+        let grafted_hasher = hasher.clone();
         let mut grafted = Mem::<F, sha256::Digest>::new();
         if !leaf_digests.is_empty() {
             let merkleized = {
@@ -1692,7 +1692,7 @@ mod tests {
                 .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
-        let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+        let grafted_hasher = hasher.clone();
         let mut grafted = Mem::<F, sha256::Digest>::new();
         let merkleized = {
             let mut batch = grafted.new_batch();
@@ -1824,8 +1824,7 @@ mod tests {
             )
             .await
             .unwrap();
-            let grafted_hasher =
-                grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+            let grafted_hasher = hasher.clone();
             let mut grafted = Mem::<F, sha256::Digest>::new();
             if !leaf_digests.is_empty() {
                 let merkleized = {
@@ -2038,7 +2037,7 @@ mod tests {
             1,
             "post-state must have 1 graftable chunk"
         );
-        let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+        let grafted_hasher = hasher.clone();
         let mut grafted_post = Mem::<F, sha256::Digest>::new();
         let merkleized = grafted_post
             .new_batch()
@@ -2115,7 +2114,7 @@ mod tests {
                 .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
-        let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
+        let grafted_hasher = hasher.clone();
         let mut grafted = Mem::<F, sha256::Digest>::new();
         let merkleized = {
             let mut batch = grafted.new_batch();


### PR DESCRIPTION
## Summary

Stacked on #4127 (base branch `hashing-boost`). Drops the node position from internal-node hashing and keys leaves by **location** instead of node position. The root already commits the leaf count, so the tree shape is fixed and the position is redundant in node digests — binding reduces to collision resistance of the location-keyed leaves plus the committed count.

Internal nodes use a single-block `merge_digest_pair` (one SHA-256 compression vs the two of the previous `hash_u64_digest_pair` node hash), domain-separated from standard hashing by a distinct compression IV (`MERGE_IV`). This gives a **uniform 128-bit leaf/node separation at every element length**, with no per-leaf tag and no element pre-hash.

Beyond the core change, this PR also makes the merkle `Hasher` trait fully position-free (grafting's chunk-fusion becomes an explicit combiner), closes a BLAKE3 domain-separation gap exposed by the positionless change and makes `merge_digest_pair` a required method so the gap can't recur, and fixes the `current::Db` verify callers left non-compiling by the base's hasher-param removal. See **Commits**.

## Why it's safe

- **Inclusion soundness** reduces to collision resistance: the verifier walks a shape fixed by the committed leaf count and only ever compares leaf-vs-leaf and node-vs-node (never cross-type), so node-position binding isn't required.
- **Leaf/node domain separation** is by construction: `merge_digest_pair` derives from a distinct IV (SHA-256) / key-derivation mode (BLAKE3), so a node digest can't equal a `hash`-derived leaf digest even when their 64-byte blocks coincide. (Same technique SHA-224 / SHA-512-256 use.) The method has **no default** — every hasher implements it explicitly, so a cryptographic hasher can't silently inherit an unsafe (non-separated) merge. Non-cryptographic hashers (checksums) delegate to `hash_digest_pair` and must not be used in authenticated structures.

## Performance

- **Primitive:** the node hash is now a single SHA-256 compression (`merge_digest_pair`, ~14.5 ns) vs the two-block previous node hash (`hash_u64_digest_pair`, ~30 ns) — roughly 2× faster. The `sha256::digest_pair` microbench shows the single- vs double-block gap (`merge_digest_pair` vs the full-hash `hash_digest_pair`).
- **Build-level:** small-to-neutral and within measurement noise. Node hashing is a fraction of a build and, on the parallel path, divided across cores, so the 2× doesn't show as a headline (`qmdb::merkleize` and the new `merkle::build` bench are within noise). No regression.
- Aside: the bigger build lever is the bulk path itself — `merkle::build` (bulk `add_leaf_digests` + parallel merkleize) is ~36% lighter than the per-leaf `append`, and is the path qmdb already uses.

_(Perf figures are from the in-repo microbenches; reproduce with `cargo bench -p commonware-cryptography` / `-p commonware-storage`.)_

## Commits

1. **`[storage/merkle] Positionless node hashing with domain-separated merge`** — the core change above. Location-keyed `leaf_digest`/`leaf_encoded`; `Standard::node_digest` via `merge_digest_pair` from `MERGE_IV` (= `SHA256("_COMMONWARE_CRYPTOGRAPHY_MERGE_DIGEST_PAIR")`, pinned by a test); removed `GraftedHasher` / `map_pos` / `merkleize_reusing_with` and the old `hash_u64_digest_pair` primitive; exposed `add_leaf_digests`; new `merkle::build` + `sha256::digest_pair` benches; conformance regenerated.
2. **`[storage/qmdb] Drop redundant hasher arg from current::Db verify callers`** — the base already removed `&hasher` from `current::Db::verify_*` but left the glue + `current_*` fuzz callers passing it (non-compiling). This updates them; required for the branch to build.
3. **`[cryptography] Domain-separate BLAKE3 merge_digest_pair`** — BLAKE3 inherited the unsafe default merge (plain `hash(l || r)`), so `Standard<Blake3>` could let an internal-node digest be reinterpreted as a leaf preimage without a hash collision. Adds a safe merge via BLAKE3's key-derivation mode (with a test) and clarifies the contract.
4. **`[storage/merkle] Position-free Hasher trait; grafting via explicit combiner`** — removes `node_digest_at` from the `Hasher` trait entirely; proof reconstruction takes an explicit combiner (`reconstruct_root_with`, defaulting to `Hasher::node_digest`); the grafting `Verifier` becomes a plain combiner (no longer a `Hasher` impl), scoped `pub(crate)`. The position-keyed grafting concern leaves the generic trait.
5. **`[cryptography] Require merge_digest_pair (remove unsafe default)`** — the plain-hash default was a silent fail-open for any cryptographic hasher that forgot to override it (the BLAKE3 gap above). Removes the default so the method is required; SHA-256/BLAKE3 already override safely, CRC32 (non-cryptographic, no collision resistance to separate anyway) delegates explicitly with a no-separation note.

## Notes

- ALPHA crates — breaking storage-format change, no migration path needed.
- **Draft:** for the `hashing-boost` author to judge whether the simplification (−net core LOC: `GraftedHasher` / `map_pos` / `node_digest_at` gone) + uniform domain separation are worth folding in. The perf is a real but small primitive win, not a headline.
- Commit 2 (verify-caller fix) completes a loose end of the base's own hasher-param removal, so it may belong in `hashing-boost` rather than here.
- A follow-up PR will internalize the canonical hasher in `current::Db`'s proof-*generation* methods too, mirroring the now-hasher-free `verify_*` methods — kept separate to avoid a ~45-site mechanical sweep bloating this PR.
- The `digest_pair` microbench and `build` bench can be dropped if undesired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
