### PR TITLE
[examples/reshare] Nits

### DIFF
--- a/cryptography/src/bls12381/benches/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/benches/dkg/feldman_desmedt.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::{
     bls12381::{
-        dkg::feldman_desmedt::{deal, Dealer, Info, Logs, Player},
+        dkg::feldman_desmedt::{deal, Dealer, Info, Logs, Player, Verdict},
         primitives::variant::MinSig,
     },
     ed25519::{Batch, PrivateKey, PublicKey},
@@ -83,9 +83,8 @@ impl Bench {
             for (target_pk, priv_msg) in priv_msgs {
                 // The only missing player should be ourselves.
                 if let Some(player) = player_states.get_mut(&target_pk) {
-                    if let Some(ack) = player
-                        .dealer_message::<N3f1>(pk.clone(), pub_msg.clone(), priv_msg)
-                        .valid()
+                    if let Verdict::Valid(ack) =
+                        player.dealer_message::<N3f1>(pk.clone(), pub_msg.clone(), priv_msg)
                     {
                         dealer.receive_player_ack(target_pk.clone(), ack).unwrap();
                     }

--- a/cryptography/src/bls12381/benches/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/benches/dkg/feldman_desmedt.rs
@@ -83,8 +83,9 @@ impl Bench {
             for (target_pk, priv_msg) in priv_msgs {
                 // The only missing player should be ourselves.
                 if let Some(player) = player_states.get_mut(&target_pk) {
-                    if let Some(ack) =
-                        player.dealer_message::<N3f1>(pk.clone(), pub_msg.clone(), priv_msg)
+                    if let Some(ack) = player
+                        .dealer_message::<N3f1>(pk.clone(), pub_msg.clone(), priv_msg)
+                        .valid()
                     {
                         dealer.receive_player_ack(target_pk.clone(), ack).unwrap();
                     }

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -575,52 +575,36 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
             .expect("player index should be < num_players"))
     }
 
-    /// Verify a dealer's public message.
-    ///
-    /// A wrong commitment degree, missing prior share commitment, or reshare
-    /// commitment whose constant term does not match the dealer's prior share
-    /// commitment, is a provable [`Verdict::Fault`].
-    fn check_dealer_pub_msg<M: Faults>(
-        &self,
-        dealer: &P,
-        pub_msg: &DealerPubMsg<V>,
-    ) -> Verdict<()> {
+    #[must_use]
+    fn check_dealer_pub_msg<M: Faults>(&self, dealer: &P, pub_msg: &DealerPubMsg<V>) -> bool {
         if self.degree::<M>() != pub_msg.commitment.degree_exact() {
-            return Verdict::Fault;
+            return false;
         }
         if let Some(previous) = self.previous.as_ref() {
             let Some(share_commitment) = previous.share_commitment(dealer) else {
-                return Verdict::Fault;
+                return false;
             };
             if *pub_msg.commitment.constant() != share_commitment {
-                return Verdict::Fault;
+                return false;
             }
         }
-        Verdict::Valid(())
+        true
     }
 
-    /// Verify a dealer's private message against its public commitment.
-    ///
-    /// A share inconsistent with the commitment, including a private share
-    /// addressed to a different participant, is a provable [`Verdict::Fault`].
+    #[must_use]
     fn check_dealer_priv_msg(
         &self,
         player: &P,
         pub_msg: &DealerPubMsg<V>,
         priv_msg: &DealerPrivMsg,
-    ) -> Verdict<()> {
+    ) -> bool {
         let Ok(scalar) = self.player_scalar(player) else {
-            return Verdict::Fault;
+            return false;
         };
         let expected = pub_msg.commitment.eval_msm(&scalar, &Sequential);
-        if priv_msg
+        priv_msg
             .share
             .expose(|share| expected == V::Public::generator() * share)
-        {
-            Verdict::Valid(())
-        } else {
-            Verdict::Fault
-        }
     }
 
     #[must_use]
@@ -635,10 +619,7 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
         if self.dealer_index(dealer).is_err() {
             return false;
         }
-        if !self
-            .check_dealer_pub_msg::<M>(dealer, &log.pub_msg)
-            .is_valid()
-        {
+        if !self.check_dealer_pub_msg::<M>(dealer, &log.pub_msg) {
             return false;
         }
         let Some(results_iter) = log.zip_players(&self.players) else {
@@ -1834,18 +1815,14 @@ impl<V: Variant, S: Signer> Player<V, S> {
         if self.info.dealer_index(&dealer).is_err() {
             return Verdict::Fault;
         }
-        match self.info.check_dealer_pub_msg::<M>(&dealer, &pub_msg) {
-            Verdict::Valid(()) => {}
-            Verdict::Skip => return Verdict::Skip,
-            Verdict::Fault => return Verdict::Fault,
+        if !self.info.check_dealer_pub_msg::<M>(&dealer, &pub_msg) {
+            return Verdict::Fault;
         }
-        match self
+        if !self
             .info
             .check_dealer_priv_msg(&self.me_pub, &pub_msg, &priv_msg)
         {
-            Verdict::Valid(()) => {}
-            Verdict::Skip => return Verdict::Skip,
-            Verdict::Fault => return Verdict::Fault,
+            return Verdict::Fault;
         }
         let sig = transcript_for_ack(&self.transcript, &dealer, &pub_msg).sign(&self.me);
         self.view.insert(dealer, (pub_msg, priv_msg));

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -901,22 +901,6 @@ pub enum Verdict<T> {
     Fault,
 }
 
-impl<T> Verdict<T> {
-    /// Returns the validated artifact, discarding skip and fault verdicts.
-    pub fn valid(self) -> Option<T> {
-        match self {
-            Self::Valid(value) => Some(value),
-            Self::Skip | Self::Fault => None,
-        }
-    }
-
-    /// Returns whether the message validated.
-    #[must_use]
-    pub const fn is_valid(&self) -> bool {
-        matches!(self, Self::Valid(_))
-    }
-}
-
 #[derive(Clone, PartialEq)]
 enum AckOrReveal<P: PublicKey> {
     Ack(PlayerAck<P>),
@@ -2508,9 +2492,14 @@ mod test_plan {
                         let player = &mut players.values_mut()[usize::from(i_player)];
                         let persisted = priv_msg.clone();
 
-                        let ack = player
-                            .dealer_message::<N3f1>(pk.clone(), pub_msg.clone(), priv_msg)
-                            .valid();
+                        let ack = match player.dealer_message::<N3f1>(
+                            pk.clone(),
+                            pub_msg.clone(),
+                            priv_msg,
+                        ) {
+                            Verdict::Valid(ack) => Some(ack),
+                            Verdict::Skip | Verdict::Fault => None,
+                        };
                         assert_eq!(ack, ReadExt::read(&mut ack.encode())?);
                         if let Some(ack) = ack {
                             acked_dealings
@@ -3118,12 +3107,13 @@ mod test {
                     Dealer::start::<QuorumTwo>(&mut rng, info.clone(), dealer_sk, None)
                         .expect("dealer initialization must succeed");
                 for (player_pk, priv_msg) in priv_msgs {
-                    let ack = players
+                    let Verdict::Valid(ack) = players
                         .get_mut(&player_pk)
                         .expect("player should exist")
                         .dealer_message::<QuorumTwo>(dealer_pk.clone(), pub_msg.clone(), priv_msg)
-                        .valid()
-                        .expect("dealer message must succeed");
+                    else {
+                        panic!("dealer message must succeed");
+                    };
                     dealer
                         .receive_player_ack(player_pk, ack)
                         .expect("ack handling must succeed");
@@ -3581,10 +3571,11 @@ mod test {
             let (mut dealer, pub_msg, priv_msgs) =
                 Dealer::start::<N3f1>(&mut test_rng(), info.clone(), sk.clone(), None)?;
             let mut player = Player::new(info.clone(), sk)?;
-            let ack = player
-                .dealer_message::<N3f1>(pk.clone(), pub_msg, priv_msgs[0].1.clone())
-                .valid()
-                .unwrap();
+            let Verdict::Valid(ack) =
+                player.dealer_message::<N3f1>(pk.clone(), pub_msg, priv_msgs[0].1.clone())
+            else {
+                panic!("dealer message must succeed");
+            };
             dealer.receive_player_ack(pk, ack)?;
             dealer.finalize::<N3f1>()
         };
@@ -3640,9 +3631,10 @@ mod test {
         ));
 
         // A correct dealing validates.
-        assert!(player
-            .dealer_message::<N3f1>(a_pk, pub_msg, priv_for_b)
-            .is_valid());
+        assert!(matches!(
+            player.dealer_message::<N3f1>(a_pk, pub_msg, priv_for_b),
+            Verdict::Valid(_)
+        ));
 
         Ok(())
     }
@@ -3665,10 +3657,11 @@ mod test {
         let (mut dealer, pub_msg, priv_msgs) =
             Dealer::start::<N3f1>(&mut test_rng(), info.clone(), a.clone(), None)?;
         let mut player = Player::new(info, a.clone())?;
-        let ack = player
-            .dealer_message::<N3f1>(a_pk.clone(), pub_msg, priv_msgs[0].1.clone())
-            .valid()
-            .expect("valid ack");
+        let Verdict::Valid(ack) =
+            player.dealer_message::<N3f1>(a_pk.clone(), pub_msg, priv_msgs[0].1.clone())
+        else {
+            panic!("valid ack");
+        };
 
         // An ack signature that does not verify is a provable fault.
         let forged = PlayerAck {

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -172,8 +172,10 @@
 //! construction is used.
 //!
 //! In practice:
-//! - [`Player::dealer_message`] returns `None` for invalid messages (implicit complaint)
-//! - [`Dealer::receive_player_ack`] validates acknowledgements
+//! - [`Player::dealer_message`] returns a [`Verdict`] that distinguishes a provably
+//!   invalid message ([`Verdict::Fault`], an implicit complaint) from a benign skip
+//! - [`Dealer::receive_player_ack`] validates acknowledgements, returning
+//!   [`Error::InvalidAck`] for a provably bad signature
 //! - Other custom mechanisms can exclude dealers before calling [`observe`] or [`Player::finalize`],
 //!   to enforce other rules for "misbehavior" beyond what the DKG does already.
 //!
@@ -195,7 +197,7 @@
 //!
 //! ```
 //! use commonware_cryptography::bls12381::{
-//!     dkg::feldman_desmedt::{Dealer, Info, Logs, Player, SignedDealerLog, observe},
+//!     dkg::feldman_desmedt::{Dealer, Info, Logs, Player, SignedDealerLog, Verdict, observe},
 //!     primitives::{variant::MinSig, sharing::Mode},
 //! };
 //! use commonware_cryptography::{ed25519, Signer};
@@ -255,7 +257,7 @@
 //!     // Distribute messages to players and collect acknowledgements
 //!     for (player_pk, priv_msg) in priv_msgs {
 //!         if let Some(player) = players.get_mut(&player_pk) {
-//!             if let Some(ack) = player.dealer_message::<N3f1>(
+//!             if let Verdict::Valid(ack) = player.dealer_message::<N3f1>(
 //!                 dealer_priv.public_key(),
 //!                 pub_msg.clone(),
 //!                 priv_msg,
@@ -343,6 +345,8 @@ pub enum Error {
     MissingDealerShare,
     #[error("player is not present in the list of players")]
     UnknownPlayer,
+    #[error("player acknowledgement signature did not verify")]
+    InvalidAck,
     #[error("dealer is not present in the previous list of players")]
     UnknownDealer(String),
     #[error("invalid number of dealers: {0}")]
@@ -571,36 +575,52 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
             .expect("player index should be < num_players"))
     }
 
-    #[must_use]
-    fn check_dealer_pub_msg<M: Faults>(&self, dealer: &P, pub_msg: &DealerPubMsg<V>) -> bool {
+    /// Verify a dealer's public message.
+    ///
+    /// A wrong commitment degree, missing prior share commitment, or reshare
+    /// commitment whose constant term does not match the dealer's prior share
+    /// commitment, is a provable [`Verdict::Fault`].
+    fn check_dealer_pub_msg<M: Faults>(
+        &self,
+        dealer: &P,
+        pub_msg: &DealerPubMsg<V>,
+    ) -> Verdict<()> {
         if self.degree::<M>() != pub_msg.commitment.degree_exact() {
-            return false;
+            return Verdict::Fault;
         }
         if let Some(previous) = self.previous.as_ref() {
             let Some(share_commitment) = previous.share_commitment(dealer) else {
-                return false;
+                return Verdict::Fault;
             };
             if *pub_msg.commitment.constant() != share_commitment {
-                return false;
+                return Verdict::Fault;
             }
         }
-        true
+        Verdict::Valid(())
     }
 
-    #[must_use]
+    /// Verify a dealer's private message against its public commitment.
+    ///
+    /// A share inconsistent with the commitment, including a private share
+    /// addressed to a different participant, is a provable [`Verdict::Fault`].
     fn check_dealer_priv_msg(
         &self,
         player: &P,
         pub_msg: &DealerPubMsg<V>,
         priv_msg: &DealerPrivMsg,
-    ) -> bool {
+    ) -> Verdict<()> {
         let Ok(scalar) = self.player_scalar(player) else {
-            return false;
+            return Verdict::Fault;
         };
         let expected = pub_msg.commitment.eval_msm(&scalar, &Sequential);
-        priv_msg
+        if priv_msg
             .share
             .expose(|share| expected == V::Public::generator() * share)
+        {
+            Verdict::Valid(())
+        } else {
+            Verdict::Fault
+        }
     }
 
     #[must_use]
@@ -615,7 +635,10 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
         if self.dealer_index(dealer).is_err() {
             return false;
         }
-        if !self.check_dealer_pub_msg::<M>(dealer, &log.pub_msg) {
+        if !self
+            .check_dealer_pub_msg::<M>(dealer, &log.pub_msg)
+            .is_valid()
+        {
             return false;
         }
         let Some(results_iter) = log.zip_players(&self.players) else {
@@ -877,6 +900,39 @@ where
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         let sig = u.arbitrary()?;
         Ok(Self { sig })
+    }
+}
+
+/// The result of validating an untrusted protocol message from a peer.
+///
+/// This drives peer punishment in adversarial deployments. A [`Verdict::Fault`]
+/// is a provable protocol violation, so the sender should be penalized (e.g.
+/// blocked). A [`Verdict::Skip`] is a benign non-action, such as a duplicate,
+/// that must not be penalized.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[must_use]
+pub enum Verdict<T> {
+    /// The message validated. Carries any resulting artifact.
+    Valid(T),
+    /// The message is not actionable, but the sender is not provably faulty.
+    Skip,
+    /// The message is provably invalid; the sender should be penalized.
+    Fault,
+}
+
+impl<T> Verdict<T> {
+    /// Returns the validated artifact, discarding skip and fault verdicts.
+    pub fn valid(self) -> Option<T> {
+        match self {
+            Self::Valid(value) => Some(value),
+            Self::Skip | Self::Fault => None,
+        }
+    }
+
+    /// Returns whether the message validated.
+    #[must_use]
+    pub const fn is_valid(&self) -> bool {
+        matches!(self, Self::Valid(_))
     }
 }
 
@@ -1536,9 +1592,10 @@ impl<V: Variant, S: Signer> Dealer<V, S> {
             .results
             .get_value_mut(&player)
             .ok_or(Error::UnknownPlayer)?;
-        if self.transcript.verify(&player, &ack.sig) {
-            *res_mut = AckOrReveal::Ack(ack);
+        if !self.transcript.verify(&player, &ack.sig) {
+            return Err(Error::InvalidAck);
         }
+        *res_mut = AckOrReveal::Ack(ack);
         Ok(())
     }
 
@@ -1730,7 +1787,8 @@ impl<V: Variant, S: Signer> Player<V, S> {
         let mut this = Self::new(info, me)?;
         let mut acks = BTreeMap::new();
         for (dealer, pub_msg, priv_msg) in msgs {
-            if let Some(ack) = this.dealer_message::<M>(dealer.clone(), pub_msg, priv_msg) {
+            if let Verdict::Valid(ack) = this.dealer_message::<M>(dealer.clone(), pub_msg, priv_msg)
+            {
                 acks.insert(dealer, ack);
             }
         }
@@ -1760,28 +1818,38 @@ impl<V: Variant, S: Signer> Player<V, S> {
     /// private message was not exposed to anyone else. A convenient way to
     /// provide this is by using an authenticated channel, e.g. via
     /// [crate::handshake], or [commonware-p2p](https://docs.rs/commonware-p2p/latest/commonware_p2p/).
+    ///
+    /// The returned [`Verdict`] distinguishes a provably-invalid message
+    /// ([`Verdict::Fault`], the dealer should be penalized) from a benign skip
+    /// ([`Verdict::Skip`]: a duplicate).
     pub fn dealer_message<M: Faults>(
         &mut self,
         dealer: S::PublicKey,
         pub_msg: DealerPubMsg<V>,
         priv_msg: DealerPrivMsg,
-    ) -> Option<PlayerAck<S::PublicKey>> {
+    ) -> Verdict<PlayerAck<S::PublicKey>> {
         if self.view.contains_key(&dealer) {
-            return None;
+            return Verdict::Skip;
         }
-        self.info.dealer_index(&dealer).ok()?;
-        if !self.info.check_dealer_pub_msg::<M>(&dealer, &pub_msg) {
-            return None;
+        if self.info.dealer_index(&dealer).is_err() {
+            return Verdict::Fault;
         }
-        if !self
+        match self.info.check_dealer_pub_msg::<M>(&dealer, &pub_msg) {
+            Verdict::Valid(()) => {}
+            Verdict::Skip => return Verdict::Skip,
+            Verdict::Fault => return Verdict::Fault,
+        }
+        match self
             .info
             .check_dealer_priv_msg(&self.me_pub, &pub_msg, &priv_msg)
         {
-            return None;
+            Verdict::Valid(()) => {}
+            Verdict::Skip => return Verdict::Skip,
+            Verdict::Fault => return Verdict::Fault,
         }
         let sig = transcript_for_ack(&self.transcript, &dealer, &pub_msg).sign(&self.me);
         self.view.insert(dealer, (pub_msg, priv_msg));
-        Some(PlayerAck { sig })
+        Verdict::Valid(PlayerAck { sig })
     }
 
     /// Finalize the player, producing an output, and a share.
@@ -2463,8 +2531,9 @@ mod test_plan {
                         let player = &mut players.values_mut()[usize::from(i_player)];
                         let persisted = priv_msg.clone();
 
-                        let ack =
-                            player.dealer_message::<N3f1>(pk.clone(), pub_msg.clone(), priv_msg);
+                        let ack = player
+                            .dealer_message::<N3f1>(pk.clone(), pub_msg.clone(), priv_msg)
+                            .valid();
                         assert_eq!(ack, ReadExt::read(&mut ack.encode())?);
                         if let Some(ack) = ack {
                             acked_dealings
@@ -3076,6 +3145,7 @@ mod test {
                         .get_mut(&player_pk)
                         .expect("player should exist")
                         .dealer_message::<QuorumTwo>(dealer_pk.clone(), pub_msg.clone(), priv_msg)
+                        .valid()
                         .expect("dealer message must succeed");
                     dealer
                         .receive_player_ack(player_pk, ack)
@@ -3536,6 +3606,7 @@ mod test {
             let mut player = Player::new(info.clone(), sk)?;
             let ack = player
                 .dealer_message::<N3f1>(pk.clone(), pub_msg, priv_msgs[0].1.clone())
+                .valid()
                 .unwrap();
             dealer.receive_player_ack(pk, ack)?;
             dealer.finalize::<N3f1>()
@@ -3543,6 +3614,102 @@ mod test {
         std::mem::swap(&mut log0.log, &mut log1.log);
         assert!(log0.check(&info).is_none());
         assert!(log1.check(&info).is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn dealer_message_classifies_faults_and_skips() -> Result<(), Error> {
+        let a = ed25519::PrivateKey::from_seed(0);
+        let b = ed25519::PrivateKey::from_seed(1);
+        let stranger = ed25519::PrivateKey::from_seed(2);
+        let (a_pk, b_pk, stranger_pk) = (a.public_key(), b.public_key(), stranger.public_key());
+        let members: Set<ed25519::PublicKey> = vec![a_pk.clone(), b_pk.clone()].try_into().unwrap();
+        let info = Info::<MinPk, _>::new::<N3f1>(
+            b"_COMMONWARE_CRYPTOGRAPHY_BLS12381_DKG_TEST",
+            0,
+            None,
+            Mode::default(),
+            members.clone(),
+            members,
+        )?;
+
+        // Dealer A produces one private message per player.
+        let (_, pub_msg, priv_msgs) =
+            Dealer::start::<N3f1>(&mut test_rng(), info.clone(), a, None)?;
+        let priv_for_a = priv_msgs
+            .iter()
+            .find(|(player, _)| *player == a_pk)
+            .map(|(_, msg)| msg.clone())
+            .expect("share for a");
+        let priv_for_b = priv_msgs
+            .iter()
+            .find(|(player, _)| *player == b_pk)
+            .map(|(_, msg)| msg.clone())
+            .expect("share for b");
+
+        // A dealing whose private share does not match the public commitment at
+        // our index is a provable fault.
+        let mut player = Player::new(info, b)?;
+        assert!(matches!(
+            player.dealer_message::<N3f1>(a_pk.clone(), pub_msg.clone(), priv_for_a),
+            Verdict::Fault
+        ));
+
+        // A dealing from a key outside the dealer set is a provable fault.
+        assert!(matches!(
+            player.dealer_message::<N3f1>(stranger_pk, pub_msg.clone(), priv_for_b.clone()),
+            Verdict::Fault
+        ));
+
+        // A correct dealing validates.
+        assert!(player
+            .dealer_message::<N3f1>(a_pk, pub_msg, priv_for_b)
+            .is_valid());
+
+        Ok(())
+    }
+
+    #[test]
+    fn receive_player_ack_rejects_invalid_signature() -> Result<(), Error> {
+        let a = ed25519::PrivateKey::from_seed(0);
+        let stranger = ed25519::PrivateKey::from_seed(1);
+        let (a_pk, stranger_pk) = (a.public_key(), stranger.public_key());
+        let members: Set<ed25519::PublicKey> = vec![a_pk.clone()].try_into().unwrap();
+        let info = Info::<MinPk, _>::new::<N3f1>(
+            b"_COMMONWARE_CRYPTOGRAPHY_BLS12381_DKG_TEST",
+            0,
+            None,
+            Mode::default(),
+            members.clone(),
+            members,
+        )?;
+
+        let (mut dealer, pub_msg, priv_msgs) =
+            Dealer::start::<N3f1>(&mut test_rng(), info.clone(), a.clone(), None)?;
+        let mut player = Player::new(info, a.clone())?;
+        let ack = player
+            .dealer_message::<N3f1>(a_pk.clone(), pub_msg, priv_msgs[0].1.clone())
+            .valid()
+            .expect("valid ack");
+
+        // An ack signature that does not verify is a provable fault.
+        let forged = PlayerAck {
+            sig: a.sign(b"_COMMONWARE_CRYPTOGRAPHY_BLS12381_DKG_TEST", b"not an ack"),
+        };
+        assert!(matches!(
+            dealer.receive_player_ack(a_pk.clone(), forged),
+            Err(Error::InvalidAck)
+        ));
+
+        // An ack from a player outside the round is a benign unknown player.
+        assert!(matches!(
+            dealer.receive_player_ack(stranger_pk, ack.clone()),
+            Err(Error::UnknownPlayer)
+        ));
+
+        // The genuine ack is still accepted.
+        assert!(dealer.receive_player_ack(a_pk, ack).is_ok());
 
         Ok(())
     }

--- a/examples/reshare/src/dkg/actor.rs
+++ b/examples/reshare/src/dkg/actor.rs
@@ -14,7 +14,7 @@ use commonware_consensus::types::{Epoch, EpochPhase, Epocher, FixedEpocher};
 use commonware_cryptography::{
     bls12381::{
         dkg::feldman_desmedt::{
-            observe, DealerPrivMsg, DealerPubMsg, Info, Logs, Output, PlayerAck,
+            observe, DealerPrivMsg, DealerPubMsg, Info, Logs, Output, PlayerAck, Verdict,
         },
         primitives::{
             group::Share,
@@ -28,7 +28,9 @@ use commonware_cryptography::{
 };
 use commonware_macros::select_loop;
 use commonware_math::algebra::Random;
-use commonware_p2p::{utils::mux::Muxer, Manager, Receiver, Recipients, Sender, TrackedPeers};
+use commonware_p2p::{
+    utils::mux::Muxer, Blocker, Manager, Receiver, Recipients, Sender, TrackedPeers,
+};
 use commonware_parallel::Sequential;
 use commonware_runtime::{
     spawn_cell,
@@ -100,8 +102,9 @@ impl<V: Variant, P: PublicKey> Read for Message<V, P> {
     }
 }
 
-pub struct Config<C: Signer, P> {
+pub struct Config<C: Signer, P, B> {
     pub manager: P,
+    pub blocker: B,
     pub signer: C,
     pub mailbox_size: NonZeroUsize,
     pub partition_prefix: String,
@@ -109,16 +112,18 @@ pub struct Config<C: Signer, P> {
     pub max_supported_mode: ModeVersion,
 }
 
-pub struct Actor<E, P, H, C, V>
+pub struct Actor<E, P, B, H, C, V>
 where
     E: BufferPooler + Spawner + Metrics + CryptoRngCore + Clock + RuntimeStorage,
     P: Manager<PublicKey = C::PublicKey>,
+    B: Blocker<PublicKey = C::PublicKey>,
     H: Hasher,
     C: Signer,
     V: Variant,
 {
     context: ContextCell<E>,
     manager: P,
+    blocker: B,
     mailbox: ActorReceiver<MailboxMessage<H, C, V>>,
     signer: C,
     peer_config: PeerConfig<C::PublicKey>,
@@ -133,17 +138,18 @@ where
     latest_ack: GaugeFamily<Peer<C::PublicKey>>,
 }
 
-impl<E, P, H, C, V> Actor<E, P, H, C, V>
+impl<E, P, B, H, C, V> Actor<E, P, B, H, C, V>
 where
     E: BufferPooler + Spawner + Metrics + CryptoRngCore + Clock + RuntimeStorage,
     P: Manager<PublicKey = C::PublicKey>,
+    B: Blocker<PublicKey = C::PublicKey>,
     H: Hasher,
     C: Signer,
     Batch: BatchVerifier<PublicKey = C::PublicKey>,
     V: Variant,
 {
     /// Create a new DKG [Actor] and its associated [Mailbox].
-    pub fn new(context: E, config: Config<C, P>) -> (Self, Mailbox<H, C, V>) {
+    pub fn new(context: E, config: Config<C, P, B>) -> (Self, Mailbox<H, C, V>) {
         // Create mailbox
         let (sender, mailbox) = mailbox::new(context.child("mailbox"), config.mailbox_size);
 
@@ -165,6 +171,7 @@ where
             Self {
                 context: ContextCell::new(context),
                 manager: config.manager,
+                blocker: config.blocker,
                 mailbox,
                 signer: config.signer,
                 peer_config: config.peer_config,
@@ -320,7 +327,7 @@ where
                 epoch.get(),
                 epoch_state.output.clone(),
                 Mode::NonZeroCounter,
-                dealers,
+                dealers.clone(),
                 players.clone(),
             )
             .expect("round info configuration should be correct");
@@ -360,14 +367,20 @@ where
                             ) {
                                 Ok(m) => m,
                                 Err(e) => {
-                                    warn!(?epoch, ?sender_pk, ?e, "failed to parse message");
+                                    commonware_p2p::block!(
+                                        self.blocker,
+                                        sender_pk,
+                                        ?epoch,
+                                        ?e,
+                                        "failed to parse message"
+                                    );
                                     continue;
                                 }
                             };
                             match msg {
                                 Message::Dealer(pub_msg, priv_msg) => {
                                     if let Some(ref mut ps) = player_state {
-                                        let response = ps
+                                        match ps
                                             .handle::<_, N3f1>(
                                                 &mut storage,
                                                 epoch,
@@ -375,41 +388,77 @@ where
                                                 pub_msg,
                                                 priv_msg,
                                             )
-                                            .await;
-                                        if let Some(ack) = response {
-                                            let _ = self
-                                                .latest_share
-                                                .get_or_create_by(&sender_pk)
-                                                .try_set_max(epoch.get());
+                                            .await
+                                        {
+                                            Verdict::Valid(ack) => {
+                                                let _ = self
+                                                    .latest_share
+                                                    .get_or_create_by(&sender_pk)
+                                                    .try_set_max(epoch.get());
 
-                                            let payload =
-                                                Message::<V, C::PublicKey>::Ack(ack).encode();
-                                            let sent = round_sender.send(
-                                                Recipients::One(sender_pk.clone()),
-                                                payload,
-                                                true,
-                                            );
-                                            if sent.is_empty() {
-                                                warn!(
+                                                let payload =
+                                                    Message::<V, C::PublicKey>::Ack(ack).encode();
+                                                let sent = round_sender.send(
+                                                    Recipients::One(sender_pk.clone()),
+                                                    payload,
+                                                    true,
+                                                );
+                                                if sent.is_empty() {
+                                                    warn!(
+                                                        ?epoch,
+                                                        dealer = ?sender_pk,
+                                                        "failed to send ack"
+                                                    );
+                                                }
+                                            }
+                                            Verdict::Skip => {}
+                                            Verdict::Fault => {
+                                                commonware_p2p::block!(
+                                                    self.blocker,
+                                                    sender_pk,
                                                     ?epoch,
-                                                    dealer = ?sender_pk,
-                                                    "failed to send ack"
+                                                    "invalid dealing"
                                                 );
                                             }
                                         }
+                                    } else if !am_player {
+                                        commonware_p2p::block!(
+                                            self.blocker,
+                                            sender_pk,
+                                            ?epoch,
+                                            "dealing sent to non-player"
+                                        );
                                     }
                                 }
                                 Message::Ack(ack) => {
                                     if let Some(ref mut ds) = dealer_state {
-                                        let added = ds
+                                        match ds
                                             .handle(&mut storage, epoch, sender_pk.clone(), ack)
-                                            .await;
-                                        if added {
-                                            let _ = self
-                                                .latest_ack
-                                                .get_or_create_by(&sender_pk)
-                                                .try_set_max(epoch.get());
+                                            .await
+                                        {
+                                            Verdict::Valid(()) => {
+                                                let _ = self
+                                                    .latest_ack
+                                                    .get_or_create_by(&sender_pk)
+                                                    .try_set_max(epoch.get());
+                                            }
+                                            Verdict::Skip => {}
+                                            Verdict::Fault => {
+                                                commonware_p2p::block!(
+                                                    self.blocker,
+                                                    sender_pk,
+                                                    ?epoch,
+                                                    "invalid ack"
+                                                );
+                                            }
                                         }
+                                    } else if !am_dealer {
+                                        commonware_p2p::block!(
+                                            self.blocker,
+                                            sender_pk,
+                                            ?epoch,
+                                            "ack sent to non-dealer"
+                                        );
                                     }
                                 }
                             }
@@ -453,15 +502,23 @@ where
                         // Process dealer log from block if present
                         if let Some(log) = block.log {
                             if let Some((dealer, dealer_log)) = log.check(&round) {
-                                // If we see our dealing outcome in a finalized block,
-                                // make sure to take it, so that we don't post
-                                // it in subsequent blocks
-                                if dealer == self_pk {
-                                    if let Some(ref mut ds) = dealer_state {
-                                        ds.take_finalized();
+                                // `log.check` only authenticates the self-signature, not
+                                // dealer-set membership. A validly self-signed log from a
+                                // key outside the round's dealer set is never selected, so
+                                // skip it rather than persisting junk under that key.
+                                if dealers.position(&dealer).is_none() {
+                                    warn!(?epoch, "ignoring dealer log from non-dealer");
+                                } else {
+                                    // If we see our dealing outcome in a finalized block,
+                                    // make sure to take it, so that we don't post
+                                    // it in subsequent blocks
+                                    if dealer == self_pk {
+                                        if let Some(ref mut ds) = dealer_state {
+                                            ds.take_finalized();
+                                        }
                                     }
+                                    storage.append_log(epoch, dealer, dealer_log).await;
                                 }
-                                storage.append_log(epoch, dealer, dealer_log).await;
                             }
                         }
 
@@ -611,16 +668,15 @@ where
             if player == *self_pk {
                 if let Some(ref mut ps) = player_state {
                     // Handle as player
-                    let ack = match ps
+                    let Verdict::Valid(ack) = ps
                         .handle::<_, N3f1>(storage, epoch, self_pk.clone(), pub_msg, priv_msg)
                         .await
-                    {
-                        Some(ack) => ack,
-                        _ => continue,
+                    else {
+                        continue;
                     };
 
-                    // Handle our own ack as dealer
-                    dealer_state
+                    // Handle our own ack as dealer (we never block ourselves).
+                    let _ = dealer_state
                         .handle(storage, epoch, self_pk.clone(), ack)
                         .await;
                 }
@@ -652,7 +708,7 @@ mod tests {
     };
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
-    use commonware_p2p::{utils::mocks::inert_channel, PeerSetSubscription, Provider};
+    use commonware_p2p::{utils::mocks::inert_channel, Blocker, PeerSetSubscription, Provider};
     use commonware_runtime::{deterministic, Runner, Supervisor as _};
     use commonware_utils::{channel::mpsc, N3f1, NZUsize, TryCollect, NZU32};
     use core::marker::PhantomData;
@@ -685,6 +741,14 @@ mod tests {
         where
             R: Into<TrackedPeers<Self::PublicKey>> + Send,
         {
+            Feedback::Ok
+        }
+    }
+
+    impl<P: PublicKey> Blocker for NoopManager<P> {
+        type PublicKey = P;
+
+        fn block(&mut self, _: Self::PublicKey) -> Feedback {
             Feedback::Ok
         }
     }
@@ -763,10 +827,11 @@ mod tests {
 
             // Restart the actor with stale bootstrap inputs (output=None, share=None). The
             // recovered epoch must override these.
-            let (actor, _mailbox) = Actor::<_, _, Sha256, _, MinSig>::new(
+            let (actor, _mailbox) = Actor::<_, _, _, Sha256, _, MinSig>::new(
                 context.child("actor"),
                 Config {
                     manager: NoopManager::<Ed25519PublicKey>::default(),
+                    blocker: NoopManager::<Ed25519PublicKey>::default(),
                     signer,
                     mailbox_size: NZUsize!(8),
                     partition_prefix,

--- a/examples/reshare/src/dkg/state.rs
+++ b/examples/reshare/src/dkg/state.rs
@@ -17,8 +17,8 @@ use commonware_consensus::types::Epoch as EpochNum;
 use commonware_cryptography::{
     bls12381::{
         dkg::feldman_desmedt::{
-            Dealer as CryptoDealer, DealerLog, DealerPrivMsg, DealerPubMsg, Info, Logs, Output,
-            Player as CryptoPlayer, PlayerAck, SignedDealerLog,
+            Dealer as CryptoDealer, DealerLog, DealerPrivMsg, DealerPubMsg, Error as DkgError,
+            Info, Logs, Output, Player as CryptoPlayer, PlayerAck, SignedDealerLog, Verdict,
         },
         primitives::{group::Share, variant::Variant},
     },
@@ -542,32 +542,37 @@ impl<V: Variant, C: Signer> Dealer<V, C> {
 
     /// Handle an incoming ack from a player.
     ///
-    /// If the ack is valid and new, persists it to storage.
-    /// Returns true if the ack was successfully processed.
+    /// Persists a valid, new ack to storage. Returns [`Verdict::Fault`] when the
+    /// player sent an ack that is provably invalid, so the caller can block
+    /// them. Returns [`Verdict::Skip`] for a benign no-op (already handled, not
+    /// a player of this round, or after dealer finalization).
     pub async fn handle<E>(
         &mut self,
         storage: &mut Storage<E, V, C::PublicKey>,
         epoch: EpochNum,
         player: C::PublicKey,
         ack: PlayerAck<C::PublicKey>,
-    ) -> bool
+    ) -> Verdict<()>
     where
         E: BufferPooler + Clock + RuntimeStorage + Metrics,
     {
         if !self.unsent.contains_key(&player) {
-            return false;
+            return Verdict::Skip;
         }
-        if let Some(ref mut dealer) = self.dealer {
-            if dealer
-                .receive_player_ack(player.clone(), ack.clone())
-                .is_ok()
-            {
+        let Some(dealer) = self.dealer.as_mut() else {
+            return Verdict::Skip;
+        };
+        match dealer.receive_player_ack(player.clone(), ack.clone()) {
+            Ok(()) => {
                 self.unsent.remove(&player);
                 storage.append_ack(epoch, player, ack).await;
-                return true;
+                Verdict::Valid(())
             }
+            // The player signed an ack that does not verify: a provable fault.
+            Err(DkgError::InvalidAck) => Verdict::Fault,
+            // Benign: the player is not part of this round.
+            Err(_) => Verdict::Skip,
         }
-        false
     }
 
     /// Finalize the dealer and produce a signed log for inclusion in a block.
@@ -618,7 +623,10 @@ pub struct Player<V: Variant, C: Signer> {
 impl<V: Variant, C: Signer> Player<V, C> {
     /// Handle an incoming dealer message.
     ///
-    /// If this is a new valid dealer message, persists it to storage before returning.
+    /// Persists a new valid dealing and returns [`Verdict::Valid`] with the ack
+    /// to send back. Returns [`Verdict::Fault`] when the dealing is provably
+    /// invalid so the caller can block the dealer, and [`Verdict::Skip`] for a
+    /// benign no-op (duplicate).
     pub async fn handle<E, M>(
         &mut self,
         storage: &mut Storage<E, V, C::PublicKey>,
@@ -626,28 +634,30 @@ impl<V: Variant, C: Signer> Player<V, C> {
         dealer: C::PublicKey,
         pub_msg: DealerPubMsg<V>,
         priv_msg: DealerPrivMsg,
-    ) -> Option<PlayerAck<C::PublicKey>>
+    ) -> Verdict<PlayerAck<C::PublicKey>>
     where
         E: BufferPooler + Clock + RuntimeStorage + Metrics,
         M: Faults,
     {
-        // If we've already generated an ack, return the cached version
+        // If we've already generated an ack, return the cached version.
         if let Some(ack) = self.acks.get(&dealer) {
-            return Some(ack.clone());
+            return Verdict::Valid(ack.clone());
         }
 
-        // Otherwise generate a new ack
-        if let Some(ack) =
-            self.player
-                .dealer_message::<M>(dealer.clone(), pub_msg.clone(), priv_msg.clone())
+        // Otherwise process the dealing.
+        match self
+            .player
+            .dealer_message::<M>(dealer.clone(), pub_msg.clone(), priv_msg.clone())
         {
-            storage
-                .append_dealing(epoch, dealer.clone(), pub_msg, priv_msg)
-                .await;
-            self.acks.insert(dealer, ack.clone());
-            return Some(ack);
+            Verdict::Valid(ack) => {
+                storage
+                    .append_dealing(epoch, dealer.clone(), pub_msg, priv_msg)
+                    .await;
+                self.acks.insert(dealer, ack.clone());
+                Verdict::Valid(ack)
+            }
+            verdict => verdict,
         }
-        None
     }
 
     /// Finalize the player's participation in the DKG round.
@@ -707,7 +717,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_dealer_handle_returns_false_when_player_not_in_unsent() {
+    fn test_dealer_handle_skips_when_player_not_in_unsent() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let signers = create_test_signers(4);
@@ -742,14 +752,14 @@ mod tests {
                 .await;
 
             assert!(
-                !result,
-                "handle should return false when player not in unsent"
+                matches!(result, Verdict::Skip),
+                "handle should skip when player not in unsent"
             );
         });
     }
 
     #[test_traced]
-    fn test_dealer_handle_returns_false_when_crypto_dealer_is_none() {
+    fn test_dealer_handle_skips_when_crypto_dealer_is_none() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let signers = create_test_signers(4);
@@ -784,14 +794,14 @@ mod tests {
                 .await;
 
             assert!(
-                !result,
-                "handle should return false when crypto dealer is None"
+                matches!(result, Verdict::Skip),
+                "handle should skip when crypto dealer is None"
             );
         });
     }
 
     #[test_traced]
-    fn test_dealer_handle_returns_true_for_valid_ack() {
+    fn test_dealer_handle_accepts_valid_ack() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let signers = create_test_signers(4);
@@ -830,18 +840,19 @@ mod tests {
                 CryptoPlayer::new(round_info, player_signer).expect("valid player");
             let ack = crypto_player
                 .dealer_message::<N3f1>(dealer_signer.public_key(), pub_msg, player_priv_msg)
+                .valid()
                 .expect("valid ack");
 
             let result = dealer
                 .handle(&mut storage, Epoch::zero(), player_pk, ack)
                 .await;
 
-            assert!(result, "handle should return true for valid ack");
+            assert!(result.is_valid(), "handle should accept a valid ack");
         });
     }
 
     #[test_traced]
-    fn test_dealer_handle_returns_false_for_duplicate_ack() {
+    fn test_dealer_handle_skips_duplicate_ack() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let signers = create_test_signers(4);
@@ -880,19 +891,59 @@ mod tests {
                 CryptoPlayer::new(round_info, player_signer).expect("valid player");
             let ack = crypto_player
                 .dealer_message::<N3f1>(dealer_signer.public_key(), pub_msg, player_priv_msg)
+                .valid()
                 .expect("valid ack");
 
             // First ack should succeed
             let result = dealer
                 .handle(&mut storage, Epoch::zero(), player_pk.clone(), ack.clone())
                 .await;
-            assert!(result, "first ack should succeed");
+            assert!(result.is_valid(), "first ack should succeed");
 
-            // Second ack from same player should fail (player removed from unsent)
+            // Second ack from same player should skip (player removed from unsent)
             let result = dealer
                 .handle(&mut storage, Epoch::zero(), player_pk, ack)
                 .await;
-            assert!(!result, "duplicate ack should return false");
+            assert!(matches!(result, Verdict::Skip), "duplicate ack should skip");
+        });
+    }
+
+    #[test_traced]
+    fn test_dealer_handle_returns_fault_for_invalid_ack() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let signers = create_test_signers(4);
+            let round_info = create_round_info(&signers);
+
+            let mut storage = Storage::<_, MinPk, ed25519::PublicKey>::init(
+                context.child("storage"),
+                "test",
+                NonZeroU32::new(10).unwrap(),
+                crate::dkg::MAX_SUPPORTED_MODE,
+            )
+            .await;
+
+            let dealer_signer = signers[0].clone();
+            let mut rng = test_rng();
+            let (crypto_dealer, pub_msg, priv_msgs) =
+                CryptoDealer::<MinPk, _>::start::<N3f1>(&mut rng, round_info, dealer_signer, None)
+                    .expect("valid dealer");
+            let unsent: BTreeMap<_, _> = priv_msgs.into_iter().collect();
+            let mut dealer = Dealer::new(Some(crypto_dealer), pub_msg, unsent);
+
+            // A player of this round signs an ack that does not verify for it.
+            let player_pk = signers[1].public_key();
+            let bad_ack: PlayerAck<ed25519::PublicKey> =
+                PlayerAck::read(&mut signers[1].sign(b"ns", b"not an ack").encode().as_ref())
+                    .expect("decodes");
+
+            let result = dealer
+                .handle(&mut storage, Epoch::zero(), player_pk, bad_ack)
+                .await;
+            assert!(
+                matches!(result, Verdict::Fault),
+                "an ack with an invalid signature should be a fault"
+            );
         });
     }
 }

--- a/examples/reshare/src/dkg/state.rs
+++ b/examples/reshare/src/dkg/state.rs
@@ -838,16 +838,22 @@ mod tests {
 
             let mut crypto_player =
                 CryptoPlayer::new(round_info, player_signer).expect("valid player");
-            let ack = crypto_player
-                .dealer_message::<N3f1>(dealer_signer.public_key(), pub_msg, player_priv_msg)
-                .valid()
-                .expect("valid ack");
+            let Verdict::Valid(ack) = crypto_player.dealer_message::<N3f1>(
+                dealer_signer.public_key(),
+                pub_msg,
+                player_priv_msg,
+            ) else {
+                panic!("valid ack");
+            };
 
             let result = dealer
                 .handle(&mut storage, Epoch::zero(), player_pk, ack)
                 .await;
 
-            assert!(result.is_valid(), "handle should accept a valid ack");
+            assert!(
+                matches!(result, Verdict::Valid(())),
+                "handle should accept a valid ack"
+            );
         });
     }
 
@@ -889,16 +895,22 @@ mod tests {
 
             let mut crypto_player =
                 CryptoPlayer::new(round_info, player_signer).expect("valid player");
-            let ack = crypto_player
-                .dealer_message::<N3f1>(dealer_signer.public_key(), pub_msg, player_priv_msg)
-                .valid()
-                .expect("valid ack");
+            let Verdict::Valid(ack) = crypto_player.dealer_message::<N3f1>(
+                dealer_signer.public_key(),
+                pub_msg,
+                player_priv_msg,
+            ) else {
+                panic!("valid ack");
+            };
 
             // First ack should succeed
             let result = dealer
                 .handle(&mut storage, Epoch::zero(), player_pk.clone(), ack.clone())
                 .await;
-            assert!(result.is_valid(), "first ack should succeed");
+            assert!(
+                matches!(result, Verdict::Valid(())),
+                "first ack should succeed"
+            );
 
             // Second ack from same player should skip (player removed from unsent)
             let result = dealer

--- a/examples/reshare/src/engine.rs
+++ b/examples/reshare/src/engine.rs
@@ -95,7 +95,7 @@ where
 {
     context: ContextCell<E>,
     config: Config<C, P, B, V, T>,
-    dkg: dkg::Actor<E, P, H, C, V>,
+    dkg: dkg::Actor<E, P, B, H, C, V>,
     dkg_mailbox: dkg::Mailbox<H, C, V>,
     buffer: buffered::Engine<E, C::PublicKey, Block<H, C, V>, P>,
     buffered_mailbox: buffered::Mailbox<C::PublicKey, Block<H, C, V>>,
@@ -147,6 +147,7 @@ where
             context.child("dkg"),
             dkg::Config {
                 manager: config.manager.clone(),
+                blocker: config.blocker.clone(),
                 signer: config.signer.clone(),
                 mailbox_size: MAILBOX_SIZE,
                 partition_prefix: config.partition_prefix.clone(),


### PR DESCRIPTION
## Overview

Fixes a few nits in `commonware-reshare`:
- We don't penalize a player for sending an `Ack` back with an invalid signature due to `Dealer::receive_player_ack` not bubbling up a verification error. This doesn't hurt security (same impact as that player never acking, they count as one of the `f`), though we also don't attribute the fault to the peer and block them.
    - We also don't penalize a peer for sending us a malformed message or routing a message to the wrong peer atm.
- `SignedDealerLogs` included in blocks in the second phase of the epoch are absorbed into storage without a dealer set membership check, just a signature verification. This, again, doesn't have an impact on security since we filter on known dealers, though allows for byzantine proposers to arbitrarily bloat storage (bounded by # of blocks in the epoch.) 