### PR TITLE
[runtime] Implement `start_sync` for `buffer::Write`

### DIFF
--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -43,6 +43,15 @@ enum SyncState {
 }
 
 impl SyncState {
+    /// Mark a new unsynced mutation.
+    fn mark_dirty(&mut self) {
+        assert!(
+            !matches!(self, Self::Pending(_)),
+            "pending sync must be joined before marking dirty"
+        );
+        *self = Self::Dirty;
+    }
+
     /// Wait for an in-flight sync before reusing or mutating the blob.
     async fn wait_for_pending(&mut self) -> Result<(), crate::Error> {
         let Self::Pending(pending) = self else {
@@ -70,7 +79,7 @@ impl SyncState {
     ) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
         blob.write_at(offset, bufs).await?;
-        *self = Self::Dirty;
+        self.mark_dirty();
         Ok(())
     }
 
@@ -92,7 +101,7 @@ impl SyncState {
             }
             Self::Clean => {
                 // If this fails, a later sync must still cover the attempted write.
-                *self = Self::Dirty;
+                self.mark_dirty();
                 blob.write_at_sync(offset, bufs).await?;
                 *self = Self::Clean;
                 Ok(())
@@ -105,7 +114,7 @@ impl SyncState {
     async fn resize(&mut self, blob: &impl crate::Blob, len: u64) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
         blob.resize(len).await?;
-        *self = Self::Dirty;
+        self.mark_dirty();
         Ok(())
     }
 

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -1530,6 +1530,7 @@ mod tests {
         });
     }
 
+    // Verifies start_sync flushes current bytes, completes durability, and marks the writer clean.
     #[test_traced]
     fn test_write_start_sync_persists_and_marks_clean() {
         let executor = deterministic::Runner::default();
@@ -1537,10 +1538,12 @@ mod tests {
             let blob = SyncTrackingBlob::new();
             let mut writer = Write::from_pooler(&context, blob.clone(), 0, NZUsize!(8));
 
+            // Start a sync for buffered bytes and wait for the returned handle.
             writer.write_at(0, b"abc").await.unwrap();
             let handle = writer.start_sync().await;
             handle.await.unwrap();
 
+            // The buffered write required a full sync because the fresh writer starts dirty.
             let (durable, writes, full_syncs, range_syncs) = blob.snapshot();
             assert_eq!(durable.as_slice(), b"abc");
             assert_eq!(writes, 1);
@@ -1566,6 +1569,7 @@ mod tests {
         });
     }
 
+    // Verifies sync waits for an outstanding start_sync instead of starting new disk work.
     #[test_traced]
     fn test_write_sync_waits_for_outstanding_start_sync() {
         let executor = deterministic::Runner::default();
@@ -1575,9 +1579,11 @@ mod tests {
                 DelayedStartSyncBlob::new(inner.clone());
             let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
 
+            // Hold the started sync open so a later sync cannot finish right away.
             let handle = writer.start_sync().await;
             started_rx.await.expect("started sync was not issued");
 
+            // The attempted sync reaches the pending handle and cannot complete yet.
             let mut sync = Box::pin(writer.sync());
             assert!(
                 sync.as_mut().now_or_never().is_none(),
@@ -1590,6 +1596,7 @@ mod tests {
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
+            // Releasing the original handle lets sync observe the completed disk sync.
             release_tx.send(Ok(())).unwrap();
             writer.sync().await.unwrap();
             handle.await.unwrap();
@@ -1599,6 +1606,7 @@ mod tests {
         });
     }
 
+    // Verifies writes made after start_sync wait before they are flushed.
     #[test_traced]
     fn test_write_sync_after_start_sync_and_small_write_waits_before_range_sync() {
         let executor = deterministic::Runner::default();
@@ -1608,14 +1616,16 @@ mod tests {
                 DelayedStartSyncBlob::new(inner.clone());
             let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
 
+            // Begin syncing the initial dirty state and keep that sync blocked.
             let handle = writer.start_sync().await;
             started_rx.await.expect("started sync was not issued");
 
+            // New bytes stay buffered while sync waits on the earlier sync.
             writer.write_at(0, b"abc").await.unwrap();
             let mut sync = Box::pin(writer.sync());
             assert!(
                 sync.as_mut().now_or_never().is_none(),
-                "sync must join the outstanding barrier before flushing the small write"
+                "sync must wait for the outstanding start_sync before flushing the small write"
             );
             blocked_rx.await.expect("sync never waited on start_sync");
             drop(sync);
@@ -1625,6 +1635,7 @@ mod tests {
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
+            // After the earlier sync completes, the buffered write can be persisted.
             release_tx.send(Ok(())).unwrap();
             writer.sync().await.unwrap();
             handle.await.unwrap();
@@ -1637,6 +1648,7 @@ mod tests {
         });
     }
 
+    // Verifies resize does not mutate the blob before an outstanding start_sync completes.
     #[test_traced]
     fn test_write_resize_waits_for_outstanding_start_sync_before_resizing() {
         let executor = deterministic::Runner::default();
@@ -1652,6 +1664,7 @@ mod tests {
             started_rx.await.expect("started sync was not issued");
             let original_size = inner.size();
 
+            // Resize reaches the pending sync wait before it can shrink the blob.
             let mut resize = Box::pin(writer.resize(3));
             assert!(
                 resize.as_mut().now_or_never().is_none(),
@@ -1665,6 +1678,7 @@ mod tests {
             );
             drop(resize);
 
+            // Releasing the sync lets the resize apply.
             release_tx.send(Ok(())).unwrap();
             writer.resize(3).await.unwrap();
             handle.await.unwrap();

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -43,15 +43,6 @@ enum SyncState {
 }
 
 impl SyncState {
-    /// Mark a new unsynced mutation.
-    fn mark_dirty(&mut self) {
-        assert!(
-            !matches!(self, Self::Pending(_)),
-            "pending sync must be joined before marking dirty"
-        );
-        *self = Self::Dirty;
-    }
-
     /// Wait for an in-flight sync before reusing or mutating the blob.
     async fn wait_for_pending(&mut self) -> Result<(), crate::Error> {
         let Self::Pending(pending) = self else {
@@ -108,6 +99,14 @@ impl SyncState {
             }
             Self::Pending(_) => unreachable!("pending sync waited above"),
         }
+    }
+
+    /// Resize the blob and require a later sync.
+    async fn resize(&mut self, blob: &impl crate::Blob, len: u64) -> Result<(), crate::Error> {
+        self.wait_for_pending().await?;
+        blob.resize(len).await?;
+        *self = Self::Dirty;
+        Ok(())
     }
 
     /// Make all pending mutations durable before returning.
@@ -1645,6 +1644,50 @@ mod tests {
             assert_eq!(writes, 1);
             assert_eq!(full_syncs, 1);
             assert_eq!(range_syncs, 1);
+        });
+    }
+
+    // Verifies overlapping writes wait before flushing buffered bytes while start_sync is pending.
+    #[test_traced]
+    fn test_write_at_overlap_flush_waits_for_outstanding_start_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            inner.write_at(0, b"xxx").await.unwrap();
+
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, inner.size(), NZUsize!(8));
+
+            let handle = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+
+            // This write stays buffered at the tip while the earlier sync is pending.
+            writer.write_at(3, b"abc").await.unwrap();
+
+            // An overlapping write would flush the tip, so it must stop at the pending sync first.
+            let mut write = Box::pin(writer.write_at(2, b"ZZ"));
+            assert!(
+                write.as_mut().now_or_never().is_none(),
+                "overlapping write must wait for the outstanding start_sync before flushing"
+            );
+            blocked_rx.await.expect("write never waited on start_sync");
+            drop(write);
+
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // Dropping the parked write leaves the buffered tip available for the retry.
+            release_tx.send(Ok(())).unwrap();
+            writer.write_at(2, b"ZZ").await.unwrap();
+            handle.await.unwrap();
+
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 3);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
         });
     }
 

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -1589,7 +1589,6 @@ mod tests {
                 "sync must wait for the outstanding start_sync handle"
             );
             blocked_rx.await.expect("sync never waited on start_sync");
-            drop(sync);
 
             let (_, _, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(full_syncs, 0);
@@ -1597,7 +1596,7 @@ mod tests {
 
             // Releasing the original handle lets sync observe the completed disk sync.
             release_tx.send(Ok(())).unwrap();
-            writer.sync().await.unwrap();
+            sync.await.unwrap();
             handle.await.unwrap();
             let (_, _, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(full_syncs, 1);
@@ -1619,7 +1618,7 @@ mod tests {
             let handle = writer.start_sync().await;
             started_rx.await.expect("started sync was not issued");
 
-            // New bytes stay buffered while sync waits on the earlier sync.
+            // The tip must not reach the blob while the earlier sync is pending.
             writer.write_at(0, b"abc").await.unwrap();
             let mut sync = Box::pin(writer.sync());
             assert!(
@@ -1627,7 +1626,6 @@ mod tests {
                 "sync must wait for the outstanding start_sync before flushing the small write"
             );
             blocked_rx.await.expect("sync never waited on start_sync");
-            drop(sync);
 
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(writes, 0);
@@ -1636,7 +1634,7 @@ mod tests {
 
             // After the earlier sync completes, the buffered write can be persisted.
             release_tx.send(Ok(())).unwrap();
-            writer.sync().await.unwrap();
+            sync.await.unwrap();
             handle.await.unwrap();
 
             let (durable, writes, full_syncs, range_syncs) = inner.snapshot();
@@ -1662,26 +1660,25 @@ mod tests {
             let handle = writer.start_sync().await;
             started_rx.await.expect("started sync was not issued");
 
-            // This write stays buffered at the tip while the earlier sync is pending.
+            // This append is local while the earlier sync is pending.
             writer.write_at(3, b"abc").await.unwrap();
 
-            // An overlapping write would flush the tip, so it must stop at the pending sync first.
+            // The drained tip must not reach the blob while the earlier sync is pending.
             let mut write = Box::pin(writer.write_at(2, b"ZZ"));
             assert!(
                 write.as_mut().now_or_never().is_none(),
                 "overlapping write must wait for the outstanding start_sync before flushing"
             );
             blocked_rx.await.expect("write never waited on start_sync");
-            drop(write);
 
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(writes, 1);
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
-            // Dropping the parked write leaves the buffered tip available for the retry.
+            // Releasing the sync lets the parked write reach the blob.
             release_tx.send(Ok(())).unwrap();
-            writer.write_at(2, b"ZZ").await.unwrap();
+            write.await.unwrap();
             handle.await.unwrap();
 
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
@@ -1707,7 +1704,7 @@ mod tests {
             started_rx.await.expect("started sync was not issued");
             let original_size = inner.size();
 
-            // Resize reaches the pending sync wait before it can shrink the blob.
+            // Resize must not reach the blob while the earlier sync is pending.
             let mut resize = Box::pin(writer.resize(3));
             assert!(
                 resize.as_mut().now_or_never().is_none(),
@@ -1719,11 +1716,10 @@ mod tests {
                 original_size,
                 "resize must not mutate the blob before the pending sync finishes"
             );
-            drop(resize);
 
             // Releasing the sync lets the resize apply.
             release_tx.send(Ok(())).unwrap();
-            writer.resize(3).await.unwrap();
+            resize.await.unwrap();
             handle.await.unwrap();
             assert_eq!(writer.size(), 3);
             assert_eq!(inner.size(), 3);

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -145,7 +145,7 @@ mod tests {
         Storage,
     };
     use commonware_macros::test_traced;
-    use commonware_utils::{sync::Mutex, NZUsize};
+    use commonware_utils::{channel::oneshot, sync::Mutex, NZUsize};
     use std::sync::Arc;
 
     #[derive(Default)]
@@ -272,6 +272,107 @@ mod tests {
 
         async fn start_sync(&self) -> Handle<()> {
             Handle::ready(self.sync().await)
+        }
+    }
+
+    type StartedSyncSender = Arc<Mutex<Option<oneshot::Sender<()>>>>;
+    type BlockedSyncSender = Arc<Mutex<Option<oneshot::Sender<()>>>>;
+    type ReleaseSyncReceiver = Arc<Mutex<Option<oneshot::Receiver<Result<(), Error>>>>>;
+
+    /// Blob wrapper that lets tests hold one started sync open until explicitly released.
+    #[derive(Clone)]
+    pub struct DelayedStartSyncBlob<B> {
+        inner: B,
+        /// Signals when `start_sync` has been issued.
+        started: StartedSyncSender,
+        /// Signals when the returned sync handle begins waiting on release.
+        blocked: BlockedSyncSender,
+        /// Releases the started sync with success or failure.
+        release: ReleaseSyncReceiver,
+    }
+
+    impl<B: crate::Blob> DelayedStartSyncBlob<B> {
+        #[allow(clippy::type_complexity)]
+        pub fn new(
+            inner: B,
+        ) -> (
+            Self,
+            oneshot::Receiver<()>,
+            oneshot::Receiver<()>,
+            oneshot::Sender<Result<(), Error>>,
+        ) {
+            let (started_tx, started_rx) = oneshot::channel();
+            let (blocked_tx, blocked_rx) = oneshot::channel();
+            let (release_tx, release_rx) = oneshot::channel();
+            (
+                Self {
+                    inner,
+                    started: Arc::new(Mutex::new(Some(started_tx))),
+                    blocked: Arc::new(Mutex::new(Some(blocked_tx))),
+                    release: Arc::new(Mutex::new(Some(release_rx))),
+                },
+                started_rx,
+                blocked_rx,
+                release_tx,
+            )
+        }
+    }
+
+    impl<B: crate::Blob> crate::Blob for DelayedStartSyncBlob<B> {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            buf: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, buf).await
+        }
+
+        async fn write_at(&self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
+            self.inner.write_at(offset, bufs).await
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            self.inner.write_at_sync(offset, bufs).await
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            self.inner.sync().await
+        }
+
+        async fn start_sync(&self) -> Handle<()> {
+            let release = self.release.lock().take();
+            let blocked = self.blocked.lock().take();
+            if let Some(started) = self.started.lock().take() {
+                let _ = started.send(());
+            }
+
+            let inner = self.inner.clone();
+            Handle::from_future(async move {
+                if let Some(blocked) = blocked {
+                    let _ = blocked.send(());
+                }
+                let Some(release) = release else {
+                    return inner.sync().await;
+                };
+                match release.await {
+                    Ok(Ok(())) => inner.sync().await,
+                    Ok(Err(err)) => Err(err),
+                    Err(_) => Err(Error::Closed),
+                }
+            })
         }
     }
 
@@ -1426,6 +1527,149 @@ mod tests {
             let mut reader = Read::from_pooler(&context, blob_check, size_check, NZUsize!(10));
             let read = reader.read(10).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), b"01234XXXXX");
+        });
+    }
+
+    #[test_traced]
+    fn test_write_start_sync_persists_and_marks_clean() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let blob = SyncTrackingBlob::new();
+            let mut writer = Write::from_pooler(&context, blob.clone(), 0, NZUsize!(8));
+
+            writer.write_at(0, b"abc").await.unwrap();
+            let handle = writer.start_sync().await;
+            handle.await.unwrap();
+
+            let (durable, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abc");
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
+
+            // The started sync marked the writer clean, so the next buffered write can use a
+            // range-scoped sync.
+            writer.write_at(3, b"d").await.unwrap();
+            writer.sync().await.unwrap();
+            let (durable, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcd");
+            assert_eq!(writes, 2);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 1);
+
+            // Nothing left to sync.
+            let handle = writer.start_sync().await;
+            handle.await.unwrap();
+            let (_, _, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 1);
+        });
+    }
+
+    #[test_traced]
+    fn test_write_sync_waits_for_outstanding_start_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
+
+            let handle = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+
+            let mut sync = Box::pin(writer.sync());
+            assert!(
+                sync.as_mut().now_or_never().is_none(),
+                "sync must wait for the outstanding start_sync handle"
+            );
+            blocked_rx.await.expect("sync never waited on start_sync");
+            drop(sync);
+
+            let (_, _, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            release_tx.send(Ok(())).unwrap();
+            writer.sync().await.unwrap();
+            handle.await.unwrap();
+            let (_, _, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
+        });
+    }
+
+    #[test_traced]
+    fn test_write_sync_after_start_sync_and_small_write_waits_before_range_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
+
+            let handle = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+
+            writer.write_at(0, b"abc").await.unwrap();
+            let mut sync = Box::pin(writer.sync());
+            assert!(
+                sync.as_mut().now_or_never().is_none(),
+                "sync must join the outstanding barrier before flushing the small write"
+            );
+            blocked_rx.await.expect("sync never waited on start_sync");
+            drop(sync);
+
+            let (_, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            release_tx.send(Ok(())).unwrap();
+            writer.sync().await.unwrap();
+            handle.await.unwrap();
+
+            let (durable, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(durable.as_slice(), b"abc");
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 1);
+        });
+    }
+
+    #[test_traced]
+    fn test_write_resize_waits_for_outstanding_start_sync_before_resizing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            inner.write_at(0, b"abcdef").await.unwrap();
+
+            let (blob, started_rx, blocked_rx, release_tx) =
+                DelayedStartSyncBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, inner.size(), NZUsize!(8));
+
+            let handle = writer.start_sync().await;
+            started_rx.await.expect("started sync was not issued");
+            let original_size = inner.size();
+
+            let mut resize = Box::pin(writer.resize(3));
+            assert!(
+                resize.as_mut().now_or_never().is_none(),
+                "resize must wait for the outstanding start_sync handle"
+            );
+            blocked_rx.await.expect("resize never waited on start_sync");
+            assert_eq!(
+                inner.size(),
+                original_size,
+                "resize must not mutate the blob before the pending sync finishes"
+            );
+            drop(resize);
+
+            release_tx.send(Ok(())).unwrap();
+            writer.resize(3).await.unwrap();
+            handle.await.unwrap();
+            assert_eq!(writer.size(), 3);
+            assert_eq!(inner.size(), 3);
         });
     }
 

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1125,7 +1125,10 @@ impl<B: Blob> Writer<B> {
 mod tests {
     use super::*;
     use crate::{
-        buffer::{paged::CHECKSUM_SLOT_LEN_SIZE, tests::SyncTrackingBlob},
+        buffer::{
+            paged::CHECKSUM_SLOT_LEN_SIZE,
+            tests::{DelayedStartSyncBlob, SyncTrackingBlob},
+        },
         deterministic,
         telemetry::metrics::Registry,
         Buf, BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Spawner as _,
@@ -2161,104 +2164,6 @@ mod tests {
             let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data);
         });
-    }
-
-    type StartedSyncSender = Arc<Mutex<Option<oneshot::Sender<()>>>>;
-    type BlockedSyncSender = Arc<Mutex<Option<oneshot::Sender<()>>>>;
-    type ReleaseSyncReceiver = Arc<Mutex<Option<oneshot::Receiver<Result<(), Error>>>>>;
-
-    /// Blob wrapper that lets tests hold one started sync open until explicitly released.
-    #[derive(Clone)]
-    struct DelayedStartSyncBlob<B: Blob> {
-        inner: B,
-        started: StartedSyncSender,
-        blocked: BlockedSyncSender,
-        release: ReleaseSyncReceiver,
-    }
-
-    impl<B: Blob> DelayedStartSyncBlob<B> {
-        #[allow(clippy::type_complexity)]
-        fn new(
-            inner: B,
-        ) -> (
-            Self,
-            oneshot::Receiver<()>,
-            oneshot::Receiver<()>,
-            oneshot::Sender<Result<(), Error>>,
-        ) {
-            let (started_tx, started_rx) = oneshot::channel();
-            let (blocked_tx, blocked_rx) = oneshot::channel();
-            let (release_tx, release_rx) = oneshot::channel();
-            (
-                Self {
-                    inner,
-                    started: Arc::new(Mutex::new(Some(started_tx))),
-                    blocked: Arc::new(Mutex::new(Some(blocked_tx))),
-                    release: Arc::new(Mutex::new(Some(release_rx))),
-                },
-                started_rx,
-                blocked_rx,
-                release_tx,
-            )
-        }
-    }
-
-    impl<B: Blob> crate::Blob for DelayedStartSyncBlob<B> {
-        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
-            self.inner.read_at(offset, len).await
-        }
-
-        async fn read_at_buf(
-            &self,
-            offset: u64,
-            len: usize,
-            buf: impl Into<IoBufsMut> + Send,
-        ) -> Result<IoBufsMut, Error> {
-            self.inner.read_at_buf(offset, len, buf).await
-        }
-
-        async fn write_at(&self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
-            self.inner.write_at(offset, bufs).await
-        }
-
-        async fn write_at_sync(
-            &self,
-            offset: u64,
-            bufs: impl Into<IoBufs> + Send,
-        ) -> Result<(), Error> {
-            self.inner.write_at_sync(offset, bufs).await
-        }
-
-        async fn resize(&self, len: u64) -> Result<(), Error> {
-            self.inner.resize(len).await
-        }
-
-        async fn sync(&self) -> Result<(), Error> {
-            self.inner.sync().await
-        }
-
-        async fn start_sync(&self) -> Handle<()> {
-            let release = self.release.lock().take();
-            let blocked = self.blocked.lock().take();
-            if let Some(started) = self.started.lock().take() {
-                let _ = started.send(());
-            }
-
-            let inner = self.inner.clone();
-            Handle::from_future(async move {
-                if let Some(blocked) = blocked {
-                    let _ = blocked.send(());
-                }
-                let Some(release) = release else {
-                    return inner.sync().await;
-                };
-                match release.await {
-                    Ok(Ok(())) => inner.sync().await,
-                    Ok(Err(err)) => Err(err),
-                    Err(_) => Err(Error::Closed),
-                }
-            })
-        }
     }
 
     #[test_traced("DEBUG")]

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1012,8 +1012,9 @@ impl<B: Blob> Writer<B> {
         // A logical shrink can leave the physical page count unchanged. Only real physical
         // resizes need to create a pending sync.
         if new_physical_size != current_physical_size {
-            self.blob.resize(new_physical_size).await?;
-            self.sync_state.mark_dirty();
+            self.sync_state
+                .resize(&self.blob, new_physical_size)
+                .await?;
         }
 
         // Evict cached pages at or beyond the new full-page boundary. The page at

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -225,11 +225,7 @@ impl<B: Blob> Write<B> {
 
     /// Flush buffered bytes and durably sync mutations tracked by this writer.
     pub async fn sync(&mut self) -> Result<(), Error> {
-        if !self.buffer.is_empty() {
-            let (buf, offset) = self
-                .buffer
-                .take()
-                .expect("take must succeed when sync observes buffered data");
+        if let Some((buf, offset)) = self.buffer.take() {
             return self.write_blob_sync(offset, buf).await;
         }
 
@@ -242,11 +238,7 @@ impl<B: Blob> Write<B> {
     /// for the state flushed by this call. Later calls to [`Self::sync`] and writer methods that
     /// mutate the blob wait before issuing blob operations.
     pub async fn start_sync(&mut self) -> Handle<()> {
-        if !self.buffer.is_empty() {
-            let (buf, offset) = self
-                .buffer
-                .take()
-                .expect("take must succeed when start_sync observes buffered data");
+        if let Some((buf, offset)) = self.buffer.take() {
             if let Err(err) = self.sync_state.write_at(&self.blob, offset, buf).await {
                 return Handle::ready(Err(err));
             }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -221,9 +221,7 @@ impl<B: Blob> Write<B> {
             self.write_blob(offset, buf).await?;
         }
 
-        // Resize the underlying blob.
-        self.blob.resize(len).await?;
-        self.sync_state.mark_dirty();
+        self.sync_state.resize(&self.blob, len).await?;
 
         Ok(())
     }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -176,10 +176,6 @@ impl<B: Blob> Write<B> {
             // if merge is possible after.
             let chunk_end = current_offset + chunk_len as u64;
             if self.buffer.offset < chunk_end {
-                if !self.buffer.is_empty() {
-                    // Flushing the tip mutates the blob and must not overtake a started sync.
-                    self.sync_state.wait_for_pending().await?;
-                }
                 if let Some((old_buf, old_offset)) = self.buffer.take() {
                     self.sync_state
                         .write_at(&self.blob, old_offset, old_buf)
@@ -215,9 +211,6 @@ impl<B: Blob> Write<B> {
     /// If buffered data exists and the resize extends beyond current size, buffered data is flushed
     /// before resizing the underlying blob.
     pub async fn resize(&mut self, len: u64) -> Result<(), Error> {
-        // Resizing mutates the blob and must not overtake a started sync.
-        self.sync_state.wait_for_pending().await?;
-
         // Flush buffered data to the underlying blob.
         //
         // This can only happen if the new size is greater than the current size.
@@ -233,8 +226,6 @@ impl<B: Blob> Write<B> {
     /// Flush buffered bytes and durably sync mutations tracked by this writer.
     pub async fn sync(&mut self) -> Result<(), Error> {
         if !self.buffer.is_empty() {
-            // Draining the tip writes new bytes and must wait for any started sync.
-            self.sync_state.wait_for_pending().await?;
             let (buf, offset) = self
                 .buffer
                 .take()
@@ -249,13 +240,9 @@ impl<B: Blob> Write<B> {
     ///
     /// Awaiting the returned [`Handle`] waits for the same durability guarantee as [`Self::sync`]
     /// for the state flushed by this call. Later calls to [`Self::sync`] and writer methods that
-    /// mutate the blob first wait for any outstanding start_sync handles.
+    /// mutate the blob wait before issuing blob operations.
     pub async fn start_sync(&mut self) -> Handle<()> {
         if !self.buffer.is_empty() {
-            // New buffered bytes must not be flushed into the prior started sync.
-            if let Err(err) = self.sync_state.wait_for_pending().await {
-                return Handle::ready(Err(err));
-            }
             let (buf, offset) = self
                 .buffer
                 .take()

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -1,6 +1,6 @@
 use crate::{
     buffer::{tip::Buffer, SyncState},
-    Blob, Buf, BufferPool, BufferPooler, Error, IoBufs,
+    Blob, Buf, BufferPool, BufferPooler, Error, Handle, IoBufs,
 };
 use std::num::NonZeroUsize;
 
@@ -176,6 +176,10 @@ impl<B: Blob> Write<B> {
             // if merge is possible after.
             let chunk_end = current_offset + chunk_len as u64;
             if self.buffer.offset < chunk_end {
+                if !self.buffer.is_empty() {
+                    // Flushing the tip mutates the blob and must not overtake a started sync.
+                    self.sync_state.wait_for_pending().await?;
+                }
                 if let Some((old_buf, old_offset)) = self.buffer.take() {
                     self.write_blob(old_offset, old_buf).await?;
                     if self.buffer.merge(chunk, current_offset) {
@@ -207,6 +211,9 @@ impl<B: Blob> Write<B> {
     /// If buffered data exists and the resize extends beyond current size, buffered data is flushed
     /// before resizing the underlying blob.
     pub async fn resize(&mut self, len: u64) -> Result<(), Error> {
+        // Resizing mutates the blob and must not overtake a started sync.
+        self.sync_state.wait_for_pending().await?;
+
         // Flush buffered data to the underlying blob.
         //
         // This can only happen if the new size is greater than the current size.
@@ -223,11 +230,40 @@ impl<B: Blob> Write<B> {
 
     /// Flush buffered bytes and durably sync mutations tracked by this writer.
     pub async fn sync(&mut self) -> Result<(), Error> {
-        if let Some((buf, offset)) = self.buffer.take() {
+        if !self.buffer.is_empty() {
+            // Draining the tip writes new bytes and must wait for any started sync.
+            self.sync_state.wait_for_pending().await?;
+            let (buf, offset) = self
+                .buffer
+                .take()
+                .expect("take must succeed when sync observes buffered data");
             return self.write_blob_sync(offset, buf).await;
         }
 
         self.sync_blob().await
+    }
+
+    /// Flush buffered bytes and begin durably syncing mutations tracked by this writer.
+    ///
+    /// Awaiting the returned [`Handle`] waits for the same durability guarantee as [`Self::sync`]
+    /// for the state flushed by this call. Later calls to [`Self::sync`] and writer methods that
+    /// mutate the blob first wait for any outstanding start_sync handles.
+    pub async fn start_sync(&mut self) -> Handle<()> {
+        if !self.buffer.is_empty() {
+            // New buffered bytes must not be flushed into the prior started sync.
+            if let Err(err) = self.sync_state.wait_for_pending().await {
+                return Handle::ready(Err(err));
+            }
+            let (buf, offset) = self
+                .buffer
+                .take()
+                .expect("take must succeed when start_sync observes buffered data");
+            if let Err(err) = self.write_blob(offset, buf).await {
+                return Handle::ready(Err(err));
+            }
+        }
+
+        self.sync_state.start_sync(&self.blob).await
     }
 
     /// Write bytes to the underlying blob and mark them as needing sync.

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -181,7 +181,9 @@ impl<B: Blob> Write<B> {
                     self.sync_state.wait_for_pending().await?;
                 }
                 if let Some((old_buf, old_offset)) = self.buffer.take() {
-                    self.write_blob(old_offset, old_buf).await?;
+                    self.sync_state
+                        .write_at(&self.blob, old_offset, old_buf)
+                        .await?;
                     if self.buffer.merge(chunk, current_offset) {
                         bufs.advance(chunk_len);
                         current_offset += chunk_len as u64;
@@ -195,7 +197,9 @@ impl<B: Blob> Write<B> {
             // once when the buffer is flushed above, then again when we write the chunk
             // below. Removing this inefficiency may not be worth the additional complexity.
             let direct = bufs.split_to(chunk_len);
-            self.write_blob(current_offset, direct).await?;
+            self.sync_state
+                .write_at(&self.blob, current_offset, direct)
+                .await?;
             current_offset += chunk_len as u64;
 
             // Maintain the "buffer at tip" invariant by advancing offset to the end of this
@@ -218,7 +222,7 @@ impl<B: Blob> Write<B> {
         //
         // This can only happen if the new size is greater than the current size.
         if let Some((buf, offset)) = self.buffer.resize(len) {
-            self.write_blob(offset, buf).await?;
+            self.sync_state.write_at(&self.blob, offset, buf).await?;
         }
 
         self.sync_state.resize(&self.blob, len).await?;
@@ -256,21 +260,12 @@ impl<B: Blob> Write<B> {
                 .buffer
                 .take()
                 .expect("take must succeed when start_sync observes buffered data");
-            if let Err(err) = self.write_blob(offset, buf).await {
+            if let Err(err) = self.sync_state.write_at(&self.blob, offset, buf).await {
                 return Handle::ready(Err(err));
             }
         }
 
         self.sync_state.start_sync(&self.blob).await
-    }
-
-    /// Write bytes to the underlying blob and mark them as needing sync.
-    async fn write_blob(
-        &mut self,
-        offset: u64,
-        bufs: impl Into<IoBufs> + Send,
-    ) -> Result<(), Error> {
-        self.sync_state.write_at(&self.blob, offset, bufs).await
     }
 
     /// Write bytes to the underlying blob and make them durable.


### PR DESCRIPTION
- Add `start_sync` to `commonware_runtime::buffer::Write`, matching the `paged::Writer` flow: flush buffered bytes with plain writes, then return a `Handle` from `SyncState::start_sync` so durability can complete asynchronously.
- Preserve ordering around pending sync barriers. Later operations that mutate the blob wait for any outstanding `start_sync` before issuing blob writes, resizes, or syncs, so newer bytes are not folded into an older durability barrier.
- Keep `sync` semantics unchanged for callers: buffer-only writes can still use `write_at_sync` when clean, while prior plain writes and resizes still require a full sync barrier.
- Share the delayed `start_sync` test blob with `paged::Writer` tests and add raw `Write` coverage for successful start, pending-sync ordering, writes after start, and resize ordering.