### PR TITLE
[storage/journal] Address Final Nits

### DIFF
--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -8,6 +8,58 @@ mod write;
 pub use read::Read;
 pub use write::Write;
 
+/// Tracks whether plain blob mutations still need a full durability barrier.
+struct SyncState {
+    needs_sync: bool,
+}
+
+impl SyncState {
+    const fn new(needs_sync: bool) -> Self {
+        Self { needs_sync }
+    }
+
+    fn mark_unsynced(&mut self) {
+        self.needs_sync = true;
+    }
+
+    async fn write_at(
+        &mut self,
+        blob: &impl crate::Blob,
+        offset: u64,
+        bufs: impl Into<crate::IoBufs> + Send,
+    ) -> Result<(), crate::Error> {
+        blob.write_at(offset, bufs).await?;
+        self.needs_sync = true;
+        Ok(())
+    }
+
+    async fn write_at_sync(
+        &mut self,
+        blob: &impl crate::Blob,
+        offset: u64,
+        bufs: impl Into<crate::IoBufs> + Send,
+    ) -> Result<(), crate::Error> {
+        if self.needs_sync {
+            self.write_at(blob, offset, bufs).await?;
+            self.sync(blob).await
+        } else {
+            self.needs_sync = true;
+            blob.write_at_sync(offset, bufs).await?;
+            self.needs_sync = false;
+            Ok(())
+        }
+    }
+
+    async fn sync(&mut self, blob: &impl crate::Blob) -> Result<(), crate::Error> {
+        if !self.needs_sync {
+            return Ok(());
+        }
+        blob.sync().await?;
+        self.needs_sync = false;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -23,7 +23,7 @@ impl SyncState {
         Self { needs_sync }
     }
 
-    fn mark_unsynced(&mut self) {
+    const fn mark_unsynced(&mut self) {
         self.needs_sync = true;
     }
 
@@ -48,6 +48,7 @@ impl SyncState {
             self.write_at(blob, offset, bufs).await?;
             self.sync(blob).await
         } else {
+            // If `write_at_sync` fails, a later sync must not treat the drained buffer as durable.
             self.needs_sync = true;
             blob.write_at_sync(offset, bufs).await?;
             self.needs_sync = false;

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -14,6 +14,11 @@ struct SyncState {
 }
 
 impl SyncState {
+    /// Create a new sync state.
+    ///
+    /// Use `needs_sync = true` when wrapping an existing blob because prior plain mutations may
+    /// still need a full [`crate::Blob::sync`] barrier. [`Self::write_at_sync`] can use
+    /// [`crate::Blob::write_at_sync`] only when this is false.
     const fn new(needs_sync: bool) -> Self {
         Self { needs_sync }
     }

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -157,6 +157,31 @@ async fn get_page_with_checksum_from_blob(
     Ok((page.freeze().slice(..len as usize), record))
 }
 
+/// One of a page footer's two CRC slots, laid out back to back after the page data.
+#[derive(Clone, Copy)]
+enum Slot {
+    First,
+    Second,
+}
+
+impl Slot {
+    /// Byte offset of this slot within the page's CRC footer.
+    const fn offset(self) -> usize {
+        match self {
+            Self::First => 0,
+            Self::Second => CHECKSUM_SLOT_SIZE,
+        }
+    }
+
+    /// The other slot.
+    const fn other(self) -> Self {
+        match self {
+            Self::First => Self::Second,
+            Self::Second => Self::First,
+        }
+    }
+}
+
 /// Describes a CRC record stored at the end of a page.
 ///
 /// The CRC accompanied by the larger length is the one that should be treated as authoritative for
@@ -174,11 +199,33 @@ impl Checksum {
     /// Create a new CRC record with the given length and CRC.
     /// The new CRC is stored in the first slot (len1/crc1), with the second slot zeroed.
     const fn new(len: u16, crc: u32) -> Self {
-        Self {
-            len1: len,
-            crc1: crc,
-            len2: 0,
-            crc2: 0,
+        Self::in_slot(Slot::First, len, crc)
+    }
+
+    /// A record carrying `(len, crc)` in `slot`, with the other slot zeroed.
+    const fn in_slot(slot: Slot, len: u16, crc: u32) -> Self {
+        match slot {
+            Slot::First => Self {
+                len1: len,
+                crc1: crc,
+                len2: 0,
+                crc2: 0,
+            },
+            Slot::Second => Self {
+                len1: 0,
+                crc1: 0,
+                len2: len,
+                crc2: crc,
+            },
+        }
+    }
+
+    /// The slot holding the authoritative (longer) CRC; the first slot wins ties.
+    const fn authoritative(&self) -> Slot {
+        if self.len1 >= self.len2 {
+            Slot::First
+        } else {
+            Slot::Second
         }
     }
 
@@ -264,10 +311,9 @@ impl Checksum {
     /// validation. If they both have the same length (which should only happen due to data
     /// corruption) return the first.
     const fn get_crc(&self) -> (u16, u32) {
-        if self.len1 >= self.len2 {
-            (self.len1, self.crc1)
-        } else {
-            (self.len2, self.crc2)
+        match self.authoritative() {
+            Slot::First => (self.len1, self.crc1),
+            Slot::Second => (self.len2, self.crc2),
         }
     }
 
@@ -275,16 +321,19 @@ impl Checksum {
     /// should only be called if the primary CRC failed validation. After this returns, get_crc will
     /// no longer return the invalid primary CRC.
     const fn get_fallback_crc(&mut self) -> (u16, u32) {
-        if self.len1 >= self.len2 {
-            // First CRC was primary, and must have been invalid. Zero it and return the second.
-            self.len1 = 0;
-            self.crc1 = 0;
-            (self.len2, self.crc2)
-        } else {
-            // Second CRC was primary, and must have been invalid. Zero it and return the first.
-            self.len2 = 0;
-            self.crc2 = 0;
-            (self.len1, self.crc1)
+        match self.authoritative() {
+            Slot::First => {
+                // First CRC was primary, and must have been invalid. Zero it and return the second.
+                self.len1 = 0;
+                self.crc1 = 0;
+                (self.len2, self.crc2)
+            }
+            Slot::Second => {
+                // Second CRC was primary, and must have been invalid. Zero it and return the first.
+                self.len2 = 0;
+                self.crc2 = 0;
+                (self.len1, self.crc1)
+            }
         }
     }
 

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -291,6 +291,13 @@ impl Checksum {
     fn to_bytes(&self) -> [u8; CHECKSUM_SIZE as usize] {
         self.encode_fixed()
     }
+
+    /// Returns one checksum slot in its storage representation.
+    fn slot_bytes(len: u16, crc: u32) -> [u8; CHECKSUM_SLOT_SIZE] {
+        Self::new(len, crc).to_bytes()[..CHECKSUM_SLOT_SIZE]
+            .try_into()
+            .expect("checksum slot size is fixed")
+    }
 }
 
 impl Write for Checksum {

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -293,7 +293,10 @@ impl Checksum {
         self.encode_fixed()
     }
 
-    /// Returns one checksum slot in its storage representation.
+    /// Encode a whole checksum slot (`[len: u16][crc: u32]`) in its storage representation.
+    ///
+    /// A page footer holds two slots; recovery treats the one with the larger `len` as
+    /// authoritative (see [`Self::get_crc`]). A `len` of 0 is never authoritative.
     fn slot_bytes(len: u16, crc: u32) -> [u8; CHECKSUM_SLOT_SIZE] {
         let mut bytes = [0; CHECKSUM_SLOT_SIZE];
         let mut buf = bytes.as_mut_slice();
@@ -302,7 +305,12 @@ impl Checksum {
         bytes
     }
 
-    /// Returns a checksum slot's length field in its storage representation.
+    /// Encode just a slot's leading `len` field (the first [`CHECKSUM_SLOT_LEN_SIZE`] bytes of
+    /// [`Self::slot_bytes`]).
+    ///
+    /// Because `len` decides which slot is authoritative, rewriting only this field flips a slot's
+    /// authority without disturbing its already-durable CRC: writing a non-zero `len` commits a
+    /// previously staged slot, while writing 0 retires one.
     fn slot_len_bytes(len: u16) -> [u8; CHECKSUM_SLOT_LEN_SIZE] {
         let mut bytes = [0; CHECKSUM_SLOT_LEN_SIZE];
         let mut buf = bytes.as_mut_slice();

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -42,7 +42,8 @@ pub use writer::Writer;
 
 // A checksum record contains two slots. Each slot stores one u16 length and one CRC.
 const CHECKSUM_SIZE: u64 = Checksum::SIZE as u64;
-const CHECKSUM_SLOT_SIZE: usize = u16::SIZE + crc32::Digest::SIZE;
+const CHECKSUM_SLOT_LEN_SIZE: usize = u16::SIZE;
+const CHECKSUM_SLOT_SIZE: usize = CHECKSUM_SLOT_LEN_SIZE + crc32::Digest::SIZE;
 
 /// Ensure `buf` has one `item_size` slot per offset, offsets are sorted and non-overlapping, and
 /// every requested range lies within the blob's size.
@@ -298,6 +299,14 @@ impl Checksum {
         let mut buf = bytes.as_mut_slice();
         len.write(&mut buf);
         crc.write(&mut buf);
+        bytes
+    }
+
+    /// Returns a checksum slot's length field in its storage representation.
+    fn slot_len_bytes(len: u16) -> [u8; CHECKSUM_SLOT_LEN_SIZE] {
+        let mut bytes = [0; CHECKSUM_SLOT_LEN_SIZE];
+        let mut buf = bytes.as_mut_slice();
+        len.write(&mut buf);
         bytes
     }
 }

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -294,9 +294,11 @@ impl Checksum {
 
     /// Returns one checksum slot in its storage representation.
     fn slot_bytes(len: u16, crc: u32) -> [u8; CHECKSUM_SLOT_SIZE] {
-        Self::new(len, crc).to_bytes()[..CHECKSUM_SLOT_SIZE]
-            .try_into()
-            .expect("checksum slot size is fixed")
+        let mut bytes = [0; CHECKSUM_SLOT_SIZE];
+        let mut buf = bytes.as_mut_slice();
+        len.write(&mut buf);
+        crc.write(&mut buf);
+        bytes
     }
 }
 

--- a/runtime/src/utils/buffer/paged/read.rs
+++ b/runtime/src/utils/buffer/paged/read.rs
@@ -48,7 +48,7 @@ impl<B: Blob> PageReader<B> {
     /// The last page may be logically partial (CRC length < logical page size), but
     /// all preceding pages must be logically full. A logically partial non-last page
     /// indicates corruption and will cause an `Error::InvalidChecksum`.
-    pub(super) const fn new(
+    pub(super) fn new(
         blob: B,
         physical_blob_size: u64,
         logical_blob_size: u64,
@@ -57,6 +57,14 @@ impl<B: Blob> PageReader<B> {
     ) -> Self {
         let logical_page_size = logical_page_size.get() as usize;
         let page_size = logical_page_size + Checksum::SIZE;
+        let physical_pages = physical_blob_size / page_size as u64;
+        let logical_pages = if logical_blob_size == 0 {
+            0
+        } else {
+            ((logical_blob_size - 1) / logical_page_size as u64) + 1
+        };
+        assert_eq!(physical_blob_size % page_size as u64, 0);
+        assert_eq!(physical_pages, logical_pages);
 
         Self {
             blob,

--- a/runtime/src/utils/buffer/paged/view.rs
+++ b/runtime/src/utils/buffer/paged/view.rs
@@ -36,6 +36,17 @@ impl<B: Blob> Clone for View<'_, B> {
 impl<B: Blob> Copy for View<'_, B> {}
 
 impl<B: Blob> View<'_, B> {
+    /// Copy any in-memory tail overlap into `buf`, returning the remaining prefix length.
+    fn copy_tail_overlap(&self, buf: &mut [u8], offset: u64) -> usize {
+        let tail_start = self.tail_offset.max(offset);
+        let prefix_len = (tail_start - offset) as usize;
+        let tail_offset = (tail_start - self.tail_offset) as usize;
+        let tail_len = buf.len() - prefix_len;
+        let (_, tail_buf) = buf.split_at_mut(prefix_len);
+        tail_buf.copy_from_slice(&self.tail[tail_offset..tail_offset + tail_len]);
+        prefix_len
+    }
+
     /// Read into `buf` if it can be done synchronously without I/O. Returns `true` only if all
     /// `buf.len()` bytes were satisfied from the page cache and/or the in-memory tail. When `false`
     /// is returned, the contents of `buf` are unspecified.
@@ -56,11 +67,7 @@ impl<B: Blob> View<'_, B> {
 
         // Copy the suffix overlapping the tail, then serve any prefix below `tail_offset` from the
         // cache.
-        let overlap_start = self.tail_offset.max(offset);
-        let dst_start = (overlap_start - offset) as usize;
-        let src_start = (overlap_start - self.tail_offset) as usize;
-        let copied = buf.len() - dst_start;
-        buf[dst_start..].copy_from_slice(&self.tail[src_start..src_start + copied]);
+        let dst_start = self.copy_tail_overlap(buf, offset);
 
         if dst_start == 0 {
             return true;
@@ -85,12 +92,7 @@ impl<B: Blob> View<'_, B> {
         let remaining = if end_offset <= self.tail_offset {
             buf.len()
         } else {
-            let overlap_start = self.tail_offset.max(offset);
-            let dst_start = (overlap_start - offset) as usize;
-            let src_start = (overlap_start - self.tail_offset) as usize;
-            let copied = buf.len() - dst_start;
-            buf[dst_start..].copy_from_slice(&self.tail[src_start..src_start + copied]);
-            dst_start
+            self.copy_tail_overlap(buf, offset)
         };
 
         if remaining == 0 {

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -41,7 +41,7 @@ use super::{
 };
 use crate::{
     buffer::{
-        paged::{CacheRef, Checksum, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE},
+        paged::{CacheRef, Checksum, CHECKSUM_SIZE, CHECKSUM_SLOT_LEN_SIZE, CHECKSUM_SLOT_SIZE},
         tip::Buffer,
         SyncState,
     },
@@ -855,12 +855,9 @@ impl<B: Blob> Writer<B> {
 
         // Publish the new shrunken length. If a crash happens before the old slot is invalidated,
         // both slots may be valid, but recovery still chooses the old longer length.
-        let published_slot = Checksum::slot_bytes(new_len, new_crc);
-        self.write_at_sync(
-            new_slot_offset,
-            published_slot[..std::mem::size_of::<u16>()].to_vec(),
-        )
-        .await?;
+        let published_len = Checksum::slot_len_bytes(new_len);
+        self.write_at_sync(new_slot_offset, published_len.to_vec())
+            .await?;
 
         // Clear only the old slot's length bytes. Rewriting the whole footer here could tear across
         // both slots and lose the already-durable shorter checksum. Once this lands, length 0 is
@@ -868,8 +865,7 @@ impl<B: Blob> Writer<B> {
         let old_slot_offset = crc_start
             .checked_add(old_slot_start as u64)
             .ok_or(Error::OffsetOverflow)?;
-        let len_size = std::mem::size_of::<u16>();
-        self.write_at_sync(old_slot_offset, vec![0u8; len_size])
+        self.write_at_sync(old_slot_offset, vec![0u8; CHECKSUM_SLOT_LEN_SIZE])
             .await?;
 
         let final_record = if new_slot_start == 0 {
@@ -4227,10 +4223,7 @@ mod tests {
                 "old-slot length invalidation should fail"
             );
             assert_eq!(write_count.load(Ordering::SeqCst), 3);
-            assert_eq!(
-                failed_write_len.load(Ordering::SeqCst),
-                std::mem::size_of::<u16>()
-            );
+            assert_eq!(failed_write_len.load(Ordering::SeqCst), CHECKSUM_SLOT_LEN_SIZE);
             drop(append);
 
             let (blob, size) = context

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -41,7 +41,7 @@ use super::{
 };
 use crate::{
     buffer::{
-        paged::{CacheRef, Checksum, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE},
+        paged::{CacheRef, Checksum, Slot, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE},
         tip::Buffer,
         SyncState,
     },
@@ -51,15 +51,6 @@ use bytes::BufMut;
 use commonware_cryptography::Crc32;
 use std::num::{NonZeroU16, NonZeroUsize};
 use tracing::warn;
-
-/// Indicates which CRC slot in a page record must not be overwritten.
-#[derive(Clone, Copy)]
-enum ProtectedCrc {
-    /// The first slot still protects the committed prefix.
-    First,
-    /// The second slot still protects the committed prefix.
-    Second,
-}
 
 /// Adjusts a requested write-buffer `capacity` upward to the value the buffer actually uses,
 /// applying two upward adjustments:
@@ -476,7 +467,7 @@ impl<B: Blob> Writer<B> {
         // Write the physical pages to the blob.
         // If there are protected regions in the first page, we need to write around them.
         match protected_regions {
-            Some((prefix_len, ProtectedCrc::First)) => {
+            Some((prefix_len, Slot::First)) => {
                 // Protected CRC is first: [page_size..page_size+6].
                 //
                 // If only one of these writes is emitted, it can be made durable here. If
@@ -518,7 +509,7 @@ impl<B: Blob> Writer<B> {
 
                 Ok(false)
             }
-            Some((prefix_len, ProtectedCrc::Second)) => {
+            Some((prefix_len, Slot::Second)) => {
                 // Protected CRC is second: [page_size+6..page_size+12].
                 //
                 // If only one of these writes is emitted, it can be made durable here. If
@@ -644,18 +635,11 @@ impl<B: Blob> Writer<B> {
     /// - `prefix_len`: bytes `[0, prefix_len)` are committed logical data already covered by the
     ///   protected CRC and do not need to be rewritten
     /// - `protected_crc`: which CRC slot must not be overwritten by the next flush
-    fn identify_protected_regions(
-        partial_page_state: Option<&Checksum>,
-    ) -> Option<(usize, ProtectedCrc)> {
+    fn identify_protected_regions(partial_page_state: Option<&Checksum>) -> Option<(usize, Slot)> {
         let crc_record = partial_page_state?;
         let (old_len, _) = crc_record.get_crc();
-        // The protected CRC is the one with the larger (authoritative) length.
-        let protected_crc = if crc_record.len1 >= crc_record.len2 {
-            ProtectedCrc::First
-        } else {
-            ProtectedCrc::Second
-        };
-        Some((old_len as usize, protected_crc))
+        // The protected CRC is the authoritative (longer) slot.
+        Some((old_len as usize, crc_record.authoritative()))
     }
 
     /// Prepare physical-page writes from buffered logical bytes.
@@ -798,23 +782,20 @@ impl<B: Blob> Writer<B> {
         old_crc: &Checksum,
     ) -> Checksum {
         let (old_len, old_crc_val) = old_crc.get_crc();
-        // The old CRC is in the slot with the larger length value (first slot wins ties).
-        if old_crc.len1 >= old_crc.len2 {
-            // Old CRC is in slot 0, put new CRC in slot 1
-            Checksum {
+        // Keep the old CRC in its slot and place the new CRC in the free one.
+        match old_crc.authoritative() {
+            Slot::First => Checksum {
                 len1: old_len,
                 crc1: old_crc_val,
                 len2: new_len,
                 crc2: new_crc,
-            }
-        } else {
-            // Old CRC is in slot 1, put new CRC in slot 0
-            Checksum {
+            },
+            Slot::Second => Checksum {
                 len1: new_len,
                 crc1: new_crc,
                 len2: old_len,
                 crc2: old_crc_val,
-            }
+            },
         }
     }
 
@@ -838,16 +819,13 @@ impl<B: Blob> Writer<B> {
             .checked_mul(physical_page_size)
             .and_then(|start| start.checked_add(logical_page_size))
             .ok_or(Error::OffsetOverflow)?;
-        let (new_slot_start, old_slot_start) = if old_crc.len1 >= old_crc.len2 {
-            (CHECKSUM_SLOT_SIZE, 0)
-        } else {
-            (0, CHECKSUM_SLOT_SIZE)
-        };
+        let old_slot = old_crc.authoritative();
+        let new_slot = old_slot.other();
 
         // Stage the new slot with a 0 length and the shrunken page CRC. A crash here leaves the
         // old slot as the only non-zero valid slot.
         let new_slot_offset = crc_start
-            .checked_add(new_slot_start as u64)
+            .checked_add(new_slot.offset() as u64)
             .ok_or(Error::OffsetOverflow)?;
         let staged_slot = Checksum::slot_bytes(0, new_crc);
         self.write_at_sync(new_slot_offset, staged_slot.to_vec())
@@ -863,27 +841,12 @@ impl<B: Blob> Writer<B> {
         // both slots and lose the already-durable shorter checksum. Once this lands, length 0 is
         // never authoritative, so the shrunken slot wins.
         let old_slot_offset = crc_start
-            .checked_add(old_slot_start as u64)
+            .checked_add(old_slot.offset() as u64)
             .ok_or(Error::OffsetOverflow)?;
         self.write_at_sync(old_slot_offset, Checksum::slot_len_bytes(0).to_vec())
             .await?;
 
-        let final_record = if new_slot_start == 0 {
-            Checksum {
-                len1: new_len,
-                crc1: new_crc,
-                len2: 0,
-                crc2: 0,
-            }
-        } else {
-            Checksum {
-                len1: 0,
-                crc1: 0,
-                len2: new_len,
-                crc2: new_crc,
-            }
-        };
-        Ok(final_record)
+        Ok(Checksum::in_slot(new_slot, new_len, new_crc))
     }
 
     /// Flushes any buffered data, then returns a [Replay] for the underlying blob.
@@ -2674,7 +2637,7 @@ mod tests {
         let (prefix_len, protected_crc) = result.unwrap();
         assert_eq!(prefix_len, 50);
         assert!(
-            matches!(protected_crc, ProtectedCrc::First),
+            matches!(protected_crc, Slot::First),
             "First CRC should be protected when lengths are equal"
         );
     }
@@ -2695,7 +2658,7 @@ mod tests {
         let (prefix_len, protected_crc) = result.unwrap();
         assert_eq!(prefix_len, 100);
         assert!(
-            matches!(protected_crc, ProtectedCrc::First),
+            matches!(protected_crc, Slot::First),
             "First CRC should be protected when len1 > len2"
         );
     }
@@ -2716,7 +2679,7 @@ mod tests {
         let (prefix_len, protected_crc) = result.unwrap();
         assert_eq!(prefix_len, 100);
         assert!(
-            matches!(protected_crc, ProtectedCrc::Second),
+            matches!(protected_crc, Slot::Second),
             "Second CRC should be protected when len2 > len1"
         );
     }

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -43,6 +43,7 @@ use crate::{
     buffer::{
         paged::{CacheRef, Checksum, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE},
         tip::Buffer,
+        SyncState,
     },
     Blob, Error, IoBuf, IoBufMut, IoBufs,
 };
@@ -112,8 +113,8 @@ pub struct Writer<B: Blob> {
     /// will contain its CRC record.
     partial_page_state: Option<Checksum>,
 
-    /// Whether prior plain writes or resizes must be made durable by a full sync.
-    needs_sync: bool,
+    /// Durability state for plain writes, resizes, and range-sync writes.
+    sync_state: SyncState,
 
     /// Unique id assigned to this blob by the page cache.
     id: u64,
@@ -129,9 +130,7 @@ pub struct Writer<B: Blob> {
 impl<B: Blob> Writer<B> {
     /// Write bytes to the underlying blob and mark them as needing sync.
     async fn write_at(&mut self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
-        self.blob.write_at(offset, bufs).await?;
-        self.needs_sync = true;
-        Ok(())
+        self.sync_state.write_at(&self.blob, offset, bufs).await
     }
 
     /// Write bytes to the underlying blob and make them durable.
@@ -143,17 +142,9 @@ impl<B: Blob> Writer<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        if self.needs_sync {
-            self.write_at(offset, bufs).await?;
-            self.sync_inner().await
-        } else {
-            // If `write_at_sync` fails, a later sync must not treat the drained
-            // buffer as durable.
-            self.needs_sync = true;
-            self.blob.write_at_sync(offset, bufs).await?;
-            self.needs_sync = false;
-            Ok(())
-        }
+        self.sync_state
+            .write_at_sync(&self.blob, offset, bufs)
+            .await
     }
 
     /// Write bytes to the underlying blob, optionally making them durable.
@@ -172,12 +163,7 @@ impl<B: Blob> Writer<B> {
 
     /// Sync the underlying blob if there are unsynced mutations.
     async fn sync_inner(&mut self) -> Result<(), Error> {
-        if !self.needs_sync {
-            return Ok(());
-        }
-        self.blob.sync().await?;
-        self.needs_sync = false;
-        Ok(())
+        self.sync_state.sync(&self.blob).await
     }
 
     /// Wrap `blob` in a [Writer]. `blob` must already hold `original_blob_size` physical bytes;
@@ -221,7 +207,7 @@ impl<B: Blob> Writer<B> {
             blob,
             current_page,
             partial_page_state,
-            needs_sync,
+            sync_state: SyncState::new(needs_sync),
             id: cache_ref.next_id(),
             cache_ref,
             buffer,
@@ -801,14 +787,6 @@ impl<B: Blob> Writer<B> {
         }
     }
 
-    /// Encode one checksum slot as `[len: u16][crc: u32]`, matching `Checksum::write`.
-    fn checksum_slot_bytes(len: u16, crc: u32) -> [u8; CHECKSUM_SLOT_SIZE] {
-        let mut bytes = [0u8; CHECKSUM_SLOT_SIZE];
-        bytes[..2].copy_from_slice(&len.to_be_bytes());
-        bytes[2..].copy_from_slice(&crc.to_be_bytes());
-        bytes
-    }
-
     /// Build a CRC record that preserves the old CRC in its original slot and places the new CRC
     /// in the other slot.
     ///
@@ -871,14 +849,18 @@ impl<B: Blob> Writer<B> {
         let new_slot_offset = crc_start
             .checked_add(new_slot_start as u64)
             .ok_or(Error::OffsetOverflow)?;
-        let staged_slot = Self::checksum_slot_bytes(0, new_crc);
+        let staged_slot = Checksum::slot_bytes(0, new_crc);
         self.write_at_sync(new_slot_offset, staged_slot.to_vec())
             .await?;
 
         // Publish the new shrunken length. If a crash happens before the old slot is invalidated,
         // both slots may be valid, but recovery still chooses the old longer length.
-        self.write_at_sync(new_slot_offset, new_len.to_be_bytes().to_vec())
-            .await?;
+        let published_slot = Checksum::slot_bytes(new_len, new_crc);
+        self.write_at_sync(
+            new_slot_offset,
+            published_slot[..std::mem::size_of::<u16>()].to_vec(),
+        )
+        .await?;
 
         // Clear only the old slot's length bytes. Rewriting the whole footer here could tear across
         // both slots and lose the already-durable shorter checksum. Once this lands, length 0 is
@@ -1054,7 +1036,7 @@ impl<B: Blob> Writer<B> {
         // resizes need to create a pending sync.
         if new_physical_size != current_physical_size {
             self.blob.resize(new_physical_size).await?;
-            self.needs_sync = true;
+            self.sync_state.mark_unsynced();
         }
 
         // Evict cached pages at or beyond the new full-page boundary. The page at

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -4223,7 +4223,10 @@ mod tests {
                 "old-slot length invalidation should fail"
             );
             assert_eq!(write_count.load(Ordering::SeqCst), 3);
-            assert_eq!(failed_write_len.load(Ordering::SeqCst), CHECKSUM_SLOT_LEN_SIZE);
+            assert_eq!(
+                failed_write_len.load(Ordering::SeqCst),
+                CHECKSUM_SLOT_LEN_SIZE
+            );
             drop(append);
 
             let (blob, size) = context

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -41,7 +41,7 @@ use super::{
 };
 use crate::{
     buffer::{
-        paged::{CacheRef, Checksum, CHECKSUM_SIZE, CHECKSUM_SLOT_LEN_SIZE, CHECKSUM_SLOT_SIZE},
+        paged::{CacheRef, Checksum, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE},
         tip::Buffer,
         SyncState,
     },
@@ -865,7 +865,7 @@ impl<B: Blob> Writer<B> {
         let old_slot_offset = crc_start
             .checked_add(old_slot_start as u64)
             .ok_or(Error::OffsetOverflow)?;
-        self.write_at_sync(old_slot_offset, vec![0u8; CHECKSUM_SLOT_LEN_SIZE])
+        self.write_at_sync(old_slot_offset, Checksum::slot_len_bytes(0).to_vec())
             .await?;
 
         let final_record = if new_slot_start == 0 {
@@ -1143,9 +1143,11 @@ impl<B: Blob> Writer<B> {
 mod tests {
     use super::*;
     use crate::{
-        buffer::tests::SyncTrackingBlob, deterministic, telemetry::metrics::Registry, Buf,
-        BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Spawner as _, Storage as _,
-        Supervisor as _,
+        buffer::{paged::CHECKSUM_SLOT_LEN_SIZE, tests::SyncTrackingBlob},
+        deterministic,
+        telemetry::metrics::Registry,
+        Buf, BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Spawner as _,
+        Storage as _, Supervisor as _,
     };
     use commonware_codec::ReadExt;
     use commonware_macros::test_traced;

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -73,7 +73,7 @@ impl<B: Blob> Write<B> {
         Self {
             blob,
             buffer: Buffer::new(size, capacity.get(), pool),
-            sync_state: SyncState::new(true),
+            sync_state: SyncState::new(true), // ensure pending writes on the wrapped blob are synced
         }
     }
 

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -1,4 +1,7 @@
-use crate::{buffer::tip::Buffer, Blob, Buf, BufferPool, BufferPooler, Error, IoBufs};
+use crate::{
+    buffer::{tip::Buffer, SyncState},
+    Blob, Buf, BufferPool, BufferPooler, Error, IoBufs,
+};
 use std::num::NonZeroUsize;
 
 /// A writer that buffers the raw content of a [Blob] to optimize the performance of appending or
@@ -59,11 +62,8 @@ pub struct Write<B: Blob> {
     /// Buffered bytes at the logical tip of the blob.
     buffer: Buffer,
 
-    /// Whether a prior plain mutation must be persisted with [`Blob::sync`].
-    ///
-    /// [`Self::write_blob_sync`] uses [`Blob::write_at_sync`] only when this is false, otherwise it
-    /// must use [`Blob::sync`] to cover earlier unsynced mutations.
-    needs_sync: bool,
+    /// Durability state for plain writes and range-sync writes.
+    sync_state: SyncState,
 }
 
 impl<B: Blob> Write<B> {
@@ -73,7 +73,7 @@ impl<B: Blob> Write<B> {
         Self {
             blob,
             buffer: Buffer::new(size, capacity.get(), pool),
-            needs_sync: true, // ensure pending writes on the wrapped blob are synced
+            sync_state: SyncState::new(true),
         }
     }
 
@@ -215,7 +215,7 @@ impl<B: Blob> Write<B> {
 
         // Resize the underlying blob.
         self.blob.resize(len).await?;
-        self.needs_sync = true;
+        self.sync_state.mark_unsynced();
 
         Ok(())
     }
@@ -235,9 +235,7 @@ impl<B: Blob> Write<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        self.blob.write_at(offset, bufs).await?;
-        self.needs_sync = true;
-        Ok(())
+        self.sync_state.write_at(&self.blob, offset, bufs).await
     }
 
     /// Write bytes to the underlying blob and make them durable.
@@ -249,25 +247,13 @@ impl<B: Blob> Write<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        if self.needs_sync {
-            self.write_blob(offset, bufs).await?;
-            self.sync_blob().await
-        } else {
-            // If `write_at_sync` fails, a later sync must not treat the drained buffer as durable.
-            self.needs_sync = true;
-            self.blob.write_at_sync(offset, bufs).await?;
-            self.needs_sync = false;
-            Ok(())
-        }
+        self.sync_state
+            .write_at_sync(&self.blob, offset, bufs)
+            .await
     }
 
     /// Sync the underlying blob if there are unsynced mutations.
     async fn sync_blob(&mut self) -> Result<(), Error> {
-        if !self.needs_sync {
-            return Ok(());
-        }
-        self.blob.sync().await?;
-        self.needs_sync = false;
-        Ok(())
+        self.sync_state.sync(&self.blob).await
     }
 }

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -1,9 +1,12 @@
 //! Blob management for a contiguous journal.
 
-use crate::{journal::Error, Context};
+use crate::{
+    journal::{frame::FrameReader, Error},
+    Context,
+};
 use commonware_formatting::hex;
 use commonware_runtime::{
-    buffer::paged::{CacheRef, Replay as PagedReplay, Sealed, Writer},
+    buffer::paged::{CacheRef, Sealed, Writer},
     telemetry::metrics::{Counter, Gauge, GaugeExt as _, MetricsExt as _},
     Blob as RBlob, Buf, Error as RError, IoBufMut, IoBufs,
 };
@@ -142,7 +145,10 @@ pub(super) struct Writable<E: Context> {
     oldest_blob_index: u64,
 
     /// Sealed historical blobs.
-    sealed: Arc<[Sealed<E::Blob>]>,
+    sealed: Vec<Sealed<E::Blob>>,
+
+    /// Cached owned snapshot of [Self::sealed].
+    sealed_snapshot: Option<Arc<[Sealed<E::Blob>]>>,
 }
 
 impl<E: Context> Writable<E> {
@@ -204,7 +210,8 @@ impl<E: Context> Writable<E> {
             metrics,
             oldest_blob_index,
             tail,
-            sealed: sealed.into(),
+            sealed,
+            sealed_snapshot: None,
         })
     }
 
@@ -234,9 +241,17 @@ impl<E: Context> Writable<E> {
 
     /// Capture owned blob handles for a snapshot reader.
     pub(super) async fn snapshot(&mut self) -> Result<Blobs<'static, E::Blob>, Error> {
+        let sealed = match &self.sealed_snapshot {
+            Some(sealed) => sealed.clone(),
+            None => {
+                let sealed: Arc<[Sealed<E::Blob>]> = self.sealed.clone().into();
+                self.sealed_snapshot = Some(sealed.clone());
+                sealed
+            }
+        };
         Ok(Blobs {
             oldest_blob_index: self.oldest_blob_index,
-            sealed: SealedBlobs::Owned(self.sealed.clone()),
+            sealed: SealedBlobs::Owned(sealed),
             tail: Blob::Sealed(self.tail.snapshot().await.map_err(Error::Runtime)?),
         })
     }
@@ -252,15 +267,8 @@ impl<E: Context> Writable<E> {
         let old_writer = std::mem::replace(&mut self.tail, new_writer);
         let sealed = old_writer.seal().await.map_err(Error::Runtime)?;
         self.metrics.tracked.inc();
-
-        // Rebuild is O(n).
-        self.sealed = self
-            .sealed
-            .iter()
-            .cloned()
-            .chain(std::iter::once(sealed))
-            .collect::<Vec<Sealed<E::Blob>>>()
-            .into();
+        self.sealed.push(sealed);
+        self.sealed_snapshot = None;
         Ok(())
     }
 
@@ -274,7 +282,8 @@ impl<E: Context> Writable<E> {
         assert!(self.oldest_blob_index < min_blob && min_blob <= self.tail_blob_index());
         let drop_count = (min_blob - self.oldest_blob_index) as usize;
         let prev_oldest_blob_index = self.oldest_blob_index;
-        self.sealed = self.sealed[drop_count..].to_vec().into();
+        self.sealed.drain(..drop_count);
+        self.sealed_snapshot = None;
         self.oldest_blob_index = min_blob;
 
         for blob in prev_oldest_blob_index..min_blob {
@@ -350,7 +359,8 @@ impl<E: Context> Writable<E> {
         }
 
         // Sealed history now ends below the target, which is the tail.
-        self.sealed = self.sealed[..idx].to_vec().into();
+        self.sealed.truncate(idx);
+        self.sealed_snapshot = None;
         Ok(())
     }
 
@@ -366,7 +376,8 @@ impl<E: Context> Writable<E> {
         self.tail = self.partition.open(tail_blob).await?;
         self.metrics.tracked.inc();
         self.oldest_blob_index = tail_blob;
-        self.sealed = Vec::new().into();
+        self.sealed.clear();
+        self.sealed_snapshot = None;
         Ok(())
     }
 
@@ -424,6 +435,98 @@ impl<B: RBlob> SealedBlobs<'_, B> {
     }
 }
 
+/// Shared read surface for writable and sealed blobs.
+trait BlobReader {
+    /// Return the blob's logical size.
+    fn size(&self) -> u64;
+
+    /// Read into `buf` if the data is already cached.
+    fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool;
+
+    /// Read exactly `len` bytes at `offset`.
+    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, RError>;
+
+    /// Read up to `len` bytes at `offset`.
+    async fn read_up_to(
+        &self,
+        offset: u64,
+        len: usize,
+        bufs: impl Into<IoBufMut> + Send,
+    ) -> Result<(IoBufMut, usize), RError>;
+
+    /// Read fixed-size items at sorted byte offsets into `buf`.
+    async fn read_many_into(
+        &self,
+        buf: &mut [u8],
+        offsets: &[u64],
+        item_size: NonZeroUsize,
+    ) -> Result<usize, RError>;
+}
+
+impl<B: RBlob> BlobReader for Writer<B> {
+    fn size(&self) -> u64 {
+        Self::size(self)
+    }
+
+    fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
+        Self::try_read_sync(self, offset, buf)
+    }
+
+    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, RError> {
+        Self::read_at(self, offset, len).await
+    }
+
+    async fn read_up_to(
+        &self,
+        offset: u64,
+        len: usize,
+        bufs: impl Into<IoBufMut> + Send,
+    ) -> Result<(IoBufMut, usize), RError> {
+        Self::read_up_to(self, offset, len, bufs).await
+    }
+
+    async fn read_many_into(
+        &self,
+        buf: &mut [u8],
+        offsets: &[u64],
+        item_size: NonZeroUsize,
+    ) -> Result<usize, RError> {
+        Self::read_many_into(self, buf, offsets, item_size).await
+    }
+}
+
+impl<B: RBlob> BlobReader for Sealed<B> {
+    fn size(&self) -> u64 {
+        Self::size(self)
+    }
+
+    fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
+        Self::try_read_sync(self, offset, buf)
+    }
+
+    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, RError> {
+        Self::read_at(self, offset, len).await
+    }
+
+    async fn read_up_to(
+        &self,
+        offset: u64,
+        len: usize,
+        bufs: impl Into<IoBufMut> + Send,
+    ) -> Result<(IoBufMut, usize), RError> {
+        Self::read_up_to(self, offset, len, bufs).await
+    }
+
+    async fn read_many_into(
+        &self,
+        buf: &mut [u8],
+        offsets: &[u64],
+        item_size: NonZeroUsize,
+    ) -> Result<usize, RError> {
+        Self::read_many_into(self, buf, offsets, item_size).await
+    }
+}
+
 /// A read handle for one journal blob.
 pub(super) enum Blob<'a, B: RBlob> {
     /// Writable tail, read through the writer's cache-aware logical view.
@@ -445,24 +548,28 @@ impl<'a, B: RBlob> Blob<'a, B> {
     /// Return the blob's logical size.
     pub(super) fn size(&self) -> u64 {
         match self {
-            Self::Writer(writer) => writer.size(),
-            Self::Sealed(sealed) => sealed.size(),
+            Self::Writer(writer) => BlobReader::size(*writer),
+            Self::Sealed(sealed) => BlobReader::size(sealed),
         }
     }
 
     /// Read into `buf` if the data is already cached.
     pub(super) fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
         match self {
-            Self::Writer(writer) => writer.try_read_sync(offset, buf),
-            Self::Sealed(sealed) => sealed.try_read_sync(offset, buf),
+            Self::Writer(writer) => BlobReader::try_read_sync(*writer, offset, buf),
+            Self::Sealed(sealed) => BlobReader::try_read_sync(sealed, offset, buf),
         }
     }
 
     /// Read exactly `len` bytes at `offset`.
     pub(super) async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, Error> {
         match self {
-            Self::Writer(writer) => writer.read_at(offset, len).await.map_err(Error::Runtime),
-            Self::Sealed(sealed) => sealed.read_at(offset, len).await.map_err(Error::Runtime),
+            Self::Writer(writer) => BlobReader::read_at(*writer, offset, len)
+                .await
+                .map_err(Error::Runtime),
+            Self::Sealed(sealed) => BlobReader::read_at(sealed, offset, len)
+                .await
+                .map_err(Error::Runtime),
         }
     }
 
@@ -474,38 +581,22 @@ impl<'a, B: RBlob> Blob<'a, B> {
         bufs: impl Into<IoBufMut> + Send,
     ) -> Result<(IoBufMut, usize), Error> {
         match self {
-            Self::Writer(writer) => writer
-                .read_up_to(offset, len, bufs)
+            Self::Writer(writer) => BlobReader::read_up_to(*writer, offset, len, bufs)
                 .await
                 .map_err(Error::Runtime),
-            Self::Sealed(sealed) => sealed
-                .read_up_to(offset, len, bufs)
+            Self::Sealed(sealed) => BlobReader::read_up_to(sealed, offset, len, bufs)
                 .await
                 .map_err(Error::Runtime),
         }
     }
 
     /// Return a sequential replay handle starting at `offset`.
-    ///
-    /// Constructing the handle is cheap: paged replay stores prefetch settings, and writer-view
-    /// replay starts with an empty buffer. Read buffers are allocated later by `Replay::ensure`.
-    ///
-    /// Sealed blobs can use paged replay directly because their bytes are already fixed. The
-    /// writable tail is replayed through a live view so replay observes logical bytes without
-    /// mutating or flushing the writer.
     pub(super) fn replay_from(
         self,
         offset: u64,
         buffer_size: NonZeroUsize,
     ) -> Result<Replay<'a, B>, Error> {
-        match self {
-            Self::Writer(writer) => Replay::view(Self::Writer(writer), offset, buffer_size),
-            Self::Sealed(sealed) => {
-                let mut replay = sealed.replay(buffer_size).map_err(Error::Runtime)?;
-                replay.seek_to(offset).map_err(Error::Runtime)?;
-                Ok(Replay::paged(replay))
-            }
-        }
+        Replay::new(self, offset, buffer_size)
     }
 
     /// Read fixed-size items at sorted byte offsets into `buf`.
@@ -516,43 +607,41 @@ impl<'a, B: RBlob> Blob<'a, B> {
         item_size: NonZeroUsize,
     ) -> Result<usize, Error> {
         match self {
-            Self::Writer(writer) => writer
-                .read_many_into(buf, offsets, item_size)
+            Self::Writer(writer) => BlobReader::read_many_into(*writer, buf, offsets, item_size)
                 .await
                 .map_err(Error::Runtime),
-            Self::Sealed(sealed) => sealed
-                .read_many_into(buf, offsets, item_size)
+            Self::Sealed(sealed) => BlobReader::read_many_into(sealed, buf, offsets, item_size)
                 .await
                 .map_err(Error::Runtime),
         }
     }
 }
 
-/// Sequential replay over either a sealed paged blob or a live writer view.
-pub(super) struct Replay<'a, B: RBlob> {
-    inner: ReplayInner<'a, B>,
+impl<B: RBlob> FrameReader for Blob<'_, B> {
+    async fn read_up_to(
+        &self,
+        offset: u64,
+        len: usize,
+        bufs: impl Into<IoBufMut> + Send,
+    ) -> Result<(IoBufMut, usize), Error> {
+        Self::read_up_to(self, offset, len, bufs).await
+    }
+
+    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, Error> {
+        Self::read_at(self, offset, len).await
+    }
 }
 
-/// Backing strategy for sequential blob replay.
-enum ReplayInner<'a, B: RBlob> {
-    /// Paged replay over sealed data. CRC bytes are validated and skipped by the runtime buffer.
-    Paged(PagedReplay<B>),
-    /// Logical replay over a live writer or any other blob view.
-    View(ViewReplay<'a, B>),
+/// Sequential replay over a journal blob view.
+pub(super) struct Replay<'a, B: RBlob> {
+    inner: ViewReplay<'a, B>,
 }
 
 impl<'a, B: RBlob> Replay<'a, B> {
-    /// Wrap a paged replay handle.
-    const fn paged(replay: PagedReplay<B>) -> Self {
-        Self {
-            inner: ReplayInner::Paged(replay),
-        }
-    }
-
     /// Build a replay handle over a logical blob view.
-    fn view(blob: Blob<'a, B>, offset: u64, buffer_size: NonZeroUsize) -> Result<Self, Error> {
+    fn new(blob: Blob<'a, B>, offset: u64, buffer_size: NonZeroUsize) -> Result<Self, Error> {
         Ok(Self {
-            inner: ReplayInner::View(ViewReplay::new(blob, offset, buffer_size)?),
+            inner: ViewReplay::new(blob, offset, buffer_size)?,
         })
     }
 
@@ -560,41 +649,26 @@ impl<'a, B: RBlob> Replay<'a, B> {
     ///
     /// The replay buffer may still hold bytes after this becomes true.
     pub(super) const fn is_exhausted(&self) -> bool {
-        match &self.inner {
-            ReplayInner::Paged(replay) => replay.is_exhausted(),
-            ReplayInner::View(replay) => replay.is_exhausted(),
-        }
+        self.inner.is_exhausted()
     }
 
     /// Ensure at least `n` logical bytes are buffered unless EOF is reached first.
     pub(super) async fn ensure(&mut self, n: usize) -> Result<bool, Error> {
-        match &mut self.inner {
-            ReplayInner::Paged(replay) => replay.ensure(n).await.map_err(Error::Runtime),
-            ReplayInner::View(replay) => replay.ensure(n).await,
-        }
+        self.inner.ensure(n).await
     }
 }
 
 impl<B: RBlob> Buf for Replay<'_, B> {
     fn remaining(&self) -> usize {
-        match &self.inner {
-            ReplayInner::Paged(replay) => replay.remaining(),
-            ReplayInner::View(replay) => replay.remaining(),
-        }
+        self.inner.remaining()
     }
 
     fn chunk(&self) -> &[u8] {
-        match &self.inner {
-            ReplayInner::Paged(replay) => replay.chunk(),
-            ReplayInner::View(replay) => replay.chunk(),
-        }
+        self.inner.chunk()
     }
 
     fn advance(&mut self, cnt: usize) {
-        match &mut self.inner {
-            ReplayInner::Paged(replay) => replay.advance(cnt),
-            ReplayInner::View(replay) => replay.advance(cnt),
-        }
+        self.inner.advance(cnt)
     }
 }
 

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use commonware_formatting::hex;
 use commonware_runtime::{
-    buffer::paged::{CacheRef, Sealed, Writer},
+    buffer::paged::{CacheRef, Replay as PagedReplay, Sealed, Writer},
     telemetry::metrics::{Counter, Gauge, GaugeExt as _, MetricsExt as _},
     Blob as RBlob, Buf, Error as RError, IoBufMut, IoBufs,
 };
@@ -221,7 +221,7 @@ impl<E: Context> Writable<E> {
     }
 
     /// Index of the newest blob.
-    pub(super) fn tail_blob_index(&self) -> u64 {
+    pub(super) const fn tail_blob_index(&self) -> u64 {
         self.oldest_blob_index + self.sealed.len() as u64
     }
 
@@ -272,8 +272,9 @@ impl<E: Context> Writable<E> {
         Ok(())
     }
 
-    /// Drop every blob below `min_blob` and remove its file, oldest-first. Readers holding
-    /// the old slice keep reading the removed blobs.
+    /// Drop every blob below `min_blob` and remove its file, oldest-first. Safe with live readers:
+    /// snapshot readers keep their own handles, which the runtime's read-after-remove contract keeps
+    /// valid.
     ///
     /// # Invariants
     ///
@@ -435,98 +436,6 @@ impl<B: RBlob> SealedBlobs<'_, B> {
     }
 }
 
-/// Shared read surface for writable and sealed blobs.
-trait BlobReader {
-    /// Return the blob's logical size.
-    fn size(&self) -> u64;
-
-    /// Read into `buf` if the data is already cached.
-    fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool;
-
-    /// Read exactly `len` bytes at `offset`.
-    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, RError>;
-
-    /// Read up to `len` bytes at `offset`.
-    async fn read_up_to(
-        &self,
-        offset: u64,
-        len: usize,
-        bufs: impl Into<IoBufMut> + Send,
-    ) -> Result<(IoBufMut, usize), RError>;
-
-    /// Read fixed-size items at sorted byte offsets into `buf`.
-    async fn read_many_into(
-        &self,
-        buf: &mut [u8],
-        offsets: &[u64],
-        item_size: NonZeroUsize,
-    ) -> Result<usize, RError>;
-}
-
-impl<B: RBlob> BlobReader for Writer<B> {
-    fn size(&self) -> u64 {
-        Self::size(self)
-    }
-
-    fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
-        Self::try_read_sync(self, offset, buf)
-    }
-
-    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, RError> {
-        Self::read_at(self, offset, len).await
-    }
-
-    async fn read_up_to(
-        &self,
-        offset: u64,
-        len: usize,
-        bufs: impl Into<IoBufMut> + Send,
-    ) -> Result<(IoBufMut, usize), RError> {
-        Self::read_up_to(self, offset, len, bufs).await
-    }
-
-    async fn read_many_into(
-        &self,
-        buf: &mut [u8],
-        offsets: &[u64],
-        item_size: NonZeroUsize,
-    ) -> Result<usize, RError> {
-        Self::read_many_into(self, buf, offsets, item_size).await
-    }
-}
-
-impl<B: RBlob> BlobReader for Sealed<B> {
-    fn size(&self) -> u64 {
-        Self::size(self)
-    }
-
-    fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
-        Self::try_read_sync(self, offset, buf)
-    }
-
-    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, RError> {
-        Self::read_at(self, offset, len).await
-    }
-
-    async fn read_up_to(
-        &self,
-        offset: u64,
-        len: usize,
-        bufs: impl Into<IoBufMut> + Send,
-    ) -> Result<(IoBufMut, usize), RError> {
-        Self::read_up_to(self, offset, len, bufs).await
-    }
-
-    async fn read_many_into(
-        &self,
-        buf: &mut [u8],
-        offsets: &[u64],
-        item_size: NonZeroUsize,
-    ) -> Result<usize, RError> {
-        Self::read_many_into(self, buf, offsets, item_size).await
-    }
-}
-
 /// A read handle for one journal blob.
 pub(super) enum Blob<'a, B: RBlob> {
     /// Writable tail, read through the writer's cache-aware logical view.
@@ -548,28 +457,24 @@ impl<'a, B: RBlob> Blob<'a, B> {
     /// Return the blob's logical size.
     pub(super) fn size(&self) -> u64 {
         match self {
-            Self::Writer(writer) => BlobReader::size(*writer),
-            Self::Sealed(sealed) => BlobReader::size(sealed),
+            Self::Writer(writer) => writer.size(),
+            Self::Sealed(sealed) => sealed.size(),
         }
     }
 
     /// Read into `buf` if the data is already cached.
     pub(super) fn try_read_sync(&self, offset: u64, buf: &mut [u8]) -> bool {
         match self {
-            Self::Writer(writer) => BlobReader::try_read_sync(*writer, offset, buf),
-            Self::Sealed(sealed) => BlobReader::try_read_sync(sealed, offset, buf),
+            Self::Writer(writer) => writer.try_read_sync(offset, buf),
+            Self::Sealed(sealed) => sealed.try_read_sync(offset, buf),
         }
     }
 
     /// Read exactly `len` bytes at `offset`.
     pub(super) async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, Error> {
         match self {
-            Self::Writer(writer) => BlobReader::read_at(*writer, offset, len)
-                .await
-                .map_err(Error::Runtime),
-            Self::Sealed(sealed) => BlobReader::read_at(sealed, offset, len)
-                .await
-                .map_err(Error::Runtime),
+            Self::Writer(writer) => writer.read_at(offset, len).await.map_err(Error::Runtime),
+            Self::Sealed(sealed) => sealed.read_at(offset, len).await.map_err(Error::Runtime),
         }
     }
 
@@ -581,22 +486,38 @@ impl<'a, B: RBlob> Blob<'a, B> {
         bufs: impl Into<IoBufMut> + Send,
     ) -> Result<(IoBufMut, usize), Error> {
         match self {
-            Self::Writer(writer) => BlobReader::read_up_to(*writer, offset, len, bufs)
+            Self::Writer(writer) => writer
+                .read_up_to(offset, len, bufs)
                 .await
                 .map_err(Error::Runtime),
-            Self::Sealed(sealed) => BlobReader::read_up_to(sealed, offset, len, bufs)
+            Self::Sealed(sealed) => sealed
+                .read_up_to(offset, len, bufs)
                 .await
                 .map_err(Error::Runtime),
         }
     }
 
     /// Return a sequential replay handle starting at `offset`.
+    ///
+    /// Constructing the handle is cheap: paged replay stores prefetch settings, and writer-view
+    /// replay starts with an empty buffer. Read buffers are allocated later by `Replay::ensure`.
+    ///
+    /// Sealed blobs can use paged replay directly because their bytes are already fixed. The
+    /// writable tail is replayed through a live view so replay observes logical bytes without
+    /// mutating or flushing the writer.
     pub(super) fn replay_from(
         self,
         offset: u64,
         buffer_size: NonZeroUsize,
     ) -> Result<Replay<'a, B>, Error> {
-        Replay::new(self, offset, buffer_size)
+        match self {
+            Self::Writer(writer) => Replay::view(Self::Writer(writer), offset, buffer_size),
+            Self::Sealed(sealed) => {
+                let mut replay = sealed.replay(buffer_size).map_err(Error::Runtime)?;
+                replay.seek_to(offset).map_err(Error::Runtime)?;
+                Ok(Replay::paged(replay))
+            }
+        }
     }
 
     /// Read fixed-size items at sorted byte offsets into `buf`.
@@ -607,10 +528,12 @@ impl<'a, B: RBlob> Blob<'a, B> {
         item_size: NonZeroUsize,
     ) -> Result<usize, Error> {
         match self {
-            Self::Writer(writer) => BlobReader::read_many_into(*writer, buf, offsets, item_size)
+            Self::Writer(writer) => writer
+                .read_many_into(buf, offsets, item_size)
                 .await
                 .map_err(Error::Runtime),
-            Self::Sealed(sealed) => BlobReader::read_many_into(sealed, buf, offsets, item_size)
+            Self::Sealed(sealed) => sealed
+                .read_many_into(buf, offsets, item_size)
                 .await
                 .map_err(Error::Runtime),
         }
@@ -632,16 +555,31 @@ impl<B: RBlob> FrameReader for Blob<'_, B> {
     }
 }
 
-/// Sequential replay over a journal blob view.
+/// Sequential replay over either a sealed paged blob or a live writer view.
 pub(super) struct Replay<'a, B: RBlob> {
-    inner: ViewReplay<'a, B>,
+    inner: ReplayInner<'a, B>,
+}
+
+/// Backing strategy for sequential blob replay.
+enum ReplayInner<'a, B: RBlob> {
+    /// Paged replay over sealed data. CRC bytes are validated and skipped by the runtime buffer.
+    Paged(PagedReplay<B>),
+    /// Logical replay over a live writer or any other blob view.
+    View(ViewReplay<'a, B>),
 }
 
 impl<'a, B: RBlob> Replay<'a, B> {
+    /// Wrap a paged replay handle.
+    const fn paged(replay: PagedReplay<B>) -> Self {
+        Self {
+            inner: ReplayInner::Paged(replay),
+        }
+    }
+
     /// Build a replay handle over a logical blob view.
-    fn new(blob: Blob<'a, B>, offset: u64, buffer_size: NonZeroUsize) -> Result<Self, Error> {
+    fn view(blob: Blob<'a, B>, offset: u64, buffer_size: NonZeroUsize) -> Result<Self, Error> {
         Ok(Self {
-            inner: ViewReplay::new(blob, offset, buffer_size)?,
+            inner: ReplayInner::View(ViewReplay::new(blob, offset, buffer_size)?),
         })
     }
 
@@ -649,26 +587,41 @@ impl<'a, B: RBlob> Replay<'a, B> {
     ///
     /// The replay buffer may still hold bytes after this becomes true.
     pub(super) const fn is_exhausted(&self) -> bool {
-        self.inner.is_exhausted()
+        match &self.inner {
+            ReplayInner::Paged(replay) => replay.is_exhausted(),
+            ReplayInner::View(replay) => replay.is_exhausted(),
+        }
     }
 
     /// Ensure at least `n` logical bytes are buffered unless EOF is reached first.
     pub(super) async fn ensure(&mut self, n: usize) -> Result<bool, Error> {
-        self.inner.ensure(n).await
+        match &mut self.inner {
+            ReplayInner::Paged(replay) => replay.ensure(n).await.map_err(Error::Runtime),
+            ReplayInner::View(replay) => replay.ensure(n).await,
+        }
     }
 }
 
 impl<B: RBlob> Buf for Replay<'_, B> {
     fn remaining(&self) -> usize {
-        self.inner.remaining()
+        match &self.inner {
+            ReplayInner::Paged(replay) => replay.remaining(),
+            ReplayInner::View(replay) => replay.remaining(),
+        }
     }
 
     fn chunk(&self) -> &[u8] {
-        self.inner.chunk()
+        match &self.inner {
+            ReplayInner::Paged(replay) => replay.chunk(),
+            ReplayInner::View(replay) => replay.chunk(),
+        }
     }
 
     fn advance(&mut self, cnt: usize) {
-        self.inner.advance(cnt)
+        match &mut self.inner {
+            ReplayInner::Paged(replay) => replay.advance(cnt),
+            ReplayInner::View(replay) => replay.advance(cnt),
+        }
     }
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -98,13 +98,14 @@ use super::{
     blobs::{Blob, Blobs, Partition, Replay as BlobReplay, Writable},
     checkpoint::Checkpoint,
 };
+#[commonware_macros::stability(ALPHA)]
+use crate::{journal::authenticated, merkle};
 use crate::{
     journal::{
-        authenticated,
         contiguous::{metrics::FixedMetrics as Metrics, Many, Mutable},
         Error,
     },
-    merkle, Context,
+    Context,
 };
 use commonware_codec::{CodecFixedShared, DecodeExt as _, ReadExt as _};
 use commonware_runtime::{

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -110,9 +110,9 @@ use commonware_runtime::{
     buffer::paged::{CacheRef, Writer},
     Blob as RBlob, Buf, IoBuf,
 };
-use futures::{stream, Stream};
+use futures::Stream;
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::BTreeMap,
     future::Future,
     marker::PhantomData,
     num::{NonZeroU64, NonZeroUsize},
@@ -131,9 +131,7 @@ pub struct PreparedAppend<A> {
 /// Return the first retained logical position in `blob`.
 #[inline]
 fn first_in_blob(pruning_boundary: u64, blob: u64, items_per_blob: u64) -> Result<u64, Error> {
-    let start = blob
-        .checked_mul(items_per_blob)
-        .ok_or(Error::OffsetOverflow)?;
+    let start = super::blob_first_position(blob, items_per_blob)?;
     Ok(pruning_boundary.max(start))
 }
 
@@ -159,8 +157,8 @@ fn replay_stream<'a, B: RBlob, A: CodecFixedShared>(
     let mut states = Vec::new();
     if start_pos < bounds.end {
         let items_per_blob = items_per_blob.get();
-        let start_blob = start_pos / items_per_blob;
-        let end_blob = (bounds.end - 1) / items_per_blob;
+        let start_blob = super::position_to_blob(start_pos, items_per_blob);
+        let end_blob = super::position_to_blob(bounds.end - 1, items_per_blob);
         let items_per_batch = (buffer.get() / A::SIZE).max(1);
 
         for blob in start_blob..=end_blob {
@@ -190,15 +188,7 @@ fn replay_stream<'a, B: RBlob, A: CodecFixedShared>(
         }
     }
 
-    Ok(stream::unfold(
-        ReplayStreamState {
-            states: states.into_iter(),
-            current: None,
-            pending: VecDeque::new(),
-            done: false,
-        },
-        ReplayStreamState::next,
-    ))
+    Ok(super::replay_stream_from_states(states))
 }
 
 /// Replay state for one fixed-size blob.
@@ -214,7 +204,9 @@ struct FixedReplayState<'a, B: RBlob, A> {
     _marker: PhantomData<A>,
 }
 
-impl<B: RBlob, A: CodecFixedShared> FixedReplayState<'_, B, A> {
+impl<B: RBlob, A: CodecFixedShared> super::ReplayBatchState for FixedReplayState<'_, B, A> {
+    type Item = A;
+
     /// Decode the next batch of fixed-size items from this blob.
     async fn next_batch(mut self) -> Option<(Vec<Result<(u64, A), Error>>, Self)> {
         if self.pos == self.end_pos {
@@ -266,55 +258,6 @@ impl<B: RBlob, A: CodecFixedShared> FixedReplayState<'_, B, A> {
         }
         self.pos = next_pos;
         Some((batch, self))
-    }
-}
-
-/// Stream driver over fixed-size blob replay states.
-struct ReplayStreamState<'a, B: RBlob, A> {
-    /// Remaining blob states, in ascending blob order.
-    states: std::vec::IntoIter<FixedReplayState<'a, B, A>>,
-    /// State currently being drained.
-    current: Option<FixedReplayState<'a, B, A>>,
-    /// Items decoded from the current state but not yet yielded by the stream.
-    pending: VecDeque<Result<(u64, A), Error>>,
-    /// Set after the first error so the stream terminates cleanly.
-    done: bool,
-}
-
-impl<'a, B: RBlob, A: CodecFixedShared> ReplayStreamState<'a, B, A> {
-    /// Yield one item, filling `pending` from the current blob when needed.
-    async fn next(mut self) -> Option<(Result<(u64, A), Error>, Self)> {
-        loop {
-            if self.done {
-                return None;
-            }
-
-            // After an error, no later blob can be trusted as a continuation of the requested
-            // replay.
-            if let Some(item) = self.pending.pop_front() {
-                if item.is_err() {
-                    self.done = true;
-                    self.pending.clear();
-                    self.current = None;
-                }
-                return Some((item, self));
-            }
-
-            let state = match self.current.take().or_else(|| self.states.next()) {
-                Some(state) => state,
-                None => return None,
-            };
-
-            match FixedReplayState::next_batch(state).await {
-                Some((batch, state)) => {
-                    self.current = Some(state);
-                    self.pending = VecDeque::from(batch);
-                }
-                None => {
-                    self.current = None;
-                }
-            }
-        }
     }
 }
 
@@ -627,7 +570,11 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             }
             // Legacy journals have no watermark. Under the old rollover-sync invariant, all
             // non-tail blobs are durable; only the tail may have unfsynced data.
-            None => first_in_blob(pruning_boundary, size / items_per_blob, items_per_blob)?,
+            None => first_in_blob(
+                pruning_boundary,
+                super::position_to_blob(size, items_per_blob),
+                items_per_blob,
+            )?,
         };
 
         Ok(RecoveredBounds {
@@ -649,9 +596,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         items_per_blob: u64,
     ) -> Result<u64, Error> {
         let blob_boundary = match oldest_blob {
-            Some(oldest) => oldest
-                .checked_mul(items_per_blob)
-                .ok_or(Error::OffsetOverflow)?,
+            Some(oldest) => super::blob_first_position(oldest, items_per_blob)?,
             None => 0,
         };
 
@@ -662,7 +607,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             return Ok(blob_boundary);
         }
 
-        let hint_blob = boundary_hint / items_per_blob;
+        let hint_blob = super::position_to_blob(boundary_hint, items_per_blob);
         match oldest_blob {
             Some(oldest_blob) if hint_blob == oldest_blob => Ok(boundary_hint),
             Some(oldest_blob) if hint_blob < oldest_blob => {
@@ -704,9 +649,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .map_or(0, |writer| writer.size() / Self::CHUNK_SIZE_U64);
         // A blob's capacity is `items_per_blob`, unless the pruning boundary falls mid-blob
         // (from `init_at_size`), in which case the skipped prefix reduces it.
-        let start = blob
-            .checked_mul(items_per_blob)
-            .ok_or(Error::OffsetOverflow)?;
+        let start = super::blob_first_position(blob, items_per_blob)?;
         let skipped = pruning_boundary.saturating_sub(start).min(items_per_blob);
         let capacity = items_per_blob - skipped;
         Ok(match len.cmp(&capacity) {
@@ -1211,7 +1154,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
     fn locate(&self, pos: u64) -> Result<(Blob<'_, E::Blob>, u64), Error> {
         self.validate_readable(pos)?;
         let items_per_blob = self.items_per_blob.get();
-        let blob = pos / items_per_blob;
+        let blob = super::position_to_blob(pos, items_per_blob);
         let pos_in_blob = pos - first_in_blob(self.bounds.start, blob, items_per_blob)?;
         let offset = Journal::<E, A>::items_to_bytes(pos_in_blob)?;
         let blob = self
@@ -1284,8 +1227,11 @@ impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Contiguous for
         let mut result: Vec<A> = Vec::with_capacity(positions.len());
         let mut reusable_buf = vec![0u8; positions.len() * chunk_size];
         let mut hits = 0u64;
-        for group in positions.chunk_by(|a, b| a / items_per_blob == b / items_per_blob) {
-            let blob = group[0] / items_per_blob;
+        for group in positions.chunk_by(|a, b| {
+            super::position_to_blob(*a, items_per_blob)
+                == super::position_to_blob(*b, items_per_blob)
+        }) {
+            let blob = super::position_to_blob(group[0], items_per_blob);
             let first_position = first_in_blob(pruning_boundary, blob, items_per_blob)?;
             let blob_offsets: Vec<u64> = group
                 .iter()

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1045,9 +1045,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             return Ok(false);
         }
 
-        let new_boundary = min_blob
-            .checked_mul(self.items_per_blob.get())
-            .ok_or(Error::OffsetOverflow)?;
+        let new_boundary = super::blob_first_position(min_blob, self.items_per_blob.get())?;
         self.blobs.prune(min_blob).await?;
         self.bounds.start = new_boundary;
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -100,10 +100,11 @@ use super::{
 };
 use crate::{
     journal::{
+        authenticated,
         contiguous::{metrics::FixedMetrics as Metrics, Many, Mutable},
         Error,
     },
-    Context,
+    merkle, Context,
 };
 use commonware_codec::{CodecFixedShared, DecodeExt as _, ReadExt as _};
 use commonware_runtime::{
@@ -1175,7 +1176,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
     }
 }
 
-impl<E: Context, A: CodecFixedShared> crate::journal::contiguous::Contiguous for Reader<'_, E, A> {
+impl<E: Context, A: CodecFixedShared> super::Contiguous for Reader<'_, E, A> {
     type Item = A;
 
     fn bounds(&self) -> Range<u64> {
@@ -1356,24 +1357,21 @@ impl<E: Context, A: CodecFixedShared> Mutable for Journal<E, A> {
 }
 
 #[commonware_macros::stability(ALPHA)]
-impl<E: Context, A: CodecFixedShared> crate::journal::authenticated::Inner<E> for Journal<E, A> {
+impl<E: Context, A: CodecFixedShared> authenticated::Inner<E> for Journal<E, A> {
     type Config = Config;
 
     async fn init<
-        F: crate::merkle::Family,
+        F: merkle::Family,
         H: commonware_cryptography::Hasher,
         S: commonware_parallel::Strategy,
     >(
         context: E,
-        merkle_cfg: crate::merkle::full::Config<S>,
+        merkle_cfg: merkle::full::Config<S>,
         journal_cfg: Self::Config,
         rewind_predicate: fn(&A) -> bool,
-        bagging: crate::merkle::Bagging,
-    ) -> Result<
-        crate::journal::authenticated::Journal<F, E, Self, H, S>,
-        crate::journal::authenticated::Error<F>,
-    > {
-        crate::journal::authenticated::Journal::<F, E, Self, H, S>::new(
+        bagging: merkle::Bagging,
+    ) -> Result<authenticated::Journal<F, E, Self, H, S>, authenticated::Error<F>> {
+        authenticated::Journal::<F, E, Self, H, S>::new(
             context,
             merkle_cfg,
             journal_cfg,

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -457,7 +457,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // Apply repair (if any). The short blob becomes the new tail; blobs strictly newer
         // than it are removed (newest-first) and the truncation is synced, so the repair is
         // durable before sealing.
-        let tail_blob = size / cfg.items_per_blob.get();
+        let tail_blob = super::position_to_blob(size, cfg.items_per_blob.get());
         if let Some(truncate_to) = repair {
             while let Some((&newest, _)) = pending.last_key_value() {
                 if newest <= tail_blob {
@@ -479,8 +479,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
         // Bytes beyond the persisted recovery watermark may be readable after reopen without
         // being crash-durable, so the next commit/sync must force a data sync before advancing it.
-        let dirty_from_blob =
-            (recovery_watermark < size).then(|| recovery_watermark / cfg.items_per_blob.get());
+        let dirty_from_blob = (recovery_watermark < size)
+            .then(|| super::position_to_blob(recovery_watermark, cfg.items_per_blob.get()));
 
         let metrics = Metrics::new(context);
         metrics.update(size, pruning_boundary, cfg.items_per_blob.get());
@@ -513,7 +513,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             cfg.page_cache,
             cfg.write_buffer,
         );
-        let tail_blob = clear_target / cfg.items_per_blob.get();
+        let tail_blob = super::position_to_blob(clear_target, cfg.items_per_blob.get());
         let blobs = Writable::recover(partition, BTreeMap::new(), tail_blob).await?;
         checkpoint
             .finish_clear(cfg.items_per_blob.get(), clear_target)
@@ -933,7 +933,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .checked_add(items_count as u64)
             .ok_or(Error::SizeOverflow)?;
 
-        let first_dirty_blob = self.bounds.end / self.items_per_blob.get();
+        let first_dirty_blob = super::position_to_blob(self.bounds.end, self.items_per_blob.get());
         self.mark_dirty_from(first_dirty_blob);
         let mut written = 0;
         while written < items_count {
@@ -993,7 +993,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             return Err(Error::ItemPruned(size));
         }
 
-        let blob = size / self.items_per_blob.get();
+        let blob = super::position_to_blob(size, self.items_per_blob.get());
         let pos_in_blob = size - first_in_blob(self.bounds.start, blob, self.items_per_blob.get())?;
         let byte_offset = Self::items_to_bytes(pos_in_blob)?;
 
@@ -1036,8 +1036,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     pub async fn prune(&mut self, min_item_pos: u64) -> Result<bool, Error> {
         // Calculate the blob that would contain min_item_pos, capped to the tail (which is
         // guaranteed to exist by our invariant).
-        let target_blob = min_item_pos / self.items_per_blob.get();
-        let tail_blob = self.bounds.end / self.items_per_blob.get();
+        let target_blob = super::position_to_blob(min_item_pos, self.items_per_blob.get());
+        let tail_blob = super::position_to_blob(self.bounds.end, self.items_per_blob.get());
         let min_blob = std::cmp::min(target_blob, tail_blob);
 
         if min_blob <= self.blobs.oldest_blob_index() {
@@ -1095,7 +1095,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
         // Remove every blob, then start fresh at the new size.
         self.blobs
-            .clear(new_size / self.items_per_blob.get())
+            .clear(super::position_to_blob(new_size, self.items_per_blob.get()))
             .await?;
         self.bounds = new_size..new_size;
         self.dirty_from_blob = None;

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -8,8 +8,8 @@
 //! leave its in-memory state inconsistent with the underlying storage.
 
 use super::Error;
-use futures::{stream, Stream};
-use std::{collections::VecDeque, future::Future, num::NonZeroUsize, ops::Range};
+use futures::{stream, Stream, StreamExt as _};
+use std::{future::Future, num::NonZeroUsize, ops::Range};
 use tracing::warn;
 
 mod blobs;
@@ -91,8 +91,6 @@ struct ReplayStreamState<S: ReplayBatchState> {
     states: std::vec::IntoIter<S>,
     /// State currently being drained.
     current: Option<S>,
-    /// Items decoded from the current state but not yet yielded by the stream.
-    pending: VecDeque<Result<(u64, S::Item), Error>>,
     /// Set after the first error so the stream terminates cleanly.
     done: bool,
 }
@@ -101,20 +99,11 @@ impl<S: ReplayBatchState + Send> ReplayStreamState<S>
 where
     S::Item: Send,
 {
-    /// Yield one item, filling `pending` from the current blob when needed.
-    async fn next(mut self) -> Option<(Result<(u64, S::Item), Error>, Self)> {
+    /// Yield the next decoded batch.
+    async fn next(mut self) -> Option<(Vec<Result<(u64, S::Item), Error>>, Self)> {
         loop {
             if self.done {
                 return None;
-            }
-
-            if let Some(item) = self.pending.pop_front() {
-                if item.is_err() {
-                    self.done = true;
-                    self.pending.clear();
-                    self.current = None;
-                }
-                return Some((item, self));
             }
 
             let state = match self.current.take().or_else(|| self.states.next()) {
@@ -124,8 +113,13 @@ where
 
             match state.next_batch().await {
                 Some((batch, state)) => {
-                    self.current = Some(state);
-                    self.pending = VecDeque::from(batch);
+                    if batch.iter().any(Result::is_err) {
+                        self.done = true;
+                        self.current = None;
+                    } else {
+                        self.current = Some(state);
+                    }
+                    return Some((batch, self));
                 }
                 None => {
                     self.current = None;
@@ -147,11 +141,11 @@ where
         ReplayStreamState {
             states: states.into_iter(),
             current: None,
-            pending: VecDeque::new(),
             done: false,
         },
         ReplayStreamState::next,
     )
+    .flat_map(stream::iter)
 }
 
 /// A read-only, position-based view of a contiguous journal.

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -34,6 +34,17 @@ fn batch_count_to_blob_boundary(position: u64, remaining: usize, items_per_blob:
 }
 
 /// Return the blob containing `position`.
+///
+/// # Examples
+///
+/// ```ignore
+/// // With 10 items per blob:
+/// assert_eq!(position_to_blob(0, 10), 0);   // position 0 -> blob 0
+/// assert_eq!(position_to_blob(9, 10), 0);   // position 9 -> blob 0
+/// assert_eq!(position_to_blob(10, 10), 1);  // position 10 -> blob 1
+/// assert_eq!(position_to_blob(25, 10), 2);  // position 25 -> blob 2
+/// assert_eq!(position_to_blob(30, 10), 3);  // position 30 -> blob 3
+/// ```
 const fn position_to_blob(position: u64, items_per_blob: u64) -> u64 {
     position / items_per_blob
 }
@@ -61,15 +72,17 @@ const fn blob_end_position(blob: u64, items_per_blob: u64, end: u64) -> u64 {
     (blob + 1) * items_per_blob
 }
 
+/// A decoded batch yielded by [ReplayBatchState::next_batch] paired with the advanced state, or
+/// `None` once the state is exhausted.
+type ReplayBatch<S> = Option<(Vec<Result<(u64, <S as ReplayBatchState>::Item), Error>>, S)>;
+
 /// Per-blob replay state that yields decoded item batches.
 trait ReplayBatchState: Sized {
     /// The decoded item type.
     type Item;
 
     /// Decode the next batch from this blob state.
-    fn next_batch(
-        self,
-    ) -> impl Future<Output = Option<(Vec<Result<(u64, Self::Item), Error>>, Self)>> + Send;
+    fn next_batch(self) -> impl Future<Output = ReplayBatch<Self>> + Send;
 }
 
 /// Stream driver over per-blob replay states.

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -8,8 +8,8 @@
 //! leave its in-memory state inconsistent with the underlying storage.
 
 use super::Error;
-use futures::Stream;
-use std::{future::Future, num::NonZeroUsize, ops::Range};
+use futures::{stream, Stream};
+use std::{collections::VecDeque, future::Future, num::NonZeroUsize, ops::Range};
 use tracing::warn;
 
 mod blobs;
@@ -33,6 +33,17 @@ fn batch_count_to_blob_boundary(position: u64, remaining: usize, items_per_blob:
     remaining_space.min(remaining as u64) as usize
 }
 
+/// Return the blob containing `position`.
+const fn position_to_blob(position: u64, items_per_blob: u64) -> u64 {
+    position / items_per_blob
+}
+
+/// Return the first position stored in `blob`.
+fn blob_first_position(blob: u64, items_per_blob: u64) -> Result<u64, Error> {
+    blob.checked_mul(items_per_blob)
+        .ok_or(Error::OffsetOverflow)
+}
+
 /// Return the exclusive logical end for `blob`, clamped to `end`.
 const fn blob_end_position(blob: u64, items_per_blob: u64, end: u64) -> u64 {
     // No positions exist, so `end - 1` would underflow
@@ -48,6 +59,86 @@ const fn blob_end_position(blob: u64, items_per_blob: u64, end: u64) -> u64 {
 
     // Earlier blobs have a representable natural boundary
     (blob + 1) * items_per_blob
+}
+
+/// Per-blob replay state that yields decoded item batches.
+trait ReplayBatchState: Sized {
+    /// The decoded item type.
+    type Item;
+
+    /// Decode the next batch from this blob state.
+    fn next_batch(
+        self,
+    ) -> impl Future<Output = Option<(Vec<Result<(u64, Self::Item), Error>>, Self)>> + Send;
+}
+
+/// Stream driver over per-blob replay states.
+struct ReplayStreamState<S: ReplayBatchState> {
+    /// Remaining blob states, in ascending blob order.
+    states: std::vec::IntoIter<S>,
+    /// State currently being drained.
+    current: Option<S>,
+    /// Items decoded from the current state but not yet yielded by the stream.
+    pending: VecDeque<Result<(u64, S::Item), Error>>,
+    /// Set after the first error so the stream terminates cleanly.
+    done: bool,
+}
+
+impl<S: ReplayBatchState + Send> ReplayStreamState<S>
+where
+    S::Item: Send,
+{
+    /// Yield one item, filling `pending` from the current blob when needed.
+    async fn next(mut self) -> Option<(Result<(u64, S::Item), Error>, Self)> {
+        loop {
+            if self.done {
+                return None;
+            }
+
+            if let Some(item) = self.pending.pop_front() {
+                if item.is_err() {
+                    self.done = true;
+                    self.pending.clear();
+                    self.current = None;
+                }
+                return Some((item, self));
+            }
+
+            let state = match self.current.take().or_else(|| self.states.next()) {
+                Some(state) => state,
+                None => return None,
+            };
+
+            match state.next_batch().await {
+                Some((batch, state)) => {
+                    self.current = Some(state);
+                    self.pending = VecDeque::from(batch);
+                }
+                None => {
+                    self.current = None;
+                }
+            }
+        }
+    }
+}
+
+/// Build a stream from per-blob replay states.
+fn replay_stream_from_states<S>(
+    states: Vec<S>,
+) -> impl Stream<Item = Result<(u64, S::Item), Error>> + Send
+where
+    S: ReplayBatchState + Send,
+    S::Item: Send,
+{
+    stream::unfold(
+        ReplayStreamState {
+            states: states.into_iter(),
+            current: None,
+            pending: VecDeque::new(),
+            done: false,
+        },
+        ReplayStreamState::next,
+    )
 }
 
 /// A read-only, position-based view of a contiguous journal.

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -10,16 +10,17 @@ use super::{
     metrics::VariableMetrics as Metrics,
     position_to_blob, Contiguous, Many, Mutable,
 };
+#[commonware_macros::stability(ALPHA)]
+use crate::{journal::authenticated, merkle};
 use crate::{
     journal::{
-        authenticated,
         frame::{
             decode_item, decode_length_prefix, encode_frame_into, find_frame, read_frame_at,
             FrameInfo,
         },
         Error,
     },
-    merkle, Context,
+    Context,
 };
 use commonware_codec::{varint::MAX_U32_VARINT_SIZE, Codec, CodecShared};
 use commonware_macros::boxed;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -12,13 +12,14 @@ use super::{
 };
 use crate::{
     journal::{
+        authenticated,
         frame::{
             decode_item, decode_length_prefix, encode_frame_into, find_frame, read_frame_at,
             FrameInfo,
         },
         Error,
     },
-    Context,
+    merkle, Context,
 };
 use commonware_codec::{varint::MAX_U32_VARINT_SIZE, Codec, CodecShared};
 use commonware_macros::boxed;
@@ -1905,24 +1906,21 @@ impl<E: Context, V: CodecShared> Mutable for Journal<E, V> {
 }
 
 #[commonware_macros::stability(ALPHA)]
-impl<E: Context, V: CodecShared> crate::journal::authenticated::Inner<E> for Journal<E, V> {
+impl<E: Context, V: CodecShared> authenticated::Inner<E> for Journal<E, V> {
     type Config = Config<V::Cfg>;
 
     async fn init<
-        F: crate::merkle::Family,
+        F: merkle::Family,
         H: commonware_cryptography::Hasher,
         S: commonware_parallel::Strategy,
     >(
         context: E,
-        merkle_cfg: crate::merkle::full::Config<S>,
+        merkle_cfg: merkle::full::Config<S>,
         journal_cfg: Self::Config,
         rewind_predicate: fn(&V) -> bool,
-        bagging: crate::merkle::Bagging,
-    ) -> Result<
-        crate::journal::authenticated::Journal<F, E, Self, H, S>,
-        crate::journal::authenticated::Error<F>,
-    > {
-        crate::journal::authenticated::Journal::<F, E, Self, H, S>::new(
+        bagging: merkle::Bagging,
+    ) -> Result<authenticated::Journal<F, E, Self, H, S>, authenticated::Error<F>> {
+        authenticated::Journal::<F, E, Self, H, S>::new(
             context,
             merkle_cfg,
             journal_cfg,

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -4,14 +4,18 @@
 //! the preferred recovery point for replaying data to rebuild offset entries.
 
 use super::{
+    blob_first_position,
     blobs::{Blob, Blobs, Partition, Replay as BlobReplay, Writable},
     fixed,
     metrics::VariableMetrics as Metrics,
-    Contiguous, Many, Mutable,
+    position_to_blob, Contiguous, Many, Mutable,
 };
 use crate::{
     journal::{
-        frame::{decode_item, decode_length_prefix, encode_frame_into, find_frame, FrameInfo},
+        frame::{
+            decode_item, decode_length_prefix, encode_frame_into, find_frame, read_frame_at,
+            FrameInfo,
+        },
         Error,
     },
     Context,
@@ -20,12 +24,12 @@ use commonware_codec::{varint::MAX_U32_VARINT_SIZE, Codec, CodecShared};
 use commonware_macros::boxed;
 use commonware_runtime::{
     buffer::paged::{CacheRef, Replay, Writer},
-    Blob as RBlob, Buf, IoBuf, IoBufMut,
+    Blob as RBlob, Buf, IoBuf,
 };
 use commonware_utils::NZUsize;
-use futures::{stream, Stream};
+use futures::Stream;
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::BTreeMap,
     io::Cursor,
     marker::PhantomData,
     num::{NonZeroU64, NonZeroUsize},
@@ -178,7 +182,9 @@ struct ReplayState<'a, B: RBlob, V: Codec> {
     _marker: PhantomData<V>,
 }
 
-impl<B: RBlob, V: CodecShared> ReplayState<'_, B, V> {
+impl<B: RBlob, V: CodecShared> super::ReplayBatchState for ReplayState<'_, B, V> {
+    type Item = V;
+
     /// Decode the next batch of varint-framed items from this blob.
     async fn next_batch(mut self) -> Option<(Vec<Result<(u64, V), Error>>, Self)> {
         if self.pos == self.end_pos {
@@ -300,91 +306,6 @@ impl<B: RBlob, V: CodecShared> ReplayState<'_, B, V> {
             }
         }
     }
-}
-
-/// Stream driver over variable-size data-blob replay states.
-struct ReplayStreamState<'a, B: RBlob, V: Codec> {
-    /// Remaining blob states, in ascending blob order.
-    states: std::vec::IntoIter<ReplayState<'a, B, V>>,
-    /// State currently being drained.
-    current: Option<ReplayState<'a, B, V>>,
-    /// Items decoded from the current state but not yet yielded by the stream.
-    pending: VecDeque<Result<(u64, V), Error>>,
-    /// Set after the first error so the stream terminates cleanly.
-    done: bool,
-}
-
-impl<'a, B: RBlob, V: CodecShared> ReplayStreamState<'a, B, V> {
-    /// Yield one item, filling `pending` from the current blob when needed.
-    async fn next(mut self) -> Option<(Result<(u64, V), Error>, Self)> {
-        loop {
-            if self.done {
-                return None;
-            }
-
-            // A frame error means the requested replay prefix is no longer trustworthy.
-            if let Some(item) = self.pending.pop_front() {
-                if item.is_err() {
-                    self.done = true;
-                    self.pending.clear();
-                    self.current = None;
-                }
-                return Some((item, self));
-            }
-
-            let state = match self.current.take().or_else(|| self.states.next()) {
-                Some(state) => state,
-                None => return None,
-            };
-
-            match ReplayState::next_batch(state).await {
-                Some((batch, state)) => {
-                    self.current = Some(state);
-                    self.pending = VecDeque::from(batch);
-                }
-                None => {
-                    self.current = None;
-                }
-            }
-        }
-    }
-}
-
-/// Build a stream from per-blob replay states.
-fn replay_stream<'a, B: RBlob, V: CodecShared>(
-    states: Vec<ReplayState<'a, B, V>>,
-) -> impl Stream<Item = Result<(u64, V), Error>> + Send + use<'a, B, V> {
-    stream::unfold(
-        ReplayStreamState {
-            states: states.into_iter(),
-            current: None,
-            pending: VecDeque::new(),
-            done: false,
-        },
-        ReplayStreamState::next,
-    )
-}
-
-/// The blob index where the item at `position` should be stored.
-///
-/// # Examples
-///
-/// ```ignore
-/// // With 10 items per blob:
-/// assert_eq!(position_to_blob(0, 10), 0);   // position 0 -> blob 0
-/// assert_eq!(position_to_blob(9, 10), 0);   // position 9 -> blob 0
-/// assert_eq!(position_to_blob(10, 10), 1);  // position 10 -> blob 1
-/// assert_eq!(position_to_blob(25, 10), 2);  // position 25 -> blob 2
-/// assert_eq!(position_to_blob(30, 10), 3);  // position 30 -> blob 3
-/// ```
-const fn position_to_blob(position: u64, items_per_blob: u64) -> u64 {
-    position / items_per_blob
-}
-
-/// The first position stored in `blob`.
-fn blob_first_position(blob: u64, items_per_blob: u64) -> Result<u64, Error> {
-    blob.checked_mul(items_per_blob)
-        .ok_or(Error::OffsetOverflow)
 }
 
 /// Configuration for a [Journal].
@@ -535,43 +456,9 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
 
     /// Read the varint-framed item at byte `offset` via `blob`.
     async fn read_at_offset(&self, blob: &Blob<'_, E::Blob>, offset: u64) -> Result<V, Error> {
-        // Read the varint header (max 5 bytes for u32).
-        let (buf, available) = blob
-            .read_up_to(
-                offset,
-                MAX_U32_VARINT_SIZE,
-                IoBufMut::with_capacity(MAX_U32_VARINT_SIZE),
-            )
-            .await?;
-        let buf = buf.freeze();
-        let mut cursor = Cursor::new(buf.slice(..available));
-        let (_, item_info) = find_frame(&mut cursor, offset)?;
-
-        // Decode the item, either directly from the buffer or by chaining the prefix with the
-        // remainder.
-        match item_info {
-            FrameInfo::Complete {
-                varint_len,
-                data_len,
-            } => decode_item::<V>(
-                buf.slice(varint_len..varint_len + data_len),
-                &self.codec_config,
-                self.compressed,
-            ),
-            FrameInfo::Incomplete {
-                varint_len,
-                prefix_len,
-                total_len,
-            } => {
-                let prefix = buf.slice(varint_len..varint_len + prefix_len);
-                let read_offset = offset
-                    .checked_add(varint_len as u64)
-                    .and_then(|offset| offset.checked_add(prefix_len as u64))
-                    .ok_or(Error::OffsetOverflow)?;
-                let remainder = blob.read_at(read_offset, total_len - prefix_len).await?;
-                decode_item::<V>(prefix.chain(remainder), &self.codec_config, self.compressed)
-            }
-        }
+        read_frame_at(blob, offset, &self.codec_config, self.compressed)
+            .await
+            .map(|(_, _, item)| item)
     }
 
     /// Read consecutive items in one blob. `offsets` must be strictly increasing byte offsets of
@@ -910,7 +797,7 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
     ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
         let states = self.replay_states(start_pos, buffer).await?;
 
-        Ok(replay_stream(states))
+        Ok(super::replay_stream_from_states(states))
     }
 }
 
@@ -1983,7 +1870,7 @@ impl<E: Context, V: CodecShared> Contiguous for Journal<E, V> {
         let reader = self.reader();
         let states = reader.replay_states(start_pos, buffer).await?;
 
-        Ok(replay_stream(states))
+        Ok(super::replay_stream_from_states(states))
     }
 }
 
@@ -2223,6 +2110,53 @@ mod tests {
             for (pos, item) in items.iter().enumerate() {
                 assert_eq!(journal.read(pos as u64).await.unwrap(), *item);
             }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_variable_append_many_exceeding_write_buffer_reopens_across_sections() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "append-many-exceeds-buffer".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
+                write_buffer: NZUsize!(512),
+            };
+            let items = (0..13)
+                .map(|i| FixedBytes::new([i as u8; 300]))
+                .collect::<Vec<_>>();
+
+            let mut journal =
+                Journal::<_, FixedBytes<300>>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+            assert_eq!(journal.append_many(Many::Flat(&items)).await.unwrap(), 12);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, FixedBytes<300>>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..13);
+            for (pos, item) in items.iter().enumerate() {
+                assert_eq!(journal.read(pos as u64).await.unwrap(), *item);
+            }
+            assert_eq!(
+                journal.read_many(&[0, 4, 5, 9, 10, 12]).await.unwrap(),
+                vec![
+                    items[0].clone(),
+                    items[4].clone(),
+                    items[5].clone(),
+                    items[9].clone(),
+                    items[10].clone(),
+                    items[12].clone(),
+                ]
+            );
 
             journal.destroy().await.unwrap();
         });
@@ -2676,7 +2610,7 @@ mod tests {
                     });
                 }
 
-                let stream = replay_stream(states);
+                let stream = crate::journal::contiguous::replay_stream_from_states(states);
                 futures::pin_mut!(stream);
 
                 for i in 0..10u64 {

--- a/storage/src/journal/frame.rs
+++ b/storage/src/journal/frame.rs
@@ -4,9 +4,50 @@
 //! zstd-compressed) encoded item.
 
 use super::Error;
-use commonware_codec::{varint::UInt, Codec, EncodeSize, ReadExt as _, Write as _};
-use commonware_runtime::Buf;
+use commonware_codec::{
+    varint::{UInt, MAX_U32_VARINT_SIZE},
+    Codec, EncodeSize, ReadExt as _, Write as _,
+};
+use commonware_runtime::{Blob, Buf, IoBufMut, IoBufs};
+use std::{future::Future, io::Cursor};
 use zstd::{bulk::compress, decode_all};
+
+/// Read access needed to decode a frame at a known offset.
+pub(super) trait FrameReader {
+    /// Read up to `len` bytes at `offset`.
+    fn read_up_to(
+        &self,
+        offset: u64,
+        len: usize,
+        buf: impl Into<IoBufMut> + Send,
+    ) -> impl Future<Output = Result<(IoBufMut, usize), Error>> + Send;
+
+    /// Read exactly `len` bytes at `offset`.
+    fn read_at(
+        &self,
+        offset: u64,
+        len: usize,
+    ) -> impl Future<Output = Result<IoBufs, Error>> + Send;
+}
+
+impl<B: Blob> FrameReader for commonware_runtime::buffer::paged::Writer<B> {
+    async fn read_up_to(
+        &self,
+        offset: u64,
+        len: usize,
+        buf: impl Into<IoBufMut> + Send,
+    ) -> Result<(IoBufMut, usize), Error> {
+        Self::read_up_to(self, offset, len, buf)
+            .await
+            .map_err(Error::Runtime)
+    }
+
+    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, Error> {
+        Self::read_at(self, offset, len)
+            .await
+            .map_err(Error::Runtime)
+    }
+}
 
 /// Decodes a varint length prefix from a buffer.
 /// Returns (item_size, varint_len).
@@ -80,6 +121,55 @@ pub(super) fn decode_item<V: Codec>(
     } else {
         V::decode_cfg(item_data, cfg).map_err(Error::Codec)
     }
+}
+
+/// Read and decode the frame at `offset`.
+pub(super) async fn read_frame_at<V: Codec>(
+    reader: &impl FrameReader,
+    offset: u64,
+    cfg: &V::Cfg,
+    compressed: bool,
+) -> Result<(u64, u32, V), Error> {
+    let (buf, available) = reader
+        .read_up_to(
+            offset,
+            MAX_U32_VARINT_SIZE,
+            IoBufMut::with_capacity(MAX_U32_VARINT_SIZE),
+        )
+        .await?;
+    let buf = buf.freeze();
+    let mut cursor = Cursor::new(buf.slice(..available));
+    let (next_offset, item_info) = find_frame(&mut cursor, offset)?;
+
+    let (item_size, decoded) = match item_info {
+        FrameInfo::Complete {
+            varint_len,
+            data_len,
+        } => {
+            let decoded = decode_item::<V>(
+                buf.slice(varint_len..varint_len + data_len),
+                cfg,
+                compressed,
+            )?;
+            (data_len as u32, decoded)
+        }
+        FrameInfo::Incomplete {
+            varint_len,
+            prefix_len,
+            total_len,
+        } => {
+            let prefix = buf.slice(varint_len..varint_len + prefix_len);
+            let read_offset = offset
+                .checked_add(varint_len as u64)
+                .and_then(|offset| offset.checked_add(prefix_len as u64))
+                .ok_or(Error::OffsetOverflow)?;
+            let remainder = reader.read_at(read_offset, total_len - prefix_len).await?;
+            let decoded = decode_item::<V>(prefix.chain(remainder), cfg, compressed)?;
+            (total_len as u32, decoded)
+        }
+    };
+
+    Ok((next_offset, item_size, decoded))
 }
 
 /// Encode an item as a frame (length prefix plus payload), appending the bytes to `buf`.

--- a/storage/src/journal/frame.rs
+++ b/storage/src/journal/frame.rs
@@ -8,7 +8,7 @@ use commonware_codec::{
     varint::{UInt, MAX_U32_VARINT_SIZE},
     Codec, EncodeSize, ReadExt as _, Write as _,
 };
-use commonware_runtime::{Blob, Buf, IoBufMut, IoBufs};
+use commonware_runtime::{buffer::paged::Writer, Blob, Buf, IoBufMut, IoBufs};
 use std::{future::Future, io::Cursor};
 use zstd::{bulk::compress, decode_all};
 
@@ -30,7 +30,7 @@ pub(super) trait FrameReader {
     ) -> impl Future<Output = Result<IoBufs, Error>> + Send;
 }
 
-impl<B: Blob> FrameReader for commonware_runtime::buffer::paged::Writer<B> {
+impl<B: Blob> FrameReader for Writer<B> {
     async fn read_up_to(
         &self,
         offset: u64,

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -226,16 +226,14 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
         for &section in &sections {
             self.prune_guard(section)?;
         }
-        let mut dirty = Vec::new();
-        for section in sections {
-            if let Some(blob) = self.blobs.remove(&section) {
-                dirty.push((section, blob));
-            }
-        }
-        let count = dirty.len() as u64;
-        let result = try_join_all(dirty.iter_mut().map(|(_, blob)| blob.sync())).await;
-        self.blobs.extend(dirty);
-        result.map_err(Error::Runtime)?;
+        let futures: Vec<_> = self
+            .blobs
+            .iter_mut()
+            .filter(|(section, _)| sections.contains(section))
+            .map(|(_, blob)| blob.sync())
+            .collect();
+        let count = futures.len() as u64;
+        try_join_all(futures).await.map_err(Error::Runtime)?;
         self.synced.inc_by(count);
         Ok(())
     }

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -14,7 +14,12 @@ use commonware_runtime::{
     Blob, BufferPool, Error as RError, Metrics, Storage,
 };
 use futures::future::try_join_all;
-use std::{collections::BTreeMap, future::Future, mem::take, num::NonZeroUsize};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
+    mem::take,
+    num::NonZeroUsize,
+};
 use tracing::debug;
 
 /// A minimal [`Blob`] wrapper for [`Manager`].
@@ -217,18 +222,20 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
 
     /// Sync the given `sections` to storage.
     pub async fn sync(&mut self, sections: impl crate::Sections) -> Result<(), Error> {
-        let sections = sections.sections().collect::<Vec<_>>();
+        let sections = sections.sections().collect::<BTreeSet<_>>();
         for &section in &sections {
             self.prune_guard(section)?;
         }
-        let futures: Vec<_> = self
-            .blobs
-            .iter_mut()
-            .filter(|(section, _)| sections.contains(section))
-            .map(|(_, blob)| blob.sync())
-            .collect();
-        let count = futures.len() as u64;
-        try_join_all(futures).await.map_err(Error::Runtime)?;
+        let mut dirty = Vec::new();
+        for section in sections {
+            if let Some(blob) = self.blobs.remove(&section) {
+                dirty.push((section, blob));
+            }
+        }
+        let count = dirty.len() as u64;
+        let result = try_join_all(dirty.iter_mut().map(|(_, blob)| blob.sync())).await;
+        self.blobs.extend(dirty);
+        result.map_err(Error::Runtime)?;
         self.synced.inc_by(count);
         Ok(())
     }

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -82,13 +82,15 @@
 
 use super::manager::{AppendFactory, Config as ManagerConfig, Manager};
 use crate::journal::{
-    frame::{decode_item, decode_length_prefix, encode_frame_into, find_frame, FrameInfo},
+    frame::{
+        decode_item, decode_length_prefix, encode_frame_into, find_frame, read_frame_at, FrameInfo,
+    },
     Error,
 };
 use commonware_codec::{varint::MAX_U32_VARINT_SIZE, Codec, CodecShared};
 use commonware_runtime::{
     buffer::paged::{CacheRef, Replay, Writer},
-    Blob, Buf, IoBuf, IoBufMut, Metrics, Storage,
+    Blob, Buf, IoBuf, Metrics, Storage,
 };
 use futures::stream::{self, Stream, StreamExt};
 use std::{io::Cursor, num::NonZeroUsize};
@@ -181,47 +183,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         blob: &Writer<E::Blob>,
         offset: u64,
     ) -> Result<(u64, u32, V), Error> {
-        // Read varint header (max 5 bytes for u32)
-        let (buf, available) = blob
-            .read_up_to(
-                offset,
-                MAX_U32_VARINT_SIZE,
-                IoBufMut::with_capacity(MAX_U32_VARINT_SIZE),
-            )
-            .await?;
-        let buf = buf.freeze();
-        let mut cursor = Cursor::new(buf.slice(..available));
-        let (next_offset, item_info) = find_frame(&mut cursor, offset)?;
-
-        // Decode item - either directly from buffer or by chaining prefix with remainder
-        let (item_size, decoded) = match item_info {
-            FrameInfo::Complete {
-                varint_len,
-                data_len,
-            } => {
-                // Data follows varint in buffer
-                let data = buf.slice(varint_len..varint_len + data_len);
-                let decoded = decode_item::<V>(data, cfg, compressed)?;
-                (data_len as u32, decoded)
-            }
-            FrameInfo::Incomplete {
-                varint_len,
-                prefix_len,
-                total_len,
-            } => {
-                // Read remainder and chain with prefix to avoid copying
-                let prefix = buf.slice(varint_len..varint_len + prefix_len);
-                let read_offset = offset + varint_len as u64 + prefix_len as u64;
-                let remainder_len = total_len - prefix_len;
-                let mut remainder = vec![0u8; remainder_len];
-                blob.read_into(&mut remainder, read_offset).await?;
-                let chained = prefix.chain(IoBuf::from(remainder));
-                let decoded = decode_item::<V>(chained, cfg, compressed)?;
-                (total_len as u32, decoded)
-            }
-        };
-
-        Ok((next_offset, item_size, decoded))
+        read_frame_at(blob, offset, cfg, compressed).await
     }
 
     /// Returns an ordered stream of all items in the journal starting with the item at the given

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -113,13 +113,13 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         let mut blobs = BTreeMap::new();
         let stored_blobs = if bits.is_none() {
             match context.remove(&config.partition, None).await {
-                Ok(()) | Err(commonware_runtime::Error::PartitionMissing(_)) => Vec::new(),
+                Ok(()) | Err(RError::PartitionMissing(_)) => Vec::new(),
                 Err(err) => return Err(Error::Runtime(err)),
             }
         } else {
             match context.scan(&config.partition).await {
                 Ok(blobs) => blobs,
-                Err(commonware_runtime::Error::PartitionMissing(_)) => Vec::new(),
+                Err(RError::PartitionMissing(_)) => Vec::new(),
                 Err(err) => return Err(Error::Runtime(err)),
             }
         };

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -426,13 +426,16 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
             return Ok(());
         }
 
-        let futures: Vec<_> = self
-            .blobs
-            .iter_mut()
-            .filter(|(section, _)| self.pending.contains(section))
-            .map(|(_, blob)| blob.sync())
-            .collect();
-        try_join_all(futures).await?;
+        let mut dirty = Vec::new();
+        for section in &self.pending {
+            if let Some(blob) = self.blobs.remove(section) {
+                dirty.push((*section, blob));
+            }
+        }
+
+        let result = try_join_all(dirty.iter_mut().map(|(_, blob)| blob.sync())).await;
+        self.blobs.extend(dirty);
+        result?;
 
         // Clear pending sections.
         self.pending.clear();

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -426,16 +426,13 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
             return Ok(());
         }
 
-        let mut dirty = Vec::new();
-        for section in &self.pending {
-            if let Some(blob) = self.blobs.remove(section) {
-                dirty.push((*section, blob));
-            }
-        }
-
-        let result = try_join_all(dirty.iter_mut().map(|(_, blob)| blob.sync())).await;
-        self.blobs.extend(dirty);
-        result?;
+        let futures: Vec<_> = self
+            .blobs
+            .iter_mut()
+            .filter(|(section, _)| self.pending.contains(section))
+            .map(|(_, blob)| blob.sync())
+            .collect();
+        try_join_all(futures).await?;
 
         // Clear pending sections.
         self.pending.clear();


### PR DESCRIPTION
## Summary

- Address final read-view nits on top of `danlaine/read-view`.
- Optimize contiguous journal replay by draining decoded batches synchronously instead of yielding each decoded item through a separate async stream transition.
- Keep the concrete-reader/memmove prototype out of this PR because it did not improve the fixed replay worst case locally and added broader replay plumbing.

## Replay Performance Investigation

The replay regression was traced to the shared replay stream driver. The previous branch implementation decoded a batch, stored it in a `VecDeque`, then yielded one item per `stream::unfold` transition. `origin/main` decoded a batch asynchronously and flattened it synchronously with `stream::iter`, avoiding that per-item async state-machine cost.

This PR now keeps the shared replay driver but changes it to yield decoded batches from `next_batch()` and drain each batch with `flat_map(stream::iter)`. Stop-after-error behavior is preserved by marking the replay stream done when a yielded batch contains an error.

Local Criterion result for the worst fixed replay case:

| Case | Time |
| --- | ---: |
| branch before replay-driver fix | ~27.4 ms |
| `origin/main` | ~10.0 ms |
| batch-driver fix | ~7.6 ms |

Benchmark filter:

```sh
cargo bench -p commonware-storage --bench journal -- \
  'journal::fixed_replay/items=500000 buffer=1048576 size=32'
```

Additional local replay checks were also favorable: fixed replay at `items=100000 buffer=1048576 size=32` was around `1.5 ms`, and variable replay at `items=100000 buffer=65536 size=32` was around `3.9 ms`.

I also prototyped a concrete-reader version that removed the `ReplayInner` enum from the item decode loop by splitting paged sealed replay from live tail replay. It passed the focused replay tests, but it stayed around `7.6 ms` on the fixed replay worst case and regressed the smaller fixed replay case locally, so that larger change is intentionally not included here.

## Validation

```sh
cargo check -p commonware-storage --lib
just test -p commonware-storage test_fixed_journal_replay
just test -p commonware-storage test_variable_replay
cargo fmt --all --check
git diff --check
```
