### PR TITLE
[runtime] Map only NotFound to missing errors in remove

### DIFF
--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -195,13 +195,18 @@ impl crate::Storage for Storage {
         let path = self.storage_directory.join(partition);
         if let Some(name) = name {
             let blob_path = path.join(hex(name));
-            fs::remove_file(blob_path)
-                .map_err(|_| Error::BlobMissing(partition.into(), hex(name)))?;
+            fs::remove_file(blob_path).map_err(|err| match err.kind() {
+                std::io::ErrorKind::NotFound => Error::BlobMissing(partition.into(), hex(name)),
+                _ => err.into(),
+            })?;
 
             // Sync the partition directory to ensure the removal is durable.
             sync_dir(&path)?;
         } else {
-            fs::remove_dir_all(&path).map_err(|_| Error::PartitionMissing(partition.into()))?;
+            fs::remove_dir_all(&path).map_err(|err| match err.kind() {
+                std::io::ErrorKind::NotFound => Error::PartitionMissing(partition.into()),
+                _ => err.into(),
+            })?;
 
             // Sync the storage directory to ensure the removal is durable.
             sync_dir(&self.storage_directory)?;

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -199,7 +199,10 @@ impl crate::Storage for Storage {
             let blob_path = path.join(hex(name));
             fs::remove_file(blob_path)
                 .await
-                .map_err(|_| Error::BlobMissing(partition.into(), hex(name)))?;
+                .map_err(|err| match err.kind() {
+                    std::io::ErrorKind::NotFound => Error::BlobMissing(partition.into(), hex(name)),
+                    _ => err.into(),
+                })?;
 
             // Sync the partition directory to ensure the removal is durable.
             // Windows doesn't have a notion of syncing a directory entry to ensure that it's
@@ -209,7 +212,10 @@ impl crate::Storage for Storage {
         } else {
             fs::remove_dir_all(&path)
                 .await
-                .map_err(|_| Error::PartitionMissing(partition.into()))?;
+                .map_err(|err| match err.kind() {
+                    std::io::ErrorKind::NotFound => Error::PartitionMissing(partition.into()),
+                    _ => err.into(),
+                })?;
 
             // Sync the storage directory to ensure the removal is durable.
             // Windows doesn't have a notion of syncing a directory entry to ensure that it's


### PR DESCRIPTION
## Summary

`Storage::remove` on the tokio and iouring backends mapped every removal failure to `BlobMissing`/`PartitionMissing`, so a real I/O error (permission denied, EIO) was misreported as a missing target. Only `ErrorKind::NotFound` now maps to the missing variants; other errors surface as `Error::Io`. This matches the memory backend, which already returns `BlobMissing` only when the entry is truly absent.

Beyond fixing the misdiagnosis, this makes `BlobMissing` a precise "already removed" signal. A later PR in this series makes the segmented journal's removal paths tolerate `BlobMissing` on retry (a removal dropped after the unlink but before untracking must succeed when retried), which is only safe once the error cannot mask real failures.