### PR TITLE
[storage/qmdb] Parallelism Nits

### DIFF
--- a/consensus/src/marshal/store.rs
+++ b/consensus/src/marshal/store.rs
@@ -2,7 +2,7 @@
 
 use crate::{simplex::types::Finalization, types::Height, Block};
 use commonware_cryptography::{certificate::Scheme, Digest, Digestible};
-use commonware_runtime::{BufferPooler, Clock, Handle, Metrics, Storage};
+use commonware_runtime::{BufferPooler, Handle};
 use commonware_storage::{
     archive::{self, immutable, prunable, Archive, Identifier},
     translator::Translator,
@@ -246,7 +246,7 @@ pub trait Blocks: Send + Sync + 'static {
 
 impl<E, B, C, S> Certificates for immutable::Archive<E, B, Finalization<S, C>>
 where
-    E: BufferPooler + Storage + Metrics + Clock,
+    E: BufferPooler + commonware_storage::Context,
     B: Digest,
     C: Digest,
     S: Scheme,
@@ -297,7 +297,7 @@ where
 
 impl<E, B> Blocks for immutable::Archive<E, B::Digest, B>
 where
-    E: BufferPooler + Storage + Metrics + Clock,
+    E: BufferPooler + commonware_storage::Context,
     B: Block,
 {
     type Block = B;
@@ -347,7 +347,7 @@ where
 impl<T, E, B, C, S> Certificates for prunable::Archive<T, E, B, Finalization<S, C>>
 where
     T: Translator,
-    E: BufferPooler + Storage + Metrics + Clock,
+    E: BufferPooler + commonware_storage::Context,
     B: Digest,
     C: Digest,
     S: Scheme,
@@ -398,7 +398,7 @@ where
 impl<T, E, B> Blocks for prunable::Archive<T, E, B::Digest, B>
 where
     T: Translator,
-    E: BufferPooler + Storage + Metrics + Clock,
+    E: BufferPooler + commonware_storage::Context,
     B: Block,
 {
     type Block = B;

--- a/examples/reshare/src/dkg/state.rs
+++ b/examples/reshare/src/dkg/state.rs
@@ -26,9 +26,7 @@ use commonware_cryptography::{
     BatchVerifier, PublicKey, Signer,
 };
 use commonware_parallel::Strategy;
-use commonware_runtime::{
-    buffer::paged::CacheRef, Buf, BufMut, BufferPooler, Clock, Metrics, Storage as RuntimeStorage,
-};
+use commonware_runtime::{buffer::paged::CacheRef, Buf, BufMut, BufferPooler};
 use commonware_storage::{
     journal::segmented::variable::{Config as SVConfig, Journal as SVJournal},
     metadata::{Config as MetadataConfig, Metadata},
@@ -179,7 +177,7 @@ impl<V: Variant, P: PublicKey> Default for EpochCache<V, P> {
 /// the position/epoch confusion that can occur with position-based journals.
 pub struct Storage<E, V, P>
 where
-    E: BufferPooler + Clock + RuntimeStorage + Metrics,
+    E: BufferPooler + commonware_storage::Context,
     V: Variant,
     P: PublicKey,
 {
@@ -193,7 +191,7 @@ where
 
 impl<E, V, P> Storage<E, V, P>
 where
-    E: BufferPooler + Clock + RuntimeStorage + Metrics,
+    E: BufferPooler + commonware_storage::Context,
     V: Variant,
     P: PublicKey,
 {
@@ -554,7 +552,7 @@ impl<V: Variant, C: Signer> Dealer<V, C> {
         ack: PlayerAck<C::PublicKey>,
     ) -> Verdict<()>
     where
-        E: BufferPooler + Clock + RuntimeStorage + Metrics,
+        E: BufferPooler + commonware_storage::Context,
     {
         if !self.unsent.contains_key(&player) {
             return Verdict::Skip;
@@ -636,7 +634,7 @@ impl<V: Variant, C: Signer> Player<V, C> {
         priv_msg: DealerPrivMsg,
     ) -> Verdict<PlayerAck<C::PublicKey>>
     where
-        E: BufferPooler + Clock + RuntimeStorage + Metrics,
+        E: BufferPooler + commonware_storage::Context,
         M: Faults,
     {
         // If we've already generated an ack, return the cached version.

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -3,7 +3,7 @@
 use crate::{Hasher, Key, Translator, Value};
 use commonware_cryptography::Hasher as CryptoHasher;
 use commonware_parallel::Sequential;
-use commonware_runtime::{buffer, BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::{buffer, BufferPooler};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     mmr::{self, full::Config as MmrConfig, Location, Proof},
@@ -17,7 +17,6 @@ use commonware_storage::{
             FixedConfig as Config,
         },
         operation::Committable,
-        InitParallelism,
     },
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -34,7 +33,6 @@ pub type Operation = FixedOperation<mmr::Family, Key, Value>;
 pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequential> {
     let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
     Config {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: MmrConfig {
             journal_partition: "mmr-journal".into(),
             metadata_partition: "mmr-metadata".into(),
@@ -56,7 +54,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
 
 impl<E> crate::databases::ExampleDatabase for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     type Family = mmr::Family;
     type Operation = Operation;
@@ -136,7 +134,7 @@ where
 
 impl<E> crate::databases::Syncable for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     async fn size(&self) -> Location {
         self.bounds().end

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -18,7 +18,7 @@ use crate::{Hasher, Key, Translator, Value};
 use commonware_codec::FixedSize;
 use commonware_cryptography::{sha256, Hasher as CryptoHasher};
 use commonware_parallel::Sequential;
-use commonware_runtime::{buffer, BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::{buffer, BufferPooler};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     mmr::{self, full::Config as MmrConfig, Location, Proof},
@@ -27,7 +27,6 @@ use commonware_storage::{
         any::unordered::{fixed::Operation as FixedOperation, Update},
         current::{self, FixedConfig as Config},
         operation::Committable,
-        InitParallelism,
     },
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -56,7 +55,6 @@ pub type Operation = FixedOperation<mmr::Family, Key, Value>;
 pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequential> {
     let page_cache = buffer::paged::CacheRef::from_pooler(context, NZU16!(2048), NZUsize!(10));
     Config {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: MmrConfig {
             journal_partition: "mmr-journal".into(),
             metadata_partition: "mmr-metadata".into(),
@@ -79,7 +77,7 @@ pub fn create_config(context: &impl BufferPooler) -> Config<Translator, Sequenti
 
 impl<E> super::ExampleDatabase for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     type Family = mmr::Family;
     type Operation = Operation;
@@ -160,7 +158,7 @@ where
 
 impl<E> super::Syncable for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     async fn size(&self) -> Location {
         self.bounds().end

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -3,7 +3,7 @@
 use crate::{Hasher, Key, Translator, Value};
 use commonware_cryptography::{Hasher as CryptoHasher, Sha256};
 use commonware_parallel::Sequential;
-use commonware_runtime::{BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::BufferPooler;
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{
@@ -90,7 +90,7 @@ pub fn create_test_operations(count: usize, seed: u64, starting_loc: u64) -> Vec
 
 impl<E> super::ExampleDatabase for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     type Family = mmr::Family;
     type Operation = Operation;
@@ -141,7 +141,7 @@ where
 
 impl<E> super::Syncable for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     async fn size(&self) -> Location {
         self.bounds().end
@@ -171,7 +171,7 @@ where
 
 impl<E> super::CompactSyncable for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     async fn target(&self) -> compact::Target<Self::Family, Key> {
         compact::Target::new(self.root(), self.bounds().end)

--- a/examples/sync/src/databases/immutable_compact.rs
+++ b/examples/sync/src/databases/immutable_compact.rs
@@ -2,7 +2,7 @@
 
 use crate::{Hasher, Key, Value};
 use commonware_parallel::Sequential;
-use commonware_runtime::{buffer::paged::CacheRef, BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::{buffer::paged::CacheRef, BufferPooler};
 use commonware_storage::{
     journal::contiguous::variable,
     merkle::mmr,
@@ -39,7 +39,7 @@ pub fn create_config(context: &impl BufferPooler) -> CompactConfig<Sequential> {
 
 impl<E> super::ExampleDatabase for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     type Family = mmr::Family;
     type Operation = Operation;
@@ -93,7 +93,7 @@ where
 
 impl<E> super::CompactSyncable for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     async fn target(&self) -> compact::Target<Self::Family, Key> {
         Self::target(self)

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -8,7 +8,7 @@
 use crate::{Hasher, Key, Value};
 use commonware_cryptography::{Hasher as CryptoHasher, Sha256};
 use commonware_parallel::Sequential;
-use commonware_runtime::{buffer, BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::{buffer, BufferPooler};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{
@@ -84,7 +84,7 @@ pub fn create_test_operations(count: usize, seed: u64, starting_loc: u64) -> Vec
 
 impl<E> super::ExampleDatabase for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     type Family = mmr::Family;
     type Operation = Operation;
@@ -135,7 +135,7 @@ where
 
 impl<E> super::Syncable for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     async fn size(&self) -> Location {
         self.bounds().end
@@ -161,7 +161,7 @@ where
 
 impl<E> super::CompactSyncable for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     async fn target(&self) -> compact::Target<Self::Family, Key> {
         compact::Target::new(self.root(), self.bounds().end)

--- a/examples/sync/src/databases/keyless_compact.rs
+++ b/examples/sync/src/databases/keyless_compact.rs
@@ -2,7 +2,7 @@
 
 use crate::{Hasher, Key, Value};
 use commonware_parallel::Sequential;
-use commonware_runtime::{buffer::paged::CacheRef, BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::{buffer::paged::CacheRef, BufferPooler};
 use commonware_storage::{
     journal::contiguous::variable,
     merkle::mmr,
@@ -39,7 +39,7 @@ pub fn create_config(context: &impl BufferPooler) -> CompactConfig<Sequential> {
 
 impl<E> super::ExampleDatabase for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     type Family = mmr::Family;
     type Operation = Operation;
@@ -93,7 +93,7 @@ where
 
 impl<E> super::CompactSyncable for Database<E>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
 {
     async fn target(&self) -> compact::Target<Self::Family, Key> {
         Self::target(self)

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -939,7 +939,7 @@ mod tests {
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedLogConfig,
         mmr::{self, full::Config as MmrJournalConfig, Location},
-        qmdb::{any, sync::Target, InitParallelism},
+        qmdb::{any, sync::Target},
         translator::TwoCap,
     };
     use commonware_utils::{
@@ -1552,7 +1552,6 @@ mod tests {
     ) -> any::FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE);
         any::FixedConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{prefix}_mmr_journal"),
                 metadata_partition: format!("{prefix}_mmr_metadata"),

--- a/glue/src/stateful/actor/syncer/mod.rs
+++ b/glue/src/stateful/actor/syncer/mod.rs
@@ -215,7 +215,7 @@ where
 /// Durable state-sync metadata.
 pub(crate) struct StateSyncMetadata<E, C>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     C: Digest,
 {
     partition_prefix: String,
@@ -224,7 +224,7 @@ where
 
 impl<E, C> StateSyncMetadata<E, C>
 where
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     C: Digest,
 {
     /// Load the durable state-sync metadata partition, creating it if needed.

--- a/glue/src/stateful/actor/syncer/plan.rs
+++ b/glue/src/stateful/actor/syncer/plan.rs
@@ -5,7 +5,6 @@ use commonware_consensus::{
     types::Height,
 };
 use commonware_cryptography::certificate::Scheme;
-use commonware_runtime::{Clock, Metrics, Storage};
 
 /// Startup plan that determines whether one-time peer state sync may still run.
 ///
@@ -26,7 +25,7 @@ use commonware_runtime::{Clock, Metrics, Storage};
 /// and marshal's processed height instead.
 pub struct SyncPlan<E, S, V>
 where
-    E: Clock + Metrics + Storage,
+    E: commonware_storage::Context,
     S: Scheme,
     V: Variant,
 {
@@ -36,7 +35,7 @@ where
 
 impl<E, S, V> SyncPlan<E, S, V>
 where
-    E: Clock + Metrics + Storage,
+    E: commonware_storage::Context,
     S: Scheme,
     V: Variant,
 {

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -13,7 +13,6 @@ use crate::stateful::db::{
 use commonware_codec::{Codec, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::{Clock, Metrics, Spawner, Storage};
 use commonware_storage::{
     index::{
         unordered::Index as UnorderedIdx, Ordered as OrderedIndex, Unordered as UnorderedIndex,
@@ -51,7 +50,7 @@ type AnyDbHandle<F, E, C, I, H, U, S> =
 pub struct AnyUnmerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
@@ -68,7 +67,7 @@ where
 impl<F, E, C, I, H, K, V, S> AnyUnmerkleized<F, E, C, I, H, unordered::Update<K, V>, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
@@ -111,7 +110,7 @@ where
 pub struct AnyMerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
@@ -126,7 +125,7 @@ where
 impl<F, E, C, I, H, U, S> Deref for AnyUnmerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
@@ -144,7 +143,7 @@ where
 impl<F, E, C, I, H, U, S> Deref for AnyMerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
@@ -163,7 +162,7 @@ where
 impl<F, E, C, I, H, K, V, S> AnyUnmerkleized<F, E, C, I, H, ordered::Update<K, V>, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
@@ -204,7 +203,7 @@ where
 impl<F, E, C, I, H, U, S> AnyMerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
@@ -232,7 +231,7 @@ impl<F, E, C, I, H, K, V, S> UnmerkleizedTrait
     for AnyUnmerkleized<F, E, C, I, H, unordered::Update<K, V>, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
@@ -259,7 +258,7 @@ impl<F, E, C, I, H, K, V, S> UnmerkleizedTrait
     for AnyUnmerkleized<F, E, C, I, H, ordered::Update<K, V>, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
@@ -285,7 +284,7 @@ where
 impl<F, E, C, I, H, U, S> MerkleizedTrait for AnyMerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
@@ -331,7 +330,7 @@ impl<F, E, K, V, H, T, S> ManagedDb<E>
     >
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher + 'static,
@@ -423,7 +422,7 @@ impl<F, E, K, V, H, T, S> ManagedDb<E>
     >
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -519,7 +518,7 @@ impl<F, E, K, V, H, T, S, R> StateSyncDb<E, R>
     >
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher,
@@ -573,7 +572,7 @@ impl<F, E, K, V, H, T, S, R> StateSyncDb<E, R>
     >
 where
     F: Family,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -13,7 +13,6 @@ use crate::stateful::db::{
 use commonware_codec::{Codec, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::{Clock, Metrics, Spawner, Storage};
 use commonware_storage::{
     index::{
         ordered::Index as OrderedIdx, unordered::Index as UnorderedIdx, Ordered as OrderedIndex,
@@ -51,7 +50,7 @@ type CurrentDbHandle<F, E, C, I, H, U, const N: usize, S> =
 pub struct CurrentUnmerkleized<F, E, C, I, H, U, const N: usize, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
@@ -69,7 +68,7 @@ impl<F, E, C, I, H, K, V, const N: usize, S>
     CurrentUnmerkleized<F, E, C, I, H, unordered::Update<K, V>, N, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
@@ -112,7 +111,7 @@ where
 pub struct CurrentMerkleized<F, E, C, I, H, U, const N: usize, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
@@ -127,7 +126,7 @@ where
 impl<F, E, C, I, H, U, const N: usize, S> Deref for CurrentUnmerkleized<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
@@ -145,7 +144,7 @@ where
 impl<F, E, C, I, H, U, const N: usize, S> Deref for CurrentMerkleized<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
@@ -165,7 +164,7 @@ impl<F, E, C, I, H, K, V, const N: usize, S>
     CurrentUnmerkleized<F, E, C, I, H, ordered::Update<K, V>, N, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
@@ -206,7 +205,7 @@ where
 impl<F, E, C, I, H, U, const N: usize, S> CurrentMerkleized<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
@@ -234,7 +233,7 @@ impl<F, E, C, I, H, K, V, const N: usize, S> UnmerkleizedTrait
     for CurrentUnmerkleized<F, E, C, I, H, unordered::Update<K, V>, N, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
@@ -261,7 +260,7 @@ impl<F, E, C, I, H, K, V, const N: usize, S> UnmerkleizedTrait
     for CurrentUnmerkleized<F, E, C, I, H, ordered::Update<K, V>, N, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
@@ -288,7 +287,7 @@ impl<F, E, C, I, H, U, const N: usize, S> MerkleizedTrait
     for CurrentMerkleized<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     U: Update,
     C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
@@ -327,7 +326,7 @@ impl<F, E, K, V, H, T, const N: usize, S> ManagedDb<E>
     >
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher + 'static,
@@ -421,7 +420,7 @@ impl<F, E, K, V, H, T, const N: usize, S> ManagedDb<E>
     >
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher + 'static,
@@ -513,7 +512,6 @@ mod open {
     use commonware_codec::{Codec, Read};
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
-    use commonware_runtime::{Clock, Metrics, Spawner, Storage};
     use commonware_storage::{
         merkle::Graftable,
         qmdb::{
@@ -544,7 +542,7 @@ mod open {
     ) -> Result<Db<F, E, K, V, H, T, N, S>, Error<F>>
     where
         F: Graftable,
-        E: Storage + Clock + Metrics + Spawner + 'static,
+        E: commonware_storage::Context,
         K: Array,
         V: VariableValue + 'static,
         H: Hasher,
@@ -561,7 +559,7 @@ mod open {
     ) -> Result<OrderedVariableDb<F, E, K, V, H, T, N, S>, Error<F>>
     where
         F: Graftable,
-        E: Storage + Clock + Metrics + Spawner + 'static,
+        E: commonware_storage::Context,
         K: commonware_storage::qmdb::operation::Key,
         V: VariableValue + 'static,
         H: Hasher,
@@ -587,7 +585,7 @@ impl<F, E, K, V, H, T, const N: usize, S> ManagedDb<E>
     >
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key + Array,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -686,7 +684,7 @@ impl<F, E, K, V, H, T, const N: usize, S> ManagedDb<E>
     >
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -785,7 +783,7 @@ impl<F, E, K, V, H, T, R, const N: usize, S> StateSyncDb<E, R>
     >
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher,
@@ -840,7 +838,7 @@ impl<F, E, K, V, H, T, R, const N: usize, S> StateSyncDb<E, R>
     >
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Array,
     V: value::FixedValue + 'static,
     H: Hasher,
@@ -895,7 +893,7 @@ impl<F, E, K, V, H, T, R, const N: usize, S> StateSyncDb<E, R>
     >
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key + Array,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -951,7 +949,7 @@ impl<F, E, K, V, H, T, R, const N: usize, S> StateSyncDb<E, R>
     >
 where
     F: Graftable,
-    E: Storage + Clock + Metrics + Spawner + 'static,
+    E: commonware_storage::Context,
     K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,
@@ -1006,12 +1004,9 @@ mod tests {
             fixed::Config as FixedJournalConfig, variable::Config as VariableJournalConfig,
         },
         merkle::{full::Config as MerkleConfig, mmr},
-        qmdb::{
-            current::{
-                ordered::{fixed as ordered_fixed, variable as ordered_variable},
-                unordered::fixed,
-            },
-            InitParallelism,
+        qmdb::current::{
+            ordered::{fixed as ordered_fixed, variable as ordered_variable},
+            unordered::fixed,
         },
         translator::TwoCap,
     };
@@ -1055,7 +1050,6 @@ mod tests {
     fn fixed_config(suffix: &str, pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("stateful-current-journal-{suffix}"),
                 metadata_partition: format!("stateful-current-metadata-{suffix}"),
@@ -1082,7 +1076,6 @@ mod tests {
     ) -> VariableConfig<TwoCap, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("stateful-current-journal-{suffix}"),
                 metadata_partition: format!("stateful-current-metadata-{suffix}"),

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -12,7 +12,7 @@ use commonware_codec::{EncodeShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_macros::select;
 use commonware_parallel::Strategy;
-use commonware_runtime::{reschedule, Clock, Metrics, Storage};
+use commonware_runtime::reschedule;
 use commonware_storage::{
     merkle::{Family, Location},
     qmdb::{
@@ -55,7 +55,7 @@ async fn drain_latest_target<T>(tip_updates: &mut mpsc::Receiver<T>) -> Option<T
 pub struct ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C = ()>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
@@ -73,7 +73,7 @@ where
 impl<F, E, K, V, H, S, C> Deref for ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
@@ -92,7 +92,7 @@ where
 impl<F, E, K, V, H, S, C> ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
@@ -124,7 +124,7 @@ where
 pub struct ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C = ()>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
@@ -140,7 +140,7 @@ where
 impl<F, E, K, V, H, S, C> Deref for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
@@ -160,7 +160,7 @@ impl<F, E, K, V, H, S, C> UnmerkleizedTrait
     for ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
@@ -189,7 +189,7 @@ where
 impl<F, E, K, V, H, S, C> MerkleizedTrait for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
@@ -218,7 +218,7 @@ where
 impl<F, E, K, V, H, S> ManagedDb<E> for fixed::CompactDb<F, E, K, V, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Array,
     V: FixedValue + 'static,
     H: Hasher + 'static,
@@ -277,7 +277,7 @@ where
 impl<F, E, K, V, H, C, S> ManagedDb<E> for variable::CompactDb<F, E, K, V, H, C, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: VariableValue + 'static,
     H: Hasher + 'static,
@@ -337,7 +337,7 @@ where
 impl<F, E, K, V, H, R, S> StateSyncDb<E, R> for fixed::CompactDb<F, E, K, V, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Array,
     V: FixedValue + 'static,
     H: Hasher + 'static,
@@ -428,7 +428,7 @@ where
 impl<F, E, K, V, H, C, R, S> StateSyncDb<E, R> for variable::CompactDb<F, E, K, V, H, C, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: VariableValue + 'static,
     H: Hasher + 'static,
@@ -523,8 +523,8 @@ mod tests {
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        buffer::paged::CacheRef, deterministic, BufferPooler, Runner as _, Spawner as _,
-        Supervisor as _,
+        buffer::paged::CacheRef, deterministic, BufferPooler, Clock as _, Runner as _,
+        Spawner as _, Supervisor as _,
     };
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedJournalConfig,

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -12,7 +12,6 @@ use crate::stateful::db::{
 use commonware_codec::{Codec, EncodeShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_storage::{
     journal::contiguous::{
         fixed::Journal as FixedJournal, variable::Journal as VariableJournal, Mutable,
@@ -41,7 +40,7 @@ type ImmutableDbHandle<F, E, K, V, C, H, T, S> =
 pub struct ImmutableUnmerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
@@ -59,7 +58,7 @@ where
 impl<F, E, K, V, C, H, T, S> Deref for ImmutableUnmerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
@@ -78,7 +77,7 @@ where
 impl<F, E, K, V, C, H, T, S> ImmutableUnmerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
@@ -128,7 +127,7 @@ where
 pub struct ImmutableMerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
@@ -144,7 +143,7 @@ where
 impl<F, E, K, V, C, H, T, S> Deref for ImmutableMerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
@@ -163,7 +162,7 @@ where
 impl<F, E, K, V, C, H, T, S> ImmutableMerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
@@ -190,7 +189,7 @@ where
 impl<F, E, K, V, C, H, T, S> UnmerkleizedTrait for ImmutableUnmerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
@@ -219,7 +218,7 @@ where
 impl<F, E, K, V, C, H, T, S> MerkleizedTrait for ImmutableMerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, K, V>>,
@@ -248,7 +247,7 @@ where
 impl<F, E, K, V, H, T, S> ManagedDb<E> for fixed::Db<F, E, K, V, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Array,
     V: FixedValue + 'static,
     H: Hasher + 'static,
@@ -332,7 +331,7 @@ where
 impl<F, E, K, V, H, T, S> ManagedDb<E> for variable::Db<F, E, K, V, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: VariableValue + 'static,
     H: Hasher + 'static,
@@ -417,7 +416,7 @@ where
 impl<F, E, K, V, H, T, R, S> StateSyncDb<E, R> for fixed::Db<F, E, K, V, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Array,
     V: FixedValue + 'static,
     H: Hasher + 'static,
@@ -457,7 +456,7 @@ where
 impl<F, E, K, V, H, T, R, S> StateSyncDb<E, R> for variable::Db<F, E, K, V, H, T, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     K: Key,
     V: VariableValue + 'static,
     H: Hasher + 'static,

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -12,7 +12,7 @@ use commonware_codec::{EncodeShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_macros::select;
 use commonware_parallel::Strategy;
-use commonware_runtime::{reschedule, Clock, Metrics, Storage};
+use commonware_runtime::reschedule;
 use commonware_storage::{
     merkle::{Family, Location},
     qmdb::{
@@ -54,7 +54,7 @@ async fn drain_latest_target<T>(tip_updates: &mut mpsc::Receiver<T>) -> Option<T
 pub struct KeylessUnjournaledUnmerkleized<F, E, V, H, S, C = ()>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     H: Hasher,
     Operation<F, V>: EncodeShared,
@@ -71,7 +71,7 @@ where
 impl<F, E, V, H, S, C> Deref for KeylessUnjournaledUnmerkleized<F, E, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     H: Hasher,
     Operation<F, V>: EncodeShared,
@@ -89,7 +89,7 @@ where
 impl<F, E, V, H, S, C> KeylessUnjournaledUnmerkleized<F, E, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     H: Hasher,
     Operation<F, V>: EncodeShared,
@@ -120,7 +120,7 @@ where
 pub struct KeylessUnjournaledMerkleized<F, E, V, H, S, C = ()>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     H: Hasher,
     Operation<F, V>: EncodeShared,
@@ -135,7 +135,7 @@ where
 impl<F, E, V, H, S, C> Deref for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     H: Hasher,
     Operation<F, V>: EncodeShared,
@@ -153,7 +153,7 @@ where
 impl<F, E, V, H, S, C> UnmerkleizedTrait for KeylessUnjournaledUnmerkleized<F, E, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     H: Hasher,
     Operation<F, V>: EncodeShared,
@@ -181,7 +181,7 @@ where
 impl<F, E, V, H, S, C> MerkleizedTrait for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     H: Hasher,
     Operation<F, V>: EncodeShared,
@@ -209,7 +209,7 @@ where
 impl<F, E, V, H, S> ManagedDb<E> for fixed::CompactDb<F, E, V, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: FixedValue + 'static,
     H: Hasher + 'static,
     S: Strategy,
@@ -267,7 +267,7 @@ where
 impl<F, E, V, H, C, S> ManagedDb<E> for variable::CompactDb<F, E, V, H, C, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: VariableValue + 'static,
     H: Hasher + 'static,
     Operation<F, VariableEncoding<V>>: EncodeShared + CodecRead<Cfg = C>,
@@ -326,7 +326,7 @@ where
 impl<F, E, V, H, S, R> StateSyncDb<E, R> for fixed::CompactDb<F, E, V, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: FixedValue + 'static,
     H: Hasher + 'static,
     S: Strategy,
@@ -412,7 +412,7 @@ where
 impl<F, E, V, H, C, S, R> StateSyncDb<E, R> for variable::CompactDb<F, E, V, H, C, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: VariableValue + 'static,
     H: Hasher + 'static,
     Operation<F, VariableEncoding<V>>: EncodeShared + CodecRead<Cfg = C>,
@@ -506,8 +506,8 @@ mod tests {
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        buffer::paged::CacheRef, deterministic, BufferPooler, Runner as _, Spawner as _,
-        Supervisor as _,
+        buffer::paged::CacheRef, deterministic, BufferPooler, Clock as _, Runner as _,
+        Spawner as _, Supervisor as _,
     };
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedJournalConfig,

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -13,7 +13,6 @@ use crate::stateful::db::{
 use commonware_codec::{EncodeShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_storage::{
     journal::contiguous::{
         fixed::Journal as FixedJournal, variable::Journal as VariableJournal, Mutable,
@@ -39,7 +38,7 @@ type KeylessDbHandle<F, E, V, C, H, S> = Arc<TracedAsyncRwLock<Keyless<F, E, V, 
 pub struct KeylessUnmerkleized<F, E, V, C, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
@@ -55,7 +54,7 @@ where
 impl<F, E, V, C, H, S> Deref for KeylessUnmerkleized<F, E, V, C, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
@@ -72,7 +71,7 @@ where
 impl<F, E, V, C, H, S> KeylessUnmerkleized<F, E, V, C, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
@@ -124,7 +123,7 @@ where
 pub struct KeylessMerkleized<F, E, V, C, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
@@ -138,7 +137,7 @@ where
 impl<F, E, V, C, H, S> Deref for KeylessMerkleized<F, E, V, C, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
@@ -155,7 +154,7 @@ where
 impl<F, E, V, C, H, S> KeylessMerkleized<F, E, V, C, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
@@ -184,7 +183,7 @@ where
 impl<F, E, V, C, H, S> UnmerkleizedTrait for KeylessUnmerkleized<F, E, V, C, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
@@ -211,7 +210,7 @@ where
 impl<F, E, V, C, H, S> MerkleizedTrait for KeylessMerkleized<F, E, V, C, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: ValueEncoding,
     C: Mutable<Item = Operation<F, V>>,
     H: Hasher,
@@ -238,7 +237,7 @@ where
 impl<F, E, V, H, S> ManagedDb<E> for fixed::Db<F, E, V, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: FixedValue + 'static,
     H: Hasher + 'static,
     S: Strategy,
@@ -304,7 +303,7 @@ where
 impl<F, E, V, H, S> ManagedDb<E> for variable::Db<F, E, V, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: VariableValue + 'static,
     H: Hasher + 'static,
     S: Strategy,
@@ -382,7 +381,7 @@ where
 impl<F, E, V, H, S, R> StateSyncDb<E, R> for fixed::Db<F, E, V, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: FixedValue + 'static,
     H: Hasher + 'static,
     S: Strategy,
@@ -420,7 +419,7 @@ where
 impl<F, E, V, H, S, R> StateSyncDb<E, R> for variable::Db<F, E, V, H, S>
 where
     F: Family,
-    E: Storage + Clock + Metrics,
+    E: commonware_storage::Context,
     V: VariableValue + 'static,
     H: Hasher + 'static,
     S: Strategy,

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -399,10 +399,7 @@ mod tests {
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedLogConfig,
         mmr::{self, full::Config as MmrJournalConfig, Location, Proof},
-        qmdb::{
-            any::{unordered::fixed, FixedConfig},
-            InitParallelism,
-        },
+        qmdb::any::{unordered::fixed, FixedConfig},
         translator::TwoCap,
     };
     use commonware_utils::{channel::oneshot, sync::TracedAsyncRwLock, NZUsize, NZU16, NZU64};
@@ -494,7 +491,6 @@ mod tests {
     fn db_config(suffix: &str, pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, NZU16!(101), NZUsize!(11));
         FixedConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{suffix}-mmr-journal"),
                 metadata_partition: format!("{suffix}-mmr-metadata"),

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -54,7 +54,6 @@ use commonware_storage::{
         any::{unordered::fixed, FixedConfig},
         immutable,
         sync::{compact as compact_sync, Target},
-        InitParallelism,
     },
     translator::TwoCap,
 };
@@ -426,7 +425,6 @@ impl EngineDefinition for MultiDbEngine {
 
         // QMDB database configs (one per database)
         let db_config_a = FixedConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{partition_prefix}-qmdb-a-mmr-journal"),
                 metadata_partition: format!("{partition_prefix}-qmdb-a-mmr-metadata"),

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -52,7 +52,6 @@ use commonware_storage::{
     qmdb::{
         any::{unordered::fixed, FixedConfig},
         sync::Target,
-        InitParallelism,
     },
     translator::TwoCap,
 };
@@ -351,7 +350,6 @@ impl EngineDefinition for SingleDbEngine {
 
         // QMDB database config (created by Stateful::start)
         let db_config = FixedConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MmrJournalConfig {
                 journal_partition: format!("{partition_prefix}-qmdb-mmr-journal"),
                 metadata_partition: format!("{partition_prefix}-qmdb-mmr-metadata"),

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -563,6 +563,49 @@ impl<E: Metrics> Metrics for SyncFaultContext<E> {
     }
 }
 
+impl<E: crate::Spawner> crate::Spawner for SyncFaultContext<E> {
+    fn shared(self, blocking: bool) -> Self {
+        Self {
+            inner: self.inner.shared(blocking),
+            fail_partition: self.fail_partition,
+        }
+    }
+
+    fn dedicated(self) -> Self {
+        Self {
+            inner: self.inner.dedicated(),
+            fail_partition: self.fail_partition,
+        }
+    }
+
+    fn spawn<F, Fut, T>(self, f: F) -> Handle<T>
+    where
+        F: FnOnce(Self) -> Fut + Send + 'static,
+        Fut: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let fail_partition = self.fail_partition;
+        self.inner.spawn(move |inner| {
+            f(Self {
+                inner,
+                fail_partition,
+            })
+        })
+    }
+
+    fn stop(
+        self,
+        value: i32,
+        timeout: Option<std::time::Duration>,
+    ) -> impl Future<Output = Result<(), Error>> + Send {
+        self.inner.stop(value, timeout)
+    }
+
+    fn stopped(&self) -> crate::signal::Signal {
+        self.inner.stopped()
+    }
+}
+
 impl<E: Clock> Clock for SyncFaultContext<E> {
     fn current(&self) -> std::time::SystemTime {
         self.inner.current()

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -118,7 +118,6 @@ fn make_config(
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -165,7 +165,6 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -155,7 +155,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
-            init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -96,7 +96,6 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -145,7 +145,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
-            init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
         };
 
         let mut db: Db<F> = Db::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/mmr_bitmap.rs
+++ b/storage/fuzz/fuzz_targets/mmr_bitmap.rs
@@ -3,7 +3,7 @@
 use arbitrary::Arbitrary;
 use commonware_cryptography::{sha256, Digest, Sha256};
 use commonware_parallel::Sequential;
-use commonware_runtime::{deterministic, Clock, Metrics, Runner, Storage, Supervisor as _};
+use commonware_runtime::{deterministic, Runner, Supervisor as _};
 use commonware_storage::{merkle::Bagging::ForwardFold, MerkleizedBitMap, UnmerkleizedBitMap};
 use commonware_utils::bitmap::BitMap;
 use libfuzzer_sys::fuzz_target;
@@ -11,7 +11,7 @@ use libfuzzer_sys::fuzz_target;
 const MAX_OPERATIONS: usize = 100;
 const CHUNK_SIZE: usize = 32;
 
-enum Bitmap<E: Clock + Storage + Metrics, D: Digest, const N: usize> {
+enum Bitmap<E: commonware_storage::Context, D: Digest, const N: usize> {
     Merkleized(MerkleizedBitMap<E, D, N, Sequential>),
     Unmerkleized(UnmerkleizedBitMap<E, D, N, Sequential>),
 }

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -112,7 +112,6 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -160,7 +160,6 @@ fn test_config(
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -107,7 +107,6 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -134,7 +134,6 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -95,7 +95,6 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
-        init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
     }
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -109,7 +109,6 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
-                init_parallelism: commonware_storage::qmdb::InitParallelism::Serial,
             };
 
             let mut db: GenericDb<F> =

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -68,14 +68,14 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     translator: T,
 
     /// Base partition index this instance addresses from: a key's global partition `p` maps to local
-    /// slot `p - offset`. A full index covers every partition and so has `offset == 0`; a parallel
+    /// slot `p - offset`. A full index covers every partition and so has `offset == 0`. A parallel
     /// snapshot-build worker (see [`Self::new_range`]) covers only `[offset, offset + len)`.
     offset: usize,
 
     /// The partitions this instance covers, indexed by `global_partition - offset`. A full index
-    /// holds all `2^(8*P)` (offset `0`); a build worker holds only its range. Each stores its
-    /// translated keys and values as sorted arrays (the inline representation); an emptied partition
-    /// may instead have spilled (see `spilled`).
+    /// holds all `2^(8*P)` (offset `0`) while a build worker holds only its range. Each stores its
+    /// translated keys and values as sorted arrays (the inline representation), though an emptied
+    /// partition may instead have spilled (see `spilled`).
     partitions: Box<[Partition<T::Key, V>]>,
 
     /// Partitions that have spilled out of their sorted arrays (reached `SPILL_THRESHOLD` entries),
@@ -96,9 +96,9 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     /// Metric: cumulative values removed (via `remove`, cursor `delete`, or `retain`).
     pruned: Counter,
 
-    /// Metric: cumulative partitions spilled to the side-table. `None` on build workers, so only the
-    /// full index is counted; emptied partitions that de-spill (rare) are not subtracted.
-    spills: Option<Counter>,
+    /// Metric: cumulative partitions spilled to the side-table. Emptied partitions that de-spill
+    /// (rare) are not subtracted. Detached on build workers and folded in at [`Self::install_range`].
+    spills: Counter,
 }
 
 impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
@@ -121,7 +121,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             keys: ctx.gauge("keys", "Number of translated keys in the index"),
             items: ctx.gauge("items", "Number of items in the index"),
             pruned: ctx.counter("pruned", "Number of items pruned"),
-            spills: Some(ctx.counter("spills", "Number of partitions spilled to the side-table")),
+            spills: ctx.counter("spills", "Number of partitions spilled to the side-table"),
         }
     }
 
@@ -141,9 +141,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         }
         let inner: BTreeMap<T::Key, Vec<V>> = self.partitions[i].drain_runs().into_iter().collect();
         self.spilled.insert(i, inner);
-        if let Some(spills) = &self.spills {
-            spills.inc();
-        }
+        self.spills.inc();
     }
 
     /// The `BTreeMap` of spilled partition `i`, or `None` if `i` has not spilled. The empty-map
@@ -215,10 +213,10 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         self.spilled.len()
     }
 
-    /// Cumulative value of the `spills` metric (full index only; `0` on build workers).
+    /// Cumulative value of the `spills` metric.
     #[cfg(test)]
     fn spills(&self) -> usize {
-        self.spills.as_ref().map_or(0, |c| c.get() as usize)
+        self.spills.get() as usize
     }
 
     /// The number of partitions (`2^(8*P)`).
@@ -233,7 +231,9 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
     /// slot in `get_mut`/`get_mut_or_insert`), so per-worker memory is the range, not the full
     /// `2^(8*P)` -- which is what makes a large `P` affordable. Its metric handles are detached (never
     /// registered): they only accumulate the counts that [`Self::install_range`] folds back into a
-    /// full index. Only the build (Unordered) operations are valid on it.
+    /// full index. Only `get_mut` and `get_mut_or_insert` (and their cursors) map the global
+    /// partition index to the local slot, so only those operations are valid on it. The other
+    /// `Unordered` methods index partitions globally and would touch the wrong slot.
     #[commonware_macros::stability(ALPHA)]
     pub(crate) fn new_range(&self, offset: usize, count: usize) -> Self {
         fn detached<M: Default>() -> Registered<M> {
@@ -252,42 +252,34 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             keys: detached(),
             items: detached(),
             pruned: detached(),
-            spills: None,
+            spills: detached(),
         }
     }
 
     /// Move a build `worker`'s partitions and spilled entries into self (a full `offset == 0` index),
     /// at the global slots `[worker.offset, worker.offset + worker.partitions.len())`, which must be
-    /// empty. Build workers are transient, so the worker's cumulative counters (`spills`, `pruned`)
-    /// are folded into self's here; the `(keys, items)` gauge totals are returned instead so the
-    /// caller can sum them across workers and apply them once via [`Self::set_metrics`].
+    /// empty. Build workers are transient, so all of the worker's metric counts (`spills`, `pruned`,
+    /// `keys`, `items`) are folded into self's here. Returns the worker's item count so the caller
+    /// can total items across workers.
     #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn install_range(&mut self, worker: &mut Self) -> (i64, i64) {
+    pub(crate) fn install_range(&mut self, worker: &mut Self) -> i64 {
         let lo = worker.offset;
         for (local, partition) in worker.partitions.iter_mut().enumerate() {
             self.partitions[lo + local] = std::mem::take(partition);
         }
         // Drain only the partitions that actually spilled (remapping local -> global), rather than
-        // probing every slot in the range. Count each toward the full index's spill metric, since
-        // the workers themselves do not.
+        // probing every slot in the range.
         for (local, inner) in worker.spilled.drain() {
             self.spilled.insert(lo + local, inner);
-            if let Some(spills) = &self.spills {
-                spills.inc();
-            }
         }
-        // Fold in the worker's delete-driven prune count (a build worker's own `pruned` handle is
-        // detached), matching what the serial replay records on the full index.
+        // Fold in the worker's metric counts (a build worker's own handles are detached), matching
+        // what the serial replay records on the full index.
+        self.spills.inc_by(worker.spills.get());
         self.pruned.inc_by(worker.pruned.get());
-        (worker.keys.get(), worker.items.get())
-    }
-
-    /// Set the `keys`/`items` gauges to the given totals (used after a parallel build installs all
-    /// worker ranges).
-    #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn set_metrics(&self, keys: i64, items: i64) {
-        self.keys.set(keys);
-        self.items.set(items);
+        self.keys.inc_by(worker.keys.get());
+        let items = worker.items.get();
+        self.items.inc_by(items);
+        items
     }
 
     /// Visit every value held across all partitions (inline and spilled), in unspecified order.
@@ -354,8 +346,9 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
     }
 
     fn get_mut<'a>(&'a mut self, key: &[u8]) -> Option<Self::Cursor<'a>> {
-        // Map the global partition index to this instance's local slot (`offset == 0` for a full
-        // index, so this is a no-op there; a build worker covers only `[offset, offset + len)`).
+        // Map the global partition index to this instance's local slot. A full index has
+        // `offset == 0`, so this is a no-op there. A build worker covers only
+        // `[offset, offset + len)`.
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let i = i - self.offset;
         let k = self.translator.transform(sub);
@@ -906,22 +899,28 @@ mod tests {
     #[test_traced]
     fn test_spill_install_range_counts() {
         deterministic::Runner::default().start(|context| async move {
-            // The full index that build workers fold into; spills once a partition holds two entries.
+            // The full index that build workers fold into. It spills once a partition holds two
+            // entries.
             let mut full = new_index_spilling(context.child("full"));
             assert_eq!(full.spills(), 0);
 
-            // A build worker covering the whole partition range. Workers do not register the metric,
-            // so a spill on a worker is counted only when it is folded into the full index.
+            // A build worker covering the whole partition range. Its detached counter records every
+            // spill event, including one whose partition later de-spills (fully drained via remove).
             let mut worker = full.new_range(0, full.partition_count());
             worker.get_mut_or_insert(&[0x10, 0x01], 1);
             worker.get_mut_or_insert(&[0x10, 0x02], 2); // second key in partition 0x10 -> spills
+            worker.insert(&[0x20, 0x01], 3);
+            worker.insert(&[0x20, 0x02], 4); // partition 0x20 spills too...
+            worker.remove(&[0x20, 0x01]);
+            worker.remove(&[0x20, 0x02]); // ...then fully drains, de-spilling
             assert_eq!(worker.spilled_count(), 1);
-            assert_eq!(worker.spills(), 0); // not tracked on the worker
+            assert_eq!(worker.spills(), 2); // cumulative: the de-spilled partition still counts
 
-            // Folding the worker in counts its spilled partition toward the full index's metric.
+            // Folding the worker in carries its cumulative count into the full index's metric,
+            // matching what a serial build over the same operations would have recorded.
             full.install_range(&mut worker);
             assert_eq!(full.spilled_count(), 1);
-            assert_eq!(full.spills(), 1);
+            assert_eq!(full.spills(), 2);
         });
     }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -111,16 +111,25 @@ commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
         }
     }
 
-    /// A runtime context providing storage, timing, and metrics capabilities.
+    /// A runtime context providing storage, timing, metrics, and task-spawning capabilities.
     ///
     /// This is a convenience alias for the trait bound
-    /// `Storage + Clock + Metrics` that appears on nearly every type in this crate.
+    /// `Storage + Clock + Metrics + Spawner + 'static` that appears on nearly every type in this
+    /// crate.
     pub trait Context:
-        commonware_runtime::Storage + commonware_runtime::Clock + commonware_runtime::Metrics
+        commonware_runtime::Storage
+        + commonware_runtime::Clock
+        + commonware_runtime::Metrics
+        + commonware_runtime::Spawner
+        + 'static
     {
     }
     impl<
-            T: commonware_runtime::Storage + commonware_runtime::Clock + commonware_runtime::Metrics,
+            T: commonware_runtime::Storage
+                + commonware_runtime::Clock
+                + commonware_runtime::Metrics
+                + commonware_runtime::Spawner
+                + 'static,
         > Context for T
     {
     }

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -25,7 +25,7 @@ use crate::{
 use commonware_codec::{DecodeExt, Write};
 use commonware_cryptography::Digest;
 use commonware_parallel::Strategy;
-use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, Storage as RStorage};
+use commonware_runtime::buffer::paged::CacheRef;
 use commonware_utils::{range::NonEmptyRange, sequence::prefixed_u64::U64};
 use std::{
     collections::BTreeMap,
@@ -137,7 +137,7 @@ pub struct SyncConfig<F: Family, D: Digest, S: Strategy> {
 }
 
 /// A Merkle structure backed by a fixed-item-length journal.
-pub struct Merkle<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> {
+pub struct Merkle<F: Family, E: crate::Context, D: Digest, S: Strategy> {
     /// A memory resident Merkle structure used to build the structure and cache updates. It caches
     /// all un-synced nodes, and the pinned node set as derived from both its own pruning boundary
     /// and the full structure's pruning boundary.
@@ -168,7 +168,7 @@ const NODE_PREFIX: u8 = 0;
 /// Prefix used for the key storing the pruning boundary (as a leaf index) in the metadata.
 pub(crate) const PRUNED_TO_PREFIX: u8 = 1;
 
-impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F, E, D, S> {
+impl<F: Family, E: crate::Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// Return the total number of nodes in the structure, irrespective of any pruning. The next
     /// added element's position will have this value.
     pub fn size(&self) -> Position<F> {
@@ -876,9 +876,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F,
 /// be tighter than the journal's prune boundary reported by [`Merkle::bounds`]). This means
 /// batch operations like `update_leaf` will correctly reject leaves that have been synced out of
 /// memory with [`Error::ElementPruned`].
-impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Readable
-    for Merkle<F, E, D, S>
-{
+impl<F: Family, E: crate::Context, D: Digest, S: Strategy> Readable for Merkle<F, E, D, S> {
     type Family = F;
     type Digest = D;
     type Error = Error<F>;
@@ -896,8 +894,8 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Readable
     }
 }
 
-impl<F: Family, E: RStorage + Clock + Metrics + Sync, D: Digest, S: Strategy>
-    crate::merkle::storage::Storage<F> for Merkle<F, E, D, S>
+impl<F: Family, E: crate::Context + Sync, D: Digest, S: Strategy> crate::merkle::storage::Storage<F>
+    for Merkle<F, E, D, S>
 {
     type Digest = D;
 
@@ -910,7 +908,7 @@ impl<F: Family, E: RStorage + Clock + Metrics + Sync, D: Digest, S: Strategy>
     }
 }
 
-impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F, E, D, S> {
+impl<F: Family, E: crate::Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// Return an inclusion proof for the element at the location `loc` against a historical
     /// state with `leaves` leaves.
     ///

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -24,7 +24,6 @@ use commonware_codec::{Codec, CodecShared};
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use commonware_utils::bitmap;
 use core::num::{NonZeroU64, NonZeroUsize};
 use std::{collections::HashMap, sync::Arc};
@@ -660,7 +659,8 @@ where
 {
     /// Returns a [Db] initialized from `log`. `shared_bitmap = None` allocates a fresh bitmap;
     /// `Some(b)` adopts a pre-allocated bitmap (used by `current::Db`, which sizes pruned chunks
-    /// from grafted metadata).
+    /// from grafted metadata). The snapshot build derives any parallelism from the log's
+    /// [Strategy].
     ///
     /// # Panics
     ///
@@ -672,13 +672,11 @@ where
         log: AuthenticatedLog<F, E, C, H, S>,
         shared_bitmap: Option<Arc<Shared<N>>>,
         cache_size: Option<NonZeroUsize>,
-        parallelism: crate::qmdb::InitParallelism,
         metrics: Metrics<E>,
     ) -> Result<Self, crate::qmdb::Error<F>>
     where
-        E: Spawner + 'static,
         I: crate::qmdb::SnapshotBuild<F>,
-        AuthenticatedLog<F, E, C, H, S>: Send + Sync + 'static,
+        C: 'static,
     {
         // Share the log so the snapshot build can hand each parallel worker its own reader. Sole
         // ownership is recovered (`Arc::into_inner`) once the build has dropped every worker clone.
@@ -725,8 +723,8 @@ where
             }
 
             // The closure takes a brief lock per call (holding it across the build's `.await`s is
-            // not `Send`). `old_loc`, when set, clears a superseded bit: the serial build supplies
-            // it per op; the parallel build pre-resolves and passes `None`.
+            // not `Send`). `old_loc`, when set, clears a superseded bit. The serial build supplies
+            // it per op while the parallel build pre-resolves and passes `None`.
             let active_keys = {
                 let bitmap = &bitmap;
                 index
@@ -734,8 +732,7 @@ where
                         context,
                         inactivity_floor_loc,
                         &log,
-                        &strategy,
-                        parallelism,
+                        strategy,
                         cache_size,
                         |is_active, old_loc| {
                             let mut guard = bitmap.write();
@@ -751,7 +748,7 @@ where
             (last_commit_loc, inactivity_floor_loc, active_keys, bitmap)
         };
 
-        // The build has returned, so every worker clone of the log is dropped; reclaim it.
+        // The build has returned, so every worker clone of the log is dropped. Reclaim it.
         let log = Arc::into_inner(log).expect("snapshot build retained a log reference");
 
         // The bitmap must have exactly one bit per retained log location.

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -83,7 +83,6 @@ use commonware_codec::CodecShared;
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use core::num::NonZeroUsize;
 use std::sync::Arc;
 use tracing::warn;
@@ -116,10 +115,6 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
-
-    /// How the ordered-partitioned snapshot build parallelizes during init. Note that only certain
-    /// index types (such as the ordered-partitioned index) support parallel construction.
-    pub init_parallelism: super::InitParallelism,
 }
 
 /// Configuration for an `Any` authenticated db with fixed-size values.
@@ -135,15 +130,14 @@ pub async fn init<F, E, U, H, T, I, J, S>(
 ) -> Result<db::Db<F, E, J, I, H, U, BITMAP_CHUNK_BYTES, S>, crate::qmdb::Error<F>>
 where
     F: Family,
-    E: Context + Spawner + 'static,
+    E: Context,
     U: Update + Send + Sync,
     H: Hasher,
     T: Translator,
-    I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
-    J: Inner<E, Item = Operation<F, U>>,
+    I: IndexFactory<T> + crate::qmdb::SnapshotBuild<F>,
+    J: Inner<E, Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
-    crate::journal::authenticated::Journal<F, E, J, H, S>: Send + Sync + 'static,
 {
     init_with_bitmap::<F, E, U, H, T, I, J, S, BITMAP_CHUNK_BYTES>(context, cfg, None).await
 }
@@ -158,15 +152,14 @@ pub(crate) async fn init_with_bitmap<F, E, U, H, T, I, J, S, const N: usize>(
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where
     F: Family,
-    E: Context + Spawner + 'static,
+    E: Context,
     U: Update + Send + Sync,
     H: Hasher,
     T: Translator,
-    I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
-    J: Inner<E, Item = Operation<F, U>>,
+    I: IndexFactory<T> + crate::qmdb::SnapshotBuild<F>,
+    J: Inner<E, Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
-    crate::journal::authenticated::Journal<F, E, J, H, S>: Send + Sync + 'static,
 {
     let mut log = J::init::<F, H, S>(
         context.child("log"),
@@ -193,7 +186,6 @@ where
         log,
         bitmap,
         cfg.init_cache_size,
-        cfg.init_parallelism,
         metrics,
     )
     .await
@@ -205,10 +197,7 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
-        qmdb::{
-            any::{FixedConfig, MerkleConfig, VariableConfig},
-            InitParallelism,
-        },
+        qmdb::any::{FixedConfig, MerkleConfig, VariableConfig},
         translator::OneCap,
     };
     use commonware_codec::{Codec, CodecShared};
@@ -238,15 +227,22 @@ pub(crate) mod test {
         suffix: &str,
         pooler: &impl BufferPooler,
     ) -> FixedConfig<T, Sequential> {
+        fixed_db_config_with_strategy(suffix, pooler, Sequential)
+    }
+
+    pub(crate) fn fixed_db_config_with_strategy<T: Translator + Default, S: Strategy>(
+        suffix: &str,
+        pooler: &impl BufferPooler,
+        strategy: S,
+    ) -> FixedConfig<T, S> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),
                 items_per_blob: NZU64!(11),
                 write_buffer: NZUsize!(1024),
-                strategy: Sequential,
+                strategy,
                 page_cache: page_cache.clone(),
             },
             journal_config: FConfig {
@@ -266,7 +262,6 @@ pub(crate) mod test {
     ) -> VariableConfig<T, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("journal-{suffix}"),
                 metadata_partition: format!("metadata-{suffix}"),

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 pub type Update<K, V> = ordered::Update<K, FixedEncoding<V>>;
@@ -36,15 +35,8 @@ pub type Db<F, E, K, V, H, T, S> = super::Db<
     S,
 >;
 
-impl<
-        F: Family,
-        E: Context + Spawner + 'static,
-        K: Array,
-        V: FixedValue,
-        H: Hasher,
-        T: Translator,
-        S: Strategy,
-    > Db<F, E, K, V, H, T, S>
+impl<F: Family, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator, S: Strategy>
+    Db<F, E, K, V, H, T, S>
 {
     /// Returns a [Db] qmdb initialized from `cfg`. Any uncommitted log operations will be
     /// discarded and the state of the db will be as of the last committed operation.
@@ -77,7 +69,6 @@ pub mod partitioned {
     };
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
-    use commonware_runtime::Spawner;
     use commonware_utils::Array;
 
     /// An ordered key-value QMDB with a partitioned snapshot index.
@@ -102,7 +93,7 @@ pub mod partitioned {
 
     impl<
             F: Family,
-            E: Context + Spawner + 'static,
+            E: Context,
             K: Array,
             V: FixedValue,
             H: Hasher,
@@ -149,7 +140,7 @@ pub(crate) mod test {
                     },
                     Update,
                 },
-                test::fixed_db_config,
+                test::{fixed_db_config, fixed_db_config_with_strategy},
             },
             verify_proof,
         },
@@ -158,12 +149,12 @@ pub(crate) mod test {
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
-    use commonware_parallel::Sequential;
+    use commonware_parallel::{Manual, Sequential};
     use commonware_runtime::{
         deterministic::{self, Context},
         Runner as _, Supervisor as _,
     };
-    use commonware_utils::{sequence::FixedBytes, test_rng_seeded, NZU64};
+    use commonware_utils::{sequence::FixedBytes, test_rng_seeded, NZUsize, NZU64};
     use futures::StreamExt as _;
     use rand::{rngs::StdRng, seq::IteratorRandom, RngCore, SeedableRng};
     use std::collections::{BTreeMap, HashMap};
@@ -593,28 +584,69 @@ pub(crate) mod test {
     }
 
     /// Build a `P`-partitioned ordered db with churny ops, then assert that reopening it with a range
-    /// of worker counts (`0` for the serial path, `1` for the single-worker de-interleave, counts that
-    /// leave trailing partition ranges empty, and counts above the partition count that clamp) all
-    /// reconstruct the identical root -- the parallel build replays the same immutable log, just split
-    /// across workers owning disjoint partition ranges (with non-zero offsets for `workers > 1`).
+    /// of worker counts (`0` for the serial path, counts that leave trailing partition ranges empty,
+    /// and counts above the partition count that clamp) all reconstruct the identical root and
+    /// key-value state -- the parallel build replays the same immutable log, just split across
+    /// workers owning disjoint partition ranges. The build derives its worker count from the
+    /// configured strategy's parallelism hint, so each reopen pins the count with a [Manual]
+    /// strategy of hint `workers` (a hint of one builds serially).
     async fn check_parallel_init_equivalence<const P: usize>(
         context: deterministic::Context,
         partition: &'static str,
-        parallelisms: &[usize],
+        worker_counts: &[usize],
     ) {
-        type PartDb<const P: usize> =
-            partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, P, Sequential>;
+        type PartDb<const P: usize, S> =
+            partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, P, S>;
+
+        /// The value each key holds after the three commits below. Keys deleted in commit 2 and
+        /// reinserted in commit 3 hold the reinserted value. Keys deleted and not reinserted are
+        /// absent. Updated keys hold the commit-2 value. The rest hold their commit-1 value.
+        fn expected_value(i: u64) -> Option<Digest> {
+            if i % 21 == 1 {
+                Some(Sha256::hash(&(i * 13).to_be_bytes()))
+            } else if i % 7 == 1 {
+                None
+            } else if i.is_multiple_of(3) {
+                Some(Sha256::hash(&((i + 1) * 11).to_be_bytes()))
+            } else {
+                Some(Sha256::hash(&(i * 7).to_be_bytes()))
+            }
+        }
+
+        /// Assert every key resolves to its expected value, catching a location filed under the
+        /// wrong key (which the root comparison alone cannot detect since the `any` root is a pure
+        /// function of the log).
+        async fn assert_expected_values<const P: usize, S: commonware_parallel::Strategy>(
+            db: &PartDb<P, S>,
+        ) {
+            for i in 0u64..4000 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                assert_eq!(
+                    db.get(&k).await.unwrap(),
+                    expected_value(i),
+                    "value mismatch for key {i}"
+                );
+            }
+        }
 
         let cfg = fixed_db_config::<OneCap>(partition, &context);
-        let mut db = PartDb::<P>::init(context.child("populate"), cfg)
+        let mut db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
             .await
             .unwrap();
+
+        // Commit 1: insert every key.
         let mut batch = db.new_batch();
         for i in 0u64..4000 {
             let k = Sha256::hash(&i.to_be_bytes());
             let v = Sha256::hash(&(i * 7).to_be_bytes());
             batch = batch.write(k, Some(v));
         }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
+
+        // Commit 2: update a third (inactivating their commit-1 ops) and delete a seventh.
+        let mut batch = db.new_batch();
         for i in (0u64..4000).step_by(3) {
             let k = Sha256::hash(&i.to_be_bytes());
             let v = Sha256::hash(&((i + 1) * 11).to_be_bytes());
@@ -627,41 +659,77 @@ pub(crate) mod test {
         let merkleized = batch.merkleize(&db, None).await.unwrap();
         db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
+
+        // Commit 3: reinsert a third of the deleted keys, so the replayed log contains
+        // delete-then-reinsert sequences for the parallel build to resolve.
+        let mut batch = db.new_batch();
+        for i in (1u64..4000).step_by(21) {
+            let k = Sha256::hash(&i.to_be_bytes());
+            let v = Sha256::hash(&(i * 13).to_be_bytes());
+            batch = batch.write(k, Some(v));
+        }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap();
         db.sync().await.unwrap();
         let root = db.root();
         drop(db);
 
-        // Reopen with a range of worker counts; all rebuild from the same log and must match.
-        for &workers in parallelisms {
-            let mut cfg = fixed_db_config::<OneCap>(partition, &context);
-            cfg.init_parallelism = match workers {
-                0 => crate::qmdb::InitParallelism::Serial,
-                n => {
-                    crate::qmdb::InitParallelism::Workers(core::num::NonZeroUsize::new(n).unwrap())
-                }
-            };
-            let ctx = context
-                .child("reopen")
-                .with_attribute("parallelism", workers);
-            let db = PartDb::<P>::init(ctx, cfg).await.unwrap();
-            assert_eq!(
-                db.root(),
-                root,
-                "root mismatch at P={P} init_parallelism={workers}"
+        // Reopen with a range of worker counts. All rebuild from the same log and must match the
+        // original root and serve the expected value for every key.
+        for &workers in worker_counts {
+            let cfg = fixed_db_config_with_strategy::<OneCap, _>(
+                partition,
+                &context,
+                Manual::new(Sequential, NZUsize!(workers.max(1))),
             );
+            let ctx = context.child("reopen").with_attribute("workers", workers);
+            let db = PartDb::<P, Manual<Sequential>>::init(ctx, cfg)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root, "root mismatch at P={P} workers={workers}");
+            assert_expected_values(&db).await;
             drop(db);
         }
+    }
+
+    /// A fresh db's log holds only the auto-appended CommitFloor. A multi-worker reopen must
+    /// handle the keyless single-op replay (every routed batch empty).
+    #[test_traced("WARN")]
+    fn test_ordered_partitioned_fresh_db_parallel_init() {
+        deterministic::Runner::default().start(|context| async move {
+            type FreshDb<S> =
+                partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 1, S>;
+
+            let cfg = fixed_db_config::<OneCap>("parallel_fresh", &context);
+            let db = FreshDb::<Sequential>::init(context.child("create"), cfg)
+                .await
+                .unwrap();
+            let root = db.root();
+            drop(db);
+
+            // A hint of 3 gives the build 3 workers.
+            let cfg = fixed_db_config_with_strategy::<OneCap, _>(
+                "parallel_fresh",
+                &context,
+                Manual::new(Sequential, NZUsize!(3)),
+            );
+            let db = FreshDb::<Manual<Sequential>>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+        });
     }
 
     #[test_traced("WARN")]
     fn test_ordered_partitioned_p1_parallel_init_equivalence() {
         deterministic::Runner::default().start(|context| async move {
-            // 200 leaves trailing ranges empty for P=1 (count=256, range_size=2); 300 exceeds the
-            // partition count and clamps. Both must reconstruct the same root without panicking.
+            // 200 leaves trailing ranges empty for P=1 (count=256, range_size=2) and 300 exceeds
+            // the partition count and clamps. Both must reconstruct the same root without panicking.
             check_parallel_init_equivalence::<1>(
                 context,
                 "parallel_equiv_p1",
-                &[0, 1, 2, 4, 8, 200, 300],
+                &[0, 2, 4, 8, 200, 300],
             )
             .await;
         });
@@ -670,24 +738,20 @@ pub(crate) mod test {
     #[test_traced("WARN")]
     fn test_ordered_partitioned_p2_parallel_init_equivalence() {
         deterministic::Runner::default().start(|context| async move {
-            check_parallel_init_equivalence::<2>(
-                context,
-                "parallel_equiv_p2",
-                &[0, 1, 2, 4, 8, 200],
-            )
-            .await;
+            check_parallel_init_equivalence::<2>(context, "parallel_equiv_p2", &[0, 2, 4, 8, 200])
+                .await;
         });
     }
 
     /// P=3 allocates `2^24` partition slots (~800 MB per index), so it is too memory-heavy for the
-    /// default suite; run explicitly with `--ignored` (and ideally `--release`). Only serial,
-    /// single-worker, and one offset-parallel reopen are checked -- enough to validate the offset-based
-    /// range build and merge at the largest prefix width without the full worker-count sweep.
+    /// default suite. Run it explicitly with `--ignored` (and ideally `--release`). Only serial and
+    /// one offset-parallel reopen are checked -- enough to validate the offset-based range build and
+    /// merge at the largest prefix width without the full worker-count sweep.
     #[test_traced("WARN")]
     #[ignore]
     fn test_ordered_partitioned_p3_parallel_init_equivalence() {
         deterministic::Runner::default().start(|context| async move {
-            check_parallel_init_equivalence::<3>(context, "parallel_equiv_p3", &[0, 1, 2]).await;
+            check_parallel_init_equivalence::<3>(context, "parallel_equiv_p3", &[0, 2]).await;
         });
     }
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -20,7 +20,6 @@ use crate::{
 use commonware_codec::{Codec, Read};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 
 pub type Update<K, V> = ordered::Update<K, VariableEncoding<V>>;
 pub type Operation<F, K, V> = ordered::Operation<F, K, VariableEncoding<V>>;
@@ -38,15 +37,8 @@ pub type Db<F, E, K, V, H, T, S> = super::Db<
     S,
 >;
 
-impl<
-        F: Family,
-        E: Context + Spawner + 'static,
-        K: Key,
-        V: VariableValue,
-        H: Hasher,
-        T: Translator,
-        S: Strategy,
-    > Db<F, E, K, V, H, T, S>
+impl<F: Family, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator, S: Strategy>
+    Db<F, E, K, V, H, T, S>
 where
     Operation<F, K, V>: Codec,
 {
@@ -86,7 +78,6 @@ pub mod partitioned {
     use commonware_codec::{Codec, Read};
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
-    use commonware_runtime::Spawner;
 
     /// An ordered key-value QMDB with a partitioned snapshot index and variable-size values.
     ///
@@ -119,7 +110,6 @@ pub mod partitioned {
             S: Strategy,
         > Db<F, E, K, V, H, T, P, S>
     where
-        E: Spawner + 'static,
         Operation<F, K, V>: Codec,
     {
         /// Returns a [Db] QMDB initialized from `cfg`. Uncommitted log operations will be
@@ -150,22 +140,19 @@ pub(crate) mod test {
     use super::*;
     use crate::{
         mmr,
-        qmdb::{
-            any::{
-                ordered::test::{
-                    test_ordered_any_db_basic, test_ordered_any_db_empty,
-                    test_ordered_any_update_collision_edge_case,
-                },
-                test::variable_db_config,
+        qmdb::any::{
+            ordered::test::{
+                test_ordered_any_db_basic, test_ordered_any_db_empty,
+                test_ordered_any_update_collision_edge_case,
             },
-            InitParallelism,
+            test::variable_db_config,
         },
         translator::TwoCap,
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
-    use commonware_parallel::Sequential;
+    use commonware_parallel::{Manual, Sequential};
     use commonware_runtime::{
         buffer::paged::CacheRef,
         deterministic::{self, Context},
@@ -177,24 +164,31 @@ pub(crate) mod test {
     const PAGE_SIZE: u16 = 103;
     const PAGE_CACHE_SIZE: usize = 13;
 
-    pub(crate) type VarConfig =
-        VariableConfig<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ())), Sequential>;
+    pub(crate) type VarConfig<S = Sequential> =
+        VariableConfig<TwoCap, ((), (commonware_codec::RangeCfg<usize>, ())), S>;
 
     /// Type alias for the concrete [Db] type used in these unit tests.
     pub(crate) type AnyTest =
         Db<mmr::Family, deterministic::Context, Digest, Vec<u8>, Sha256, TwoCap, Sequential>;
 
     pub(crate) fn create_test_config(seed: u64, pooler: &impl BufferPooler) -> VarConfig {
+        create_test_config_with_strategy(seed, pooler, Sequential)
+    }
+
+    pub(crate) fn create_test_config_with_strategy<S: Strategy>(
+        seed: u64,
+        pooler: &impl BufferPooler,
+        strategy: S,
+    ) -> VarConfig<S> {
         let page_cache =
             CacheRef::from_pooler(pooler, NZU16!(PAGE_SIZE), NZUsize!(PAGE_CACHE_SIZE));
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: crate::mmr::full::Config {
                 journal_partition: format!("mmr-journal-{seed}"),
                 metadata_partition: format!("mmr-metadata-{seed}"),
                 items_per_blob: NZU64!(12), // intentionally small and janky size
                 write_buffer: NZUsize!(64),
-                strategy: Sequential,
+                strategy,
                 page_cache: page_cache.clone(),
             },
             journal_config: crate::journal::contiguous::variable::Config {
@@ -215,6 +209,90 @@ pub(crate) mod test {
         let seed = context.next_u64();
         let config = create_test_config(seed, &context);
         AnyTest::init(context, config).await.unwrap()
+    }
+
+    /// Serial-vs-parallel init equivalence for the variable-value partitioned db. The parallel
+    /// build streams variable-size ops through the shared log, which the fixed-value equivalence
+    /// tests cannot cover. The build derives its worker count from the configured strategy's
+    /// parallelism hint, so each reopen pins the count with a [Manual] strategy of hint `workers`
+    /// (a hint of one builds serially).
+    #[test_traced("WARN")]
+    fn test_ordered_partitioned_variable_parallel_init_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            type PartDb<S> = partitioned::Db<
+                mmr::Family,
+                deterministic::Context,
+                Digest,
+                Vec<u8>,
+                Sha256,
+                TwoCap,
+                1,
+                S,
+            >;
+
+            /// The value each key holds after the two commits below.
+            fn expected_value(i: u64) -> Option<Vec<u8>> {
+                if i % 7 == 1 {
+                    None
+                } else if i.is_multiple_of(3) {
+                    Some(vec![0xAB; (i % 17 + 1) as usize])
+                } else {
+                    Some(vec![(i % 251) as u8; (i % 40 + 1) as usize])
+                }
+            }
+
+            // Commit 1: insert every key.
+            let cfg = create_test_config(77, &context);
+            let mut db = PartDb::<Sequential>::init(context.child("populate"), cfg)
+                .await
+                .unwrap();
+            let mut batch = db.new_batch();
+            for i in 0u64..500 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                let v = vec![(i % 251) as u8; (i % 40 + 1) as usize];
+                batch = batch.write(k, Some(v));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap();
+
+            // Commit 2: update a third and delete a seventh so the replay carries churn.
+            let mut batch = db.new_batch();
+            for i in (0u64..500).step_by(3) {
+                let k = Sha256::hash(&i.to_be_bytes());
+                batch = batch.write(k, Some(vec![0xAB; (i % 17 + 1) as usize]));
+            }
+            for i in (1u64..500).step_by(7) {
+                let k = Sha256::hash(&i.to_be_bytes());
+                batch = batch.write(k, None);
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap();
+            db.sync().await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            for workers in [0usize, 3] {
+                let cfg = create_test_config_with_strategy(
+                    77,
+                    &context,
+                    Manual::new(Sequential, NZUsize!(workers.max(1))),
+                );
+                let ctx = context.child("reopen").with_attribute("workers", workers);
+                let db = PartDb::<Manual<Sequential>>::init(ctx, cfg).await.unwrap();
+                assert_eq!(db.root(), root, "root mismatch at workers={workers}");
+                for i in 0u64..500 {
+                    let k = Sha256::hash(&i.to_be_bytes());
+                    assert_eq!(
+                        db.get(&k).await.unwrap(),
+                        expected_value(i),
+                        "value mismatch for key {i}"
+                    );
+                }
+                drop(db);
+            }
+        });
     }
 
     /// Deterministic byte vector generator for variable-value tests.

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -45,7 +45,6 @@ use crate::{
 use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use commonware_utils::{range::NonEmptyRange, Array};
 use core::num::NonZeroUsize;
 
@@ -66,15 +65,14 @@ async fn build_db<F, E, U, I, H, C, T, S>(
 ) -> Result<Db<F, E, C, I, H, U, { crate::qmdb::any::BITMAP_CHUNK_BYTES }, S>, qmdb::Error<F>>
 where
     F: merkle::Family,
-    E: Context + Spawner + 'static,
+    E: Context,
     U: Update + Send + Sync + 'static,
-    I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
+    I: IndexFactory<T> + crate::qmdb::SnapshotBuild<F>,
     H: Hasher,
     T: Translator,
-    C: Mutable<Item = Operation<F, U>>,
+    C: Mutable<Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Codec + Committable + CodecShared,
-    authenticated::Journal<F, E, C, H, S>: Send + Sync + 'static,
 {
     let hasher = qmdb::hasher::<H>();
 
@@ -99,17 +97,7 @@ where
     .await?;
     let snapshot_context = context.child("snapshot");
     let metrics = Metrics::new(context);
-    // State-sync rebuilds derive the worker count from the runtime (`Auto`) for the snapshot build.
-    let db = Db::init_from_log(
-        snapshot_context,
-        index,
-        log,
-        None,
-        cache_size,
-        crate::qmdb::InitParallelism::Auto,
-        metrics,
-    )
-    .await?;
+    let db = Db::init_from_log(snapshot_context, index, log, None, cache_size, metrics).await?;
 
     Ok(db)
 }
@@ -122,7 +110,7 @@ macro_rules! impl_sync_database {
         impl<F, E, K, V, H, T, S> qmdb::sync::Database for $db<F, E, K, V, H, T, S>
         where
             F: merkle::Family,
-            E: Context + Spawner + 'static,
+            E: Context,
             K: $key_bound,
             V: $value_bound + 'static,
             H: Hasher,

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 pub type Update<K, V> = unordered::Update<K, FixedEncoding<V>>;
@@ -32,15 +31,8 @@ pub type Db<F, E, K, V, H, T, S> = super::Db<
     S,
 >;
 
-impl<
-        F: Family,
-        E: Context + Spawner + 'static,
-        K: Array,
-        V: FixedValue,
-        H: Hasher,
-        T: Translator,
-        S: Strategy,
-    > Db<F, E, K, V, H, T, S>
+impl<F: Family, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator, S: Strategy>
+    Db<F, E, K, V, H, T, S>
 {
     /// Returns a [Db] QMDB initialized from `cfg`. Uncommitted log operations will be
     /// discarded and the state of the db will be as of the last committed operation.
@@ -69,7 +61,6 @@ pub mod partitioned {
     };
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
-    use commonware_runtime::Spawner;
     use commonware_utils::Array;
 
     /// A key-value QMDB with a partitioned snapshot index.
@@ -94,7 +85,7 @@ pub mod partitioned {
 
     impl<
             F: Family,
-            E: Context + Spawner + 'static,
+            E: Context,
             K: Array,
             V: FixedValue,
             H: Hasher,

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -19,7 +19,6 @@ use crate::{
 use commonware_codec::{Codec, Read};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 
 pub type Update<K, V> = unordered::Update<K, VariableEncoding<V>>;
 pub type Operation<F, K, V> = unordered::Operation<F, K, VariableEncoding<V>>;
@@ -37,15 +36,8 @@ pub type Db<F, E, K, V, H, T, S> = super::Db<
     S,
 >;
 
-impl<
-        F: Family,
-        E: Context + Spawner + 'static,
-        K: Key,
-        V: VariableValue,
-        H: Hasher,
-        T: Translator,
-        S: Strategy,
-    > Db<F, E, K, V, H, T, S>
+impl<F: Family, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator, S: Strategy>
+    Db<F, E, K, V, H, T, S>
 where
     Operation<F, K, V>: Codec,
 {
@@ -81,7 +73,6 @@ pub mod partitioned {
     use commonware_codec::{Codec, Read};
     use commonware_cryptography::Hasher;
     use commonware_parallel::Strategy;
-    use commonware_runtime::Spawner;
 
     /// A key-value QMDB with a partitioned snapshot index and variable-size values.
     ///
@@ -105,7 +96,7 @@ pub mod partitioned {
 
     impl<
             F: Family,
-            E: Context + Spawner + 'static,
+            E: Context,
             K: Key,
             V: VariableValue,
             H: Hasher,
@@ -142,7 +133,7 @@ pub mod partitioned {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use crate::{index::Unordered as _, mmr, qmdb::InitParallelism, translator::TwoCap};
+    use crate::{index::Unordered as _, mmr, translator::TwoCap};
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
@@ -165,7 +156,6 @@ pub(crate) mod test {
     pub(crate) fn create_test_config(seed: u64, pooler: &impl BufferPooler) -> VarConfig {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: crate::mmr::full::Config {
                 journal_partition: format!("journal-{seed}"),
                 metadata_partition: format!("metadata-{seed}"),

--- a/storage/src/qmdb/benches/chained_growth.rs
+++ b/storage/src/qmdb/benches/chained_growth.rs
@@ -21,7 +21,6 @@ use commonware_storage::{
     qmdb::{
         any::traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
         current::{ordered::fixed::Db as OCFixed, unordered::fixed::Db as UCFixed},
-        InitParallelism,
     },
     translator::EightCap,
 };
@@ -83,7 +82,6 @@ fn cur_fix_cfg(
 ) -> commonware_storage::qmdb::current::FixedConfig<EightCap, Rayon> {
     let pc = pc(ctx);
     commonware_storage::qmdb::current::FixedConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -27,7 +27,6 @@ use commonware_storage::{
         },
         immutable::fixed::{Config as ImmutableFixedConfig, Db as IFixed},
         keyless::variable::{Config as KeylessConfig, Db as Keyless},
-        InitParallelism,
     },
     translator::EightCap,
 };
@@ -59,9 +58,10 @@ pub type AnyOFixDb<F> = OFixed<F, Context, Digest, Digest, Sha256, EightCap, Ray
 /// partitioned ordered index's cursor (get_mut/find/update) on apply.
 pub type AnyOFixP256Db<F> = OFixP256<F, Context, Digest, Digest, Sha256, EightCap, Rayon>;
 /// Ordered "any" DB with a partitioned snapshot index (~16.8M partitions, P=3). The inline-SoA config
-/// for very large key sets (P=2 spills past ~33M entries); used by the `init_scale` bench.
+/// for very large key sets (P=2 spills past ~33M entries), used by the `init_scale` bench. Generic
+/// over the strategy so `init_scale` can pin the snapshot build's worker count with a manual hint.
 #[allow(dead_code)]
-pub type AnyOFixP3Db<F> = OFixPart<F, Context, Digest, Digest, Sha256, EightCap, 3, Rayon>;
+pub type AnyOFixP3Db<F, S = Rayon> = OFixPart<F, Context, Digest, Digest, Sha256, EightCap, 3, S>;
 pub type CurUFixDb<F> = UCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE, Rayon>;
 pub type CurOFixDb<F> = OCFixed<F, Context, Digest, Digest, Sha256, EightCap, CHUNK_SIZE, Rayon>;
 
@@ -157,7 +157,6 @@ pub fn any_fix_cfg_with(
 ) -> AnyFixedConfig<EightCap, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, page_cache_size);
     AnyFixedConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         translator: EightCap,
@@ -190,7 +189,6 @@ pub fn cur_fix_cfg_with(
 ) -> CurrentFixedConfig<EightCap, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentFixedConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_FIX}"),
@@ -211,7 +209,6 @@ pub fn any_var_digest_cfg_with(
 ) -> AnyVariableConfig<EightCap, ((), ()), Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         translator: EightCap,
@@ -231,7 +228,6 @@ pub fn cur_var_digest_cfg_with(
 ) -> CurrentVariableConfig<EightCap, ((), ()), Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
@@ -255,7 +251,6 @@ pub fn any_var_vec_cfg_with(
 ) -> AnyVariableConfig<EightCap, VarVecCfg, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     AnyVariableConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(
             PARTITION_VAR,
@@ -280,7 +275,6 @@ pub fn cur_var_vec_cfg_with(
 ) -> CurrentVariableConfig<EightCap, VarVecCfg, Rayon> {
     let page_cache = CacheRef::from_pooler(ctx, PAGE_SIZE, PAGE_CACHE_SIZE);
     CurrentVariableConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(PARTITION_VAR, ctx, page_cache.clone(), items_per_blob),
         journal_config: var_log_cfg(
             PARTITION_VAR,

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -30,7 +30,7 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{full, mmb},
-    qmdb::{any::FixedConfig, current::FixedConfig as CurrentFixedConfig, InitParallelism},
+    qmdb::{any::FixedConfig, current::FixedConfig as CurrentFixedConfig},
     translator::EightCap,
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -322,7 +322,6 @@ fn main() {
         match db_kind.as_str() {
             "current::unordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
-                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
@@ -339,7 +338,6 @@ fn main() {
             }
             "current::ordered::fixed::mmb" => {
                 let cfg = CurrentFixedConfig {
-                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config,
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
@@ -356,7 +354,6 @@ fn main() {
             }
             "any::ordered::fixed::mmb" => {
                 let cfg = FixedConfig {
-                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config,
                     translator: EightCap,
@@ -367,7 +364,6 @@ fn main() {
             }
             "any::unordered::variable::mmb" => {
                 let cfg = commonware_storage::qmdb::any::VariableConfig {
-                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config: VConfig {
                         partition: "constantinople-var-log".into(),
@@ -385,7 +381,6 @@ fn main() {
             }
             _ => {
                 let cfg = FixedConfig {
-                    init_parallelism: InitParallelism::Serial,
                     merkle_config,
                     journal_config,
                     translator: EightCap,

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -26,11 +26,11 @@
 //! reporting the total build time.
 //!
 //! `bench` reopens it (read-only) and times one `init` at the given init cache size (`cache` entries,
-//! `0` = off) and `parallelism` (`0` = serial, `N` = N worker tasks, `auto` = from the runtime). It
-//! reports the replay-region size `R` (so a full-coverage cache is `cache = R`) and the elapsed time,
-//! and uses the P=3 partitioned ordered index (the inline-SoA config for large key sets) so the
-//! parallel `build_snapshot` override is exercised. Sweep cache/parallelism by driving the command
-//! from a shell loop.
+//! `0` = off) and `parallelism` (`0` or `1` = serial, `N > 1` = N worker tasks, `auto` = derived from the
+//! strategy). It reports the replay-region size `R` (so a full-coverage cache is `cache = R`) and the
+//! elapsed time, and uses the P=3 partitioned ordered index (the inline-SoA config for large key
+//! sets) so the parallel `build_snapshot` override is exercised. Sweep cache/parallelism by driving
+//! the command from a shell loop.
 //!
 //! Each invocation does exactly one reopen, so numbers are warm only if the OS file cache is already
 //! warm. For the realistic cold-cache case (init at process start), have the driver drop the OS cache
@@ -41,13 +41,15 @@
 mod common;
 
 use common::{any_fix_cfg_with, gen_random_kv, make_fixed_value, AnyOFixP3Db};
+use commonware_parallel::{Manual, Rayon, Strategy};
 use commonware_runtime::{
-    tokio::{Config, Runner},
+    tokio::{Config, Context, Runner},
     Runner as _, Supervisor as _,
 };
 use commonware_storage::{
     merkle::mmr::Family as Mmr,
-    qmdb::{any::traits::DbAny as _, InitParallelism},
+    qmdb::any::{traits::DbAny as _, FixedConfig},
+    translator::EightCap,
 };
 use commonware_utils::{NZUsize, NZU64};
 use std::{
@@ -78,27 +80,20 @@ const PRUNE_FREQUENCY: u32 = 100;
 /// workloads. Higher = more skew; ~1.0 is classic Zipf (near YCSB's 0.99).
 const KEY_ZIPF_EXPONENT: f64 = 1.0;
 
-/// Map a worker count to an [InitParallelism]: `0` is the serial build, `n` spawns `n` worker tasks.
-const fn workers(n: usize) -> InitParallelism {
-    match n {
-        0 => InitParallelism::Serial,
-        n => InitParallelism::Workers(NonZeroUsize::new(n).unwrap()),
-    }
-}
-
-/// Parse a `parallelism` CLI argument: `auto` for [`InitParallelism::Auto`], otherwise a worker count
-/// (`0` = serial, `n` = `n` worker tasks).
-fn parse_parallelism(arg: &str) -> Option<InitParallelism> {
+/// Parse a `parallelism` CLI argument. `auto` derives the worker count from the strategy (`None`).
+/// Otherwise it is an exact worker count (`0` or `1` = serial, `n > 1` = `n` worker tasks).
+#[allow(clippy::option_option)]
+fn parse_parallelism(arg: &str) -> Option<Option<usize>> {
     if arg == "auto" {
-        Some(InitParallelism::Auto)
+        Some(None)
     } else {
-        arg.parse::<usize>().ok().map(workers)
+        arg.parse::<usize>().ok().map(Some)
     }
 }
 
 fn usage() {
     eprintln!(
-        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <parallelism>   reopen + time one init (cache=entries, 0=off; parallelism=0 serial / N workers / auto)\n  destroy   <folder>                          delete the database"
+        "usage:\n  generate <folder> <keyspace> <num_updates> [zipf_exponent]   build a database (omit exponent => zipf 1.0; 0 => uniform)\n  bench     <folder> <cache> <parallelism>   reopen + time one init (cache=entries, 0=off; parallelism=0 or 1 serial / N>1 workers / auto)\n  destroy   <folder>                          delete the database"
     );
 }
 
@@ -188,9 +183,10 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
 }
 
 /// Reopen the database at `folder` (read-only) and time one `init` of the P=3 partitioned ordered
-/// index at the given init cache size (`cache` entries; `0` = off) and `parallelism`. Reports the
-/// replay-region size `R` (a full-coverage cache is `cache = R`) and the elapsed time.
-fn bench(folder: &str, cache: usize, parallelism: InitParallelism) {
+/// index at the given init cache size (`cache` entries, `0` = off) and worker count (`None` derives
+/// it from the strategy). Reports the replay-region size `R` (a full-coverage cache is `cache = R`)
+/// and the elapsed time.
+fn bench(folder: &str, cache: usize, workers: Option<usize>) {
     if !db_dir_nonempty(folder) {
         eprintln!(
             "no database at {folder}; run `generate {folder} <keyspace> <num_updates>` first"
@@ -198,7 +194,7 @@ fn bench(folder: &str, cache: usize, parallelism: InitParallelism) {
         return;
     }
     let cfg = Config::default().with_storage_directory(folder);
-    let (elapsed, region) = time_init(&cfg, NonZeroUsize::new(cache), parallelism);
+    let (elapsed, region) = time_init(&cfg, NonZeroUsize::new(cache), workers);
     if region == 0 {
         eprintln!(
             "database at {folder} is empty; run `generate {folder} <keyspace> <num_updates>` first"
@@ -206,7 +202,7 @@ fn bench(folder: &str, cache: usize, parallelism: InitParallelism) {
         return;
     }
     println!(
-        "init_scale (any::ordered::fixed::p3::mmr) {folder} cache={cache} parallelism={parallelism:?} region={region} time={elapsed:?}"
+        "init_scale (any::ordered::fixed::p3::mmr) {folder} cache={cache} workers={workers:?} region={region} time={elapsed:?}"
     );
 }
 
@@ -218,26 +214,60 @@ fn destroy(folder: &str) {
     }
 }
 
-/// Time a single `init` of the database at `cfg`'s folder with the given cache size and worker count,
-/// returning the elapsed time and the replay-region size (`0` if the database is empty/absent).
+/// Time a single `init` of the database at `cfg`'s folder with the given cache size and worker count
+/// (`None` derives the count from the strategy), returning the elapsed time and the replay-region
+/// size (`0` if the database is empty/absent).
 fn time_init(
     cfg: &Config,
     cache_size: Option<NonZeroUsize>,
-    parallelism: InitParallelism,
+    workers: Option<usize>,
 ) -> (Duration, u64) {
     Runner::new(cfg.clone()).start(|ctx| async move {
         let mut config = any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE);
         config.init_cache_size = cache_size;
-        config.init_parallelism = parallelism;
-        let start = Instant::now();
-        let db = AnyOFixP3Db::<Mmr>::init(ctx.child("storage"), config)
-            .await
-            .unwrap();
-        let elapsed = start.elapsed();
-        let end: u64 = *db.bounds().end;
-        let floor: u64 = *db.inactivity_floor_loc().await;
-        (elapsed, end.saturating_sub(floor))
+        match workers {
+            None => timed_reopen(&ctx, config).await,
+            Some(workers) => timed_reopen(&ctx, pin_workers(config, workers)).await,
+        }
     })
+}
+
+/// Rewrap `cfg`'s strategy in a [Manual] hint of `workers` so the snapshot build derives exactly
+/// `workers` workers (a hint of one builds serially), without touching the underlying thread pool.
+fn pin_workers(
+    cfg: FixedConfig<EightCap, Rayon>,
+    workers: usize,
+) -> FixedConfig<EightCap, Manual<Rayon>> {
+    let mc = cfg.merkle_config;
+    FixedConfig {
+        merkle_config: commonware_storage::merkle::full::Config {
+            journal_partition: mc.journal_partition,
+            metadata_partition: mc.metadata_partition,
+            items_per_blob: mc.items_per_blob,
+            write_buffer: mc.write_buffer,
+            strategy: Manual::new(mc.strategy, NZUsize!(workers.max(1))),
+            page_cache: mc.page_cache,
+        },
+        journal_config: cfg.journal_config,
+        translator: cfg.translator,
+        init_cache_size: cfg.init_cache_size,
+    }
+}
+
+/// Reopen the P=3 db with `config`, timing the init. Returns the elapsed time and the replay-region
+/// size.
+async fn timed_reopen<S: Strategy>(
+    ctx: &Context,
+    config: FixedConfig<EightCap, S>,
+) -> (Duration, u64) {
+    let start = Instant::now();
+    let db = AnyOFixP3Db::<Mmr, S>::init(ctx.child("storage"), config)
+        .await
+        .unwrap();
+    let elapsed = start.elapsed();
+    let end: u64 = *db.bounds().end;
+    let floor: u64 = *db.inactivity_floor_loc().await;
+    (elapsed, end.saturating_sub(floor))
 }
 
 /// Whether `folder` exists and contains any entries (used to avoid silently appending to an existing

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -22,10 +22,7 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{self, full},
-    qmdb::{
-        any::traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
-        InitParallelism,
-    },
+    qmdb::any::traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
     translator::EightCap,
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
@@ -328,7 +325,6 @@ fn any_fix_cfg(
 ) -> commonware_storage::qmdb::any::FixedConfig<EightCap, Rayon> {
     let pc = CacheRef::from_pooler(ctx, PAGE_SIZE, cache_size);
     commonware_storage::qmdb::any::FixedConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         translator: EightCap,
@@ -342,7 +338,6 @@ fn any_var_cfg(
 ) -> commonware_storage::qmdb::any::VariableConfig<EightCap, ((), ()), Rayon> {
     let pc = CacheRef::from_pooler(ctx, PAGE_SIZE, cache_size);
     commonware_storage::qmdb::any::VariableConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         translator: EightCap,
@@ -356,7 +351,6 @@ fn cur_fix_cfg(
 ) -> commonware_storage::qmdb::current::FixedConfig<EightCap, Rayon> {
     let pc = CacheRef::from_pooler(ctx, PAGE_SIZE, cache_size);
     commonware_storage::qmdb::current::FixedConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: fix_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
@@ -371,7 +365,6 @@ fn cur_var_cfg(
 ) -> commonware_storage::qmdb::current::VariableConfig<EightCap, ((), ()), Rayon> {
     let pc = CacheRef::from_pooler(ctx, PAGE_SIZE, cache_size);
     commonware_storage::qmdb::current::VariableConfig {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_cfg(ctx, pc.clone()),
         journal_config: var_log_cfg(pc),
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -15,7 +15,7 @@ use crate::{
             self,
             traits::{DbAny, UnmerkleizedBatch as _},
         },
-        current, immutable, keyless, InitParallelism,
+        current, immutable, keyless,
     },
     translator::{OneCap, TwoCap},
 };
@@ -184,7 +184,6 @@ fn any_fixed_config(
 ) -> any::FixedConfig<OneCap, Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     any::Config {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
@@ -198,7 +197,6 @@ fn any_variable_config(
 ) -> any::VariableConfig<OneCap, ((), ()), Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     any::Config {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
@@ -212,7 +210,6 @@ fn current_fixed_config(
 ) -> current::FixedConfig<OneCap, Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     current::Config {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: fixed_log_config(suffix, pc),
         grafted_metadata_partition: format!("{suffix}-graft"),
@@ -227,7 +224,6 @@ fn current_variable_config(
 ) -> current::VariableConfig<OneCap, ((), ()), Sequential> {
     let pc = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
     current::Config {
-        init_parallelism: InitParallelism::Serial,
         merkle_config: merkle_config(suffix, &pc),
         journal_config: variable_log_config(suffix, pc, ((), ())),
         grafted_metadata_partition: format!("{suffix}-graft"),

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -330,7 +330,7 @@ use crate::{
         authenticated::Inner,
         contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     },
-    merkle::{self, full::Config as MerkleConfig, Location},
+    merkle::{self, full::Config as MerkleConfig},
     qmdb::{
         any::{
             self,
@@ -347,7 +347,6 @@ use commonware_codec::{CodecShared, FixedSize};
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use commonware_utils::bitmap::Prunable as BitMap;
 use core::num::NonZeroUsize;
 use std::sync::Arc;
@@ -381,10 +380,6 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
-
-    /// How the ordered-partitioned snapshot build parallelizes during init. Note that only certain
-    /// index types (such as the ordered-partitioned index) support parallel construction.
-    pub init_parallelism: super::InitParallelism,
 }
 
 impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S> {
@@ -394,7 +389,6 @@ impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S>
             journal_config: cfg.journal_config,
             translator: cfg.translator,
             init_cache_size: cfg.init_cache_size,
-            init_parallelism: cfg.init_parallelism,
         }
     }
 }
@@ -413,15 +407,14 @@ pub(super) async fn init<F, E, U, H, T, I, J, const N: usize, S>(
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where
     F: merkle::Graftable,
-    E: Context + Spawner + 'static,
+    E: Context,
     U: Update + Send + Sync,
     H: Hasher,
     T: Translator,
-    I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
-    J: Inner<E, Item = Operation<F, U>>,
+    I: IndexFactory<T> + crate::qmdb::SnapshotBuild<F>,
+    J: Inner<E, Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
-    crate::journal::authenticated::Journal<F, E, J, H, S>: Send + Sync + 'static,
 {
     // TODO: Re-evaluate assertion placement after `generic_const_exprs` is stable.
     const {
@@ -523,11 +516,11 @@ pub mod tests {
                 traits::{DbAny, MerkleizedBatch as _, UnmerkleizedBatch as _},
             },
             store::tests::{TestKey, TestValue},
-            verify_proof, InitParallelism,
+            verify_proof,
         },
         translator::Translator,
     };
-    use commonware_parallel::Sequential;
+    use commonware_parallel::{Sequential, Strategy};
     use commonware_runtime::{
         buffer::paged::CacheRef,
         deterministic::{self, Context},
@@ -557,15 +550,22 @@ pub mod tests {
         partition_prefix: &str,
         pooler: &impl BufferPooler,
     ) -> FixedConfig<T, Sequential> {
+        fixed_config_with_strategy(partition_prefix, pooler, Sequential)
+    }
+
+    pub(crate) fn fixed_config_with_strategy<T: Translator + Default, S: Strategy>(
+        partition_prefix: &str,
+        pooler: &impl BufferPooler,
+        strategy: S,
+    ) -> FixedConfig<T, S> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         FixedConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
                 items_per_blob: NZU64!(11),
                 write_buffer: NZUsize!(1024),
-                strategy: Sequential,
+                strategy,
                 page_cache: page_cache.clone(),
             },
             journal_config: FConfig {
@@ -587,7 +587,6 @@ pub mod tests {
     ) -> VariableConfig<T, ((), ()), Sequential> {
         let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE);
         VariableConfig {
-            init_parallelism: InitParallelism::Serial,
             merkle_config: MerkleConfig {
                 journal_partition: format!("{partition_prefix}-journal-partition"),
                 metadata_partition: format!("{partition_prefix}-metadata-partition"),
@@ -1389,7 +1388,6 @@ pub mod tests {
         executor.start(|context| async move {
             let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
             let cfg = VariableConfig {
-                init_parallelism: InitParallelism::Serial,
                 merkle_config: MerkleConfig {
                     journal_partition: "forged-exclusion-journal".to_string(),
                     metadata_partition: "forged-exclusion-metadata".to_string(),

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
@@ -39,7 +38,7 @@ pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
 
 impl<
         F: Graftable,
-        E: Context + Spawner + 'static,
+        E: Context,
         K: Array,
         V: FixedValue,
         H: Hasher,
@@ -82,7 +81,7 @@ pub mod partitioned {
 
     impl<
             F: Graftable,
-            E: Context + Spawner + 'static,
+            E: Context,
             K: Array,
             V: FixedValue,
             H: Hasher,
@@ -93,7 +92,8 @@ pub mod partitioned {
         > Db<F, E, K, V, H, T, P, N, S>
     {
         /// Initializes a [Db] authenticated database from the given `config`.
-        /// The configured [`Strategy`] is used to parallelize merkleization.
+        /// The configured [`Strategy`] is used to parallelize merkleization and the snapshot
+        /// build during init.
         pub async fn init(context: E, config: Config<T, S>) -> Result<Self, Error<F>> {
             crate::qmdb::current::init(context, config).await
         }
@@ -106,30 +106,26 @@ pub mod test {
     use crate::{
         mmr,
         qmdb::{
-            current::{ordered::tests as shared, tests::fixed_config},
+            current::{
+                ordered::tests as shared,
+                tests::{fixed_config, fixed_config_with_strategy},
+            },
             Error,
         },
         translator::OneCap,
     };
     use commonware_cryptography::{sha256::Digest, Sha256};
     use commonware_macros::test_traced;
+    use commonware_parallel::{Manual, Sequential};
     use commonware_runtime::{deterministic, Runner as _, Supervisor as _};
     use commonware_utils::{
         bitmap::{Prunable as BitMap, Readable as _},
-        NZU64,
+        NZUsize, NZU64,
     };
 
     /// A type alias for the concrete [Db] type used in these unit tests.
-    type CurrentTest = Db<
-        mmr::Family,
-        deterministic::Context,
-        Digest,
-        Digest,
-        Sha256,
-        OneCap,
-        32,
-        commonware_parallel::Sequential,
-    >;
+    type CurrentTest =
+        Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, OneCap, 32, Sequential>;
 
     /// Return an [Db] database initialized with a fixed config.
     async fn open_db(context: deterministic::Context, partition_prefix: String) -> CurrentTest {
@@ -208,16 +204,19 @@ pub mod test {
     }
 
     /// Build a `P`-partitioned current db with churny ops across two commits (so the second commit's
-    /// updates and deletes inactivate locations from the first), then assert that reopening it at a
-    /// range of worker counts all reconstruct the identical root. Unlike the `any` equivalence tests,
-    /// the current root commits to the activity bitmap, so this exercises the parallel build's bitmap
-    /// reconstruction (`for_each_value` + last-commit), not just the snapshot index and MMR.
+    /// updates and deletes inactivate locations from the first), prune it, then assert that
+    /// reopening it at a range of worker counts reconstructs the identical root and key-value
+    /// state. Unlike the `any` equivalence tests, the current root commits to the activity bitmap,
+    /// so this exercises the parallel build's bitmap reconstruction (`for_each_value` +
+    /// last-commit) over a pruned prefix, not just the snapshot index and MMR. The build derives
+    /// its worker count from the configured strategy's parallelism hint, so each reopen pins the
+    /// count with a [Manual] strategy of hint `workers` (a hint of one builds serially).
     async fn check_current_parallel_init_equivalence<const P: usize>(
         context: deterministic::Context,
         partition: &'static str,
-        parallelisms: &[usize],
+        worker_counts: &[usize],
     ) {
-        type PartDb<const P: usize> = partitioned::Db<
+        type PartDb<const P: usize, S> = partitioned::Db<
             mmr::Family,
             deterministic::Context,
             Digest,
@@ -226,11 +225,22 @@ pub mod test {
             OneCap,
             P,
             32,
-            commonware_parallel::Sequential,
+            S,
         >;
 
+        /// The value each key holds after the two commits below.
+        fn expected_value(i: u64) -> Option<Digest> {
+            if i % 7 == 1 {
+                None
+            } else if i.is_multiple_of(3) {
+                Some(Sha256::hash(&((i + 1) * 11).to_be_bytes()))
+            } else {
+                Some(Sha256::hash(&(i * 7).to_be_bytes()))
+            }
+        }
+
         let cfg = fixed_config::<OneCap>(partition, &context);
-        let mut db = PartDb::<P>::init(context.child("populate"), cfg)
+        let mut db = PartDb::<P, Sequential>::init(context.child("populate"), cfg)
             .await
             .unwrap();
 
@@ -259,28 +269,38 @@ pub mod test {
         let merkleized = batch.merkleize(&db, None).await.unwrap();
         db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
+
+        // Prune so the reopens rebuild the grafted root over a bitmap with a pruned prefix.
+        db.prune(db.sync_boundary()).await.unwrap();
         db.sync().await.unwrap();
         let root = db.root();
         drop(db);
 
-        // Reopen at each worker count; all rebuild (snapshot + bitmap) from the same log and must match.
-        for &workers in parallelisms {
-            let mut cfg = fixed_config::<OneCap>(partition, &context);
-            cfg.init_parallelism = match workers {
-                0 => crate::qmdb::InitParallelism::Serial,
-                n => {
-                    crate::qmdb::InitParallelism::Workers(core::num::NonZeroUsize::new(n).unwrap())
-                }
-            };
-            let ctx = context
-                .child("reopen")
-                .with_attribute("parallelism", workers);
-            let db = PartDb::<P>::init(ctx, cfg).await.unwrap();
+        // Reopen at each worker count. All rebuild (snapshot + bitmap) from the same log and must
+        // match the original root and serve the expected value for every key.
+        for &workers in worker_counts {
+            let cfg = fixed_config_with_strategy::<OneCap, _>(
+                partition,
+                &context,
+                Manual::new(Sequential, NZUsize!(workers.max(1))),
+            );
+            let ctx = context.child("reopen").with_attribute("workers", workers);
+            let db = PartDb::<P, Manual<Sequential>>::init(ctx, cfg)
+                .await
+                .unwrap();
             assert_eq!(
                 db.root(),
                 root,
-                "current root mismatch at P={P} init_parallelism={workers}"
+                "current root mismatch at P={P} workers={workers}"
             );
+            for i in 0u64..2000 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                assert_eq!(
+                    db.get(&k).await.unwrap(),
+                    expected_value(i),
+                    "value mismatch for key {i}"
+                );
+            }
             drop(db);
         }
     }
@@ -291,7 +311,7 @@ pub mod test {
             check_current_parallel_init_equivalence::<1>(
                 context,
                 "current_parallel_equiv_p1",
-                &[0, 1, 2, 4],
+                &[0, 2, 4],
             )
             .await;
         });
@@ -303,14 +323,14 @@ pub mod test {
             check_current_parallel_init_equivalence::<2>(
                 context,
                 "current_parallel_equiv_p2",
-                &[0, 1, 2, 4],
+                &[0, 2, 4],
             )
             .await;
         });
     }
 
     /// P=3 allocates `2^24` partition slots per index, so it is too memory-heavy for the default
-    /// suite; run explicitly with `--ignored` (and ideally `--release`). Only serial and one
+    /// suite. Run it explicitly with `--ignored` (and ideally `--release`). Only serial and one
     /// offset-parallel reopen are checked.
     #[test_traced("WARN")]
     #[ignore]

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -23,7 +23,6 @@ use crate::{
 use commonware_codec::{Codec, Read};
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 
 pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
     F,
@@ -39,7 +38,7 @@ pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
 
 impl<
         F: Graftable,
-        E: Context + Spawner + 'static,
+        E: Context,
         K: Key,
         V: VariableValue,
         H: Hasher,
@@ -87,7 +86,7 @@ pub mod partitioned {
 
     impl<
             F: Graftable,
-            E: Context + Spawner + 'static,
+            E: Context,
             K: Key,
             V: VariableValue,
             H: Hasher,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -70,7 +70,6 @@ use crate::{
 use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use commonware_utils::{bitmap::Prunable as BitMap, channel::oneshot, range::NonEmptyRange, Array};
 use core::num::NonZeroUsize;
 use std::sync::Arc;
@@ -108,15 +107,14 @@ async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, qmdb::Error<F>>
 where
     F: Graftable,
-    E: Context + Spawner + 'static,
+    E: Context,
     U: Update + Send + Sync + 'static,
-    I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
+    I: IndexFactory<T> + crate::qmdb::SnapshotBuild<F>,
     H: Hasher,
     T: Translator,
-    J: Mutable<Item = Operation<F, U>>,
+    J: Mutable<Item = Operation<F, U>> + 'static,
     S: Strategy,
     Operation<F, U>: Codec + Committable + CodecShared,
-    authenticated::Journal<F, E, J, H, S>: Send + Sync + 'static,
 {
     // Build authenticated log.
     let merkle = Merkle::<F, _, _, S>::init_sync(
@@ -152,14 +150,12 @@ where
     // during replay.
     let snapshot_context = context.child("any_snapshot");
     let any_metrics = AnyMetrics::new(context.child("any"));
-    // State-sync rebuilds derive the worker count from the runtime (`Auto`) for the snapshot build.
     let any: AnyDb<F, E, J, I, H, U, N, S> = AnyDb::init_from_log(
         snapshot_context,
         index,
         log,
         Some(bitmap),
         cache_size,
-        crate::qmdb::InitParallelism::Auto,
         any_metrics,
     )
     .await?;
@@ -252,7 +248,7 @@ macro_rules! impl_current_sync_database {
         impl<F, E, K, V, H, T, const N: usize, S> Database for $db<F, E, K, V, H, T, N, S>
         where
             F: Graftable,
-            E: Context + Spawner + 'static,
+            E: Context,
             K: $key_bound,
             V: $value_bound + 'static,
             H: Hasher,

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -21,7 +21,6 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 /// A specialization of [super::db::Db] for unordered key spaces and fixed-size values.
@@ -39,7 +38,7 @@ pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
 
 impl<
         F: Graftable,
-        E: Context + Spawner + 'static,
+        E: Context,
         K: Array,
         V: FixedValue,
         H: Hasher,
@@ -85,7 +84,7 @@ pub mod partitioned {
 
     impl<
             F: Graftable,
-            E: Context + Spawner + 'static,
+            E: Context,
             K: Array,
             V: FixedValue,
             H: Hasher,

--- a/storage/src/qmdb/current/unordered/variable.rs
+++ b/storage/src/qmdb/current/unordered/variable.rs
@@ -22,7 +22,6 @@ use crate::{
 use commonware_codec::Read;
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::Spawner;
 use commonware_utils::Array;
 
 pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
@@ -39,7 +38,7 @@ pub type Db<F, E, K, V, H, T, const N: usize, S> = super::db::Db<
 
 impl<
         F: Graftable,
-        E: Context + Spawner + 'static,
+        E: Context,
         K: Array,
         V: VariableValue,
         H: Hasher,
@@ -87,7 +86,7 @@ pub mod partitioned {
 
     impl<
             F: Graftable,
-            E: Context + Spawner + 'static,
+            E: Context,
             K: Array,
             V: VariableValue,
             H: Hasher,

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::{Clock, Metrics, Storage};
 use commonware_utils::Array;
 
 /// Type alias for a fixed-size operation.
@@ -41,7 +40,7 @@ pub type CompactConfig<S> = super::CompactConfig<(), S>;
 
 impl<
         F: Family,
-        E: Storage + Clock + Metrics,
+        E: crate::Context,
         K: Array,
         V: FixedValue,
         H: Hasher,
@@ -64,7 +63,7 @@ impl<
     }
 }
 
-impl<F: Family, E: Storage + Clock + Metrics, K: Array, V: FixedValue, H: Hasher, S: Strategy>
+impl<F: Family, E: crate::Context, K: Array, V: FixedValue, H: Hasher, S: Strategy>
     CompactDb<F, E, K, V, H, S>
 {
     /// Returns a [CompactDb] initialized from `cfg`.

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -19,7 +19,6 @@ use crate::{
 use commonware_codec::Read;
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::{Clock, Metrics, Storage};
 
 /// Type alias for a variable-size operation.
 pub type Operation<F, K, V> = BaseOperation<F, K, VariableEncoding<V>>;
@@ -42,7 +41,7 @@ pub type CompactConfig<C, S> = super::CompactConfig<C, S>;
 
 impl<
         F: Family,
-        E: Storage + Clock + Metrics,
+        E: crate::Context,
         K: Key,
         V: VariableValue,
         H: Hasher,
@@ -70,7 +69,7 @@ impl<
 
 impl<
         F: Family,
-        E: Storage + Clock + Metrics,
+        E: crate::Context,
         K: Key,
         V: VariableValue,
         H: Hasher,

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::{Clock, Metrics, Storage};
 
 /// Keyless operation for fixed-size values.
 pub type Operation<F, V> = BaseOperation<F, FixedEncoding<V>>;
@@ -38,9 +37,7 @@ pub type Config<S> = super::Config<JournalConfig, S>;
 /// Configuration for a fixed-size [keyless](super) compact db.
 pub type CompactConfig<S> = super::CompactConfig<(), S>;
 
-impl<F: Family, E: Storage + Clock + Metrics, V: FixedValue, H: Hasher, S: Strategy>
-    Db<F, E, V, H, S>
-{
+impl<F: Family, E: crate::Context, V: FixedValue, H: Hasher, S: Strategy> Db<F, E, V, H, S> {
     /// Returns a [Db] initialized from `cfg`. Any uncommitted operations will be
     /// discarded and the state of the db will be as of the last committed operation.
     pub async fn init(context: E, cfg: Config<S>) -> Result<Self, Error<F>> {
@@ -56,9 +53,7 @@ impl<F: Family, E: Storage + Clock + Metrics, V: FixedValue, H: Hasher, S: Strat
     }
 }
 
-impl<F: Family, E: Storage + Clock + Metrics, V: FixedValue, H: Hasher, S: Strategy>
-    CompactDb<F, E, V, H, S>
-{
+impl<F: Family, E: crate::Context, V: FixedValue, H: Hasher, S: Strategy> CompactDb<F, E, V, H, S> {
     /// Returns a [CompactDb] initialized from `cfg`.
     pub async fn init(context: E, cfg: CompactConfig<S>) -> Result<Self, Error<F>> {
         let merkle = crate::merkle::compact::Merkle::new(cfg.strategy);
@@ -77,7 +72,8 @@ mod test {
     use commonware_macros::{boxed, test_traced};
     use commonware_parallel::{Rayon, Sequential, Strategy};
     use commonware_runtime::{
-        buffer::paged::CacheRef, deterministic, BufferPooler, Runner as _, Supervisor as _,
+        buffer::paged::CacheRef, deterministic, BufferPooler, Metrics as _, Runner as _,
+        Supervisor as _,
     };
     use commonware_utils::{NZUsize, NZU16, NZU64};
     use std::num::{NonZeroU16, NonZeroUsize};

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -18,7 +18,6 @@ use crate::{
 use commonware_codec::Read;
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::{Clock, Metrics, Storage};
 
 /// Keyless operation for variable-length values.
 pub type Operation<F, V> = BaseOperation<F, VariableEncoding<V>>;
@@ -39,9 +38,7 @@ pub type Config<C, S> = super::Config<JournalConfig<C>, S>;
 /// Configuration for a variable-size [keyless](super) compact db.
 pub type CompactConfig<C, S> = super::CompactConfig<C, S>;
 
-impl<F: Family, E: Storage + Clock + Metrics, V: VariableValue, H: Hasher, S: Strategy>
-    Db<F, E, V, H, S>
-{
+impl<F: Family, E: crate::Context, V: VariableValue, H: Hasher, S: Strategy> Db<F, E, V, H, S> {
     /// Returns a [Db] initialized from `cfg`. Any uncommitted operations will be
     /// discarded and the state of the db will be as of the last committed operation.
     pub async fn init(
@@ -62,7 +59,7 @@ impl<F: Family, E: Storage + Clock + Metrics, V: VariableValue, H: Hasher, S: St
 
 impl<
         F: Family,
-        E: Storage + Clock + Metrics,
+        E: crate::Context,
         V: VariableValue,
         H: Hasher,
         C: Clone + Send + Sync + 'static,

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -50,15 +50,17 @@ use crate::{
     merkle::{hasher::Standard as StandardHasher, Bagging, Family, Location},
     qmdb::operation::Operation,
     translator::Translator,
-    Context,
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use commonware_runtime::Spawner;
 use commonware_utils::{bitmap::BitMap, cache::Clock, channel::mpsc, NZUsize};
 use core::num::NonZeroUsize;
-use futures::{future::join_all, pin_mut, StreamExt as _};
-use std::{pin::Pin, sync::Arc};
+use futures::{
+    future::{join_all, BoxFuture},
+    pin_mut, StreamExt as _,
+};
+use std::sync::Arc;
 use thiserror::Error;
 
 pub mod any;
@@ -400,13 +402,16 @@ const SNAPSHOT_ROUTE_BATCH: usize = 4096;
 /// the main replay from running arbitrarily far ahead of a slow worker.
 const SNAPSHOT_CHANNEL_DEPTH: usize = 4;
 
+/// A batch of keyed operations routed to a snapshot-build worker: each entry is the op's key, its
+/// location, and whether it is a delete.
+type RoutedBatch<K> = Vec<(K, u64, bool)>;
+
 /// Build one parallel-init worker's partial snapshot: apply the routed operations (streamed in log
 /// order over `rx`) to `index`, resolving translated-key collisions with the worker's own log
 /// `reader` and `(location -> key)` cache. Returns the populated worker index.
-#[allow(clippy::type_complexity)]
 async fn build_snapshot_worker<F, C, T, const P: usize>(
     log: Arc<C>,
-    mut rx: mpsc::Receiver<Vec<(<C::Item as Operation<F>>::Key, u64, bool)>>,
+    mut rx: mpsc::Receiver<RoutedBatch<<C::Item as Operation<F>>::Key>>,
     mut index: crate::index::partitioned::ordered::Index<T, Location<F>, P>,
     cache_size: Option<NonZeroUsize>,
 ) -> Result<crate::index::partitioned::ordered::Index<T, Location<F>, P>, Error<F>>
@@ -435,60 +440,37 @@ where
     Ok(index)
 }
 
-/// How `init` builds the snapshot index, for index types that support parallel construction
-/// (currently only the ordered partitioned index; every other index type builds serially regardless).
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum InitParallelism {
-    /// Build serially on the calling task (no worker tasks).
-    #[default]
-    Serial,
-    /// Build with this many worker tasks, plus the task that replays and routes the log. `Workers(1)`
-    /// still de-interleaves replay from the build onto a separate task.
-    Workers(NonZeroUsize),
-    /// Build with `strategy.parallelism_hint() - 1` worker tasks, reserving one core for the
-    /// replay/routing task. Falls back to a serial build when the hint leaves no spare core.
-    Auto,
-}
-
 /// Builds a database's snapshot index from the operations log.
 ///
-/// Generic over the `Index` type so each index controls how it builds: serial index types replay the
-/// log sequentially, while the ordered partitioned index builds its partitions in parallel.
+/// Generic over the `Index` type so each index controls how it builds: serially with the default
+/// method body, or split across parallel workers with an override.
 pub trait SnapshotBuild<F: Family>: Index<Value = Location<F>> + Sized + 'static {
     /// Replay `log` from `inactivity_floor_loc`, populating `self` and invoking `callback` once per
     /// replayed location, in location order. Each call carries an activity status to append and,
-    /// optionally, an earlier location whose status it clears; implementations may report per-op
-    /// transitions (a status that a later call clears) or pre-resolved final statuses (never clearing),
-    /// but the state after the last call is identical either way. Returns the number of active keys.
-    /// `parallelism` selects how index types that build in parallel split the work; extra workers have
-    /// diminishing returns once the replay/routing task becomes the bottleneck. `cache_size` bounds
-    /// each build's `(location -> key)` cache (`None` disables it).
-    #[allow(clippy::too_many_arguments)]
+    /// optionally, an earlier location whose status it clears. Implementations may report per-op
+    /// transitions (a status that a later call clears) or pre-resolved final statuses (never
+    /// clearing), but the state after the last call is identical either way. Returns the number of
+    /// active keys.
+    ///
+    /// Index types that build in parallel split the work across `strategy`'s parallelism hint
+    /// worth of workers (a hint of one builds serially, matching how [Strategy::run] dispatches).
+    /// Index types that build serially ignore it. `cache_size` bounds each build's
+    /// `(location -> key)` cache (`None` disables it).
     fn build_snapshot<'a, E, C, S, Fn>(
         &'a mut self,
-        context: E,
+        _context: E,
         inactivity_floor_loc: Location<F>,
         log: &'a Arc<C>,
-        strategy: &'a S,
-        parallelism: InitParallelism,
+        _strategy: S,
         cache_size: Option<NonZeroUsize>,
         callback: Fn,
-    ) -> Pin<Box<dyn core::future::Future<Output = Result<usize, Error<F>>> + Send + 'a>>
+    ) -> BoxFuture<'a, Result<usize, Error<F>>>
     where
-        E: Context + Spawner + 'static,
-        C: Contiguous<Item: Operation<F> + Send> + Send + Sync + 'static,
+        E: Spawner,
+        C: Contiguous<Item: Operation<F>> + 'static,
         S: Strategy,
         Fn: FnMut(bool, Option<Location<F>>) + Send + 'a,
     {
-        // This index type builds serially, so `parallelism` has no effect; warn on an explicit
-        // worker count rather than silently ignore it (`Auto` is best-effort and stays quiet).
-        if matches!(parallelism, InitParallelism::Workers(_)) {
-            tracing::warn!(
-                ?parallelism,
-                "init_parallelism configured but this index builds serially; ignoring"
-            );
-        }
-        let _ = (context, strategy);
         Box::pin(async move {
             build_snapshot_from_log(inactivity_floor_loc, &**log, self, cache_size, callback).await
         })
@@ -505,38 +487,26 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
 impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
     for crate::index::partitioned::ordered::Index<T, Location<F>, P>
 {
-    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     fn build_snapshot<'a, E, C, S, Fn>(
         &'a mut self,
         context: E,
         inactivity_floor_loc: Location<F>,
         log: &'a Arc<C>,
-        strategy: &'a S,
-        parallelism: InitParallelism,
+        strategy: S,
         cache_size: Option<NonZeroUsize>,
         mut callback: Fn,
-    ) -> Pin<Box<dyn core::future::Future<Output = Result<usize, Error<F>>> + Send + 'a>>
+    ) -> BoxFuture<'a, Result<usize, Error<F>>>
     where
-        E: Context + Spawner + 'static,
-        C: Contiguous<Item: Operation<F> + Send> + Send + Sync + 'static,
+        E: Spawner,
+        C: Contiguous<Item: Operation<F>> + 'static,
         S: Strategy,
         Fn: FnMut(bool, Option<Location<F>>) + Send + 'a,
     {
         Box::pin(async move {
-            let count = self.partition_count();
-            let workers = match parallelism {
-                InitParallelism::Serial => 0,
-                InitParallelism::Workers(n) => n.get().min(count),
-                // The replay/routing task occupies one core, so leave it one and spawn the rest.
-                InitParallelism::Auto => strategy
-                    .manual()
-                    .parallelism_hint()
-                    .saturating_sub(1)
-                    .min(count),
-            };
-
-            // Serial, or Auto where the hint left no spare core: build on this task.
-            if workers == 0 {
+            // A strategy without parallelism builds serially on this task, mirroring how
+            // `Strategy::run` dispatches serial bodies for such strategies.
+            let hint = strategy.manual().parallelism_hint();
+            if hint <= 1 {
                 return build_snapshot_from_log(
                     inactivity_floor_loc,
                     &**log,
@@ -547,12 +517,17 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
                 .await;
             }
 
+            // Split the build across `hint` workers (the same sizing every other hint consumer
+            // uses), fed by this task's replay/routing loop.
+            let count = self.partition_count();
+            let workers = hint.min(count);
+
             let floor = *inactivity_floor_loc;
             let range_size = count.div_ceil(workers);
 
             // `range_size` rounds up, so `range_size * workers` can exceed `count`, leaving trailing
             // ranges empty (and a naive `count - lo` would underflow). Reduce to the number of
-            // non-empty ranges; routing (`p / range_size`) then stays in `[0, workers)`.
+            // non-empty ranges so routing (`p / range_size`) stays in `[0, workers)`.
             let workers = count.div_ceil(range_size);
             let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
 
@@ -564,7 +539,7 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
                 senders.push(tx);
                 let log = log.clone();
 
-                // This worker owns the contiguous partition range [lo, lo + range_len); it allocates
+                // This worker owns the contiguous partition range [lo, lo + range_len). It allocates
                 // only that many slots, so per-worker memory is the range, not the full partition set.
                 let lo = w * range_size;
                 let range_len = range_size.min(count - lo);
@@ -585,8 +560,7 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
                 let last_commit = end.saturating_sub(1);
                 let stream = log.replay(floor, SNAPSHOT_READ_BUFFER_SIZE).await?;
                 pin_mut!(stream);
-                let mut batches: Vec<Vec<(<C::Item as Operation<F>>::Key, u64, bool)>> = (0
-                    ..workers)
+                let mut batches: Vec<RoutedBatch<_>> = (0..workers)
                     .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
                     .collect();
 
@@ -613,8 +587,8 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
                     }
                 }
 
-                // Flush remaining batches before the channels close (skip if a worker already died;
-                // the join surfaces its error).
+                // Flush remaining batches before the channels close (skip if a worker already
+                // died, since the join surfaces its error).
                 if !aborted {
                     for (w, batch) in batches.into_iter().enumerate() {
                         if !batch.is_empty() && senders[w].send(batch).await.is_err() {
@@ -630,15 +604,11 @@ impl<F: Family, T: Translator, const P: usize> SnapshotBuild<F>
 
             // Join workers and install each worker's partition range into self. Each worker carries
             // its own partition offset, so installation needs no range arguments.
-            let mut total_keys = 0i64;
             let mut total_items = 0i64;
             for handle in join_all(handles).await {
-                let mut worker_index = handle.expect("snapshot worker task failed")?;
-                let (keys, items) = self.install_range(&mut worker_index);
-                total_keys += keys;
-                total_items += items;
+                let mut worker_index = handle??;
+                total_items += self.install_range(&mut worker_index);
             }
-            self.set_metrics(total_keys, total_items);
 
             // Reconstruct the activity bitmap in location order: a location is active iff it is the
             // current location of an active key, or it is the last commit. This matches the serial


### PR DESCRIPTION
Related: #4121

A final review sweep of #4121 before merge, focused on API minimalness, trait-bound noise, and correctness. Every substantive change below was verified end-to-end (full workspace check, clippy, MSRV 1.91.1, stability checks, and the equivalence suite including the `#[ignore]`d P=3 tests in release).

## Bug fix: worker join no longer panics the runtime

`handle.expect("snapshot worker task failed")?` in the parallel build's join loop is now `handle??`. A supervision-tree abort (an ancestor task completing or aborted mid-init) resolves worker handles as `Err(Error::Closed)` rather than panicking. On multithreaded tokio the cascade can land while init is mid-poll in `join_all`, so the `expect` converted an orderly abort of one subtree into a whole-runtime panic (default `catch_panics = false` resume-unwinds at the root). The deterministic runtime is single-threaded and always short-circuits at init's own `Abortable` first, which is why no test could catch this. `qmdb::Error` already has `Runtime(#[from] ...)`, and the production precedent (`try_join_all` in journal `segmented/manager.rs`) returns the error.

## Derive init parallelism from the configured `Strategy`

`InitParallelism` (enum + `pub init_parallelism` Config field) is deleted. It had zero production consumers: all ~45 call sites set `Serial` (tests/fuzz/benches/examples, all `Sequential`, where derivation is behaviorally identical), and both state-sync paths ignored the field and hardcoded `Auto` — silently overriding a user's `Serial`. The repo idiom is to derive parallelism from the strategy at the point of use (`get_many_map`, batch resolution, ed25519 batching, reed_solomon striping), so init now does the same:

- `build_snapshot` takes the strategy (consumed by value, since the caller cloned it off the log anyway) instead of `strategy + parallelism` args.
- The partitioned-ordered impl splits the build across `parallelism_hint()` workers, using the hint directly like every other consumer (no reserved core: the operator's budget already accounts for other work). A hint of one builds serially, mirroring how `Strategy::run` dispatches serial bodies for strategies without parallelism.
- `Strategy::run` itself cannot host this dispatch: its arms are synchronous closures (both would need `&mut self` to build their futures), `Manual::run` delegates to the inner strategy's `run` (so a manually-hinted `Sequential` would never parallelize), and policy-backed `Rayon::run` uses per-call-site adaptive probing that is meaningless for a once-per-process init.
- Tests pin exact worker counts by configuring `Manual::new(Sequential, hint)` as the db's strategy — through the same public `init` as production, with no test-only entry points. `init_scale` sweeps by rewrapping its Rayon pool in a `Manual` hint.

## Trait-bound cleanup

- `storage::Context` (the pre-existing convenience alias) absorbs `Spawner + 'static`, collapsing every `E: Context + Spawner + 'static` in qmdb back to `E: Context` and converting ~60 pre-existing raw `Storage + Clock + Metrics` spellings (glue, examples, consensus, fuzz) to the alias. The one workspace type affected is the `SyncFaultContext` test mock, which gains a small `Spawner` delegation.
- The `Journal<...>: Send + Sync + 'static` where-clauses reduce to `+ 'static` on the existing `J`/`C` bounds (`Contiguous` already carries `Send + Sync` with `Item: Send`).
- `build_snapshot` asks only for what it uses: `E: Spawner`, `C: Contiguous<Item: Operation<F>> + 'static`.
- The `Value = Location<F>` binding restated at init sites is dropped (implied by `SnapshotBuild`'s supertrait).
- `futures::future::BoxFuture` replaces the hand-rolled `Pin<Box<dyn Future + Send + 'a>>` (the boxed return itself is load-bearing: the opaque-return form was already reverted for MSRV in 5f5a3f1b7, and `#[boxed]` only heap-allocates an `async fn` body without changing the signature). A `RoutedBatch<K>` alias removes the `clippy::type_complexity` allows.

## Metrics simplification

- `spills` is a plain `Counter` (detached on build workers, folded at install exactly like `pruned`), deleting the `Option` special-casing. This also restores serial parity: the previous install-time count missed spill-then-despill events, so the metric's value depended on how init parallelized.
- `install_range` folds `keys`/`items` into the full index via `Gauge::inc_by` and returns just the worker's item count; `set_metrics` is deleted.

## Test strengthening

- Both equivalence tests now assert `get()` for every key after each reopen. The `any` root is a pure function of the log, so the previous root-only assertion could not detect a location filed under the wrong key.
- The `any` test adds a delete-then-reinsert commit; the `current` test prunes before its reopen sweep, pinning the grafted root over a pruned bitmap prefix.
- New coverage: a fresh single-commit db reopened with workers (keyless replay), a variable-value partitioned equivalence test, and derived-worker-count reopens via `Manual` hints in every sweep.

## Docs

`new_range` now names the exact offset-aware surface (`get_mut`/`get_mut_or_insert` and their cursors) instead of overclaiming all `Unordered` operations, and the new doc text is swept for style (sentence splits, comment placement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
