### PR TITLE
consensus/marshal: handle non-monotonic parent heights during gap repair

### DIFF
--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -967,6 +967,11 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_coding_non_monotonic_parent_height() {
+        harness::non_monotonic_parent_height::<CodingHarness>();
+    }
+
+    #[test_traced("WARN")]
     fn test_coding_certify_persists_equivocated_block() {
         harness::certify_persists_equivocated_block::<CodingHarness>();
     }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -2002,16 +2002,16 @@ where
                     .find_block_by_commitment(buffer, parent_commitment)
                     .await;
 
-                // Treat a block whose height does not strictly decrease as
-                // missing so that the existing fetch path requests the correct
-                // block from the network. This prevents an infinite loop when
-                // the archive contains corrupted parent pointers.
+                // Treat a block whose parent height is not contiguous (does not
+                // decrease by exactly one) as missing so that the existing fetch path
+                // requests the correct block from the network. This prevents an infinite
+                // loop when the archive contains corrupted parent pointers.
                 let parent_block = match parent_block {
-                    Some(ref block) if block.height() >= height => {
+                    Some(ref block) if Some(block.height()) != height.previous() => {
                         warn!(
                             current = %height,
                             parent = %block.height(),
-                            "non-monotonic parent height during gap repair, treating as missing"
+                            "non-contiguous parent height during gap repair, treating as missing"
                         );
                         None
                     }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1998,10 +1998,27 @@ where
 
             // Iterate backwards, repairing blocks as we go.
             while height > gap_start {
-                if let Some(block) = self
+                let parent_block = self
                     .find_block_by_commitment(buffer, parent_commitment)
-                    .await
-                {
+                    .await;
+
+                // Treat a block whose height does not strictly decrease as
+                // missing so that the existing fetch path requests the correct
+                // block from the network. This prevents an infinite loop when
+                // the archive contains corrupted parent pointers.
+                let parent_block = match parent_block {
+                    Some(ref block) if block.height() >= height => {
+                        warn!(
+                            current = %height,
+                            parent = %block.height(),
+                            "non-monotonic parent height during gap repair, treating as missing"
+                        );
+                        None
+                    }
+                    other => other,
+                };
+
+                if let Some(block) = parent_block {
                     let finalization = self.cache.get_finalization_for(parent_digest).await;
                     let next = (block.height(), block.parent(), V::parent_commitment(&block));
                     wrote |= self

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -5252,3 +5252,75 @@ pub fn broadcast_caches_block<H: TestHarness>() {
             .expect("block should be cached after broadcast");
     })
 }
+
+/// Test that a non-monotonic parent height does not cause an infinite loop during gap repair.
+pub fn non_monotonic_parent_height<H: TestHarness>() {
+    let runner = deterministic::Runner::timed(Duration::from_secs(10));
+    runner.start(|mut context| async move {
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+        let mut oracle = setup_network_with_participants(
+            context.child("network"),
+            NZUsize!(1),
+            participants.clone(),
+        )
+        .await;
+
+        let setup = H::setup_validator(
+            context.child("validator").with_attribute("index", 0),
+            &mut oracle,
+            participants[0].clone(),
+            ConstantProvider::new(schemes[0].clone()),
+        )
+        .await;
+        let mut handle = ValidatorHandle {
+            mailbox: setup.mailbox,
+            extra: setup.extra,
+        };
+
+        // Create a parent block with height 2 (non-monotonic)
+        let bad_block = H::make_test_block(
+            Sha256::hash(b""),
+            H::genesis_parent_commitment(participants.len() as u16),
+            Height::new(2),
+            1,
+            participants.len() as u16,
+        );
+        let bad_digest = H::digest(&bad_block);
+        let bad_commitment = H::commitment(&bad_block);
+
+        // Create a descendant block at height 2, pointing to the bad block
+        let descendant_block = H::make_test_block(
+            bad_digest,
+            bad_commitment,
+            Height::new(2),
+            2,
+            participants.len() as u16,
+        );
+        let descendant_commitment = H::commitment(&descendant_block);
+
+        // Propose both blocks so they are in the buffer
+        H::propose(&mut handle, Round::new(Epoch::new(0), View::new(1)), &bad_block).await;
+        H::propose(&mut handle, Round::new(Epoch::new(0), View::new(2)), &descendant_block).await;
+
+        // Report finalization for the descendant only (creates a gap at height 1)
+        let descendant_proposal = Proposal {
+            round: Round::new(Epoch::new(0), View::new(2)),
+            parent: View::new(1),
+            payload: descendant_commitment,
+        };
+        let descendant_finalization = H::make_finalization(descendant_proposal, &schemes, QUORUM);
+        H::report_finalization(&mut handle.mailbox, descendant_finalization).await;
+
+        // Sleep to allow processing. Without the fix, the actor hangs here and the runner times out.
+        context.sleep(Duration::from_millis(500)).await;
+
+        // Verify the mailbox is still responsive
+        let processed_height = handle.mailbox.get_processed_height().await;
+        assert_eq!(processed_height, Height::zero());
+    });
+}
+

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -5253,7 +5253,7 @@ pub fn broadcast_caches_block<H: TestHarness>() {
     })
 }
 
-/// Test that a non-monotonic parent height does not cause an infinite loop during gap repair.
+/// Test that a non-contiguous parent height does not cause an infinite loop during gap repair.
 pub fn non_monotonic_parent_height<H: TestHarness>() {
     let runner = deterministic::Runner::timed(Duration::from_secs(10));
     runner.start(|mut context| async move {
@@ -5281,22 +5281,22 @@ pub fn non_monotonic_parent_height<H: TestHarness>() {
             extra: setup.extra,
         };
 
-        // Create a parent block with height 2 (non-monotonic)
+        // Create a parent block with height 1
         let bad_block = H::make_test_block(
             Sha256::hash(b""),
             H::genesis_parent_commitment(participants.len() as u16),
-            Height::new(2),
+            Height::new(1),
             1,
             participants.len() as u16,
         );
         let bad_digest = H::digest(&bad_block);
         let bad_commitment = H::commitment(&bad_block);
 
-        // Create a descendant block at height 2, pointing to the bad block
+        // Create a descendant block at height 3, pointing directly to the bad block (skipping height 2)
         let descendant_block = H::make_test_block(
             bad_digest,
             bad_commitment,
-            Height::new(2),
+            Height::new(3),
             2,
             participants.len() as u16,
         );
@@ -5304,11 +5304,11 @@ pub fn non_monotonic_parent_height<H: TestHarness>() {
 
         // Propose both blocks so they are in the buffer
         H::propose(&mut handle, Round::new(Epoch::new(0), View::new(1)), &bad_block).await;
-        H::propose(&mut handle, Round::new(Epoch::new(0), View::new(2)), &descendant_block).await;
+        H::propose(&mut handle, Round::new(Epoch::new(0), View::new(3)), &descendant_block).await;
 
-        // Report finalization for the descendant only (creates a gap at height 1)
+        // Report finalization for the descendant only (creates a gap at height 2)
         let descendant_proposal = Proposal {
-            round: Round::new(Epoch::new(0), View::new(2)),
+            round: Round::new(Epoch::new(0), View::new(3)),
             parent: View::new(1),
             payload: descendant_commitment,
         };

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -1298,6 +1298,12 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_standard_non_monotonic_parent_height() {
+        harness::non_monotonic_parent_height::<InlineHarness>();
+        harness::non_monotonic_parent_height::<DeferredHarness>();
+    }
+
+    #[test_traced("WARN")]
     fn test_standard_init_processed_height() {
         harness::init_processed_height::<InlineHarness>();
         harness::init_processed_height::<DeferredHarness>();


### PR DESCRIPTION
## Summary

Fixes #4155.

During startup gap repair, `try_repair_gaps` assumes that each resolved parent block is strictly lower than the current block. A malformed finalized-blocks archive containing a non-monotonic parent link can violate this assumption, causing the repair loop to repeatedly rediscover the same gap and preventing the marshal actor from reaching its mailbox loop.

This change treats a resolved parent whose height is not strictly less than the current height as a missing parent. A warning is emitted, and the existing fetch path is reused to request the expected finalized block, allowing startup recovery to continue instead of spinning indefinitely.

## Test plan

- Added regression tests covering malformed archives with non-monotonic parent links across the marshal harnesses.
- Verified the actor remains responsive and recovers without hanging.
- Ran:

```bash
$env:AWS_LC_SYS_NO_ASM="1"; cargo test -p commonware-consensus -- non_monotonic_parent_height
```