### PR TITLE
[ci] Temporarily disable performance workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,10 +1,7 @@
 name: Performance
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 permissions:
   actions: read


### PR DESCRIPTION
## Overview

Temporarily disables the performance check workflow to reduce maintainer burden. At the moment, it uses `criterion` wall-clock measurements which vary largely between different runners depending on noise, reporting false positive performance regressions most of the time. #3956 takes a step in a better direction using [`gungraun`](https://gungraun.github.io/), which records stable measurements.