### PR TITLE
[storage/qmdb] Simplify staged batch bookkeeping

### DIFF
--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -1016,7 +1016,7 @@ impl<
 
         // Initialize journal
         let cfg = JournalConfig {
-            partition: format!("{}{}", &self.journal_name_prefix, sequencer),
+            partition: format!("{}{}", self.journal_name_prefix, sequencer),
             compression: self.journal_compression,
             codec_config: P::Scheme::certificate_codec_config_unbounded(),
             page_cache: self.journal_page_cache.clone(),

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -200,21 +200,11 @@ where
     base: Base<F, H::Digest, U, S>,
 }
 
-/// Pending mutations whose old committed location was already resolved by a staged read. The
-/// value is `Some` for an update and `None` for a delete; only the unordered path stages deletes
-/// (the ordered path cannot skip the deleted key's predecessor-bucket scan, so its deletes fall
-/// back to normal mutations).
-pub(crate) struct StagedUpdates<F: Family, U: update::Update> {
-    entries: Vec<StagedUpdate<F, U>>,
-}
-
-impl<F: Family, U: update::Update> StagedUpdates<F, U> {
-    pub(crate) const fn new() -> Self {
-        Self {
-            entries: Vec::new(),
-        }
-    }
-}
+/// Pending mutations whose old committed locations were already resolved by staged reads, sorted
+/// by location. Each value is `Some` for an update and `None` for a delete; only the unordered
+/// path stages deletes (the ordered path cannot skip the deleted key's predecessor-bucket scan,
+/// so its deletes fall back to normal mutations).
+pub(crate) type StagedUpdates<F, U> = Vec<StagedUpdate<F, U>>;
 
 /// A staged read slot's committed-DB resolution: the location and cached payload the read
 /// resolved to, or `None` when it resolved from batch mutations or ancestor diffs (or missed).
@@ -1151,7 +1141,7 @@ where
             keys,
             resolutions,
         } = self;
-        let mut staged_updates = StagedUpdates::new();
+        let mut staged_updates = StagedUpdates::<F, U>::new();
         if updates.is_empty() {
             return (Self::apply_upserts(batch, upserts), staged_updates);
         }
@@ -1161,7 +1151,7 @@ where
         // last and win.
         let mut handled = AHashSet::with_capacity(updates.len() + upserts.len());
         handled.extend(upserts.iter().map(|(key, _)| key));
-        staged_updates.entries.reserve(updates.len());
+        staged_updates.reserve(updates.len());
         for (slot, value) in updates.into_iter().rev() {
             assert!(slot < keys.len(), "update index out of staged read range");
             let key = &keys[slot];
@@ -1174,16 +1164,14 @@ where
                     // This staged update is the surviving write for `key`; do not also emit an
                     // older batch mutation for the same key.
                     batch.mutations.remove(key);
-                    staged_updates
-                        .entries
-                        .push((key.clone(), *loc, payload.clone(), value));
+                    staged_updates.push((key.clone(), *loc, payload.clone(), value));
                 }
                 _ => {
                     batch.mutations.insert(key.clone(), value);
                 }
             }
         }
-        staged_updates.entries.sort_unstable_by_key(|entry| entry.1);
+        staged_updates.sort_unstable_by_key(|entry| entry.1);
         (Self::apply_upserts(batch, upserts), staged_updates)
     }
 }
@@ -1500,12 +1488,9 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(
-            db,
-            metadata,
-            StagedUpdates::new(),
-            |floor, tip, limit, out| fill_candidates(&db.bitmap, floor, tip, limit, out),
-        )
+        self.merkleize_with_floor_scan(db, metadata, Vec::new(), |floor, tip, limit, out| {
+            fill_candidates(&db.bitmap, floor, tip, limit, out)
+        })
         .await
     }
 
@@ -1533,7 +1518,7 @@ where
 
         // `value` is `Some` for a staged update and `None` for a staged delete; the
         // location-ordered merge below emits each as an `Update`/`Delete` at the cached location.
-        let cached = staged_updates.entries;
+        let cached = staged_updates;
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, false);
@@ -1691,12 +1676,9 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(
-            db,
-            metadata,
-            StagedUpdates::new(),
-            |floor, tip, limit, out| fill_candidates(&db.bitmap, floor, tip, limit, out),
-        )
+        self.merkleize_with_floor_scan(db, metadata, Vec::new(), |floor, tip, limit, out| {
+            fill_candidates(&db.bitmap, floor, tip, limit, out)
+        })
         .await
     }
 
@@ -1726,7 +1708,7 @@ where
         // Staged updates skip the index probe and journal re-read, and their old op's next key
         // feeds the candidate sets directly. The ordered path never stages deletes (see
         // `Staged::resolve_updates`), so every staged entry carries a value.
-        let cached = staged_updates.entries;
+        let cached = staged_updates;
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);
@@ -3465,7 +3447,7 @@ mod tests {
             );
 
             assert_eq!(
-                staged_updates.entries,
+                staged_updates,
                 vec![(k1, loc(10), (), None), (k0, loc(30), (), Some(new0))]
             );
             assert_eq!(batch.mutations.len(), 2);
@@ -3580,7 +3562,7 @@ mod tests {
             );
 
             assert_eq!(
-                staged_updates.entries,
+                staged_updates,
                 vec![
                     (update_b, loc(7), next_b, Some(value_b)),
                     (update_a, loc(30), next_a, Some(value_a)),

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     Context,
 };
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashSet;
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
@@ -216,9 +216,12 @@ impl<F: Family, U: update::Update> StagedUpdates<F, U> {
     }
 }
 
