### PR TITLE
[runtime] Implement `start_sync` for `paged::Writer`

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -469,7 +469,7 @@ impl Handle {
         self.start_sync(file)
             .await
             .await
-            .map_err(|_| Error::Io(std::io::Error::other("failed to read result")))?
+            .map_err(|_| Error::Io(std::io::Error::other("failed to read result").into()))?
     }
 
     /// Begin a logical fsync request, returning the completion receiver without waiting.
@@ -488,9 +488,9 @@ impl Handle {
             let Request::Sync(request) = err.0 else {
                 unreachable!("sync enqueue returned wrong request variant");
             };
-            let _ = request
-                .sender
-                .send(Err(Error::Io(std::io::Error::other("failed to send work"))));
+            let _ = request.sender.send(Err(Error::Io(
+                std::io::Error::other("failed to send work").into(),
+            )));
         }
         rx
     }

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -623,13 +623,13 @@ impl SyncRequest {
         match CqeResult::from_raw(result, state) {
             CqeResult::Retry => false,
             CqeResult::Cancelled => {
-                self.result = Some(Err(Error::Io(std::io::Error::from_raw_os_error(
-                    libc::ECANCELED,
-                ))));
+                let err = std::io::Error::from_raw_os_error(libc::ECANCELED);
+                self.result = Some(Err(Error::Io(err.into())));
                 true
             }
             CqeResult::Error(code) => {
-                self.result = Some(Err(Error::Io(std::io::Error::from_raw_os_error(-code))));
+                let err = std::io::Error::from_raw_os_error(-code);
+                self.result = Some(Err(Error::Io(err.into())));
                 true
             }
             CqeResult::Zero | CqeResult::Positive(_) => {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -57,6 +57,7 @@ stability_scope!(BETA {
         io::Error as IoError,
         net::SocketAddr,
         num::NonZeroUsize,
+        sync::Arc,
         time::{Duration, SystemTime},
     };
     pub(crate) use telemetry::metrics::{child_label, prefixed_name, METRICS_PREFIX};
@@ -77,7 +78,7 @@ stability_scope!(BETA {
     pub const DEFAULT_BLOB_VERSION: u16 = 0;
 
     /// Errors that can occur when interacting with the runtime.
-    #[derive(Error, Debug)]
+    #[derive(Error, Debug, Clone)]
     pub enum Error {
         #[error("exited")]
         Exited,
@@ -110,13 +111,13 @@ stability_scope!(BETA {
         #[error("partition corrupt: {0}")]
         PartitionCorrupt(String),
         #[error("blob open failed: {0}/{1} error: {2}")]
-        BlobOpenFailed(String, String, IoError),
+        BlobOpenFailed(String, String, Arc<IoError>),
         #[error("blob missing: {0}/{1}")]
         BlobMissing(String, String),
         #[error("blob resize failed: {0}/{1} error: {2}")]
-        BlobResizeFailed(String, String, IoError),
+        BlobResizeFailed(String, String, Arc<IoError>),
         #[error("blob sync failed: {0}/{1} error: {2}")]
-        BlobSyncFailed(String, String, IoError),
+        BlobSyncFailed(String, String, Arc<IoError>),
         #[error("blob insufficient length")]
         BlobInsufficientLength,
         #[error("blob corrupt: {0}/{1} reason: {2}")]
@@ -135,9 +136,15 @@ stability_scope!(BETA {
         #[error("offsets invalid")]
         OffsetsInvalid,
         #[error("io error: {0}")]
-        Io(#[from] IoError),
+        Io(Arc<IoError>),
         #[error("buffer pool: {0}")]
         Pool(#[from] PoolError),
+    }
+
+    impl From<IoError> for Error {
+        fn from(err: IoError) -> Self {
+            Self::Io(Arc::new(err))
+        }
     }
 
     /// Interface that any task scheduler must implement to start

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -241,7 +241,7 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
         versions: std::ops::RangeInclusive<u16>,
     ) -> Result<(Self::Blob, u64, u16), Error> {
         if self.ctx.should_fail(Op::Open) {
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
         self.inner
             .open_versioned(partition, name, versions)
@@ -253,14 +253,14 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
         if self.ctx.should_fail(Op::Remove) {
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
         self.inner.remove(partition, name).await
     }
 
     async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
         if self.ctx.should_fail(Op::Scan) {
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
         self.inner.scan(partition).await
     }
@@ -288,7 +288,7 @@ impl<B: crate::Blob> Blob<B> {
 impl<B: crate::Blob> crate::Blob for Blob<B> {
     async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
         if self.ctx.should_fail(Op::Read) {
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
         self.inner.read_at(offset, len).await
     }
@@ -300,7 +300,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         bufs: impl Into<IoBufsMut> + Send,
     ) -> Result<IoBufsMut, Error> {
         if self.ctx.should_fail(Op::Read) {
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
         self.inner.read_at_buf(offset, len, bufs.into()).await
     }
@@ -319,9 +319,9 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
                 self.inner.sync().await?;
                 self.size
                     .fetch_max(offset.saturating_add(bytes), Ordering::Relaxed);
-                return Err(Error::Io(injected_io_error().into()));
+                return Err(injected_io_error().into());
             }
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
 
         self.inner.write_at(offset, bufs).await?;
@@ -349,16 +349,16 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
                     .await?;
                 self.size
                     .fetch_max(offset.saturating_add(bytes), Ordering::Relaxed);
-                return Err(Error::Io(injected_io_error().into()));
+                return Err(injected_io_error().into());
             }
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
 
         if self.ctx.should_fail(Op::Sync) {
             self.inner.write_at(offset, bufs).await?;
             self.size
                 .fetch_max(offset.saturating_add(total_bytes), Ordering::Relaxed);
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
 
         self.inner.write_at_sync(offset, bufs).await?;
@@ -376,9 +376,9 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
                 self.inner.resize(len).await?;
                 self.inner.sync().await?;
                 self.size.store(len, Ordering::Relaxed);
-                return Err(Error::Io(injected_io_error().into()));
+                return Err(injected_io_error().into());
             }
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
         self.inner.resize(len).await?;
         self.size.store(len, Ordering::Relaxed);
@@ -387,14 +387,14 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
 
     async fn sync(&self) -> Result<(), Error> {
         if self.ctx.should_fail(Op::Sync) {
-            return Err(Error::Io(injected_io_error().into()));
+            return Err(injected_io_error().into());
         }
         self.inner.sync().await
     }
 
     async fn start_sync(&self) -> Handle<()> {
         if self.ctx.should_fail(Op::Sync) {
-            return Handle::ready(Err(Error::Io(injected_io_error().into())));
+            return Handle::ready(Err(injected_io_error().into()));
         }
         self.inner.start_sync().await
     }

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -241,7 +241,7 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
         versions: std::ops::RangeInclusive<u16>,
     ) -> Result<(Self::Blob, u64, u16), Error> {
         if self.ctx.should_fail(Op::Open) {
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
         self.inner
             .open_versioned(partition, name, versions)
@@ -253,14 +253,14 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
         if self.ctx.should_fail(Op::Remove) {
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
         self.inner.remove(partition, name).await
     }
 
     async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
         if self.ctx.should_fail(Op::Scan) {
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
         self.inner.scan(partition).await
     }
@@ -288,7 +288,7 @@ impl<B: crate::Blob> Blob<B> {
 impl<B: crate::Blob> crate::Blob for Blob<B> {
     async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
         if self.ctx.should_fail(Op::Read) {
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
         self.inner.read_at(offset, len).await
     }
@@ -300,7 +300,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         bufs: impl Into<IoBufsMut> + Send,
     ) -> Result<IoBufsMut, Error> {
         if self.ctx.should_fail(Op::Read) {
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
         self.inner.read_at_buf(offset, len, bufs.into()).await
     }
@@ -319,9 +319,9 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
                 self.inner.sync().await?;
                 self.size
                     .fetch_max(offset.saturating_add(bytes), Ordering::Relaxed);
-                return Err(Error::Io(injected_io_error()));
+                return Err(Error::Io(injected_io_error().into()));
             }
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
 
         self.inner.write_at(offset, bufs).await?;
@@ -349,16 +349,16 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
                     .await?;
                 self.size
                     .fetch_max(offset.saturating_add(bytes), Ordering::Relaxed);
-                return Err(Error::Io(injected_io_error()));
+                return Err(Error::Io(injected_io_error().into()));
             }
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
 
         if self.ctx.should_fail(Op::Sync) {
             self.inner.write_at(offset, bufs).await?;
             self.size
                 .fetch_max(offset.saturating_add(total_bytes), Ordering::Relaxed);
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
 
         self.inner.write_at_sync(offset, bufs).await?;
@@ -376,9 +376,9 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
                 self.inner.resize(len).await?;
                 self.inner.sync().await?;
                 self.size.store(len, Ordering::Relaxed);
-                return Err(Error::Io(injected_io_error()));
+                return Err(Error::Io(injected_io_error().into()));
             }
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
         self.inner.resize(len).await?;
         self.size.store(len, Ordering::Relaxed);
@@ -387,14 +387,14 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
 
     async fn sync(&self) -> Result<(), Error> {
         if self.ctx.should_fail(Op::Sync) {
-            return Err(Error::Io(injected_io_error()));
+            return Err(Error::Io(injected_io_error().into()));
         }
         self.inner.sync().await
     }
 
     async fn start_sync(&self) -> Handle<()> {
         if self.ctx.should_fail(Op::Sync) {
-            return Handle::ready(Err(Error::Io(injected_io_error())));
+            return Handle::ready(Err(Error::Io(injected_io_error().into())));
         }
         self.inner.start_sync().await
     }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -44,14 +44,14 @@ fn sync_dir(path: &Path) -> Result<(), Error> {
         Error::BlobOpenFailed(
             path.to_string_lossy().to_string(),
             "directory".to_string(),
-            e,
+            e.into(),
         )
     })?;
     dir.sync_all().map_err(|e| {
         Error::BlobSyncFailed(
             path.to_string_lossy().to_string(),
             "directory".to_string(),
-            e,
+            e.into(),
         )
     })
 }
@@ -137,7 +137,7 @@ impl crate::Storage for Storage {
             .create(true)
             .truncate(false)
             .open(&path)
-            .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e))?;
+            .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e.into()))?;
 
         // Assume empty files are newly created. Existing empty files will be synced too; that's OK.
         let raw_len = file.metadata().map_err(|_| Error::ReadFailed)?.len();
@@ -148,13 +148,13 @@ impl crate::Storage for Storage {
             // New (or corrupted) blob - truncate and write header with latest version
             let (header, blob_version) = Header::new(&versions);
             file.set_len(Header::SIZE_U64)
-                .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e))?;
+                .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
             file.seek(SeekFrom::Start(0))
                 .map_err(|_| Error::WriteFailed)?;
             file.write_all(&header.encode())
                 .map_err(|_| Error::WriteFailed)?;
             file.sync_all()
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e))?;
+                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
 
             // For new files, sync the parent directory to ensure the directory entry is durable.
             if raw_len == 0 {
@@ -379,7 +379,11 @@ impl crate::Blob for Blob {
             .checked_add(Header::SIZE_U64)
             .ok_or(Error::OffsetOverflow)?;
         self.file.set_len(len).map_err(|e| {
-            Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), IoError::other(e))
+            Error::BlobResizeFailed(
+                self.partition.clone(),
+                hex(&self.name),
+                IoError::other(e).into(),
+            )
         })
     }
 

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -56,7 +56,7 @@ impl Blob {
     async fn sync_inner(file: &fs::File, partition: &str, name: &[u8]) -> Result<(), Error> {
         file.sync_all()
             .await
-            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e))
+            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e.into()))
     }
 }
 
@@ -126,9 +126,9 @@ impl crate::Blob for Blob {
         let len = len
             .checked_add(Header::SIZE_U64)
             .ok_or(Error::OffsetOverflow)?;
-        file.set_len(len)
-            .await
-            .map_err(|e| Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e))?;
+        file.set_len(len).await.map_err(|e| {
+            Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e.into())
+        })?;
         Ok(())
     }
 

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -25,14 +25,14 @@ async fn sync_dir(path: &Path) -> Result<(), Error> {
         Error::BlobOpenFailed(
             path.to_string_lossy().to_string(),
             "directory".to_string(),
-            e,
+            e.into(),
         )
     })?;
     dir.sync_all().await.map_err(|e| {
         Error::BlobSyncFailed(
             path.to_string_lossy().to_string(),
             "directory".to_string(),
-            e,
+            e.into(),
         )
     })
 }
