### PR TITLE
[cryptography/ed25519] Defer Hashing in Batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
 name = "commonware-cryptography"
 version = "2026.5.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "arbitrary",
  "aws-lc-rs",
@@ -1380,6 +1381,7 @@ dependencies = [
  "ecdsa",
  "fixedbitset",
  "getrandom 0.2.16",
+ "hashbrown 0.16.1",
  "num-rational",
  "num-traits",
  "once_cell",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://docs.rs/commonware-cryptography"
 workspace = true
 
 [dependencies]
+ahash = { workspace = true, features = ["no-rng"] }
 anyhow = { workspace = true, optional = true }
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 blake3 = { workspace = true, features = ["zeroize"] }
@@ -31,6 +32,7 @@ ctutils.workspace = true
 curve25519-dalek.workspace = true
 ecdsa.workspace = true
 fixedbitset.workspace = true
+hashbrown.workspace = true
 num-rational = { workspace = true, optional = true }
 num-traits = { workspace = true, optional = true }
 once_cell = { workspace = true, features = ["alloc", "race"] }
@@ -88,6 +90,8 @@ arbitrary = [
 ]
 fuzz = [ "arbitrary", "std" ]
 std = [
+	"ahash/runtime-rng",
+	"ahash/std",
 	"anyhow?/std",
 	"blake3/std",
 	"bytes/std",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -90,6 +90,7 @@ arbitrary = [
 ]
 fuzz = [ "arbitrary", "std" ]
 std = [
+	"ahash/std",
 	"anyhow?/std",
 	"blake3/std",
 	"bytes/std",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -90,8 +90,6 @@ arbitrary = [
 ]
 fuzz = [ "arbitrary", "std" ]
 std = [
-	"ahash/runtime-rng",
-	"ahash/std",
 	"anyhow?/std",
 	"blake3/std",
 	"bytes/std",

--- a/cryptography/fuzz/fuzz_targets/bls12381_batch_operations.rs
+++ b/cryptography/fuzz/fuzz_targets/bls12381_batch_operations.rs
@@ -54,7 +54,7 @@ struct FuzzState {
 impl FuzzState {
     fn new() -> Self {
         Self {
-            batch: Batch::new(),
+            batch: Batch::new(0),
             expected_result: true,
         }
     }

--- a/cryptography/fuzz/fuzz_targets/ed25519_batch_verifier.rs
+++ b/cryptography/fuzz/fuzz_targets/ed25519_batch_verifier.rs
@@ -50,7 +50,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 fn fuzz(input: FuzzInput) {
     let mut rng = StdRng::seed_from_u64(input.rng_seed);
 
-    let mut ed25519_batch = Ed25519Batch::new();
+    let mut ed25519_batch = Ed25519Batch::new(0);
     let mut expected_ed25519_result = true;
 
     for op in input.operations {
@@ -109,7 +109,7 @@ fn fuzz(input: FuzzInput) {
                 );
 
                 // Reset batch and expectation after verification
-                ed25519_batch = Ed25519Batch::new();
+                ed25519_batch = Ed25519Batch::new(0);
                 expected_ed25519_result = true;
             }
         }

--- a/cryptography/src/bls12381/benches/scheme_batch_verify_same_message.rs
+++ b/cryptography/src/bls12381/benches/scheme_batch_verify_same_message.rs
@@ -18,7 +18,7 @@ fn bench_scheme_batch_verify_same_message(c: &mut Criterion) {
                 |b| {
                     b.iter_batched(
                         || {
-                            let mut batch = bls12381::Batch::new();
+                            let mut batch = bls12381::Batch::new(n_signers);
                             for _ in 0..n_signers {
                                 let signer = bls12381::PrivateKey::random(&mut thread_rng());
                                 let sig = signer.sign(namespace, &msg);

--- a/cryptography/src/bls12381/benches/scheme_batch_verify_same_signer.rs
+++ b/cryptography/src/bls12381/benches/scheme_batch_verify_same_signer.rs
@@ -27,7 +27,7 @@ fn bench_scheme_batch_verify_same_signer(c: &mut Criterion) {
                 |b| {
                     b.iter_batched(
                         || {
-                            let mut batch = bls12381::Batch::new();
+                            let mut batch = bls12381::Batch::new(n_messages);
                             let signer = bls12381::PrivateKey::random(&mut thread_rng());
                             for msg in msgs.iter() {
                                 let sig = signer.sign(namespace, msg);

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -626,7 +626,7 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
             return false;
         };
         let ack_summary = transcript_for_ack(round_transcript, dealer, &log.pub_msg).summarize();
-        let mut ack_batch = B::new();
+        let mut ack_batch = B::with_capacity(self.players.len());
         let mut reveal_count = 0;
         let max_reveals = self.max_reveals::<M>();
         let mut reveal_eval_points = Vec::new();

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -626,7 +626,7 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
             return false;
         };
         let ack_summary = transcript_for_ack(round_transcript, dealer, &log.pub_msg).summarize();
-        let mut ack_batch = B::with_capacity(self.players.len());
+        let mut ack_batch = B::new(self.players.len());
         let mut reveal_count = 0;
         let max_reveals = self.max_reveals::<M>();
         let mut reveal_eval_points = Vec::new();

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -380,6 +380,14 @@ impl BatchVerifier for Batch {
         }
     }
 
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            publics: Vec::with_capacity(capacity),
+            hms: Vec::with_capacity(capacity),
+            signatures: Vec::with_capacity(capacity),
+        }
+    }
+
     fn add(
         &mut self,
         namespace: &[u8],

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -372,15 +372,7 @@ pub struct Batch {
 impl BatchVerifier for Batch {
     type PublicKey = PublicKey;
 
-    fn new() -> Self {
-        Self {
-            publics: Vec::new(),
-            hms: Vec::new(),
-            signatures: Vec::new(),
-        }
-    }
-
-    fn with_capacity(capacity: usize) -> Self {
+    fn new(capacity: usize) -> Self {
         Self {
             publics: Vec::with_capacity(capacity),
             hms: Vec::with_capacity(capacity),
@@ -492,7 +484,7 @@ mod tests {
 
     #[test]
     fn batch_verify_empty() {
-        let batch = Batch::new();
+        let batch = Batch::new(0);
         assert!(batch.verify(&mut test_rng(), &Sequential));
     }
 

--- a/cryptography/src/ed25519/benches/batch_verify_same_message.rs
+++ b/cryptography/src/ed25519/benches/batch_verify_same_message.rs
@@ -18,7 +18,7 @@ fn bench_batch_verify_same_message(c: &mut Criterion) {
                 |b| {
                     b.iter_batched(
                         || {
-                            let mut batch = ed25519::Batch::new();
+                            let mut batch = ed25519::Batch::new(n_signers);
                             for _ in 0..n_signers {
                                 let signer = ed25519::PrivateKey::random(&mut thread_rng());
                                 let sig = signer.sign(namespace, &msg);

--- a/cryptography/src/ed25519/benches/batch_verify_same_signer.rs
+++ b/cryptography/src/ed25519/benches/batch_verify_same_signer.rs
@@ -27,7 +27,7 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
                 |b| {
                     b.iter_batched(
                         || {
-                            let mut batch = ed25519::Batch::new();
+                            let mut batch = ed25519::Batch::new(n_messages);
                             let signer = ed25519::PrivateKey::random(&mut thread_rng());
                             for msg in msgs.iter() {
                                 let sig = signer.sign(namespace, msg);

--- a/cryptography/src/ed25519/certificate/mod.rs
+++ b/cryptography/src/ed25519/certificate/mod.rs
@@ -131,11 +131,12 @@ impl<N: Namespace> Generic<N> {
         let namespace = subject.namespace(&self.namespace);
         let message = subject.message();
 
+        let attestations = attestations.into_iter();
         let mut invalid = BTreeSet::new();
-        let mut candidates = Vec::new();
-        let mut batch = Batch::new();
+        let mut candidates = Vec::with_capacity(attestations.size_hint().0);
+        let mut batch = Batch::new(attestations.size_hint().0);
 
-        for attestation in attestations.into_iter() {
+        for attestation in attestations {
             let Some(public_key) = self.participants.key(attestation.signer) else {
                 invalid.insert(attestation.signer);
                 continue;
@@ -270,7 +271,7 @@ impl<N: Namespace> Generic<N> {
         D: Digest,
         M: Faults,
     {
-        let mut batch = Batch::new();
+        let mut batch = Batch::new(certificate.signatures.len());
         if !self.batch_verify_certificate::<S, D, M>(&mut batch, subject, certificate) {
             return false;
         }
@@ -293,7 +294,9 @@ impl<N: Namespace> Generic<N> {
         I: Iterator<Item = (S::Subject<'a, D>, &'a Certificate)>,
         M: Faults,
     {
-        let mut batch = Batch::new();
+        // Each certificate stages at most one signature per participant.
+        let per_certificate = self.participants.len();
+        let mut batch = Batch::new(certificates.size_hint().0.saturating_mul(per_certificate));
         for (subject, certificate) in certificates {
             if !self.batch_verify_certificate::<S, D, M>(&mut batch, subject, certificate) {
                 return false;

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -40,6 +40,7 @@ use crate::transcript::{Summary, Transcript};
 use alloc::{collections::BTreeMap as Map, vec::Vec};
 use commonware_math::algebra::Random;
 use commonware_parallel::Strategy;
+use commonware_utils::union_unique;
 use core::iter::once;
 use curve25519_dalek::{
     constants::ED25519_BASEPOINT_POINT as B,
@@ -63,36 +64,14 @@ fn gen_u128<R: RngCore + CryptoRng>(mut rng: R) -> u128 {
     u128::from_le_bytes(bytes)
 }
 
-/// A batch verification item.
-///
-/// This struct exists to allow batch processing to be decoupled from the
-/// lifetime of the message. This is useful when using the batch verification API
-/// in an async context.
-#[derive(Clone, Debug)]
-pub struct Item {
-    vk: VerificationKey,
-    sig: Signature,
-    k: Scalar,
-}
-
-impl<'msg, M: AsRef<[u8]> + ?Sized> From<(VerificationKey, Signature, &'msg M)> for Item {
-    fn from(tup: (VerificationKey, Signature, &'msg M)) -> Self {
-        let (vk, sig, msg) = tup;
-        let k = super::scalar_from_hash(
-            Sha512::default()
-                .chain(&sig.R_bytes[..])
-                .chain(vk.as_bytes())
-                .chain(msg),
-        );
-        Self { vk, sig, k }
-    }
-}
-
 /// A batch verification context.
 #[derive(Default)]
 pub struct Verifier {
-    /// Signature data queued for verification.
-    signatures: Map<VerificationKey, Vec<(Scalar, Signature)>>,
+    /// Signature data queued for verification. Payloads are copied (instead
+    /// of hashed at queue time) so the SHA-512 challenge computation for
+    /// every signature is deferred to [`Verifier::verify`], where it runs
+    /// under the caller's [`Strategy`] instead of serially at queue time.
+    signatures: Map<VerificationKey, Vec<(Vec<u8>, Signature)>>,
     /// Caching this count avoids a map traversal to figure out
     /// how much to preallocate.
     batch_size: usize,
@@ -104,16 +83,26 @@ impl Verifier {
         Self::default()
     }
 
-    /// Queue a `(key, signature, message)` tuple for verification.
-    pub fn queue<I: Into<Item>>(&mut self, item: I) {
-        let Item { vk, sig, k } = item.into();
+    /// Queue a `(key, signature)` pair for verification of `message` under
+    /// `namespace`.
+    pub fn queue(
+        &mut self,
+        vk: VerificationKey,
+        sig: Signature,
+        namespace: Option<&[u8]>,
+        message: &[u8],
+    ) {
+        let payload = namespace.map_or_else(
+            || message.to_vec(),
+            |namespace| union_unique(namespace, message),
+        );
 
         self.signatures
             .entry(vk)
             // The common case is 1 signature per public key.
             // We could also consider using a smallvec here.
             .or_insert_with(|| Vec::with_capacity(1))
-            .push((k, sig));
+            .push((payload, sig));
         self.batch_size += 1;
     }
 
@@ -160,7 +149,9 @@ impl Verifier {
                 // - A_i is the verification key;
                 // - R_i is the signature's R value;
                 // - s_i is the signature's s value;
-                // - k_i is the hash of the message and other data;
+                // - k_i is the hash of the message and other data, computed
+                //   here so the per-signature SHA-512 work runs under the
+                //   caller's strategy;
                 // - z_i is a random 128-bit Scalar.
                 //
                 // Normally n signatures would require a multiscalar multiplication of
@@ -190,7 +181,13 @@ impl Verifier {
                     let A = -vk.minus_A;
                     let mut A_coeff = Scalar::ZERO;
 
-                    for (k, sig) in sigs.iter() {
+                    for (payload, sig) in sigs.iter() {
+                        let k = super::scalar_from_hash(
+                            Sha512::default()
+                                .chain(&sig.R_bytes[..])
+                                .chain(vk.as_bytes())
+                                .chain(payload),
+                        );
                         let R = CompressedEdwardsY(sig.R_bytes)
                             .decompress()
                             .ok_or(Error::InvalidSignature)?;
@@ -221,5 +218,82 @@ impl Verifier {
             },
             |left, right| left.and(right),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::SigningKey, *};
+    use commonware_parallel::{Rayon, Sequential};
+    use commonware_utils::{test_rng, NZUsize};
+    use rand::Rng;
+
+    /// Generate `signers` keys with `per_signer` signed messages each.
+    fn signatures(
+        signers: usize,
+        per_signer: usize,
+    ) -> Vec<(VerificationKey, Signature, [u8; 32])> {
+        let mut rng = test_rng();
+        let mut items = Vec::with_capacity(signers * per_signer);
+        for _ in 0..signers {
+            let sk = SigningKey::new(&mut rng);
+            let vk = sk.verification_key();
+            for _ in 0..per_signer {
+                let mut msg = [0u8; 32];
+                rng.fill(&mut msg);
+                items.push((vk, sk.sign(&msg), msg));
+            }
+        }
+        items
+    }
+
+    /// Queue `items` and verify them with `strategy`.
+    fn verify_with(
+        items: &[(VerificationKey, Signature, [u8; 32])],
+        strategy: &impl Strategy,
+    ) -> bool {
+        let mut verifier = Verifier::new();
+        for (vk, sig, msg) in items {
+            verifier.queue(*vk, *sig, None, msg);
+        }
+        verifier.verify(test_rng(), strategy).is_ok()
+    }
+
+    /// Verify `items` with both the sequential and a parallel strategy,
+    /// asserting the outcomes agree, and return the outcome.
+    fn verify(items: &[(VerificationKey, Signature, [u8; 32])]) -> bool {
+        let sequential = verify_with(items, &Sequential);
+        let parallel = verify_with(items, &Rayon::new(NZUsize!(4)).unwrap());
+        assert_eq!(sequential, parallel);
+        sequential
+    }
+
+    #[test]
+    fn test_verify_deferred_hashing() {
+        let mut items = signatures(4, 3);
+        assert!(verify(&items));
+
+        // Altering any message must fail the whole batch.
+        items[7].2[0] ^= 1;
+        assert!(!verify(&items));
+    }
+
+    #[test]
+    fn test_deferred_framing_matches_union_unique() {
+        // A signature over union_unique(ns, msg) must verify when queued as
+        // (ns, msg), pinning the deferred framing to union_unique's format.
+        let mut rng = test_rng();
+        let sk = SigningKey::new(&mut rng);
+        let namespace = b"namespace";
+        let msg = b"message";
+        let sig = sk.sign(&union_unique(namespace, msg));
+        let mut verifier = Verifier::new();
+        verifier.queue(sk.verification_key(), sig, Some(namespace), msg);
+        assert!(verifier.verify(test_rng(), &Sequential).is_ok());
+
+        // A different namespace must fail.
+        let mut verifier = Verifier::new();
+        verifier.queue(sk.verification_key(), sig, Some(b"other"), msg);
+        assert!(verifier.verify(test_rng(), &Sequential).is_err());
     }
 }

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -35,7 +35,7 @@
 //!
 //! [ZIP215]: https://github.com/zcash/zips/blob/master/zip-0215.rst
 
-use super::{Error, Signature, VerificationKey};
+use super::{Error, Signature, VerificationKey, VerificationKeyBytes};
 use crate::transcript::{Summary, Transcript};
 use ahash::RandomState;
 #[cfg(not(feature = "std"))]
@@ -159,7 +159,7 @@ impl Verifier {
                 // single verification key, this is nearly twice as fast.
 
                 let n = shard.len();
-                let mut key_indices: HashMap<&[u8; 32], usize, RandomState> =
+                let mut key_indices: HashMap<&VerificationKeyBytes, usize, RandomState> =
                     HashMap::with_capacity_and_hasher(n, RandomState::default());
                 let mut A_coeffs: Vec<Scalar> = Vec::with_capacity(n);
                 let mut As = Vec::with_capacity(n);
@@ -184,7 +184,7 @@ impl Verifier {
                     B_coeff -= z * s;
                     Rs.push(R);
                     R_coeffs.push(z);
-                    let index = *key_indices.entry(vk.as_bytes()).or_insert_with(|| {
+                    let index = *key_indices.entry(&vk.A_bytes).or_insert_with(|| {
                         As.push(-vk.minus_A);
                         A_coeffs.push(Scalar::ZERO);
                         As.len() - 1

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -21,10 +21,11 @@
 //!
 //! This batch verification implementation is adaptive in the sense that it
 //! detects multiple signatures created with the same verification key and
-//! automatically coalesces terms in the final verification equation. In the
-//! limiting case where all signatures in the batch are made with the same
-//! verification key, coalesced batch verification runs twice as fast as ordinary
-//! batch verification.
+//! automatically coalesces terms in the final verification equation. Signatures
+//! are sharded for parallel verification, so coalescing applies to signatures
+//! that land in the same shard. In the limiting case where all signatures in
+//! the batch are made with the same verification key, coalesced batch
+//! verification runs twice as fast as ordinary batch verification.
 //!
 //! ![benchmark](https://www.zfnd.org/images/coalesced-batch-graph.png)
 //!
@@ -36,8 +37,9 @@
 
 use super::{Error, Signature, VerificationKey};
 use crate::transcript::{Summary, Transcript};
+use ahash::RandomState;
 #[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap as Map, vec::Vec};
+use alloc::vec::Vec;
 use commonware_math::algebra::Random;
 use commonware_parallel::Strategy;
 use commonware_utils::union_unique;
@@ -48,12 +50,9 @@ use curve25519_dalek::{
     scalar::Scalar,
     traits::{IsIdentity, VartimeMultiscalarMul},
 };
+use hashbrown::HashMap;
 use rand_core::{CryptoRng, RngCore};
 use sha2::{digest::Update, Sha512};
-#[cfg(feature = "std")]
-use std::collections::HashMap;
-#[cfg(feature = "std")]
-type Map<K, V> = HashMap<K, V>;
 
 const NOISE_BATCH_VERIFY: &[u8] = b"batch_verify";
 
@@ -67,14 +66,12 @@ fn gen_u128<R: RngCore + CryptoRng>(mut rng: R) -> u128 {
 /// A batch verification context.
 #[derive(Default)]
 pub struct Verifier {
-    /// Signature data queued for verification. Payloads are copied (instead
-    /// of hashed at queue time) so the SHA-512 challenge computation for
-    /// every signature is deferred to [`Verifier::verify`], where it runs
-    /// under the caller's [`Strategy`] instead of serially at queue time.
-    signatures: Map<VerificationKey, Vec<(Vec<u8>, Signature)>>,
-    /// Caching this count avoids a map traversal to figure out
-    /// how much to preallocate.
-    batch_size: usize,
+    /// Signature data queued for verification, in insertion order. Payloads
+    /// are copied (instead of hashed at queue time) so the SHA-512 challenge
+    /// computation for every signature is deferred to [`Verifier::verify`],
+    /// where it runs under the caller's [`Strategy`] instead of serially at
+    /// queue time.
+    signatures: Vec<(VerificationKey, Vec<u8>, Signature)>,
 }
 
 impl Verifier {
@@ -97,13 +94,7 @@ impl Verifier {
             |namespace| union_unique(namespace, message),
         );
 
-        self.signatures
-            .entry(vk)
-            // The common case is 1 signature per public key.
-            // We could also consider using a smallvec here.
-            .or_insert_with(|| Vec::with_capacity(1))
-            .push((payload, sig));
-        self.batch_size += 1;
+        self.signatures.push((vk, payload, sig));
     }
 
     /// Perform batch verification, returning `Ok(())` if all signatures were
@@ -125,11 +116,10 @@ impl Verifier {
         // `n_signatures / cores` in size. Random seeds are generated for each shard, derived
         // from the provided RNG, to compute a random scalar for each signature in the shard.
         let manual = strategy.manual();
-        let groups: Vec<_> = self.signatures.into_iter().collect();
-        let shard_count = manual.parallelism_hint().min(groups.len().max(1));
-        let shard_size = groups.len().div_ceil(shard_count).max(1);
+        let shard_count = manual.parallelism_hint().min(self.signatures.len().max(1));
+        let shard_size = self.signatures.len().div_ceil(shard_count).max(1);
         let mut shards = Vec::with_capacity(shard_count);
-        for shard in groups.chunks(shard_size) {
+        for shard in self.signatures.chunks(shard_size) {
             let seed = Summary::random(&mut rng);
             shards.push((shard, seed));
         }
@@ -156,9 +146,9 @@ impl Verifier {
                 //
                 // Normally n signatures would require a multiscalar multiplication of
                 // size 2*n + 1, together with 2*n point decompressions (to obtain A_i
-                // and R_i). However, because we store batch entries in a map
-                // indexed by the verification key, we can "coalesce" all z_i * k_i
-                // terms for each distinct verification key into a single coefficient.
+                // and R_i). However, by grouping the shard's entries by verification
+                // key, we can "coalesce" all z_i * k_i terms for each distinct
+                // verification key into a single coefficient.
                 //
                 // For n signatures from m verification keys, this approach instead
                 // requires a multiscalar multiplication of size n + m + 1 together with
@@ -168,41 +158,38 @@ impl Verifier {
                 // the usual method. However, when m = 1 and all signatures are from a
                 // single verification key, this is nearly twice as fast.
 
-                let m = shard.len();
-                let batch_size = shard.iter().map(|(_, sigs)| sigs.len()).sum();
-
-                let mut A_coeffs = Vec::with_capacity(m);
-                let mut As = Vec::with_capacity(m);
-                let mut R_coeffs = Vec::with_capacity(batch_size);
-                let mut Rs = Vec::with_capacity(batch_size);
+                let n = shard.len();
+                let mut key_indices: HashMap<&[u8; 32], usize, RandomState> =
+                    HashMap::with_capacity_and_hasher(n, RandomState::default());
+                let mut A_coeffs: Vec<Scalar> = Vec::with_capacity(n);
+                let mut As = Vec::with_capacity(n);
+                let mut R_coeffs = Vec::with_capacity(n);
+                let mut Rs = Vec::with_capacity(n);
                 let mut B_coeff = Scalar::ZERO;
 
-                for (vk, sigs) in shard {
-                    let A = -vk.minus_A;
-                    let mut A_coeff = Scalar::ZERO;
-
-                    for (payload, sig) in sigs.iter() {
-                        let k = super::scalar_from_hash(
-                            Sha512::default()
-                                .chain(&sig.R_bytes[..])
-                                .chain(vk.as_bytes())
-                                .chain(payload),
-                        );
-                        let R = CompressedEdwardsY(sig.R_bytes)
-                            .decompress()
-                            .ok_or(Error::InvalidSignature)?;
-                        let s = Scalar::from_canonical_bytes(sig.s_bytes)
-                            .into_option()
-                            .ok_or(Error::InvalidSignature)?;
-                        let z = Scalar::from(gen_u128(&mut rng));
-                        B_coeff -= z * s;
-                        Rs.push(R);
-                        R_coeffs.push(z);
-                        A_coeff += z * k;
-                    }
-
-                    As.push(A);
-                    A_coeffs.push(A_coeff);
+                for (vk, payload, sig) in shard {
+                    let k = super::scalar_from_hash(
+                        Sha512::default()
+                            .chain(&sig.R_bytes[..])
+                            .chain(vk.as_bytes())
+                            .chain(payload),
+                    );
+                    let R = CompressedEdwardsY(sig.R_bytes)
+                        .decompress()
+                        .ok_or(Error::InvalidSignature)?;
+                    let s = Scalar::from_canonical_bytes(sig.s_bytes)
+                        .into_option()
+                        .ok_or(Error::InvalidSignature)?;
+                    let z = Scalar::from(gen_u128(&mut rng));
+                    B_coeff -= z * s;
+                    Rs.push(R);
+                    R_coeffs.push(z);
+                    let index = *key_indices.entry(vk.as_bytes()).or_insert_with(|| {
+                        As.push(-vk.minus_A);
+                        A_coeffs.push(Scalar::ZERO);
+                        As.len() - 1
+                    });
+                    A_coeffs[index] += z * k;
                 }
 
                 let check = EdwardsPoint::vartime_multiscalar_mul(
@@ -275,6 +262,23 @@ mod tests {
 
         // Altering any message must fail the whole batch.
         items[7].2[0] ^= 1;
+        assert!(!verify(&items));
+    }
+
+    #[test]
+    fn test_verify_interleaved_duplicate_keys() {
+        // Round-robin queueing scatters each signer's signatures across shard
+        // boundaries, exercising coalescing of non-adjacent duplicate keys
+        // within a shard and duplicate keys split across shards.
+        let grouped = signatures(2, 6);
+        let mut items = Vec::with_capacity(grouped.len());
+        for i in 0..6 {
+            items.push(grouped[i]);
+            items.push(grouped[6 + i]);
+        }
+        assert!(verify(&items));
+
+        items[5].2[0] ^= 1;
         assert!(!verify(&items));
     }
 

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -80,6 +80,14 @@ impl Verifier {
         Self::default()
     }
 
+    /// Construct a new batch verifier with capacity for `capacity` queued
+    /// signatures.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            signatures: Vec::with_capacity(capacity),
+        }
+    }
+
     /// Queue a `(key, signature)` pair for verification of `message` under
     /// `namespace`.
     pub fn queue(
@@ -158,6 +166,9 @@ impl Verifier {
                 // the usual method. However, when m = 1 and all signatures are from a
                 // single verification key, this is nearly twice as fast.
 
+                // Group the shard's signatures by verification key (ahash's
+                // AHashMap requires std, so use hashbrown's map with the ahash
+                // hasher to retain no_std support).
                 let n = shard.len();
                 let mut key_indices: HashMap<&VerificationKeyBytes, usize, RandomState> =
                     HashMap::with_capacity_and_hasher(n, RandomState::default());

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -23,7 +23,9 @@
 //! detects multiple signatures created with the same verification key and
 //! automatically coalesces terms in the final verification equation. Signatures
 //! are sharded for parallel verification, so coalescing applies to signatures
-//! that land in the same shard. In the limiting case where all signatures in
+//! that land in the same shard. Shards are contiguous ranges of the queue, so
+//! callers that queue signatures sharing a verification key adjacently
+//! maximize coalescing. In the limiting case where all signatures in
 //! the batch are made with the same verification key, coalesced batch
 //! verification runs twice as fast as ordinary batch verification.
 //!
@@ -75,11 +77,6 @@ pub struct Verifier {
 }
 
 impl Verifier {
-    /// Construct a new batch verifier.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Construct a new batch verifier with capacity for `capacity` queued
     /// signatures.
     pub fn with_capacity(capacity: usize) -> Self {
@@ -90,6 +87,10 @@ impl Verifier {
 
     /// Queue a `(key, signature)` pair for verification of `message` under
     /// `namespace`.
+    ///
+    /// The framed payload (`namespace` joined with `message`) is copied into
+    /// the batch and retained until [`Verifier::verify`], so a batch holds
+    /// memory proportional to the total payload bytes queued.
     pub fn queue(
         &mut self,
         vk: VerificationKey,
@@ -166,9 +167,10 @@ impl Verifier {
                 // the usual method. However, when m = 1 and all signatures are from a
                 // single verification key, this is nearly twice as fast.
 
-                // Group the shard's signatures by verification key (ahash's
-                // AHashMap requires std, so use hashbrown's map with the ahash
-                // hasher to retain no_std support).
+                // Group the shard's signatures by verification key. hashbrown's
+                // map with the ahash hasher stands in for ahash::AHashMap, which
+                // wraps std::collections::HashMap and is unavailable in no_std
+                // builds.
                 let n = shard.len();
                 let mut key_indices: HashMap<&VerificationKeyBytes, usize, RandomState> =
                     HashMap::with_capacity_and_hasher(n, RandomState::default());
@@ -250,7 +252,7 @@ mod tests {
         items: &[(VerificationKey, Signature, [u8; 32])],
         strategy: &impl Strategy,
     ) -> bool {
-        let mut verifier = Verifier::new();
+        let mut verifier = Verifier::default();
         for (vk, sig, msg) in items {
             verifier.queue(*vk, *sig, None, msg);
         }
@@ -302,12 +304,12 @@ mod tests {
         let namespace = b"namespace";
         let msg = b"message";
         let sig = sk.sign(&union_unique(namespace, msg));
-        let mut verifier = Verifier::new();
+        let mut verifier = Verifier::default();
         verifier.queue(sk.verification_key(), sig, Some(namespace), msg);
         assert!(verifier.verify(test_rng(), &Sequential).is_ok());
 
         // A different namespace must fail.
-        let mut verifier = Verifier::new();
+        let mut verifier = Verifier::default();
         verifier.queue(sk.verification_key(), sig, Some(b"other"), msg);
         assert!(verifier.verify(test_rng(), &Sequential).is_err());
     }

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -78,7 +78,7 @@ pub struct Verifier {
 
 impl Verifier {
     /// Construct a batch verifier with space for `capacity` queued signatures.
-    pub fn with_capacity(capacity: usize) -> Self {
+    pub fn new(capacity: usize) -> Self {
         Self {
             signatures: Vec::with_capacity(capacity),
         }

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -77,8 +77,7 @@ pub struct Verifier {
 }
 
 impl Verifier {
-    /// Construct a new batch verifier with capacity for `capacity` queued
-    /// signatures.
+    /// Construct a batch verifier with space for `capacity` queued signatures.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             signatures: Vec::with_capacity(capacity),
@@ -87,10 +86,6 @@ impl Verifier {
 
     /// Queue a `(key, signature)` pair for verification of `message` under
     /// `namespace`.
-    ///
-    /// The framed payload (`namespace` joined with `message`) is copied into
-    /// the batch and retained until [`Verifier::verify`], so a batch holds
-    /// memory proportional to the total payload bytes queued.
     pub fn queue(
         &mut self,
         vk: VerificationKey,

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -23,11 +23,11 @@
 //! detects multiple signatures created with the same verification key and
 //! automatically coalesces terms in the final verification equation. Signatures
 //! are sharded for parallel verification, so coalescing applies to signatures
-//! that land in the same shard. Signatures sharing a verification key are
-//! partitioned into the same shard regardless of queue order. In the limiting
-//! case where all signatures in the batch are made with the same verification
-//! key, coalesced batch verification runs twice as fast as ordinary batch
-//! verification.
+//! that land in the same shard. Sharding groups signatures by verification
+//! key on a best-effort basis, no matter how the batch was queued. In the
+//! limiting case where all signatures in the batch are made with the same
+//! verification key, coalesced batch verification runs twice as fast as
+//! ordinary batch verification.
 //!
 //! ![benchmark](https://www.zfnd.org/images/coalesced-batch-graph.png)
 //!
@@ -156,13 +156,14 @@ impl Verifier {
         )
     }
 
-    /// Build an iteration order in which signatures sharing a verification
-    /// key occupy one contiguous run, using a counting sort on each key's
-    /// first byte. Chunking the order into equal-size shards then places
-    /// signatures sharing a key into the same shard, while skewed batches
-    /// (like a single signer) still split evenly across shards. Keys crafted
-    /// to share a first byte just forfeit the grouping, which costs no more
-    /// than the unpartitioned order.
+    /// Build an iteration order that groups signatures by the first byte of
+    /// their verification key, using a counting sort. Chunking the order into
+    /// equal-size shards then keeps signatures sharing a key in the same
+    /// shard, except where a shard boundary cuts through a byte group.
+    /// Grouping is best-effort: skewed batches (like a single signer) still
+    /// split evenly across shards, and keys crafted to share a first byte
+    /// just forfeit the grouping, costing no more than the unpartitioned
+    /// order.
     fn partition(signatures: &[(VerificationKey, Vec<u8>, Signature)]) -> Vec<usize> {
         let mut counts = [0; 256];
         for (vk, _, _) in signatures {

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -23,11 +23,11 @@
 //! detects multiple signatures created with the same verification key and
 //! automatically coalesces terms in the final verification equation. Signatures
 //! are sharded for parallel verification, so coalescing applies to signatures
-//! that land in the same shard. Shards are contiguous ranges of the queue, so
-//! callers that queue signatures sharing a verification key adjacently
-//! maximize coalescing. In the limiting case where all signatures in
-//! the batch are made with the same verification key, coalesced batch
-//! verification runs twice as fast as ordinary batch verification.
+//! that land in the same shard. Signatures sharing a verification key are
+//! partitioned into the same shard regardless of queue order. In the limiting
+//! case where all signatures in the batch are made with the same verification
+//! key, coalesced batch verification runs twice as fast as ordinary batch
+//! verification.
 //!
 //! ![benchmark](https://www.zfnd.org/images/coalesced-batch-graph.png)
 //!
@@ -41,7 +41,7 @@ use super::{Error, Signature, VerificationKey, VerificationKeyBytes};
 use crate::transcript::{Summary, Transcript};
 use ahash::RandomState;
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use commonware_math::algebra::Random;
 use commonware_parallel::Strategy;
 use commonware_utils::union_unique;
@@ -110,109 +110,162 @@ impl Verifier {
     /// verifications. This function does not have the same verification criteria
     /// as individual verification, which may reject some signatures this method
     /// accepts.
-    #[allow(non_snake_case)]
     pub fn verify<R: RngCore + CryptoRng>(
         self,
         mut rng: R,
         strategy: &impl Strategy,
     ) -> Result<(), Error> {
-        // Split all signatures into shards for parallel processing. Each shard is roughly
-        // `n_signatures / cores` in size. Random seeds are generated for each shard, derived
-        // from the provided RNG, to compute a random scalar for each signature in the shard.
+        // Seeds are drawn before an execution path is chosen so both paths
+        // can borrow them.
         let manual = strategy.manual();
-        let shard_count = manual.parallelism_hint().min(self.signatures.len().max(1));
-        let shard_size = self.signatures.len().div_ceil(shard_count).max(1);
-        let mut shards = Vec::with_capacity(shard_count);
-        for shard in self.signatures.chunks(shard_size) {
-            let seed = Summary::random(&mut rng);
-            shards.push((shard, seed));
+        let total = self.signatures.len();
+        let shard_count = manual.parallelism_hint().min(total.max(1));
+        let seeds: Vec<Summary> = (0..shard_count)
+            .map(|_| Summary::random(&mut rng))
+            .collect();
+
+        strategy.run(
+            total,
+            // Serial verification checks the whole batch as one equation, so
+            // coalescing is global and no partition is needed.
+            || Self::verify_shard(self.signatures.iter(), total, seeds[0]),
+            // Parallel verification partitions the batch so signatures
+            // sharing a verification key coalesce within their shard, then
+            // checks one equation per shard.
+            || {
+                let order = Self::partition(&self.signatures);
+                let shard_size = total.div_ceil(shard_count).max(1);
+                let shards: Vec<_> = order
+                    .chunks(shard_size)
+                    .zip(seeds.iter().copied())
+                    .collect();
+                manual.fold(
+                    shards,
+                    || Ok(()),
+                    |result, (shard, seed)| {
+                        result?;
+                        Self::verify_shard(
+                            shard.iter().map(|&idx| &self.signatures[idx]),
+                            shard.len(),
+                            seed,
+                        )
+                    },
+                    |left, right| left.and(right),
+                )
+            },
+        )
+    }
+
+    /// Build an iteration order in which signatures sharing a verification
+    /// key occupy one contiguous run, using a counting sort on each key's
+    /// first byte. Chunking the order into equal-size shards then places
+    /// signatures sharing a key into the same shard, while skewed batches
+    /// (like a single signer) still split evenly across shards. Keys crafted
+    /// to share a first byte just forfeit the grouping, which costs no more
+    /// than the unpartitioned order.
+    fn partition(signatures: &[(VerificationKey, Vec<u8>, Signature)]) -> Vec<usize> {
+        let mut counts = [0; 256];
+        for (vk, _, _) in signatures {
+            counts[vk.as_bytes()[0] as usize] += 1;
+        }
+        let mut offsets = [0; 256];
+        let mut acc = 0;
+        for (offset, count) in offsets.iter_mut().zip(counts) {
+            *offset = acc;
+            acc += count;
+        }
+        let mut order = vec![0; signatures.len()];
+        for (i, (vk, _, _)) in signatures.iter().enumerate() {
+            let bucket = vk.as_bytes()[0] as usize;
+            order[offsets[bucket]] = i;
+            offsets[bucket] += 1;
+        }
+        order
+    }
+
+    /// Verify `n` signatures as a single verification equation, drawing a
+    /// randomizer for each signature from `seed`.
+    #[allow(non_snake_case)]
+    fn verify_shard<'a>(
+        items: impl Iterator<Item = &'a (VerificationKey, Vec<u8>, Signature)>,
+        n: usize,
+        seed: Summary,
+    ) -> Result<(), Error> {
+        let mut rng = Transcript::resume(seed).noise(NOISE_BATCH_VERIFY);
+
+        // The batch verification equation is
+        //
+        // [-sum(z_i * s_i)]B + sum([z_i]R_i) + sum([z_i * k_i]A_i) = 0.
+        //
+        // where for each signature i,
+        // - A_i is the verification key;
+        // - R_i is the signature's R value;
+        // - s_i is the signature's s value;
+        // - k_i is the hash of the message and other data, computed
+        //   here so the per-signature SHA-512 work runs under the
+        //   caller's strategy;
+        // - z_i is a random 128-bit Scalar.
+        //
+        // Normally n signatures would require a multiscalar multiplication of
+        // size 2*n + 1, together with 2*n point decompressions (to obtain A_i
+        // and R_i). However, by grouping the entries by verification key, we
+        // can "coalesce" all z_i * k_i terms for each distinct verification
+        // key into a single coefficient.
+        //
+        // For n signatures from m verification keys, this approach instead
+        // requires a multiscalar multiplication of size n + m + 1 together with
+        // only n point decompressions because verification keys are decompressed
+        // before they are queued. When m = n, so all signatures are from
+        // distinct verification keys, this saves n decompressions relative to
+        // the usual method. However, when m = 1 and all signatures are from a
+        // single verification key, this is nearly twice as fast.
+
+        // Group the signatures by verification key. hashbrown's map with the
+        // ahash hasher stands in for ahash::AHashMap, which wraps
+        // std::collections::HashMap and is unavailable in no_std builds.
+        let mut key_indices: HashMap<&VerificationKeyBytes, usize, RandomState> =
+            HashMap::with_capacity_and_hasher(n, RandomState::default());
+        let mut A_coeffs: Vec<Scalar> = Vec::with_capacity(n);
+        let mut As = Vec::with_capacity(n);
+        let mut R_coeffs = Vec::with_capacity(n);
+        let mut Rs = Vec::with_capacity(n);
+        let mut B_coeff = Scalar::ZERO;
+
+        for (vk, payload, sig) in items {
+            let k = super::scalar_from_hash(
+                Sha512::default()
+                    .chain(&sig.R_bytes[..])
+                    .chain(vk.as_bytes())
+                    .chain(payload),
+            );
+            let R = CompressedEdwardsY(sig.R_bytes)
+                .decompress()
+                .ok_or(Error::InvalidSignature)?;
+            let s = Scalar::from_canonical_bytes(sig.s_bytes)
+                .into_option()
+                .ok_or(Error::InvalidSignature)?;
+            let z = Scalar::from(gen_u128(&mut rng));
+            B_coeff -= z * s;
+            Rs.push(R);
+            R_coeffs.push(z);
+            let index = *key_indices.entry(&vk.A_bytes).or_insert_with(|| {
+                As.push(-vk.minus_A);
+                A_coeffs.push(Scalar::ZERO);
+                As.len() - 1
+            });
+            A_coeffs[index] += z * k;
         }
 
-        manual.fold(
-            shards,
-            || Ok(()),
-            |result, (shard, seed)| {
-                result?;
-                let mut rng = Transcript::resume(seed).noise(NOISE_BATCH_VERIFY);
+        let check = EdwardsPoint::vartime_multiscalar_mul(
+            once(&B_coeff).chain(A_coeffs.iter()).chain(R_coeffs.iter()),
+            once(&B).chain(As.iter()).chain(Rs.iter()),
+        );
 
-                // The batch verification equation is
-                //
-                // [-sum(z_i * s_i)]B + sum([z_i]R_i) + sum([z_i * k_i]A_i) = 0.
-                //
-                // where for each signature i,
-                // - A_i is the verification key;
-                // - R_i is the signature's R value;
-                // - s_i is the signature's s value;
-                // - k_i is the hash of the message and other data, computed
-                //   here so the per-signature SHA-512 work runs under the
-                //   caller's strategy;
-                // - z_i is a random 128-bit Scalar.
-                //
-                // Normally n signatures would require a multiscalar multiplication of
-                // size 2*n + 1, together with 2*n point decompressions (to obtain A_i
-                // and R_i). However, by grouping the shard's entries by verification
-                // key, we can "coalesce" all z_i * k_i terms for each distinct
-                // verification key into a single coefficient.
-                //
-                // For n signatures from m verification keys, this approach instead
-                // requires a multiscalar multiplication of size n + m + 1 together with
-                // only n point decompressions because verification keys are decompressed
-                // before they are queued. When m = n, so all signatures are from
-                // distinct verification keys, this saves n decompressions relative to
-                // the usual method. However, when m = 1 and all signatures are from a
-                // single verification key, this is nearly twice as fast.
-
-                // Group the shard's signatures by verification key. hashbrown's
-                // map with the ahash hasher stands in for ahash::AHashMap, which
-                // wraps std::collections::HashMap and is unavailable in no_std
-                // builds.
-                let n = shard.len();
-                let mut key_indices: HashMap<&VerificationKeyBytes, usize, RandomState> =
-                    HashMap::with_capacity_and_hasher(n, RandomState::default());
-                let mut A_coeffs: Vec<Scalar> = Vec::with_capacity(n);
-                let mut As = Vec::with_capacity(n);
-                let mut R_coeffs = Vec::with_capacity(n);
-                let mut Rs = Vec::with_capacity(n);
-                let mut B_coeff = Scalar::ZERO;
-
-                for (vk, payload, sig) in shard {
-                    let k = super::scalar_from_hash(
-                        Sha512::default()
-                            .chain(&sig.R_bytes[..])
-                            .chain(vk.as_bytes())
-                            .chain(payload),
-                    );
-                    let R = CompressedEdwardsY(sig.R_bytes)
-                        .decompress()
-                        .ok_or(Error::InvalidSignature)?;
-                    let s = Scalar::from_canonical_bytes(sig.s_bytes)
-                        .into_option()
-                        .ok_or(Error::InvalidSignature)?;
-                    let z = Scalar::from(gen_u128(&mut rng));
-                    B_coeff -= z * s;
-                    Rs.push(R);
-                    R_coeffs.push(z);
-                    let index = *key_indices.entry(&vk.A_bytes).or_insert_with(|| {
-                        As.push(-vk.minus_A);
-                        A_coeffs.push(Scalar::ZERO);
-                        As.len() - 1
-                    });
-                    A_coeffs[index] += z * k;
-                }
-
-                let check = EdwardsPoint::vartime_multiscalar_mul(
-                    once(&B_coeff).chain(A_coeffs.iter()).chain(R_coeffs.iter()),
-                    once(&B).chain(As.iter()).chain(Rs.iter()),
-                );
-
-                if check.mul_by_cofactor().is_identity() {
-                    Ok(())
-                } else {
-                    Err(Error::InvalidSignature)
-                }
-            },
-            |left, right| left.and(right),
-        )
+        if check.mul_by_cofactor().is_identity() {
+            Ok(())
+        } else {
+            Err(Error::InvalidSignature)
+        }
     }
 }
 
@@ -275,9 +328,9 @@ mod tests {
 
     #[test]
     fn test_verify_interleaved_duplicate_keys() {
-        // Round-robin queueing scatters each signer's signatures across shard
-        // boundaries, exercising coalescing of non-adjacent duplicate keys
-        // within a shard and duplicate keys split across shards.
+        // Round-robin queueing scatters each signer's signatures across the
+        // queue, exercising the partition that regroups them into shards and
+        // coalescing of duplicate keys within and across shard boundaries.
         let grouped = signatures(2, 6);
         let mut items = Vec::with_capacity(grouped.len());
         for i in 0..6 {

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -355,14 +355,12 @@ impl Batch {
         public_key: &PublicKey,
         signature: &Signature,
     ) -> bool {
-        let payload = namespace
-            .map(|ns| Cow::Owned(union_unique(ns, message)))
-            .unwrap_or_else(|| Cow::Borrowed(message));
-        self.verifier.queue((
+        self.verifier.queue(
             public_key.key,
             ed_core::Signature::from(signature.raw),
-            &payload,
-        ));
+            namespace,
+            message,
+        );
         true
     }
 }

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -331,6 +331,12 @@ impl BatchVerifier for Batch {
         }
     }
 
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            verifier: ed_core::batch::Verifier::with_capacity(capacity),
+        }
+    }
+
     fn add(
         &mut self,
         namespace: &[u8],
@@ -736,6 +742,17 @@ mod tests {
     #[test]
     fn batch_verify_empty() {
         let batch = Batch::new();
+        assert!(batch.verify(&mut test_rng(), &Sequential));
+    }
+
+    #[test]
+    fn batch_verify_with_capacity() {
+        let v1 = vector_1();
+        let v2 = vector_2();
+        // The capacity is a hint: adding more items must still verify.
+        let mut batch = Batch::with_capacity(1);
+        assert!(batch.add_inner(None, &v1.2, &v1.1, &v1.3));
+        assert!(batch.add_inner(None, &v2.2, &v2.1, &v2.3));
         assert!(batch.verify(&mut test_rng(), &Sequential));
     }
 

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -318,11 +318,6 @@ impl arbitrary::Arbitrary<'_> for Signature {
 }
 
 /// Ed25519 Batch Verifier.
-///
-/// Each added item copies its framed payload (namespace and message) into the
-/// batch and retains it until verification, where per-signature hashing runs
-/// under the caller's [Strategy]. A batch therefore holds memory proportional
-/// to the total payload bytes added.
 pub struct Batch {
     verifier: ed_core::batch::Verifier,
 }

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -318,6 +318,11 @@ impl arbitrary::Arbitrary<'_> for Signature {
 }
 
 /// Ed25519 Batch Verifier.
+///
+/// Each added item copies its framed payload (namespace and message) into the
+/// batch and retains it until verification, where per-signature hashing runs
+/// under the caller's [Strategy]. A batch therefore holds memory proportional
+/// to the total payload bytes added.
 pub struct Batch {
     verifier: ed_core::batch::Verifier,
 }
@@ -325,13 +330,7 @@ pub struct Batch {
 impl BatchVerifier for Batch {
     type PublicKey = PublicKey;
 
-    fn new() -> Self {
-        Self {
-            verifier: ed_core::batch::Verifier::new(),
-        }
-    }
-
-    fn with_capacity(capacity: usize) -> Self {
+    fn new(capacity: usize) -> Self {
         Self {
             verifier: ed_core::batch::Verifier::with_capacity(capacity),
         }
@@ -715,7 +714,7 @@ mod tests {
     fn batch_verify_valid() {
         let v1 = vector_1();
         let v2 = vector_2();
-        let mut batch = ed25519::Batch::new();
+        let mut batch = ed25519::Batch::new(2);
         assert!(batch.add_inner(None, &v1.2, &v1.1, &v1.3));
         assert!(batch.add_inner(None, &v2.2, &v2.1, &v2.3));
         assert!(batch.verify(&mut test_rng(), &Sequential));
@@ -728,7 +727,7 @@ mod tests {
         let mut bad_signature = v2.3.to_vec();
         bad_signature[3] = 0xff;
 
-        let mut batch = Batch::new();
+        let mut batch = Batch::new(2);
         assert!(batch.add_inner(None, &v1.2, &v1.1, &v1.3));
         assert!(batch.add_inner(
             None,
@@ -741,16 +740,16 @@ mod tests {
 
     #[test]
     fn batch_verify_empty() {
-        let batch = Batch::new();
+        let batch = Batch::new(0);
         assert!(batch.verify(&mut test_rng(), &Sequential));
     }
 
     #[test]
-    fn batch_verify_with_capacity() {
+    fn batch_verify_capacity_hint() {
         let v1 = vector_1();
         let v2 = vector_2();
         // The capacity is a hint: adding more items must still verify.
-        let mut batch = Batch::with_capacity(1);
+        let mut batch = Batch::new(1);
         assert!(batch.add_inner(None, &v1.2, &v1.1, &v1.3));
         assert!(batch.add_inner(None, &v2.2, &v2.1, &v2.3));
         assert!(batch.verify(&mut test_rng(), &Sequential));

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -327,7 +327,7 @@ impl BatchVerifier for Batch {
 
     fn new(capacity: usize) -> Self {
         Self {
-            verifier: ed_core::batch::Verifier::with_capacity(capacity),
+            verifier: ed_core::batch::Verifier::new(capacity),
         }
     }
 

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -158,6 +158,18 @@ commonware_macros::stability_scope!(BETA {
         /// Create a new batch verifier.
         fn new() -> Self;
 
+        /// Create a new batch verifier with capacity for at least `capacity` items.
+        ///
+        /// The capacity is a hint: more than `capacity` items may be added, and
+        /// implementations may ignore it.
+        fn with_capacity(capacity: usize) -> Self
+        where
+            Self: Sized,
+        {
+            let _ = capacity;
+            Self::new()
+        }
+
         /// Append item to the batch.
         ///
         /// The message should not be hashed prior to calling this function. If a particular scheme

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -155,20 +155,11 @@ commonware_macros::stability_scope!(BETA {
         /// The type of public keys that this verifier can accept.
         type PublicKey: PublicKey;
 
-        /// Create a new batch verifier.
-        fn new() -> Self;
-
         /// Create a new batch verifier with capacity for at least `capacity` items.
         ///
         /// The capacity is a hint: more than `capacity` items may be added, and
         /// implementations may ignore it.
-        fn with_capacity(capacity: usize) -> Self
-        where
-            Self: Sized,
-        {
-            let _ = capacity;
-            Self::new()
-        }
+        fn new(capacity: usize) -> Self;
 
         /// Append item to the batch.
         ///

--- a/cryptography/src/transcript.rs
+++ b/cryptography/src/transcript.rs
@@ -544,9 +544,9 @@ mod test {
         let summary = transcript.summarize();
         let sig = transcript.sign(&sk);
 
-        let mut summary_batch = ed25519::Batch::new();
+        let mut summary_batch = ed25519::Batch::new(1);
         assert!(summary.add_to_batch(&mut summary_batch, &pk, &sig));
-        let mut transcript_batch = ed25519::Batch::new();
+        let mut transcript_batch = ed25519::Batch::new(1);
         assert!(transcript.add_to_batch(&mut transcript_batch, &pk, &sig));
 
         assert!(summary_batch.verify(&mut test_rng(), &Sequential));


### PR DESCRIPTION
## Summary

- Defers the per-signature SHA-512 challenge hash from `Batch::add` to `Batch::verify`. `add` just copies the framed payload (retained until `verify`), and every signature's hash is computed inside the verification fold under the caller's `Strategy` instead of serially at queue time.
- Flattens the `Verifier` from a queue-time `Map<VerificationKey, Vec<(Scalar, Signature)>>` to an insertion-order `Vec<(VerificationKey, Vec<u8>, Signature)>`. `add` becomes a plain push, and shards are balanced by signature count rather than key count, so single-signer batches parallelize (previously one key = one group = one serial shard).
- Routes `verify` through `strategy.run(total, serial, parallel)`. The adaptive policy picks between verifying the whole batch as one equation (serial, with global coalescing) and sharded parallel verification. Both paths share a `verify_shard` helper.
- Partitions the parallel path so signatures sharing a verification key land in the same shard: a counting sort on each key's first byte builds a permutation in O(n) with no comparisons, and shards are equal-size chunks of it. Coalescing no longer depends on queue order (e.g. `verify_certificates` queues the same validator set certificate-major, which previously paid up to the all-distinct rate). Skewed batches (like a single signer) still split evenly across shards, and keys crafted to share a first byte only forfeit the grouping.
- Coalesces duplicate keys within a shard via a pre-sized `hashbrown::HashMap` with `ahash::RandomState` on plain `no-rng` (`AHashMap` is std-gated in ahash 0.8, and fixed-seed hashing matches the workspace's existing assumption).
- Replaces `BatchVerifier::new()` + `with_capacity` with a single `new(capacity: usize)` hint. Call sites pass real sizes.
- Adds tests for deferred hashing, framing pinned to `union_unique`, and interleaved duplicate keys (sequential and parallel results asserted to agree).

## Why

For large batches of mostly-distinct keys (the certificate/vote shape), the old `add` loop was a serial bottleneck: at 32k signatures it spent ~7-8ms hashing and building the per-key map before `verify` could fan out. Deferring the hash moves that work under the strategy, the flat layout removes the remaining serial map/alloc costs, and the partition makes coalescing a property of the batch rather than of the order callers happened to queue it in.

The trade-off is that `VerificationKey` (192 bytes) and the framed payload are stored per queued signature until `verify` (~6MB of transient memory for a pathological 32k single-signer batch), in exchange for balanced shards that verify that same batch 5.8x faster.

## Benchmarks

E2E = `add` loop + `verify`, 32-byte messages with namespace framing, `Rayon(8)` (or `Sequential`), min of 12 iterations, Apple M5 Pro. All times in ms.

Deferral + flat layout, vs merge-base (a5915db4f), measured before the partition:

| scenario | main add | main E2E | PR add | PR E2E | E2E delta |
|---|---|---|---|---|---|
| 16k distinct keys, conc=8 | 3.56 | 20.91 | 0.55 | 18.15 | -13% |
| 32k distinct keys, conc=8 | 7.34 | 39.99 | 1.07 | 35.21 | -12% |
| 32k single signer, conc=8 | 8.55 | 129.43 | 0.87 | 22.36 | -83% (5.8x) |
| 64 signers x 512 sigs, conc=8 | 8.71 | 28.00 | 1.04 | 22.28 | -20% |
| 1k distinct keys, conc=8 | 0.23 | 1.97 | 0.02 | 1.63 | -17% |
| 32k distinct keys, serial | 7.48 | 210.84 | 0.90 | 211.23 | ~0% |

Key partition, before/after on this branch (bracketed run):

| scenario | before | after |
|---|---|---|
| 4096 signers x 8 sigs, round-robin interleaved | 28.5 | 20.2 (-29%) |
| 50 certificates x 640 signers, certificate-major | 19.6 | 18.1 (-7%) |
| 4096 x 8, caller pre-grouped | 18.8 | 19.0 |
| 32k distinct keys | 27.2 | 28.5 |
| 32k single signer | 17.4 | 17.6 |
| 32k distinct keys, serial | 41.2 | 41.4 |

The interleaved and certificate-major improvements reproduce across every run. The remaining deltas are within the build-to-build layout and load variance observed on this machine (the partition's arithmetic is ~0.2ms, and the residual vs pre-grouped order is shard-side index gather, which any runtime reordering pays).

Hasher choice for the per-shard grouping map (pre-sized, 32-byte keys, entry-or-insert micro): SipHash 10.6 ns/op, foldhash 6.4, ahash 3.6. The map is ~0.1% of E2E either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019M4zv2iQQWuqJAMHssUBMB