-/// Committed locations resolved by staged reads, as `(slot, location, cached payload)` entries in
-/// staged read-slot order.
-type StagedReads<F, U> = Vec<(usize, Location<F>, <U as update::Update>::Cached)>;
+/// One staged read slot: the key and, when the read resolved from the committed DB, the location
+/// and cached payload it resolved to.
+type StagedSlot<F, U> = (
+    <U as update::Update>::Key,
+    Option<(Location<F>, <U as update::Update>::Cached)>,
+);
 
 /// Staged batch returned by [`UnmerkleizedBatch::stage`].
 ///
@@ -231,8 +234,7 @@ where
     Operation<F, U>: Codec,
 {
     batch: UnmerkleizedBatch<F, H, U, S>,
-    keys: Vec<U::Key>,
-    cached: StagedReads<F, U>,
+    slots: Vec<StagedSlot<F, U>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -1100,13 +1102,12 @@ where
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        let start = self.keys.len();
+        let start = self.slots.len();
         let end = start
             .checked_add(keys.len())
             .expect("staged read index overflow");
-        let (values, keys, mut cached) = self.batch.stage_reads(keys, db, start).await?;
-        self.keys.extend(keys);
-        self.cached.append(&mut cached);
+        let (values, mut slots) = self.batch.stage_reads(keys, db).await?;
+        self.slots.append(&mut slots);
         Ok((start..end, values, self))
     }
 
@@ -1133,88 +1134,50 @@ where
     /// `write` semantics and wins.
     ///
     /// Committed-resolved updates reuse the staged location. Committed-resolved deletes reuse it