@@ -110,7 +110,7 @@ impl crate::Storage for Storage {
             .truncate(false)
             .open(&path)
             .await
-            .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e))?;
+            .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e.into()))?;
 
         // Assume empty files are newly created. Existing empty files will be synced too; that's OK.
         let len = file.metadata().await.map_err(|_| Error::ReadFailed)?.len();
@@ -121,7 +121,7 @@ impl crate::Storage for Storage {
             // Sync the file to ensure it is durable
             file.sync_all()
                 .await
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e))?;
+                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
 
             // Windows doesn't have a notion of syncing a directory entry to ensure that it's
             // durably persisted. See https://github.com/commonwarexyz/monorepo/issues/2026.
@@ -147,13 +147,13 @@ impl crate::Storage for Storage {
             let (header, blob_version) = Header::new(&versions);
             file.set_len(Header::SIZE_U64)
                 .await
-                .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e))?;
+                .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
             file.write_all(&header.encode())
                 .await
                 .map_err(|_| Error::WriteFailed)?;
             file.sync_all()
                 .await
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e))?;
+                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
             (blob_version, 0)
         } else {
             // Existing blob - read and validate header

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -35,7 +35,7 @@ impl Blob {
 
     fn sync_inner(file: &File, partition: &str, name: &[u8]) -> Result<(), Error> {
         file.sync_all()
-            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e))
+            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e.into()))
     }
 
     fn write_single_at(file: &File, offset: u64, buf: &[u8]) -> Result<(), Error> {
@@ -202,7 +202,9 @@ impl crate::Blob for Blob {
             .await
             .map_err(|e| e.into())
             .and_then(|r| r)
-            .map_err(|e| Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e))?;
+            .map_err(|e| {
+                Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e.into())
+            })?;
         Ok(())
     }
 
