### PR TITLE
[parallel] Improve `spawn` API

### DIFF
--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -250,7 +250,7 @@ where
                 continue;
             } => {
                 let config = self.codec_config.clone();
-                let handle = self.strategy.spawn(move || {
+                let handle = self.strategy.spawn(move |_| {
                     let result = V::decode_cfg(bytes.as_ref(), &config);
                     (peer, result)
                 });
@@ -420,15 +420,16 @@ mod tests {
 
         fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
         where
-            F: FnOnce() -> T + Send + 'static,
+            F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,
         {
             let pending = self.pending;
+            let s = self.clone();
             async move {
                 if pending {
                     futures::future::pending::<()>().await;
                 }
-                f()
+                f(s)
             }
         }
 

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -137,7 +137,7 @@ commonware_macros::stability_scope!(BETA {
         /// If the job panics, the panic is propagated to the caller; it never aborts the process.
         fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
         where
-            F: FnOnce() -> T + Send + 'static,
+            F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static;
 
         /// Runs either a serial or parallel body.
@@ -593,10 +593,11 @@ commonware_macros::stability_scope!(BETA {
 
         fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
         where
-            F: FnOnce() -> T + Send + 'static,
+            F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,
         {
-            self.strategy.spawn(f)
+            let s = self.clone();
+            self.strategy.spawn(|_| f(s))
         }
 
         #[track_caller]
@@ -769,10 +770,10 @@ commonware_macros::stability_scope!(BETA {
 
         fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
         where
-            F: FnOnce() -> T + Send + 'static,
+            F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,
         {
-            let result = f();
+            let result = f(self.clone());
             async move { result }
         }
 
@@ -941,18 +942,19 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
 
         fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
         where
-            F: FnOnce() -> T + Send + 'static,
+            F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,
         {
             if self.thread_pool.current_num_threads() <= 1 {
-                return Either::Left(future::ready(f()));
+                return Either::Left(future::ready(f(self.clone())));
             }
 
             let (tx, rx) = oneshot::channel();
+            let s = self.clone();
             self.thread_pool.spawn(move || {
                 // Catch the panic so a panicking job propagates to the awaiting task rather than
                 // aborting the process (rayon aborts on an uncaught panic in a spawned job).
-                let result = panic::catch_unwind(AssertUnwindSafe(f));
+                let result = panic::catch_unwind(AssertUnwindSafe(|| f(s)));
                 let _ = tx.send(result);
             });
             Either::Right(async move {
@@ -1365,7 +1367,7 @@ mod test {
 
     #[test]
     fn sequential_spawn_runs_job() {
-        let result = futures::executor::block_on(Sequential.spawn(|| 7));
+        let result = futures::executor::block_on(Sequential.spawn(|_| 7));
 
         assert_eq!(result, 7);
     }
@@ -1374,7 +1376,7 @@ mod test {
     fn rayon_spawn_runs_job_on_pool() {
         let strategy = parallel_strategy();
 
-        let result = futures::executor::block_on(strategy.spawn(|| {
+        let result = futures::executor::block_on(strategy.spawn(|_| {
             assert!(rayon::current_thread_index().is_some());
             7
         }));
@@ -1392,7 +1394,7 @@ mod test {
             .unwrap();
         let strategy = Rayon::with_pool(Arc::new(pool));
 
-        let result = strategy.spawn(|| 7).now_or_never();
+        let result = strategy.spawn(|_| 7).now_or_never();
 
         assert_eq!(result, Some(7));
         assert_eq!(policy_len(&strategy), 0);
@@ -1404,13 +1406,13 @@ mod test {
         // A panic on a pool worker must surface at the await point, not abort the process.
         let strategy = parallel_strategy();
 
-        let _: () = futures::executor::block_on(strategy.spawn(|| panic!("boom")));
+        let _: () = futures::executor::block_on(strategy.spawn(|_| panic!("boom")));
     }
 
     #[test]
     #[should_panic(expected = "boom")]
     fn sequential_spawn_propagates_job_panic() {
-        let _: () = futures::executor::block_on(Sequential.spawn(|| panic!("boom")));
+        let _: () = futures::executor::block_on(Sequential.spawn(|_| panic!("boom")));
     }
 
     proptest! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3926,14 +3926,11 @@ mod tests {
 
     #[test]
     fn test_deterministic_nested_parallel_strategy_uses_spawn_worker() {
-        // The deterministic runtime is single-threaded.
-        const NUM_THREADS: usize = 1;
-
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let strategy = context
                 .child("pool")
-                .create_strategy(NZUsize!(NUM_THREADS))
+                .create_strategy(NZUsize!(1))
                 .unwrap()
                 .manual();
 
@@ -3947,13 +3944,11 @@ mod tests {
 
     #[test]
     fn test_tokio_nested_parallel_strategy_uses_spawn_worker() {
-        const WORKERS: usize = 2;
-
         let executor = tokio::Runner::default();
         executor.start(|context| async move {
             let strategy = context
                 .child("pool")
-                .create_strategy(NZUsize!(WORKERS))
+                .create_strategy(NZUsize!(1))
                 .unwrap()
                 .manual();
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -842,6 +842,7 @@ mod tests {
     };
     use bytes::Bytes;
     use commonware_macros::select;
+    use commonware_parallel::Strategy as _;
     use commonware_utils::{
         channel::{mpsc, oneshot},
         futures::Pool as FuturesPool,
@@ -3920,6 +3921,47 @@ mod tests {
             pool.install(|| {
                 assert_eq!(v.par_iter().sum::<i32>(), 10000 * 9999 / 2);
             });
+        });
+    }
+
+    #[test]
+    fn test_deterministic_nested_parallel_strategy_uses_spawn_worker() {
+        // The deterministic runtime is single-threaded.
+        const NUM_THREADS: usize = 1;
+
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let strategy = context
+                .child("pool")
+                .create_strategy(NZUsize!(NUM_THREADS))
+                .unwrap()
+                .manual();
+
+            let output = strategy
+                .spawn(|strategy| strategy.map_collect_vec(0..2, |i| i + 1))
+                .await;
+
+            assert_eq!(output, vec![1, 2]);
+        });
+    }
+
+    #[test]
+    fn test_tokio_nested_parallel_strategy_uses_spawn_worker() {
+        const WORKERS: usize = 2;
+
+        let executor = tokio::Runner::default();
+        executor.start(|context| async move {
+            let strategy = context
+                .child("pool")
+                .create_strategy(NZUsize!(WORKERS))
+                .unwrap()
+                .manual();
+
+            let output = strategy
+                .spawn(|strategy| strategy.map_collect_vec(0..2, |i| i + 1))
+                .await;
+
+            assert_eq!(output, vec![1, 2]);
         });
     }
 


### PR DESCRIPTION
## Overview

Improves the `Strategy::spawn` API by automatically passing the `strategy` into the closure. This avoids an ugly callsite for users that want to offload work to rayon but yield to the worker thread while waiting for it to finish:

```rs
let strategy = ...;

// Instead of
let s = strategy.clone();
strategy.spawn(move || {
    s.<op>(...)
}); 

// just
strategy.spawn(|s| {
    s.<op>(...)
});
```

### `tokio` <-> `rayon` cooperation

This pattern also facilitates better cooperation between `tokio` and `rayon`. Currently, we block worker threads while waiting for the output of `rayon` tasks. This reduces effective parallelism in the `tokio` worker thread pool by a significant amount, especially for long-running operations like erasure {en/de}coding.

<img width="2151" height="1245" alt="Untitled-2026-03-24-1123(3)" src="https://github.com/user-attachments/assets/8d2f9086-4dbd-47ba-96a6-47c9d1a83e2a" />

### Note on nested rayon

`rayon` supports nested parallelism. The closure executed by `spawn` can yield for `rayon` operations executed within it that are placed within the same thread pool. This pattern does _not_ reduce effective parallelism in the thread pool to `N-1`. Example: https://play.rust-lang.org/?version=stable&mode=release&edition=2024&gist=d094a9d9a98d7db2acabeaf6728ee08c