-    /// only when `stage_deletes` is set (the unordered path): an unordered delete just emits a
-    /// `Delete` at the cached location, whereas an ordered delete must rewrite the deleted key's
-    /// predecessor via a snapshot-bucket scan the cached location cannot skip, so ordered passes
-    /// `stage_deletes = false` and its deletes fall back to normal mutations. Keys resolved from
-    /// ancestors or missing from committed state always fall back.
+    /// only when [`update::Update::STAGES_DELETES`] is set (the unordered kind). Keys resolved
+    /// from ancestors or missing from committed state always fall back to normal mutations.
     ///
     /// # Panics
     ///
     /// Panics if any update's `read_index` is out of the staged read range.
     pub(crate) fn resolve_updates(
-        mut self,
-        mut updates: Vec<(usize, Option<U::Value>)>,
+        self,
+        updates: Vec<(usize, Option<U::Value>)>,
         upserts: Vec<(U::Key, Option<U::Value>)>,
-        stage_deletes: bool,
     ) -> (UnmerkleizedBatch<F, H, U, S>, StagedUpdates<F, U>) {
+        let Self { mut batch, slots } = self;
         let mut staged_updates = StagedUpdates::new();
         if updates.is_empty() {
-            return (Self::apply_upserts(self.batch, upserts), staged_updates);
+            return (Self::apply_upserts(batch, upserts), staged_updates);
         }
 
-        let upsert_keys = if upserts.is_empty() {
-            None
-        } else {
-            Some(upserts.iter().map(|(key, _)| key).collect::<AHashSet<_>>())
-        };
-
-        // Each update value is consumed at most once: last-write-wins means at most one update
-        // index survives per read slot, so values are moved out with `Option::take` rather than
-        // cloned.
-        let mut latest = vec![None; self.keys.len()];
-        let mut seen = AHashMap::with_capacity(updates.len());
-        for (update_idx, (slot, _)) in updates.iter().enumerate() {
-            assert!(
-                *slot < self.keys.len(),
-                "update index out of staged read range"
-            );
-            if let Some(prev) = seen.insert(&self.keys[*slot], update_idx) {
-                latest[updates[prev].0] = None;
+        // Walk updates newest-first so the first surviving occurrence of a key is its last
+        // write. Pre-seeding with the upsert keys drops overlapping updates: upserts are applied
+        // last and win.
+        let mut handled: AHashSet<&U::Key> = upserts.iter().map(|(key, _)| key).collect();
+        staged_updates.entries.reserve(updates.len());
+        for (slot, value) in updates.into_iter().rev() {
+            assert!(slot < slots.len(), "update index out of staged read range");
+            let (key, resolution) = &slots[slot];
+            if !handled.insert(key) {
+                continue;
             }
-            latest[*slot] = Some(update_idx);
-        }
-
-        // Upserts are applied last, so matching staged updates can be ignored.
-        if let Some(upsert_keys) = &upsert_keys {
-            for (slot, update_idx) in latest.iter_mut().enumerate() {
-                if update_idx.is_some() && upsert_keys.contains(&self.keys[slot]) {
-                    *update_idx = None;
+            match resolution {
+                Some((loc, payload)) if value.is_some() || U::STAGES_DELETES => {
+                    // This staged update is the surviving write for `key`; do not also emit an
+                    // older batch mutation for the same key.
+                    batch.mutations.remove(key);
+                    staged_updates
+                        .entries
+                        .push((key.clone(), *loc, payload.clone(), value));
+                }
+                _ => {
+                    batch.mutations.insert(key.clone(), value);
                 }
             }
         }
-
-        // Committed-resolved updates (and, when `stage_deletes`, deletes) reuse the staged
-        // location/payload. Ordered deletes, keys resolved from ancestors, and keys missing from
-        // committed state fall back to normal mutations: leaving `latest[slot]` set routes them to
-        // the fallback loop below.
-        staged_updates
-            .entries
-            .reserve(updates.len().min(self.cached.len()));
-        for (slot, loc, payload) in self.cached {
-            let Some(update_idx) = latest[slot] else {
-                continue;
-            };
-            if updates[update_idx].1.is_none() && !stage_deletes {
-                continue;
-            }
-            latest[slot] = None;
-            let key = self.keys[slot].clone();
-            // This staged update is the surviving write for `key`; do not also emit an older
-            // batch mutation for the same key.
-            self.batch.mutations.remove(&key);
-            let value = updates[update_idx].1.take();
-            staged_updates.entries.push((key, loc, payload, value));
-        }
         staged_updates.entries.sort_unstable_by_key(|entry| entry.1);
-        for (slot, update_idx) in latest.into_iter().enumerate() {
-            let Some(update_idx) = update_idx else {
-                continue;
-            };
-            let value = updates[update_idx].1.take();
-            self.batch.mutations.insert(self.keys[slot].clone(), value);
-        }
-        (Self::apply_upserts(self.batch, upserts), staged_updates)
+        (Self::apply_upserts(batch, upserts), staged_updates)
     }
 }
 
@@ -1256,8 +1219,7 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        // Unordered deletes emit a `Delete` at the cached location, so they may be staged.
-        let (batch, staged_updates) = self.resolve_updates(updates, upserts, true);
+        let (batch, staged_updates) = self.resolve_updates(updates, upserts);
         batch
             .merkleize_with_floor_scan(db, metadata, staged_updates, |floor, tip, limit, out| {
                 fill_candidates(&db.bitmap, floor, tip, limit, out)
@@ -1304,9 +1266,7 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
-        // Ordered deletes must rewrite the deleted key's predecessor, so they fall back to normal
-        // mutations rather than reusing the cached location.
-        let (batch, staged_updates) = self.resolve_updates(updates, upserts, false);
+        let (batch, staged_updates) = self.resolve_updates(updates, upserts);
         batch
             .merkleize_with_floor_scan(db, metadata, staged_updates, |floor, tip, limit, out| {
                 fill_candidates(&db.bitmap, floor, tip, limit, out)
@@ -1454,50 +1414,37 @@ where
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        let (results, keys, cached) = self.stage_reads(keys, db, 0).await?;
-        Ok((
-            results,
-            Staged {
-                batch: self,
-                keys,
-                cached,
-            },
-        ))
+        let (results, slots) = self.stage_reads(keys, db).await?;
+        Ok((results, Staged { batch: self, slots }))
     }
 
-    /// Read keys through this batch and return the values, owned staged keys, and committed-read
-    /// cache entries. `offset` is the staged index assigned to `keys[0]`, so cached entries can be
-    /// appended by [`stage`](Self::stage) and [`expand`](Staged::expand) without rewriting slots.
+    /// Read keys through this batch and return the values plus one staged slot per key;
+    /// committed-resolved slots carry the location and cached payload they resolved to.
     async fn stage_reads<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
         db: &Db<F, E, C, I, H, U, N, S>,
-        offset: usize,
-    ) -> Result<(Vec<Option<U::Value>>, Vec<U::Key>, StagedReads<F, U>), crate::qmdb::Error<F>>
+    ) -> Result<(Vec<Option<U::Value>>, Vec<StagedSlot<F, U>>), crate::qmdb::Error<F>>
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        let mut cached = Vec::new();
+        let mut slots: Vec<StagedSlot<F, U>> =
+            keys.iter().map(|key| ((*key).to_owned(), None)).collect();
         let (mut results, unresolved) = self.resolve_uncommitted_reads(keys, db.strategy());
-        cached.reserve(unresolved.len());
         Self::fill_committed_reads(
             unresolved,
             db,
             &mut results,
             |data, loc| (data.value().clone(), loc, data.cached()),
             |slot, (value, loc, payload)| {
-                cached.push((offset + slot, loc, payload));
+                slots[slot].1 = Some((loc, payload));
                 value
             },
         )
         .await?;
-        Ok((
-            results,
-            keys.iter().map(|key| (*key).to_owned()).collect(),
-            cached,
-        ))
+        Ok((results, slots))
     }
 }
 
@@ -3476,13 +3423,13 @@ mod tests {
 
             let staged = Staged::<mmr::Family, Sha256, TestUpdate, Sequential> {
                 batch: db.new_batch(),
-                keys: vec![k0, k1, k0, k2, k1, k3],
-                cached: vec![
-                    (0, loc(30), ()),
-                    (1, loc(10), ()),
-                    (2, loc(30), ()),
-                    (3, loc(40), ()),
-                    (4, loc(10), ()),
+                slots: vec![
+                    (k0, Some((loc(30), ()))),
+                    (k1, Some((loc(10), ()))),
+                    (k0, Some((loc(30), ()))),
+                    (k2, Some((loc(40), ()))),
+                    (k1, Some((loc(10), ()))),
+                    (k3, None),
                 ],
             };
 
@@ -3496,7 +3443,6 @@ mod tests {
                     (5, Some(fallback)),
                 ],
                 vec![(k2, Some(upsert))],
-                true,
             );
 
             assert_eq!(
@@ -3558,8 +3504,7 @@ mod tests {
 
             let staged = Staged::<mmr::Family, Sha256, TestUpdate, Sequential> {
                 batch: db.new_batch().write(key, Some(prior)),
-                keys: vec![key],
-                cached: vec![(0, old_loc, ())],
+                slots: vec![(key, Some((old_loc, ())))],
             };
             let staged = staged
                 .merkleize(vec![(0, Some(replacement))], Vec::new(), None, &db)
@@ -3601,18 +3546,16 @@ mod tests {
 
             let staged = Staged::<mmr::Family, Sha256, TestUpdate, Sequential> {
                 batch: db.new_batch(),
-                keys: vec![delete_key, update_a, update_b],
-                cached: vec![
-                    (0, loc(11), next_delete),
-                    (1, loc(30), next_a),
-                    (2, loc(7), next_b),
+                slots: vec![
+                    (delete_key, Some((loc(11), next_delete))),
+                    (update_a, Some((loc(30), next_a))),
+                    (update_b, Some((loc(7), next_b))),
                 ],
             };
 
             let (batch, staged_updates) = staged.resolve_updates(
                 vec![(0, None), (1, Some(value_a)), (2, Some(value_b))],
                 Vec::new(),
-                false,
             );
 
             assert_eq!(

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1507,9 +1507,12 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(db, metadata, Vec::new(), |floor, tip, limit, out| {
-            fill_candidates(&db.bitmap, floor, tip, limit, out)
-        })
+        self.merkleize_with_floor_scan(
+            db,
+            metadata,
+            StagedUpdates::<F, update::Unordered<K, V>>::new(),
+            |floor, tip, limit, out| fill_candidates(&db.bitmap, floor, tip, limit, out),
+        )
         .await
     }
 
@@ -1693,9 +1696,12 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
-        self.merkleize_with_floor_scan(db, metadata, Vec::new(), |floor, tip, limit, out| {
-            fill_candidates(&db.bitmap, floor, tip, limit, out)
-        })
+        self.merkleize_with_floor_scan(
+            db,
+            metadata,
+            StagedUpdates::<F, update::Ordered<K, V>>::new(),
+            |floor, tip, limit, out| fill_candidates(&db.bitmap, floor, tip, limit, out),
+        )
         .await
     }
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1633,9 +1633,7 @@ where
                 creates.push((key, value, None));
             }
         }
-        for (key, value, base_old_loc) in parent_deleted_creates {
-            creates.push((key, value, base_old_loc));
-        }
+        creates.extend(parent_deleted_creates);
         db.strategy()
             .sort_by(&mut creates, |(a, _, _), (b, _, _)| a.cmp(b));
         for (key, value, base_old_loc) in creates {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -216,17 +216,16 @@ impl<F: Family, U: update::Update> StagedUpdates<F, U> {
     }
 }
 
-/// One staged read slot: the key and, when the read resolved from the committed DB, the location
-/// and cached payload it resolved to.
-type StagedSlot<F, U> = (
-    <U as update::Update>::Key,
-    Option<(Location<F>, <U as update::Update>::Cached)>,
-);
+/// A staged read slot's committed-DB resolution: the location and cached payload the read
+/// resolved to, or `None` when it resolved from batch mutations or ancestor diffs (or missed).
+type StagedResolution<F, U> = Option<(Location<F>, <U as update::Update>::Cached)>;
 
 /// Staged batch returned by [`UnmerkleizedBatch::stage`].
 ///
 /// Owns the batch and the locations its reads resolved, so the staged reads cannot be paired with a
-/// different batch.
+/// different batch. `keys` and `resolutions` are parallel vectors indexed by staged read slot;
+/// they are kept separate so the read path only streams the 16-byte resolutions while the update
+/// path only hashes the keys.
 pub struct Staged<F: Family, H, U, S: Strategy>
 where
     U: update::Update + Send + Sync,
@@ -234,7 +233,8 @@ where
     Operation<F, U>: Codec,
 {
     batch: UnmerkleizedBatch<F, H, U, S>,
-    slots: Vec<StagedSlot<F, U>>,
+    keys: Vec<U::Key>,
+    resolutions: Vec<StagedResolution<F, U>>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -1102,12 +1102,13 @@ where
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        let start = self.slots.len();
+        let start = self.keys.len();
         let end = start
             .checked_add(keys.len())
             .expect("staged read index overflow");
-        let (values, mut slots) = self.batch.stage_reads(keys, db).await?;
-        self.slots.append(&mut slots);
+        let (values, mut keys, mut resolutions) = self.batch.stage_reads(keys, db).await?;
+        self.keys.append(&mut keys);
+        self.resolutions.append(&mut resolutions);
         Ok((start..end, values, self))
     }
 
@@ -1145,7 +1146,11 @@ where
         updates: Vec<(usize, Option<U::Value>)>,
         upserts: Vec<(U::Key, Option<U::Value>)>,
     ) -> (UnmerkleizedBatch<F, H, U, S>, StagedUpdates<F, U>) {
-        let Self { mut batch, slots } = self;
+        let Self {
+            mut batch,
+            keys,
+            resolutions,
+        } = self;
         let mut staged_updates = StagedUpdates::new();
         if updates.is_empty() {
             return (Self::apply_upserts(batch, upserts), staged_updates);
@@ -1158,11 +1163,12 @@ where
         handled.extend(upserts.iter().map(|(key, _)| key));
         staged_updates.entries.reserve(updates.len());
         for (slot, value) in updates.into_iter().rev() {
-            assert!(slot < slots.len(), "update index out of staged read range");
-            let (key, resolution) = &slots[slot];
+            assert!(slot < keys.len(), "update index out of staged read range");
+            let key = &keys[slot];
             if !handled.insert(key) {
                 continue;
             }
+            let resolution = &resolutions[slot];
             match resolution {
                 Some((loc, payload)) if value.is_some() || U::STAGES_DELETES => {
                     // This staged update is the surviving write for `key`; do not also emit an
@@ -1415,24 +1421,39 @@ where
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        let (results, slots) = self.stage_reads(keys, db).await?;
-        Ok((results, Staged { batch: self, slots }))
+        let (results, keys, resolutions) = self.stage_reads(keys, db).await?;
+        Ok((
+            results,
+            Staged {
+                batch: self,
+                keys,
+                resolutions,
+            },
+        ))
     }
 
-    /// Read keys through this batch and return the values plus one staged slot per key;
-    /// committed-resolved slots carry the location and cached payload they resolved to.
+    /// Read keys through this batch and return the values plus one owned key and resolution per
+    /// staged slot; committed-resolved slots carry the location and cached payload they resolved
+    /// to.
+    #[allow(clippy::type_complexity)]
     async fn stage_reads<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],
         db: &Db<F, E, C, I, H, U, N, S>,
-    ) -> Result<(Vec<Option<U::Value>>, Vec<StagedSlot<F, U>>), crate::qmdb::Error<F>>
+    ) -> Result<
+        (
+            Vec<Option<U::Value>>,
+            Vec<U::Key>,
+            Vec<StagedResolution<F, U>>,
+        ),
+        crate::qmdb::Error<F>,
+    >
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        let mut slots: Vec<StagedSlot<F, U>> =
-            keys.iter().map(|key| ((*key).to_owned(), None)).collect();
+        let mut resolutions: Vec<StagedResolution<F, U>> = vec![None; keys.len()];
         let (mut results, unresolved) = self.resolve_uncommitted_reads(keys, db.strategy());
         Self::fill_committed_reads(
             unresolved,
@@ -1440,12 +1461,16 @@ where
             &mut results,
             |data, loc| (data.value().clone(), loc, data.cached()),
             |slot, (value, loc, payload)| {
-                slots[slot].1 = Some((loc, payload));
+                resolutions[slot] = Some((loc, payload));
                 value
             },
         )
         .await?;
-        Ok((results, slots))
+        Ok((
+            results,
+            keys.iter().map(|key| (*key).to_owned()).collect(),
+            resolutions,
+        ))
     }
 }
 
@@ -3424,13 +3449,14 @@ mod tests {
 
             let staged = Staged::<mmr::Family, Sha256, TestUpdate, Sequential> {
                 batch: db.new_batch(),
-                slots: vec![
-                    (k0, Some((loc(30), ()))),
-                    (k1, Some((loc(10), ()))),
-                    (k0, Some((loc(30), ()))),
-                    (k2, Some((loc(40), ()))),
-                    (k1, Some((loc(10), ()))),
-                    (k3, None),
+                keys: vec![k0, k1, k0, k2, k1, k3],
+                resolutions: vec![
+                    Some((loc(30), ())),
+                    Some((loc(10), ())),
+                    Some((loc(30), ())),
+                    Some((loc(40), ())),
+                    Some((loc(10), ())),
+                    None,
                 ],
             };
 
@@ -3505,7 +3531,8 @@ mod tests {
 
             let staged = Staged::<mmr::Family, Sha256, TestUpdate, Sequential> {
                 batch: db.new_batch().write(key, Some(prior)),
-                slots: vec![(key, Some((old_loc, ())))],
+                keys: vec![key],
+                resolutions: vec![Some((old_loc, ()))],
             };
             let staged = staged
                 .merkleize(vec![(0, Some(replacement))], Vec::new(), None, &db)
@@ -3547,10 +3574,11 @@ mod tests {
 
             let staged = Staged::<mmr::Family, Sha256, TestUpdate, Sequential> {
                 batch: db.new_batch(),
-                slots: vec![
-                    (delete_key, Some((loc(11), next_delete))),
-                    (update_a, Some((loc(30), next_a))),
-                    (update_b, Some((loc(7), next_b))),
+                keys: vec![delete_key, update_a, update_b],
+                resolutions: vec![
+                    Some((loc(11), next_delete)),
+                    Some((loc(30), next_a)),
+                    Some((loc(7), next_b)),
                 ],
             };
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -435,6 +435,37 @@ fn resolve_pending_from_diffs<'a, K, F: Family, V: Clone + Send + Sync + 'a, S: 
     }
 }
 
+/// Resolve `keys` against a local source (`local` returns `Some` when it owns the key, with the
+/// inner `Option` distinguishing a live value from a delete) and then against `diffs`, returning
+/// per-slot results and the slots that still need committed DB reads.
+fn resolve_reads<'a, K, F: Family, V, S: Strategy>(
+    keys: &[&'a K],
+    local: impl Fn(&K) -> Option<Option<V>>,
+    diffs: &[&DiffSlice<K, F, V>],
+    strategy: &S,
+) -> UncommittedReadResolution<'a, K, V>
+where
+    K: Ord + Sync,
+    V: Clone + Send + Sync,
+{
+    let mut results = vec![None; keys.len()];
+    let mut resolved = vec![false; keys.len()];
+    let mut pending = Vec::new();
+
+    for (i, key) in keys.iter().enumerate() {
+        if let Some(value) = local(key) {
+            results[i] = value;
+            resolved[i] = true;
+        } else {
+            pending.push((i, *key));
+        }
+    }
+    resolve_pending_from_diffs(&pending, diffs, strategy, &mut resolved, &mut results);
+
+    let unresolved = pending.into_iter().filter(|(i, _)| !resolved[*i]).collect();
+    (results, unresolved)
+}
+
 /// Apply a single diff entry to the snapshot index and activity bitmap in lockstep:
 /// install the winning `Active` location and clear the prior committed location.
 fn apply_diff<F: Family, V, I: UnorderedIndex<Value = Location<F>>, const N: usize>(
@@ -1282,8 +1313,8 @@ where
         self.mutations.is_empty() && self.base.parent().is_none()
     }
 
-    /// Resolve keys against this batch and any live ancestor diffs, returning partial results and
-    /// the unresolved slots that still need committed DB reads.
+    /// Resolve keys against this batch's mutations and any live ancestor diffs, returning partial
+    /// results and the unresolved slots that still need committed DB reads.
     fn resolve_uncommitted_reads<'a>(
         &self,
         keys: &[&'a U::Key],
@@ -1292,32 +1323,22 @@ where
     where
         U::Value: Send + Sync,
     {
-        let mut results = vec![None; keys.len()];
-        let mut resolved = vec![false; keys.len()];
-        let mut pending = Vec::new();
-
-        for (i, key) in keys.iter().enumerate() {
-            // Check local mutations.
-            if let Some(value) = self.mutations.get(*key) {
-                results[i] = value.clone();
-                resolved[i] = true;
-            } else {
-                pending.push((i, *key));
-            }
-        }
-
-        if let Some(parent) = self.base.parent() {
+        let ancestors = self.base.parent().map(|parent| {
             let mut ancestors = vec![Arc::clone(parent)];
             ancestors.extend(parent.ancestors());
-            let diffs: Vec<_> = ancestors
-                .iter()
-                .map(|batch| batch.diff.as_slice())
-                .collect();
-            resolve_pending_from_diffs(&pending, &diffs, strategy, &mut resolved, &mut results);
-        }
-
-        let unresolved = pending.into_iter().filter(|(i, _)| !resolved[*i]).collect();
-        (results, unresolved)
+            ancestors
+        });
+        let diffs: Vec<_> = ancestors
+            .iter()
+            .flatten()
+            .map(|batch| batch.diff.as_slice())
+            .collect();
+        resolve_reads(
+            keys,
+            |key| self.mutations.get(key).cloned(),
+            &diffs,
+            strategy,
+        )
     }
 
     /// Read unresolved slots from the committed DB and merge them back into `results`.
@@ -2156,40 +2177,22 @@ where
             return Ok(Vec::new());
         }
 
-        let mut results = vec![None; keys.len()];
-        let mut resolved = vec![false; keys.len()];
-        let mut pending = Vec::new();
-        let mut db_indices = Vec::new();
-        let mut db_keys = Vec::new();
-
-        for (i, key) in keys.iter().enumerate() {
-            // Check local diff.
-            if let Some(entry) = lookup_sorted(self.diff.as_slice(), *key) {
-                results[i] = entry.value().cloned();
-                resolved[i] = true;
-            } else {
-                pending.push((i, *key));
-            }
-        }
-
         let ancestors: Vec<_> = self.ancestors().collect();
         let diffs: Vec<_> = ancestors
             .iter()
             .map(|batch| batch.diff.as_slice())
             .collect();
-        resolve_pending_from_diffs(&pending, &diffs, db.strategy(), &mut resolved, &mut results);
+        let (mut results, unresolved) = resolve_reads(
+            keys,
+            |key| lookup_sorted(self.diff.as_slice(), key).map(|entry| entry.value().cloned()),
+            &diffs,
+            db.strategy(),
+        );
 
-        // Need DB fallthrough.
-        for (i, key) in pending {
-            if !resolved[i] {
-                db_indices.push(i);
-                db_keys.push(key);
-            }
-        }
-
-        if !db_keys.is_empty() {
+        if !unresolved.is_empty() {
+            let db_keys: Vec<_> = unresolved.iter().map(|(_, key)| *key).collect();
             let db_results = db.get_many(&db_keys).await?;
-            for (slot, value) in db_indices.into_iter().zip(db_results) {
+            for ((slot, _), value) in unresolved.into_iter().zip(db_results) {
                 results[slot] = value;
             }
         }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1154,7 +1154,8 @@ where
         // Walk updates newest-first so the first surviving occurrence of a key is its last
         // write. Pre-seeding with the upsert keys drops overlapping updates: upserts are applied
         // last and win.
-        let mut handled: AHashSet<&U::Key> = upserts.iter().map(|(key, _)| key).collect();
+        let mut handled = AHashSet::with_capacity(updates.len() + upserts.len());
+        handled.extend(upserts.iter().map(|(key, _)| key));
         staged_updates.entries.reserve(updates.len());
         for (slot, value) in updates.into_iter().rev() {
             assert!(slot < slots.len(), "update index out of staged read range");

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1168,7 +1168,7 @@ where
         let Self {
             mut batch,
             keys,
-            resolutions,
+            mut resolutions,
         } = self;
         let mut staged_updates = StagedUpdates::<F, U>::new();
         if updates.is_empty() {
@@ -1187,13 +1187,12 @@ where
             if !handled.insert(key) {
                 continue;
             }
-            let resolution = &resolutions[slot];
-            match resolution {
+            match resolutions[slot].take() {
                 Some((loc, payload)) if value.is_some() || U::STAGES_DELETES => {
                     // This staged update is the surviving write for `key`; do not also emit an
                     // older batch mutation for the same key.
                     batch.mutations.remove(key);
-                    staged_updates.push((key.clone(), *loc, payload.clone(), value));
+                    staged_updates.push((key.clone(), loc, payload, value));
                 }
                 _ => {
                     batch.mutations.insert(key.clone(), value);
@@ -1460,7 +1459,8 @@ where
         C: Contiguous<Item = Operation<F, U>>,
         I: UnorderedIndex<Value = Location<F>> + 'static,
     {
-        let mut resolutions: Vec<StagedResolution<F, U>> = vec![None; keys.len()];
+        let mut resolutions: Vec<StagedResolution<F, U>> =
+            iter::repeat_with(|| None).take(keys.len()).collect();
         let (mut results, unresolved) = self.resolve_uncommitted_reads(keys, db.strategy());
         Self::fill_committed_reads(
             unresolved,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -213,9 +213,7 @@ type StagedResolution<F, U> = Option<(Location<F>, <U as update::Update>::Cached
 /// Staged batch returned by [`UnmerkleizedBatch::stage`].
 ///
 /// Owns the batch and the locations its reads resolved, so the staged reads cannot be paired with a
-/// different batch. `keys` and `resolutions` are parallel vectors indexed by staged read slot;
-/// they are kept separate so the read path only streams the 16-byte resolutions while the update
-/// path only hashes the keys.
+/// different batch.
 pub struct Staged<F: Family, H, U, S: Strategy>
 where
     U: update::Update + Send + Sync,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1533,11 +1533,7 @@ where
 
         // `value` is `Some` for a staged update and `None` for a staged delete; the
         // location-ordered merge below emits each as an `Update`/`Delete` at the cached location.
-        let mut cached: Vec<(K, Location<F>, Option<V::Value>)> =
-            Vec::with_capacity(staged_updates.entries.len());
-        for (key, loc, (), value) in staged_updates.entries {
-            cached.push((key, loc, value));
-        }
+        let cached = staged_updates.entries;
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, false);
@@ -1583,8 +1579,8 @@ where
         // diffs.
         let mut cached = cached.into_iter().peekable();
         for (op, &old_loc) in results.iter().zip(&locations) {
-            while cached.peek().is_some_and(|&(_, loc, _)| loc < old_loc) {
-                let (key, loc, mutation) = cached.next().expect("peeked entry exists");
+            while cached.peek().is_some_and(|&(_, loc, (), _)| loc < old_loc) {
+                let (key, loc, (), mutation) = cached.next().expect("peeked entry exists");
                 emit(key, Some(loc), mutation);
             }
 
@@ -1613,7 +1609,7 @@ where
 
             emit(key.clone(), base_old_loc, mutation);
         }
-        for (key, loc, mutation) in cached {
+        for (key, loc, (), mutation) in cached {
             emit(key, Some(loc), mutation);
         }
 
@@ -1730,12 +1726,7 @@ where
         // Staged updates skip the index probe and journal re-read, and their old op's next key
         // feeds the candidate sets directly. The ordered path never stages deletes (see
         // `Staged::resolve_updates`), so every staged entry carries a value.
-        let mut cached: Vec<(K, V::Value, Location<F>, K)> =
-            Vec::with_capacity(staged_updates.entries.len());
-        for (key, loc, old_next, value) in staged_updates.entries {
-            let value = value.expect("ordered path never stages deletes");
-            cached.push((key, value, loc, old_next));
-        }
+        let cached = staged_updates.entries;
 
         // Resolve existing keys.
         let locations = m.gather_existing_locations(&mutations, db, true);
@@ -1785,7 +1776,8 @@ where
         // candidate sets exactly as the skipped journal read would have. No prev-candidate
         // value is stored: it is only consumed when the predecessor-rewrite loop emits an op
         // for the key, and that loop skips every key present in `updated`.
-        for (key, value, loc, old_next) in cached {
+        for (key, loc, old_next, value) in cached {
+            let value = value.expect("ordered path never stages deletes");
             next_candidates.push(old_next);
             prev_candidates.push((key.clone(), (None, loc)));
             updated.push((key, value, loc));

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -24,7 +24,11 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     type ValueEncoding: ValueEncoding<Value = Self::Value>;
 
     /// Payload cached alongside the resolved location of a batch read, consumed by merkleize.
-    type Cached: Send + Sync;
+    type Cached: Clone + Send + Sync;
+
+    /// Whether merkleize may emit a staged delete directly at its read-resolved committed
+    /// location. When false, staged deletes fall back to normal mutations.
+    const STAGES_DELETES: bool;
 
     /// The updated key.
     fn key(&self) -> &Self::Key;

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -24,7 +24,7 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync {
     type ValueEncoding: ValueEncoding<Value = Self::Value>;
 
     /// Payload cached alongside the resolved location of a batch read, consumed by merkleize.
-    type Cached: Clone + Send + Sync;
+    type Cached: Send + Sync;
 
     /// Whether merkleize may emit a staged delete directly at its read-resolved committed
     /// location. When false, staged deletes fall back to normal mutations.

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -44,6 +44,10 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type ValueEncoding = V;
     type Cached = K;
 
+    /// An ordered delete must rewrite the deleted key's predecessor via a snapshot-bucket scan
+    /// the resolved location cannot skip, so its deletes gain nothing from staging.
+    const STAGES_DELETES: bool = false;
+
     fn key(&self) -> &K {
         &self.key
     }

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -36,6 +36,9 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
     type ValueEncoding = V;
     type Cached = ();
 
+    /// An unordered delete just emits a `Delete` at the resolved location.
+    const STAGES_DELETES: bool = true;
+
     fn key(&self) -> &K {
         &self.0
     }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -515,7 +515,7 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let (inner, staged_updates) = inner.resolve_updates(updates, upserts, true);
+        let (inner, staged_updates) = inner.resolve_updates(updates, upserts);
         let inner = inner
             .merkleize_with_floor_scan(
                 &db.any,
@@ -572,7 +572,7 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let (inner, staged_updates) = inner.resolve_updates(updates, upserts, false);
+        let (inner, staged_updates) = inner.resolve_updates(updates, upserts);
         let inner = inner
             .merkleize_with_floor_scan(
                 &db.any,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -12,7 +12,7 @@ use crate::{
     qmdb::{
         any::{
             self,
-            batch::{DiffCursors, DiffEntry, Staged as AnyStaged},
+            batch::{DiffCursors, DiffEntry, Staged as AnyStaged, StagedUpdates},
             operation::{update, Operation},
             ValueEncoding,
         },
@@ -685,9 +685,12 @@ where
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(&db.any, metadata, Vec::new(), |floor, tip, limit, out| {
-                fill_candidates(&bitmap_parent, floor, tip, limit, out)
-            })
+            .merkleize_with_floor_scan(
+                &db.any,
+                metadata,
+                StagedUpdates::<F, update::Unordered<K, V>>::new(),
+                |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
+            )
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }
@@ -793,9 +796,12 @@ where
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(&db.any, metadata, Vec::new(), |floor, tip, limit, out| {
-                fill_candidates(&bitmap_parent, floor, tip, limit, out)
-            })
+            .merkleize_with_floor_scan(
+                &db.any,
+                metadata,
+                StagedUpdates::<F, update::Ordered<K, V>>::new(),
+                |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
+            )
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -12,7 +12,7 @@ use crate::{
     qmdb::{
         any::{
             self,
-            batch::{DiffCursors, DiffEntry, Staged as AnyStaged, StagedUpdates},
+            batch::{DiffCursors, DiffEntry, Staged as AnyStaged},
             operation::{update, Operation},
             ValueEncoding,
         },
@@ -685,12 +685,9 @@ where
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(
-                &db.any,
-                metadata,
-                StagedUpdates::new(),
-                |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
-            )
+            .merkleize_with_floor_scan(&db.any, metadata, Vec::new(), |floor, tip, limit, out| {
+                fill_candidates(&bitmap_parent, floor, tip, limit, out)
+            })
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }
@@ -796,12 +793,9 @@ where
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
         let inner = inner
-            .merkleize_with_floor_scan(
-                &db.any,
-                metadata,
-                StagedUpdates::new(),
-                |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
-            )
+            .merkleize_with_floor_scan(&db.any, metadata, Vec::new(), |floor, tip, limit, out| {
+                fill_candidates(&bitmap_parent, floor, tip, limit, out)
+            })
             .await?;
         compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
     }


### PR DESCRIPTION
## Summary

Follow-up simplification for #4144, targeting its branch. Net -50 lines (+172/-222) across six files, with `any/batch.rs` alone down 55 (+150/-205). No behavior change: the staged parity tests (which pin roots byte-identical to the explicit-write path) and the full storage + glue suites pass unchanged after every commit.

- **Replace the sparse staged-read side table with dense parallel vecs.** `Staged` now holds `keys: Vec<Key>` and `resolutions: Vec<Option<(Location, Cached)>>`, both indexed by staged read slot, instead of a keys vec paralleled by a sparse `(slot, location, payload)` list. This removes the `offset` parameter threaded through `stage_reads` and the global-slot-index arithmetic in `stage`/`expand`; expansion is now a plain `append`. (A first cut fused both into one `Vec<(Key, Option<...>)>`; that benched +13% on the constantinople load path from the fatter 48-byte elements, so the vecs stay split.)
- **Collapse `resolve_updates` into a single newest-first pass.** The four-phase join (per-slot `latest` vec + per-key `seen` map, upsert-overlap clearing against a separately built set, cached walk, fallback walk) becomes one reverse walk over `updates` with a pre-sized `handled` set seeded with the upsert keys: the first surviving occurrence of a key is its last write, and upsert precedence falls out of the pre-seeding. Drops the `vec![None; n_reads]` allocation and two extra passes; hashing count per update is unchanged.
- **Replace the `stage_deletes: bool` parameter with `Update::STAGES_DELETES`.** The unordered/ordered delete-staging split is a property of the update kind, so it now lives as an associated const on the `Update` trait (documented on each impl) instead of a bare bool at four call sites. `Update::Cached` gains a `Clone` bound (`()` and `K` both satisfy it trivially).
- **Consume staged entries directly in merkleize.** Both `merkleize_with_floor_scan` variants copied staged entries into a reshaped vec before merging; they now destructure the entries where they are consumed, removing two ~32k-element copies per merkleize.
- **Replace the `StagedUpdates` wrapper struct with a type alias.** It had become a pure `Vec` wrapper reached through `.entries` everywhere; the alias keeps the name at every signature.
- **Share read resolution between batch types.** `UnmerkleizedBatch::resolve_uncommitted_reads` and `MerkleizedBatch::get_many` implemented the same local-source -> ancestor-diffs -> DB-fallthrough resolution inline; both now delegate to one `resolve_reads` helper parameterized by the local lookup.

Also removes a redundant `&` in `ordered_broadcast`'s journal partition `format!` (nightly-clippy-only lint; stable is unaffected).

## Testing

- Full `commonware-storage` + `commonware-glue` suites: 2859 passed, 0 failed, including `unordered/ordered_bulk_update_paths_match_explicit_writes`, `*_staged_updates_survive_ancestor_commit`, the `resolve_updates` unit tests with exact-output assertions, and the current/glue staged parity tests. The three tests constructing `Staged` directly were updated to the new representation.
- `cargo clippy -p commonware-storage --all-targets` clean; `cargo +stable clippy -p commonware-consensus --all-targets` clean.

## Benchmarks

A/B/A/B on `constantinople any::unordered::fixed::mmb 0 20 1000000 131072 4 32768 8` with prebuilt binaries (no compilation between runs). Against the `fix-caching` base after the layout fix: base p50 12.32/12.67 ms vs 12.36/12.50 ms across two rounds (neutral, within run-to-run noise). The two later commits touching hot paths were each benched the same way against the then-current head and came in neutral-to-marginally-faster (consume-entries: 12.26/12.23 -> 12.20/11.92; shared resolution: 12.30/12.17 -> 12.21/11.97). Roots are byte-identical to the base branch on every iteration of every run.

Also measured and rejected: flipping the four hot-path `sort_unstable*` calls to stable sorts (12.38/12.14 -> 12.70/12.16, slightly worse; the inputs are random key-to-location mappings with no presorted runs for Timsort to exploit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