@@ -212,7 +214,10 @@ impl crate::Blob for Blob {
         let name = self.name.clone();
         task::spawn_blocking(move || Self::sync_inner(&file, &partition, &name))
             .await
-            .map_err(|e| Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e.into()))?
+            .map_err(|e| {
+                let err: std::io::Error = e.into();
+                Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), err.into())
+            })?
     }
 
     async fn start_sync(&self) -> Handle<()> {

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -20,41 +20,30 @@ enum Durability {
     Pending(Completion),
 }
 
+/// A shared sync result.
 #[derive(Clone)]
-struct Completion {
-    inner: Shared<BoxFuture<'static, Result<(), crate::Error>>>,
-}
+struct Completion(Shared<BoxFuture<'static, Result<(), crate::Error>>>);
 
 impl Completion {
-    /// Share a started sync.
-    fn start(handle: crate::Handle<()>) -> Self {
-        Self {
-            inner: handle.boxed().shared(),
-        }
-    }
-
-    /// Return another waiter.
+    /// Return a handle for the sync result.
     fn handle(&self) -> crate::Handle<()> {
-        let inner = self.inner.clone();
-        crate::Handle::from_future(inner)
+        crate::Handle::from_future(self.0.clone())
     }
 
-    /// Wait internally.
+    /// Wait for the sync result.
     async fn wait(&self) -> Result<(), crate::Error> {
-        self.inner.clone().await
+        self.0.clone().await
+    }
+}
+
+impl From<crate::Handle<()>> for Completion {
+    fn from(handle: crate::Handle<()>) -> Self {
+        Self(handle.boxed().shared())
     }
 }
 
 impl Durability {
-    /// `needs_sync` means existing blob contents may not be durable.
-    const fn new(needs_sync: bool) -> Self {
-        if needs_sync {
-            Self::Dirty
-        } else {
-            Self::Clean
-        }
-    }
-
+    /// Mark a new unsynced mutation.
     fn mark_dirty(&mut self) {
         assert!(
             !matches!(self, Self::Pending(_)),
@@ -63,11 +52,11 @@ impl Durability {
         *self = Self::Dirty;
     }
 
+    /// Wait for an in-flight sync before reusing or mutating the blob.
     async fn wait_for_pending(&mut self) -> Result<(), crate::Error> {
         let Self::Pending(pending) = self else {
             return Ok(());
         };
-        // Keep `self` pending until the await resolves.
         let pending = pending.clone();
         match pending.wait().await {
             Ok(()) => {
@@ -75,12 +64,14 @@ impl Durability {
                 Ok(())
             }
             Err(err) => {
+                // The sync failed, so the pending mutations still need durability.
                 *self = Self::Dirty;
                 Err(err)
             }
         }
     }
 
+    /// Write data that will require a later sync.
     async fn write_at(
         &mut self,
         blob: &impl crate::Blob,
@@ -93,6 +84,7 @@ impl Durability {
         Ok(())
     }
 
+    /// Write data and make it durable before returning.
     async fn write_at_sync(
         &mut self,
         blob: &impl crate::Blob,
@@ -102,13 +94,14 @@ impl Durability {
         self.wait_for_pending().await?;
         match self {
             Self::Dirty => {
+                // Earlier mutations need a full durability barrier too.
                 blob.write_at(offset, bufs).await?;
                 blob.sync().await?;
                 *self = Self::Clean;
                 Ok(())
             }
             Self::Clean => {
-                // If `write_at_sync` fails, a later sync must not treat the drained buffer as durable.
+                // If this fails, a later sync must still cover the attempted write.
                 *self = Self::Dirty;
                 blob.write_at_sync(offset, bufs).await?;
                 *self = Self::Clean;
@@ -118,6 +111,7 @@ impl Durability {
         }
     }
 
+    /// Make all pending mutations durable before returning.
     async fn sync(&mut self, blob: &impl crate::Blob) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
         if matches!(self, Self::Clean) {
@@ -128,12 +122,13 @@ impl Durability {
         Ok(())
     }
 
+    /// Start making pending mutations durable and return a handle for completion.
     async fn start_sync(&mut self, blob: &impl crate::Blob) -> crate::Handle<()> {
         match self {
             Self::Clean => crate::Handle::ready(Ok(())),
             Self::Dirty => {
-                // Share one completion with all waiters.
-                let pending = Completion::start(blob.start_sync().await);
+                // Store a shared completion so repeated calls observe the same sync.
+                let pending = Completion::from(blob.start_sync().await);
                 let handle = pending.handle();
                 *self = Self::Pending(pending);
                 handle

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -64,6 +64,15 @@ impl SyncState {
         self.needs_sync = false;
         Ok(())
     }
+
+    async fn start_sync(&mut self, blob: &impl crate::Blob) -> crate::Handle<()> {
+        if !self.needs_sync {
+            return crate::Handle::ready(Ok(()));
+        }
+        let handle = blob.start_sync().await;
+        self.needs_sync = false;
+        handle
+    }
 }
 
 #[cfg(test)]

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -1,5 +1,7 @@
 //! Buffers for reading and writing to [crate::Blob]s.
 
+use futures::future::{BoxFuture, FutureExt as _, Shared};
+
 pub mod paged;
 mod read;
 mod tip;
@@ -9,22 +11,71 @@ pub use read::Read;
 pub use write::Write;
 
 /// Tracks whether plain blob mutations still need a full durability barrier.
-struct SyncState {
-    needs_sync: bool,
+enum Durability {
+    Clean,
+    Dirty,
+    Pending(Completion),
 }
 
-impl SyncState {
+#[derive(Clone)]
+struct Completion {
+    inner: Shared<BoxFuture<'static, Result<(), crate::Error>>>,
+}
+
+impl Completion {
+    fn start(handle: crate::Handle<()>) -> Self {
+        Self {
+            inner: async move { handle.await }.boxed().shared(),
+        }
+    }
+
+    fn handle(&self) -> crate::Handle<()> {
+        let inner = self.inner.clone();
+        crate::Handle::from_future(async move { inner.await })
+    }
+
+    async fn wait(&self) -> Result<(), crate::Error> {
+        self.inner.clone().await
+    }
+}
+
+impl Durability {
     /// Create a new sync state.
     ///
     /// Use `needs_sync = true` when wrapping an existing blob because prior plain mutations may
     /// still need a full [`crate::Blob::sync`] barrier. [`Self::write_at_sync`] can use
     /// [`crate::Blob::write_at_sync`] only when this is false.
     const fn new(needs_sync: bool) -> Self {
-        Self { needs_sync }
+        if needs_sync {
+            Self::Dirty
+        } else {
+            Self::Clean
+        }
     }
 
-    const fn mark_unsynced(&mut self) {
-        self.needs_sync = true;
+    fn mark_dirty(&mut self) {
+        assert!(
+            !matches!(self, Self::Pending(_)),
+            "pending sync must be joined before marking dirty"
+        );
+        *self = Self::Dirty;
+    }
+
+    async fn wait_for_pending(&mut self) -> Result<(), crate::Error> {
+        let Self::Pending(pending) = self else {
+            return Ok(());
+        };
+        let pending = pending.clone();
+        match pending.wait().await {
+            Ok(()) => {
+                *self = Self::Clean;
+                Ok(())
+            }
+            Err(err) => {
+                *self = Self::Dirty;
+                Err(err)
+            }
+        }
     }
 
     async fn write_at(
@@ -33,8 +84,9 @@ impl SyncState {
         offset: u64,
         bufs: impl Into<crate::IoBufs> + Send,
     ) -> Result<(), crate::Error> {
+        self.wait_for_pending().await?;
         blob.write_at(offset, bufs).await?;
-        self.needs_sync = true;
+        *self = Self::Dirty;
         Ok(())
     }
 
@@ -44,34 +96,46 @@ impl SyncState {
         offset: u64,
         bufs: impl Into<crate::IoBufs> + Send,
     ) -> Result<(), crate::Error> {
-        if self.needs_sync {
-            self.write_at(blob, offset, bufs).await?;
-            self.sync(blob).await
-        } else {
-            // If `write_at_sync` fails, a later sync must not treat the drained buffer as durable.
-            self.needs_sync = true;
-            blob.write_at_sync(offset, bufs).await?;
-            self.needs_sync = false;
-            Ok(())
+        self.wait_for_pending().await?;
+        match self {
+            Self::Dirty => {
+                blob.write_at(offset, bufs).await?;
+                blob.sync().await?;
+                *self = Self::Clean;
+                Ok(())
+            }
+            Self::Clean => {
+                // If `write_at_sync` fails, a later sync must not treat the drained buffer as durable.
+                *self = Self::Dirty;
+                blob.write_at_sync(offset, bufs).await?;
+                *self = Self::Clean;
+                Ok(())
+            }
+            Self::Pending(_) => unreachable!("pending sync waited above"),
         }
     }
 
     async fn sync(&mut self, blob: &impl crate::Blob) -> Result<(), crate::Error> {
-        if !self.needs_sync {
+        self.wait_for_pending().await?;
+        if matches!(self, Self::Clean) {
             return Ok(());
         }
         blob.sync().await?;
-        self.needs_sync = false;
+        *self = Self::Clean;
         Ok(())
     }
 
     async fn start_sync(&mut self, blob: &impl crate::Blob) -> crate::Handle<()> {
-        if !self.needs_sync {
-            return crate::Handle::ready(Ok(()));
+        match self {
+            Self::Clean => crate::Handle::ready(Ok(())),
+            Self::Dirty => {
+                let pending = Completion::start(blob.start_sync().await);
+                let handle = pending.handle();
+                *self = Self::Pending(pending);
+                handle
+            }
+            Self::Pending(pending) => pending.handle(),
         }
-        let handle = blob.start_sync().await;
-        self.needs_sync = false;
-        handle
     }
 }
 

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -32,8 +32,8 @@ impl From<crate::Handle<()>> for Completion {
     }
 }
 
-/// Tracks whether blob state is durably persisted.
-enum Durability {
+/// Tracks whether blob mutations still need a sync.
+enum SyncState {
     // No unsynced mutations.
     Clean,
     // Unsynced mutations need a sync.
@@ -42,7 +42,7 @@ enum Durability {
     Pending(Completion),
 }
 
-impl Durability {
+impl SyncState {
     /// Mark a new unsynced mutation.
     fn mark_dirty(&mut self) {
         assert!(
@@ -172,7 +172,7 @@ mod tests {
 
     /// Test blob with separate visible and durable state.
     ///
-    /// Unsynced writes and resizes only update `data`. `write_at_sync` updates `data`
+    /// Writes and resizes only update `data`. `write_at_sync` updates `data`
     /// and then copies only that submitted range into `durable`. `sync` copies all
     /// of `data` to `durable`. This lets tests assert that `Write::sync` uses range
     /// sync only when no earlier unsynced mutation needs a full durability barrier.

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -57,7 +57,6 @@ impl SyncState {
         let Self::Pending(pending) = self else {
             return Ok(());
         };
-        let pending = pending.clone();
         match pending.wait().await {
             Ok(()) => {
                 *self = Self::Clean;

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -10,10 +10,13 @@ mod write;
 pub use read::Read;
 pub use write::Write;
 
-/// Tracks whether plain blob mutations still need a full durability barrier.
+/// Tracks whether blob state is durably persisted.
 enum Durability {
+    // No unsynced mutations.
     Clean,
+    // Unsynced mutations need a sync.
     Dirty,
+    // A started sync is in flight.
     Pending(Completion),
 }
 
@@ -23,28 +26,27 @@ struct Completion {
 }
 
 impl Completion {
+    /// Share a started sync.
     fn start(handle: crate::Handle<()>) -> Self {
         Self {
-            inner: async move { handle.await }.boxed().shared(),
+            inner: handle.boxed().shared(),
         }
     }
 
+    /// Return another waiter.
     fn handle(&self) -> crate::Handle<()> {
         let inner = self.inner.clone();
-        crate::Handle::from_future(async move { inner.await })
+        crate::Handle::from_future(inner)
     }
 
+    /// Wait internally.
     async fn wait(&self) -> Result<(), crate::Error> {
         self.inner.clone().await
     }
 }
 
 impl Durability {
-    /// Create a new sync state.
-    ///
-    /// Use `needs_sync = true` when wrapping an existing blob because prior plain mutations may
-    /// still need a full [`crate::Blob::sync`] barrier. [`Self::write_at_sync`] can use
-    /// [`crate::Blob::write_at_sync`] only when this is false.
+    /// `needs_sync` means existing blob contents may not be durable.
     const fn new(needs_sync: bool) -> Self {
         if needs_sync {
             Self::Dirty
@@ -65,6 +67,7 @@ impl Durability {
         let Self::Pending(pending) = self else {
             return Ok(());
         };
+        // Keep `self` pending until the await resolves.
         let pending = pending.clone();
         match pending.wait().await {
             Ok(()) => {
@@ -129,6 +132,7 @@ impl Durability {
         match self {
             Self::Clean => crate::Handle::ready(Ok(())),
             Self::Dirty => {
+                // Share one completion with all waiters.
                 let pending = Completion::start(blob.start_sync().await);
                 let handle = pending.handle();
                 *self = Self::Pending(pending);
@@ -173,7 +177,7 @@ mod tests {
 
     /// Test blob with separate visible and durable state.
     ///
-    /// Plain writes and resizes only update `data`. `write_at_sync` updates `data`
+    /// Unsynced writes and resizes only update `data`. `write_at_sync` updates `data`
     /// and then copies only that submitted range into `durable`. `sync` copies all
     /// of `data` to `durable`. This lets tests assert that `Write::sync` uses range
     /// sync only when no earlier unsynced mutation needs a full durability barrier.

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -10,16 +10,6 @@ mod write;
 pub use read::Read;
 pub use write::Write;
 
-/// Tracks whether blob state is durably persisted.
-enum Durability {
-    // No unsynced mutations.
-    Clean,
-    // Unsynced mutations need a sync.
-    Dirty,
-    // A started sync is in flight.
-    Pending(Completion),
-}
-
 /// A shared sync result.
 #[derive(Clone)]
 struct Completion(Shared<BoxFuture<'static, Result<(), crate::Error>>>);
@@ -40,6 +30,16 @@ impl From<crate::Handle<()>> for Completion {
     fn from(handle: crate::Handle<()>) -> Self {
         Self(handle.boxed().shared())
     }
+}
+
+/// Tracks whether blob state is durably persisted.
+enum Durability {
+    // No unsynced mutations.
+    Clean,
+    // Unsynced mutations need a sync.
+    Dirty,
+    // A started sync is in flight.
+    Pending(Completion),
 }
 
 impl Durability {

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -2460,6 +2460,182 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
+    // Verifies snapshot cannot flush buffered bytes before pending start_sync finishes.
+    fn test_snapshot_waits_for_outstanding_start_sync_before_flushing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+
+            // Start a sync, then buffer newer bytes not covered by it.
+            let prior = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+            writer.append(b"hello world").await.unwrap();
+
+            let snapshot = context.child("snapshot").spawn(move |_| async move {
+                let snapshot = writer.snapshot().await.unwrap();
+                let read = snapshot
+                    .read_at(0, b"hello world".len())
+                    .await
+                    .unwrap()
+                    .coalesce();
+                assert_eq!(read.as_ref(), b"hello world");
+                writer
+            });
+
+            // Snapshot must wait before flushing buffered bytes.
+            blocked_rx
+                .await
+                .expect("snapshot never waited on start_sync");
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // Releasing the sync lets snapshot flush and read the buffered bytes.
+            release_tx.send(Ok(())).unwrap();
+            let _writer = snapshot.await.unwrap();
+            prior.await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    // Verifies replay cannot flush buffered bytes before pending start_sync finishes.
+    fn test_replay_waits_for_outstanding_start_sync_before_flushing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+
+            // Start a sync, then buffer newer bytes not covered by it.
+            let prior = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+            writer.append(b"hello world").await.unwrap();
+
+            let replay = context.child("replay").spawn(move |_| async move {
+                {
+                    let mut replay = writer.replay(NZUsize!(BUFFER_SIZE)).await.unwrap();
+                    assert!(replay.ensure(1).await.unwrap());
+                    assert_eq!(replay.chunk()[0], b'h');
+                }
+                writer
+            });
+
+            // Replay must wait before flushing buffered bytes.
+            blocked_rx.await.expect("replay never waited on start_sync");
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // Releasing the sync lets replay flush and read the buffered bytes.
+            release_tx.send(Ok(())).unwrap();
+            let _writer = replay.await.unwrap();
+            prior.await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    // Verifies resize growth cannot write zeros before pending start_sync finishes.
+    fn test_resize_grow_waits_for_outstanding_start_sync_before_writing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+
+            // Start a sync before growing into the direct-write path.
+            let prior = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+
+            let target_size = (BUFFER_SIZE + PAGE_SIZE.get() as usize) as u64;
+            let resize = context.child("resize_grow").spawn(move |_| async move {
+                writer.resize(target_size).await.unwrap();
+                writer
+            });
+
+            // Growth must wait before writing zero-filled pages.
+            blocked_rx
+                .await
+                .expect("resize grow never waited on start_sync");
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // Releasing the sync lets the resize complete.
+            release_tx.send(Ok(())).unwrap();
+            let mut writer = resize.await.unwrap();
+            prior.await.unwrap();
+            assert_eq!(writer.size(), target_size);
+            writer.sync().await.unwrap();
+            let (_, writes, full_syncs, _) = inner.snapshot();
+            assert!(writes > 0);
+            assert!(full_syncs > 0);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    // Verifies shrink cannot resize the blob before pending start_sync finishes.
+    fn test_resize_shrink_waits_for_outstanding_start_sync_before_resizing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+
+            // Build durable pages, then start a sync for a newer partial page.
+            let data = vec![3; PAGE_SIZE.get() as usize * 2];
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+            writer.append(b"x").await.unwrap();
+            let prior = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+            let physical_size = inner.size();
+
+            let resize = context.child("resize_shrink").spawn(move |_| async move {
+                writer.resize(PAGE_SIZE.get() as u64).await.unwrap();
+                writer
+            });
+
+            // Shrink must wait before truncating the physical blob.
+            blocked_rx
+                .await
+                .expect("resize shrink never waited on start_sync");
+            assert_eq!(
+                inner.size(),
+                physical_size,
+                "resize must not shrink the blob before the pending sync finishes"
+            );
+
+            // Releasing the sync lets the shrink truncate the blob.
+            release_tx.send(Ok(())).unwrap();
+            let writer = resize.await.unwrap();
+            prior.await.unwrap();
+            assert_eq!(writer.size(), PAGE_SIZE.get() as u64);
+            assert!(inner.size() < physical_size);
+        });
+    }
+
+    #[test_traced("DEBUG")]
     fn test_sync_failed_range_sync_does_not_mark_clean() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -43,7 +43,7 @@ use crate::{
     buffer::{
         paged::{CacheRef, Checksum, Slot, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE},
         tip::Buffer,
-        Durability,
+        SyncState,
     },
     Blob, Error, Handle, IoBuf, IoBufMut, IoBufs,
 };
@@ -104,8 +104,8 @@ pub struct Writer<B: Blob> {
     /// will contain its CRC record.
     partial_page_state: Option<Checksum>,
 
-    /// Durability state for writes, resizes, and range-sync writes.
-    durability: Durability,
+    /// Sync state for writes, resizes, and range-sync writes.
+    sync_state: SyncState,
 
     /// Unique id assigned to this blob by the page cache.
     id: u64,
@@ -121,7 +121,7 @@ pub struct Writer<B: Blob> {
 impl<B: Blob> Writer<B> {
     /// Write bytes to the underlying blob and mark them as needing sync.
     async fn write_at(&mut self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
-        self.durability.write_at(&self.blob, offset, bufs).await
+        self.sync_state.write_at(&self.blob, offset, bufs).await
     }
 
     /// Write bytes to the underlying blob and make them durable.
@@ -133,7 +133,7 @@ impl<B: Blob> Writer<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        self.durability
+        self.sync_state
             .write_at_sync(&self.blob, offset, bufs)
             .await
     }
@@ -193,10 +193,10 @@ impl<B: Blob> Writer<B> {
             blob,
             current_page,
             partial_page_state,
-            durability: if needs_sync {
-                Durability::Dirty
+            sync_state: if needs_sync {
+                SyncState::Dirty
             } else {
-                Durability::Clean
+                SyncState::Clean
             },
             id: cache_ref.next_id(),
             cache_ref,
@@ -345,7 +345,7 @@ impl<B: Blob> Writer<B> {
             "an empty tip implies no partial page state"
         );
         // Direct blob writes must not overtake an earlier started sync barrier.
-        self.durability.wait_for_pending().await?;
+        self.sync_state.wait_for_pending().await?;
 
         // Cache the pages before `replace` publishes the new size, so reads of the bulk range are
         // served from the cache while the blob write is still in flight. Insert in
@@ -396,7 +396,7 @@ impl<B: Blob> Writer<B> {
     /// If `sync` is true and the flush emits a single write, that write is made durable
     /// immediately: with [`Blob::write_at_sync`] when there are no earlier unsynced mutations, or
     /// by writing it and syncing the blob when there are. Flushes split around a protected CRC use
-    /// unsynced writes so the caller can make them durable with one sync.
+    /// plain writes so the caller can make them durable with one sync.
     ///
     /// Returns `true` if the flush made its writes durable, so no additional sync is needed.
     async fn flush_internal(
@@ -418,7 +418,7 @@ impl<B: Blob> Writer<B> {
         }
 
         // A flush mutates the blob, so first resolve any outstanding start_sync barrier.
-        self.durability.wait_for_pending().await?;
+        self.sync_state.wait_for_pending().await?;
 
         // Split buffered bytes into full logical pages to hand off now, leaving any trailing
         // partial page in tip for continued buffering.
@@ -929,9 +929,9 @@ impl<B: Blob> Writer<B> {
             return Ok(());
         }
 
-        // Otherwise, the flush either had no bytes to write or used unsynced writes. Sync only if a
+        // Otherwise, the flush either had no bytes to write or used plain writes. Sync only if a
         // durability barrier is still pending.
-        self.durability.sync(&self.blob).await
+        self.sync_state.sync(&self.blob).await
     }
 
     /// Flushes buffered data and begins making all pending mutations durable, returning a
@@ -944,7 +944,7 @@ impl<B: Blob> Writer<B> {
         if let Err(err) = self.flush_internal(true, false).await {
             return Handle::ready(Err(err));
         }
-        self.durability.start_sync(&self.blob).await
+        self.sync_state.start_sync(&self.blob).await
     }
 
     /// Resize the blob to the provided logical `size`.
@@ -1012,7 +1012,7 @@ impl<B: Blob> Writer<B> {
         // resizes need to create a pending sync.
         if new_physical_size != current_physical_size {
             self.blob.resize(new_physical_size).await?;
-            self.durability.mark_dirty();
+            self.sync_state.mark_dirty();
         }
 
         // Evict cached pages at or beyond the new full-page boundary. The page at
@@ -1114,7 +1114,7 @@ impl<B: Blob> Writer<B> {
     /// not fsynced. The returned [`super::Sealed`] handle can be made durable later via
     /// [`super::Sealed::sync`].
     pub async fn seal(mut self) -> Result<super::Sealed<B>, Error> {
-        self.durability.wait_for_pending().await?;
+        self.sync_state.wait_for_pending().await?;
         self.flush_internal(true, false).await?;
         Ok(self.sealed_handle(self.id))
     }

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -43,7 +43,7 @@ use crate::{
     buffer::{
         paged::{CacheRef, Checksum, Slot, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE},
         tip::Buffer,
-        SyncState,
+        Durability,
     },
     Blob, Error, Handle, IoBuf, IoBufMut, IoBufs,
 };
@@ -105,7 +105,7 @@ pub struct Writer<B: Blob> {
     partial_page_state: Option<Checksum>,
 
     /// Durability state for plain writes, resizes, and range-sync writes.
-    sync_state: SyncState,
+    durability: Durability,
 
     /// Unique id assigned to this blob by the page cache.
     id: u64,
@@ -121,7 +121,7 @@ pub struct Writer<B: Blob> {
 impl<B: Blob> Writer<B> {
     /// Write bytes to the underlying blob and mark them as needing sync.
     async fn write_at(&mut self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
-        self.sync_state.write_at(&self.blob, offset, bufs).await
+        self.durability.write_at(&self.blob, offset, bufs).await
     }
 
     /// Write bytes to the underlying blob and make them durable.
@@ -133,7 +133,7 @@ impl<B: Blob> Writer<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        self.sync_state
+        self.durability
             .write_at_sync(&self.blob, offset, bufs)
             .await
     }
@@ -154,7 +154,7 @@ impl<B: Blob> Writer<B> {
 
     /// Sync the underlying blob if there are unsynced mutations.
     async fn sync_inner(&mut self) -> Result<(), Error> {
-        self.sync_state.sync(&self.blob).await
+        self.durability.sync(&self.blob).await
     }
 
     /// Wrap `blob` in a [Writer]. `blob` must already hold `original_blob_size` physical bytes;
@@ -198,7 +198,7 @@ impl<B: Blob> Writer<B> {
             blob,
             current_page,
             partial_page_state,
-            sync_state: SyncState::new(needs_sync),
+            durability: Durability::new(needs_sync),
             id: cache_ref.next_id(),
             cache_ref,
             buffer,
@@ -345,6 +345,7 @@ impl<B: Blob> Writer<B> {
             self.partial_page_state.is_none(),
             "an empty tip implies no partial page state"
         );
+        self.durability.wait_for_pending().await?;
 
         // Cache the pages before `replace` publishes the new size, so reads of the bulk range are
         // served from the cache while the blob write is still in flight. Insert in
@@ -415,6 +416,8 @@ impl<B: Blob> Writer<B> {
         if physical_pages.is_empty() {
             return Ok(false);
         }
+
+        self.durability.wait_for_pending().await?;
 
         // Split buffered bytes into full logical pages to hand off now, leaving any trailing
         // partial page in tip for continued buffering.
@@ -933,14 +936,14 @@ impl<B: Blob> Writer<B> {
     /// Flushes buffered data and begins making all pending mutations durable, returning a
     /// completion handle.
     ///
-    /// Awaiting the returned [`Handle`] waits for the same durability guarantee as [`Self::sync`].
-    /// The writer is marked clean as soon as the sync starts, so do not call [`Self::sync`] until the
-    /// handle resolves: before the next write it returns success even if the started sync failed.
+    /// Awaiting the returned [`Handle`] waits for the same durability guarantee as [`Self::sync`]
+    /// for the state flushed by this call. Later calls to [`Self::sync`] and writer methods that
+    /// mutate the blob first wait for any outstanding start_sync handles.
     pub async fn start_sync(&mut self) -> Handle<()> {
         if let Err(err) = self.flush_internal(true, false).await {
             return Handle::ready(Err(err));
         }
-        self.sync_state.start_sync(&self.blob).await
+        self.durability.start_sync(&self.blob).await
     }
 
     /// Resize the blob to the provided logical `size`.
@@ -1008,7 +1011,7 @@ impl<B: Blob> Writer<B> {
         // resizes need to create a pending sync.
         if new_physical_size != current_physical_size {
             self.blob.resize(new_physical_size).await?;
-            self.sync_state.mark_unsynced();
+            self.durability.mark_dirty();
         }
 
         // Evict cached pages at or beyond the new full-page boundary. The page at
@@ -1110,6 +1113,7 @@ impl<B: Blob> Writer<B> {
     /// not fsynced. The returned [`super::Sealed`] handle can be made durable later via
     /// [`super::Sealed::sync`].
     pub async fn seal(mut self) -> Result<super::Sealed<B>, Error> {
+        self.durability.wait_for_pending().await?;
         self.flush_internal(true, false).await?;
         Ok(self.sealed_handle(self.id))
     }
@@ -1122,18 +1126,20 @@ mod tests {
         buffer::{paged::CHECKSUM_SLOT_LEN_SIZE, tests::SyncTrackingBlob},
         deterministic,
         telemetry::metrics::Registry,
-        Buf, BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Spawner as _,
-        Storage as _, Supervisor as _,
+        Buf, BufferPool, BufferPoolConfig, Clock as _, Handle, IoBufsMut, Runner as _,
+        Spawner as _, Storage as _, Supervisor as _,
     };
     use commonware_codec::ReadExt;
     use commonware_macros::test_traced;
     use commonware_utils::{channel::oneshot, sync::Mutex, NZUsize, NZU16, NZU32};
+    use futures::FutureExt as _;
     use std::{
         num::NonZeroU16,
         sync::{
             atomic::{AtomicUsize, Ordering},
             Arc,
         },
+        time::Duration,
     };
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(103); // janky size to ensure we test page alignment
@@ -2156,6 +2162,90 @@ mod tests {
         });
     }
 
+    /// Blob wrapper that lets tests hold one started sync open until explicitly released.
+    #[derive(Clone)]
+    struct DelayedStartSyncBlob<B: Blob> {
+        inner: B,
+        started: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+        release: Arc<Mutex<Option<oneshot::Receiver<Result<(), Error>>>>>,
+    }
+
+    impl<B: Blob> DelayedStartSyncBlob<B> {
+        fn new(
+            inner: B,
+        ) -> (
+            Self,
+            oneshot::Receiver<()>,
+            oneshot::Sender<Result<(), Error>>,
+        ) {
+            let (started_tx, started_rx) = oneshot::channel();
+            let (release_tx, release_rx) = oneshot::channel();
+            (
+                Self {
+                    inner,
+                    started: Arc::new(Mutex::new(Some(started_tx))),
+                    release: Arc::new(Mutex::new(Some(release_rx))),
+                },
+                started_rx,
+                release_tx,
+            )
+        }
+    }
+
+    impl<B: Blob> crate::Blob for DelayedStartSyncBlob<B> {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            buf: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, buf).await
+        }
+
+        async fn write_at(&self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
+            self.inner.write_at(offset, bufs).await
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            self.inner.write_at_sync(offset, bufs).await
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            self.inner.sync().await
+        }
+
+        async fn start_sync(&self) -> Handle<()> {
+            let release = self.release.lock().take();
+            if let Some(started) = self.started.lock().take() {
+                let _ = started.send(());
+            }
+
+            let inner = self.inner.clone();
+            Handle::from_future(async move {
+                let Some(release) = release else {
+                    return inner.sync().await;
+                };
+                match release.await {
+                    Ok(Ok(())) => inner.sync().await,
+                    Ok(Err(err)) => Err(err),
+                    Err(_) => Err(Error::Closed),
+                }
+            })
+        }
+    }
+
     #[test_traced("DEBUG")]
     fn test_start_sync_persists_and_marks_clean() {
         let executor = deterministic::Runner::default();
@@ -2197,6 +2287,171 @@ mod tests {
                 .unwrap();
             let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_sync_waits_for_outstanding_start_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+
+            let handle = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+
+            let mut sync = Box::pin(writer.sync());
+            assert!(
+                sync.as_mut().now_or_never().is_none(),
+                "sync must wait for the outstanding start_sync handle"
+            );
+            drop(sync);
+            let (_, _, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            release_tx.send(Ok(())).unwrap();
+            writer.sync().await.unwrap();
+            handle.await.unwrap();
+            let (_, _, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_sync_after_start_sync_and_small_write_waits_before_range_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+
+            let handle = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+            writer.append(b"hello world").await.unwrap();
+
+            let mut sync = Box::pin(writer.sync());
+            assert!(
+                sync.as_mut().now_or_never().is_none(),
+                "sync must join the outstanding barrier before flushing the small write"
+            );
+            drop(sync);
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            release_tx.send(Ok(())).unwrap();
+            writer.sync().await.unwrap();
+            handle.await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 1);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_write_flush_waits_for_outstanding_start_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+
+            let handle = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+
+            let data = vec![7; BUFFER_SIZE + PAGE_SIZE.get() as usize];
+            let append = context.child("append").spawn(move |_| async move {
+                writer.append(&data).await.unwrap();
+                writer
+            });
+            context.sleep(Duration::from_millis(1)).await;
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            release_tx.send(Ok(())).unwrap();
+            let mut writer = append.await.unwrap();
+            handle.await.unwrap();
+            writer.sync().await.unwrap();
+            let (_, writes, full_syncs, _) = inner.snapshot();
+            assert!(writes > 0);
+            assert!(full_syncs > 0);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_outstanding_start_sync_failure_keeps_full_barrier_required() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+
+            let handle = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+            release_tx
+                .send(Err(Error::from(std::io::Error::other(
+                    "injected sync failure",
+                ))))
+                .unwrap();
+
+            assert!(writer.sync().await.is_err());
+            assert!(handle.await.is_err());
+
+            writer.append(b"hello world").await.unwrap();
+            writer.sync().await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_seal_waits_for_outstanding_start_sync_before_flushing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+
+            let prior = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+            writer.append(b"hello world").await.unwrap();
+
+            let seal = context
+                .child("seal")
+                .spawn(move |_| async move { writer.seal().await });
+            context.sleep(Duration::from_millis(1)).await;
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            release_tx.send(Ok(())).unwrap();
+            let sealed = seal.await.unwrap().unwrap();
+            prior.await.unwrap();
+            let read = sealed
+                .read_at(0, b"hello world".len())
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), b"hello world");
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
         });
     }
 
@@ -2520,7 +2775,9 @@ mod tests {
                     .write_at(offset, bytes.slice(..partial_len))
                     .await?;
                 self.inner.sync().await?;
-                return Err(Error::Io(std::io::Error::other("injected partial write")));
+                return Err(Error::Io(
+                    std::io::Error::other("injected partial write").into(),
+                ));
             }
 
             self.inner.write_at(offset, bufs).await
@@ -2540,7 +2797,9 @@ mod tests {
                 self.inner
                     .write_at_sync(offset, bytes.slice(..partial_len))
                     .await?;
-                return Err(Error::Io(std::io::Error::other("injected partial write")));
+                return Err(Error::Io(
+                    std::io::Error::other("injected partial write").into(),
+                ));
             }
 
             self.inner.write_at_sync(offset, bufs).await

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -104,7 +104,7 @@ pub struct Writer<B: Blob> {
     /// will contain its CRC record.
     partial_page_state: Option<Checksum>,
 
-    /// Durability state for writes, resizes, and range-sync writes.
+    /// Durability state for plain writes, resizes, and range-sync writes.
     sync_state: SyncState,
 
     /// Unique id assigned to this blob by the page cache.
@@ -2272,6 +2272,7 @@ mod tests {
 
             // A fresh writer is dirty, so start_sync does one full fsync; nothing is buffered to write.
             let handle = writer.start_sync().await;
+            // Let the started sync finish.
             handle.await.unwrap();
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
             assert_eq!(writes, 0);
@@ -2318,6 +2319,7 @@ mod tests {
             let handle = writer.start_sync().await;
             started_rx.await.expect("started sync was not issued");
 
+            // Try to sync while the started sync is still blocked.
             let mut sync = Box::pin(writer.sync());
             assert!(
                 sync.as_mut().now_or_never().is_none(),
@@ -2328,6 +2330,7 @@ mod tests {
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
+            // Release the started sync and retry.
             release_tx.send(Ok(())).unwrap();
             writer.sync().await.unwrap();
             handle.await.unwrap();
@@ -2352,6 +2355,7 @@ mod tests {
             started_rx.await.expect("started sync was not issued");
             writer.append(b"hello world").await.unwrap();
 
+            // Sync must wait before flushing the buffered write.
             let mut sync = Box::pin(writer.sync());
             assert!(
                 sync.as_mut().now_or_never().is_none(),
@@ -2363,6 +2367,7 @@ mod tests {
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
+            // Release the started sync, then flush the buffered write.
             release_tx.send(Ok(())).unwrap();
             writer.sync().await.unwrap();
             handle.await.unwrap();
@@ -2392,12 +2397,14 @@ mod tests {
                 writer.append(&data).await.unwrap();
                 writer
             });
+            // The append has reached the pending sync wait.
             blocked_rx.await.expect("append never waited on start_sync");
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(writes, 0);
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
+            // Release the started sync so the append can flush.
             release_tx.send(Ok(())).unwrap();
             let mut writer = append.await.unwrap();
             handle.await.unwrap();
@@ -2426,12 +2433,14 @@ mod tests {
             let seal = context
                 .child("seal")
                 .spawn(move |_| async move { writer.seal().await });
+            // The seal has reached the pending sync wait.
             blocked_rx.await.expect("seal never waited on start_sync");
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(writes, 0);
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
+            // Release the started sync so seal can flush.
             release_tx.send(Ok(())).unwrap();
             let sealed = seal.await.unwrap().unwrap();
             prior.await.unwrap();

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -2176,6 +2176,7 @@ mod tests {
     }
 
     impl<B: Blob> DelayedStartSyncBlob<B> {
+        #[allow(clippy::type_complexity)]
         fn new(
             inner: B,
         ) -> (

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -2162,12 +2162,12 @@ mod tests {
         executor.start(|context: deterministic::Context| async move {
             let blob = SyncTrackingBlob::new();
             let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut append = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref)
+            let mut writer = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref)
                 .await
                 .unwrap();
 
             // A fresh writer is dirty, so start_sync does one full fsync; nothing is buffered to write.
-            let handle = append.start_sync().await;
+            let handle = writer.start_sync().await;
             handle.await.unwrap();
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
             assert_eq!(writes, 0);
@@ -2176,15 +2176,15 @@ mod tests {
 
             // Now clean, so the next write syncs just its range instead of the whole blob.
             let data = b"hello world";
-            append.append(data).await.unwrap();
-            append.sync().await.unwrap();
+            writer.append(data).await.unwrap();
+            writer.sync().await.unwrap();
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
             assert_eq!(writes, 1);
             assert_eq!(full_syncs, 1);
             assert_eq!(range_syncs, 1);
 
             // Nothing left to sync, so start_sync does nothing.
-            let handle = append.start_sync().await;
+            let handle = writer.start_sync().await;
             handle.await.unwrap();
             let (_, _, full_syncs, range_syncs) = blob.snapshot();
             assert_eq!(full_syncs, 1);

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -340,10 +340,11 @@ impl<B: Blob> Writer<B> {
         let mut physical_pages = IoBufs::default();
         self.append_full_pages(&bulk, None, &mut physical_pages);
 
-        debug_assert!(
+        assert!(
             self.partial_page_state.is_none(),
             "an empty tip implies no partial page state"
         );
+
         // Direct blob writes must not overtake an earlier started sync barrier.
         self.sync_state.wait_for_pending().await?;
 

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -104,7 +104,7 @@ pub struct Writer<B: Blob> {
     /// will contain its CRC record.
     partial_page_state: Option<Checksum>,
 
-    /// Sync state for writes, resizes, and range-sync writes.
+    /// Durability state for writes, resizes, and range-sync writes.
     sync_state: SyncState,
 
     /// Unique id assigned to this blob by the page cache.
@@ -1127,8 +1127,8 @@ mod tests {
         buffer::{paged::CHECKSUM_SLOT_LEN_SIZE, tests::SyncTrackingBlob},
         deterministic,
         telemetry::metrics::Registry,
-        Buf, BufferPool, BufferPoolConfig, Clock as _, Handle, IoBufsMut, Runner as _,
-        Spawner as _, Storage as _, Supervisor as _,
+        Buf, BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Spawner as _,
+        Storage as _, Supervisor as _,
     };
     use commonware_codec::ReadExt;
     use commonware_macros::test_traced;
@@ -1140,7 +1140,6 @@ mod tests {
             atomic::{AtomicUsize, Ordering},
             Arc,
         },
-        time::Duration,
     };
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(103); // janky size to ensure we test page alignment
@@ -2164,6 +2163,7 @@ mod tests {
     }
 
     type StartedSyncSender = Arc<Mutex<Option<oneshot::Sender<()>>>>;
+    type BlockedSyncSender = Arc<Mutex<Option<oneshot::Sender<()>>>>;
     type ReleaseSyncReceiver = Arc<Mutex<Option<oneshot::Receiver<Result<(), Error>>>>>;
 
     /// Blob wrapper that lets tests hold one started sync open until explicitly released.
@@ -2171,6 +2171,7 @@ mod tests {
     struct DelayedStartSyncBlob<B: Blob> {
         inner: B,
         started: StartedSyncSender,
+        blocked: BlockedSyncSender,
         release: ReleaseSyncReceiver,
     }
 
@@ -2180,17 +2181,21 @@ mod tests {
         ) -> (
             Self,
             oneshot::Receiver<()>,
+            oneshot::Receiver<()>,
             oneshot::Sender<Result<(), Error>>,
         ) {
             let (started_tx, started_rx) = oneshot::channel();
+            let (blocked_tx, blocked_rx) = oneshot::channel();
             let (release_tx, release_rx) = oneshot::channel();
             (
                 Self {
                     inner,
                     started: Arc::new(Mutex::new(Some(started_tx))),
+                    blocked: Arc::new(Mutex::new(Some(blocked_tx))),
                     release: Arc::new(Mutex::new(Some(release_rx))),
                 },
                 started_rx,
+                blocked_rx,
                 release_tx,
             )
         }
@@ -2232,12 +2237,16 @@ mod tests {
 
         async fn start_sync(&self) -> Handle<()> {
             let release = self.release.lock().take();
+            let blocked = self.blocked.lock().take();
             if let Some(started) = self.started.lock().take() {
                 let _ = started.send(());
             }
 
             let inner = self.inner.clone();
             Handle::from_future(async move {
+                if let Some(blocked) = blocked {
+                    let _ = blocked.send(());
+                }
                 let Some(release) = release else {
                     return inner.sync().await;
                 };
@@ -2251,6 +2260,7 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
+    // Verifies a successful start_sync marks the writer clean.
     fn test_start_sync_persists_and_marks_clean() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
@@ -2295,11 +2305,13 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
+    // Verifies sync waits for a pending start_sync with no new writes.
     fn test_sync_waits_for_outstanding_start_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let inner = SyncTrackingBlob::new();
-            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
+            let (blob, started_rx, _blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
             let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
             let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
 
@@ -2326,11 +2338,13 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
+    // Verifies a small buffered write cannot range-sync before pending start_sync finishes.
     fn test_sync_after_start_sync_and_small_write_waits_before_range_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let inner = SyncTrackingBlob::new();
-            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
+            let (blob, started_rx, _blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
             let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
             let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
 
@@ -2360,11 +2374,13 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
+    // Verifies a large append cannot flush before pending start_sync finishes.
     fn test_write_flush_waits_for_outstanding_start_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let inner = SyncTrackingBlob::new();
-            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
             let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
             let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
 
@@ -2376,7 +2392,7 @@ mod tests {
                 writer.append(&data).await.unwrap();
                 writer
             });
-            context.sleep(Duration::from_millis(1)).await;
+            blocked_rx.await.expect("append never waited on start_sync");
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(writes, 0);
             assert_eq!(full_syncs, 0);
@@ -2393,40 +2409,13 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
-    fn test_outstanding_start_sync_failure_keeps_full_barrier_required() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let inner = SyncTrackingBlob::new();
-            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
-
-            let handle = writer.start_sync().await;
-            started_rx.await.expect("started sync was not issued");
-            release_tx
-                .send(Err(Error::from(std::io::Error::other(
-                    "injected sync failure",
-                ))))
-                .unwrap();
-
-            assert!(writer.sync().await.is_err());
-            assert!(handle.await.is_err());
-
-            writer.append(b"hello world").await.unwrap();
-            writer.sync().await.unwrap();
-            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
-            assert_eq!(writes, 1);
-            assert_eq!(full_syncs, 1);
-            assert_eq!(range_syncs, 0);
-        });
-    }
-
-    #[test_traced("DEBUG")]
+    // Verifies seal cannot flush buffered bytes before pending start_sync finishes.
     fn test_seal_waits_for_outstanding_start_sync_before_flushing() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let inner = SyncTrackingBlob::new();
-            let (blob, started_rx, release_tx) = DelayedStartSyncBlob::new(inner.clone());
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
             let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
             let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
 
@@ -2437,7 +2426,7 @@ mod tests {
             let seal = context
                 .child("seal")
                 .spawn(move |_| async move { writer.seal().await });
-            context.sleep(Duration::from_millis(1)).await;
+            blocked_rx.await.expect("seal never waited on start_sync");
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(writes, 0);
             assert_eq!(full_syncs, 0);

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -104,7 +104,7 @@ pub struct Writer<B: Blob> {
     /// will contain its CRC record.
     partial_page_state: Option<Checksum>,
 
-    /// Durability state for plain writes, resizes, and range-sync writes.
+    /// Durability state for writes, resizes, and range-sync writes.
     durability: Durability,
 
     /// Unique id assigned to this blob by the page cache.
@@ -150,11 +150,6 @@ impl<B: Blob> Writer<B> {
         } else {
             self.write_at(offset, bufs).await
         }
-    }
-
-    /// Sync the underlying blob if there are unsynced mutations.
-    async fn sync_inner(&mut self) -> Result<(), Error> {
-        self.durability.sync(&self.blob).await
     }
 
     /// Wrap `blob` in a [Writer]. `blob` must already hold `original_blob_size` physical bytes;
@@ -345,6 +340,7 @@ impl<B: Blob> Writer<B> {
             self.partial_page_state.is_none(),
             "an empty tip implies no partial page state"
         );
+        // Direct blob writes must not overtake an earlier started sync barrier.
         self.durability.wait_for_pending().await?;
 
         // Cache the pages before `replace` publishes the new size, so reads of the bulk range are
@@ -396,7 +392,7 @@ impl<B: Blob> Writer<B> {
     /// If `sync` is true and the flush emits a single write, that write is made durable
     /// immediately: with [`Blob::write_at_sync`] when there are no earlier unsynced mutations, or
     /// by writing it and syncing the blob when there are. Flushes split around a protected CRC use
-    /// plain writes so the caller can make them durable with one sync.
+    /// unsynced writes so the caller can make them durable with one sync.
     ///
     /// Returns `true` if the flush made its writes durable, so no additional sync is needed.
     async fn flush_internal(
@@ -417,6 +413,7 @@ impl<B: Blob> Writer<B> {
             return Ok(false);
         }
 
+        // A flush mutates the blob, so first resolve any outstanding start_sync barrier.
         self.durability.wait_for_pending().await?;
 
         // Split buffered bytes into full logical pages to hand off now, leaving any trailing
@@ -928,9 +925,9 @@ impl<B: Blob> Writer<B> {
             return Ok(());
         }
 
-        // Otherwise, the flush either had no bytes to write or used plain writes. Sync only if a
+        // Otherwise, the flush either had no bytes to write or used unsynced writes. Sync only if a
         // durability barrier is still pending.
-        self.sync_inner().await
+        self.durability.sync(&self.blob).await
     }
 
     /// Flushes buffered data and begins making all pending mutations durable, returning a
@@ -2162,12 +2159,15 @@ mod tests {
         });
     }
 
+    type StartedSyncSender = Arc<Mutex<Option<oneshot::Sender<()>>>>;
+    type ReleaseSyncReceiver = Arc<Mutex<Option<oneshot::Receiver<Result<(), Error>>>>>;
+
     /// Blob wrapper that lets tests hold one started sync open until explicitly released.
     #[derive(Clone)]
     struct DelayedStartSyncBlob<B: Blob> {
         inner: B,
-        started: Arc<Mutex<Option<oneshot::Sender<()>>>>,
-        release: Arc<Mutex<Option<oneshot::Receiver<Result<(), Error>>>>>,
+        started: StartedSyncSender,
+        release: ReleaseSyncReceiver,
     }
 
     impl<B: Blob> DelayedStartSyncBlob<B> {

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -45,7 +45,7 @@ use crate::{
         tip::Buffer,
         SyncState,
     },
-    Blob, Error, IoBuf, IoBufMut, IoBufs,
+    Blob, Error, Handle, IoBuf, IoBufMut, IoBufs,
 };
 use bytes::BufMut;
 use commonware_cryptography::Crc32;
@@ -928,6 +928,19 @@ impl<B: Blob> Writer<B> {
         // Otherwise, the flush either had no bytes to write or used plain writes. Sync only if a
         // durability barrier is still pending.
         self.sync_inner().await
+    }
+
+    /// Flushes buffered data and begins making all pending mutations durable, returning a
+    /// completion handle.
+    ///
+    /// Awaiting the returned [`Handle`] waits for the same durability guarantee as [`Self::sync`].
+    /// The writer is marked clean as soon as the sync starts, so do not call [`Self::sync`] until the
+    /// handle resolves: before the next write it returns success even if the started sync failed.
+    pub async fn start_sync(&mut self) -> Handle<()> {
+        if let Err(err) = self.flush_internal(true, false).await {
+            return Handle::ready(Err(err));
+        }
+        self.sync_state.start_sync(&self.blob).await
     }
 
     /// Resize the blob to the provided logical `size`.
@@ -2134,6 +2147,50 @@ mod tests {
             assert_eq!(full_syncs, 1);
             assert_eq!(range_syncs, 1);
 
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let reopened = Writer::new(blob.clone(), blob.size(), BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_start_sync_persists_and_marks_clean() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let blob = SyncTrackingBlob::new();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut append = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            // A fresh writer is dirty, so start_sync does one full fsync; nothing is buffered to write.
+            let handle = append.start_sync().await;
+            handle.await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
+
+            // Now clean, so the next write syncs just its range instead of the whole blob.
+            let data = b"hello world";
+            append.append(data).await.unwrap();
+            append.sync().await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 1);
+
+            // Nothing left to sync, so start_sync does nothing.
+            let handle = append.start_sync().await;
+            handle.await.unwrap();
+            let (_, _, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 1);
+
+            // Durable and readable after reopening.
             let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
             let reopened = Writer::new(blob.clone(), blob.size(), BUFFER_SIZE, cache_ref)
                 .await

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -193,7 +193,11 @@ impl<B: Blob> Writer<B> {
             blob,
             current_page,
             partial_page_state,
-            durability: Durability::new(needs_sync),
+            durability: if needs_sync {
+                Durability::Dirty
+            } else {
+                Durability::Clean
+            },
             id: cache_ref.next_id(),
             cache_ref,
             buffer,

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -73,7 +73,8 @@ impl<B: Blob> Write<B> {
         Self {
             blob,
             buffer: Buffer::new(size, capacity.get(), pool),
-            durability: Durability::new(true), // ensure pending writes on the wrapped blob are synced
+            // Existing blob contents may not be durable yet.
+            durability: Durability::Dirty,
         }
     }
 

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -62,7 +62,7 @@ pub struct Write<B: Blob> {
     /// Buffered bytes at the logical tip of the blob.
     buffer: Buffer,
 
-    /// Durability state for writes and range-sync writes.
+    /// Durability state for plain writes and range-sync writes.
     sync_state: SyncState,
 }
 

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -1,5 +1,5 @@
 use crate::{
-    buffer::{tip::Buffer, Durability},
+    buffer::{tip::Buffer, SyncState},
     Blob, Buf, BufferPool, BufferPooler, Error, IoBufs,
 };
 use std::num::NonZeroUsize;
@@ -62,8 +62,8 @@ pub struct Write<B: Blob> {
     /// Buffered bytes at the logical tip of the blob.
     buffer: Buffer,
 
-    /// Durability state for writes and range-sync writes.
-    durability: Durability,
+    /// Sync state for writes and range-sync writes.
+    sync_state: SyncState,
 }
 
 impl<B: Blob> Write<B> {
@@ -74,7 +74,7 @@ impl<B: Blob> Write<B> {
             blob,
             buffer: Buffer::new(size, capacity.get(), pool),
             // Existing blob contents may not be durable yet.
-            durability: Durability::Dirty,
+            sync_state: SyncState::Dirty,
         }
     }
 
@@ -214,11 +214,11 @@ impl<B: Blob> Write<B> {
             self.write_blob(offset, buf).await?;
         }
 
-        self.durability.wait_for_pending().await?;
+        self.sync_state.wait_for_pending().await?;
 
         // Resize the underlying blob.
         self.blob.resize(len).await?;
-        self.durability.mark_dirty();
+        self.sync_state.mark_dirty();
 
         Ok(())
     }
@@ -238,7 +238,7 @@ impl<B: Blob> Write<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        self.durability.write_at(&self.blob, offset, bufs).await
+        self.sync_state.write_at(&self.blob, offset, bufs).await
     }
 
     /// Write bytes to the underlying blob and make them durable.
@@ -250,13 +250,13 @@ impl<B: Blob> Write<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        self.durability
+        self.sync_state
             .write_at_sync(&self.blob, offset, bufs)
             .await
     }
 
     /// Sync the underlying blob if there are unsynced mutations.
     async fn sync_blob(&mut self) -> Result<(), Error> {
-        self.durability.sync(&self.blob).await
+        self.sync_state.sync(&self.blob).await
     }
 }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -214,8 +214,6 @@ impl<B: Blob> Write<B> {
             self.write_blob(offset, buf).await?;
         }
 
-        self.sync_state.wait_for_pending().await?;
-
         // Resize the underlying blob.
         self.blob.resize(len).await?;
         self.sync_state.mark_dirty();

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -1,5 +1,5 @@
 use crate::{
-    buffer::{tip::Buffer, SyncState},
+    buffer::{tip::Buffer, Durability},
     Blob, Buf, BufferPool, BufferPooler, Error, IoBufs,
 };
 use std::num::NonZeroUsize;
@@ -63,7 +63,7 @@ pub struct Write<B: Blob> {
     buffer: Buffer,
 
     /// Durability state for plain writes and range-sync writes.
-    sync_state: SyncState,
+    durability: Durability,
 }
 
 impl<B: Blob> Write<B> {
@@ -73,7 +73,7 @@ impl<B: Blob> Write<B> {
         Self {
             blob,
             buffer: Buffer::new(size, capacity.get(), pool),
-            sync_state: SyncState::new(true), // ensure pending writes on the wrapped blob are synced
+            durability: Durability::new(true), // ensure pending writes on the wrapped blob are synced
         }
     }
 
@@ -213,9 +213,11 @@ impl<B: Blob> Write<B> {
             self.write_blob(offset, buf).await?;
         }
 
+        self.durability.wait_for_pending().await?;
+
         // Resize the underlying blob.
         self.blob.resize(len).await?;
-        self.sync_state.mark_unsynced();
+        self.durability.mark_dirty();
 
         Ok(())
     }
@@ -235,7 +237,7 @@ impl<B: Blob> Write<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        self.sync_state.write_at(&self.blob, offset, bufs).await
+        self.durability.write_at(&self.blob, offset, bufs).await
     }
 
     /// Write bytes to the underlying blob and make them durable.
@@ -247,13 +249,13 @@ impl<B: Blob> Write<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        self.sync_state
+        self.durability
             .write_at_sync(&self.blob, offset, bufs)
             .await
     }
 
     /// Sync the underlying blob if there are unsynced mutations.
     async fn sync_blob(&mut self) -> Result<(), Error> {
-        self.sync_state.sync(&self.blob).await
+        self.durability.sync(&self.blob).await
     }
 }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -62,7 +62,7 @@ pub struct Write<B: Blob> {
     /// Buffered bytes at the logical tip of the blob.
     buffer: Buffer,
 
-    /// Durability state for plain writes and range-sync writes.
+    /// Durability state for writes and range-sync writes.
     durability: Durability,
 }
 

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -62,7 +62,7 @@ pub struct Write<B: Blob> {
     /// Buffered bytes at the logical tip of the blob.
     buffer: Buffer,
 
-    /// Sync state for writes and range-sync writes.
+    /// Durability state for writes and range-sync writes.
     sync_state: SyncState,
 }
 

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -164,7 +164,9 @@ pub(super) mod partition_sync_fault {
 
         async fn sync(&self) -> Result<(), Error> {
             if self.partition == self.fail_partition {
-                return Err(Error::Io(IoError::other("injected partition sync fault")));
+                return Err(Error::Io(
+                    IoError::other("injected partition sync fault").into(),
+                ));
             }
             self.inner.sync().await
         }

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2627,7 +2627,7 @@ mod bitmap_tests {
         qmdb::any::unordered::variable::test::{create_test_config, AnyTest},
     };
     use commonware_cryptography::{Hasher, Sha256};
-    use commonware_macros::test_traced;
+    use commonware_macros::{boxed, test_traced};
     use commonware_runtime::{
         deterministic::{self, Context},
         Runner as _, Supervisor as _,
@@ -2649,6 +2649,7 @@ mod bitmap_tests {
     }
 
     /// Commit, drop, reopen, and assert the rebuilt bitmap matches the in-memory bitmap.
+    #[boxed]
     async fn assert_oracle_round_trip(mut db: AnyTest, context: Context, label: &str) -> AnyTest {
         let pre_active = bitmap_active_locs(&db);
         let pre_len = db.bitmap.len();
@@ -2712,7 +2713,7 @@ mod bitmap_tests {
             // Most recent commit is current -> bit=1.
             assert!(db.bitmap.get_bit(*commit_locs[2]));
 
-            let db = Box::pin(assert_oracle_round_trip(db, context, "commit_floor")).await;
+            let db = assert_oracle_round_trip(db, context, "commit_floor").await;
             db.destroy().await.unwrap();
         });
     }
@@ -2765,7 +2766,7 @@ mod bitmap_tests {
             assert_eq!(db.get(&k1).await.unwrap(), Some(vec![10]));
             assert!(db.get(&k2).await.unwrap().is_none());
 
-            let db = Box::pin(assert_oracle_round_trip(db, context, "rewind")).await;
+            let db = assert_oracle_round_trip(db, context, "rewind").await;
             db.destroy().await.unwrap();
         });
     }
@@ -2842,7 +2843,7 @@ mod bitmap_tests {
             assert_eq!(db.root(), expected_root);
             assert_eq!(db.get(&anchor).await.unwrap(), Some(vec![3]));
 
-            let db = Box::pin(assert_oracle_round_trip(db, context, "tail")).await;
+            let db = assert_oracle_round_trip(db, context, "tail").await;
             db.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2712,7 +2712,7 @@ mod bitmap_tests {
             // Most recent commit is current -> bit=1.
             assert!(db.bitmap.get_bit(*commit_locs[2]));
 
-            let db = assert_oracle_round_trip(db, context, "commit_floor").await;
+            let db = Box::pin(assert_oracle_round_trip(db, context, "commit_floor")).await;
             db.destroy().await.unwrap();
         });
     }
@@ -2765,7 +2765,7 @@ mod bitmap_tests {
             assert_eq!(db.get(&k1).await.unwrap(), Some(vec![10]));
             assert!(db.get(&k2).await.unwrap().is_none());
 
-            let db = assert_oracle_round_trip(db, context, "rewind").await;
+            let db = Box::pin(assert_oracle_round_trip(db, context, "rewind")).await;
             db.destroy().await.unwrap();
         });
     }
@@ -2842,7 +2842,7 @@ mod bitmap_tests {
             assert_eq!(db.root(), expected_root);
             assert_eq!(db.get(&anchor).await.unwrap(), Some(vec![3]));
 
-            let db = assert_oracle_round_trip(db, context, "tail").await;
+            let db = Box::pin(assert_oracle_round_trip(db, context, "tail")).await;
             db.destroy().await.unwrap();
         });
     }


### PR DESCRIPTION
## Summary

This PR lets buffered writers use non-blocking durability without weakening sync ordering.

`Blob::start_sync` starts durability work and returns a handle for the result. Buffered writers now expose the same shape:

```rust
let handle = writer.start_sync().await;
handle.await?;
```

`start_sync().await` submits the work. `handle.await?` proves it finished durably.

## Sync State

Writers track durability with three states:

- `Clean`: known blob state is durable.
- `Dirty`: blob state needs a sync.
- `Pending`: a sync is in flight.

`Pending` stores one shared completion. Repeated `start_sync` calls while a sync is in flight return handles for the same sync.

Runtime errors are cloneable so shared completions can return the same result to multiple waiters. I/O errors now live behind `Arc`.

## Ordering

Blob mutations must not overtake an earlier sync.

Before a writer mutates the underlying blob, it waits for any pending sync. This covers writes, range-sync writes, resizes, flushes, sealing, and blocking sync.

In-memory buffering may continue while a sync is pending. Those bytes are newer work, not covered by the old handle, and need a later durability operation.

If a pending sync fails, the writer does not claim durability. The state becomes dirty again.

Range sync remains an optimization, not a shortcut. It is used only when there are no earlier dirty mutations.

## Guarantees

After `writer.sync().await?`, all writer-visible mutations before the call are durable.

After `let handle = writer.start_sync().await; handle.await?`, all writer-visible mutations flushed by that `start_sync` call are durable.

Bytes written after `start_sync` returns are not covered by that handle.
