### PR TITLE
[storage] QMDB: drop hasher params from proof/verify API; parallelize recovery replay

### DIFF
--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -7,7 +7,7 @@
 //! documentation for more details.
 //!
 //! For sync, the engine targets the **ops root** (not the canonical root). The operations and proof
-//! format are identical to `any`; direct proof verifiers should use `qmdb::hasher`. The bitmap is
+//! format are identical to `any`; verify proofs directly with `qmdb::verify_proof`. The bitmap is
 //! reconstructed deterministically from the operations after sync completes. See the
 //! [Root structure](commonware_storage::qmdb::current) module documentation for details.
 //!

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1153,10 +1153,8 @@ mod tests {
             assert_eq!(guard.root(), expected_root);
             assert_eq!(guard.get(&key).await.unwrap(), Some(value));
 
-            let hasher = commonware_storage::qmdb::hasher::<Sha256>();
-            let proof = guard.exclusion_proof(&hasher, &missing).await.unwrap();
+            let proof = guard.exclusion_proof(&missing).await.unwrap();
             assert!(OrderedFixedDb::verify_exclusion_proof(
-                &hasher,
                 &missing,
                 &proof,
                 &guard.root(),
@@ -1197,10 +1195,8 @@ mod tests {
             assert_eq!(guard.root(), expected_root);
             assert_eq!(guard.get(&key).await.unwrap(), Some(value));
 
-            let hasher = commonware_storage::qmdb::hasher::<Sha256>();
-            let proof = guard.exclusion_proof(&hasher, &missing).await.unwrap();
+            let proof = guard.exclusion_proof(&missing).await.unwrap();
             assert!(OrderedVariableDb::verify_exclusion_proof(
-                &hasher,
                 &missing,
                 &proof,
                 &guard.root(),

--- a/glue/src/stateful/db/p2p/compact/actor.rs
+++ b/glue/src/stateful/db/p2p/compact/actor.rs
@@ -319,9 +319,7 @@ where
             return false;
         }
 
-        let hasher = qmdb::hasher::<H>();
-        qmdb::verify_proof(
-            &hasher,
+        qmdb::verify_proof::<H, _, _>(
             &state.last_commit_proof,
             Location::new(*state.leaf_count - 1),
             std::slice::from_ref(&state.last_commit_op),

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -17,10 +17,7 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable, Location},
-    qmdb::{
-        self,
-        current::{unordered::variable::Db as Current, VariableConfig},
-    },
+    qmdb::current::{unordered::variable::Db as Current, VariableConfig},
     translator::TwoCap,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU64};
@@ -303,8 +300,6 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
             .await
             .expect("recovery must succeed");
 
-            let hasher = qmdb::hasher::<Sha256>();
-
             // Verify all committed KV pairs survived the crash and are provable.
             let root = db.root();
             for (key, value) in &committed {
@@ -319,11 +314,11 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 );
 
                 let proof = db
-                    .key_value_proof(&hasher, k.clone())
+                    .key_value_proof(k.clone())
                     .await
                     .expect("proof generation should not fail for committed key");
                 assert!(
-                    Db::<F>::verify_key_value_proof(&hasher, k, v, &proof, &root),
+                    Db::<F>::verify_key_value_proof(k, v, &proof, &root),
                     "key value proof failed to verify after crash recovery"
                 );
             }
@@ -334,11 +329,11 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
             for i in floor..size {
                 let loc = Location::<F>::new(i);
                 let (proof, ops, chunks) = db
-                    .range_proof(&hasher, loc, NZU64!(4))
+                    .range_proof(loc, NZU64!(4))
                     .await
                     .expect("range proof should not fail after recovery");
                 assert!(
-                    Db::<F>::verify_range_proof(&hasher, &proof, loc, &ops, &chunks, &root),
+                    Db::<F>::verify_range_proof(&proof, loc, &ops, &chunks, &root),
                     "range proof failed to verify after crash recovery at loc {loc}"
                 );
             }

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -7,10 +7,7 @@ use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervi
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable, Location},
-    qmdb::{
-        self,
-        current::{ordered::fixed::Db as CurrentDb, FixedConfig as Config},
-    },
+    qmdb::current::{ordered::fixed::Db as CurrentDb, FixedConfig as Config},
     translator::TwoCap,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
@@ -135,7 +132,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let initial_writes = data.initial_writes;
     let operations = data.operations.clone();
     runner.start(|context| async move {
-        let hasher = qmdb::hasher::<Sha256>();
         let page_cache = CacheRef::from_pooler(
             &context,
             PAGE_SIZE,
@@ -292,13 +288,12 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     let oldest_loc = db.sync_boundary();
                     if start_loc >= oldest_loc {
                         let (proof, ops, chunks) = db
-                            .range_proof(&hasher, start_loc, *max_ops)
+                            .range_proof(start_loc, *max_ops)
                             .await
                             .expect("Range proof should not fail");
 
                         assert!(
                             Db::<F>::verify_range_proof(
-                                &hasher,
                                 &proof,
                                 start_loc,
                                 &ops,
@@ -333,7 +328,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     let root = db.root();
 
                     if let Ok((range_proof, ops, chunks)) = db
-                        .range_proof(&hasher, start_loc, *max_ops)
+                        .range_proof(start_loc, *max_ops)
                         .await {
                         // Try to verify the proof when providing bad proof digests.
                         let bad_digests = bad_digests.iter().map(|d| Digest::from(*d)).collect();
@@ -341,7 +336,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_digest_proof = range_proof.clone();
                             bad_digest_proof.proof.digests = bad_digests;
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &bad_digest_proof,
                                 start_loc,
                                 &ops,
@@ -356,7 +350,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                                 let mut bad_pending_proof = range_proof.clone();
                                 bad_pending_proof.pending_chunk_digest = bad_pending;
                                 assert!(!Db::<F>::verify_range_proof(
-                                    &hasher,
                                     &bad_pending_proof,
                                     start_loc,
                                     &ops,
@@ -371,7 +364,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_partial_proof = range_proof.clone();
                             bad_partial_proof.partial_chunk_digest = bad_partial_digest;
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &bad_partial_proof,
                                 start_loc,
                                 &ops,
@@ -390,7 +382,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         }).collect();
                         if chunks != bad_chunks {
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &range_proof,
                                 start_loc,
                                 &ops,
@@ -412,11 +403,10 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
-                    match db.key_value_proof(&hasher, k.clone()).await {
+                    match db.key_value_proof(k.clone()).await {
                         Ok(proof) => {
                             let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
                             let verification_result = Db::<F>::verify_key_value_proof(
-                                &hasher,
                                 k,
                                 value,
                                 &proof,
@@ -443,10 +433,9 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
-                    match db.exclusion_proof(&hasher, &k).await {
+                    match db.exclusion_proof(&k).await {
                         Ok(proof) => {
                             let verification_result = Db::<F>::verify_exclusion_proof(
-                                &hasher,
                                 &k,
                                 &proof,
                                 &current_root,

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -7,10 +7,7 @@ use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervi
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{full::Config as MerkleConfig, mmb, mmr, Graftable, Location},
-    qmdb::{
-        self,
-        current::{unordered::fixed::Db as CurrentDb, FixedConfig as Config},
-    },
+    qmdb::current::{unordered::fixed::Db as CurrentDb, FixedConfig as Config},
     translator::TwoCap,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
@@ -125,7 +122,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let initial_writes = data.initial_writes;
     let operations = data.operations.clone();
     runner.start(|context| async move {
-        let hasher = qmdb::hasher::<Sha256>();
         let page_cache = CacheRef::from_pooler(
             &context,
             PAGE_SIZE,
@@ -266,13 +262,12 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     let oldest_loc = db.sync_boundary();
                     if start_loc >= oldest_loc {
                         let (proof, ops, chunks) = db
-                            .range_proof(&hasher, start_loc, *max_ops)
+                            .range_proof(start_loc, *max_ops)
                             .await
                             .expect("Range proof should not fail");
 
                         assert!(
                             Db::<F>::verify_range_proof(
-                                &hasher,
                                 &proof,
                                 start_loc,
                                 &ops,
@@ -304,7 +299,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     let root = db.root();
 
                     if let Ok((range_proof, ops, chunks)) = db
-                        .range_proof(&hasher, start_loc, *max_ops)
+                        .range_proof(start_loc, *max_ops)
                         .await {
                         // Try to verify the proof when providing bad proof digests.
                         let bad_digests = bad_digests.iter().map(|d| Digest::from(*d)).collect();
@@ -312,7 +307,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_digest_proof = range_proof.clone();
                             bad_digest_proof.proof.digests = bad_digests;
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &bad_digest_proof,
                                 start_loc,
                                 &ops,
@@ -327,7 +321,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                                 let mut bad_pending_proof = range_proof.clone();
                                 bad_pending_proof.pending_chunk_digest = bad_pending;
                                 assert!(!Db::<F>::verify_range_proof(
-                                    &hasher,
                                     &bad_pending_proof,
                                     start_loc,
                                     &ops,
@@ -342,7 +335,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             let mut bad_partial_proof = range_proof.clone();
                             bad_partial_proof.partial_chunk_digest = bad_partial_digest;
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &bad_partial_proof,
                                 start_loc,
                                 &ops,
@@ -361,7 +353,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         }).collect();
                         if chunks != bad_chunks {
                             assert!(!Db::<F>::verify_range_proof(
-                                &hasher,
                                 &range_proof,
                                 start_loc,
                                 &ops,
@@ -380,11 +371,10 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
-                    match db.key_value_proof(&hasher, k.clone()).await {
+                    match db.key_value_proof(k.clone()).await {
                         Ok(proof) => {
                             let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
                             let verification_result = Db::<F>::verify_key_value_proof(
-                                &hasher,
                                 k,
                                 value,
                                 &proof,

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -8,10 +8,7 @@ use commonware_runtime::{
 };
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::{
-        self, full::Config as MerkleConfig, mmb, mmr, Bagging::BackwardFold,
-        Family as MerkleFamily, Location,
-    },
+    merkle::{full::Config as MerkleConfig, mmb, mmr, Family as MerkleFamily, Location},
     qmdb::{
         any::{unordered::variable::Db, VariableConfig as Config},
         verify_proof,
@@ -171,7 +168,6 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
 
     let test_name = test_name.to_string();
     runner.start(|context| async move {
-        let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
         let cfg = test_config(&test_name, &context);
         let mut db = Db::<F, _, Key, Vec<u8>, Sha256, TwoCap, Sequential>::init(
             context.child("storage"),
@@ -243,7 +239,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                     if start_loc >= oldest_retained_loc && start_loc < op_count {
                         if let Ok((proof, log)) = db.proof(start_loc, *max_ops).await {
                             let root = db.root();
-                            assert!(verify_proof(&hasher, &proof, start_loc, &log, &root,));
+                            assert!(verify_proof::<Sha256, _, _>(&proof, start_loc, &log, &root,));
                         }
                     }
                 }
@@ -283,7 +279,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         let root = historical_roots
                             .get(&op_count)
                             .expect("historical root missing for known commit point");
-                        assert!(verify_proof(&hasher, &proof, start_loc, &log, root));
+                        assert!(verify_proof::<Sha256, _, _>(&proof, start_loc, &log, root,));
                     }
                 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -7,7 +7,7 @@ use commonware_parallel::Sequential;
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, BufferPooler, Runner};
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::{self, mmb, mmr, Bagging::BackwardFold, Family as MerkleFamily, Location},
+    merkle::{mmb, mmr, Family as MerkleFamily, Location},
     mmr::full::Config as MerkleConfig,
     qmdb::{
         immutable::{variable::Db as Immutable, Config},
@@ -153,7 +153,6 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                     .await
                     .unwrap();
 
-            let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
             let mut keys_set: Vec<(Digest, Location<F>)> = Vec::new();
             let mut set_locations: Vec<(Digest, Location<F>)> = Vec::new();
             let mut last_commit_loc: Option<Location<F>> = None;
@@ -272,7 +271,8 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             last_commit_loc = Some(db.bounds().end - 1);
                             if let Ok((proof, ops)) = db.proof(safe_start, safe_max_ops).await {
                                 let root = db.root();
-                                let _ = verify_proof(&hasher, &proof, safe_start, &ops, &root);
+                                let _ =
+                                    verify_proof::<Sha256, _, _>(&proof, safe_start, &ops, &root);
                             }
                         }
                     }

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -8,9 +8,7 @@ use commonware_runtime::{
 };
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
-    merkle::{
-        self, full::Config as MerkleConfig, mmb, mmr, Bagging::BackwardFold, Family, Location,
-    },
+    merkle::{full::Config as MerkleConfig, mmb, mmr, Family, Location},
     qmdb::{
         keyless::variable::{Config, Db as Keyless},
         verify_proof, Error,
@@ -222,7 +220,6 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
     let runner = deterministic::Runner::default();
 
     runner.start(|context| async move {
-        let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
         let cfg = test_config(suffix, &context, strategy.clone());
         let mut db: Db<F, S> = Db::init(context.child("storage"), cfg)
             .await
@@ -426,8 +423,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                     let root = db.root();
                     if let Ok((proof, ops)) = db.proof(start_loc, NZU64!(max_ops_value)).await {
                             assert!(
-                                verify_proof(
-                                    &hasher,
+                                verify_proof::<Sha256, _, _>(
                                     &proof,
                                     start_loc,
                                     &ops,
@@ -465,8 +461,7 @@ fn fuzz_family<F: Family, S: Strategy>(input: &FuzzInput, suffix: &str, strategy
                         .historical_proof(op_count, start_loc, NZU64!(max_ops_value))
                             .await {
                             assert!(
-                                verify_proof(
-                                    &hasher,
+                                verify_proof::<Sha256, _, _>(
                                     &proof,
                                     start_loc,
                                     &ops,

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -7,7 +7,7 @@ use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervi
 use commonware_storage::{
     index::ordered::Index,
     journal::contiguous::fixed::{Config as FConfig, Journal},
-    merkle::{self, mmb, mmr, Bagging::BackwardFold, Family as MerkleFamily, Location, Proof},
+    merkle::{mmb, mmr, Family as MerkleFamily, Location, Proof},
     mmr::full::Config as MerkleConfig,
     qmdb::{
         any::{
@@ -107,7 +107,6 @@ async fn commit_pending<F: MerkleFamily>(
 }
 
 fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
-    let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
     let runner = deterministic::Runner::default();
 
     runner.start(|context| {
@@ -204,8 +203,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                                 .expect("proof should not fail");
 
                             assert!(
-                                verify_proof(
-                                    &hasher,
+                                verify_proof::<Sha256, _, _>(
                                     &proof,
                                     adjusted_start,
                                     &log,
@@ -235,8 +233,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             if let Ok(res) = db
                                 .proof(adjusted_start, *max_ops)
                                 .await {
-                                    let _ = verify_proof(
-                                        &hasher,
+                                    let _ = verify_proof::<Sha256, _, _>(
                                         &proof,
                                         adjusted_start,
                                         &res.1,

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -7,7 +7,7 @@ use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervi
 use commonware_storage::{
     index::unordered::Index,
     journal::contiguous::fixed::{Config as FConfig, Journal},
-    merkle::{self, mmb, mmr, Bagging::BackwardFold, Family as MerkleFamily, Location},
+    merkle::{mmb, mmr, Family as MerkleFamily, Location},
     mmr::full::Config as MerkleConfig,
     qmdb::{
         any::{
@@ -82,7 +82,6 @@ async fn commit_pending<F: MerkleFamily>(
 }
 
 fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
-    let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
     let runner = deterministic::Runner::default();
 
     runner.start(|context| {
@@ -179,8 +178,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             .expect("proof should not fail");
 
                         assert!(
-                            verify_proof(
-                                &hasher,
+                            verify_proof::<Sha256, _, _>(
                                 &proof,
                                 adjusted_start,
                                 &log,

--- a/storage/fuzz/fuzz_targets/verify_proof.rs
+++ b/storage/fuzz/fuzz_targets/verify_proof.rs
@@ -3,7 +3,7 @@
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::{sha256::Digest, Sha256};
 use commonware_storage::{
-    merkle::{self, mmb, mmr, Bagging::BackwardFold, Family as MerkleFamily, Location, Proof},
+    merkle::{mmb, mmr, Family as MerkleFamily, Location, Proof},
     qmdb::verify::verify_multi_proof,
 };
 use libfuzzer_sys::fuzz_target;
@@ -43,8 +43,6 @@ impl<'a, F: MerkleFamily> Arbitrary<'a> for FuzzInput<F> {
 }
 
 fn fuzz_family<F: MerkleFamily>(input: &FuzzInput<F>) {
-    let hasher = merkle::hasher::Standard::<Sha256>::new(BackwardFold);
-
     let digests: Vec<Digest> = input
         .digests
         .iter()
@@ -72,7 +70,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput<F>) {
     }
 
     let root = Digest::from(input.root);
-    let _ = verify_multi_proof(&hasher, &proof, operations.as_slice(), &root);
+    let _ = verify_multi_proof::<Sha256, _, _>(&proof, operations.as_slice(), &root);
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -423,12 +423,27 @@ where
             while merkle_leaves < journal_size {
                 let batch = {
                     let mut batch = merkle.new_batch();
+                    let first = batch.leaves();
+                    let mut items = Vec::new();
                     let mut count = 0u64;
                     while count < apply_batch_size && merkle_leaves < journal_size {
                         let op = journal.read(*merkle_leaves).await?;
-                        batch = batch.add(hasher, &op.encode());
+                        items.push(op);
                         merkle_leaves += 1;
                         count += 1;
+                    }
+
+                    // Hash the batch's leaves in parallel, then append them.
+                    let digests =
+                        batch
+                            .strategy()
+                            .map_collect_vec(items.iter().enumerate(), |(i, item)| {
+                                let pos = Position::try_from(first + i as u64)
+                                    .expect("valid leaf location");
+                                hasher.leaf_digest(pos, item.encode().as_ref())
+                            });
+                    for digest in digests {
+                        batch = batch.add_leaf_digest(digest);
                     }
                     batch
                 };

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -23,7 +23,7 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use commonware_codec::{CodecFixedShared, CodecShared, Encode, EncodeShared};
+use commonware_codec::{CodecFixedShared, CodecShared, Encode, EncodeShared, Write};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
@@ -433,15 +433,19 @@ where
                         count += 1;
                     }
 
-                    // Hash the batch's leaves in parallel, then append them.
-                    let digests =
-                        batch
-                            .strategy()
-                            .map_collect_vec(items.iter().enumerate(), |(i, item)| {
-                                let pos = Position::try_from(first + i as u64)
-                                    .expect("valid leaf location");
-                                hasher.leaf_digest(pos, item.encode().as_ref())
-                            });
+                    // Hash the batch's leaves in parallel, then append them. A per-worker scratch
+                    // buffer avoids a per-leaf allocation (mirrors `add_many`).
+                    let digests = batch.strategy().map_init_collect_vec(
+                        items.iter().enumerate(),
+                        Vec::new,
+                        |buf, (i, item)| {
+                            let pos =
+                                Position::try_from(first + i as u64).expect("valid leaf location");
+                            buf.clear();
+                            item.write(buf);
+                            hasher.leaf_digest(pos, buf.as_slice())
+                        },
+                    );
                     for digest in digests {
                         batch = batch.add_leaf_digest(digest);
                     }

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -11,11 +11,8 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
-        self, batch,
-        full::Merkle,
-        hasher::{Hasher as _, Standard as StandardHasher},
-        mem::Mem,
-        Bagging, Family, Location, Position, Proof, Readable,
+        self, batch, full::Merkle, hasher::Standard as StandardHasher, mem::Mem, Bagging, Family,
+        Location, Position, Proof, Readable,
     },
     Context,
 };
@@ -23,7 +20,7 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use commonware_codec::{CodecFixedShared, CodecShared, Encode, EncodeShared, Write};
+use commonware_codec::{CodecFixedShared, CodecShared, Encode, EncodeShared};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
@@ -130,20 +127,7 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
             "add_many expects no items added via add"
         );
 
-        let first = self.inner.leaves();
-        let hasher = &self.hasher;
-        let digests = self.inner.strategy().map_init_collect_vec(
-            items.iter().enumerate(),
-            Vec::new,
-            |buf, (i, item)| {
-                let pos = Position::try_from(first + i as u64).expect("valid leaf location");
-                buf.clear();
-                item.write(buf);
-                hasher.leaf_digest(pos, buf.as_slice())
-            },
-        );
-
-        self.inner = self.inner.add_leaf_digests(digests);
+        self.inner = self.inner.add_many(&self.hasher, &items);
         self.items = items;
         self
     }
@@ -390,8 +374,9 @@ where
 
     /// Align the Merkle structure to be consistent with the journal. Any items in the structure
     /// that are not in the journal are popped, and any items in the journal that are not in the
-    /// structure are added. Items are added in batches of size `apply_batch_size` to avoid memory
-    /// bloat.
+    /// structure are added. Items are added in batches of size `apply_batch_size` to bound peak
+    /// memory use: each batch's items are buffered in memory so their leaves can be hashed
+    /// across the strategy.
     async fn align(
         merkle: &mut Merkle<F, E, H::Digest, S>,
         journal: &C,
@@ -421,47 +406,14 @@ where
             );
 
             while merkle_leaves < journal_size {
-                let first = merkle_leaves;
-                let mut items = Vec::new();
-                let mut count = 0u64;
-                while count < apply_batch_size && merkle_leaves < journal_size {
-                    let op = journal.read(*merkle_leaves).await?;
-                    items.push(op);
+                let count = apply_batch_size.min(journal_size - *merkle_leaves);
+                let mut items = Vec::with_capacity(count as usize);
+                for _ in 0..count {
+                    items.push(journal.read(*merkle_leaves).await?);
                     merkle_leaves += 1;
-                    count += 1;
                 }
 
-                // Hash the batch's leaves across the strategy. The serial path appends in place;
-                // the parallel path hashes with a per-worker scratch buffer to avoid a per-leaf
-                // allocation (mirrors `add_many`), then appends the collected digests.
-                let strategy = merkle.strategy();
-                let batch = strategy.run(
-                    items.len(),
-                    || {
-                        let mut buf = Vec::new();
-                        let mut batch = merkle.new_batch();
-                        for item in &items {
-                            buf.clear();
-                            item.write(&mut buf);
-                            batch = batch.add(hasher, &buf);
-                        }
-                        batch
-                    },
-                    || {
-                        let digests = strategy.map_init_collect_vec(
-                            items.iter().enumerate(),
-                            Vec::new,
-                            |buf, (i, item)| {
-                                let pos = Position::try_from(first + i as u64)
-                                    .expect("valid leaf location");
-                                buf.clear();
-                                item.write(buf);
-                                hasher.leaf_digest(pos, buf.as_slice())
-                            },
-                        );
-                        merkle.new_batch().add_leaf_digests(digests)
-                    },
-                );
+                let batch = merkle.new_batch().add_many(hasher, &items);
                 let batch = merkle.with_mem(|mem| batch.merkleize(mem, hasher));
                 merkle.apply_batch(&batch)?;
             }
@@ -1227,9 +1179,9 @@ mod tests {
         journal.sync().await.unwrap();
 
         // Replay with a batch size that forces multiple batches on each side. `Sequential`
-        // always takes `run()`'s serial arm, and a `Manual`-wrapped strategy with more than one
-        // thread always takes the parallel arm (no adaptive policy), so the two replays are
-        // guaranteed to exercise both paths deterministically.
+        // hashes each batch serially, and a `Manual`-wrapped strategy runs the batch hashing
+        // across its pool without any adaptive policy, so the two replays deterministically
+        // exercise both the serial and parallel hashing paths.
         let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut serial = Merkle::<F, _, Digest, Sequential>::init(
             context.child("mmr_serial"),

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -876,7 +876,7 @@ mod tests {
     use commonware_codec::Encode;
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
-    use commonware_parallel::Sequential;
+    use commonware_parallel::{Rayon, Sequential};
     use commonware_runtime::{
         buffer::paged::CacheRef,
         deterministic::{self, Context},
@@ -923,16 +923,25 @@ mod tests {
         batch.add_many(items).merkleize(base)
     }
 
-    /// Create Merkle configuration for tests.
-    fn merkle_config(suffix: &str, pooler: &impl BufferPooler) -> MerkleConfig<Sequential> {
+    /// Create Merkle configuration for tests with the given strategy.
+    fn merkle_config_with<S: Strategy>(
+        suffix: &str,
+        pooler: &impl BufferPooler,
+        strategy: S,
+    ) -> MerkleConfig<S> {
         MerkleConfig {
             journal_partition: format!("mmr-journal-{suffix}"),
             metadata_partition: format!("mmr-metadata-{suffix}"),
             items_per_blob: NZU64!(11),
             write_buffer: NZUsize!(1024),
-            strategy: Sequential,
+            strategy,
             page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
         }
+    }
+
+    /// Create Merkle configuration for tests.
+    fn merkle_config(suffix: &str, pooler: &impl BufferPooler) -> MerkleConfig<Sequential> {
+        merkle_config_with(suffix, pooler, Sequential)
     }
 
     /// Create journal configuration for tests.
@@ -1186,6 +1195,85 @@ mod tests {
     fn test_align_when_journal_ahead_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(test_align_when_journal_ahead_inner::<mmb::Family>);
+    }
+
+    /// Verify that align()'s parallel replay produces the same Merkle state as the serial path.
+    async fn test_align_replay_parallel_matches_serial_inner<F: Family + PartialEq>(
+        context: Context,
+    ) {
+        type RayonJournal<F> = Journal<
+            F,
+            deterministic::Context,
+            ContiguousJournal<deterministic::Context, TestOp<F>>,
+            Sha256,
+            Rayon,
+        >;
+
+        // Build a journal that is ahead of both Merkle structures.
+        let mut journal = ContiguousJournal::init(
+            context.child("journal"),
+            journal_config("replay-strategies", &context),
+        )
+        .await
+        .unwrap();
+        for i in 0..20 {
+            journal
+                .append(&create_operation::<F>(i as u8))
+                .await
+                .unwrap();
+        }
+        let commit_op = TestOp::<F>::CommitFloor(None, Location::<F>::new(0));
+        journal.append(&commit_op).await.unwrap();
+        journal.sync().await.unwrap();
+
+        // Replay with a batch size that forces multiple batches. A fresh Rayon strategy runs
+        // its first batch on the parallel path (the policy seeds parallel timing before
+        // serial), so both replay paths are exercised.
+        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
+        let mut serial = Merkle::<F, _, Digest, Sequential>::init(
+            context.child("mmr_serial"),
+            &hasher,
+            merkle_config("replay-serial", &context),
+        )
+        .await
+        .unwrap();
+        TestJournal::<F>::align(&mut serial, &journal, &hasher, 7)
+            .await
+            .unwrap();
+
+        let mut parallel = Merkle::<F, _, Digest, Rayon>::init(
+            context.child("mmr_parallel"),
+            &hasher,
+            merkle_config_with(
+                "replay-parallel",
+                &context,
+                Rayon::new(NZUsize!(2)).unwrap(),
+            ),
+        )
+        .await
+        .unwrap();
+        RayonJournal::<F>::align(&mut parallel, &journal, &hasher, 7)
+            .await
+            .unwrap();
+
+        assert_eq!(serial.leaves(), Location::<F>::new(21));
+        assert_eq!(parallel.leaves(), Location::<F>::new(21));
+        assert_eq!(
+            serial.root(&hasher, 0).unwrap(),
+            parallel.root(&hasher, 0).unwrap()
+        );
+    }
+
+    #[test_traced("WARN")]
+    fn test_align_replay_parallel_matches_serial_mmr() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_align_replay_parallel_matches_serial_inner::<mmr::Family>);
+    }
+
+    #[test_traced("WARN")]
+    fn test_align_replay_parallel_matches_serial_mmb() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_align_replay_parallel_matches_serial_inner::<mmb::Family>);
     }
 
     /// Verify that align() discards uncommitted operations.

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -422,7 +422,7 @@ where
 
             while merkle_leaves < journal_size {
                 let batch = {
-                    let mut batch = merkle.new_batch();
+                    let batch = merkle.new_batch();
                     let first = batch.leaves();
                     let mut items = Vec::new();
                     let mut count = 0u64;
@@ -446,10 +446,7 @@ where
                             hasher.leaf_digest(pos, buf.as_slice())
                         },
                     );
-                    for digest in digests {
-                        batch = batch.add_leaf_digest(digest);
-                    }
-                    batch
+                    batch.add_leaf_digests(digests)
                 };
                 let batch = merkle.with_mem(|mem| batch.merkleize(mem, hasher));
                 merkle.apply_batch(&batch)?;

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -876,7 +876,7 @@ mod tests {
     use commonware_codec::Encode;
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
-    use commonware_parallel::{Rayon, Sequential};
+    use commonware_parallel::{Manual, Rayon, Sequential};
     use commonware_runtime::{
         buffer::paged::CacheRef,
         deterministic::{self, Context},
@@ -1201,12 +1201,12 @@ mod tests {
     async fn test_align_replay_parallel_matches_serial_inner<F: Family + PartialEq>(
         context: Context,
     ) {
-        type RayonJournal<F> = Journal<
+        type ParallelJournal<F> = Journal<
             F,
             deterministic::Context,
             ContiguousJournal<deterministic::Context, TestOp<F>>,
             Sha256,
-            Rayon,
+            Manual<Rayon>,
         >;
 
         // Build a journal that is ahead of both Merkle structures.
@@ -1226,9 +1226,10 @@ mod tests {
         journal.append(&commit_op).await.unwrap();
         journal.sync().await.unwrap();
 
-        // Replay with a batch size that forces multiple batches. A fresh Rayon strategy runs
-        // its first batch on the parallel path (the policy seeds parallel timing before
-        // serial), so both replay paths are exercised.
+        // Replay with a batch size that forces multiple batches on each side. `Sequential`
+        // always takes `run()`'s serial arm, and a `Manual`-wrapped strategy with more than one
+        // thread always takes the parallel arm (no adaptive policy), so the two replays are
+        // guaranteed to exercise both paths deterministically.
         let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let mut serial = Merkle::<F, _, Digest, Sequential>::init(
             context.child("mmr_serial"),
@@ -1241,18 +1242,18 @@ mod tests {
             .await
             .unwrap();
 
-        let mut parallel = Merkle::<F, _, Digest, Rayon>::init(
+        let mut parallel = Merkle::<F, _, Digest, Manual<Rayon>>::init(
             context.child("mmr_parallel"),
             &hasher,
             merkle_config_with(
                 "replay-parallel",
                 &context,
-                Rayon::new(NZUsize!(2)).unwrap(),
+                Rayon::new(NZUsize!(2)).unwrap().manual(),
             ),
         )
         .await
         .unwrap();
-        RayonJournal::<F>::align(&mut parallel, &journal, &hasher, 7)
+        ParallelJournal::<F>::align(&mut parallel, &journal, &hasher, 7)
             .await
             .unwrap();
 

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -421,33 +421,47 @@ where
             );
 
             while merkle_leaves < journal_size {
-                let batch = {
-                    let batch = merkle.new_batch();
-                    let first = batch.leaves();
-                    let mut items = Vec::new();
-                    let mut count = 0u64;
-                    while count < apply_batch_size && merkle_leaves < journal_size {
-                        let op = journal.read(*merkle_leaves).await?;
-                        items.push(op);
-                        merkle_leaves += 1;
-                        count += 1;
-                    }
+                let first = merkle_leaves;
+                let mut items = Vec::new();
+                let mut count = 0u64;
+                while count < apply_batch_size && merkle_leaves < journal_size {
+                    let op = journal.read(*merkle_leaves).await?;
+                    items.push(op);
+                    merkle_leaves += 1;
+                    count += 1;
+                }
 
-                    // Hash the batch's leaves in parallel, then append them. A per-worker scratch
-                    // buffer avoids a per-leaf allocation (mirrors `add_many`).
-                    let digests = batch.strategy().map_init_collect_vec(
-                        items.iter().enumerate(),
-                        Vec::new,
-                        |buf, (i, item)| {
-                            let pos =
-                                Position::try_from(first + i as u64).expect("valid leaf location");
+                // Hash the batch's leaves across the strategy. The serial path appends in place;
+                // the parallel path hashes with a per-worker scratch buffer to avoid a per-leaf
+                // allocation (mirrors `add_many`), then appends the collected digests.
+                let strategy = merkle.strategy();
+                let batch = strategy.run(
+                    items.len(),
+                    || {
+                        let mut buf = Vec::new();
+                        let mut batch = merkle.new_batch();
+                        for item in &items {
                             buf.clear();
-                            item.write(buf);
-                            hasher.leaf_digest(pos, buf.as_slice())
-                        },
-                    );
-                    batch.add_leaf_digests(digests)
-                };
+                            item.write(&mut buf);
+                            batch = batch.add(hasher, &buf);
+                        }
+                        batch
+                    },
+                    || {
+                        let digests = strategy.map_init_collect_vec(
+                            items.iter().enumerate(),
+                            Vec::new,
+                            |buf, (i, item)| {
+                                let pos = Position::try_from(first + i as u64)
+                                    .expect("valid leaf location");
+                                buf.clear();
+                                item.write(buf);
+                                hasher.leaf_digest(pos, buf.as_slice())
+                            },
+                        );
+                        merkle.new_batch().add_leaf_digests(digests)
+                    },
+                );
                 let batch = merkle.with_mem(|mem| batch.merkleize(mem, hasher));
                 merkle.apply_batch(&batch)?;
             }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -88,6 +88,8 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
+#[cfg(feature = "std")]
+use commonware_codec::Write;
 use commonware_cryptography::Digest;
 use commonware_parallel::{Sequential, Strategy};
 use core::ops::Range;
@@ -265,6 +267,27 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     pub fn add(self, hasher: &impl Hasher<F, Digest = D>, element: &[u8]) -> Self {
         let digest = hasher.leaf_digest(self.size(), element);
         self.add_leaf_digest(digest)
+    }
+
+    /// Encode and hash `items` across the strategy, adding their leaf digests in order.
+    #[cfg(feature = "std")]
+    pub(crate) fn add_many<Item: Write + Send + Sync>(
+        self,
+        hasher: &impl Hasher<F, Digest = D>,
+        items: &[Item],
+    ) -> Self {
+        let first = self.leaves();
+        let digests = self.strategy().map_init_collect_vec(
+            items.iter().enumerate(),
+            Vec::new,
+            |buf, (i, item)| {
+                let pos = Position::try_from(first + i as u64).expect("valid leaf location");
+                buf.clear();
+                item.write(buf);
+                hasher.leaf_digest(pos, buf.as_slice())
+            },
+        );
+        self.add_leaf_digests(digests)
     }
 
     /// Validate that `loc` refers to an in-bounds, non-pruned leaf and return its position.

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     metadata::{Config as MConfig, Metadata},
 };
-use commonware_codec::DecodeExt;
+use commonware_codec::{DecodeExt, Write};
 use commonware_cryptography::Digest;
 use commonware_parallel::Strategy;
 use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, Storage as RStorage};
@@ -60,10 +60,14 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         }
     }
 
-    /// Add a run of pre-computed leaf digests, in order.
-    pub(crate) fn add_leaf_digests(self, digests: impl IntoIterator<Item = D>) -> Self {
+    /// Encode and hash `items` across the strategy, adding their leaf digests in order.
+    pub(crate) fn add_many<Item: Write + Send + Sync>(
+        self,
+        hasher: &impl Hasher<F, Digest = D>,
+        items: &[Item],
+    ) -> Self {
         Self {
-            inner: self.inner.add_leaf_digests(digests),
+            inner: self.inner.add_many(hasher, items),
         }
     }
 

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -60,6 +60,13 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         }
     }
 
+    /// Add a run of pre-computed leaf digests, in order.
+    pub(crate) fn add_leaf_digests(self, digests: impl IntoIterator<Item = D>) -> Self {
+        Self {
+            inner: self.inner.add_leaf_digests(digests),
+        }
+    }
+
     /// The number of leaves visible through this batch.
     pub fn leaves(&self) -> Location<F> {
         self.inner.leaves()

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -188,10 +188,7 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
-        qmdb::{
-            self,
-            any::{FixedConfig, MerkleConfig, VariableConfig},
-        },
+        qmdb::any::{FixedConfig, MerkleConfig, VariableConfig},
         translator::OneCap,
     };
     use commonware_codec::{Codec, CodecShared};
@@ -752,14 +749,12 @@ pub(crate) mod test {
                 assert!(db.get(&k).await.unwrap().is_none());
             }
         }
-
-        let hasher = qmdb::hasher::<Sha256>();
         let bounds = db.bounds();
         let inactivity_floor = db.inactivity_floor_loc().await;
         for loc in *inactivity_floor..*bounds.end {
             let loc = Location::new(loc);
             let (proof, ops) = db.proof(loc, NZU64!(10)).await.unwrap();
-            assert!(verify_proof(&hasher, &proof, loc, &ops, &root));
+            assert!(verify_proof::<Sha256, _, _>(&proof, loc, &ops, &root));
         }
 
         db.destroy().await.unwrap();
@@ -843,9 +838,7 @@ pub(crate) mod test {
         assert_eq!(historical_proof.leaves, regular_proof.leaves);
         assert_eq!(historical_proof.digests, regular_proof.digests);
         assert_eq!(historical_ops, regular_ops);
-        let hasher = qmdb::hasher::<Sha256>();
-        assert!(verify_proof(
-            &hasher,
+        assert!(verify_proof::<Sha256, _, _>(
             &historical_proof,
             start_loc,
             &historical_ops,
@@ -872,8 +865,7 @@ pub(crate) mod test {
         assert_eq!(historical_proof2.leaves, original_op_count);
         assert_eq!(historical_proof2.digests, regular_proof.digests);
         assert_eq!(historical_ops2, regular_ops);
-        assert!(verify_proof(
-            &hasher,
+        assert!(verify_proof::<Sha256, _, _>(
             &historical_proof2,
             start_loc,
             &historical_ops2,
@@ -922,15 +914,12 @@ pub(crate) mod test {
         assert_eq!(proof.leaves, historical_op_count);
         assert_eq!(ops.len(), expected_ops_len);
 
-        let hasher = qmdb::hasher::<Sha256>();
-
         // Changing the proof digests should cause verification to fail
         {
             let mut tampered_proof = proof.clone();
             tampered_proof.digests[0] = Sha256::hash(b"invalid");
             let root_hash = db.root();
-            assert!(!verify_proof(
-                &hasher,
+            assert!(!verify_proof::<Sha256, _, _>(
                 &tampered_proof,
                 Location::new(1),
                 &ops,
@@ -943,8 +932,7 @@ pub(crate) mod test {
             let mut tampered_proof = proof.clone();
             tampered_proof.digests.push(Sha256::hash(b"invalid"));
             let root_hash = db.root();
-            assert!(!verify_proof(
-                &hasher,
+            assert!(!verify_proof::<Sha256, _, _>(
                 &tampered_proof,
                 Location::new(1),
                 &ops,
@@ -959,8 +947,7 @@ pub(crate) mod test {
             // Swap first two ops if we have at least 2
             if tampered_ops.len() >= 2 {
                 tampered_ops.swap(0, 1);
-                assert!(!verify_proof(
-                    &hasher,
+                assert!(!verify_proof::<Sha256, _, _>(
                     &proof,
                     Location::new(1),
                     &tampered_ops,
@@ -974,8 +961,7 @@ pub(crate) mod test {
             let root_hash = db.root();
             let mut tampered_ops = ops.clone();
             tampered_ops.push(tampered_ops[0].clone());
-            assert!(!verify_proof(
-                &hasher,
+            assert!(!verify_proof::<Sha256, _, _>(
                 &proof,
                 Location::new(1),
                 &tampered_ops,
@@ -986,8 +972,7 @@ pub(crate) mod test {
         // Changing the start location should cause verification to fail
         {
             let root_hash = db.root();
-            assert!(!verify_proof(
-                &hasher,
+            assert!(!verify_proof::<Sha256, _, _>(
                 &proof,
                 Location::new(2),
                 &ops,
@@ -998,8 +983,7 @@ pub(crate) mod test {
         // Changing the root digest should cause verification to fail
         {
             let invalid_root = Sha256::hash(b"invalid");
-            assert!(!verify_proof(
-                &hasher,
+            assert!(!verify_proof::<Sha256, _, _>(
                 &proof,
                 Location::new(1),
                 &ops,
@@ -1012,8 +996,7 @@ pub(crate) mod test {
             let mut tampered_proof = proof.clone();
             tampered_proof.leaves = Location::new(100);
             let root_hash = db.root();
-            assert!(!verify_proof(
-                &hasher,
+            assert!(!verify_proof::<Sha256, _, _>(
                 &tampered_proof,
                 Location::new(1),
                 &ops,
@@ -2626,7 +2609,7 @@ mod bitmap_tests {
         merkle::Location,
         qmdb::any::unordered::variable::test::{create_test_config, AnyTest},
     };
-    use commonware_cryptography::{Hasher, Sha256};
+    use commonware_cryptography::{Hasher as _, Sha256};
     use commonware_macros::{boxed, test_traced};
     use commonware_runtime::{
         deterministic::{self, Context},

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -949,7 +949,6 @@ pub(crate) mod test {
     fn test_ordered_any_fixed_db_historical_proof_edge_cases() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-
             let mut db = create_test_db(context.child("first")).await;
             // Apply ops in multiple batches; each apply_ops ends in a commit, so the size
             // after each batch is a commit-boundary historical size.
@@ -966,10 +965,12 @@ pub(crate) mod test {
             // Verify a single-op proof at the full commit size.
             let (proof, proof_ops) = db.proof(Location::new(1), NZU64!(1)).await.unwrap();
             assert_eq!(proof_ops.len(), 1);
-            assert!(verify_proof::<Sha256, _, _>(&proof,
+            assert!(verify_proof::<Sha256, _, _>(
+                &proof,
                 Location::new(1),
                 &proof_ops,
-                &root));
+                &root
+            ));
 
             // historical_proof at full size should match proof.
             let (hp, hp_ops) = db

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -132,7 +132,6 @@ pub(crate) mod test {
             Location as GenericLocation,
         },
         qmdb::{
-            self,
             any::{
                 ordered::{
                     test::{
@@ -147,7 +146,7 @@ pub(crate) mod test {
         },
         translator::{OneCap, TwoCap},
     };
-    use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
+    use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
     use commonware_parallel::Sequential;
@@ -591,7 +590,6 @@ pub(crate) mod test {
         // confirm that the end state of the db matches that of an identically updated hashmap.
         const ELEMENTS: u64 = 1000;
         executor.start(|context| async move {
-            let hasher = qmdb::hasher::<Sha256>();
             let mut db = open_db(context.child("first")).await;
 
             let mut map = HashMap::<Digest, Digest>::default();
@@ -672,7 +670,7 @@ pub(crate) mod test {
             for i in start_loc.as_u64()..end_loc.as_u64() {
                 let loc = Location::from(i);
                 let (proof, log) = db.proof(loc, max_ops).await.unwrap();
-                assert!(verify_proof(&hasher, &proof, loc, &log, &root));
+                assert!(verify_proof::<Sha256, _, _>(&proof, loc, &log, &root));
             }
 
             db.destroy().await.unwrap();
@@ -900,7 +898,6 @@ pub(crate) mod test {
             let mut db = create_test_db(context.child("storage")).await;
             let ops = create_test_ops(20);
             apply_ops(&mut db, ops.clone()).await;
-            let hasher = qmdb::hasher::<Sha256>();
             let root_hash = db.root();
             let original_op_count = db.bounds().end;
 
@@ -915,8 +912,7 @@ pub(crate) mod test {
             assert_eq!(historical_proof.leaves, regular_proof.leaves);
             assert_eq!(historical_proof.digests, regular_proof.digests);
             assert_eq!(historical_ops, regular_ops);
-            assert!(verify_proof(
-                &hasher,
+            assert!(verify_proof::<Sha256, _, _>(
                 &historical_proof,
                 Location::new(5),
                 &historical_ops,
@@ -938,8 +934,7 @@ pub(crate) mod test {
             assert_eq!(historical_ops.len(), 10);
             assert_eq!(historical_proof.digests, regular_proof.digests);
             assert_eq!(historical_ops, regular_ops);
-            assert!(verify_proof(
-                &hasher,
+            assert!(verify_proof::<Sha256, _, _>(
                 &historical_proof,
                 Location::new(5),
                 &historical_ops,
@@ -954,7 +949,6 @@ pub(crate) mod test {
     fn test_ordered_any_fixed_db_historical_proof_edge_cases() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = qmdb::hasher::<Sha256>();
 
             let mut db = create_test_db(context.child("first")).await;
             // Apply ops in multiple batches; each apply_ops ends in a commit, so the size
@@ -972,9 +966,7 @@ pub(crate) mod test {
             // Verify a single-op proof at the full commit size.
             let (proof, proof_ops) = db.proof(Location::new(1), NZU64!(1)).await.unwrap();
             assert_eq!(proof_ops.len(), 1);
-            assert!(verify_proof(
-                &hasher,
-                &proof,
+            assert!(verify_proof::<Sha256, _, _>(&proof,
                 Location::new(1),
                 &proof_ops,
                 &root));
@@ -1024,8 +1016,6 @@ pub(crate) mod test {
             let mut db = create_test_db(context.child("storage")).await;
             let ops = create_test_ops(100);
             apply_ops(&mut db, ops.clone()).await;
-
-            let hasher = qmdb::hasher::<Sha256>();
             let root = db.root();
 
             let start_loc = Location::new(20);
@@ -1049,8 +1039,7 @@ pub(crate) mod test {
                 assert_eq!(proof.digests, historical_proof.digests);
 
                 // Verify proof against reference root
-                assert!(verify_proof(
-                    &hasher,
+                assert!(verify_proof::<Sha256, _, _>(
                     &historical_proof,
                     start_loc,
                     &historical_ops,

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -2,7 +2,7 @@
 //! Contains implementation of [crate::qmdb::sync::Database] for all [Db] variants
 //! (ordered/unordered, fixed/variable).
 //!
-//! Callers verifying `any` sync proofs directly should use `qmdb::hasher`.
+//! Callers verifying `any` sync proofs directly should use [`crate::qmdb::verify_proof`].
 
 use crate::{
     index::Factory as IndexFactory,

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -950,7 +950,6 @@ pub(crate) mod test {
     fn test_any_fixed_db_historical_proof_edge_cases() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-
             let mut db = create_test_db(context.child("first")).await;
             // Apply ops in multiple batches; each apply_ops ends in a commit, so the size
             // after each batch is a commit-boundary historical size.
@@ -967,10 +966,12 @@ pub(crate) mod test {
             // Verify a single-op proof at the full commit size.
             let (proof, proof_ops) = db.proof(Location::new(1), NZU64!(1)).await.unwrap();
             assert_eq!(proof_ops.len(), 1);
-            assert!(verify_proof::<Sha256, _, _>(&proof,
+            assert!(verify_proof::<Sha256, _, _>(
+                &proof,
                 Location::new(1),
                 &proof_ops,
-                &root));
+                &root
+            ));
 
             // historical_proof at full size should match proof.
             let (hp, hp_ops) = db

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -125,7 +125,6 @@ pub(crate) mod test {
             Location as GenericLocation,
         },
         qmdb::{
-            self,
             any::{
                 test::fixed_db_config,
                 unordered::{fixed::Operation, Update},
@@ -134,7 +133,7 @@ pub(crate) mod test {
         },
         translator::TwoCap,
     };
-    use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
+    use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
     use commonware_parallel::Sequential;
@@ -906,9 +905,7 @@ pub(crate) mod test {
             assert_eq!(historical_proof.leaves, regular_proof.leaves);
             assert_eq!(historical_proof.digests, regular_proof.digests);
             assert_eq!(historical_ops, regular_ops);
-            let hasher = qmdb::hasher::<Sha256>();
-            assert!(verify_proof(
-                &hasher,
+            assert!(verify_proof::<Sha256, _, _>(
                 &historical_proof,
                 Location::new(6),
                 &historical_ops,
@@ -930,8 +927,7 @@ pub(crate) mod test {
             assert_eq!(historical_ops.len(), 10);
             assert_eq!(historical_proof.digests, regular_proof.digests);
             assert_eq!(historical_ops, regular_ops);
-            assert!(verify_proof(
-                &hasher,
+            assert!(verify_proof::<Sha256, _, _>(
                 &historical_proof,
                 Location::new(6),
                 &historical_ops,
@@ -954,7 +950,6 @@ pub(crate) mod test {
     fn test_any_fixed_db_historical_proof_edge_cases() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = qmdb::hasher::<Sha256>();
 
             let mut db = create_test_db(context.child("first")).await;
             // Apply ops in multiple batches; each apply_ops ends in a commit, so the size
@@ -972,9 +967,7 @@ pub(crate) mod test {
             // Verify a single-op proof at the full commit size.
             let (proof, proof_ops) = db.proof(Location::new(1), NZU64!(1)).await.unwrap();
             assert_eq!(proof_ops.len(), 1);
-            assert!(verify_proof(
-                &hasher,
-                &proof,
+            assert!(verify_proof::<Sha256, _, _>(&proof,
                 Location::new(1),
                 &proof_ops,
                 &root));
@@ -1022,7 +1015,6 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ops = create_test_ops(100);
-            let hasher = qmdb::hasher::<Sha256>();
             let start_loc = Location::new(2);
             let max_ops = NZU64!(10);
 
@@ -1052,8 +1044,7 @@ pub(crate) mod test {
                 assert_eq!(historical_proof.leaves, reference_proof.leaves);
                 assert_eq!(historical_proof.digests, reference_proof.digests);
                 assert_eq!(historical_ops, reference_ops);
-                assert!(verify_proof(
-                    &hasher,
+                assert!(verify_proof::<Sha256, _, _>(
                     &historical_proof,
                     start_loc,
                     &historical_ops,
@@ -1064,8 +1055,7 @@ pub(crate) mod test {
             // Verify the current full-size proof against the current root as a final sanity check.
             let full_root = db.root();
             let (full_proof, full_ops) = db.proof(start_loc, max_ops).await.unwrap();
-            assert!(verify_proof(
-                &hasher,
+            assert!(verify_proof::<Sha256, _, _>(
                 &full_proof,
                 start_loc,
                 &full_ops,

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -134,7 +134,7 @@ pub mod partitioned {
 pub(crate) mod test {
     use super::*;
     use crate::{index::Unordered as _, mmr, translator::TwoCap};
-    use commonware_cryptography::{sha256::Digest, Hasher, Sha256};
+    use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
     use commonware_parallel::Sequential;

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -1,7 +1,7 @@
 //! Shared infrastructure for QMDB benchmarks: constants, config builders, type aliases, dispatch
 //! macros, and the common `gen_random_kv` helper.
 
-use commonware_cryptography::{Hasher, Sha256};
+use commonware_cryptography::{DigestOf, Hasher as _, Sha256};
 use commonware_parallel::Rayon;
 use commonware_runtime::{buffer::paged::CacheRef, tokio::Context, BufferPooler, ThreadPooler};
 use commonware_storage::{
@@ -32,7 +32,7 @@ use rand::{distributions::Distribution, rngs::StdRng, RngCore, SeedableRng};
 use rand_distr::Zipf;
 use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
 
-pub type Digest = <Sha256 as Hasher>::Digest;
+pub type Digest = DigestOf<Sha256>;
 
 /// Default items per blob for benchmarks. This is small enough that blob boundary crossings can
 /// affect benchmark time. Benchmarks that don't want to measure that cost should override via the

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -20,7 +20,7 @@
 //! - updates: keys written per batch (default 32,768)
 //! - threads: strategy pool threads (default 8)
 
-use commonware_cryptography::{Hasher, Sha256};
+use commonware_cryptography::{DigestOf, Hasher as _, Sha256};
 use commonware_parallel::Rayon;
 use commonware_runtime::{
     buffer::paged::CacheRef,
@@ -41,7 +41,7 @@ use std::{
     time::Instant,
 };
 
-type Digest = <Sha256 as Hasher>::Digest;
+type Digest = DigestOf<Sha256>;
 const CHUNK_SIZE: usize = 32;
 type AnyDb = commonware_storage::qmdb::any::unordered::fixed::Db<
     mmb::Family,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -10,7 +10,6 @@ use crate::{
         storage::Storage as MerkleStorage, Graftable, Location, Position, Readable,
     },
     qmdb::{
-        self,
         any::{
             self,
             batch::{DiffCursors, DiffEntry},
@@ -650,9 +649,7 @@ where
         (idx, chunk)
     });
 
-    let hasher = qmdb::hasher::<H>();
     let new_leaves = compute_grafted_leaves::<F, H, S, N>(
-        &hasher,
         &ops_tree_adapter,
         chunks_to_update,
         &current_db.strategy,
@@ -672,8 +669,9 @@ where
                 grafted_batch = grafted_batch.add_leaf_digest(digest);
             }
         }
-        let gh = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
-        grafted_batch.merkleize(&current_db.grafted_tree, &gh)
+        let grafted_hasher =
+            grafting::GraftedHasher::<F, _>::new(crate::qmdb::hasher::<H>(), grafting_height);
+        grafted_batch.merkleize(&current_db.grafted_tree, &grafted_hasher)
     };
 
     // Build the layered bitmap (parent + overlay) before computing the canonical root, so that
@@ -693,7 +691,7 @@ where
         mem: &current_db.grafted_tree,
     };
     let grafted_storage =
-        grafting::Storage::new(&layered, grafting_height, &ops_tree_adapter, hasher.clone());
+        grafting::Storage::<F, H, _, _>::new(&layered, grafting_height, &ops_tree_adapter);
     // Compute partial chunk (last incomplete chunk, if any). The partial chunk lives at
     // index `new_complete_chunks` (the chunk currently being filled with bits) -- distinct
     // from `graftable_overlay` (the grafted-tree boundary). At gh >= 3, partial and pending can
@@ -710,7 +708,6 @@ where
         }
     };
     let canonical_root = compute_db_root::<F, H, _, _, N>(
-        &hasher,
         &bitmap_batch,
         &grafted_storage,
         overlay_ops_leaves,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -10,7 +10,6 @@ use crate::{
         storage::Storage as MerkleStorage, Graftable, Location, Position, Readable,
     },
     qmdb::{
-        self,
         any::{
             self,
             batch::{DiffCursors, DiffEntry},
@@ -670,8 +669,7 @@ where
                 grafted_batch = grafted_batch.add_leaf_digest(digest);
             }
         }
-        let grafted_hasher =
-            grafting::GraftedHasher::<F, _>::new(qmdb::hasher::<H>(), grafting_height);
+        let grafted_hasher = grafting::hasher::<F, H>(grafting_height);
         grafted_batch.merkleize(&current_db.grafted_tree, &grafted_hasher)
     };
 

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -10,6 +10,7 @@ use crate::{
         storage::Storage as MerkleStorage, Graftable, Location, Position, Readable,
     },
     qmdb::{
+        self,
         any::{
             self,
             batch::{DiffCursors, DiffEntry},
@@ -670,7 +671,7 @@ where
             }
         }
         let grafted_hasher =
-            grafting::GraftedHasher::<F, _>::new(crate::qmdb::hasher::<H>(), grafting_height);
+            grafting::GraftedHasher::<F, _>::new(qmdb::hasher::<H>(), grafting_height);
         grafted_batch.merkleize(&current_db.grafted_tree, &grafted_hasher)
     };
 

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1130,8 +1130,7 @@ pub(super) async fn build_grafted_tree<
         let batch = {
             let batch = grafted_tree.new_batch_with_strategy(strategy.clone());
             let batch = batch.add_leaf_digests(leaves.iter().map(|&(_, digest)| digest));
-            let grafted_hasher =
-                grafting::GraftedHasher::<F, _>::new(qmdb::hasher::<H>(), grafting_height);
+            let grafted_hasher = grafting::hasher::<F, H>(grafting_height);
             batch.merkleize(&grafted_tree, &grafted_hasher)
         };
         grafted_tree.apply_batch(&batch)?;

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -9,11 +9,8 @@ use crate::{
         Error as JournalError,
     },
     merkle::{
-        self,
-        hasher::{Hasher as MerkleHasher, Standard as StandardHasher},
-        mem::Mem,
-        storage::Storage as MerkleStorage,
-        Graftable, Location, Position,
+        self, hasher::Hasher as _, mem::Mem, storage::Storage as MerkleStorage, Graftable,
+        Location, Position,
     },
     metadata::{Config as MConfig, Metadata},
     qmdb::{
@@ -206,14 +203,13 @@ where
     /// Return true if the given sequence of `ops` were applied starting at location `start_loc`
     /// in the log with the provided `root`, having the activity status described by `chunks`.
     pub fn verify_range_proof(
-        hasher: &StandardHasher<H>,
         proof: &RangeProof<F, H::Digest>,
         start_loc: Location<F>,
         ops: &[Operation<F, U>],
         chunks: &[[u8; N]],
         root: &H::Digest,
     ) -> bool {
-        proof.verify(hasher, start_loc, ops, chunks, root)
+        proof.verify::<H, _, N>(start_loc, ops, chunks, root)
     }
 }
 
@@ -233,11 +229,10 @@ where
     /// or above the grafting height, returns the grafted node. For positions below the grafting
     /// height, the ops tree is used.
     fn grafted_storage(&self) -> impl MerkleStorage<F, Digest = H::Digest> + '_ {
-        grafting::Storage::new(
+        grafting::Storage::<F, H, _, _>::new(
             &self.grafted_tree,
             grafting::height::<N>(),
             &self.any.log.merkle,
-            qmdb::hasher::<H>(),
         )
     }
 
@@ -269,29 +264,26 @@ where
     /// Returns a witness that this database's canonical root commits to its ops root.
     ///
     /// This can be used to authenticate an ops root against a trusted canonical `current` root.
-    pub async fn ops_root_witness(
-        &self,
-        hasher: &StandardHasher<H>,
-    ) -> Result<OpsRootWitness<F, H::Digest>, Error<F>> {
+    pub async fn ops_root_witness(&self) -> Result<OpsRootWitness<F, H::Digest>, Error<F>> {
         let storage = self.grafted_storage();
         let ops_size = storage.size().await;
         let ops_leaves = Location::<F>::try_from(ops_size)?;
         let grafted_root = compute_grafted_root::<F, H, _, _, N>(
-            hasher,
             self.any.bitmap.as_ref(),
             &storage,
             ops_leaves,
             self.any.inactivity_floor_loc,
         )
         .await?;
+        let hasher = crate::qmdb::hasher::<H>();
         let partial_chunk = partial_chunk::<_, N>(self.any.bitmap.as_ref())
-            .map(|(chunk, next_bit)| (next_bit, hasher.digest(&chunk)));
+            .map(|(chunk, next_bit)| (next_bit, hasher.digest(chunk.as_slice())));
         let pending_chunk_digest: F::PendingChunk<H::Digest> = pending_chunk::<F, _, N>(
             self.any.bitmap.as_ref(),
             ops_leaves,
             grafting::height::<N>(),
         )?
-        .map(|chunk| hasher.digest(&chunk))
+        .map(|chunk| hasher.digest(chunk.as_slice()))
         .try_into()
         .expect("pending_chunk must be consistent with family");
         Ok(OpsRootWitness {
@@ -321,13 +313,11 @@ where
     /// Returns a proof for the operation at `loc`.
     pub(super) async fn operation_proof(
         &self,
-        hasher: &StandardHasher<H>,
         loc: Location<F>,
     ) -> Result<OperationProof<F, H::Digest, N>, Error<F>> {
         let storage = self.grafted_storage();
         let ops_root = self.any.root();
-        OperationProof::new(
-            hasher,
+        OperationProof::new::<H, _>(
             self.any.bitmap.as_ref(),
             &storage,
             self.any.inactivity_floor_loc,
@@ -360,14 +350,12 @@ where
     )]
     pub async fn range_proof(
         &self,
-        hasher: &StandardHasher<H>,
         start_loc: Location<F>,
         max_ops: NonZeroU64,
     ) -> Result<(RangeProof<F, H::Digest>, Vec<Operation<F, U>>, Vec<[u8; N]>), Error<F>> {
         let storage = self.grafted_storage();
         let ops_root = self.any.root();
-        RangeProof::new_with_ops(
-            hasher,
+        RangeProof::new_with_ops::<H, _, _, N>(
             self.any.bitmap.as_ref(),
             &storage,
             &self.any.log,
@@ -398,7 +386,7 @@ where
     ///
     /// Unlike [`range_proof`](Self::range_proof) which returns grafted proofs incorporating the
     /// activity bitmap, this returns ops-tree Merkle proofs suitable for state sync. Direct
-    /// verifiers should use [`crate::qmdb::hasher`].
+    /// verifiers should use [`crate::qmdb::verify_proof`].
     pub async fn ops_historical_proof(
         &self,
         historical_size: Location<F>,
@@ -635,11 +623,9 @@ where
         // the caller; reads through them now return inconsistent data.
         self.any.rewind(size).await?;
 
-        let hasher = qmdb::hasher::<H>();
         let ops_size = self.any.log.merkle.size();
         let ops_leaves = Location::<F>::try_from(ops_size)?;
         let grafted_tree = build_grafted_tree::<F, H, S, N>(
-            &hasher,
             self.any.bitmap.as_ref(),
             &pinned_nodes,
             &self.any.log.merkle,
@@ -647,16 +633,14 @@ where
             &self.strategy,
         )
         .await?;
-        let storage = grafting::Storage::new(
+        let storage = grafting::Storage::<F, H, _, _>::new(
             &grafted_tree,
             grafting::height::<N>(),
             &self.any.log.merkle,
-            hasher.clone(),
         );
         let partial_chunk = partial_chunk(self.any.bitmap.as_ref());
         let ops_root = self.any.root();
-        let root = compute_db_root(
-            &hasher,
+        let root = compute_db_root::<F, H, _, _, N>(
             self.any.bitmap.as_ref(),
             &storage,
             ops_leaves,
@@ -909,12 +893,12 @@ pub(super) fn pending_chunk<F: merkle::Graftable, B: bitmap::Readable<N>, const 
 /// digest size). Different fixed lengths, so the two cannot produce the same input bytes,
 /// even when their digests are identical. Collisions reduce to H.
 pub(super) fn combine_roots<H: Hasher>(
-    hasher: &StandardHasher<H>,
     ops_root: &H::Digest,
     grafted_root: &H::Digest,
     pending: Option<&H::Digest>,
     partial: Option<(u64, &H::Digest)>,
 ) -> H::Digest {
+    let hasher = crate::qmdb::hasher::<H>();
     match (pending, partial) {
         (None, None) => hasher.hash([ops_root.as_ref(), grafted_root.as_ref()]),
         (Some(pe), None) => hasher.hash([ops_root.as_ref(), grafted_root.as_ref(), pe.as_ref()]),
@@ -957,7 +941,6 @@ pub(super) async fn compute_db_root<
     S: MerkleStorage<F, Digest = H::Digest>,
     const N: usize,
 >(
-    hasher: &StandardHasher<H>,
     status: &B,
     storage: &S,
     ops_leaves: Location<F>,
@@ -966,15 +949,16 @@ pub(super) async fn compute_db_root<
     ops_root: &H::Digest,
 ) -> Result<H::Digest, Error<F>> {
     let grafted_root =
-        compute_grafted_root(hasher, status, storage, ops_leaves, inactivity_floor).await?;
+        compute_grafted_root::<F, H, B, S, N>(status, storage, ops_leaves, inactivity_floor)
+            .await?;
+    let hasher = crate::qmdb::hasher::<H>();
     let pending = pending_chunk::<F, B, N>(status, ops_leaves, grafting::height::<N>())?
         .map(|chunk| hasher.digest(&chunk));
     let partial = partial_chunk.map(|(chunk, next_bit)| {
         let digest = hasher.digest(&chunk);
         (next_bit, digest)
     });
-    Ok(combine_roots(
-        hasher,
+    Ok(combine_roots::<H>(
         ops_root,
         &grafted_root,
         pending.as_ref(),
@@ -998,7 +982,6 @@ pub(super) async fn compute_grafted_root<
     S: MerkleStorage<F, Digest = H::Digest>,
     const N: usize,
 >(
-    hasher: &StandardHasher<H>,
     status: &B,
     storage: &S,
     ops_leaves: Location<F>,
@@ -1024,6 +1007,7 @@ pub(super) async fn compute_grafted_root<
 
     let inactive_peaks =
         grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting_height)?;
+    let hasher = qmdb::hasher::<H>();
 
     // Every peak the storage layer surfaces is either a grafted-tree node (graftable chunks already
     // incorporate `hash(chunk || h_G_node)`), an ops node above G (hashed normally), or an ops node
@@ -1048,7 +1032,6 @@ pub(super) async fn compute_grafted_leaves<
     S: Strategy,
     const N: usize,
 >(
-    hasher: &StandardHasher<H>,
     ops_tree: &impl MerkleStorage<F, Digest = H::Digest>,
     chunks: impl IntoIterator<Item = (usize, [u8; N])>,
     strategy: &S,
@@ -1073,7 +1056,7 @@ pub(super) async fn compute_grafted_leaves<
     let zero_chunk = [0u8; N];
     Ok(strategy.map_init_collect_vec(
         inputs,
-        || hasher.clone(),
+        || crate::qmdb::hasher::<H>(),
         |h, (chunk_idx, chunk_ops_digest, chunk)| {
             if chunk == zero_chunk {
                 (chunk_idx, chunk_ops_digest)
@@ -1107,7 +1090,6 @@ pub(super) async fn build_grafted_tree<
     S: Strategy,
     const N: usize,
 >(
-    hasher: &StandardHasher<H>,
     bitmap: &impl bitmap::Readable<N>,
     pinned_nodes: &[H::Digest],
     ops_tree: &impl MerkleStorage<F, Digest = H::Digest>,
@@ -1128,7 +1110,6 @@ pub(super) async fn build_grafted_tree<
     // sits at index `graftable_chunks` and is excluded; its digest is hashed directly into
     // the canonical root.
     let leaves = compute_grafted_leaves::<F, H, S, N>(
-        hasher,
         ops_tree,
         (pruned_chunks..graftable_chunks).map(|chunk_idx| (chunk_idx, bitmap.get_chunk(chunk_idx))),
         strategy,
@@ -1136,7 +1117,6 @@ pub(super) async fn build_grafted_tree<
     .await?;
 
     // Build the base grafted tree: either from pruned components or empty.
-    let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
     let mut grafted_tree = if pruned_chunks > 0 {
         let grafted_pruning_boundary = Location::<F>::new(pruned_chunks as u64);
         Mem::from_components(Vec::new(), grafted_pruning_boundary, pinned_nodes.to_vec())
@@ -1150,6 +1130,8 @@ pub(super) async fn build_grafted_tree<
         let batch = {
             let batch = grafted_tree.new_batch_with_strategy(strategy.clone());
             let batch = batch.add_leaf_digests(leaves.iter().map(|&(_, digest)| digest));
+            let grafted_hasher =
+                grafting::GraftedHasher::<F, _>::new(crate::qmdb::hasher::<H>(), grafting_height);
             batch.merkleize(&grafted_tree, &grafted_hasher)
         };
         grafted_tree.apply_batch(&batch)?;
@@ -1223,7 +1205,7 @@ pub(super) async fn init_metadata<F: merkle::Graftable, E: Context, D: Digest>(
 mod tests {
     use super::*;
     use crate::{
-        merkle::{mmb, mmr, Bagging::ForwardFold},
+        merkle::{hasher::Standard as StandardHasher, mmb, mmr, Bagging::ForwardFold},
         qmdb::{
             any::traits::{DbAny, UnmerkleizedBatch as _},
             current::{tests::fixed_config, unordered::fixed},
@@ -1273,50 +1255,46 @@ mod tests {
 
     #[test]
     fn combine_roots_deterministic() {
-        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let ops = Sha256::hash(b"ops");
         let grafted = Sha256::hash(b"grafted");
-        let r1 = combine_roots(&hasher, &ops, &grafted, None, None);
-        let r2 = combine_roots(&hasher, &ops, &grafted, None, None);
+        let r1 = combine_roots::<Sha256>(&ops, &grafted, None, None);
+        let r2 = combine_roots::<Sha256>(&ops, &grafted, None, None);
         assert_eq!(r1, r2);
     }
 
     #[test]
     fn combine_roots_with_partial_differs() {
-        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let ops = Sha256::hash(b"ops");
         let grafted = Sha256::hash(b"grafted");
         let partial_digest = Sha256::hash(b"partial");
 
-        let without = combine_roots(&hasher, &ops, &grafted, None, None);
-        let with = combine_roots(&hasher, &ops, &grafted, None, Some((5, &partial_digest)));
+        let without = combine_roots::<Sha256>(&ops, &grafted, None, None);
+        let with = combine_roots::<Sha256>(&ops, &grafted, None, Some((5, &partial_digest)));
         assert_ne!(without, with);
     }
 
     #[test]
     fn combine_roots_with_pending_differs() {
-        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let ops = Sha256::hash(b"ops");
         let grafted = Sha256::hash(b"grafted");
         let pending_digest = Sha256::hash(b"pending");
 
-        let without = combine_roots(&hasher, &ops, &grafted, None, None);
-        let with = combine_roots(&hasher, &ops, &grafted, Some(&pending_digest), None);
+        let without = combine_roots::<Sha256>(&ops, &grafted, None, None);
+        let with = combine_roots::<Sha256>(&ops, &grafted, Some(&pending_digest), None);
         assert_ne!(without, with);
     }
 
     #[test]
     fn combine_roots_pending_and_partial_independent() {
-        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let ops = Sha256::hash(b"ops");
         let grafted = Sha256::hash(b"grafted");
         let pending_digest = Sha256::hash(b"pending");
         let partial_digest = Sha256::hash(b"partial");
 
-        let only_pending = combine_roots(&hasher, &ops, &grafted, Some(&pending_digest), None);
-        let only_partial = combine_roots(&hasher, &ops, &grafted, None, Some((5, &partial_digest)));
-        let both = combine_roots(
-            &hasher,
+        let only_pending = combine_roots::<Sha256>(&ops, &grafted, Some(&pending_digest), None);
+        let only_partial =
+            combine_roots::<Sha256>(&ops, &grafted, None, Some((5, &partial_digest)));
+        let both = combine_roots::<Sha256>(
             &ops,
             &grafted,
             Some(&pending_digest),
@@ -1329,13 +1307,12 @@ mod tests {
 
     #[test]
     fn combine_roots_different_ops_root() {
-        let hasher = StandardHasher::<Sha256>::new(ForwardFold);
         let ops_a = Sha256::hash(b"ops_a");
         let ops_b = Sha256::hash(b"ops_b");
         let grafted = Sha256::hash(b"grafted");
 
-        let r1 = combine_roots(&hasher, &ops_a, &grafted, None, None);
-        let r2 = combine_roots(&hasher, &ops_b, &grafted, None, None);
+        let r1 = combine_roots::<Sha256>(&ops_a, &grafted, None, None);
+        let r2 = combine_roots::<Sha256>(&ops_b, &grafted, None, None);
         assert_ne!(r1, r2);
     }
 
@@ -1353,19 +1330,19 @@ mod tests {
 
         // Neither pending nor partial.
         assert_eq!(
-            combine_roots(&hasher, &ops, &grafted, None, None),
+            combine_roots::<Sha256>(&ops, &grafted, None, None),
             hasher.hash([ops.as_ref(), grafted.as_ref()])
         );
 
         // Pending only.
         assert_eq!(
-            combine_roots(&hasher, &ops, &grafted, Some(&pending), None),
+            combine_roots::<Sha256>(&ops, &grafted, Some(&pending), None),
             hasher.hash([ops.as_ref(), grafted.as_ref(), pending.as_ref()])
         );
 
         // Partial only.
         assert_eq!(
-            combine_roots(&hasher, &ops, &grafted, None, Some((next_bit, &partial))),
+            combine_roots::<Sha256>(&ops, &grafted, None, Some((next_bit, &partial))),
             hasher.hash([
                 ops.as_ref(),
                 grafted.as_ref(),
@@ -1376,13 +1353,7 @@ mod tests {
 
         // Both: pending precedes partial.
         assert_eq!(
-            combine_roots(
-                &hasher,
-                &ops,
-                &grafted,
-                Some(&pending),
-                Some((next_bit, &partial))
-            ),
+            combine_roots::<Sha256>(&ops, &grafted, Some(&pending), Some((next_bit, &partial))),
             hasher.hash([
                 ops.as_ref(),
                 grafted.as_ref(),
@@ -1447,24 +1418,22 @@ mod tests {
                 populate_fixed_db::<mmr::Family, _>(&mut db, next_idx, 1).await;
                 next_idx += 1;
             }
-
-            let hasher = qmdb::hasher::<Sha256>();
-            let witness = db.ops_root_witness(&hasher).await.unwrap();
+            let witness = db.ops_root_witness().await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
 
             assert!(witness.partial_chunk.is_none());
-            assert!(witness.verify(&hasher, &ops_root, &canonical_root));
+            assert!(witness.verify::<Sha256>(&ops_root, &canonical_root));
 
             let wrong_ops_root = Sha256::hash(b"wrong ops root");
-            assert!(!witness.verify(&hasher, &wrong_ops_root, &canonical_root));
+            assert!(!witness.verify::<Sha256>(&wrong_ops_root, &canonical_root));
 
             let wrong_canonical_root = Sha256::hash(b"wrong canonical root");
-            assert!(!witness.verify(&hasher, &ops_root, &wrong_canonical_root));
+            assert!(!witness.verify::<Sha256>(&ops_root, &wrong_canonical_root));
 
             let mut tampered = witness;
             tampered.grafted_root = Sha256::hash(b"wrong grafted root");
-            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify::<Sha256>(&ops_root, &canonical_root));
         });
     }
 
@@ -1479,32 +1448,30 @@ mod tests {
             .await
             .unwrap();
             populate_fixed_db::<mmb::Family, _>(&mut db, 0, 260).await;
-
-            let hasher = qmdb::hasher::<Sha256>();
-            let witness = db.ops_root_witness(&hasher).await.unwrap();
+            let witness = db.ops_root_witness().await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
 
             assert!(witness.partial_chunk.is_some());
-            assert!(witness.verify(&hasher, &ops_root, &canonical_root));
+            assert!(witness.verify::<Sha256>(&ops_root, &canonical_root));
 
             let wrong_ops_root = Sha256::hash(b"wrong ops root");
-            assert!(!witness.verify(&hasher, &wrong_ops_root, &canonical_root));
+            assert!(!witness.verify::<Sha256>(&wrong_ops_root, &canonical_root));
 
             let wrong_canonical_root = Sha256::hash(b"wrong canonical root");
-            assert!(!witness.verify(&hasher, &ops_root, &wrong_canonical_root));
+            assert!(!witness.verify::<Sha256>(&ops_root, &wrong_canonical_root));
 
             let mut tampered = witness.clone();
             tampered.grafted_root = Sha256::hash(b"wrong grafted root");
-            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify::<Sha256>(&ops_root, &canonical_root));
 
             let mut tampered = witness.clone();
             tampered.partial_chunk.as_mut().unwrap().0 += 1;
-            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify::<Sha256>(&ops_root, &canonical_root));
 
             let mut tampered = witness;
             tampered.partial_chunk.as_mut().unwrap().1 = Sha256::hash(b"wrong partial chunk");
-            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify::<Sha256>(&ops_root, &canonical_root));
         });
     }
 
@@ -1528,20 +1495,18 @@ mod tests {
                 db.any.bitmap.pruned_chunks() > 0,
                 "test requires at least one pruned chunk to exercise the zero-chunk path"
             );
-
-            let hasher = qmdb::hasher::<Sha256>();
-            let witness = db.ops_root_witness(&hasher).await.unwrap();
+            let witness = db.ops_root_witness().await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
 
-            assert!(witness.verify(&hasher, &ops_root, &canonical_root));
+            assert!(witness.verify::<Sha256>(&ops_root, &canonical_root));
 
             let wrong_canonical_root = Sha256::hash(b"wrong canonical root");
-            assert!(!witness.verify(&hasher, &ops_root, &wrong_canonical_root));
+            assert!(!witness.verify::<Sha256>(&ops_root, &wrong_canonical_root));
 
             let mut tampered = witness;
             tampered.grafted_root = Sha256::hash(b"wrong grafted root");
-            assert!(!tampered.verify(&hasher, &ops_root, &canonical_root));
+            assert!(!tampered.verify::<Sha256>(&ops_root, &canonical_root));
         });
     }
 
@@ -1555,13 +1520,11 @@ mod tests {
             )
             .await
             .unwrap();
-
-            let hasher = qmdb::hasher::<Sha256>();
-            let witness = db.ops_root_witness(&hasher).await.unwrap();
+            let witness = db.ops_root_witness().await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
 
-            assert!(witness.verify(&hasher, &ops_root, &canonical_root));
+            assert!(witness.verify::<Sha256>(&ops_root, &canonical_root));
         });
     }
 }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -275,7 +275,7 @@ where
             self.any.inactivity_floor_loc,
         )
         .await?;
-        let hasher = crate::qmdb::hasher::<H>();
+        let hasher = qmdb::hasher::<H>();
         let partial_chunk = partial_chunk::<_, N>(self.any.bitmap.as_ref())
             .map(|(chunk, next_bit)| (next_bit, hasher.digest(chunk.as_slice())));
         let pending_chunk_digest: F::PendingChunk<H::Digest> = pending_chunk::<F, _, N>(
@@ -898,7 +898,7 @@ pub(super) fn combine_roots<H: Hasher>(
     pending: Option<&H::Digest>,
     partial: Option<(u64, &H::Digest)>,
 ) -> H::Digest {
-    let hasher = crate::qmdb::hasher::<H>();
+    let hasher = qmdb::hasher::<H>();
     match (pending, partial) {
         (None, None) => hasher.hash([ops_root.as_ref(), grafted_root.as_ref()]),
         (Some(pe), None) => hasher.hash([ops_root.as_ref(), grafted_root.as_ref(), pe.as_ref()]),
@@ -951,7 +951,7 @@ pub(super) async fn compute_db_root<
     let grafted_root =
         compute_grafted_root::<F, H, B, S, N>(status, storage, ops_leaves, inactivity_floor)
             .await?;
-    let hasher = crate::qmdb::hasher::<H>();
+    let hasher = qmdb::hasher::<H>();
     let pending = pending_chunk::<F, B, N>(status, ops_leaves, grafting::height::<N>())?
         .map(|chunk| hasher.digest(&chunk));
     let partial = partial_chunk.map(|(chunk, next_bit)| {
@@ -1056,7 +1056,7 @@ pub(super) async fn compute_grafted_leaves<
     let zero_chunk = [0u8; N];
     Ok(strategy.map_init_collect_vec(
         inputs,
-        || crate::qmdb::hasher::<H>(),
+        || qmdb::hasher::<H>(),
         |h, (chunk_idx, chunk_ops_digest, chunk)| {
             if chunk == zero_chunk {
                 (chunk_idx, chunk_ops_digest)
@@ -1131,7 +1131,7 @@ pub(super) async fn build_grafted_tree<
             let batch = grafted_tree.new_batch_with_strategy(strategy.clone());
             let batch = batch.add_leaf_digests(leaves.iter().map(|&(_, digest)| digest));
             let grafted_hasher =
-                grafting::GraftedHasher::<F, _>::new(crate::qmdb::hasher::<H>(), grafting_height);
+                grafting::GraftedHasher::<F, _>::new(qmdb::hasher::<H>(), grafting_height);
             batch.merkleize(&grafted_tree, &grafted_hasher)
         };
         grafted_tree.apply_batch(&batch)?;

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -370,10 +370,7 @@ impl<
             grafted_tree,
             grafting_height,
             ops_tree,
-            grafted_hasher: GraftedHasher::new(
-                merkle::hasher::Standard::new(merkle::Bagging::ForwardFold),
-                grafting_height,
-            ),
+            grafted_hasher: GraftedHasher::new(crate::qmdb::hasher::<H>(), grafting_height),
             _phantom: PhantomData,
         }
     }

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -250,7 +250,7 @@ pub struct Verifier<'a, F: Graftable, H: Hasher> {
 }
 
 impl<'a, F: Graftable, H: Hasher> Verifier<'a, F, H> {
-    /// Create a new Verifier whose internal hasher uses the supplied bagging policy.
+    /// Create a new verifier using QMDB's fixed Merkle hasher configuration.
     ///
     /// `start_chunk_index` is the chunk index corresponding to `chunks[0]`.
     /// `graftable_chunks` is the number of chunks committed by the grafted tree; any chunk index
@@ -261,10 +261,9 @@ impl<'a, F: Graftable, H: Hasher> Verifier<'a, F, H> {
         start_chunk_index: u64,
         chunks: Vec<&'a [u8]>,
         graftable_chunks: u64,
-        bagging: merkle::Bagging,
     ) -> Self {
         Self {
-            hasher: merkle::hasher::Standard::new(bagging),
+            hasher: crate::qmdb::hasher::<H>(),
             grafting_height,
             chunks,
             start_chunk_index,
@@ -437,7 +436,7 @@ impl<
 mod tests {
     use super::*;
     use crate::{
-        merkle::{conformance::build_test_mmr, Bagging::ForwardFold},
+        merkle::conformance::build_test_mmr,
         mmb, mmr,
         mmr::{
             iterator::{pos_to_height, PeakIterator},
@@ -567,12 +566,12 @@ mod tests {
         // combine the chunk (chunk_idx >= graftable_chunks).
         let pos_at_g = mmr::Family::subtree_root_position(Location::new(0), GH);
 
-        let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
+        let standard = crate::qmdb::hasher::<Sha256>();
         let expected_no_combine = <StandardHasher<Sha256> as HasherTrait<mmr::Family>>::node_digest(
             &standard, pos_at_g, &left, &right,
         );
 
-        let v = Verifier::<mmr::Family, Sha256>::new(GH, 0, vec![&chunk], 0, ForwardFold);
+        let v = Verifier::<mmr::Family, Sha256>::new(GH, 0, vec![&chunk], 0);
         let got = <Verifier<'_, mmr::Family, Sha256> as HasherTrait<mmr::Family>>::node_digest(
             &v, pos_at_g, &left, &right,
         );
@@ -582,7 +581,7 @@ mod tests {
         );
 
         // Sanity: with graftable_chunks=1 the chunk IS combined, so the digest differs.
-        let v_graftable = Verifier::<mmr::Family, Sha256>::new(GH, 0, vec![&chunk], 1, ForwardFold);
+        let v_graftable = Verifier::<mmr::Family, Sha256>::new(GH, 0, vec![&chunk], 1);
         let got_graftable =
             <Verifier<'_, mmr::Family, Sha256> as HasherTrait<mmr::Family>>::node_digest(
                 &v_graftable,
@@ -621,7 +620,7 @@ mod tests {
         if !chunks.is_empty() {
             // Use a separate hasher for leaf digest computation to avoid borrow conflict
             // with grafted_hasher (which borrows standard via fork()).
-            let leaf_hasher = StandardHasher::<Sha256>::new(ForwardFold);
+            let leaf_hasher = crate::qmdb::hasher::<Sha256>();
             let batch = {
                 let mut batch = grafted_mmr.new_batch();
                 for (i, chunk) in chunks.iter().enumerate() {
@@ -731,7 +730,7 @@ mod tests {
         executor.start(|_| async move {
             const NUM_ELEMENTS: u64 = 200;
 
-            let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
+            let standard = crate::qmdb::hasher::<Sha256>();
             let mmr = Mmr::new();
             let ops_mmr = build_test_mmr(&standard, mmr, NUM_ELEMENTS);
 
@@ -774,7 +773,7 @@ mod tests {
 
     #[test_traced]
     fn test_merkleize_grafted() {
-        let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
+        let standard = crate::qmdb::hasher::<Sha256>();
         let grafting_height = 1u32;
 
         // Build ops MMR with 4 leaves.
@@ -798,7 +797,7 @@ mod tests {
         let pos1 = chunk_idx_to_ops_pos(1, grafting_height);
 
         let batch = {
-            let leaf_hasher = StandardHasher::<Sha256>::new(ForwardFold);
+            let leaf_hasher = crate::qmdb::hasher::<Sha256>();
             let sub0 = ops_mmr.get_node(pos0).unwrap();
             let batch = grafted
                 .new_batch()
@@ -831,7 +830,7 @@ mod tests {
             let b2 = Sha256::fill(0x02);
             let b3 = Sha256::fill(0x03);
             let b4 = Sha256::fill(0x04);
-            let hasher: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
+            let hasher = crate::qmdb::hasher::<Sha256>();
 
             // Build an ops MMR with 4 leaves.
             let mut ops_mmr = Mmr::new();
@@ -892,7 +891,6 @@ mod tests {
                         0,
                         vec![&c1],
                         ALL_CHUNKS_GRAFTABLE,
-                        ForwardFold,
                     );
                     assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root));
 
@@ -911,7 +909,6 @@ mod tests {
                         1,
                         vec![&c2],
                         ALL_CHUNKS_GRAFTABLE,
-                        ForwardFold,
                     );
                     assert!(proof.verify_element_inclusion(&verifier, &b3, loc, &grafted_root));
 
@@ -933,7 +930,6 @@ mod tests {
                         1,
                         vec![&c2],
                         ALL_CHUNKS_GRAFTABLE,
-                        ForwardFold,
                     );
                     assert!(proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
 
@@ -957,7 +953,6 @@ mod tests {
                         0,
                         vec![&c1],
                         ALL_CHUNKS_GRAFTABLE,
-                        ForwardFold,
                     );
                     assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
 
@@ -967,7 +962,6 @@ mod tests {
                         2,
                         vec![&c2],
                         ALL_CHUNKS_GRAFTABLE,
-                        ForwardFold,
                     );
                     assert!(!proof.verify_element_inclusion(&verifier, &b4, loc, &grafted_root));
                 }
@@ -988,7 +982,6 @@ mod tests {
                         0,
                         vec![&c1, &c2],
                         ALL_CHUNKS_GRAFTABLE,
-                        ForwardFold,
                     );
                     assert!(proof.verify_range_inclusion(
                         &verifier,
@@ -1003,7 +996,6 @@ mod tests {
                         0,
                         vec![&c1],
                         ALL_CHUNKS_GRAFTABLE,
-                        ForwardFold,
                     );
                     assert!(!proof.verify_range_inclusion(
                         &verifier,
@@ -1058,7 +1050,6 @@ mod tests {
                 0,
                 vec![&c1],
                 ALL_CHUNKS_GRAFTABLE,
-                ForwardFold,
             );
             assert!(proof.verify_element_inclusion(&verifier, &b1, loc, &grafted_root));
 
@@ -1067,7 +1058,6 @@ mod tests {
                 0,
                 vec![],
                 ALL_CHUNKS_GRAFTABLE,
-                ForwardFold,
             );
             let loc = Location::new(4);
             let proof = merkle::verification::range_proof(&hasher, &combined, loc..loc + 1, 0)
@@ -1080,7 +1070,7 @@ mod tests {
     #[test_traced]
     fn test_grafted_mmr_basic() {
         let grafting_height = 1u32;
-        let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
+        let standard = crate::qmdb::hasher::<Sha256>();
 
         // Build a grafted MMR with 2 leaves.
         let d0 = Sha256::fill(0x01);
@@ -1114,7 +1104,7 @@ mod tests {
     #[test_traced]
     fn test_grafted_mmr_with_pruning() {
         let grafting_height = 1u32;
-        let standard: StandardHasher<Sha256> = StandardHasher::new(ForwardFold);
+        let standard = crate::qmdb::hasher::<Sha256>();
 
         // Simulate pruning 4 chunks. The pruned sub-MMR has 4 grafted leaves,
         // mmr_size(4) = 7, with one peak at grafted position 6.

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -77,6 +77,13 @@ pub const fn height<const N: usize>() -> u32 {
     BitMap::<N>::CHUNK_SIZE_BITS.trailing_zeros()
 }
 
+/// Return a [GraftedHasher] over QMDB's fixed Merkle hasher configuration.
+pub(super) const fn hasher<F: Graftable, H: Hasher>(
+    grafting_height: u32,
+) -> GraftedHasher<F, merkle::hasher::Standard<H>> {
+    GraftedHasher::new(qmdb::hasher(), grafting_height)
+}
+
 /// Return the number of bitmap chunks that have a corresponding height-G ancestor in the ops tree.
 ///
 /// - For MMR, this is always the same as the number of complete_chunks.
@@ -355,7 +362,6 @@ pub(super) struct Storage<
     grafting_height: u32,
     ops_tree: &'a S,
     grafted_hasher: GraftedHasher<F, merkle::hasher::Standard<H>>,
-    _phantom: PhantomData<F>,
 }
 
 impl<
@@ -372,8 +378,7 @@ impl<
             grafted_tree,
             grafting_height,
             ops_tree,
-            grafted_hasher: GraftedHasher::new(qmdb::hasher::<H>(), grafting_height),
-            _phantom: PhantomData,
+            grafted_hasher: hasher::<F, H>(grafting_height),
         }
     }
 

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -64,7 +64,7 @@ use crate::merkle::{
     self, hasher::Hasher as HasherTrait, storage::Storage as StorageTrait, Family, Graftable,
     Location, Position, Readable,
 };
-use commonware_cryptography::{Digest, Hasher as CHasher};
+use commonware_cryptography::Hasher;
 use commonware_utils::bitmap::BitMap;
 use core::{cmp::Ordering, marker::PhantomData};
 use tracing::debug;
@@ -233,7 +233,7 @@ impl<F: Graftable, H: HasherTrait<F>> HasherTrait<F> for GraftedHasher<F, H> {
 /// - **At**: the children form an ops subtree root, which is combined with a bitmap chunk element
 ///   to reconstruct the grafted leaf digest.
 #[derive(Clone)]
-pub struct Verifier<'a, F: Graftable, H: CHasher> {
+pub struct Verifier<'a, F: Graftable, H: Hasher> {
     hasher: merkle::hasher::Standard<H>,
     grafting_height: u32,
 
@@ -249,7 +249,7 @@ pub struct Verifier<'a, F: Graftable, H: CHasher> {
     _ops_family: PhantomData<F>,
 }
 
-impl<'a, F: Graftable, H: CHasher> Verifier<'a, F, H> {
+impl<'a, F: Graftable, H: Hasher> Verifier<'a, F, H> {
     /// Create a new Verifier whose internal hasher uses the supplied bagging policy.
     ///
     /// `start_chunk_index` is the chunk index corresponding to `chunks[0]`.
@@ -274,7 +274,7 @@ impl<'a, F: Graftable, H: CHasher> Verifier<'a, F, H> {
     }
 }
 
-impl<F: Graftable, H: CHasher> HasherTrait<F> for Verifier<'_, F, H> {
+impl<F: Graftable, H: Hasher> HasherTrait<F> for Verifier<'_, F, H> {
     type Digest = H::Digest;
 
     fn hash<'a>(&self, parts: impl IntoIterator<Item = &'a [u8]>) -> H::Digest {
@@ -345,39 +345,35 @@ impl<F: Graftable, H: CHasher> HasherTrait<F> for Verifier<'_, F, H> {
 pub(super) struct Storage<
     'a,
     F: Graftable,
-    D: Digest,
-    G: Readable<Family = F, Digest = D, Error = merkle::Error<F>>,
-    S: StorageTrait<F, Digest = D>,
-    H: HasherTrait<F, Digest = D> + Clone,
+    H: Hasher,
+    G: Readable<Family = F, Digest = H::Digest, Error = merkle::Error<F>>,
+    S: StorageTrait<F, Digest = H::Digest>,
 > {
     grafted_tree: &'a G,
     grafting_height: u32,
     ops_tree: &'a S,
-    grafted_hasher: GraftedHasher<F, H>,
-    _phantom: PhantomData<(F, D)>,
+    grafted_hasher: GraftedHasher<F, merkle::hasher::Standard<H>>,
+    _phantom: PhantomData<F>,
 }
 
 impl<
         'a,
         F: Graftable,
-        D: Digest,
-        G: Readable<Family = F, Digest = D, Error = merkle::Error<F>>,
-        S: StorageTrait<F, Digest = D>,
-        H: HasherTrait<F, Digest = D> + Clone,
-    > Storage<'a, F, D, G, S, H>
+        H: Hasher,
+        G: Readable<Family = F, Digest = H::Digest, Error = merkle::Error<F>>,
+        S: StorageTrait<F, Digest = H::Digest>,
+    > Storage<'a, F, H, G, S>
 {
     /// Creates a new [Storage] instance.
-    pub(super) const fn new(
-        grafted_tree: &'a G,
-        grafting_height: u32,
-        ops_tree: &'a S,
-        hasher: H,
-    ) -> Self {
+    pub(super) const fn new(grafted_tree: &'a G, grafting_height: u32, ops_tree: &'a S) -> Self {
         Self {
             grafted_tree,
             grafting_height,
             ops_tree,
-            grafted_hasher: GraftedHasher::new(hasher, grafting_height),
+            grafted_hasher: GraftedHasher::new(
+                merkle::hasher::Standard::new(merkle::Bagging::ForwardFold),
+                grafting_height,
+            ),
             _phantom: PhantomData,
         }
     }
@@ -398,7 +394,7 @@ impl<
     /// Returns `None` at height 0 (a grafted leaf), since leaves encode bitmap data and
     /// cannot be recomputed from the tree structure alone. The settlement guard in
     /// [`super::db::Db::sync_boundary`] ensures this case is unreachable for pruned chunks.
-    fn reconstruct_grafted_node(&self, pos: Position<F>) -> Option<D> {
+    fn reconstruct_grafted_node(&self, pos: Position<F>) -> Option<H::Digest> {
         if let Some(node) = self.grafted_tree.get_node(pos) {
             return Some(node);
         }
@@ -419,19 +415,18 @@ impl<
 
 impl<
         F: Graftable,
-        D: Digest,
-        G: Readable<Family = F, Digest = D, Error = merkle::Error<F>>,
-        S: StorageTrait<F, Digest = D>,
-        H: HasherTrait<F, Digest = D> + Clone + Send + Sync,
-    > StorageTrait<F> for Storage<'_, F, D, G, S, H>
+        H: Hasher,
+        G: Readable<Family = F, Digest = H::Digest, Error = merkle::Error<F>>,
+        S: StorageTrait<F, Digest = H::Digest>,
+    > StorageTrait<F> for Storage<'_, F, H, G, S>
 {
-    type Digest = D;
+    type Digest = H::Digest;
 
     async fn size(&self) -> Position<F> {
         self.ops_tree.size().await
     }
 
-    async fn get_node(&self, pos: Position<F>) -> Result<Option<D>, merkle::Error<F>> {
+    async fn get_node(&self, pos: Position<F>) -> Result<Option<H::Digest>, merkle::Error<F>> {
         let ops_height = F::pos_to_height(pos);
         if ops_height < self.grafting_height {
             return self.ops_tree.get_node(pos).await;
@@ -865,7 +860,8 @@ mod tests {
             let ops_root = ops_mmr.root(&hasher, 0).unwrap();
 
             {
-                let combined = Storage::new(&grafted, GRAFTING_HEIGHT, &ops_mmr, hasher.clone());
+                let combined =
+                    Storage::<mmr::Family, Sha256, _, _>::new(&grafted, GRAFTING_HEIGHT, &ops_mmr);
                 assert_eq!(combined.size().await, ops_mmr.size());
 
                 // Compute the grafted root by iterating ops peaks.
@@ -1032,7 +1028,8 @@ mod tests {
 
             ops_mmr.apply_batch(&batch).unwrap();
 
-            let combined = Storage::new(&grafted, GRAFTING_HEIGHT, &ops_mmr, hasher.clone());
+            let combined =
+                Storage::<mmr::Family, Sha256, _, _>::new(&grafted, GRAFTING_HEIGHT, &ops_mmr);
             assert_eq!(combined.size().await, ops_mmr.size());
 
             // Compute the grafted root.

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -60,9 +60,12 @@
 //!
 //! The grafted tree is incrementally maintained when grafted leaves change.
 
-use crate::merkle::{
-    self, hasher::Hasher as HasherTrait, storage::Storage as StorageTrait, Family, Graftable,
-    Location, Position, Readable,
+use crate::{
+    merkle::{
+        self, hasher::Hasher as HasherTrait, storage::Storage as StorageTrait, Family, Graftable,
+        Location, Position, Readable,
+    },
+    qmdb,
 };
 use commonware_cryptography::Hasher;
 use commonware_utils::bitmap::BitMap;
@@ -263,7 +266,7 @@ impl<'a, F: Graftable, H: Hasher> Verifier<'a, F, H> {
         graftable_chunks: u64,
     ) -> Self {
         Self {
-            hasher: crate::qmdb::hasher::<H>(),
+            hasher: qmdb::hasher::<H>(),
             grafting_height,
             chunks,
             start_chunk_index,
@@ -369,7 +372,7 @@ impl<
             grafted_tree,
             grafting_height,
             ops_tree,
-            grafted_hasher: GraftedHasher::new(crate::qmdb::hasher::<H>(), grafting_height),
+            grafted_hasher: GraftedHasher::new(qmdb::hasher::<H>(), grafting_height),
             _phantom: PhantomData,
         }
     }
@@ -566,7 +569,7 @@ mod tests {
         // combine the chunk (chunk_idx >= graftable_chunks).
         let pos_at_g = mmr::Family::subtree_root_position(Location::new(0), GH);
 
-        let standard = crate::qmdb::hasher::<Sha256>();
+        let standard = qmdb::hasher::<Sha256>();
         let expected_no_combine = <StandardHasher<Sha256> as HasherTrait<mmr::Family>>::node_digest(
             &standard, pos_at_g, &left, &right,
         );
@@ -620,7 +623,7 @@ mod tests {
         if !chunks.is_empty() {
             // Use a separate hasher for leaf digest computation to avoid borrow conflict
             // with grafted_hasher (which borrows standard via fork()).
-            let leaf_hasher = crate::qmdb::hasher::<Sha256>();
+            let leaf_hasher = qmdb::hasher::<Sha256>();
             let batch = {
                 let mut batch = grafted_mmr.new_batch();
                 for (i, chunk) in chunks.iter().enumerate() {
@@ -730,7 +733,7 @@ mod tests {
         executor.start(|_| async move {
             const NUM_ELEMENTS: u64 = 200;
 
-            let standard = crate::qmdb::hasher::<Sha256>();
+            let standard = qmdb::hasher::<Sha256>();
             let mmr = Mmr::new();
             let ops_mmr = build_test_mmr(&standard, mmr, NUM_ELEMENTS);
 
@@ -773,7 +776,7 @@ mod tests {
 
     #[test_traced]
     fn test_merkleize_grafted() {
-        let standard = crate::qmdb::hasher::<Sha256>();
+        let standard = qmdb::hasher::<Sha256>();
         let grafting_height = 1u32;
 
         // Build ops MMR with 4 leaves.
@@ -797,7 +800,7 @@ mod tests {
         let pos1 = chunk_idx_to_ops_pos(1, grafting_height);
 
         let batch = {
-            let leaf_hasher = crate::qmdb::hasher::<Sha256>();
+            let leaf_hasher = qmdb::hasher::<Sha256>();
             let sub0 = ops_mmr.get_node(pos0).unwrap();
             let batch = grafted
                 .new_batch()
@@ -830,7 +833,7 @@ mod tests {
             let b2 = Sha256::fill(0x02);
             let b3 = Sha256::fill(0x03);
             let b4 = Sha256::fill(0x04);
-            let hasher = crate::qmdb::hasher::<Sha256>();
+            let hasher = qmdb::hasher::<Sha256>();
 
             // Build an ops MMR with 4 leaves.
             let mut ops_mmr = Mmr::new();
@@ -1070,7 +1073,7 @@ mod tests {
     #[test_traced]
     fn test_grafted_mmr_basic() {
         let grafting_height = 1u32;
-        let standard = crate::qmdb::hasher::<Sha256>();
+        let standard = qmdb::hasher::<Sha256>();
 
         // Build a grafted MMR with 2 leaves.
         let d0 = Sha256::fill(0x01);
@@ -1104,7 +1107,7 @@ mod tests {
     #[test_traced]
     fn test_grafted_mmr_with_pruning() {
         let grafting_height = 1u32;
-        let standard = crate::qmdb::hasher::<Sha256>();
+        let standard = qmdb::hasher::<Sha256>();
 
         // Simulate pruning 4 chunks. The pruned sub-MMR has 4 grafted leaves,
         // mmr_size(4) = 7, with one peak at grafted position 6.

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -319,9 +319,9 @@
 //! against the ops root, not the canonical root.
 //!
 //! For state sync, the sync engine targets the ops root and verifies each batch against it. Callers
-//! verifying ops proofs directly should use [`crate::qmdb::hasher`]. After sync, the bitmap and
-//! grafted tree are reconstructed deterministically from the operations, and the canonical root is
-//! computed. [proof::OpsRootWitness] can be used to validate that a particular ops root is
+//! verifying ops proofs directly should use [`crate::qmdb::verify_proof`]. After sync, the bitmap
+//! and grafted tree are reconstructed deterministically from the operations, and the canonical root
+//! is computed. [proof::OpsRootWitness] can be used to validate that a particular ops root is
 //! committed by a trusted canonical root; the sync engine does not perform this check itself.
 
 use crate::{
@@ -332,7 +332,6 @@ use crate::{
     },
     merkle::{self, full::Config as MerkleConfig, Location},
     qmdb::{
-        self,
         any::{
             self,
             operation::{Operation, Update},
@@ -448,11 +447,9 @@ where
     let any = any::init_with_bitmap(context.child("any"), config.into(), Some(bitmap)).await?;
 
     // Build the grafted tree from the bitmap and ops tree.
-    let hasher = qmdb::hasher::<H>();
     let ops_size = any.log.merkle.size();
     let ops_leaves = crate::merkle::Location::<F>::try_from(ops_size)?;
     let grafted_tree = db::build_grafted_tree::<F, H, S, N>(
-        &hasher,
         any.bitmap.as_ref(),
         &pinned_nodes,
         &any.log.merkle,
@@ -462,16 +459,14 @@ where
     .await?;
 
     // Compute and cache the root.
-    let storage = grafting::Storage::new(
+    let storage = grafting::Storage::<F, H, _, _>::new(
         &grafted_tree,
         grafting::height::<N>(),
         &any.log.merkle,
-        hasher.clone(),
     );
     let partial_chunk = db::partial_chunk(any.bitmap.as_ref());
     let ops_root = any.root();
-    let root = db::compute_db_root(
-        &hasher,
+    let root = db::compute_db_root::<F, H, _, _, N>(
         any.bitmap.as_ref(),
         &storage,
         ops_leaves,
@@ -514,9 +509,8 @@ pub mod tests {
     pub use super::BitmapPrunedBits;
     use super::{ordered, unordered, FConfig, FixedConfig, MerkleConfig, VConfig, VariableConfig};
     use crate::{
-        merkle::{self, mmb, mmr, Bagging::ForwardFold},
+        merkle::{self, mmb, mmr},
         qmdb::{
-            self,
             any::{
                 test::colliding_digest,
                 traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
@@ -1383,7 +1377,6 @@ pub mod tests {
 
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = qmdb::hasher::<Sha256>();
             let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
             let cfg = VariableConfig {
                 merkle_config: MerkleConfig {
@@ -1451,17 +1444,17 @@ pub mod tests {
 
             // Honest exclusion proving refuses a live key.
             assert!(matches!(
-                db.exclusion_proof(&hasher, &c).await,
+                db.exclusion_proof(&c).await,
                 Err(Error::KeyExists)
             ));
 
             // Forge attempt: package `b`'s authenticated update as an exclusion proof for `c`. The
             // span [b, c) does not cover `c`, so the verifier rejects it (pre-fix the span was
             // [b, a), which cyclically covered `c` and verified).
-            let kvp = db.key_value_proof(&hasher, b.clone()).await.unwrap();
+            let kvp = db.key_value_proof(b.clone()).await.unwrap();
             let forged = ordered::ExclusionProof::KeyValue(kvp.proof, span_b);
             assert!(!ForgedExclusionDb::verify_exclusion_proof(
-                &hasher, &c, &forged, &root
+                &c, &forged, &root
             ));
 
             db.destroy().await.unwrap();
@@ -1955,8 +1948,7 @@ pub mod tests {
             assert_eq!(reopened.get(&k).await.unwrap(), expected);
 
             // key_value_proof: RangeProof::new must also handle pruned chunk 0.
-            let hasher = qmdb::hasher::<Sha256>();
-            let _proof = reopened.key_value_proof(&hasher, k).await.unwrap();
+            let _proof = reopened.key_value_proof(k).await.unwrap();
 
             reopened.destroy().await.unwrap();
         });
@@ -2196,10 +2188,8 @@ pub mod tests {
                 mmb_commit(&mut db, [(key(1), Some(val(round)))]).await;
             }
 
-            let hasher = qmdb::hasher::<Sha256>();
-            let proof = db.key_value_proof(&hasher, k).await.unwrap();
+            let proof = db.key_value_proof(k).await.unwrap();
             assert!(UnorderedVariableMmbDb::verify_key_value_proof(
-                &hasher,
                 k,
                 val(60_000 + 199),
                 &proof,
@@ -2219,10 +2209,8 @@ pub mod tests {
 
             assert_eq!(reopened.root(), target_root);
 
-            let hasher = qmdb::hasher::<Sha256>();
-            let proof = reopened.key_value_proof(&hasher, k).await.unwrap();
+            let proof = reopened.key_value_proof(k).await.unwrap();
             assert!(UnorderedVariableMmbDb::verify_key_value_proof(
-                &hasher,
                 k,
                 val(60_000 + 199),
                 &proof,
@@ -2446,11 +2434,9 @@ pub mod tests {
                     "root mismatch after prune at round {round}"
                 );
 
-                let hasher = qmdb::hasher::<Sha256>();
-                let proof = db.key_value_proof(&hasher, k).await.unwrap();
+                let proof = db.key_value_proof(k).await.unwrap();
                 assert!(
                     UnorderedVariableMmbDb::verify_key_value_proof(
-                        &hasher,
                         k,
                         expected.expect("value should exist"),
                         &proof,
@@ -2479,11 +2465,9 @@ pub mod tests {
                     "value mismatch after reopen at round {round}"
                 );
 
-                let hasher = qmdb::hasher::<Sha256>();
-                let proof = db.key_value_proof(&hasher, k).await.unwrap();
+                let proof = db.key_value_proof(k).await.unwrap();
                 assert!(
                     UnorderedVariableMmbDb::verify_key_value_proof(
-                        &hasher,
                         k,
                         expected.expect("value should exist"),
                         &proof,
@@ -3885,7 +3869,7 @@ pub mod tests {
     /// Regression: `ops_historical_proof` must verify with QMDB's ops-tree hasher configuration.
     #[test_traced("INFO")]
     fn test_current_mmb_ops_historical_proof_verifies_with_backward_bagging() {
-        use crate::{merkle::hasher::Standard, qmdb::verify_proof};
+        use crate::qmdb::verify_proof;
         use commonware_utils::NZU64;
 
         let executor = deterministic::Runner::default();
@@ -3911,19 +3895,7 @@ pub mod tests {
                 .unwrap();
 
             // Verifies under the QMDB ops-tree hasher configuration.
-            let hasher = qmdb::hasher::<Sha256>();
-            assert!(verify_proof(
-                &hasher,
-                &proof,
-                Location::new(0),
-                &ops,
-                &ops_root
-            ));
-
-            // Sanity: a different Merkle hasher configuration must not accept this proof.
-            let plain = Standard::<Sha256>::new(ForwardFold);
-            assert!(!verify_proof(
-                &plain,
+            assert!(verify_proof::<Sha256, _, _>(
                 &proof,
                 Location::new(0),
                 &ops,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -516,6 +516,7 @@ pub mod tests {
                 traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
             },
             store::tests::{TestKey, TestValue},
+            verify_proof,
         },
         translator::Translator,
     };
@@ -3869,9 +3870,6 @@ pub mod tests {
     /// Regression: `ops_historical_proof` must verify with QMDB's ops-tree hasher configuration.
     #[test_traced("INFO")]
     fn test_current_mmb_ops_historical_proof_verifies_with_backward_bagging() {
-        use crate::qmdb::verify_proof;
-        use commonware_utils::NZU64;
-
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -6,7 +6,7 @@
 use crate::{
     index::Ordered as OrderedIndex,
     journal::contiguous::{Contiguous, Mutable},
-    merkle::{self, hasher::Standard as StandardHasher, Location},
+    merkle::{self, Location},
     qmdb::{
         any::{
             ordered::{Operation, Update},
@@ -107,7 +107,6 @@ where
     /// Return true if the proof authenticates that `key` currently has value `value` in the db with
     /// the provided `root`.
     pub fn verify_key_value_proof(
-        hasher: &StandardHasher<H>,
         key: K,
         value: V::Value,
         proof: &KeyValueProof<F, K, H::Digest, N>,
@@ -119,7 +118,7 @@ where
             next_key: proof.next_key.clone(),
         });
 
-        proof.proof.verify(hasher, op, root)
+        proof.proof.verify::<H, _>(op, root)
     }
 
     /// Get the operation that currently defines the span whose range contains `key`, or None if the
@@ -143,7 +142,6 @@ where
     /// Return true if the proof authenticates that `key` does _not_ exist in the db with the
     /// provided `root`.
     pub fn verify_exclusion_proof(
-        hasher: &StandardHasher<H>,
         key: &K,
         proof: &super::ExclusionProof<F, K, V, H::Digest, N>,
         root: &H::Digest,
@@ -178,7 +176,7 @@ where
             }
         };
 
-        op_proof.verify(hasher, op, root)
+        op_proof.verify::<H, _>(op, root)
     }
 }
 
@@ -205,14 +203,13 @@ where
     /// Returns [Error::KeyNotFound] if the key is not currently assigned any value.
     pub async fn key_value_proof(
         &self,
-        hasher: &StandardHasher<H>,
         key: K,
     ) -> Result<KeyValueProof<F, K, H::Digest, N>, Error<F>> {
         let op_loc = self.any.get_with_loc(&key).await?;
         let Some((data, loc)) = op_loc else {
             return Err(Error::<F>::KeyNotFound);
         };
-        let proof = self.operation_proof(hasher, loc).await?;
+        let proof = self.operation_proof(loc).await?;
 
         Ok(KeyValueProof {
             proof,
@@ -227,7 +224,6 @@ where
     /// Returns [Error::KeyExists] if the key exists in the db.
     pub async fn exclusion_proof(
         &self,
-        hasher: &StandardHasher<H>,
         key: &K,
     ) -> Result<super::ExclusionProof<F, K, V, H::Digest, N>, Error<F>> {
         match self.any.get_span(key).await? {
@@ -236,7 +232,7 @@ where
                     // Cannot prove exclusion of a key that exists in the db.
                     return Err(Error::<F>::KeyExists);
                 }
-                let op_proof = self.operation_proof(hasher, loc).await?;
+                let op_proof = self.operation_proof(loc).await?;
                 Ok(super::ExclusionProof::KeyValue(op_proof, key_data))
             }
             None => {
@@ -252,9 +248,7 @@ where
                     "inconsistent commit floor: expected last_commit_loc={}, got floor={}",
                     self.any.last_commit_loc, floor
                 );
-                let op_proof = self
-                    .operation_proof(hasher, self.any.last_commit_loc)
-                    .await?;
+                let op_proof = self.operation_proof(self.any.last_commit_loc).await?;
                 Ok(super::ExclusionProof::Commit(op_proof, value))
             }
         }

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -153,7 +153,6 @@ pub mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let partition = "range-proofs-pruned".to_string();
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let mut db = open_db(context.child("db"), partition).await;
 
             let chunk_bits = BitMap::<32>::CHUNK_SIZE_BITS;
@@ -182,7 +181,7 @@ pub mod test {
 
             // Requesting a range proof at location 0 (in the pruned range) should return
             // OperationPruned, not panic.
-            let result = db.range_proof(&hasher, Location::new(0), NZU64!(1)).await;
+            let result = db.range_proof(Location::new(0), NZU64!(1)).await;
             assert!(
                 matches!(result, Err(Error::OperationPruned(_))),
                 "expected OperationPruned, got {result:?}"

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -309,7 +309,6 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "build-small".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -325,24 +324,23 @@ pub mod tests {
             db.apply_batch(merkleized).await.unwrap();
 
             let (_, op_loc) = db.any.get_with_loc(&k).await.unwrap().unwrap();
-            let proof = db.key_value_proof(&hasher, k).await.unwrap();
+            let proof = db.key_value_proof(k).await.unwrap();
 
             // Proof should be verifiable against current root.
             let root = db.root();
             assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v1, &proof, &root,
+                k, v1, &proof, &root,
             ));
 
             let v2 = Sha256::fill(0xA2);
             // Proof should not verify against a different value.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v2, &proof, &root,
+                k, v2, &proof, &root,
             ));
             // Proof should not verify against a mangled next_key.
             let mut mangled_proof = proof.clone();
             mangled_proof.next_key = Sha256::fill(0xFF);
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher,
                 k,
                 v1,
                 &mangled_proof,
@@ -361,23 +359,23 @@ pub mod tests {
 
             // New value should not be verifiable against the old proof.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v2, &proof, &root,
+                k, v2, &proof, &root,
             ));
 
             // But the new value should verify against a new proof.
-            let proof = db.key_value_proof(&hasher, k).await.unwrap();
+            let proof = db.key_value_proof(k).await.unwrap();
             assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v2, &proof, &root,
+                k, v2, &proof, &root,
             ));
 
             // Old value will not verify against new proof.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v1, &proof, &root,
+                k, v1, &proof, &root,
             ));
 
             // Create a proof of the now-inactive update operation assigning v1 to k against the
             // current root.
-            let (p, _, chunks) = db.range_proof(&hasher, op_loc, NZU64!(1)).await.unwrap();
+            let (p, _, chunks) = db.range_proof(op_loc, NZU64!(1)).await.unwrap();
             let proof_inactive = db::KeyValueProof {
                 proof: crate::qmdb::current::proof::OperationProof {
                     loc: op_loc,
@@ -394,7 +392,6 @@ pub mod tests {
                 next_key: k,
             });
             assert!(TestDb::<F, C, V>::verify_range_proof(
-                &hasher,
                 &proof_inactive.proof.range_proof,
                 proof_inactive.proof.loc,
                 &[op],
@@ -405,7 +402,6 @@ pub mod tests {
             // But this proof should *not* verify as a key value proof, since verification will see
             // that the operation is inactive.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher,
                 k,
                 v1,
                 &proof_inactive,
@@ -425,7 +421,6 @@ pub mod tests {
             let mut fake_proof = proof_inactive.clone();
             fake_proof.proof.loc = active_loc;
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher,
                 k,
                 v1,
                 &fake_proof,
@@ -445,7 +440,6 @@ pub mod tests {
             let mut fake_proof = proof_inactive.clone();
             fake_proof.proof.chunk = modified_chunk;
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher,
                 k,
                 v1,
                 &fake_proof,
@@ -473,7 +467,6 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let db = open_db(context.child("db"), partition.clone()).await;
             let root = db.root();
 
@@ -485,7 +478,6 @@ pub mod tests {
                 ops_root: Digest::EMPTY,
             };
             assert!(!TestDb::<F, C, V>::verify_range_proof(
-                &hasher,
                 &proof,
                 Location::<F>::new(0),
                 &[],
@@ -508,19 +500,15 @@ pub mod tests {
 
             for loc in *start_loc..*end_loc {
                 let loc = Location::<F>::new(loc);
-                let (proof, ops, chunks) =
-                    db.range_proof(&hasher, loc, NZU64!(max_ops)).await.unwrap();
+                let (proof, ops, chunks) = db.range_proof(loc, NZU64!(max_ops)).await.unwrap();
                 assert!(
-                    TestDb::<F, C, V>::verify_range_proof(
-                        &hasher, &proof, loc, &ops, &chunks, &root
-                    ),
+                    TestDb::<F, C, V>::verify_range_proof(&proof, loc, &ops, &chunks, &root),
                     "failed to verify range at start_loc {start_loc}",
                 );
                 // Proof should not verify if we include extra chunks.
                 let mut chunks_with_extra = chunks.clone();
                 chunks_with_extra.push(chunks[chunks.len() - 1]);
                 assert!(!TestDb::<F, C, V>::verify_range_proof(
-                    &hasher,
                     &proof,
                     loc,
                     &ops,
@@ -550,7 +538,6 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let db = open_db(context.child("db"), partition.clone()).await;
             let mut db = apply_random_ops::<F, TestDb<F, C, V>>(500, true, context.next_u64(), db)
                 .await
@@ -561,7 +548,7 @@ pub mod tests {
 
             // Confirm bad keys produce the expected error.
             let bad_key = Sha256::fill(0xAA);
-            let res = db.key_value_proof(&hasher, bad_key).await;
+            let res = db.key_value_proof(bad_key).await;
             assert!(matches!(res, Err(Error::KeyNotFound)));
 
             let start = *db.inactivity_floor_loc();
@@ -577,28 +564,27 @@ pub mod tests {
                     Operation::CommitFloor(_, _) => continue,
                     _ => unreachable!("expected update or commit floor operation"),
                 };
-                let proof = db.key_value_proof(&hasher, key).await.unwrap();
+                let proof = db.key_value_proof(key).await.unwrap();
 
                 // Proof should validate against the current value and correct root.
                 assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                    &hasher, key, value, &proof, &root
+                    key, value, &proof, &root
                 ));
                 // Proof should fail against the wrong value. Use hash instead of fill to ensure
                 // the value differs from any key/value created by TestKey::from_seed (which uses
                 // fill patterns).
                 let wrong_val = Sha256::hash(&[0xFF]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &hasher, key, wrong_val, &proof, &root
+                    key, wrong_val, &proof, &root
                 ));
                 // Proof should fail against the wrong key.
                 let wrong_key = Sha256::hash(&[0xEE]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &hasher, wrong_key, value, &proof, &root
+                    wrong_key, value, &proof, &root
                 ));
                 // Proof should fail against the wrong root.
                 let wrong_root = Sha256::hash(&[0xDD]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &hasher,
                     key,
                     value,
                     &proof,
@@ -608,7 +594,7 @@ pub mod tests {
                 let mut bad_proof = proof.clone();
                 bad_proof.next_key = wrong_key;
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &hasher, key, value, &bad_proof, &root,
+                    key, value, &bad_proof, &root,
                 ));
             }
 
@@ -632,7 +618,6 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "build-small".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -652,14 +637,14 @@ pub mod tests {
                 let root = db.root();
 
                 // Create a proof for the current value of k.
-                let proof = db.key_value_proof(&hasher, k).await.unwrap();
+                let proof = db.key_value_proof(k).await.unwrap();
                 assert!(
-                    TestDb::<F, C, V>::verify_key_value_proof(&hasher, k, v, &proof, &root),
+                    TestDb::<F, C, V>::verify_key_value_proof(k, v, &proof, &root),
                     "proof of update {i} failed to verify"
                 );
                 // Ensure the proof does NOT verify if we use the previous value.
                 assert!(
-                    !TestDb::<F, C, V>::verify_key_value_proof(&hasher, k, old_val, &proof, &root,),
+                    !TestDb::<F, C, V>::verify_key_value_proof(k, old_val, &proof, &root,),
                     "proof of update {i} verified when it should not have"
                 );
                 old_val = v;
@@ -686,7 +671,6 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "exclusion-proofs".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -694,9 +678,8 @@ pub mod tests {
 
             // We should be able to prove exclusion for any key against an empty db.
             let empty_root = db.root();
-            let empty_proof = db.exclusion_proof(&hasher, &key_exists_1).await.unwrap();
+            let empty_proof = db.exclusion_proof(&key_exists_1).await.unwrap();
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &key_exists_1,
                 &empty_proof,
                 &empty_root,
@@ -714,34 +697,31 @@ pub mod tests {
             let root = db.root();
 
             // We shouldn't be able to generate an exclusion proof for a key already in the db.
-            let result = db.exclusion_proof(&hasher, &key_exists_1).await;
+            let result = db.exclusion_proof(&key_exists_1).await;
             assert!(matches!(result, Err(Error::KeyExists)));
 
             // Generate some valid exclusion proofs for keys on either side.
             let greater_key = Sha256::fill(0xFF);
             let lesser_key = Sha256::fill(0x00);
-            let proof = db.exclusion_proof(&hasher, &greater_key).await.unwrap();
-            let proof2 = db.exclusion_proof(&hasher, &lesser_key).await.unwrap();
+            let proof = db.exclusion_proof(&greater_key).await.unwrap();
+            let proof2 = db.exclusion_proof(&lesser_key).await.unwrap();
 
             // Since there's only one span in the DB, the two exclusion proofs should be identical,
             // and the proof should verify any key but the one that exists in the db.
             assert_eq!(proof, proof2);
             // Any key except the one that exists should verify against this proof.
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &greater_key,
                 &proof,
                 &root,
             ));
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &lesser_key,
                 &proof,
                 &root,
             ));
             // Exclusion should fail if we test it on a key that exists.
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &key_exists_1,
                 &proof,
                 &root,
@@ -765,50 +745,44 @@ pub mod tests {
             let lesser_key = Sha256::fill(0x0F); // < k1=0x10
             let greater_key = Sha256::fill(0x31); // > k2=0x30
             let middle_key = Sha256::fill(0x20); // between k1=0x10 and k2=0x30
-            let proof = db.exclusion_proof(&hasher, &greater_key).await.unwrap();
+            let proof = db.exclusion_proof(&greater_key).await.unwrap();
             // Test the "cycle around" span. This should prove exclusion of greater_key & lesser
             // key, but fail on middle_key.
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &greater_key,
                 &proof,
                 &root,
             ));
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &lesser_key,
                 &proof,
                 &root,
             ));
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &middle_key,
                 &proof,
                 &root,
             ));
 
             // Due to the cycle, lesser & greater keys should produce the same proof.
-            let new_proof = db.exclusion_proof(&hasher, &lesser_key).await.unwrap();
+            let new_proof = db.exclusion_proof(&lesser_key).await.unwrap();
             assert_eq!(proof, new_proof);
 
             // Test the inner span [k, k2).
-            let proof = db.exclusion_proof(&hasher, &middle_key).await.unwrap();
+            let proof = db.exclusion_proof(&middle_key).await.unwrap();
             // `k` should fail since it's in the db.
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &key_exists_1,
                 &proof,
                 &root,
             ));
             // `middle_key` should succeed since it's in range.
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &middle_key,
                 &proof,
                 &root,
             ));
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &key_exists_2,
                 &proof,
                 &root,
@@ -816,7 +790,6 @@ pub mod tests {
 
             let conflicting_middle_key = Sha256::fill(0x11); // between k1=0x10 and k2=0x30
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &conflicting_middle_key,
                 &proof,
                 &root,
@@ -824,13 +797,11 @@ pub mod tests {
 
             // Using lesser/greater keys for the middle-proof should fail.
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &greater_key,
                 &proof,
                 &root,
             ));
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &lesser_key,
                 &proof,
                 &root,
@@ -854,15 +825,13 @@ pub mod tests {
             assert_ne!(db.bounds().end, 0);
             assert_ne!(root, empty_root);
 
-            let proof = db.exclusion_proof(&hasher, &key_exists_1).await.unwrap();
+            let proof = db.exclusion_proof(&key_exists_1).await.unwrap();
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &key_exists_1,
                 &proof,
                 &root,
             ));
             assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &key_exists_2,
                 &proof,
                 &root,
@@ -870,13 +839,11 @@ pub mod tests {
 
             // Try fooling the verifier with improper values.
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &key_exists_1,
                 &empty_proof, // wrong proof
                 &root,
             ));
             assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &hasher,
                 &key_exists_1,
                 &proof,
                 &empty_root, // wrong root

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -355,7 +355,6 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             start_chunk,
             chunk_vec,
             graftable_chunks,
-            qmdb::ROOT_BAGGING,
         );
 
         if self.pending_chunk_digest.as_ref().is_some() != has_pending_chunk {

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -30,10 +30,8 @@
 use crate::{
     journal::contiguous::Contiguous,
     merkle::{
-        self,
-        hasher::{Hasher, Standard as StandardHasher},
-        storage::Storage,
-        Family, Graftable, Location, PendingChunk, Position, Proof,
+        self, hasher::Hasher as _, storage::Storage, Family, Graftable, Location, PendingChunk,
+        Position, Proof,
     },
     qmdb::{
         self,
@@ -46,7 +44,7 @@ use crate::{
 };
 use bytes::{Buf, BufMut};
 use commonware_codec::{varint::UInt, Codec, EncodeSize, Read, ReadExt as _, Write};
-use commonware_cryptography::{Digest, Hasher as CHasher};
+use commonware_cryptography::{Digest, Hasher};
 use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
 use core::{num::NonZeroU64, ops::Range};
 use futures::future::try_join_all;
@@ -74,10 +72,9 @@ impl<F: Graftable, D: Digest> OpsRootWitness<F, D> {
     ///
     /// See the [Canonical root structure](self#canonical-root-structure) section in the module
     /// documentation for the full layout.
-    pub fn root<H: CHasher<Digest = D>>(&self, hasher: &StandardHasher<H>, ops_root: &D) -> D {
+    pub fn root<H: Hasher<Digest = D>>(&self, ops_root: &D) -> D {
         let partial = self.partial_chunk.as_ref().map(|(nb, d)| (*nb, d));
-        combine_roots(
-            hasher,
+        combine_roots::<H>(
             ops_root,
             &self.grafted_root,
             self.pending_chunk_digest.as_ref(),
@@ -86,13 +83,8 @@ impl<F: Graftable, D: Digest> OpsRootWitness<F, D> {
     }
 
     /// Return true if this witness proves that `root` commits to `ops_root`.
-    pub fn verify<H: CHasher<Digest = D>>(
-        &self,
-        hasher: &StandardHasher<H>,
-        ops_root: &D,
-        root: &D,
-    ) -> bool {
-        self.root(hasher, ops_root) == *root
+    pub fn verify<H: Hasher<Digest = D>>(&self, ops_root: &D, root: &D) -> bool {
+        self.root::<H>(ops_root) == *root
     }
 }
 
@@ -189,8 +181,7 @@ pub struct RangeProofSpec<F: Family, D: Digest> {
 
 impl<F: Graftable, D: Digest> RangeProof<F, D> {
     /// Create a new range proof for the provided `range` of operations.
-    pub async fn new<H: CHasher<Digest = D>, S: Storage<F, Digest = D>, const N: usize>(
-        hasher: &StandardHasher<H>,
+    pub async fn new<H: Hasher<Digest = D>, S: Storage<F, Digest = D>, const N: usize>(
         status: &impl BitmapReadable<N>,
         storage: &S,
         inactivity_floor: Location<F>,
@@ -207,8 +198,9 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             grafting_height,
         )?;
 
+        let hasher = qmdb::hasher::<H>();
         let proof = merkle::verification::historical_range_proof(
-            hasher,
+            &hasher,
             storage,
             ops_leaves,
             range,
@@ -216,12 +208,13 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         )
         .await?;
 
+        let hasher = crate::qmdb::hasher::<H>();
         let partial_chunk_digest =
-            partial_chunk::<_, N>(status).map(|(chunk, _)| hasher.digest(&chunk));
+            partial_chunk::<_, N>(status).map(|(chunk, _)| hasher.digest(chunk.as_slice()));
 
         let pending_chunk_digest: F::PendingChunk<D> =
             pending_chunk::<_, _, N>(status, ops_leaves, grafting_height)?
-                .map(|chunk| hasher.digest(&chunk))
+                .map(|chunk| hasher.digest(chunk.as_slice()))
                 .try_into()
                 .expect("pending_chunk must be consistent with family");
 
@@ -243,12 +236,11 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
     /// Returns [`merkle::Error::LocationOverflow`] if `start_loc` > [merkle::Family::MAX_LEAVES].
     /// Returns [`merkle::Error::RangeOutOfBounds`] if `start_loc` >= number of leaves in the tree.
     pub async fn new_with_ops<
-        H: CHasher<Digest = D>,
+        H: Hasher<Digest = D>,
         C: Contiguous,
         S: Storage<F, Digest = D>,
         const N: usize,
     >(
-        hasher: &StandardHasher<H>,
         status: &impl BitmapReadable<N>,
         storage: &S,
         log: &C,
@@ -271,8 +263,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         let end_loc = core::cmp::min(max_loc, leaves);
 
         // Generate the proof from the grafted storage.
-        let proof = Self::new(
-            hasher,
+        let proof = Self::new::<H, S, N>(
             status,
             storage,
             request.inactivity_floor,
@@ -300,14 +291,13 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
     /// required to compute the peaks covering the proven range.
     fn reconstruct_root<H, O, const N: usize>(
         &self,
-        root_hasher: &StandardHasher<H>,
         start_loc: Location<F>,
         ops: &[O],
         chunks: &[[u8; N]],
         collected: Option<&mut Vec<(Position<F>, D)>>,
     ) -> Result<D, merkle::Error<F>>
     where
-        H: CHasher<Digest = D>,
+        H: Hasher<Digest = D>,
         O: Codec,
     {
         if ops.is_empty() || chunks.is_empty() {
@@ -438,8 +428,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
 
         let partial =
             has_partial_chunk.then(|| (next_bit, self.partial_chunk_digest.as_ref().unwrap()));
-        Ok(combine_roots(
-            root_hasher,
+        Ok(combine_roots::<H>(
             &self.ops_root,
             &merkle_root,
             self.pending_chunk_digest.as_ref(),
@@ -449,16 +438,15 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
 
     /// Return true if the given sequence of `ops` were applied starting at location `start_loc` in
     /// the db with the provided root, and having the activity status described by `chunks`.
-    pub fn verify<H: CHasher<Digest = D>, O: Codec, const N: usize>(
+    pub fn verify<H: Hasher<Digest = D>, O: Codec, const N: usize>(
         &self,
-        root_hasher: &StandardHasher<H>,
         start_loc: Location<F>,
         ops: &[O],
         chunks: &[[u8; N]],
         root: &H::Digest,
     ) -> bool {
         matches!(
-            self.reconstruct_root(root_hasher, start_loc, ops, chunks, None),
+            self.reconstruct_root::<H, O, N>(start_loc, ops, chunks, None),
             Ok(reconstructed_root) if reconstructed_root == *root
         )
     }
@@ -467,7 +455,6 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
 /// Verify that a [RangeProof] is valid for a range of operations and return the positioned digests
 /// required to compute the peaks covering the proven range.
 pub fn verify_proof_and_extract_digests<F, Op, H, D, const N: usize>(
-    hasher: &StandardHasher<H>,
     proof: &RangeProof<F, D>,
     start_loc: Location<F>,
     operations: &[Op],
@@ -477,12 +464,12 @@ pub fn verify_proof_and_extract_digests<F, Op, H, D, const N: usize>(
 where
     F: Graftable,
     Op: Codec,
-    H: CHasher<Digest = D>,
+    H: Hasher<Digest = D>,
     D: Digest,
 {
     let mut collected = Vec::new();
     let reconstructed_root =
-        proof.reconstruct_root(hasher, start_loc, operations, chunks, Some(&mut collected))?;
+        proof.reconstruct_root::<H, Op, N>(start_loc, operations, chunks, Some(&mut collected))?;
     if reconstructed_root != *target_root {
         debug!("verification failed, root mismatch");
         return Err(merkle::Error::RootMismatch);
@@ -566,8 +553,7 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
     /// # Errors
     ///
     /// Returns [Error::OperationPruned] if `loc` falls in a pruned bitmap chunk.
-    pub async fn new<H: CHasher<Digest = D>, S: Storage<F, Digest = D>>(
-        hasher: &StandardHasher<H>,
+    pub async fn new<H: Hasher<Digest = D>, S: Storage<F, Digest = D>>(
         status: &impl BitmapReadable<N>,
         storage: &S,
         inactivity_floor: Location<F>,
@@ -578,15 +564,9 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
         if BitMap::<N>::to_chunk_index(*loc) < status.pruned_chunks() {
             return Err(Error::OperationPruned(loc));
         }
-        let range_proof = RangeProof::new(
-            hasher,
-            status,
-            storage,
-            inactivity_floor,
-            loc..loc + 1,
-            ops_root,
-        )
-        .await?;
+        let range_proof =
+            RangeProof::new::<H, S, N>(status, storage, inactivity_floor, loc..loc + 1, ops_root)
+                .await?;
         let chunk = status.get_chunk(BitMap::<N>::to_chunk_index(*loc));
         Ok(Self {
             loc,
@@ -599,12 +579,7 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
 impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
     /// Verify that the proof proves that `operation` is active in the database with the given
     /// `root`.
-    pub fn verify<H: CHasher<Digest = D>, O: Codec>(
-        &self,
-        hasher: &StandardHasher<H>,
-        operation: O,
-        root: &D,
-    ) -> bool {
+    pub fn verify<H: Hasher<Digest = D>, O: Codec>(&self, operation: O, root: &D) -> bool {
         // Make sure that the bit for the operation in the bitmap chunk is actually a 1 (indicating
         // the operation is indeed active).
         if !BitMap::<N>::get_bit_from_chunk(&self.chunk, *self.loc) {
@@ -616,7 +591,7 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
         }
 
         self.range_proof
-            .verify(hasher, self.loc, &[operation], &[self.chunk], root)
+            .verify::<H, O, N>(self.loc, &[operation], &[self.chunk], root)
     }
 }
 
@@ -672,7 +647,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        merkle::{conformance::build_test_mem, mem::Mem},
+        merkle::{conformance::build_test_mem, hasher::Standard as StandardHasher, mem::Mem},
         mmb, mmr,
         qmdb::current::{db, grafting},
     };
@@ -707,7 +682,6 @@ mod tests {
     fn test_ops_root_witness_root_matches_verify() {
         type F = mmb::Family;
 
-        let hasher = qmdb::hasher::<Sha256>();
         let ops_root = Sha256::hash(b"ops root");
         let witness: OpsRootWitness<F, _> = OpsRootWitness {
             grafted_root: Sha256::hash(b"grafted root"),
@@ -715,13 +689,13 @@ mod tests {
             partial_chunk: Some((13, Sha256::hash(b"partial chunk"))),
         };
 
-        let root = witness.root(&hasher, &ops_root);
+        let root = witness.root::<Sha256>(&ops_root);
 
-        assert!(witness.verify(&hasher, &ops_root, &root));
+        assert!(witness.verify::<Sha256>(&ops_root, &root));
         assert_ne!(root, ops_root);
 
         let wrong_ops_root = Sha256::hash(b"wrong ops root");
-        assert!(!witness.verify(&hasher, &wrong_ops_root, &root));
+        assert!(!witness.verify::<Sha256>(&wrong_ops_root, &root));
     }
 
     fn range_proof_digest_count<F: Graftable, D: Digest>(proof: &RangeProof<F, D>) -> usize {
@@ -937,14 +911,10 @@ mod tests {
                 )
             })
             .collect();
-        let mut leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
-            &hasher,
-            &ops,
-            chunk_inputs,
-            &Sequential,
-        )
-        .await
-        .unwrap();
+        let mut leaf_digests =
+            db::compute_grafted_leaves::<F, Sha256, Sequential, N>(&ops, chunk_inputs, &Sequential)
+                .await
+                .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
         let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
@@ -958,10 +928,9 @@ mod tests {
         };
         grafted.apply_batch(&merkleized).unwrap();
 
-        let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+        let storage = grafting::Storage::<F, Sha256, _, _>::new(&grafted, grafting_height, &ops);
         let ops_leaves_for_root = Location::<F>::try_from(ops.size()).unwrap();
         let root = db::compute_db_root::<F, Sha256, _, _, N>(
-            &hasher,
             &status,
             &storage,
             ops_leaves_for_root,
@@ -973,8 +942,7 @@ mod tests {
         .unwrap();
 
         let loc = mmb::Location::new(BitMap::<N>::CHUNK_SIZE_BITS + 4);
-        let proof = RangeProof::new(
-            &hasher,
+        let proof = RangeProof::new::<Sha256, _, N>(
             &status,
             &storage,
             Location::new(0),
@@ -985,8 +953,7 @@ mod tests {
         .unwrap();
 
         let element = hasher.digest(&(*loc).to_be_bytes());
-        assert!(proof.verify(
-            &hasher,
+        assert!(proof.verify::<Sha256, _, N>(
             loc,
             &[element],
             &[<BitMap<N> as BitmapReadable<N>>::get_chunk(&status, 1)],
@@ -1037,14 +1004,10 @@ mod tests {
                 )
             })
             .collect();
-        let mut leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
-            &hasher,
-            &ops,
-            chunk_inputs,
-            &Sequential,
-        )
-        .await
-        .unwrap();
+        let mut leaf_digests =
+            db::compute_grafted_leaves::<F, Sha256, Sequential, N>(&ops, chunk_inputs, &Sequential)
+                .await
+                .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
         let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
@@ -1058,14 +1021,13 @@ mod tests {
         };
         grafted.apply_batch(&merkleized).unwrap();
 
-        let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+        let storage = grafting::Storage::<F, Sha256, _, _>::new(&grafted, grafting_height, &ops);
         let partial = {
             let (chunk, next_bit) = status.last_chunk();
             Some((*chunk, next_bit))
         };
         let ops_leaves_for_root = Location::<F>::try_from(ops.size()).unwrap();
         let root = db::compute_db_root::<F, Sha256, _, _, N>(
-            &hasher,
             &status,
             &storage,
             ops_leaves_for_root,
@@ -1075,8 +1037,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let proof = RangeProof::new(
-            &hasher,
+        let proof = RangeProof::new::<Sha256, _, N>(
             &status,
             &storage,
             Location::new(0),
@@ -1088,8 +1049,7 @@ mod tests {
 
         let element = hasher.digest(&(*loc).to_be_bytes());
         let chunk_idx = (*loc / BitMap::<N>::CHUNK_SIZE_BITS) as usize;
-        assert!(proof.verify(
-            &hasher,
+        assert!(proof.verify::<Sha256, _, N>(
             loc,
             &[element],
             &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1146,14 +1106,10 @@ mod tests {
                 )
             })
             .collect();
-        let mut leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
-            &hasher,
-            &ops,
-            chunk_inputs,
-            &Sequential,
-        )
-        .await
-        .unwrap();
+        let mut leaf_digests =
+            db::compute_grafted_leaves::<F, Sha256, Sequential, N>(&ops, chunk_inputs, &Sequential)
+                .await
+                .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
         let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
@@ -1167,14 +1123,13 @@ mod tests {
         };
         grafted.apply_batch(&merkleized).unwrap();
 
-        let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+        let storage = grafting::Storage::<F, Sha256, _, _>::new(&grafted, grafting_height, &ops);
         let partial = {
             let (chunk, next_bit) = status.last_chunk();
             Some((*chunk, next_bit))
         };
         let ops_leaves_for_root = Location::<F>::try_from(ops.size()).unwrap();
         let root = db::compute_db_root::<F, Sha256, _, _, N>(
-            &hasher,
             &status,
             &storage,
             ops_leaves_for_root,
@@ -1186,8 +1141,7 @@ mod tests {
         .unwrap();
 
         let leaves_loc = mmb::Location::new(leaf_count);
-        let proof = RangeProof::new(
-            &hasher,
+        let proof = RangeProof::new::<Sha256, _, N>(
             &status,
             &storage,
             Location::new(0),
@@ -1205,14 +1159,14 @@ mod tests {
         let chunks = (start_chunk_idx..=end_chunk_idx)
             .map(|chunk_idx| <BitMap<N> as BitmapReadable<N>>::get_chunk(&status, chunk_idx))
             .collect::<Vec<_>>();
-        assert!(proof.verify(&hasher, start_loc, &elements, &chunks, &root,));
+        assert!(proof.verify::<Sha256, _, N>(start_loc, &elements, &chunks, &root,));
 
         // Flip a byte in the trailing partial chunk while preserving the window shape.
         let mut bad_chunks = chunks;
         let last = bad_chunks.last_mut().unwrap();
         last[0] ^= 1;
         assert!(
-            !proof.verify(&hasher, start_loc, &elements, &bad_chunks, &root),
+            !proof.verify::<Sha256, _, N>(start_loc, &elements, &bad_chunks, &root),
             "tampered partial chunk bytes should not verify"
         );
     }
@@ -1248,14 +1202,10 @@ mod tests {
                 )
             })
             .collect();
-        let mut leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
-            &hasher,
-            &ops,
-            chunk_inputs,
-            &Sequential,
-        )
-        .await
-        .unwrap();
+        let mut leaf_digests =
+            db::compute_grafted_leaves::<F, Sha256, Sequential, N>(&ops, chunk_inputs, &Sequential)
+                .await
+                .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
         let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
@@ -1269,10 +1219,9 @@ mod tests {
         };
         grafted.apply_batch(&merkleized).unwrap();
 
-        let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+        let storage = grafting::Storage::<F, Sha256, _, _>::new(&grafted, grafting_height, &ops);
         let ops_leaves_for_root = Location::<F>::try_from(ops.size()).unwrap();
         let root = db::compute_db_root::<F, Sha256, _, _, N>(
-            &hasher,
             &status,
             &storage,
             ops_leaves_for_root,
@@ -1284,8 +1233,7 @@ mod tests {
         .unwrap();
 
         let loc = mmb::Location::new(0);
-        let mut proof = RangeProof::new(
-            &hasher,
+        let mut proof = RangeProof::new::<Sha256, _, N>(
             &status,
             &storage,
             Location::new(0),
@@ -1301,10 +1249,10 @@ mod tests {
         // Tamper with the proof by injecting a fake partial chunk digest
         let mut tampered = proof.clone();
         tampered.partial_chunk_digest = Some(hasher.digest(b"fake partial chunk"));
-        assert!(!tampered.verify(&hasher, loc, &[element], &[chunk], &root,));
+        assert!(!tampered.verify::<Sha256, _, N>(loc, &[element], &[chunk], &root,));
 
         proof.partial_chunk_digest = Some(hasher.digest(b"fake partial chunk"));
-        assert!(!proof.verify(&hasher, loc, &[element], &[chunk], &root,));
+        assert!(!proof.verify::<Sha256, _, N>(loc, &[element], &[chunk], &root,));
     }
 
     async fn current_range_proof_fixture<F: Graftable, const N: usize>(
@@ -1343,14 +1291,10 @@ mod tests {
                 )
             })
             .collect();
-        let mut leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
-            &hasher,
-            &ops,
-            chunk_inputs,
-            &Sequential,
-        )
-        .await
-        .unwrap();
+        let mut leaf_digests =
+            db::compute_grafted_leaves::<F, Sha256, Sequential, N>(&ops, chunk_inputs, &Sequential)
+                .await
+                .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
         let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
@@ -1366,9 +1310,8 @@ mod tests {
             grafted.apply_batch(&merkleized).unwrap();
         }
 
-        let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+        let storage = grafting::Storage::<F, Sha256, _, _>::new(&grafted, grafting_height, &ops);
         let root = db::compute_db_root::<F, Sha256, _, _, N>(
-            &hasher,
             &status,
             &storage,
             ops_leaves,
@@ -1379,8 +1322,7 @@ mod tests {
         .await
         .unwrap();
 
-        let proof = RangeProof::new(
-            &hasher,
+        let proof = RangeProof::new::<Sha256, _, N>(
             &status,
             &storage,
             Location::new(0),
@@ -1400,7 +1342,7 @@ mod tests {
             .map(|chunk_idx| <BitMap<N> as BitmapReadable<N>>::get_chunk(&status, chunk_idx))
             .collect::<Vec<_>>();
 
-        assert!(proof.verify(&hasher, range.start, &operations, &chunks, &root));
+        assert!(proof.verify::<Sha256, _, N>(range.start, &operations, &chunks, &root));
 
         (hasher, proof, operations, chunks, root, ops)
     }
@@ -1412,9 +1354,14 @@ mod tests {
         let (hasher, proof, operations, chunks, root, ops) =
             current_range_proof_fixture::<F, N>(18, start..end).await;
 
-        let extracted =
-            verify_proof_and_extract_digests(&hasher, &proof, start, &operations, &chunks, &root)
-                .unwrap();
+        let extracted = verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
+            &proof,
+            start,
+            &operations,
+            &chunks,
+            &root,
+        )
+        .unwrap();
         assert!(!extracted.is_empty());
 
         // The extractor should return the authenticated digest for every proven leaf.
@@ -1432,8 +1379,7 @@ mod tests {
         // Root mismatches are reported distinctly from malformed proof inputs.
         let wrong_root = hasher.digest(b"wrong current root");
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &proof,
                 start,
                 &operations,
@@ -1446,8 +1392,7 @@ mod tests {
         // Mutating operations or bitmap chunks must invalidate the extracted proof.
         let mut wrong_operations = operations.clone();
         wrong_operations[0] = hasher.digest(b"wrong operation");
-        assert!(verify_proof_and_extract_digests(
-            &hasher,
+        assert!(verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
             &proof,
             start,
             &wrong_operations,
@@ -1458,8 +1403,7 @@ mod tests {
 
         let mut bad_chunks = chunks;
         bad_chunks.last_mut().unwrap()[0] ^= 1;
-        assert!(verify_proof_and_extract_digests(
-            &hasher,
+        assert!(verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
             &proof,
             start,
             &operations,
@@ -1475,12 +1419,17 @@ mod tests {
         const N: usize = 1;
         let start = Location::<F>::new(2);
         let end = Location::<F>::new(4);
-        let (hasher, proof, operations, chunks, root, _ops) =
+        let (_, proof, operations, chunks, root, _ops) =
             current_range_proof_fixture::<F, N>(6, start..end).await;
 
-        let extracted =
-            verify_proof_and_extract_digests(&hasher, &proof, start, &operations, &chunks, &root)
-                .unwrap();
+        let extracted = verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
+            &proof,
+            start,
+            &operations,
+            &chunks,
+            &root,
+        )
+        .unwrap();
 
         assert!(!extracted.is_empty());
     }
@@ -1491,13 +1440,12 @@ mod tests {
         const N: usize = 1;
         let start = Location::<F>::new(14);
         let end = Location::<F>::new(18);
-        let (hasher, proof, operations, chunks, root, _ops) =
+        let (_, proof, operations, chunks, root, _ops) =
             current_range_proof_fixture::<F, N>(18, start..end).await;
 
         let no_operations = Vec::<sha256::Digest>::new();
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &proof,
                 start,
                 &no_operations,
@@ -1509,8 +1457,7 @@ mod tests {
 
         let no_chunks = Vec::<[u8; N]>::new();
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &proof,
                 start,
                 &operations[..1],
@@ -1521,8 +1468,7 @@ mod tests {
         ));
 
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &proof,
                 F::MAX_LEAVES,
                 &operations[..1],
@@ -1533,8 +1479,7 @@ mod tests {
         ));
 
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &proof,
                 proof.proof.leaves,
                 &operations[..1],
@@ -1545,8 +1490,7 @@ mod tests {
         ));
 
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &proof,
                 start,
                 &operations,
@@ -1559,8 +1503,7 @@ mod tests {
         let mut missing_partial = proof.clone();
         missing_partial.partial_chunk_digest = None;
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &missing_partial,
                 start,
                 &operations,
@@ -1574,8 +1517,7 @@ mod tests {
         assert!(!broken_merkle.proof.digests.is_empty());
         broken_merkle.proof.digests.clear();
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &broken_merkle,
                 start,
                 &operations,
@@ -1600,8 +1542,7 @@ mod tests {
         let mut missing_pending = proof.clone();
         missing_pending.pending_chunk_digest = None;
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &missing_pending,
                 start,
                 &operations,
@@ -1614,8 +1555,7 @@ mod tests {
         let mut wrong_pending = proof.clone();
         wrong_pending.pending_chunk_digest = Some(hasher.digest(b"wrong pending"));
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &wrong_pending,
                 start,
                 &operations,
@@ -1635,8 +1575,7 @@ mod tests {
         let mut unexpected_partial = proof;
         unexpected_partial.partial_chunk_digest = Some(hasher.digest(b"unexpected partial"));
         assert!(matches!(
-            verify_proof_and_extract_digests(
-                &hasher,
+            verify_proof_and_extract_digests::<F, _, Sha256, _, N>(
                 &unexpected_partial,
                 aligned_start,
                 &operations,
@@ -1731,14 +1670,10 @@ mod tests {
                 )
             })
             .collect();
-        let mut leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
-            &hasher,
-            &ops,
-            chunk_inputs,
-            &Sequential,
-        )
-        .await
-        .unwrap();
+        let mut leaf_digests =
+            db::compute_grafted_leaves::<F, Sha256, Sequential, N>(&ops, chunk_inputs, &Sequential)
+                .await
+                .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
         let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
@@ -1752,10 +1687,9 @@ mod tests {
         };
         grafted.apply_batch(&merkleized).unwrap();
 
-        let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+        let storage = grafting::Storage::<F, Sha256, _, _>::new(&grafted, grafting_height, &ops);
         let ops_leaves_for_root = Location::<F>::try_from(ops.size()).unwrap();
         let root = db::compute_db_root::<F, Sha256, _, _, N>(
-            &hasher,
             &status,
             &storage,
             ops_leaves_for_root,
@@ -1765,8 +1699,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let proof = RangeProof::new(
-            &hasher,
+        let proof = RangeProof::new::<Sha256, _, N>(
             &status,
             &storage,
             Location::new(0),
@@ -1778,8 +1711,7 @@ mod tests {
 
         let element = hasher.digest(&(*loc).to_be_bytes());
         let chunk_idx = (*loc / chunk_bits) as usize;
-        assert!(proof.verify(
-            &hasher,
+        assert!(proof.verify::<Sha256, _, N>(
             loc,
             &[element],
             &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1790,8 +1722,7 @@ mod tests {
 
         let mut tampered = proof.clone();
         tampered.proof.inactive_peaks = 1;
-        assert!(!tampered.verify(
-            &hasher,
+        assert!(!tampered.verify::<Sha256, _, N>(
             loc,
             &[element],
             &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1802,8 +1733,7 @@ mod tests {
 
         let mut tampered = proof.clone();
         tampered.proof.inactive_peaks = usize::MAX;
-        assert!(!tampered.verify(
-            &hasher,
+        assert!(!tampered.verify::<Sha256, _, N>(
             loc,
             &[element],
             &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1815,8 +1745,7 @@ mod tests {
         let mut tampered = proof;
         assert!(!tampered.proof.digests.is_empty());
         tampered.proof.digests[0] = hasher.digest(b"fake generic sibling");
-        assert!(!tampered.verify(
-            &hasher,
+        assert!(!tampered.verify::<Sha256, _, N>(
             loc,
             &[element],
             &[<BitMap<N> as BitmapReadable<N>>::get_chunk(
@@ -1872,7 +1801,6 @@ mod tests {
                 })
                 .collect();
             let leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
-                &hasher,
                 &ops,
                 chunk_inputs,
                 &Sequential,
@@ -1892,11 +1820,11 @@ mod tests {
                 };
                 grafted.apply_batch(&merkleized).unwrap();
             }
-            let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+            let storage =
+                grafting::Storage::<F, Sha256, _, _>::new(&grafted, grafting_height, &ops);
 
             let ops_leaves_for_root = Location::<F>::try_from(ops.size()).unwrap();
             let canonical_root = db::compute_db_root::<F, Sha256, _, _, N>(
-                &hasher,
                 &status,
                 &storage,
                 ops_leaves_for_root,
@@ -1915,7 +1843,6 @@ mod tests {
             let partial_digest =
                 db::partial_chunk::<_, N>(&status).map(|(c, nb)| (nb, hasher.digest(&c)));
             let grafted_root = db::compute_grafted_root::<F, Sha256, _, _, N>(
-                &hasher,
                 &status,
                 &storage,
                 ops_leaves_for_root,
@@ -1929,7 +1856,7 @@ mod tests {
                 partial_chunk: partial_digest,
             };
             assert!(
-                witness.verify(&hasher, &ops_root, &canonical_root),
+                witness.verify::<Sha256>(&ops_root, &canonical_root),
                 "OpsRootWitness verify failed at k={k}"
             );
             assert!(
@@ -1944,8 +1871,7 @@ mod tests {
             // Range proof spanning the pending chunk into the partial bits
             let start = mmb::Location::new(0);
             let end = mmb::Location::new(leaf_count);
-            let proof = RangeProof::new(
-                &hasher,
+            let proof = RangeProof::new::<Sha256, _, N>(
                 &status,
                 &storage,
                 Location::new(0),
@@ -1971,13 +1897,12 @@ mod tests {
                 .map(|i| <BitMap<N> as BitmapReadable<N>>::get_chunk(&status, i))
                 .collect();
             assert!(
-                proof.verify(&hasher, start, &elements, &chunks, &canonical_root),
+                proof.verify::<Sha256, _, N>(start, &elements, &chunks, &canonical_root),
                 "RangeProof verify failed at k={k}"
             );
 
             let pending_loc = mmb::Location::new(3);
-            let pending_proof = RangeProof::new(
-                &hasher,
+            let pending_proof = RangeProof::new::<Sha256, _, N>(
                 &status,
                 &storage,
                 Location::new(0),
@@ -1992,8 +1917,7 @@ mod tests {
             );
             let pending_element = hasher.digest(&(*pending_loc).to_be_bytes());
             assert!(
-                pending_proof.verify(
-                    &hasher,
+                pending_proof.verify::<Sha256, _, N>(
                     pending_loc,
                     &[pending_element],
                     &[chunks[0]],
@@ -2006,21 +1930,21 @@ mod tests {
             let mut tampered = proof.clone();
             tampered.pending_chunk_digest = Some(hasher.digest(b"fake pending"));
             assert!(
-                !tampered.verify(&hasher, start, &elements, &chunks, &canonical_root),
+                !tampered.verify::<Sha256, _, N>(start, &elements, &chunks, &canonical_root),
                 "tampered pending digest accepted at k={k}"
             );
 
             let mut tampered = proof.clone();
             tampered.pending_chunk_digest = None;
             assert!(
-                !tampered.verify(&hasher, start, &elements, &chunks, &canonical_root),
+                !tampered.verify::<Sha256, _, N>(start, &elements, &chunks, &canonical_root),
                 "missing pending digest accepted at k={k}"
             );
 
             let mut bad_chunks = chunks.clone();
             bad_chunks[0][0] ^= 1;
             assert!(
-                !proof.verify(&hasher, start, &elements, &bad_chunks, &canonical_root),
+                !proof.verify::<Sha256, _, N>(start, &elements, &bad_chunks, &canonical_root),
                 "tampered pending chunk bytes accepted at k={k}"
             );
         }
@@ -2061,9 +1985,8 @@ mod tests {
         let ops_root_pre = ops_pre.root(&hasher, 0).unwrap();
         let grafted_pre = Mem::<F, sha256::Digest>::new();
         let storage_pre =
-            grafting::Storage::new(&grafted_pre, grafting_height, &ops_pre, hasher.clone());
+            grafting::Storage::<F, Sha256, _, _>::new(&grafted_pre, grafting_height, &ops_pre);
         let canonical_pre = db::compute_db_root::<F, Sha256, _, _, N>(
-            &hasher,
             &status_pre,
             &storage_pre,
             Location::<F>::new(pre_state_leaves),
@@ -2083,7 +2006,6 @@ mod tests {
         let ops_root_post = ops_post.root(&hasher, 0).unwrap();
         // After transition chunk 0 has a single h=G ancestor; build the grafted tree.
         let leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
-            &hasher,
             &ops_post,
             core::iter::once((
                 0usize,
@@ -2106,10 +2028,9 @@ mod tests {
             .merkleize(&grafted_post, &grafted_hasher);
         grafted_post.apply_batch(&merkleized).unwrap();
         let storage_post =
-            grafting::Storage::new(&grafted_post, grafting_height, &ops_post, hasher.clone());
+            grafting::Storage::<F, Sha256, _, _>::new(&grafted_post, grafting_height, &ops_post);
 
         let canonical_post = db::compute_db_root::<F, Sha256, _, _, N>(
-            &hasher,
             &status_post,
             &storage_post,
             Location::<F>::new(post_state_leaves),
@@ -2170,14 +2091,10 @@ mod tests {
                 )
             })
             .collect();
-        let mut leaf_digests = db::compute_grafted_leaves::<F, Sha256, Sequential, N>(
-            &hasher,
-            &ops,
-            chunk_inputs,
-            &Sequential,
-        )
-        .await
-        .unwrap();
+        let mut leaf_digests =
+            db::compute_grafted_leaves::<F, Sha256, Sequential, N>(&ops, chunk_inputs, &Sequential)
+                .await
+                .unwrap();
         leaf_digests.sort_by_key(|(chunk_idx, _)| *chunk_idx);
 
         let grafted_hasher = grafting::GraftedHasher::<F, _>::new(hasher.clone(), grafting_height);
@@ -2191,10 +2108,9 @@ mod tests {
         };
         grafted.apply_batch(&merkleized).unwrap();
 
-        let storage = grafting::Storage::new(&grafted, grafting_height, &ops, hasher.clone());
+        let storage = grafting::Storage::<F, Sha256, _, _>::new(&grafted, grafting_height, &ops);
         let ops_leaves_for_root = Location::<F>::try_from(ops.size()).unwrap();
         let root = db::compute_db_root::<F, Sha256, _, _, N>(
-            &hasher,
             &status,
             &storage,
             ops_leaves_for_root,
@@ -2206,8 +2122,7 @@ mod tests {
         .unwrap();
 
         let loc = mmb::Location::new(chunk_bits - 1);
-        let proof = RangeProof::new(
-            &hasher,
+        let proof = RangeProof::new::<Sha256, _, N>(
             &status,
             &storage,
             inactivity_floor,
@@ -2220,7 +2135,7 @@ mod tests {
 
         let element = hasher.digest(&(*loc).to_be_bytes());
         let chunk = <BitMap<N> as BitmapReadable<N>>::get_chunk(&status, 0);
-        assert!(proof.verify(&hasher, loc, &[element], &[chunk], &root));
+        assert!(proof.verify::<Sha256, _, N>(loc, &[element], &[chunk], &root));
     }
 
     #[cfg(feature = "arbitrary")]

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -208,7 +208,6 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         )
         .await?;
 
-        let hasher = crate::qmdb::hasher::<H>();
         let partial_chunk_digest =
             partial_chunk::<_, N>(status).map(|(chunk, _)| hasher.digest(chunk.as_slice()));
 

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -117,7 +117,6 @@ where
     Operation<F, U>: Codec + Committable + CodecShared,
 {
     // Build authenticated log.
-    let hasher = qmdb::hasher::<H>();
     let merkle = Merkle::<F, _, _, S>::init_sync(
         context.child("merkle"),
         full::SyncConfig {
@@ -131,7 +130,7 @@ where
     let log = authenticated::Journal::<F, _, _, _, S>::from_components(
         merkle,
         log,
-        hasher.clone(),
+        qmdb::hasher::<H>(),
         apply_batch_size as u64,
     )
     .await?;

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -197,28 +197,16 @@ where
         &any.log.merkle,
     );
     let partial = db::partial_chunk(any.bitmap.as_ref());
-    let grafted_root = db::compute_grafted_root::<F, H, _, _, N>(
+    let ops_root = any.root();
+    let root = db::compute_db_root::<F, H, _, _, N>(
         any.bitmap.as_ref(),
         &storage,
         ops_leaves,
+        partial,
         any.inactivity_floor_loc,
+        &ops_root,
     )
     .await?;
-    let ops_root = any.root();
-    let hasher = qmdb::hasher::<H>();
-    let partial_digest = partial.map(|(chunk, next_bit)| {
-        let digest = hasher.digest(chunk.as_slice());
-        (next_bit, digest)
-    });
-    let pending_digest =
-        db::pending_chunk::<F, _, N>(any.bitmap.as_ref(), ops_leaves, grafting::height::<N>())?
-            .map(|chunk| hasher.digest(chunk.as_slice()));
-    let root = db::combine_roots::<H>(
-        &ops_root,
-        &grafted_root,
-        pending_digest.as_ref(),
-        partial_digest.as_ref().map(|(nb, d)| (*nb, d)),
-    );
 
     // Initialize metadata store and construct the Db.
     let (metadata, _, _) =

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -8,9 +8,9 @@
 //! the module documentation). The sync engine operates on the **ops root**, not the canonical root:
 //! it downloads operations and verifies each batch against the ops root using ops-tree range proofs
 //! (identical to `any` sync). Callers that verify current ops proofs directly should use
-//! `qmdb::hasher`. [crate::qmdb::current::proof::OpsRootWitness] can be used by callers that need
-//! to authenticate the synced ops root against a trusted canonical root; the sync engine does not
-//! perform this check itself.
+//! [crate::qmdb::verify_proof]. [crate::qmdb::current::proof::OpsRootWitness] can be used by
+//! callers that need to authenticate the synced ops root against a trusted canonical root; the sync
+//! engine does not perform this check itself.
 //!
 //! After all operations are synced, the bitmap and grafted tree are reconstructed deterministically
 //! from the operations. The canonical root is then computed from the ops root, the reconstructed
@@ -131,7 +131,7 @@ where
     let log = authenticated::Journal::<F, _, _, _, S>::from_components(
         merkle,
         log,
-        hasher,
+        hasher.clone(),
         apply_batch_size as u64,
     )
     .await?;
@@ -178,11 +178,9 @@ where
     };
 
     // Build grafted tree.
-    let hasher = qmdb::hasher::<H>();
     let ops_size = any.log.merkle.size();
     let ops_leaves = Location::<F>::try_from(ops_size)?;
     let grafted_tree = db::build_grafted_tree::<F, H, S, N>(
-        &hasher,
         any.bitmap.as_ref(),
         &grafted_pinned_nodes,
         &any.log.merkle,
@@ -194,15 +192,13 @@ where
     // Compute the canonical root. The grafted root is deterministic from the ops
     // (which are authenticated by the engine) and the bitmap (which is deterministic
     // from the ops).
-    let storage = grafting::Storage::new(
+    let storage = grafting::Storage::<F, H, _, _>::new(
         &grafted_tree,
         grafting::height::<N>(),
         &any.log.merkle,
-        hasher.clone(),
     );
     let partial = db::partial_chunk(any.bitmap.as_ref());
-    let grafted_root = db::compute_grafted_root(
-        &hasher,
+    let grafted_root = db::compute_grafted_root::<F, H, _, _, N>(
         any.bitmap.as_ref(),
         &storage,
         ops_leaves,
@@ -210,15 +206,15 @@ where
     )
     .await?;
     let ops_root = any.root();
+    let hasher = crate::qmdb::hasher::<H>();
     let partial_digest = partial.map(|(chunk, next_bit)| {
-        let digest = hasher.digest(&chunk);
+        let digest = hasher.digest(chunk.as_slice());
         (next_bit, digest)
     });
     let pending_digest =
         db::pending_chunk::<F, _, N>(any.bitmap.as_ref(), ops_leaves, grafting::height::<N>())?
-            .map(|chunk| hasher.digest(&chunk));
-    let root = db::combine_roots(
-        &hasher,
+            .map(|chunk| hasher.digest(chunk.as_slice()));
+    let root = db::combine_roots::<H>(
         &ops_root,
         &grafted_root,
         pending_digest.as_ref(),

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -205,7 +205,7 @@ where
     )
     .await?;
     let ops_root = any.root();
-    let hasher = crate::qmdb::hasher::<H>();
+    let hasher = qmdb::hasher::<H>();
     let partial_digest = partial.map(|(chunk, next_bit)| {
         let digest = hasher.digest(chunk.as_slice());
         (next_bit, digest)

--- a/storage/src/qmdb/current/unordered/db.rs
+++ b/storage/src/qmdb/current/unordered/db.rs
@@ -6,7 +6,7 @@
 use crate::{
     index::Unordered as UnorderedIndex,
     journal::contiguous::{Contiguous, Mutable},
-    merkle::{self, hasher::Standard as StandardHasher, Location},
+    merkle::{self, Location},
     qmdb::{
         any::{
             operation::update::Unordered as UnorderedUpdate,
@@ -56,7 +56,6 @@ where
     /// Return true if the proof authenticates that `key` currently has value `value` in the db with
     /// the provided `root`.
     pub fn verify_key_value_proof(
-        hasher: &StandardHasher<H>,
         key: K,
         value: V::Value,
         proof: &KeyValueProof<F, H::Digest, N>,
@@ -64,7 +63,7 @@ where
     ) -> bool {
         let op = Operation::Update(UnorderedUpdate(key, value));
 
-        proof.verify(hasher, op, root)
+        proof.verify::<H, _>(op, root)
     }
 }
 
@@ -91,13 +90,12 @@ where
     /// Returns [Error::KeyNotFound] if the key is not currently assigned any value.
     pub async fn key_value_proof(
         &self,
-        hasher: &StandardHasher<H>,
         key: K,
     ) -> Result<KeyValueProof<F, H::Digest, N>, Error<F>> {
         let op_loc = self.any.get_with_loc(&key).await?;
         let Some((_, loc)) = op_loc else {
             return Err(Error::<F>::KeyNotFound);
         };
-        self.operation_proof(hasher, loc).await
+        self.operation_proof(loc).await
     }
 }

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -175,7 +175,6 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "build-small".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -191,18 +190,18 @@ pub mod tests {
             db.apply_batch(merkleized).await.unwrap();
 
             let (_, op_loc) = db.any.get_with_loc(&k).await.unwrap().unwrap();
-            let proof = db.key_value_proof(&hasher, k).await.unwrap();
+            let proof = db.key_value_proof(k).await.unwrap();
 
             // Proof should be verifiable against current root.
             let root = db.root();
             assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v1, &proof, &root
+                k, v1, &proof, &root
             ));
 
             let v2 = Sha256::fill(0xA2);
             // Proof should not verify against a different value.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v2, &proof, &root,
+                k, v2, &proof, &root,
             ));
 
             // Update the key to a new value (v2), which inactivates the previous operation.
@@ -217,24 +216,23 @@ pub mod tests {
 
             // New value should not be verifiable against the old proof.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v2, &proof, &root,
+                k, v2, &proof, &root,
             ));
 
             // But the new value should verify against a new proof.
-            let proof = db.key_value_proof(&hasher, k).await.unwrap();
+            let proof = db.key_value_proof(k).await.unwrap();
             assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v2, &proof, &root,
+                k, v2, &proof, &root,
             ));
 
             // Old value will not verify against new proof.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher, k, v1, &proof, &root,
+                k, v1, &proof, &root,
             ));
 
             // Create a proof of the now-inactive update operation assigning v1 to k against the
             // current root.
-            let (range_proof, _, chunks) =
-                db.range_proof(&hasher, op_loc, NZU64!(1)).await.unwrap();
+            let (range_proof, _, chunks) = db.range_proof(op_loc, NZU64!(1)).await.unwrap();
             let proof_inactive = db::KeyValueProof {
                 loc: op_loc,
                 chunk: chunks[0],
@@ -244,7 +242,6 @@ pub mod tests {
             // status.
             let op = Operation::Update(UnorderedUpdate(k, v1));
             assert!(TestDb::<F, C, V>::verify_range_proof(
-                &hasher,
                 &proof_inactive.range_proof,
                 proof_inactive.loc,
                 &[op],
@@ -255,7 +252,6 @@ pub mod tests {
             // But this proof should *not* verify as a key value proof, since verification will see
             // that the operation is inactive.
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher,
                 k,
                 v1,
                 &proof_inactive,
@@ -275,7 +271,6 @@ pub mod tests {
             let mut fake_proof = proof_inactive.clone();
             fake_proof.loc = active_loc;
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher,
                 k,
                 v1,
                 &fake_proof,
@@ -295,7 +290,6 @@ pub mod tests {
             let mut fake_proof = proof_inactive.clone();
             fake_proof.chunk = modified_chunk;
             assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                &hasher,
                 k,
                 v1,
                 &fake_proof,
@@ -323,7 +317,6 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let db = open_db(context.child("db"), partition.clone()).await;
             let root = db.root();
 
@@ -336,7 +329,6 @@ pub mod tests {
                 ops_root: Digest::EMPTY,
             };
             assert!(!TestDb::<F, C, V>::verify_range_proof(
-                &hasher,
                 &proof,
                 Location::<F>::new(0),
                 &[],
@@ -359,19 +351,15 @@ pub mod tests {
 
             for loc in *start_loc..*end_loc {
                 let loc = Location::<F>::new(loc);
-                let (proof, ops, chunks) =
-                    db.range_proof(&hasher, loc, NZU64!(max_ops)).await.unwrap();
+                let (proof, ops, chunks) = db.range_proof(loc, NZU64!(max_ops)).await.unwrap();
                 assert!(
-                    TestDb::<F, C, V>::verify_range_proof(
-                        &hasher, &proof, loc, &ops, &chunks, &root
-                    ),
+                    TestDb::<F, C, V>::verify_range_proof(&proof, loc, &ops, &chunks, &root),
                     "failed to verify range at start_loc {start_loc}",
                 );
                 // Proof should not verify if we include extra chunks.
                 let mut chunks_with_extra = chunks.clone();
                 chunks_with_extra.push(chunks[chunks.len() - 1]);
                 assert!(!TestDb::<F, C, V>::verify_range_proof(
-                    &hasher,
                     &proof,
                     loc,
                     &ops,
@@ -401,7 +389,6 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let db = open_db(context.child("db"), partition.clone()).await;
             let mut db = apply_random_ops::<F, TestDb<F, C, V>>(500, true, context.next_u64(), db)
                 .await
@@ -412,7 +399,7 @@ pub mod tests {
 
             // Confirm bad keys produce the expected error.
             let bad_key = Sha256::fill(0xAA);
-            let res = db.key_value_proof(&hasher, bad_key).await;
+            let res = db.key_value_proof(bad_key).await;
             assert!(matches!(res, Err(Error::KeyNotFound)));
 
             let start = *db.inactivity_floor_loc();
@@ -430,27 +417,26 @@ pub mod tests {
                     }
                 };
 
-                let proof = db.key_value_proof(&hasher, key).await.unwrap();
+                let proof = db.key_value_proof(key).await.unwrap();
                 // Proof should validate against the current value and correct root.
                 assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                    &hasher, key, value, &proof, &root
+                    key, value, &proof, &root
                 ));
                 // Proof should fail against the wrong value. Use hash instead of fill to ensure
                 // the value differs from any key/value created by TestKey::from_seed (which uses
                 // fill patterns).
                 let wrong_val = Sha256::hash(&[0xFF]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &hasher, key, wrong_val, &proof, &root
+                    key, wrong_val, &proof, &root
                 ));
                 // Proof should fail against the wrong key.
                 let wrong_key = Sha256::hash(&[0xEE]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &hasher, wrong_key, value, &proof, &root
+                    wrong_key, value, &proof, &root
                 ));
                 // Proof should fail against the wrong root.
                 let wrong_root = Sha256::hash(&[0xDD]);
                 assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    &hasher,
                     key,
                     value,
                     &proof,
@@ -478,7 +464,6 @@ pub mod tests {
     {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let hasher = crate::qmdb::hasher::<Sha256>();
             let partition = "build-small".to_string();
             let mut db = open_db(context.child("db"), partition.clone()).await;
 
@@ -498,14 +483,14 @@ pub mod tests {
                 let root = db.root();
 
                 // Create a proof for the current value of k.
-                let proof = db.key_value_proof(&hasher, k).await.unwrap();
+                let proof = db.key_value_proof(k).await.unwrap();
                 assert!(
-                    TestDb::<F, C, V>::verify_key_value_proof(&hasher, k, v, &proof, &root),
+                    TestDb::<F, C, V>::verify_key_value_proof(k, v, &proof, &root),
                     "proof of update {i} failed to verify"
                 );
                 // Ensure the proof does NOT verify if we use the previous value.
                 assert!(
-                    !TestDb::<F, C, V>::verify_key_value_proof(&hasher, k, old_val, &proof, &root,),
+                    !TestDb::<F, C, V>::verify_key_value_proof(k, old_val, &proof, &root,),
                     "proof of update {i} verified when it should not have"
                 );
                 old_val = v;

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -15,7 +15,7 @@ use crate::{
     Context,
 };
 use commonware_codec::EncodeShared;
-use commonware_cryptography::{Digest, Hasher as CHasher};
+use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use std::{
     collections::BTreeMap,
@@ -42,7 +42,7 @@ where
     F: Family,
     K: Key,
     V: ValueEncoding,
-    H: CHasher,
+    H: Hasher,
 {
     /// Authenticated journal batch for computing the speculative Merkle root.
     journal_batch: authenticated::UnmerkleizedBatch<F, H, Operation<F, K, V>, S>,
@@ -95,7 +95,7 @@ where
     F: Family,
     K: Key,
     V: ValueEncoding,
-    H: CHasher,
+    H: Hasher,
     Operation<F, K, V>: EncodeShared,
 {
     /// Create a batch from a committed DB (no parent chain).
@@ -334,7 +334,7 @@ where
         E: Context,
         C: Mutable<Item = Operation<F, K, V>>,
         C::Item: EncodeShared,
-        H: CHasher<Digest = D>,
+        H: Hasher<Digest = D>,
         T: Translator,
     {
         if let Some(entry) = lookup_sorted(self.diff.as_slice(), key) {
@@ -360,7 +360,7 @@ where
         E: Context,
         C: Mutable<Item = Operation<F, K, V>>,
         C::Item: EncodeShared,
-        H: CHasher<Digest = D>,
+        H: Hasher<Digest = D>,
         T: Translator,
     {
         if keys.is_empty() {
@@ -415,7 +415,7 @@ where
     /// loss detected at `apply_batch` time.
     pub fn new_batch<H>(self: &Arc<Self>) -> UnmerkleizedBatch<F, H, K, V, S>
     where
-        H: CHasher<Digest = D>,
+        H: Hasher<Digest = D>,
     {
         UnmerkleizedBatch {
             journal_batch: self.journal_batch.new_batch::<H>(),
@@ -435,7 +435,7 @@ where
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
     C::Item: EncodeShared,
-    H: CHasher,
+    H: Hasher,
     T: Translator,
     S: Strategy,
 {

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -96,7 +96,7 @@ use crate::{
 };
 use ahash::AHashSet;
 use commonware_codec::EncodeShared;
-use commonware_cryptography::Hasher as CHasher;
+use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
 use core::num::{NonZeroU64, NonZeroUsize};
@@ -170,7 +170,7 @@ pub struct Immutable<
     K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
-    H: CHasher,
+    H: Hasher,
     T: Translator,
     S: Strategy,
 > where
@@ -209,7 +209,7 @@ where
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
     C::Item: EncodeShared,
-    H: CHasher,
+    H: Hasher,
     T: Translator,
     S: Strategy,
 {
@@ -772,7 +772,7 @@ pub(super) mod test {
     use super::*;
     use crate::{
         merkle::{Family, Location},
-        qmdb::{self, verify_proof},
+        qmdb::verify_proof,
         translator::TwoCap,
     };
     use commonware_codec::EncodeShared;
@@ -979,8 +979,12 @@ pub(super) mod test {
 
         let (proof, ops) = db.proof(Location::new(0), NZU64!(100)).await.unwrap();
         let root = db.root();
-        let hasher = qmdb::hasher::<Sha256>();
-        assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root));
+        assert!(verify_proof::<Sha256, _, _>(
+            &proof,
+            Location::new(0),
+            &ops,
+            &root
+        ));
 
         db.destroy().await.unwrap();
     }
@@ -1092,7 +1096,6 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         // Build a db with `ELEMENTS` key/value pairs and prove ranges over them.
-        let hasher = qmdb::hasher::<Sha256>();
         let mut db = open_db(context.child("first")).await;
 
         let mut batch = db.new_batch();
@@ -1124,7 +1127,12 @@ pub(super) mod test {
         let max_ops = NZU64!(5);
         for i in 0..*db.bounds().end {
             let (proof, log) = db.proof(Location::new(i), max_ops).await.unwrap();
-            assert!(verify_proof(&hasher, &proof, Location::new(i), &log, &root));
+            assert!(verify_proof::<Sha256, _, _>(
+                &proof,
+                Location::new(i),
+                &log,
+                &root
+            ));
         }
 
         db.destroy().await.unwrap();
@@ -1882,7 +1890,6 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
-        let hasher = qmdb::hasher::<Sha256>();
 
         const BATCHES: u64 = 20;
         const KEYS_PER_BATCH: u64 = 5;
@@ -1910,7 +1917,12 @@ pub(super) mod test {
         // Verify proof over the full range.
         let root = db.root();
         let (proof, ops) = db.proof(Location::new(0), NZU64!(10000)).await.unwrap();
-        assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root));
+        assert!(verify_proof::<Sha256, _, _>(
+            &proof,
+            Location::new(0),
+            &ops,
+            &root
+        ));
 
         // Expected: 1 initial commit + BATCHES * (KEYS_PER_BATCH + 1 commit).
         let expected = 1 + BATCHES * (KEYS_PER_BATCH + 1);
@@ -2028,7 +2040,6 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         let mut db = open_db(context.child("db")).await;
-        let hasher = qmdb::hasher::<Sha256>();
 
         const N: u64 = 500;
         let mut kvs: Vec<(Digest, Digest)> = Vec::new();
@@ -2051,7 +2062,12 @@ pub(super) mod test {
         // Verify proof over the full range.
         let root = db.root();
         let (proof, ops) = db.proof(Location::new(0), NZU64!(1000)).await.unwrap();
-        assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root));
+        assert!(verify_proof::<Sha256, _, _>(
+            &proof,
+            Location::new(0),
+            &ops,
+            &root
+        ));
 
         // Expected: 1 initial commit + N sets + 1 commit.
         assert_eq!(db.bounds().end, 1 + N + 1);

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -12,12 +12,12 @@ use crate::{
     Context,
 };
 use commonware_codec::EncodeShared;
-use commonware_cryptography::{Digest, Hasher};
+use commonware_cryptography::{Digest, DigestOf, Hasher};
 use commonware_parallel::Strategy;
 use std::sync::{Arc, Weak};
 
 /// Strong ref to an ancestor [`MerkleizedBatch`] in the keyless-batch chain.
-type MerkleizedParent<F, H, V, S> = Arc<MerkleizedBatch<F, <H as Hasher>::Digest, V, S>>;
+type MerkleizedParent<F, H, V, S> = Arc<MerkleizedBatch<F, DigestOf<H>, V, S>>;
 
 /// A speculative batch of operations whose root digest has not yet been computed, in contrast
 /// to [`MerkleizedBatch`].

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -563,10 +563,7 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::{
-        journal::contiguous::Mutable,
-        qmdb::{self, verify_proof},
-    };
+    use crate::{journal::contiguous::Mutable, qmdb::verify_proof};
     use commonware_cryptography::Sha256;
     use commonware_parallel::Strategy;
     use commonware_runtime::{deterministic, Supervisor as _};
@@ -835,7 +832,6 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = qmdb::hasher::<Sha256>();
         const ELEMENTS: u64 = 50;
 
         {
@@ -850,12 +846,16 @@ pub(crate) mod tests {
         let root = db.root();
 
         let (proof, ops) = db.proof(Location::new(0), NZU64!(100)).await.unwrap();
-        assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root,));
+        assert!(verify_proof::<Sha256, _, _>(
+            &proof,
+            Location::new(0),
+            &ops,
+            &root,
+        ));
         assert_eq!(ops.len() as u64, 1 + ELEMENTS + 1);
 
         let (proof, ops) = db.proof(Location::new(10), NZU64!(5)).await.unwrap();
-        assert!(verify_proof(
-            &hasher,
+        assert!(verify_proof::<Sha256, _, _>(
             &proof,
             Location::new(10),
             &ops,
@@ -1412,8 +1412,6 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = qmdb::hasher::<Sha256>();
-
         // Build a db with some values.
         const ELEMENTS: u64 = 100;
         {
@@ -1451,23 +1449,21 @@ pub(crate) mod tests {
                 .await
                 .unwrap();
             assert!(
-                verify_proof(&hasher, &proof, Location::new(start_loc), &ops, &root,),
+                verify_proof::<Sha256, _, _>(&proof, Location::new(start_loc), &ops, &root,),
                 "Failed to verify proof for range starting at {start_loc} with max {max_ops} ops",
             );
             let expected_ops = std::cmp::min(max_ops, *db.bounds().end - start_loc);
             assert_eq!(ops.len() as u64, expected_ops);
 
             let wrong_root = Sha256::hash(&[0xFF; 32]);
-            assert!(!verify_proof(
-                &hasher,
+            assert!(!verify_proof::<Sha256, _, _>(
                 &proof,
                 Location::new(start_loc),
                 &ops,
                 &wrong_root,
             ));
             if start_loc > 0 {
-                assert!(!verify_proof(
-                    &hasher,
+                assert!(!verify_proof::<Sha256, _, _>(
                     &proof,
                     Location::new(start_loc - 1),
                     &ops,
@@ -1489,8 +1485,6 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = qmdb::hasher::<Sha256>();
-
         const ELEMENTS: u64 = 100;
         {
             let mut batch = db.new_batch();
@@ -1535,7 +1529,7 @@ pub(crate) mod tests {
                 continue;
             }
             let (proof, ops) = db.proof(start_loc, NZU64!(max_ops)).await.unwrap();
-            assert!(verify_proof(&hasher, &proof, start_loc, &ops, &root,));
+            assert!(verify_proof::<Sha256, _, _>(&proof, start_loc, &ops, &root,));
         }
 
         let aggressive_prune: Location<F> = Location::new(150);
@@ -1543,15 +1537,16 @@ pub(crate) mod tests {
 
         let new_oldest = db.bounds().start;
         let (proof, ops) = db.proof(new_oldest, NZU64!(20)).await.unwrap();
-        assert!(verify_proof(&hasher, &proof, new_oldest, &ops, &root,));
+        assert!(verify_proof::<Sha256, _, _>(
+            &proof, new_oldest, &ops, &root,
+        ));
 
         let almost_all = db.bounds().end - 5;
         db.prune(almost_all).await.unwrap();
         let final_oldest = db.bounds().start;
         if final_oldest < db.bounds().end {
             let (final_proof, final_ops) = db.proof(final_oldest, NZU64!(10)).await.unwrap();
-            assert!(verify_proof(
-                &hasher,
+            assert!(verify_proof::<Sha256, _, _>(
                 &final_proof,
                 final_oldest,
                 &final_ops,
@@ -1776,8 +1771,6 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = qmdb::hasher::<Sha256>();
-
         const BATCHES: u64 = 20;
         const APPENDS_PER_BATCH: u64 = 5;
         let mut all_values: Vec<V::Value> = Vec::new();
@@ -1802,7 +1795,12 @@ pub(crate) mod tests {
 
         let root = db.root();
         let (proof, ops) = db.proof(Location::new(0), NZU64!(1000)).await.unwrap();
-        assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root,));
+        assert!(verify_proof::<Sha256, _, _>(
+            &proof,
+            Location::new(0),
+            &ops,
+            &root,
+        ));
         assert_eq!(db.bounds().end, 1 + BATCHES * (APPENDS_PER_BATCH + 1));
 
         db.destroy().await.unwrap();
@@ -1889,7 +1887,6 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared + std::fmt::Debug,
     {
-        let hasher = qmdb::hasher::<Sha256>();
         const N: u64 = 500;
         let mut values = Vec::new();
         let mut locs = Vec::new();
@@ -1910,7 +1907,12 @@ pub(crate) mod tests {
 
         let root = db.root();
         let (proof, ops) = db.proof(Location::new(0), NZU64!(1000)).await.unwrap();
-        assert!(verify_proof(&hasher, &proof, Location::new(0), &ops, &root,));
+        assert!(verify_proof::<Sha256, _, _>(
+            &proof,
+            Location::new(0),
+            &ops,
+            &root,
+        ));
         assert_eq!(db.bounds().end, 1 + N + 1);
 
         db.destroy().await.unwrap();

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     merkle::{hasher::Standard as StandardHasher, Bagging, Family, Location},
     qmdb::operation::Operation,
 };
-use commonware_cryptography::Hasher as CryptoHasher;
+use commonware_cryptography::Hasher;
 use commonware_utils::{cache::Clock, NZUsize};
 use core::num::NonZeroUsize;
 use futures::{pin_mut, StreamExt as _};
@@ -80,7 +80,7 @@ pub use verify::{
 pub(crate) const ROOT_BAGGING: Bagging = Bagging::BackwardFold;
 
 /// Return the Merkle hasher configuration used by QMDB operation roots and proofs.
-pub const fn hasher<H: CryptoHasher>() -> StandardHasher<H> {
+pub const fn hasher<H: Hasher>() -> StandardHasher<H> {
     StandardHasher::new(ROOT_BAGGING)
 }
 

--- a/storage/src/qmdb/store/mod.rs
+++ b/storage/src/qmdb/store/mod.rs
@@ -5,7 +5,7 @@ pub mod db;
 #[cfg(test)]
 pub(crate) mod tests {
     use commonware_codec::Codec;
-    use commonware_cryptography::{sha256, Hasher};
+    use commonware_cryptography::{sha256, Hasher as _};
     use commonware_utils::Array;
     use core::fmt::Debug;
 

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -450,10 +450,8 @@ where
         });
     }
 
-    let hasher = qmdb::hasher::<DB::Hasher>();
     let last_commit_loc = Location::new(*state.leaf_count - 1);
-    if !verify_proof(
-        &hasher,
+    if !verify_proof::<DB::Hasher, _, _>(
         &state.last_commit_proof,
         last_commit_loc,
         std::slice::from_ref(&state.last_commit_op),

--- a/storage/src/qmdb/verify.rs
+++ b/storage/src/qmdb/verify.rs
@@ -1,81 +1,81 @@
-use crate::merkle::{
-    hasher::Standard, verification::ProofStore, Error, Family, Location, Position, Proof,
+use crate::{
+    merkle::{verification::ProofStore, Error, Family, Location, Position, Proof},
+    qmdb,
 };
 use commonware_codec::Encode;
-use commonware_cryptography::{Digest, Hasher};
+use commonware_cryptography::{Digest, DigestOf, Hasher};
+
+/// Digests extracted from a verified proof, paired with their Merkle positions.
+pub type ExtractedDigests<F, H> = Vec<(Position<F>, DigestOf<H>)>;
 
 /// Verify that a [Proof] is valid for a range of operations and a target root.
-pub fn verify_proof<F, Op, H, D>(
-    hasher: &Standard<H>,
-    proof: &Proof<F, D>,
+pub fn verify_proof<H, F, Op>(
+    proof: &Proof<F, DigestOf<H>>,
     start_loc: Location<F>,
     operations: &[Op],
-    target_root: &D,
+    target_root: &DigestOf<H>,
 ) -> bool
 where
     F: Family,
     Op: Encode,
-    H: Hasher<Digest = D>,
-    D: Digest,
+    H: Hasher,
 {
+    let hasher = qmdb::hasher::<H>();
     let elements = operations.iter().map(|op| op.encode()).collect::<Vec<_>>();
-    proof.verify_range_inclusion(hasher, &elements, start_loc, target_root)
+    proof.verify_range_inclusion(&hasher, &elements, start_loc, target_root)
 }
 
 /// Verify that both a [Proof] and a set of pinned nodes are valid with respect to a target root.
-pub fn verify_proof_and_pinned_nodes<F, Op, H, D>(
-    hasher: &Standard<H>,
-    proof: &Proof<F, D>,
+pub fn verify_proof_and_pinned_nodes<H, F, Op>(
+    proof: &Proof<F, DigestOf<H>>,
     start_loc: Location<F>,
     operations: &[Op],
-    pinned_nodes: &[D],
-    target_root: &D,
+    pinned_nodes: &[DigestOf<H>],
+    target_root: &DigestOf<H>,
 ) -> bool
 where
     F: Family,
     Op: Encode,
-    H: Hasher<Digest = D>,
-    D: Digest,
+    H: Hasher,
 {
+    let hasher = qmdb::hasher::<H>();
     let elements = operations.iter().map(|op| op.encode()).collect::<Vec<_>>();
-    proof.verify_proof_and_pinned_nodes(hasher, &elements, start_loc, pinned_nodes, target_root)
+    proof.verify_proof_and_pinned_nodes(&hasher, &elements, start_loc, pinned_nodes, target_root)
 }
 
 /// Verify that a [Proof] is valid for a range of operations and extract all digests (and their
 /// positions) in the range of the [Proof].
-pub fn verify_proof_and_extract_digests<F, Op, H, D>(
-    hasher: &Standard<H>,
-    proof: &Proof<F, D>,
+pub fn verify_proof_and_extract_digests<H, F, Op>(
+    proof: &Proof<F, DigestOf<H>>,
     start_loc: Location<F>,
     operations: &[Op],
-    target_root: &D,
-) -> Result<Vec<(Position<F>, D)>, Error<F>>
+    target_root: &DigestOf<H>,
+) -> Result<ExtractedDigests<F, H>, Error<F>>
 where
     F: Family,
     Op: Encode,
-    H: Hasher<Digest = D>,
-    D: Digest,
+    H: Hasher,
 {
+    let hasher = qmdb::hasher::<H>();
     let elements = operations.iter().map(|op| op.encode()).collect::<Vec<_>>();
-    proof.verify_range_inclusion_and_extract_digests(hasher, &elements, start_loc, target_root)
+    proof.verify_range_inclusion_and_extract_digests(&hasher, &elements, start_loc, target_root)
 }
 
 /// Verify a [Proof] and convert it into a [ProofStore].
-pub fn create_proof_store<F, Op, H, D>(
-    hasher: &Standard<H>,
-    proof: &Proof<F, D>,
+pub fn create_proof_store<H, F, Op>(
+    proof: &Proof<F, DigestOf<H>>,
     start_loc: Location<F>,
     operations: &[Op],
-    root: &D,
-) -> Result<ProofStore<F, D>, Error<F>>
+    root: &DigestOf<H>,
+) -> Result<ProofStore<F, DigestOf<H>>, Error<F>>
 where
     F: Family,
     Op: Encode,
-    H: Hasher<Digest = D>,
-    D: Digest,
+    H: Hasher,
 {
+    let hasher = qmdb::hasher::<H>();
     let elements = operations.iter().map(|op| op.encode()).collect::<Vec<_>>();
-    ProofStore::new(hasher, proof, &elements, start_loc, root)
+    ProofStore::new(&hasher, proof, &elements, start_loc, root)
 }
 
 /// Create a Multi-Proof for specific operations (identified by location) from a [ProofStore].
@@ -100,30 +100,29 @@ where
 }
 
 /// Verify a Multi-Proof for operations at specific locations.
-pub fn verify_multi_proof<F, Op, H, D>(
-    hasher: &Standard<H>,
-    proof: &Proof<F, D>,
+pub fn verify_multi_proof<H, F, Op>(
+    proof: &Proof<F, DigestOf<H>>,
     operations: &[(Location<F>, Op)],
-    target_root: &D,
+    target_root: &DigestOf<H>,
 ) -> bool
 where
     F: Family,
     Op: Encode,
-    H: Hasher<Digest = D>,
-    D: Digest,
+    H: Hasher,
 {
+    let hasher = qmdb::hasher::<H>();
     let elements = operations
         .iter()
         .map(|(loc, op)| (op.encode(), *loc))
         .collect::<Vec<_>>();
-    proof.verify_multi_inclusion(hasher, &elements, target_root)
+    proof.verify_multi_inclusion(&hasher, &elements, target_root)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        merkle::{build_range_proof, mem::Mem, Bagging::ForwardFold, LocationRangeExt as _},
+        merkle::{build_range_proof, hasher::Standard, mem::Mem, LocationRangeExt as _},
         mmb, mmr,
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
@@ -136,7 +135,7 @@ mod tests {
     }
 
     fn test_hasher() -> Standard<Sha256> {
-        Standard::new(ForwardFold)
+        qmdb::hasher::<Sha256>()
     }
 
     fn qmdb_range_proof<F: Family>(
@@ -184,8 +183,7 @@ mod tests {
         );
 
         // Verify the proof
-        assert!(verify_proof(
-            &hasher,
+        assert!(verify_proof::<Sha256, _, _>(
             &proof,
             Location::<F>::new(0), // start_loc
             &operations,
@@ -194,8 +192,7 @@ mod tests {
 
         // Verify the proof with the wrong root
         let wrong_root = test_digest(99);
-        assert!(!verify_proof(
-            &hasher,
+        assert!(!verify_proof::<Sha256, _, _>(
             &proof,
             Location::<F>::new(0),
             &operations,
@@ -204,8 +201,7 @@ mod tests {
 
         // Verify the proof with the wrong operations
         let wrong_operations = vec![9, 10, 11];
-        assert!(!verify_proof(
-            &hasher,
+        assert!(!verify_proof::<Sha256, _, _>(
             &proof,
             Location::<F>::new(0),
             &wrong_operations,
@@ -255,11 +251,15 @@ mod tests {
         );
 
         // Verify with correct start location
-        assert!(verify_proof(&hasher, &proof, start_loc, &operations, &root));
+        assert!(verify_proof::<Sha256, _, _>(
+            &proof,
+            start_loc,
+            &operations,
+            &root
+        ));
 
         // Verify fails with wrong start location
-        assert!(!verify_proof(
-            &hasher,
+        assert!(!verify_proof::<Sha256, _, _>(
             &proof,
             Location::<F>::new(0), // wrong start_loc
             &operations,
@@ -299,8 +299,7 @@ mod tests {
         let proof = qmdb_range_proof(&hasher, &merkle, 0, range.clone());
 
         // Verify and extract digests for subset of operations
-        let result = verify_proof_and_extract_digests(
-            &hasher,
+        let result = verify_proof_and_extract_digests::<Sha256, _, _>(
             &proof,
             Location::<F>::new(1), // start_loc
             &operations[range.to_usize_range()],
@@ -312,8 +311,7 @@ mod tests {
 
         // Should fail with wrong root
         let wrong_root = test_digest(99);
-        assert!(verify_proof_and_extract_digests(
-            &hasher,
+        assert!(verify_proof_and_extract_digests::<Sha256, _, _>(
             &proof,
             Location::<F>::new(1),
             &operations[range.to_usize_range()],
@@ -355,8 +353,7 @@ mod tests {
         let proof = qmdb_range_proof(&hasher, &merkle, 0, range.clone());
 
         // Create proof store
-        let result = create_proof_store(
-            &hasher,
+        let result = create_proof_store::<Sha256, _, _>(
             &proof,
             range.start,                         // start_loc
             &operations[range.to_usize_range()], // Only the first 3 operations covered by the proof
@@ -370,8 +367,7 @@ mod tests {
         let sub_proof = proof_store.range_proof(&hasher, range.clone()).unwrap();
 
         // Verify the sub-proof
-        assert!(verify_proof(
-            &hasher,
+        assert!(verify_proof::<Sha256, _, _>(
             &sub_proof,
             range.start,
             &operations[range.to_usize_range()],
@@ -411,8 +407,7 @@ mod tests {
 
         // Should fail with invalid root
         let wrong_root = test_digest(99);
-        assert!(create_proof_store(
-            &hasher,
+        assert!(create_proof_store::<Sha256, _, _>(
             &proof,
             Location::<F>::new(0),
             &operations,
@@ -460,7 +455,8 @@ mod tests {
 
         // Create proof store
         let proof_store =
-            create_proof_store(&hasher, &proof, Location::<F>::new(0), &operations, &root).unwrap();
+            create_proof_store::<Sha256, _, _>(&proof, Location::<F>::new(0), &operations, &root)
+                .unwrap();
 
         // Generate multi-proof for specific locations
         let target_locations = vec![
@@ -479,8 +475,7 @@ mod tests {
             .collect();
 
         // Verify the multi-proof
-        assert!(verify_multi_proof(
-            &hasher,
+        assert!(verify_multi_proof::<Sha256, _, _>(
             &multi_proof,
             &selected_ops,
             &root
@@ -519,8 +514,7 @@ mod tests {
         // Proof store starts at 32, so the first peak is folded into the proof prefix.
         let range = Location::<F>::new(32)..Location::<F>::new(49);
         let proof = qmdb_range_proof(&hasher, &merkle, inactive_peaks, range.clone());
-        let proof_store = create_proof_store(
-            &hasher,
+        let proof_store = create_proof_store::<Sha256, _, _>(
             &proof,
             range.start,
             &operations[range.to_usize_range()],
@@ -531,15 +525,13 @@ mod tests {
 
         let mut tampered = proof.clone();
         tampered.inactive_peaks = 0;
-        assert!(!verify_proof(
-            &hasher,
+        assert!(!verify_proof::<Sha256, _, _>(
             &tampered,
             range.start,
             &operations[range.to_usize_range()],
             &root
         ));
-        assert!(create_proof_store(
-            &hasher,
+        assert!(create_proof_store::<Sha256, _, _>(
             &tampered,
             range.start,
             &operations[range.to_usize_range()],
@@ -549,15 +541,13 @@ mod tests {
 
         let mut tampered = proof;
         tampered.inactive_peaks = inactive_peaks + 1;
-        assert!(!verify_proof(
-            &hasher,
+        assert!(!verify_proof::<Sha256, _, _>(
             &tampered,
             range.start,
             &operations[range.to_usize_range()],
             &root
         ));
-        assert!(create_proof_store(
-            &hasher,
+        assert!(create_proof_store::<Sha256, _, _>(
             &tampered,
             range.start,
             &operations[range.to_usize_range()],
@@ -596,8 +586,7 @@ mod tests {
             .iter()
             .map(|&loc| (loc, operations[*loc as usize]))
             .collect();
-        assert!(verify_multi_proof(
-            &hasher,
+        assert!(verify_multi_proof::<Sha256, _, _>(
             &multi_proof,
             &selected_ops,
             &root
@@ -605,8 +594,7 @@ mod tests {
 
         let mut tampered = multi_proof;
         tampered.inactive_peaks = 0;
-        assert!(!verify_multi_proof(
-            &hasher,
+        assert!(!verify_multi_proof::<Sha256, _, _>(
             &tampered,
             &selected_ops,
             &root
@@ -654,7 +642,8 @@ mod tests {
         ];
         let proof = qmdb_range_proof(&hasher, &merkle, 0, Location::<F>::new(0)..merkle.leaves());
         let proof_store =
-            create_proof_store(&hasher, &proof, Location::<F>::new(0), &operations, &root).unwrap();
+            create_proof_store::<Sha256, _, _>(&proof, Location::<F>::new(0), &operations, &root)
+                .unwrap();
         let multi_proof = create_multi_proof(&proof_store, &target_locations, &[]).unwrap();
 
         // Verify with correct operations
@@ -663,8 +652,7 @@ mod tests {
             (Location::<F>::new(4), operations[4]),
             (Location::<F>::new(7), operations[7]),
         ];
-        assert!(verify_multi_proof(
-            &hasher,
+        assert!(verify_multi_proof::<Sha256, _, _>(
             &multi_proof,
             &selected_ops,
             &root
@@ -676,8 +664,7 @@ mod tests {
             (Location::<F>::new(4), operations[4]),
             (Location::<F>::new(7), operations[7]),
         ];
-        assert!(!verify_multi_proof(
-            &hasher,
+        assert!(!verify_multi_proof::<Sha256, _, _>(
             &multi_proof,
             &wrong_ops,
             &root
@@ -689,8 +676,7 @@ mod tests {
             (Location::<F>::new(4), operations[4]),
             (Location::<F>::new(7), operations[7]),
         ];
-        assert!(!verify_multi_proof(
-            &hasher,
+        assert!(!verify_multi_proof::<Sha256, _, _>(
             &multi_proof,
             &wrong_locations,
             &root
@@ -716,8 +702,7 @@ mod tests {
 
         // Empty proof should verify against an empty merkle structure.
         let empty_proof = Proof::default();
-        assert!(verify_multi_proof(
-            &hasher,
+        assert!(verify_multi_proof::<Sha256, _, _>(
             &empty_proof,
             &[] as &[(Location<F>, u64)],
             &empty_root
@@ -737,7 +722,8 @@ mod tests {
         let root = merkle.root(&hasher, 0).unwrap();
         let proof = qmdb_range_proof(&hasher, &merkle, 0, Location::<F>::new(0)..merkle.leaves());
         let proof_store =
-            create_proof_store(&hasher, &proof, Location::<F>::new(0), &operations, &root).unwrap();
+            create_proof_store::<Sha256, _, _>(&proof, Location::<F>::new(0), &operations, &root)
+                .unwrap();
         assert!(matches!(
             create_multi_proof(&proof_store, &[], &[]),
             Err(crate::merkle::Error::Empty)
@@ -781,14 +767,14 @@ mod tests {
             Location::<F>::new(0)..Location::<F>::new(3),
         );
         let proof_store =
-            create_proof_store(&hasher, &proof, Location::<F>::new(0), &operations, &root).unwrap();
+            create_proof_store::<Sha256, _, _>(&proof, Location::<F>::new(0), &operations, &root)
+                .unwrap();
 
         // Generate multi-proof for single element
         let multi_proof = create_multi_proof(&proof_store, &[Location::<F>::new(1)], &[]).unwrap();
 
         // Verify single element
-        assert!(verify_multi_proof(
-            &hasher,
+        assert!(verify_multi_proof::<Sha256, _, _>(
             &multi_proof,
             &[(Location::<F>::new(1), operations[1])],
             &root


### PR DESCRIPTION
Two related QMDB improvements, split out of #4127. The hashing-performance work from that PR is deferred to a separate follow-up (benchmarks showed the proposed slice-based `Hasher` API regressed merkle hashing ~15-20%).

## 1. Remove the hasher parameter from QMDB's proof/verify API

QMDB's proof, verify, and root helpers took a `&Standard<H>` hasher threaded down from callers. The hasher is fully determined by the type parameter `H` (the root bagging policy is fixed, via `qmdb::hasher::<H>()`), so passing it was redundant. This reconstructs it internally, drops the parameter, and removes the now-redundant generic parameters it enabled (e.g. `verify_proof<F, Op, H, D>` becomes `verify_proof<H, F, Op>`).

## 2. Parallelize authenticated-journal recovery replay

During `align()` recovery replay, hash each apply-batch's leaves across the merkleization strategy (mirroring `add_many`) instead of serially, one op at a time. Byte-identical to the serial path; only the leaf hashing is parallelized.

## Testing

- `just test -p commonware-storage` — 2677/2677 pass
- `just test -p commonware-glue` — 140/140 pass
- `just test-conformance` — 288/288 pass (hashing is unchanged from `main`, so storage/codec formats are byte-identical)
- `cargo check --workspace --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViJ2JVK4RX8Eyh8rvbL2zz