### PR TITLE
[actor] Actor mailbox + service

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,6 +95,11 @@ jobs:
       continue-on-error: true
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    - name: Publish actor-macros
+      run: cargo publish --manifest-path actor/macros/Cargo.toml
+      continue-on-error: true
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     - name: Publish actor
       run: cargo publish --manifest-path actor/Cargo.toml
       continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,7 @@ name = "commonware-actor"
 version = "2026.7.0"
 dependencies = [
  "cfg-if",
+ "commonware-actor-macros",
  "commonware-macros",
  "commonware-runtime",
  "commonware-utils",
@@ -1192,6 +1193,20 @@ dependencies = [
  "futures-util",
  "loom",
  "parking_lot",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "commonware-actor-macros"
+version = "2026.7.0"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ chrono = "0.4.45"
 clap = "4.6.1"
 colored = "3.1.1"
 commonware-actor = { version = "2026.7.0", path = "actor" }
+commonware-actor-macros = { version = "2026.7.0", path = "actor/macros" }
 commonware-bench = { version = "2026.7.0", path = "bench" }
 commonware-broadcast = { version = "2026.7.0", path = "broadcast" }
 commonware-codec = { version = "2026.7.0", path = "codec", default-features = false }
@@ -161,6 +162,7 @@ glob = "0.3.3"
 governor = "0.10.4"
 gungraun = "0.19.4"
 hashbrown = { version = "0.17.1", default-features = false, features = ["default-hasher"] }
+heck = "0.5.0"
 io-uring = "0.7.13"
 libc = "0.2.186"
 libfuzzer-sys = "0.4.13"
@@ -203,6 +205,7 @@ thiserror = { version = "2.0.18", default-features = false }
 tokio = "1.52.3"
 toml = "1.1.3"
 tracing = "0.1.44"
+tracing-core = "0.1.34"
 tracing-opentelemetry = "0.33.0"
 tracing-subscriber = "0.3.23"
 uuid = "1.23.5"

--- a/actor/Cargo.toml
+++ b/actor/Cargo.toml
@@ -15,17 +15,21 @@ workspace = true
 
 [dependencies]
 cfg-if.workspace = true
-commonware-macros.workspace = true
+commonware-actor-macros.workspace = true
+commonware-macros = { workspace = true, features = ["std"] }
 commonware-runtime.workspace = true
+commonware-utils = { workspace = true, features = ["std"] }
 crossbeam-queue.workspace = true
 futures-util.workspace = true
 loom = { workspace = true, features = ["futures"], optional = true }
 parking_lot.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-commonware-utils = { workspace = true, features = ["std"] }
 criterion.workspace = true
 futures.workspace = true
+tracing-core.workspace = true
 
 [features]
 loom = [ "dep:loom" ]
@@ -36,4 +40,9 @@ bench = false
 [[bench]]
 name = "mailbox"
 harness = false
-path = "src/benches/bench.rs"
+path = "src/benches/mailbox.rs"
+
+[[bench]]
+name = "throughput"
+harness = false
+path = "src/benches/throughput.rs"

--- a/actor/macros/Cargo.toml
+++ b/actor/macros/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "commonware-actor-macros"
+edition.workspace = true
+publish = true
+version.workspace = true
+license.workspace = true
+description = "Procedural macros for commonware-actor."
+readme = "README.md"
+homepage.workspace = true
+repository = "https://github.com/commonwarexyz/monorepo/tree/main/actor/macros"
+documentation = "https://docs.rs/commonware-actor-macros"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+heck.workspace = true
+proc-macro-crate.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn = { workspace = true, features = ["full", "parsing", "visit"] }
+
+[lints]
+workspace = true

--- a/actor/macros/README.md
+++ b/actor/macros/README.md
@@ -1,0 +1,9 @@
+# commonware-actor-macros
+
+[![Crates.io](https://img.shields.io/crates/v/commonware-actor-macros.svg)](https://crates.io/crates/commonware-actor-macros)
+[![Docs.rs](https://docs.rs/commonware-actor-macros/badge.svg)](https://docs.rs/commonware-actor-macros)
+
+Procedural macros for `commonware-actor`.
+
+This crate provides the `ingress!` macro used by `commonware-actor` to
+generate ingress enums, queue policies, and typed mailboxes.

--- a/actor/macros/src/ingress/emit.rs
+++ b/actor/macros/src/ingress/emit.rs
@@ -1,0 +1,452 @@
+use super::{
+    input::SpanRecord,
+    model::{
+        Branch, Feedback, Field, Ingress, MailboxKind, Message, Method, MethodKind, Policy,
+        PolicyMode, SpanField,
+    },
+};
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{ToTokens, quote};
+
+fn variant_fields(fields: &[Field]) -> Vec<TokenStream2> {
+    fields
+        .iter()
+        .map(|field| {
+            let attrs = &field.attrs;
+            let name = &field.name;
+            let ty = &field.ty;
+            quote! {
+                #(#attrs)*
+                #name: #ty,
+            }
+        })
+        .collect()
+}
+
+fn method_args(fields: &[Field]) -> Vec<TokenStream2> {
+    fields
+        .iter()
+        .map(|field| {
+            let name = &field.name;
+            let ty = &field.ty;
+            quote! {
+                #name: #ty
+            }
+        })
+        .collect()
+}
+
+fn method_values(fields: &[Field]) -> Vec<TokenStream2> {
+    fields
+        .iter()
+        .map(|field| {
+            let name = &field.name;
+            quote! {
+                #name,
+            }
+        })
+        .collect()
+}
+
+fn method_call_values(fields: &[Field]) -> Vec<TokenStream2> {
+    fields
+        .iter()
+        .map(|field| {
+            let name = &field.name;
+            quote!(#name,)
+        })
+        .collect()
+}
+
+/// Span field recordings for fields annotated with `#[span]`, referencing
+/// the generated method arguments by name.
+fn span_field_tokens(fields: &[SpanField]) -> Vec<TokenStream2> {
+    fields
+        .iter()
+        .map(|field| {
+            let name = &field.name;
+            match field.record {
+                SpanRecord::Display => quote!(#name = %#name,),
+                SpanRecord::Debug => quote!(#name = ?#name,),
+            }
+        })
+        .collect()
+}
+
+fn message_variant(message: &Message, actor: &TokenStream2) -> TokenStream2 {
+    let attrs = &message.attrs;
+    let name = &message.name;
+    let fields = variant_fields(&message.fields);
+
+    match &message.response {
+        Some(response) => quote! {
+            #(#attrs)*
+            #name {
+                #(#fields)*
+                response: #actor::oneshot::Sender<#response>,
+            },
+        },
+        None if message.is_unit() => quote! {
+            #(#attrs)*
+            #name,
+        },
+        None => quote! {
+            #(#attrs)*
+            #name { #(#fields)* },
+        },
+    }
+}
+
+fn response_closed_arm(message: &Message) -> TokenStream2 {
+    let name = &message.name;
+    match &message.response {
+        Some(_) => quote!(Self::#name { response, .. } => response.is_closed(),),
+        None if message.is_unit() => quote!(Self::#name => false,),
+        None => quote!(Self::#name { .. } => false,),
+    }
+}
+
+impl ToTokens for Branch {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let ingress = &self.name;
+        let generics = &self.generics;
+        let variants: Vec<_> = self
+            .messages
+            .iter()
+            .map(|message| message_variant(message, &self.actor))
+            .collect();
+        let closed_arms: Vec<_> = self.messages.iter().map(response_closed_arm).collect();
+        let (impl_generics, ty_generics, _) = generics.split_for_impl();
+
+        // Matching a reference to an uninhabited enum still requires an arm, so
+        // an empty enum matches on the dereferenced (uninhabited) place instead.
+        let closed_body = if variants.is_empty() {
+            quote!(match *self {})
+        } else {
+            quote! {
+                match self {
+                    #(#closed_arms)*
+                }
+            }
+        };
+
+        tokens.extend(quote! {
+            pub enum #ingress #generics {
+                #(#variants)*
+            }
+
+            impl #impl_generics #ingress #ty_generics {
+                #[doc(hidden)]
+                pub fn response_closed(&self) -> bool {
+                    #closed_body
+                }
+            }
+        });
+    }
+}
+
+impl ToTokens for Method {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let actor = &self.actor;
+        let ingress = &self.ingress;
+        let attrs = &self.attrs;
+        let variant = &self.variant;
+        let method = &self.name;
+        let method_internal = quote::format_ident!("{}_internal", method);
+        let visibility = if self.public { quote!(pub) } else { quote!() };
+        let dead_code = if self.public {
+            quote!()
+        } else {
+            quote!(#[allow(dead_code)])
+        };
+        let args = method_args(&self.fields);
+
+        match &self.kind {
+            MethodKind::Tell { feedback, message } => {
+                let span_name = &self.span_name;
+                let span_fields = span_field_tokens(&self.span_fields);
+                let values = method_values(&self.fields);
+                let message = if self.fields.is_empty() {
+                    quote!(#message::#variant)
+                } else {
+                    quote!(#message::#variant { #(#values)* })
+                };
+                let feedback = match feedback {
+                    Feedback::Reliable => quote!(#actor::Feedback),
+                    Feedback::Unreliable => quote!(#actor::Unreliable<#actor::Feedback>),
+                };
+
+                tokens.extend(quote! {
+                    #(#attrs)*
+                    #dead_code
+                    #[must_use = "caller must handle enqueue feedback"]
+                    #visibility fn #method_internal(&self #(, #args)*) -> #feedback {
+                        let __commonware_actor_current = #actor::tracing::Span::current();
+                        let __commonware_actor_span = #actor::tracing::debug_span!(
+                            parent: None::<#actor::tracing::span::Id>,
+                            #span_name,
+                            #(#span_fields)*
+                        );
+                        __commonware_actor_span.follows_from(__commonware_actor_current.id());
+                        self.0.enqueue(#ingress::ReadWrite {
+                            span: __commonware_actor_span,
+                            message: #message,
+                        })
+                    }
+                });
+            }
+            MethodKind::Request {
+                feedback,
+                route,
+                message,
+                response,
+                await_response,
+            } => {
+                let span_name = &self.span_name;
+                let span_fields = span_field_tokens(&self.span_fields);
+                let values = method_values(&self.fields);
+                let call_values = method_call_values(&self.fields);
+                let enqueue_method = quote::format_ident!("enqueue_{}_internal", method);
+                let feedback = match feedback {
+                    Feedback::Reliable => quote!(#actor::Feedback),
+                    Feedback::Unreliable => quote!(#actor::Unreliable<#actor::Feedback>),
+                };
+                let enqueue = quote! {
+                    let __commonware_actor_span = #actor::tracing::debug_span!(#span_name, #(#span_fields)*);
+                    let (__commonware_actor_response, __commonware_actor_receiver) =
+                        #actor::oneshot::channel::<#response>();
+                    let __commonware_actor_feedback = self.0.enqueue(#ingress::#route {
+                        span: __commonware_actor_span,
+                        message: #message::#variant {
+                            #(#values)*
+                            response: __commonware_actor_response,
+                        },
+                    });
+                    (__commonware_actor_feedback, __commonware_actor_receiver)
+                };
+
+                tokens.extend(quote! {
+                    #(#attrs)*
+                    #dead_code
+                    #[must_use = "caller must handle enqueue feedback and response receiver"]
+                    #visibility fn #enqueue_method(&self #(, #args)*) -> (#feedback, #actor::oneshot::Receiver<#response>) {
+                        #enqueue
+                    }
+                });
+
+                if *await_response {
+                    tokens.extend(quote! {
+                        #(#attrs)*
+                        #dead_code
+                        #visibility async fn #method_internal(&self #(, #args)*) -> Result<#response, #actor::ingress::Cancelled> {
+                            let (_, __commonware_actor_receiver) = self.#enqueue_method(#(#call_values)*);
+                            __commonware_actor_receiver
+                                .await
+                                .map_err(|_| #actor::ingress::Cancelled)
+                        }
+                    });
+                } else {
+                    tokens.extend(quote! {
+                        #(#attrs)*
+                        #dead_code
+                        #visibility fn #method_internal(&self #(, #args)*) -> #actor::oneshot::Receiver<#response> {
+                            let (_, __commonware_actor_receiver) = self.#enqueue_method(#(#call_values)*);
+                            __commonware_actor_receiver
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+impl ToTokens for Policy {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let actor = &self.actor;
+        let ingress = &self.names.ingress;
+        let overflow = &self.names.overflow;
+        let generics = &self.generics;
+        let (impl_generics, ty_generics, _) = generics.split_for_impl();
+
+        match self.mode {
+            PolicyMode::Custom => {}
+            PolicyMode::Reliable => {
+                tokens.extend(quote! {
+                    #[doc(hidden)]
+                    pub struct #overflow #generics (
+                        ::std::collections::VecDeque<#ingress #ty_generics>
+                    );
+
+                    impl #impl_generics ::core::default::Default for #overflow #ty_generics {
+                        fn default() -> Self {
+                            Self(::std::collections::VecDeque::new())
+                        }
+                    }
+
+                    impl #impl_generics #actor::mailbox::Overflow<#ingress #ty_generics>
+                        for #overflow #ty_generics
+                    {
+                        fn is_empty(&self) -> bool {
+                            self.0.is_empty()
+                        }
+
+                        fn drain<__Push>(&mut self, mut push: __Push)
+                        where
+                            __Push: FnMut(#ingress #ty_generics) -> Option<#ingress #ty_generics>,
+                        {
+                            while let Some(message) = self.0.pop_front() {
+                                if message.response_closed() {
+                                    continue;
+                                }
+                                if let Some(message) = push(message) {
+                                    self.0.push_front(message);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    impl #impl_generics #actor::mailbox::Policy for #ingress #ty_generics {
+                        type Overflow = #overflow #ty_generics;
+
+                        fn handle(overflow: &mut Self::Overflow, message: Self) {
+                            if !message.response_closed() {
+                                overflow.0.push_back(message);
+                            }
+                        }
+                    }
+                });
+            }
+            PolicyMode::Unreliable => {
+                tokens.extend(quote! {
+                    #[doc(hidden)]
+                    #[derive(Default)]
+                    pub struct #overflow;
+
+                    impl #impl_generics #actor::mailbox::Overflow<#ingress #ty_generics> for #overflow {
+                        fn is_empty(&self) -> bool {
+                            true
+                        }
+
+                        fn drain<__Push>(&mut self, _push: __Push)
+                        where
+                            __Push: FnMut(#ingress #ty_generics) -> Option<#ingress #ty_generics>,
+                        {
+                        }
+                    }
+
+                    impl #impl_generics #actor::mailbox::UnreliablePolicy for #ingress #ty_generics {
+                        type Overflow = #overflow;
+
+                        fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
+                            false
+                        }
+                    }
+                });
+            }
+        }
+    }
+}
+
+impl ToTokens for Ingress {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let actor = &self.actor;
+        let names = &self.names;
+        let mailbox = &names.mailbox;
+        let ingress = &names.ingress;
+        let read_only_ingress = &names.read_only_ingress;
+        let read_write_ingress = &names.read_write_ingress;
+        let generics = &self.generics;
+        let read_only = &self.read_only;
+        let read_write = &self.read_write;
+        let methods = &self.methods;
+        let policy = &self.policy;
+
+        let (impl_generics, ty_generics, _) = generics.split_for_impl();
+        let (_, ro_ty, _) = read_only.generics.split_for_impl();
+        let (_, rw_ty, _) = read_write.generics.split_for_impl();
+
+        let mailbox_inner_ty = match self.mailbox_kind {
+            MailboxKind::Reliable => {
+                quote!(#actor::ingress::Mailbox<#ingress #ty_generics>)
+            }
+            MailboxKind::Unreliable => {
+                quote!(#actor::ingress::UnreliableMailbox<#ingress #ty_generics>)
+            }
+        };
+
+        tokens.extend(quote! {
+            #read_only
+
+            #read_write
+
+            pub enum #ingress #generics {
+                ReadOnly {
+                    span: #actor::tracing::Span,
+                    message: #read_only_ingress #ro_ty,
+                },
+                ReadWrite {
+                    span: #actor::tracing::Span,
+                    message: #read_write_ingress #rw_ty,
+                },
+            }
+
+            impl #impl_generics #ingress #ty_generics {
+                #[doc(hidden)]
+                pub fn response_closed(&self) -> bool {
+                    match self {
+                        Self::ReadOnly { message, .. } => message.response_closed(),
+                        Self::ReadWrite { message, .. } => message.response_closed(),
+                    }
+                }
+            }
+
+            #policy
+
+            pub struct #mailbox #generics (#mailbox_inner_ty);
+
+            impl #impl_generics Clone for #mailbox #ty_generics {
+                fn clone(&self) -> Self {
+                    Self(self.0.clone())
+                }
+            }
+
+            impl #impl_generics ::core::fmt::Debug for #mailbox #ty_generics {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    f.write_str(stringify!(#mailbox))
+                }
+            }
+
+            impl #impl_generics ::core::convert::From<#mailbox_inner_ty> for #mailbox #ty_generics {
+                fn from(inner: #mailbox_inner_ty) -> Self {
+                    Self(inner)
+                }
+            }
+
+            impl #impl_generics #mailbox #ty_generics {
+                #(#methods)*
+            }
+
+            impl #impl_generics #actor::ingress::IntoEnvelope for #ingress #ty_generics {
+                type ReadOnlyMessage = #read_only_ingress #ro_ty;
+                type ReadWriteMessage = #read_write_ingress #rw_ty;
+
+                fn into_envelope(
+                    self,
+                ) -> (
+                    #actor::tracing::Span,
+                    #actor::ingress::Envelope<Self::ReadOnlyMessage, Self::ReadWriteMessage>,
+                ) {
+                    match self {
+                        Self::ReadOnly { span, message } => {
+                            (span, #actor::ingress::Envelope::ReadOnly(message))
+                        }
+                        Self::ReadWrite { span, message } => {
+                            (span, #actor::ingress::Envelope::ReadWrite(message))
+                        }
+                    }
+                }
+            }
+        });
+    }
+}

--- a/actor/macros/src/ingress/generics.rs
+++ b/actor/macros/src/ingress/generics.rs
@@ -1,0 +1,340 @@
+use super::input::{Field, Item, ItemKind};
+use std::collections::BTreeSet;
+use syn::{GenericParam, Generics, Result, Type, visit::Visit};
+
+/// A set of generic parameter names, partitioned by kind.
+///
+/// Used both for the full set of mailbox parameters and for the subset a
+/// branch's items actually reference.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct GenericSet {
+    type_params: BTreeSet<String>,
+    lifetime_params: BTreeSet<String>,
+    const_params: BTreeSet<String>,
+}
+
+impl GenericSet {
+    pub(crate) fn from_generics(generics: &Generics) -> Self {
+        let mut set = Self::default();
+        for param in &generics.params {
+            match param {
+                GenericParam::Type(param) => {
+                    set.type_params.insert(param.ident.to_string());
+                }
+                GenericParam::Lifetime(param) => {
+                    set.lifetime_params.insert(param.lifetime.ident.to_string());
+                }
+                GenericParam::Const(param) => {
+                    set.const_params.insert(param.ident.to_string());
+                }
+            }
+        }
+        set
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.type_params.extend(other.type_params);
+        self.lifetime_params.extend(other.lifetime_params);
+        self.const_params.extend(other.const_params);
+    }
+
+    fn merge_const_params(&mut self, other: Self) -> bool {
+        let before = self.const_params.len();
+        self.const_params.extend(other.const_params);
+        self.const_params.len() != before
+    }
+
+    fn contains(&self, param: &GenericParam) -> bool {
+        match param {
+            GenericParam::Type(param) => self.type_params.contains(&param.ident.to_string()),
+            GenericParam::Lifetime(param) => self
+                .lifetime_params
+                .contains(&param.lifetime.ident.to_string()),
+            GenericParam::Const(param) => self.const_params.contains(&param.ident.to_string()),
+        }
+    }
+
+    /// Names present in `self` but absent from `other`, formatted for display.
+    fn missing_from(&self, other: &Self) -> Vec<String> {
+        let mut missing = Vec::new();
+        missing.extend(self.type_params.difference(&other.type_params).cloned());
+        missing.extend(
+            self.lifetime_params
+                .difference(&other.lifetime_params)
+                .map(|name| format!("'{name}")),
+        );
+        missing.extend(self.const_params.difference(&other.const_params).cloned());
+        missing
+    }
+}
+
+struct TypeGenericUseCollector<'a> {
+    declared: &'a GenericSet,
+    found: GenericSet,
+}
+
+impl<'a> TypeGenericUseCollector<'a> {
+    fn new(declared: &'a GenericSet) -> Self {
+        Self {
+            declared,
+            found: GenericSet::default(),
+        }
+    }
+}
+
+impl Visit<'_> for TypeGenericUseCollector<'_> {
+    fn visit_type_path(&mut self, node: &syn::TypePath) {
+        if node.qself.is_none() && !node.path.segments.is_empty() {
+            let ident = node.path.segments[0].ident.to_string();
+            if self.declared.type_params.contains(&ident) {
+                self.found.type_params.insert(ident);
+            } else if node.path.segments.len() == 1 && self.declared.const_params.contains(&ident) {
+                self.found.const_params.insert(ident);
+            }
+        }
+
+        syn::visit::visit_type_path(self, node);
+    }
+
+    fn visit_lifetime(&mut self, node: &syn::Lifetime) {
+        let ident = node.ident.to_string();
+        if self.declared.lifetime_params.contains(&ident) {
+            self.found.lifetime_params.insert(ident);
+        }
+
+        syn::visit::visit_lifetime(self, node);
+    }
+
+    fn visit_expr_path(&mut self, node: &syn::ExprPath) {
+        if node.qself.is_none() && node.path.segments.len() == 1 {
+            let ident = node.path.segments[0].ident.to_string();
+            if self.declared.const_params.contains(&ident) {
+                self.found.const_params.insert(ident);
+            }
+        }
+
+        syn::visit::visit_expr_path(self, node);
+    }
+}
+
+fn collect_usage_from_type(ty: &Type, declared: &GenericSet) -> GenericSet {
+    let mut visitor = TypeGenericUseCollector::new(declared);
+    visitor.visit_type(ty);
+    visitor.found
+}
+
+fn collect_usage_from_fields(fields: &[Field], declared: &GenericSet) -> GenericSet {
+    let mut usage = GenericSet::default();
+    for field in fields {
+        usage.merge(collect_usage_from_type(&field.ty, declared));
+    }
+    usage
+}
+
+/// Mailbox parameters referenced by a generic parameter's own bounds.
+fn collect_usage_from_param_bounds(param: &GenericParam, declared: &GenericSet) -> GenericSet {
+    let mut visitor = TypeGenericUseCollector::new(declared);
+    match param {
+        GenericParam::Type(param) => {
+            for bound in &param.bounds {
+                visitor.visit_type_param_bound(bound);
+            }
+        }
+        GenericParam::Lifetime(param) => {
+            for bound in &param.bounds {
+                visitor.visit_lifetime(bound);
+            }
+        }
+        GenericParam::Const(param) => {
+            visitor.visit_type(&param.ty);
+        }
+    }
+    visitor.found
+}
+
+pub(crate) fn collect_readonly_ingress_usage(items: &[Item], declared: &GenericSet) -> GenericSet {
+    let mut usage = GenericSet::default();
+    for item in items {
+        match &item.kind {
+            ItemKind::Request {
+                response,
+                read_write: false,
+                ..
+            } => {
+                usage.merge(collect_usage_from_fields(&item.fields, declared));
+                usage.merge(collect_usage_from_type(response, declared));
+            }
+            ItemKind::Internal
+            | ItemKind::Tell
+            | ItemKind::Request {
+                read_write: true, ..
+            } => {}
+        }
+    }
+    usage
+}
+
+pub(crate) fn collect_read_write_ingress_usage(
+    items: &[Item],
+    declared: &GenericSet,
+) -> GenericSet {
+    let mut usage = GenericSet::default();
+    for item in items {
+        match &item.kind {
+            ItemKind::Internal | ItemKind::Tell => {
+                usage.merge(collect_usage_from_fields(&item.fields, declared));
+            }
+            ItemKind::Request {
+                response,
+                read_write: true,
+                ..
+            } => {
+                usage.merge(collect_usage_from_fields(&item.fields, declared));
+                usage.merge(collect_usage_from_type(response, declared));
+            }
+            ItemKind::Request {
+                read_write: false, ..
+            } => {}
+        }
+    }
+    usage
+}
+
+/// Retain const generics referenced by bounds on already-retained parameters.
+pub(crate) fn retain_const_bound_dependencies(
+    generics: &Generics,
+    usage: &mut GenericSet,
+    declared: &GenericSet,
+) {
+    loop {
+        let mut changed = false;
+        for param in &generics.params {
+            if !usage.contains(param) {
+                continue;
+            }
+            changed |= usage.merge_const_params(collect_usage_from_param_bounds(param, declared));
+        }
+        if !changed {
+            return;
+        }
+    }
+}
+
+/// Retain only the parameters whose name is in `usage`, preserving order,
+/// attributes, and bounds. Order preservation keeps lifetimes ahead of types
+/// and consts, so the filtered list stays valid.
+pub(crate) fn filter_generics(generics: &Generics, usage: &GenericSet) -> Generics {
+    let mut filtered = generics.clone();
+    filtered.params = filtered
+        .params
+        .into_iter()
+        .filter(|param| usage.contains(param))
+        .collect();
+    if filtered.params.is_empty() {
+        filtered.lt_token = None;
+        filtered.gt_token = None;
+    }
+    filtered.where_clause = None;
+    filtered
+}
+
+fn reject_generic_defaults(generics: &Generics) -> Result<()> {
+    for param in &generics.params {
+        let has_default = match param {
+            GenericParam::Type(param) => param.default.is_some(),
+            GenericParam::Const(param) => param.default.is_some(),
+            GenericParam::Lifetime(_) => false,
+        };
+        if has_default {
+            return Err(syn::Error::new_spanned(
+                param,
+                "defaults are not supported on ingress! generics",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn push_error(accumulator: &mut Option<syn::Error>, error: syn::Error) {
+    match accumulator {
+        Some(existing) => existing.combine(error),
+        None => *accumulator = Some(error),
+    }
+}
+
+fn param_name(param: &GenericParam) -> String {
+    match param {
+        GenericParam::Type(param) => param.ident.to_string(),
+        GenericParam::Lifetime(param) => format!("'{}", param.lifetime.ident),
+        GenericParam::Const(param) => param.ident.to_string(),
+    }
+}
+
+fn unused_param_error(param: &GenericParam) -> syn::Error {
+    let span = match param {
+        GenericParam::Type(param) => param.ident.span(),
+        GenericParam::Lifetime(param) => param.lifetime.ident.span(),
+        GenericParam::Const(param) => param.ident.span(),
+    };
+    syn::Error::new(
+        span,
+        format!(
+            "generic parameter `{}` is not used by any ingress item",
+            param_name(param)
+        ),
+    )
+}
+
+/// Reject mailbox generics that filtering cannot satisfy.
+///
+/// Two conditions are fatal:
+/// - A parameter used by no item. The top-level ingress enum and mailbox struct
+///   keep the full mailbox generics, so an unused parameter would otherwise
+///   surface as an opaque rustc error on generated code.
+/// - A retained parameter whose bounds reference a parameter the same branch
+///   drops. Filtering would then emit an enum that names a parameter it no
+///   longer declares, so the reference must be an error instead.
+pub(crate) fn validate_generics(
+    generics: &Generics,
+    declared: &GenericSet,
+    readonly_usage: &GenericSet,
+    read_write_usage: &GenericSet,
+) -> Result<()> {
+    reject_generic_defaults(generics)?;
+
+    let mut error = None;
+
+    let mut used = readonly_usage.clone();
+    used.merge(read_write_usage.clone());
+    for param in &generics.params {
+        if !used.contains(param) {
+            push_error(&mut error, unused_param_error(param));
+        }
+    }
+
+    for (label, usage) in [
+        ("read-only", readonly_usage),
+        ("read-write", read_write_usage),
+    ] {
+        for param in &generics.params {
+            if !usage.contains(param) {
+                continue;
+            }
+            let referenced = collect_usage_from_param_bounds(param, declared);
+            let name = param_name(param);
+            for missing in referenced.missing_from(usage) {
+                push_error(
+                    &mut error,
+                    syn::Error::new_spanned(
+                        param,
+                        format!(
+                            "{label} items use `{name}`, whose bounds reference `{missing}`, but no {label} item uses `{missing}`; use `{missing}` in a {label} item or remove it from `{name}`'s bounds"
+                        ),
+                    ),
+                );
+            }
+        }
+    }
+
+    error.map_or(Ok(()), Err)
+}

--- a/actor/macros/src/ingress/input.rs
+++ b/actor/macros/src/ingress/input.rs
@@ -1,0 +1,496 @@
+use proc_macro2::Span;
+use syn::{
+    Attribute, Generics, Ident, Result, Token, Type, braced,
+    parse::{Parse, ParseStream},
+};
+
+mod kw {
+    syn::custom_keyword!(ask);
+    syn::custom_keyword!(custom_policy);
+    syn::custom_keyword!(internal);
+    syn::custom_keyword!(read_write);
+    syn::custom_keyword!(subscribe);
+    syn::custom_keyword!(tell);
+    syn::custom_keyword!(unreliable);
+}
+
+pub(crate) enum ItemKind {
+    Internal,
+    Tell,
+    Request {
+        response: Box<Type>,
+        read_write: bool,
+        await_response: bool,
+    },
+}
+
+/// How a field annotated with `#[span]` is recorded on the enqueue span.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SpanRecord {
+    /// Record with the field's `Display` implementation (`#[span]`).
+    Display,
+    /// Record with the field's `Debug` implementation (`#[span(debug)]`).
+    Debug,
+}
+
+pub(crate) struct Field {
+    pub(crate) attrs: Vec<Attribute>,
+    pub(crate) name: Ident,
+    pub(crate) ty: Type,
+    pub(crate) span_record: Option<SpanRecord>,
+}
+
+pub(crate) struct Item {
+    pub(crate) attrs: Vec<Attribute>,
+    pub(crate) name: Ident,
+    pub(crate) fields: Vec<Field>,
+    pub(crate) public_method: bool,
+    pub(crate) kind: ItemKind,
+}
+
+pub(crate) struct Input {
+    pub(crate) unreliable: bool,
+    pub(crate) custom_policy: bool,
+    pub(crate) mailbox: Ident,
+    pub(crate) generics: Generics,
+    pub(crate) items: Vec<Item>,
+}
+
+impl Parse for Field {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut attrs = input.call(Attribute::parse_outer)?;
+        let span_record = extract_span_record(&mut attrs)?;
+        let name: Ident = input.parse()?;
+        input.parse::<Token![:]>()?;
+        let ty: Type = input.parse()?;
+        Ok(Self {
+            attrs,
+            name,
+            ty,
+            span_record,
+        })
+    }
+}
+
+/// Remove any `#[span]` / `#[span(debug)]` marker from `attrs` and return
+/// the requested recording mode. Remaining attributes pass through to the
+/// generated enum variant field.
+fn extract_span_record(attrs: &mut Vec<Attribute>) -> Result<Option<SpanRecord>> {
+    let mut record = None;
+    let mut kept = Vec::with_capacity(attrs.len());
+    for attr in attrs.drain(..) {
+        if !attr.path().is_ident("span") {
+            kept.push(attr);
+            continue;
+        }
+        if record.is_some() {
+            return Err(syn::Error::new_spanned(
+                &attr,
+                "duplicate `#[span]` attribute",
+            ));
+        }
+        record = Some(match &attr.meta {
+            syn::Meta::Path(_) => SpanRecord::Display,
+            syn::Meta::List(list) => {
+                let mode: Ident = list.parse_args()?;
+                if mode == "debug" {
+                    SpanRecord::Debug
+                } else if mode == "display" {
+                    SpanRecord::Display
+                } else {
+                    return Err(syn::Error::new(
+                        mode.span(),
+                        "expected `#[span]`, `#[span(display)]`, or `#[span(debug)]`",
+                    ));
+                }
+            }
+            syn::Meta::NameValue(_) => {
+                return Err(syn::Error::new_spanned(
+                    &attr,
+                    "expected `#[span]`, `#[span(display)]`, or `#[span(debug)]`",
+                ));
+            }
+        });
+    }
+    *attrs = kept;
+    Ok(record)
+}
+
+/// Parse the optional `unreliable` and `custom_policy` header flags.
+///
+/// The flags compose: `unreliable custom_policy,` selects an unreliable
+/// mailbox with a hand-written `UnreliablePolicy` implementation.
+fn parse_header_flags(input: ParseStream<'_>) -> Result<(bool, bool)> {
+    let unreliable = if input.peek(kw::unreliable) {
+        input.parse::<kw::unreliable>()?;
+        true
+    } else {
+        false
+    };
+
+    let custom_policy = if input.peek(kw::custom_policy) {
+        input.parse::<kw::custom_policy>()?;
+        true
+    } else {
+        false
+    };
+
+    if unreliable || custom_policy {
+        input.parse::<Token![,]>()?;
+    }
+
+    Ok((unreliable, custom_policy))
+}
+
+fn parse_fields(input: ParseStream<'_>) -> Result<Vec<Field>> {
+    if !input.peek(syn::token::Brace) {
+        return Ok(Vec::new());
+    }
+
+    let content;
+    braced!(content in input);
+    let fields: Vec<_> = content
+        .parse_terminated(Field::parse, Token![,])?
+        .into_iter()
+        .collect();
+    reject_reserved_fields(&fields)?;
+    Ok(fields)
+}
+
+fn reject_reserved_fields(fields: &[Field]) -> Result<()> {
+    for field in fields {
+        let name = field.name.to_string();
+        if name == "response" || name == "span" || name.starts_with("__commonware_actor") {
+            return Err(syn::Error::new(
+                field.name.span(),
+                format!("`{name}` is reserved for fields and bindings generated by ingress!"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_item(input: ParseStream<'_>) -> Result<Item> {
+    let attrs = input.call(Attribute::parse_outer)?;
+    let public_method = if input.peek(Token![pub]) {
+        input.parse::<Token![pub]>()?;
+        true
+    } else {
+        false
+    };
+
+    let kind = if input.peek(kw::internal) {
+        if public_method {
+            return Err(input.error("`internal` items cannot be public"));
+        }
+        input.parse::<kw::internal>()?;
+        ItemKind::Internal
+    } else if input.peek(kw::tell) {
+        input.parse::<kw::tell>()?;
+        ItemKind::Tell
+    } else if input.peek(kw::ask) || input.peek(kw::subscribe) {
+        let await_response = if input.peek(kw::ask) {
+            input.parse::<kw::ask>()?;
+            true
+        } else {
+            input.parse::<kw::subscribe>()?;
+            false
+        };
+        let read_write = if input.peek(kw::read_write) {
+            input.parse::<kw::read_write>()?;
+            true
+        } else {
+            false
+        };
+        let name: Ident = input.parse()?;
+        let fields = parse_fields(input)?;
+        input.parse::<Token![->]>()?;
+        let response: Type = input.parse()?;
+        input.parse::<Token![;]>()?;
+        return Ok(Item {
+            attrs,
+            name,
+            fields,
+            public_method,
+            kind: ItemKind::Request {
+                response: Box::new(response),
+                read_write,
+                await_response,
+            },
+        });
+    } else {
+        return Err(input.error("expected `internal`, `tell`, `ask`, or `subscribe` item"));
+    };
+
+    let name: Ident = input.parse()?;
+    let fields = parse_fields(input)?;
+    input.parse::<Token![;]>()?;
+
+    Ok(Item {
+        attrs,
+        name,
+        fields,
+        public_method,
+        kind,
+    })
+}
+
+impl Parse for Input {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let (unreliable, custom_policy) = parse_header_flags(input)?;
+
+        let has_header = !(input.peek(kw::internal)
+            || input.peek(kw::tell)
+            || input.peek(kw::ask)
+            || input.peek(kw::subscribe)
+            || input.peek(Token![pub])
+            || input.peek(Token![#]));
+        let (mailbox, generics) = if has_header {
+            let mailbox: Ident = input.parse()?;
+            let generics = if input.peek(Token![<]) {
+                input.parse()?
+            } else {
+                Generics::default()
+            };
+            if input.peek(Token![where]) {
+                return Err(input.error("where clauses are not supported on ingress! generics; use inline bounds like `<P: Trait>` instead"));
+            }
+            input.parse::<Token![,]>()?;
+            (mailbox, generics)
+        } else {
+            (
+                Ident::new("Mailbox", Span::call_site()),
+                Generics::default(),
+            )
+        };
+
+        let mut items = Vec::new();
+        while !input.is_empty() {
+            items.push(parse_item(input)?);
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        for item in &items {
+            if !seen.insert(item.name.to_string()) {
+                return Err(syn::Error::new(
+                    item.name.span(),
+                    format!("duplicate item name `{}`", item.name),
+                ));
+            }
+        }
+
+        if items.is_empty() {
+            return Err(syn::Error::new(
+                mailbox.span(),
+                "ingress! requires at least one `internal`, `tell`, `ask`, or `subscribe` item",
+            ));
+        }
+
+        Ok(Self {
+            unreliable,
+            custom_policy,
+            mailbox,
+            generics,
+            items,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_custom_policy_header() {
+        let input: Input = syn::parse_str(
+            r#"
+            custom_policy,
+            ApiMailbox,
+            pub tell Ping;
+            "#,
+        )
+        .unwrap();
+
+        assert!(!input.unreliable);
+        assert!(input.custom_policy);
+        assert_eq!(input.mailbox, "ApiMailbox");
+        assert_eq!(input.items.len(), 1);
+    }
+
+    #[test]
+    fn parses_unreliable_header() {
+        let input: Input = syn::parse_str(
+            r#"
+            unreliable,
+            ApiMailbox,
+            pub ask Get -> u64;
+            "#,
+        )
+        .unwrap();
+
+        assert!(input.unreliable);
+        assert!(!input.custom_policy);
+        assert_eq!(input.items.len(), 1);
+    }
+
+    #[test]
+    fn parses_unreliable_custom_policy_header() {
+        let input: Input = syn::parse_str(
+            r#"
+            unreliable custom_policy,
+            ApiMailbox,
+            pub tell Ping;
+            "#,
+        )
+        .unwrap();
+
+        assert!(input.unreliable);
+        assert!(input.custom_policy);
+    }
+
+    #[test]
+    fn parses_span_field_attributes() {
+        let input: Input = syn::parse_str(
+            r#"
+            ApiMailbox,
+            pub tell Vote { #[span] view: u64, #[span(debug)] digest: u64, payload: u64 };
+            "#,
+        )
+        .unwrap();
+
+        let fields = &input.items[0].fields;
+        assert_eq!(fields[0].span_record, Some(SpanRecord::Display));
+        assert_eq!(fields[1].span_record, Some(SpanRecord::Debug));
+        assert_eq!(fields[2].span_record, None);
+        // The marker is stripped so it never reaches the generated variant.
+        assert!(fields.iter().all(|field| field.attrs.is_empty()));
+    }
+
+    #[test]
+    fn parses_read_write_subscribe() {
+        let input: Input = syn::parse_str(
+            r#"
+            ApiMailbox,
+            subscribe read_write Next -> u64;
+            "#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            input.items[0].kind,
+            ItemKind::Request {
+                read_write: true,
+                await_response: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parses_internal_item() {
+        let input: Input = syn::parse_str(
+            r#"
+            ApiMailbox,
+            internal Tick {
+                /// Deadline that fired.
+                deadline: u64
+            };
+            "#,
+        )
+        .unwrap();
+
+        assert!(matches!(input.items[0].kind, ItemKind::Internal));
+        assert_eq!(input.items[0].name, "Tick");
+        assert_eq!(input.items[0].fields.len(), 1);
+        assert!(!input.items[0].public_method);
+    }
+
+    #[test]
+    fn rejects_public_internal_item() {
+        let result = syn::parse_str::<Input>(
+            r#"
+            ApiMailbox,
+            pub internal Tick;
+            "#,
+        );
+        let err = result
+            .err()
+            .expect("public internal item should fail")
+            .to_string();
+
+        assert!(err.contains("`internal` items cannot be public"), "{err}");
+    }
+
+    #[test]
+    fn parses_generic_defaults_for_lowering_validation() {
+        let input: Input = syn::parse_str(
+            r#"
+            ApiMailbox<T = u64>,
+            tell Ping { value: T };
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(input.generics.params.len(), 1);
+    }
+
+    #[test]
+    fn rejects_unknown_span_mode() {
+        let result = syn::parse_str::<Input>(
+            r#"
+            ApiMailbox,
+            pub tell Vote { #[span(pretty)] view: u64 };
+            "#,
+        );
+        let Err(err) = result else {
+            panic!("unknown span mode was accepted");
+        };
+
+        assert!(err.to_string().contains("expected"));
+    }
+
+    #[test]
+    fn rejects_duplicate_span_attribute() {
+        let result = syn::parse_str::<Input>(
+            r#"
+            ApiMailbox,
+            pub tell Vote { #[span] #[span(debug)] view: u64 };
+            "#,
+        );
+        let Err(err) = result else {
+            panic!("duplicate span attribute was accepted");
+        };
+
+        assert!(err.to_string().contains("duplicate"));
+    }
+
+    #[test]
+    fn rejects_reserved_span_field() {
+        let result = syn::parse_str::<Input>(
+            r#"
+            ApiMailbox,
+            pub tell Ping { span: u64 };
+            "#,
+        );
+        let Err(err) = result else {
+            panic!("reserved span field was accepted");
+        };
+
+        assert!(err.to_string().contains("reserved"));
+    }
+
+    #[test]
+    fn rejects_reserved_binding_prefix() {
+        let result = syn::parse_str::<Input>(
+            r#"
+            ApiMailbox,
+            pub tell Ping { __commonware_actor_value: u64 };
+            "#,
+        );
+        let Err(err) = result else {
+            panic!("reserved binding prefix was accepted");
+        };
+
+        assert!(err.to_string().contains("reserved"));
+    }
+}

--- a/actor/macros/src/ingress/mod.rs
+++ b/actor/macros/src/ingress/mod.rs
@@ -1,0 +1,228 @@
+use proc_macro::TokenStream;
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{ToTokens, quote};
+use syn::{Ident, Result, parse_macro_input};
+
+mod emit;
+mod generics;
+mod input;
+mod model;
+
+use input::Input;
+use model::Ingress;
+
+fn actor_path() -> Result<TokenStream2> {
+    match crate_name("commonware-actor") {
+        Ok(FoundCrate::Itself) => Ok(quote!(::commonware_actor)),
+        Ok(FoundCrate::Name(name)) => {
+            let ident = Ident::new(&name.replace('-', "_"), Span::call_site());
+            Ok(quote!(::#ident))
+        }
+        Err(err) => Err(syn::Error::new(
+            Span::call_site(),
+            format!("unable to locate commonware-actor crate: {err}"),
+        )),
+    }
+}
+
+pub(crate) fn expand(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as Input);
+    actor_path()
+        .and_then(|actor| lower_and_emit(input, actor))
+        .unwrap_or_else(|error| error.to_compile_error())
+        .into()
+}
+
+fn lower_and_emit(input: Input, actor: TokenStream2) -> Result<TokenStream2> {
+    Ok(Ingress::lower(input, actor)?.into_token_stream())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expand_str(source: &str) -> Result<TokenStream2> {
+        let input = syn::parse_str::<Input>(source)?;
+        lower_and_emit(input, quote!(::commonware_actor))
+    }
+
+    /// All error messages joined, so substring assertions do not depend on the
+    /// order in which errors were combined.
+    fn expand_errors(source: &str) -> String {
+        expand_str(source)
+            .expect_err("expected expansion to fail")
+            .into_iter()
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn find_enum<'a>(file: &'a syn::File, name: &str) -> &'a syn::ItemEnum {
+        file.items
+            .iter()
+            .find_map(|item| match item {
+                syn::Item::Enum(item) if item.ident == name => Some(item),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("generated enum `{name}` not found"))
+    }
+
+    fn doc_values(attrs: &[syn::Attribute]) -> Vec<String> {
+        attrs
+            .iter()
+            .filter_map(|attr| {
+                if !attr.path().is_ident("doc") {
+                    return None;
+                }
+                match &attr.meta {
+                    syn::Meta::NameValue(meta) => match &meta.value {
+                        syn::Expr::Lit(expr) => match &expr.lit {
+                            syn::Lit::Str(value) => Some(value.value()),
+                            _ => None,
+                        },
+                        _ => None,
+                    },
+                    _ => None,
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn rejects_fully_unused_generic() {
+        let errors = expand_errors("Mailbox<T: Send + 'static>, tell Ping;");
+        assert!(
+            errors.contains("`T` is not used by any ingress item"),
+            "{errors}"
+        );
+    }
+
+    #[test]
+    fn rejects_unused_generic_among_used() {
+        let errors = expand_errors(
+            "Mailbox<A: Send + 'static, B: Send + 'static>, \
+             tell Push { value: A }; \
+             ask Get -> u64;",
+        );
+        assert!(
+            errors.contains("`B` is not used by any ingress item"),
+            "{errors}"
+        );
+        assert!(!errors.contains("`A` is not used"), "{errors}");
+    }
+
+    #[test]
+    fn rejects_bound_dependency_on_dropped_generic() {
+        let errors = expand_errors(
+            "Mailbox<A: Send + 'static, B: AsRef<A> + Send + 'static>, \
+             tell Push { value: A }; \
+             ask Get { key: B } -> u64;",
+        );
+        assert!(errors.contains("read-only items use `B`"), "{errors}");
+        assert!(errors.contains("bounds reference `A`"), "{errors}");
+    }
+
+    #[test]
+    fn rejects_type_param_default() {
+        let errors = expand_errors("Mailbox<D: Digest = Foo>, tell Ping { value: D };");
+        assert!(
+            errors.contains("defaults are not supported on ingress! generics"),
+            "{errors}"
+        );
+    }
+
+    #[test]
+    fn log_shape_expansion_drops_unused_generic_without_phantom() {
+        let tokens = expand_str(
+            "Mailbox<D: Digest>, \
+             subscribe read_write Propose -> D; \
+             subscribe Verify -> bool;",
+        )
+        .expect("expansion should succeed");
+        let rendered = tokens.to_string();
+        assert!(!rendered.contains("_Phantom"), "{rendered}");
+        assert!(!rendered.contains("PhantomData"), "{rendered}");
+
+        let file: syn::File = syn::parse2(tokens).expect("output should parse");
+        assert!(
+            find_enum(&file, "MailboxReadOnlyMessage")
+                .generics
+                .params
+                .is_empty(),
+            "read-only enum should carry no generics"
+        );
+        assert_eq!(
+            find_enum(&file, "MailboxReadWriteMessage")
+                .generics
+                .params
+                .len(),
+            1,
+            "read-write enum should carry only `D`"
+        );
+    }
+
+    #[test]
+    fn split_generics_are_filtered_per_branch() {
+        let tokens = expand_str(
+            "Mailbox<A: Send + 'static, B: Send + 'static>, \
+             tell Left { value: A }; \
+             ask Right -> B;",
+        )
+        .expect("expansion should succeed");
+
+        let file: syn::File = syn::parse2(tokens).expect("output should parse");
+        let read_only = find_enum(&file, "MailboxReadOnlyMessage");
+        assert_eq!(read_only.generics.params.len(), 1);
+        let read_write = find_enum(&file, "MailboxReadWriteMessage");
+        assert_eq!(read_write.generics.params.len(), 1);
+    }
+
+    #[test]
+    fn const_generic_used_in_retained_bound_is_retained() {
+        let tokens = expand_str(
+            "Mailbox<const N: usize, T: Bound<N>>, \
+             ask Get -> T;",
+        )
+        .expect("expansion should succeed");
+
+        let file: syn::File = syn::parse2(tokens).expect("output should parse");
+        let read_only = find_enum(&file, "MailboxReadOnlyMessage");
+        assert_eq!(read_only.generics.params.len(), 2);
+    }
+
+    #[test]
+    fn field_docs_are_emitted_on_message_fields() {
+        let tokens = expand_str(
+            r#"
+            Mailbox,
+            tell Store {
+                /// Value retained by the actor.
+                value: u64
+            };
+            "#,
+        )
+        .expect("expansion should succeed");
+
+        let file: syn::File = syn::parse2(tokens).expect("output should parse");
+        let read_write = find_enum(&file, "MailboxReadWriteMessage");
+        let variant = read_write
+            .variants
+            .iter()
+            .find(|variant| variant.ident == "Store")
+            .expect("Store variant should exist");
+        let syn::Fields::Named(fields) = &variant.fields else {
+            panic!("Store should have named fields");
+        };
+        let field = fields
+            .named
+            .iter()
+            .find(|field| field.ident.as_ref().is_some_and(|ident| ident == "value"))
+            .expect("value field should exist");
+
+        assert_eq!(
+            doc_values(&field.attrs),
+            vec![" Value retained by the actor."]
+        );
+    }
+}

--- a/actor/macros/src/ingress/model.rs
+++ b/actor/macros/src/ingress/model.rs
@@ -1,0 +1,507 @@
+use super::{
+    generics::{
+        GenericSet, collect_read_write_ingress_usage, collect_readonly_ingress_usage,
+        filter_generics, retain_const_bound_dependencies, validate_generics,
+    },
+    input::{self, Input, ItemKind, SpanRecord},
+};
+use heck::ToSnakeCase as _;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::format_ident;
+use syn::{Attribute, Generics, Ident, LitStr, Result, Type};
+
+#[derive(Clone)]
+pub(crate) struct Ingress {
+    pub(crate) actor: TokenStream2,
+    pub(crate) names: GeneratedNames,
+    pub(crate) generics: Generics,
+    pub(crate) read_only: Branch,
+    pub(crate) read_write: Branch,
+    pub(crate) methods: Vec<Method>,
+    pub(crate) policy: Policy,
+    pub(crate) mailbox_kind: MailboxKind,
+}
+
+impl Ingress {
+    pub(crate) fn lower(input: Input, actor: TokenStream2) -> Result<Self> {
+        let Input {
+            unreliable,
+            custom_policy,
+            mailbox,
+            generics,
+            items,
+        } = input;
+
+        let names = GeneratedNames::new(mailbox);
+        let declared = GenericSet::from_generics(&generics);
+        let mut read_only_usage = collect_readonly_ingress_usage(&items, &declared);
+        let mut read_write_usage = collect_read_write_ingress_usage(&items, &declared);
+        retain_const_bound_dependencies(&generics, &mut read_only_usage, &declared);
+        retain_const_bound_dependencies(&generics, &mut read_write_usage, &declared);
+        validate_generics(&generics, &declared, &read_only_usage, &read_write_usage)?;
+
+        let mut read_only_messages = Vec::new();
+        let mut read_write_messages = Vec::new();
+        let mut methods = Vec::with_capacity(items.len());
+
+        for item in &items {
+            let fields = lower_fields(&item.fields);
+
+            match &item.kind {
+                ItemKind::Internal => {
+                    read_write_messages.push(Message::tell(item, fields));
+                }
+                ItemKind::Tell => {
+                    methods.push(Method::lower(item, &fields, &actor, &names, unreliable));
+                    read_write_messages.push(Message::tell(item, fields));
+                }
+                ItemKind::Request {
+                    response,
+                    read_write,
+                    ..
+                } => {
+                    methods.push(Method::lower(item, &fields, &actor, &names, unreliable));
+                    let message = Message::request(item, fields, response.as_ref().clone());
+                    if *read_write {
+                        read_write_messages.push(message);
+                    } else {
+                        read_only_messages.push(message);
+                    }
+                }
+            }
+        }
+
+        let read_only = Branch {
+            actor: actor.clone(),
+            name: names.read_only_ingress.clone(),
+            generics: filter_generics(&generics, &read_only_usage),
+            messages: read_only_messages,
+        };
+        let read_write = Branch {
+            actor: actor.clone(),
+            name: names.read_write_ingress.clone(),
+            generics: filter_generics(&generics, &read_write_usage),
+            messages: read_write_messages,
+        };
+
+        let mailbox_kind = if unreliable {
+            MailboxKind::Unreliable
+        } else {
+            MailboxKind::Reliable
+        };
+        let policy = Policy {
+            mode: match (custom_policy, mailbox_kind) {
+                (true, _) => PolicyMode::Custom,
+                (false, MailboxKind::Reliable) => PolicyMode::Reliable,
+                (false, MailboxKind::Unreliable) => PolicyMode::Unreliable,
+            },
+            actor: actor.clone(),
+            names: names.clone(),
+            generics: generics.clone(),
+        };
+
+        Ok(Self {
+            actor,
+            names,
+            generics,
+            read_only,
+            read_write,
+            methods,
+            policy,
+            mailbox_kind,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct GeneratedNames {
+    pub(crate) mailbox: Ident,
+    pub(crate) ingress: Ident,
+    pub(crate) read_only_ingress: Ident,
+    pub(crate) read_write_ingress: Ident,
+    pub(crate) overflow: Ident,
+}
+
+impl GeneratedNames {
+    fn new(mailbox: Ident) -> Self {
+        Self {
+            ingress: format_ident!("{}Message", mailbox),
+            read_only_ingress: format_ident!("{}ReadOnlyMessage", mailbox),
+            read_write_ingress: format_ident!("{}ReadWriteMessage", mailbox),
+            overflow: format_ident!("{}Overflow", mailbox),
+            mailbox,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MailboxKind {
+    Reliable,
+    Unreliable,
+}
+
+#[derive(Clone)]
+pub(crate) struct Branch {
+    pub(crate) actor: TokenStream2,
+    pub(crate) name: Ident,
+    pub(crate) generics: Generics,
+    pub(crate) messages: Vec<Message>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BranchKind {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl BranchKind {
+    fn route_ident(self) -> Ident {
+        match self {
+            Self::ReadOnly => Ident::new("ReadOnly", Span::call_site()),
+            Self::ReadWrite => Ident::new("ReadWrite", Span::call_site()),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Message {
+    pub(crate) attrs: Vec<Attribute>,
+    pub(crate) name: Ident,
+    pub(crate) fields: Vec<Field>,
+    pub(crate) response: Option<Type>,
+}
+
+impl Message {
+    fn tell(item: &input::Item, fields: Vec<Field>) -> Self {
+        Self {
+            attrs: item.attrs.clone(),
+            name: item.name.clone(),
+            fields,
+            response: None,
+        }
+    }
+
+    fn request(item: &input::Item, fields: Vec<Field>, response: Type) -> Self {
+        Self {
+            attrs: item.attrs.clone(),
+            name: item.name.clone(),
+            fields,
+            response: Some(response),
+        }
+    }
+
+    pub(crate) const fn is_unit(&self) -> bool {
+        self.fields.is_empty()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Field {
+    pub(crate) attrs: Vec<Attribute>,
+    pub(crate) name: Ident,
+    pub(crate) ty: Type,
+    pub(crate) span_record: Option<SpanRecord>,
+}
+
+impl From<&input::Field> for Field {
+    fn from(field: &input::Field) -> Self {
+        Self {
+            attrs: field.attrs.clone(),
+            name: field.name.clone(),
+            ty: field.ty.clone(),
+            span_record: field.span_record,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SpanField {
+    pub(crate) name: Ident,
+    pub(crate) record: SpanRecord,
+}
+
+#[derive(Clone)]
+pub(crate) struct Method {
+    pub(crate) actor: TokenStream2,
+    pub(crate) ingress: Ident,
+    pub(crate) attrs: Vec<Attribute>,
+    pub(crate) public: bool,
+    pub(crate) name: Ident,
+    pub(crate) variant: Ident,
+    pub(crate) fields: Vec<Field>,
+    pub(crate) span_name: LitStr,
+    pub(crate) span_fields: Vec<SpanField>,
+    pub(crate) kind: MethodKind,
+}
+
+impl Method {
+    fn lower(
+        item: &input::Item,
+        fields: &[Field],
+        actor: &TokenStream2,
+        names: &GeneratedNames,
+        unreliable: bool,
+    ) -> Self {
+        Self {
+            actor: actor.clone(),
+            ingress: names.ingress.clone(),
+            attrs: item.attrs.clone(),
+            public: item.public_method,
+            name: format_ident!("{}", item.name.to_string().to_snake_case()),
+            variant: item.name.clone(),
+            fields: fields.to_vec(),
+            span_name: span_name(&names.mailbox, &item.name),
+            span_fields: lower_span_fields(fields),
+            kind: MethodKind::lower(item, names, unreliable),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum MethodKind {
+    Tell {
+        feedback: Feedback,
+        message: Ident,
+    },
+    Request {
+        feedback: Feedback,
+        route: Ident,
+        message: Ident,
+        response: Box<Type>,
+        await_response: bool,
+    },
+}
+
+impl MethodKind {
+    fn lower(item: &input::Item, names: &GeneratedNames, unreliable: bool) -> Self {
+        match &item.kind {
+            ItemKind::Internal => unreachable!("internal items do not generate mailbox methods"),
+            ItemKind::Tell => Self::Tell {
+                feedback: if unreliable {
+                    Feedback::Unreliable
+                } else {
+                    Feedback::Reliable
+                },
+                message: names.read_write_ingress.clone(),
+            },
+            ItemKind::Request {
+                response,
+                read_write,
+                await_response,
+            } => {
+                let branch = if *read_write {
+                    BranchKind::ReadWrite
+                } else {
+                    BranchKind::ReadOnly
+                };
+                let message = if *read_write {
+                    names.read_write_ingress.clone()
+                } else {
+                    names.read_only_ingress.clone()
+                };
+
+                Self::Request {
+                    feedback: if unreliable {
+                        Feedback::Unreliable
+                    } else {
+                        Feedback::Reliable
+                    },
+                    route: branch.route_ident(),
+                    message,
+                    response: response.clone(),
+                    await_response: *await_response,
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum Feedback {
+    Reliable,
+    Unreliable,
+}
+
+#[derive(Clone)]
+pub(crate) struct Policy {
+    pub(crate) mode: PolicyMode,
+    pub(crate) actor: TokenStream2,
+    pub(crate) names: GeneratedNames,
+    pub(crate) generics: Generics,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PolicyMode {
+    Custom,
+    Reliable,
+    Unreliable,
+}
+
+fn lower_fields(fields: &[input::Field]) -> Vec<Field> {
+    fields.iter().map(Field::from).collect()
+}
+
+fn lower_span_fields(fields: &[Field]) -> Vec<SpanField> {
+    fields
+        .iter()
+        .filter_map(|field| {
+            field.span_record.map(|record| SpanField {
+                name: field.name.clone(),
+                record,
+            })
+        })
+        .collect()
+}
+
+/// The compile-time span name for a generated mailbox method:
+/// `actor.<mailbox_snake>.<method_snake>`.
+fn span_name(mailbox: &Ident, item: &Ident) -> LitStr {
+    let mailbox = mailbox.to_string().to_snake_case();
+    let item = item.to_string().to_snake_case();
+    LitStr::new(&format!("actor.{mailbox}.{item}"), Span::call_site())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+    use syn::GenericParam;
+
+    fn lower_str(source: &str) -> Result<Ingress> {
+        let input = syn::parse_str::<Input>(source)?;
+        Ingress::lower(input, quote!(::commonware_actor))
+    }
+
+    /// All error messages joined, so substring assertions do not depend on the
+    /// order in which errors were combined.
+    fn lower_errors(source: &str) -> String {
+        match lower_str(source) {
+            Ok(_) => panic!("expected lowering to fail"),
+            Err(error) => error
+                .into_iter()
+                .map(|error| error.to_string())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }
+    }
+
+    fn generic_names(generics: &Generics) -> Vec<String> {
+        generics
+            .params
+            .iter()
+            .map(|param| match param {
+                GenericParam::Type(param) => param.ident.to_string(),
+                GenericParam::Lifetime(param) => format!("'{}", param.lifetime.ident),
+                GenericParam::Const(param) => param.ident.to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn log_shape_lowers_to_bare_readonly_and_generic_readwrite() {
+        let ingress = lower_str(
+            "Mailbox<D: Digest>, \
+             subscribe read_write Propose -> D; \
+             subscribe Verify -> bool;",
+        )
+        .expect("lowering should succeed");
+
+        assert_eq!(ingress.read_only.messages.len(), 1);
+        assert_eq!(ingress.read_only.messages[0].name, "Verify");
+        assert!(ingress.read_only.generics.params.is_empty());
+
+        assert_eq!(ingress.read_write.messages.len(), 1);
+        assert_eq!(ingress.read_write.messages[0].name, "Propose");
+        assert_eq!(generic_names(&ingress.read_write.generics), vec!["D"]);
+    }
+
+    #[test]
+    fn split_generic_input_assigns_one_generic_per_branch() {
+        let ingress = lower_str(
+            "Mailbox<A: Send + 'static, B: Send + 'static>, \
+             tell Left { value: A }; \
+             ask Right -> B;",
+        )
+        .expect("lowering should succeed");
+
+        assert_eq!(generic_names(&ingress.read_write.generics), vec!["A"]);
+        assert_eq!(generic_names(&ingress.read_only.generics), vec!["B"]);
+    }
+
+    #[test]
+    fn const_generic_bound_dependency_is_retained() {
+        let ingress = lower_str(
+            "Mailbox<const N: usize, T: Bound<N>>, \
+             ask Get -> T;",
+        )
+        .expect("lowering should succeed");
+
+        assert_eq!(generic_names(&ingress.read_only.generics), vec!["N", "T"]);
+        assert!(ingress.read_write.generics.params.is_empty());
+    }
+
+    #[test]
+    fn all_tell_generic_input_has_uninhabited_generic_free_readonly() {
+        let ingress = lower_str(
+            "Mailbox<T>, \
+             tell Store { value: T };",
+        )
+        .expect("lowering should succeed");
+
+        assert!(ingress.read_only.generics.params.is_empty());
+        assert!(ingress.read_only.messages.is_empty());
+        assert_eq!(generic_names(&ingress.read_write.generics), vec!["T"]);
+    }
+
+    #[test]
+    fn internal_items_lower_to_readwrite_without_methods() {
+        let ingress = lower_str(
+            "Mailbox<T>, \
+             internal Tick { value: T }; \
+             tell Ping;",
+        )
+        .expect("lowering should succeed");
+
+        assert!(ingress.read_only.messages.is_empty());
+        assert_eq!(generic_names(&ingress.read_write.generics), vec!["T"]);
+        assert_eq!(ingress.read_write.messages.len(), 2);
+        assert_eq!(ingress.read_write.messages[0].name, "Tick");
+        assert_eq!(ingress.methods.len(), 1);
+        assert_eq!(ingress.methods[0].variant, "Ping");
+    }
+
+    #[test]
+    fn rejects_generic_defaults_during_lowering() {
+        let errors = lower_errors("Mailbox<D: Digest = Foo>, tell Ping { value: D };");
+        assert!(
+            errors.contains("defaults are not supported on ingress! generics"),
+            "{errors}"
+        );
+
+        let errors = lower_errors("Mailbox<const N: usize = 4>, tell Ping { value: [u8; N] };");
+        assert!(
+            errors.contains("defaults are not supported on ingress! generics"),
+            "{errors}"
+        );
+    }
+
+    #[test]
+    fn rejects_unused_generics_during_lowering() {
+        let errors = lower_errors("Mailbox<T: Send + 'static>, tell Ping;");
+        assert!(
+            errors.contains("`T` is not used by any ingress item"),
+            "{errors}"
+        );
+    }
+
+    #[test]
+    fn rejects_bound_dependency_on_dropped_generic_during_lowering() {
+        let errors = lower_errors(
+            "Mailbox<A: Send + 'static, B: AsRef<A> + Send + 'static>, \
+             tell Push { value: A }; \
+             ask Get { key: B } -> u64;",
+        );
+        assert!(errors.contains("read-only items use `B`"), "{errors}");
+        assert!(errors.contains("bounds reference `A`"), "{errors}");
+    }
+}

--- a/actor/macros/src/lib.rs
+++ b/actor/macros/src/lib.rs
@@ -1,0 +1,222 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
+    html_favicon_url = "https://commonware.xyz/favicon.ico"
+)]
+
+use proc_macro::TokenStream;
+
+mod ingress;
+
+/// Defines ingress enums, a queue policy, and a typed mailbox API for one actor.
+///
+/// You declare the message protocol; the macro generates the types needed by
+/// callers (typed mailbox methods) and by actor implementations (`ReadOnly`
+/// and `ReadWrite` ingress enums).
+///
+/// # DSL
+///
+/// ```rust,ignore
+/// ingress! {
+///     // Optional header flags (terminated by a comma when present):
+///     //   unreliable,               // unreliable mailbox, generated reject-all policy
+///     //   custom_policy,            // reliable mailbox, hand-written Policy impl
+///     //   unreliable custom_policy, // unreliable mailbox, hand-written UnreliablePolicy impl
+///     //
+///     // Optional mailbox name (defaults to `Mailbox`) plus generics with
+///     // inline bounds (`where` clauses are not supported).
+///     MailboxName<Generics...>,
+///
+///     pub tell Name { fields... };
+///     internal Name { fields... };
+///     pub ask Name { fields... } -> Response;
+///     pub ask read_write Name { fields... } -> Response;
+///     pub subscribe [read_write] Name { fields... } -> Response;
+/// }
+/// ```
+///
+/// Fields may be annotated with `#[span]`, `#[span(display)]`, or
+/// `#[span(debug)]` to attach their values to the enqueue span. Bare
+/// `#[span]` is an alias for `#[span(display)]`. Only annotated fields incur
+/// formatting bounds. Field doc comments are emitted on the generated message
+/// enum fields.
+///
+/// # Item semantics
+///
+/// - `tell`: fire-and-forget, routed to the read-write enum. The generated
+///   method is synchronous, never blocks, and returns `Feedback`
+///   (`Unreliable<Feedback>` for unreliable mailboxes).
+/// - `internal`: actor-owned event, routed to the read-write enum without
+///   generating any mailbox methods. Use this for events returned from
+///   `Actor::next_event`.
+/// - `ask`: request/response, routed to the read-only enum by default. The
+///   generated method enqueues exactly like `subscribe` and awaits the
+///   response receiver inline, returning
+///   `Result<Response, commonware_actor::ingress::Cancelled>`.
+/// - `ask read_write`: as `ask`, but routed to the read-write enum. Use this
+///   when handling the request mutates actor state.
+/// - `subscribe`: request/response split into enqueue-now, await-later. Like
+///   `ask`, it is routed to the read-only enum by default, and
+///   `subscribe read_write` routes to the read-write enum. The generated
+///   method returns the `oneshot::Receiver<Response>` immediately. The
+///   receiver resolves to an error if the mailbox is closed, the queue policy
+///   drops the message, or the actor drops the response sender.
+/// - Each `ask` and `subscribe` item also generates an `enqueue_<method>`
+///   variant that returns enqueue feedback and the response receiver
+///   immediately. Use this when the caller needs to distinguish direct
+///   acceptance, overflow handling, closure, or unreliable rejection before
+///   awaiting the response.
+///
+/// Item visibility controls mailbox method visibility. `pub` items generate
+/// public methods; items without `pub` generate private methods that can be
+/// called from the declaring module. `internal` items do not generate methods.
+///
+/// # Generated code shape
+///
+/// Given:
+///
+/// ```rust,ignore
+/// ingress! {
+///     MyMailbox,
+///     pub tell Ping;
+///     pub ask GetValue -> u64;
+/// }
+/// ```
+///
+/// the macro expands to (attributes and hidden items elided):
+///
+/// ```rust,ignore
+/// // --- Ingress enums (matched by Actor::on_read_only / on_read_write) ---
+///
+/// pub enum MyMailboxReadOnlyMessage {
+///     GetValue { response: oneshot::Sender<u64> },
+/// }
+///
+/// pub enum MyMailboxReadWriteMessage {
+///     Ping,
+/// }
+///
+/// // --- Top-level ingress carrying the enqueue span ---
+///
+/// pub enum MyMailboxMessage {
+///     ReadOnly { span: tracing::Span, message: MyMailboxReadOnlyMessage },
+///     ReadWrite { span: tracing::Span, message: MyMailboxReadWriteMessage },
+/// }
+///
+/// impl MyMailboxMessage {
+///     pub fn response_closed(&self) -> bool { /* ... */ }
+/// }
+///
+/// // --- Default queue policy (skipped with `custom_policy`) ---
+///
+/// impl commonware_actor::mailbox::Policy for MyMailboxMessage { /* FIFO */ }
+///
+/// // --- Typed mailbox newtype over the ingress endpoint ---
+///
+/// pub struct MyMailbox(commonware_actor::ingress::Mailbox<MyMailboxMessage>);
+///
+/// impl MyMailbox {
+///     pub fn ping(&self) -> Feedback { /* enqueue */ }
+///     pub fn enqueue_get_value(&self) -> (Feedback, oneshot::Receiver<u64>) { /* enqueue */ }
+///     pub async fn get_value(&self) -> Result<u64, ingress::Cancelled> { /* subscribe + await */ }
+/// }
+///
+/// // --- Envelope routing (consumed by the service loop) ---
+///
+/// impl commonware_actor::ingress::IntoEnvelope for MyMailboxMessage { /* ... */ }
+/// ```
+///
+/// # Generics
+///
+/// Each generated branch enum carries only the mailbox generics its own items
+/// use. If no read-only item references a parameter, the read-only enum drops
+/// it (and vice versa), so the enum can be named without that parameter. The
+/// top-level `{Mailbox}Message` enum and the `{Mailbox}` struct keep the full
+/// mailbox generics.
+///
+/// Every mailbox generic must be used by at least one item; a parameter used by
+/// no item is a compile error. Likewise, a parameter's bounds may only
+/// reference other parameters that the same branch retains.
+///
+/// # Queue policies
+///
+/// By default the macro implements `mailbox::Policy` for the top-level
+/// ingress enum: overflow is retained in FIFO order and messages whose
+/// response channel has already closed are dropped. With the `unreliable`
+/// flag it implements `mailbox::UnreliablePolicy` instead: overflow is
+/// rejected outright and senders observe `Unreliable::Rejected`.
+///
+/// `custom_policy` suppresses policy generation so the enclosing module can
+/// implement `Policy` (or `UnreliablePolicy` with `unreliable custom_policy`)
+/// by hand, e.g. to coalesce redundant messages. The generated
+/// `response_closed` helper is public for use in such implementations.
+///
+/// # Tracing
+///
+/// Every generated variant carries a debug-level `tracing::Span` created at enqueue time
+/// and hidden from actor handlers; the service loop re-enters it when the
+/// message is dispatched, so traces follow requests across the mailbox
+/// boundary. Span names are `actor.<mailbox_snake>.<method>`.
+///
+/// Fields annotated with `#[span]`, `#[span(display)]`, or `#[span(debug)]`
+/// are recorded on that span at enqueue time, so identifying values (epochs,
+/// views, digests) appear in traces without exposing spans to handlers:
+///
+/// ```rust,ignore
+/// ingress! {
+///     VoterMailbox,
+///     pub tell Vote { #[span] view: u64, #[span(debug)] digest: Digest, payload: Bytes };
+/// }
+/// // span: actor.voter_mailbox.vote{view=42 digest=0x51ae...}
+/// ```
+///
+/// To keep traces bounded, `tell` methods start a *new root* span that
+/// `follows_from` the caller's current span: fire-and-forget messages begin a
+/// new causal unit of work, so actors that `tell` each other in a loop link
+/// their traces instead of growing one trace without bound. `ask` and
+/// `subscribe` methods create a *child* of the caller's current span: the
+/// caller awaits the response inside its own span, so depth is bounded by the
+/// request chain.
+///
+/// # Reserved names
+///
+/// Field names `response`, `span`, and any name beginning with
+/// `__commonware_actor` are reserved for generated code.
+///
+/// # Examples
+///
+/// Mixed ingress with a generic payload:
+///
+/// ```rust,ignore
+/// use commonware_actor::ingress;
+///
+/// ingress! {
+///     CounterMailbox,
+///     pub tell Increment { amount: u64 };
+///     pub ask Get -> u64;
+///     pub ask read_write AddAndGet { amount: u64 } -> u64;
+///     pub subscribe WaitForNext -> u64;
+/// }
+///
+/// ingress! {
+///     PeerMailbox<P: Clone + Send + 'static>,
+///     pub tell Connect { peer: P };
+///     pub ask IsConnected { peer: P } -> bool;
+/// }
+/// ```
+///
+/// A lossy mailbox that rejects work under backpressure:
+///
+/// ```rust,ignore
+/// use commonware_actor::ingress;
+///
+/// ingress! {
+///     unreliable,
+///     SampleMailbox,
+///     pub tell Sample { value: u64 };
+/// }
+/// ```
+#[proc_macro]
+pub fn ingress(input: TokenStream) -> TokenStream {
+    ingress::expand(input)
+}

--- a/actor/src/benches/bench.rs
+++ b/actor/src/benches/bench.rs
@@ -1,5 +1,0 @@
-use criterion::criterion_main;
-
-mod mailbox;
-
-criterion_main!(mailbox::benches);

--- a/actor/src/benches/mailbox.rs
+++ b/actor/src/benches/mailbox.rs
@@ -4,7 +4,7 @@ use commonware_runtime::{
     telemetry::metrics::{Metric, Registered, Registration},
 };
 use commonware_utils::NZUsize;
-use criterion::{BatchSize, Criterion, Throughput, criterion_group};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use futures::pin_mut;
 use std::{
     collections::VecDeque,
@@ -409,3 +409,4 @@ criterion_group! {
         bench_overflow_replace,
         bench_concurrent_enqueue,
 }
+criterion_main!(benches);

--- a/actor/src/benches/throughput.rs
+++ b/actor/src/benches/throughput.rs
@@ -1,0 +1,513 @@
+use commonware_actor::{Actor, ingress, service::Builder};
+use commonware_runtime::{
+    Handle, Spawner, Supervisor as _,
+    benchmarks::{context, tokio},
+};
+use commonware_utils::NZUsize;
+use criterion::{BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main};
+use futures::stream::{FuturesUnordered, StreamExt};
+use std::{
+    hint::black_box,
+    num::NonZeroUsize,
+    time::{Duration, Instant},
+};
+
+const MAILBOX_CAPACITY: usize = 4096;
+const OVERFLOW_CAPACITY: usize = 1;
+const READ_CONCURRENCY: usize = 256;
+const MESSAGES: u64 = 1024;
+const READS_PER_WRITE: u64 = 7;
+const MIXED_CYCLES: u64 = 128;
+const PRODUCERS: usize = 4;
+const PRODUCER_MESSAGES: u64 = 512;
+
+ingress! {
+    ThroughputMailbox,
+
+    pub tell Increment;
+    pub ask Value -> u64;
+    pub subscribe Read -> u64;
+    pub ask read_write Drain -> u64;
+}
+
+struct ThroughputActor {
+    value: u64,
+    lane_batch: NonZeroUsize,
+}
+
+impl<E: Spawner> Actor<E> for ThroughputActor {
+    type Mailbox = ThroughputMailbox;
+    type Ingress = ThroughputMailboxMessage;
+    type Error = std::convert::Infallible;
+    type Snapshot = u64;
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {
+        self.value
+    }
+
+    fn max_lane_batch(&self, _args: &Self::Args) -> NonZeroUsize {
+        self.lane_batch
+    }
+
+    async fn on_read_only(
+        _context: E,
+        snapshot: Self::Snapshot,
+        message: ThroughputMailboxReadOnlyMessage,
+    ) -> Result<(), Self::Error> {
+        match message {
+            ThroughputMailboxReadOnlyMessage::Value { response }
+            | ThroughputMailboxReadOnlyMessage::Read { response } => {
+                let _ = response.send(snapshot);
+                Ok(())
+            }
+        }
+    }
+
+    async fn on_read_write(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        message: ThroughputMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        match message {
+            ThroughputMailboxReadWriteMessage::Increment => {
+                self.value += 1;
+            }
+            ThroughputMailboxReadWriteMessage::Drain { response } => {
+                let _ = response.send(self.value);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn start_single(
+    label: &'static str,
+    lane_batch: usize,
+    value: u64,
+    capacity: usize,
+    read_concurrency: usize,
+) -> (ThroughputMailbox, Handle<()>) {
+    let context = context::get::<commonware_runtime::tokio::Context>();
+    let actor = ThroughputActor {
+        value,
+        lane_batch: NZUsize!(lane_batch),
+    };
+    let (mailbox, service) = Builder::new(actor)
+        .with_read_concurrency(NZUsize!(read_concurrency))
+        .build_with_capacity(context.child(label), NZUsize!(capacity));
+    (mailbox, service.start())
+}
+
+async fn stop_actor(mailbox: ThroughputMailbox, handle: Handle<()>) {
+    drop(mailbox);
+    handle.await.expect("service join failed");
+}
+
+async fn tell_flush(mailbox: &ThroughputMailbox, iters: u64, msgs: u64) -> Duration {
+    let mut expected = 0;
+    let start = Instant::now();
+    for _ in 0..iters {
+        for _ in 0..msgs {
+            let feedback = mailbox.increment_internal();
+            assert!(feedback.accepted());
+            black_box(feedback);
+        }
+        expected += msgs;
+        assert_eq!(
+            mailbox.drain_internal().await.expect("drain ask failed"),
+            expected
+        );
+    }
+    start.elapsed()
+}
+
+async fn ask_readonly_seq(mailbox: &ThroughputMailbox, iters: u64, msgs: u64) -> Duration {
+    let start = Instant::now();
+    for _ in 0..iters {
+        for _ in 0..msgs {
+            black_box(mailbox.value_internal().await.expect("value ask failed"));
+        }
+    }
+    start.elapsed()
+}
+
+async fn ask_readwrite_seq(mailbox: &ThroughputMailbox, iters: u64, msgs: u64) -> Duration {
+    let start = Instant::now();
+    for _ in 0..iters {
+        for _ in 0..msgs {
+            black_box(mailbox.drain_internal().await.expect("drain ask failed"));
+        }
+    }
+    start.elapsed()
+}
+
+async fn ask_readonly_parallel(
+    mailbox: &ThroughputMailbox,
+    iters: u64,
+    msgs: u64,
+    window: usize,
+) -> Duration {
+    let start = Instant::now();
+    for _ in 0..iters {
+        let mut issued = 0;
+        let mut completed = 0;
+        let mut inflight = FuturesUnordered::new();
+        while issued < msgs || completed < msgs {
+            while issued < msgs && inflight.len() < window {
+                let mailbox = mailbox.clone();
+                inflight
+                    .push(async move { mailbox.value_internal().await.expect("value ask failed") });
+                issued += 1;
+            }
+            if let Some(value) = inflight.next().await {
+                black_box(value);
+                completed += 1;
+            }
+        }
+    }
+    start.elapsed()
+}
+
+async fn mixed_readonly_readwrite(mailbox: &ThroughputMailbox, iters: u64) -> Duration {
+    let start = Instant::now();
+    for _ in 0..iters {
+        for _ in 0..MIXED_CYCLES {
+            let mut reads = Vec::with_capacity(READS_PER_WRITE as usize);
+            for _ in 0..READS_PER_WRITE {
+                reads.push(mailbox.read_internal());
+            }
+            black_box(mailbox.drain_internal().await.expect("drain ask failed"));
+            for read in reads {
+                black_box(read.await.expect("read response missing"));
+            }
+        }
+    }
+    start.elapsed()
+}
+
+fn bench_tell_flush(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>) {
+    for lane_batch in [1usize, 8, 64] {
+        group.throughput(Throughput::Elements(MESSAGES + 1));
+        group.bench_function(
+            format!("kind=tell_flush lane_batch={lane_batch} capacity={MAILBOX_CAPACITY} msgs={MESSAGES} flushes=1"),
+            |b| {
+                b.to_async(tokio_runner()).iter_custom(move |iters| async move {
+                    let (mailbox, handle) = start_single(
+                        "tell_flush",
+                        lane_batch,
+                        0,
+                        MAILBOX_CAPACITY,
+                        READ_CONCURRENCY,
+                    );
+                    let elapsed = tell_flush(&mailbox, iters, MESSAGES).await;
+                    stop_actor(mailbox, handle).await;
+                    elapsed
+                });
+            },
+        );
+    }
+}
+
+fn bench_tell_overflow(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>) {
+    group.throughput(Throughput::Elements(MESSAGES + 1));
+    group.bench_function(
+        format!(
+            "kind=tell_overflow lane_batch=64 capacity={OVERFLOW_CAPACITY} msgs={MESSAGES} flushes=1"
+        ),
+        |b| {
+            b.to_async(tokio_runner())
+                .iter_custom(move |iters| async move {
+                    let (mailbox, handle) =
+                        start_single("tell_overflow", 64, 0, OVERFLOW_CAPACITY, READ_CONCURRENCY);
+                    let elapsed = tell_flush(&mailbox, iters, MESSAGES).await;
+                    stop_actor(mailbox, handle).await;
+                    elapsed
+                });
+        },
+    );
+}
+
+fn bench_sequential_asks(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>) {
+    group.throughput(Throughput::Elements(MESSAGES));
+    group.bench_function(
+        format!("kind=ask_readonly_seq lane_batch=1 msgs={MESSAGES}"),
+        |b| {
+            b.to_async(tokio_runner())
+                .iter_custom(move |iters| async move {
+                    let (mailbox, handle) = start_single(
+                        "ask_readonly_seq",
+                        1,
+                        42,
+                        MAILBOX_CAPACITY,
+                        READ_CONCURRENCY,
+                    );
+                    let elapsed = ask_readonly_seq(&mailbox, iters, MESSAGES).await;
+                    stop_actor(mailbox, handle).await;
+                    elapsed
+                });
+        },
+    );
+
+    group.bench_function(
+        format!("kind=ask_readwrite_seq lane_batch=1 msgs={MESSAGES}"),
+        |b| {
+            b.to_async(tokio_runner())
+                .iter_custom(move |iters| async move {
+                    let (mailbox, handle) = start_single(
+                        "ask_readwrite_seq",
+                        1,
+                        42,
+                        MAILBOX_CAPACITY,
+                        READ_CONCURRENCY,
+                    );
+                    let elapsed = ask_readwrite_seq(&mailbox, iters, MESSAGES).await;
+                    stop_actor(mailbox, handle).await;
+                    elapsed
+                });
+        },
+    );
+}
+
+fn bench_parallel_reads(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>) {
+    for lane_batch in [1usize, 64] {
+        for window in [8usize, 64] {
+            group.throughput(Throughput::Elements(MESSAGES));
+            group.bench_function(
+                format!("kind=ask_readonly_parallel lane_batch={lane_batch} window={window} msgs={MESSAGES}"),
+                |b| {
+                    b.to_async(tokio_runner()).iter_custom(move |iters| async move {
+                        let (mailbox, handle) = start_single(
+                            "ask_readonly_parallel",
+                            lane_batch,
+                            42,
+                            MAILBOX_CAPACITY,
+                            READ_CONCURRENCY,
+                        );
+                        let elapsed =
+                            ask_readonly_parallel(&mailbox, iters, MESSAGES, window).await;
+                        stop_actor(mailbox, handle).await;
+                        elapsed
+                    });
+                },
+            );
+        }
+    }
+}
+
+fn bench_mixed_fence(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>) {
+    let messages = MIXED_CYCLES * (READS_PER_WRITE + 1);
+    for lane_batch in [1usize, 64] {
+        group.throughput(Throughput::Elements(messages));
+        group.bench_function(
+            format!(
+                "kind=mixed_readonly_readwrite lane_batch={lane_batch} reads_per_write={READS_PER_WRITE} msgs={messages}"
+            ),
+            |b| {
+                b.to_async(tokio_runner()).iter_custom(move |iters| async move {
+                    let (mailbox, handle) = start_single(
+                        "mixed_readonly_readwrite",
+                        lane_batch,
+                        42,
+                        MAILBOX_CAPACITY,
+                        READ_CONCURRENCY,
+                    );
+                    let elapsed = mixed_readonly_readwrite(&mailbox, iters).await;
+                    stop_actor(mailbox, handle).await;
+                    elapsed
+                });
+            },
+        );
+    }
+}
+
+async fn multi_lane_tell(
+    first: &ThroughputMailbox,
+    second: &ThroughputMailbox,
+    iters: u64,
+    msgs: u64,
+    balanced: bool,
+) -> Duration {
+    let mut expected = 0;
+    let start = Instant::now();
+    for _ in 0..iters {
+        for i in 0..msgs {
+            let mailbox = if balanced && i % 2 == 1 {
+                second
+            } else {
+                first
+            };
+            let feedback = mailbox.increment_internal();
+            assert!(feedback.accepted());
+            black_box(feedback);
+        }
+        expected += msgs;
+        assert_eq!(
+            second.drain_internal().await.expect("drain ask failed"),
+            expected
+        );
+    }
+    start.elapsed()
+}
+
+fn bench_multi_lane(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>) {
+    for lane_batch in [1usize, 64] {
+        for (distribution, balanced) in [("hot", false), ("balanced", true)] {
+            group.throughput(Throughput::Elements(MESSAGES + 1));
+            group.bench_function(
+                format!(
+                    "kind=multi_lane_tell lanes=2 distribution={distribution} lane_batch={lane_batch} msgs={MESSAGES} flushes=1"
+                ),
+                |b| {
+                    b.to_async(tokio_runner()).iter_custom(move |iters| async move {
+                        let context = context::get::<commonware_runtime::tokio::Context>();
+                        let actor = ThroughputActor {
+                            value: 0,
+                            lane_batch: NZUsize!(lane_batch),
+                        };
+                        let (lanes, service) = Builder::new(actor)
+                            .with_lane(0usize, NZUsize!(MAILBOX_CAPACITY))
+                            .with_lane(1usize, NZUsize!(MAILBOX_CAPACITY))
+                            .build(context.child("multi_lane_tell"))
+                            .expect("multi-lane build failed");
+                        let mut lanes = lanes.into_inner();
+                        let first = lanes.remove(&0).expect("first lane missing");
+                        let second = lanes.remove(&1).expect("second lane missing");
+                        let handle = service.start();
+
+                        let elapsed =
+                            multi_lane_tell(&first, &second, iters, MESSAGES, balanced).await;
+
+                        drop(first);
+                        stop_actor(second, handle).await;
+                        elapsed
+                    });
+                },
+            );
+        }
+    }
+}
+
+fn bench_cloned_producers(group: &mut BenchmarkGroup<'_, criterion::measurement::WallTime>) {
+    let total = PRODUCERS as u64 * PRODUCER_MESSAGES;
+
+    group.throughput(Throughput::Elements(total + 1));
+    group.bench_function(
+        format!("kind=producer_tell producers={PRODUCERS} msgs={total} flushes=1"),
+        |b| {
+            b.to_async(tokio_runner())
+                .iter_custom(move |iters| async move {
+                    let context = context::get::<commonware_runtime::tokio::Context>();
+                    let actor = ThroughputActor {
+                        value: 0,
+                        lane_batch: NZUsize!(64),
+                    };
+                    let (mailbox, service) = Builder::new(actor)
+                        .with_read_concurrency(NZUsize!(READ_CONCURRENCY))
+                        .build_with_capacity(
+                            context.child("producer_tell"),
+                            NZUsize!(MAILBOX_CAPACITY),
+                        );
+                    let handle = service.start();
+
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        let mut producers = FuturesUnordered::new();
+                        for producer in 0..PRODUCERS {
+                            let mailbox = mailbox.clone();
+                            let context =
+                                context.child("producer").with_attribute("index", producer);
+                            producers.push(context.spawn(|_| async move {
+                                for _ in 0..PRODUCER_MESSAGES {
+                                    let feedback = mailbox.increment_internal();
+                                    assert!(feedback.accepted());
+                                    black_box(feedback);
+                                }
+                            }));
+                        }
+                        while let Some(result) = producers.next().await {
+                            result.expect("producer join failed");
+                        }
+                        black_box(mailbox.drain_internal().await.expect("drain ask failed"));
+                    }
+                    let elapsed = start.elapsed();
+
+                    stop_actor(mailbox, handle).await;
+                    elapsed
+                });
+        },
+    );
+
+    group.throughput(Throughput::Elements(total));
+    group.bench_function(
+        format!("kind=producer_ask_readonly producers={PRODUCERS} msgs={total}"),
+        |b| {
+            b.to_async(tokio_runner())
+                .iter_custom(move |iters| async move {
+                    let context = context::get::<commonware_runtime::tokio::Context>();
+                    let actor = ThroughputActor {
+                        value: 42,
+                        lane_batch: NZUsize!(64),
+                    };
+                    let (mailbox, service) = Builder::new(actor)
+                        .with_read_concurrency(NZUsize!(READ_CONCURRENCY))
+                        .build_with_capacity(
+                            context.child("producer_ask_readonly"),
+                            NZUsize!(MAILBOX_CAPACITY),
+                        );
+                    let handle = service.start();
+
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        let mut producers = FuturesUnordered::new();
+                        for producer in 0..PRODUCERS {
+                            let mailbox = mailbox.clone();
+                            let context =
+                                context.child("producer").with_attribute("index", producer);
+                            producers.push(context.spawn(|_| async move {
+                                for _ in 0..PRODUCER_MESSAGES {
+                                    black_box(
+                                        mailbox.value_internal().await.expect("value ask failed"),
+                                    );
+                                }
+                            }));
+                        }
+                        while let Some(result) = producers.next().await {
+                            result.expect("producer join failed");
+                        }
+                    }
+                    let elapsed = start.elapsed();
+
+                    stop_actor(mailbox, handle).await;
+                    elapsed
+                });
+        },
+    );
+}
+
+fn tokio_runner() -> &'static tokio::Runner {
+    static RUNNER: std::sync::OnceLock<tokio::Runner> = std::sync::OnceLock::new();
+    RUNNER.get_or_init(|| {
+        tokio::Runner::new(commonware_runtime::tokio::Config::new().with_worker_threads(4))
+    })
+}
+
+fn bench_message_throughput(c: &mut Criterion) {
+    let mut group = c.benchmark_group(module_path!());
+    group.measurement_time(Duration::from_secs(3));
+    group.sample_size(10);
+
+    bench_tell_flush(&mut group);
+    bench_tell_overflow(&mut group);
+    bench_sequential_asks(&mut group);
+    bench_parallel_reads(&mut group);
+    bench_mixed_fence(&mut group);
+    bench_multi_lane(&mut group);
+    bench_cloned_producers(&mut group);
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_message_throughput);
+criterion_main!(benches);

--- a/actor/src/ingress.rs
+++ b/actor/src/ingress.rs
@@ -1,0 +1,970 @@
+//! Typed ingress helpers built on the non-blocking mailbox.
+//!
+//! [`Mailbox`] and [`UnreliableMailbox`] wrap the corresponding [`mailbox`]
+//! senders with a typed request/response API. The [`crate::ingress!`] macro
+//! generates message enums and a typed wrapper over these endpoints; the
+//! [`Tell`] and [`Ask`] traits support hand-written message types.
+//!
+//! # Submission Shapes
+//!
+//! `tell` methods are synchronous and never block. `ask` methods enqueue like
+//! `subscribe`, then await the response receiver inline. `subscribe` returns
+//! the response receiver immediately so the caller can await it later.
+//!
+//! # Overflow
+//!
+//! By default, generated reliable ingress keeps FIFO overflow storage and drops
+//! queued requests whose response channel has already closed. The macro's
+//! `custom_policy`, `unreliable`, and `unreliable custom_policy` headers let
+//! callers provide custom overflow behavior or use an unreliable mailbox that
+//! may reject work under backpressure.
+//!
+//! # Tracing
+//!
+//! Generated ingress carries debug-level enqueue spans for tracing. `tell`
+//! spans are new roots that `follows_from` the caller's current span so actor
+//! ping-pong does not grow one unbounded trace. `ask` and `subscribe` spans
+//! are children of the caller's span. Use `#[span]`, `#[span(display)]`, or
+//! `#[span(debug)]` on message fields in [`crate::ingress!`] declarations to
+//! record identifying values. Bare `#[span]` is an alias for
+//! `#[span(display)]`.
+
+use crate::{
+    Feedback, Unreliable,
+    mailbox::{self, Policy, UnreliablePolicy},
+};
+use commonware_utils::channel::oneshot;
+use std::fmt::{self, Formatter};
+use thiserror::Error;
+use tracing::{Span, debug_span};
+
+/// The actor dropped a request before responding.
+///
+/// Returned when the mailbox is closed, the queue policy drops the message,
+/// or the actor drops the response sender without answering.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[error("request cancelled before a response was received")]
+pub struct Cancelled;
+
+/// Conversion trait for request/response messages.
+pub trait Ask<I>: Send + 'static {
+    /// Response type expected from the actor.
+    type Response: Send + 'static;
+
+    /// Convert this request into an ingress message.
+    fn into_ingress(self, span: Span, response: oneshot::Sender<Self::Response>) -> I;
+}
+
+/// Conversion trait for fire-and-forget messages.
+pub trait Tell<I>: Send + 'static {
+    /// Convert this message into an ingress value.
+    fn into_ingress(self, span: Span) -> I;
+}
+
+/// Scheduler route for an ingress message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Envelope<R, W> {
+    /// Read-only ingress executed concurrently on a snapshot.
+    ReadOnly(R),
+    /// Read-write ingress executed serially on the control loop.
+    ReadWrite(W),
+}
+
+/// Conversion into a scheduler route.
+pub trait IntoEnvelope: Send + 'static {
+    /// Read-only ingress branch.
+    type ReadOnlyMessage: Send + 'static;
+    /// Read-write ingress branch.
+    type ReadWriteMessage: Send + 'static;
+
+    /// Convert this value into its enqueue span and scheduler route.
+    fn into_envelope(
+        self,
+    ) -> (
+        Span,
+        Envelope<Self::ReadOnlyMessage, Self::ReadWriteMessage>,
+    );
+}
+
+/// Create the enqueue span for a fire-and-forget message.
+///
+/// The span is a new root that `follows_from` the caller's current span:
+/// a tell begins a new causal unit of work, so actors that tell each other
+/// in a loop link their traces instead of growing one trace without bound.
+fn tell_span() -> Span {
+    let current = Span::current();
+    let span = debug_span!(parent: None::<tracing::span::Id>, "actor.mailbox.tell");
+    span.follows_from(current.id());
+    span
+}
+
+async fn response<T>(receiver: oneshot::Receiver<T>) -> Result<T, Cancelled> {
+    receiver.await.map_err(|_| Cancelled)
+}
+
+/// Typed reliable mailbox endpoint.
+pub struct Mailbox<I: Policy> {
+    sender: mailbox::Sender<I>,
+}
+
+impl<I: Policy> Clone for Mailbox<I> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+impl<I: Policy> fmt::Debug for Mailbox<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Mailbox").finish_non_exhaustive()
+    }
+}
+
+impl<I: Policy> Mailbox<I> {
+    /// Create a typed mailbox from a reliable sender.
+    pub const fn new(sender: mailbox::Sender<I>) -> Self {
+        Self { sender }
+    }
+
+    /// Submit a fully-constructed ingress message.
+    ///
+    /// Callers are responsible for any span carried inside `message`.
+    /// Generated mailboxes use this to enqueue without conversion traits.
+    #[must_use = "caller must handle enqueue feedback"]
+    pub fn enqueue(&self, message: I) -> Feedback {
+        self.sender.enqueue(message)
+    }
+
+    /// Send a fire-and-forget message.
+    #[must_use = "caller must handle enqueue feedback"]
+    pub fn tell<T>(&self, message: T) -> Feedback
+    where
+        T: Tell<I>,
+    {
+        self.tell_with_span(message, tell_span())
+    }
+
+    /// Send a fire-and-forget message with a caller-provided enqueue span.
+    #[must_use = "caller must handle enqueue feedback"]
+    pub fn tell_with_span<T>(&self, message: T, span: Span) -> Feedback
+    where
+        T: Tell<I>,
+    {
+        self.enqueue(message.into_ingress(span))
+    }
+
+    /// Send a request and wait for the response.
+    ///
+    /// This is [`Mailbox::subscribe`] with the receiver awaited inline.
+    /// Returns [`Cancelled`] when the mailbox is closed, the queue policy
+    /// drops the message, or the actor drops the response sender.
+    pub async fn ask<A>(&self, message: A) -> Result<A::Response, Cancelled>
+    where
+        A: Ask<I>,
+    {
+        self.ask_with_span(message, debug_span!("actor.mailbox.ask"))
+            .await
+    }
+
+    /// Send a request with a caller-provided enqueue span and wait for the response.
+    pub async fn ask_with_span<A>(&self, message: A, span: Span) -> Result<A::Response, Cancelled>
+    where
+        A: Ask<I>,
+    {
+        self.subscribe_with_span(message, span)
+            .await
+            .map_err(|_| Cancelled)
+    }
+
+    /// Enqueue a request and return the response receiver to be awaited later.
+    ///
+    /// The receiver resolves to an error when the mailbox is closed, the
+    /// queue policy drops the message, or the actor drops the response
+    /// sender.
+    pub fn subscribe<A>(&self, message: A) -> oneshot::Receiver<A::Response>
+    where
+        A: Ask<I>,
+    {
+        self.subscribe_with_span(message, debug_span!("actor.mailbox.subscribe"))
+    }
+
+    /// Enqueue a request with a caller-provided enqueue span and return the response receiver.
+    pub fn subscribe_with_span<A>(&self, message: A, span: Span) -> oneshot::Receiver<A::Response>
+    where
+        A: Ask<I>,
+    {
+        let (sender, receiver) = oneshot::channel();
+        let _ = self.enqueue(message.into_ingress(span, sender));
+        receiver
+    }
+}
+
+impl<I: Policy> From<mailbox::Sender<I>> for Mailbox<I> {
+    fn from(sender: mailbox::Sender<I>) -> Self {
+        Self::new(sender)
+    }
+}
+
+/// Typed unreliable mailbox endpoint.
+pub struct UnreliableMailbox<I: UnreliablePolicy> {
+    sender: mailbox::UnreliableSender<I>,
+}
+
+impl<I: UnreliablePolicy> Clone for UnreliableMailbox<I> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+impl<I: UnreliablePolicy> fmt::Debug for UnreliableMailbox<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnreliableMailbox").finish_non_exhaustive()
+    }
+}
+
+impl<I: UnreliablePolicy> UnreliableMailbox<I> {
+    /// Create a typed mailbox from an unreliable sender.
+    pub const fn new(sender: mailbox::UnreliableSender<I>) -> Self {
+        Self { sender }
+    }
+
+    /// Submit a fully-constructed ingress message.
+    ///
+    /// Callers are responsible for any span carried inside `message`.
+    /// Generated mailboxes use this to enqueue without conversion traits.
+    #[must_use = "caller must handle enqueue feedback"]
+    pub fn enqueue(&self, message: I) -> Unreliable<Feedback> {
+        self.sender.enqueue(message)
+    }
+
+    /// Send a fire-and-forget message.
+    #[must_use = "caller must handle enqueue feedback"]
+    pub fn tell<T>(&self, message: T) -> Unreliable<Feedback>
+    where
+        T: Tell<I>,
+    {
+        self.tell_with_span(message, tell_span())
+    }
+
+    /// Send a fire-and-forget message with a caller-provided enqueue span.
+    #[must_use = "caller must handle enqueue feedback"]
+    pub fn tell_with_span<T>(&self, message: T, span: Span) -> Unreliable<Feedback>
+    where
+        T: Tell<I>,
+    {
+        self.enqueue(message.into_ingress(span))
+    }
+
+    /// Send a request and wait for the response.
+    ///
+    /// This is [`UnreliableMailbox::subscribe`] with the receiver awaited
+    /// inline. Rejection under backpressure also surfaces as [`Cancelled`];
+    /// callers that need to observe rejection directly should use
+    /// [`UnreliableMailbox::tell`]-style messages or
+    /// [`UnreliableMailbox::enqueue`].
+    pub async fn ask<A>(&self, message: A) -> Result<A::Response, Cancelled>
+    where
+        A: Ask<I>,
+    {
+        self.ask_with_span(message, debug_span!("actor.mailbox.ask"))
+            .await
+    }
+
+    /// Send a request with a caller-provided enqueue span and wait for the response.
+    pub async fn ask_with_span<A>(&self, message: A, span: Span) -> Result<A::Response, Cancelled>
+    where
+        A: Ask<I>,
+    {
+        response(self.subscribe_with_span(message, span)).await
+    }
+
+    /// Enqueue a request and return the response receiver to be awaited later.
+    ///
+    /// The receiver resolves to an error when the mailbox is closed, the
+    /// message is rejected under backpressure, or the actor drops the
+    /// response sender.
+    pub fn subscribe<A>(&self, message: A) -> oneshot::Receiver<A::Response>
+    where
+        A: Ask<I>,
+    {
+        self.subscribe_with_span(message, debug_span!("actor.mailbox.subscribe"))
+    }
+
+    /// Enqueue a request with a caller-provided enqueue span and return the response receiver.
+    pub fn subscribe_with_span<A>(&self, message: A, span: Span) -> oneshot::Receiver<A::Response>
+    where
+        A: Ask<I>,
+    {
+        let (sender, receiver) = oneshot::channel();
+        let _ = self.enqueue(message.into_ingress(span, sender));
+        receiver
+    }
+}
+
+impl<I: UnreliablePolicy> From<mailbox::UnreliableSender<I>> for UnreliableMailbox<I> {
+    fn from(sender: mailbox::UnreliableSender<I>) -> Self {
+        Self::new(sender)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mocks::TraceRecorder;
+    use commonware_runtime::{Runner as _, Supervisor as _, deterministic};
+    use commonware_utils::NZUsize;
+    use std::{collections::VecDeque, sync::mpsc::TryRecvError};
+
+    crate::ingress! {
+        GeneratedMailbox,
+        pub tell Ping { value: u64 };
+        pub ask Get -> u64;
+        pub ask read_write Set { value: u64 } -> u64;
+        pub subscribe Watch -> u64;
+    }
+
+    crate::ingress! {
+        unreliable,
+        LossyMailbox,
+        pub tell Pulse;
+        pub ask Fetch -> u64;
+    }
+
+    // A generic payload exercising type parameters in both ingress enums.
+    crate::ingress! {
+        TypedMailbox<T: Clone + Send + 'static>,
+        pub tell Store { value: T };
+        pub ask read_write Take -> T;
+    }
+
+    // `T` reaches only the read-only enum, so the read-write enum drops it and
+    // is generic-free.
+    crate::ingress! {
+        HalfGenericMailbox<T: Send + 'static>,
+        pub tell Nudge;
+        pub ask Peek -> T;
+    }
+
+    // `N` reaches only the read-only enum (via the `Get` response), so it is
+    // filtered onto the read-only enum and dropped from the read-write enum.
+    crate::ingress! {
+        ConstMailbox<const N: usize>,
+        pub tell Push { value: u64 };
+        pub ask Get -> [u8; N];
+    }
+
+    // The log-shape protocol: the read-write branch uses `T` but the read-only
+    // branch does not, so the read-only enum is generic-free.
+    crate::ingress! {
+        LogShapeMailbox<T: Clone + Send + 'static>,
+        subscribe read_write Propose -> T;
+        subscribe Verify -> bool;
+    }
+
+    // Each branch uses a different parameter, so each sub-enum keeps exactly
+    // one of them.
+    crate::ingress! {
+        SplitMailbox<A: Send + 'static, B: Send + 'static>,
+        pub tell Left { value: A };
+        pub ask Right -> B;
+    }
+
+    // Every item is a `tell`, so the read-only enum is an uninhabited `enum {}`
+    // even though the mailbox is generic.
+    crate::ingress! {
+        AllTellMailbox<T: Send + 'static>,
+        pub tell Store { value: T };
+    }
+
+    // Fields annotated with `#[span]` are recorded on the enqueue span.
+    crate::ingress! {
+        ObservedMailbox,
+        pub tell Observe { #[span] view: &'static str, #[span(debug)] tag: &'static str, payload: u64 };
+        pub ask Lookup { #[span] key: &'static str } -> u64;
+    }
+
+    // Hand-written coalescing policy: overflow keeps only the latest message.
+    crate::ingress! {
+        custom_policy,
+        CoalescingMailbox,
+        pub tell Set2 { value: u64 };
+    }
+
+    #[derive(Default)]
+    pub struct Latest(Option<CoalescingMailboxMessage>);
+
+    impl mailbox::Overflow<CoalescingMailboxMessage> for Latest {
+        fn is_empty(&self) -> bool {
+            self.0.is_none()
+        }
+
+        fn drain<F>(&mut self, mut push: F)
+        where
+            F: FnMut(CoalescingMailboxMessage) -> Option<CoalescingMailboxMessage>,
+        {
+            if let Some(message) = self.0.take() {
+                self.0 = push(message);
+            }
+        }
+    }
+
+    impl mailbox::Policy for CoalescingMailboxMessage {
+        type Overflow = Latest;
+
+        fn handle(overflow: &mut Self::Overflow, message: Self) {
+            overflow.0 = Some(message);
+        }
+    }
+
+    // Hand-written unreliable policy composed with the `unreliable` flag.
+    crate::ingress! {
+        unreliable custom_policy,
+        DroppyMailbox,
+        pub tell Poke;
+    }
+
+    #[derive(Default)]
+    pub struct NoOverflow;
+
+    impl mailbox::Overflow<DroppyMailboxMessage> for NoOverflow {
+        fn is_empty(&self) -> bool {
+            true
+        }
+
+        fn drain<F>(&mut self, _push: F)
+        where
+            F: FnMut(DroppyMailboxMessage) -> Option<DroppyMailboxMessage>,
+        {
+        }
+    }
+
+    impl mailbox::UnreliablePolicy for DroppyMailboxMessage {
+        type Overflow = NoOverflow;
+
+        fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
+            false
+        }
+    }
+
+    enum Message {
+        Tell {
+            span: Span,
+            value: u64,
+        },
+        Ask {
+            span: Span,
+            response: oneshot::Sender<u64>,
+        },
+    }
+
+    impl mailbox::Policy for Message {
+        type Overflow = VecDeque<Self>;
+
+        fn handle(overflow: &mut Self::Overflow, message: Self) {
+            overflow.push_back(message);
+        }
+    }
+
+    impl mailbox::UnreliablePolicy for Message {
+        type Overflow = VecDeque<Self>;
+
+        fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
+            false
+        }
+    }
+
+    struct TellValue(u64);
+
+    impl Tell<Message> for TellValue {
+        fn into_ingress(self, span: Span) -> Message {
+            Message::Tell {
+                span,
+                value: self.0,
+            }
+        }
+    }
+
+    struct AskValue;
+
+    impl Ask<Message> for AskValue {
+        type Response = u64;
+
+        fn into_ingress(self, span: Span, response: oneshot::Sender<u64>) -> Message {
+            Message::Ask { span, response }
+        }
+    }
+
+    #[test]
+    fn tell_returns_backoff_when_ready_is_full() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(1));
+            let mailbox = Mailbox::new(sender);
+
+            assert_eq!(mailbox.tell(TellValue(1)), Feedback::Ok);
+            assert_eq!(mailbox.tell(TellValue(2)), Feedback::Backoff);
+
+            match receiver.try_recv().expect("first message") {
+                Message::Tell { span, value } => {
+                    assert!(span.is_disabled());
+                    assert_eq!(value, 1);
+                }
+                Message::Ask { .. } => panic!("unexpected ask"),
+            }
+            match receiver.try_recv().expect("second message") {
+                Message::Tell { span, value } => {
+                    assert!(span.is_disabled());
+                    assert_eq!(value, 2);
+                }
+                Message::Ask { .. } => panic!("unexpected ask"),
+            }
+        });
+    }
+
+    #[test]
+    fn tell_starts_root_span_that_follows_caller() {
+        let (recorder, state) = TraceRecorder::new();
+        tracing::subscriber::with_default(recorder, || {
+            let runner = deterministic::Runner::default();
+            runner.start(|context| async move {
+                let (sender, _receiver) =
+                    mailbox::new::<Message>(context.child("mailbox"), NZUsize!(1));
+                let mailbox = Mailbox::new(sender);
+
+                let caller = tracing::info_span!("test.actor.caller");
+                let _guard = caller.enter();
+                assert_eq!(mailbox.tell(TellValue(1)), Feedback::Ok);
+            });
+        });
+
+        let caller = state.span("test.actor.caller");
+        let tell = state.span("actor.mailbox.tell");
+        assert_eq!(tell.parent, None);
+        assert_eq!(tell.follows, vec![caller.id]);
+    }
+
+    #[test]
+    fn span_fields_recorded_from_annotated_fields() {
+        let (recorder, state) = TraceRecorder::new();
+        tracing::subscriber::with_default(recorder, || {
+            let runner = deterministic::Runner::default();
+            runner.start(|context| async move {
+                let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(2));
+                let mailbox = ObservedMailbox::from(Mailbox::new(sender));
+
+                assert_eq!(mailbox.observe_internal("7", "hot", 9), Feedback::Ok);
+                let responder = async move {
+                    let (_, first) = receiver.recv().await.unwrap().into_envelope();
+                    match first {
+                        Envelope::ReadWrite(ObservedMailboxReadWriteMessage::Observe {
+                            view,
+                            tag,
+                            payload,
+                        }) => {
+                            assert_eq!((view, tag, payload), ("7", "hot", 9));
+                        }
+                        _ => panic!("expected observe"),
+                    }
+
+                    let (_, second) = receiver.recv().await.unwrap().into_envelope();
+                    match second {
+                        Envelope::ReadOnly(ObservedMailboxReadOnlyMessage::Lookup {
+                            key,
+                            response,
+                        }) => {
+                            assert_eq!(key, "3");
+                            response.send(4).unwrap();
+                        }
+                        _ => panic!("expected lookup"),
+                    }
+                };
+                let (looked, ()) = futures::join!(mailbox.lookup_internal("3"), responder);
+                assert_eq!(looked.unwrap(), 4);
+            });
+        });
+
+        let observe = state.span("actor.observed_mailbox.observe");
+        assert_eq!(observe.field("view"), "7");
+        assert_eq!(observe.field("tag"), "\"hot\"");
+        assert!(observe.fields.iter().all(|(name, _)| *name != "payload"));
+
+        let lookup = state.span("actor.observed_mailbox.lookup");
+        assert_eq!(lookup.field("key"), "3");
+    }
+
+    #[test]
+    fn ask_roundtrip() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(1));
+            let mailbox = Mailbox::new(sender);
+
+            let requester = async move { mailbox.ask(AskValue).await.expect("response") };
+            let responder = async move {
+                match receiver.recv().await.expect("message") {
+                    Message::Ask { span, response } => {
+                        assert!(span.is_disabled());
+                        response.send(7).expect("send response");
+                    }
+                    Message::Tell { .. } => panic!("unexpected tell"),
+                }
+            };
+            assert_eq!(futures::join!(requester, responder).0, 7);
+        });
+    }
+
+    #[test]
+    fn ask_resolves_cancelled_when_mailbox_closed() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, receiver) = mailbox::new::<Message>(context.child("mailbox"), NZUsize!(1));
+            let mailbox = Mailbox::new(sender);
+            drop(receiver);
+
+            assert_eq!(mailbox.ask(AskValue).await.unwrap_err(), Cancelled);
+        });
+    }
+
+    #[test]
+    fn ask_resolves_cancelled_when_actor_drops_response() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(1));
+            let mailbox = Mailbox::new(sender);
+
+            let requester = async move { mailbox.ask(AskValue).await };
+            let responder = async move {
+                let message = receiver.recv().await.expect("message");
+                drop(message);
+            };
+            assert_eq!(futures::join!(requester, responder).0, Err(Cancelled));
+        });
+    }
+
+    #[test]
+    fn subscribe_resolves_after_reply() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(1));
+            let mailbox = Mailbox::new(sender);
+
+            let pending = mailbox.subscribe(AskValue);
+            match receiver.recv().await.expect("message") {
+                Message::Ask { response, .. } => response.send(3).expect("send response"),
+                Message::Tell { .. } => panic!("unexpected tell"),
+            }
+            assert_eq!(pending.await.expect("response"), 3);
+        });
+    }
+
+    #[test]
+    fn unreliable_ask_rejection_resolves_cancelled() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, _receiver) =
+                mailbox::new_unreliable(context.child("mailbox"), NZUsize!(1));
+            let mailbox = UnreliableMailbox::new(sender);
+
+            assert_eq!(mailbox.tell(TellValue(1)), Unreliable::new(Feedback::Ok));
+            assert_eq!(mailbox.ask(AskValue).await.unwrap_err(), Cancelled);
+        });
+    }
+
+    #[test]
+    fn generated_mailbox_routes_messages() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(2));
+            let mailbox = GeneratedMailbox::from(Mailbox::new(sender));
+
+            assert_eq!(mailbox.ping_internal(5), Feedback::Ok);
+            let responder = async move {
+                let (_, first) = receiver.recv().await.unwrap().into_envelope();
+                assert!(matches!(
+                    first,
+                    Envelope::ReadWrite(GeneratedMailboxReadWriteMessage::Ping { value: 5 })
+                ));
+
+                let (_, second) = receiver.recv().await.unwrap().into_envelope();
+                match second {
+                    Envelope::ReadOnly(GeneratedMailboxReadOnlyMessage::Get { response }) => {
+                        response.send(7).unwrap();
+                    }
+                    _ => panic!("expected read-only get"),
+                }
+
+                let (_, third) = receiver.recv().await.unwrap().into_envelope();
+                match third {
+                    Envelope::ReadWrite(GeneratedMailboxReadWriteMessage::Set {
+                        value,
+                        response,
+                    }) => {
+                        assert_eq!(value, 9);
+                        response.send(10).unwrap();
+                    }
+                    _ => panic!("expected read-write set"),
+                }
+            };
+
+            let (get_feedback, get_pending) = mailbox.enqueue_get_internal();
+            let (set_feedback, set_pending) = mailbox.enqueue_set_internal(9);
+            assert_eq!(get_feedback, Feedback::Ok);
+            assert!(set_feedback.accepted());
+
+            let (get, set, ()) = futures::join!(get_pending, set_pending, responder);
+            assert_eq!(get.unwrap(), 7);
+            assert_eq!(set.unwrap(), 10);
+        });
+    }
+
+    #[test]
+    fn generated_generic_mailbox_routes_messages() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(2));
+            let mailbox = TypedMailbox::from(Mailbox::new(sender));
+
+            assert_eq!(mailbox.store_internal("payload".to_string()), Feedback::Ok);
+            let responder = async move {
+                let (_, first) = receiver.recv().await.unwrap().into_envelope();
+                match first {
+                    Envelope::ReadWrite(TypedMailboxReadWriteMessage::Store { value }) => {
+                        assert_eq!(value, "payload");
+                    }
+                    _ => panic!("expected store"),
+                }
+
+                let (_, second) = receiver.recv().await.unwrap().into_envelope();
+                match second {
+                    Envelope::ReadWrite(TypedMailboxReadWriteMessage::Take { response }) => {
+                        response.send("stored".to_string()).unwrap();
+                    }
+                    _ => panic!("expected take"),
+                }
+            };
+
+            let (taken, ()) = futures::join!(mailbox.take_internal(), responder);
+            assert_eq!(taken.unwrap(), "stored");
+        });
+    }
+
+    #[test]
+    fn generated_filtered_generics_compile_and_route() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            // `T` reaches only the read-only enum, so the read-write enum is
+            // bare: the annotation names it without generics.
+            let (sender, mut receiver) = mailbox::new(context.child("half_generic"), NZUsize!(1));
+            let mailbox = HalfGenericMailbox::<u64>::from(Mailbox::new(sender));
+            assert_eq!(mailbox.nudge_internal(), Feedback::Ok);
+            let (_, event) = receiver.recv().await.unwrap().into_envelope();
+            let nudge: HalfGenericMailboxReadWriteMessage = match event {
+                Envelope::ReadWrite(message) => message,
+                _ => panic!("expected nudge"),
+            };
+            match nudge {
+                HalfGenericMailboxReadWriteMessage::Nudge => {}
+            }
+
+            // `N` reaches only the read-only enum. The read-write enum is bare
+            // (named without generics) while the read-only enum routes `[u8; N]`.
+            let (sender, mut receiver) = mailbox::new(context.child("const"), NZUsize!(2));
+            let mailbox = ConstMailbox::<4>::from(Mailbox::new(sender));
+            assert_eq!(mailbox.push_internal(3), Feedback::Ok);
+            let responder = async move {
+                let (_, first) = receiver.recv().await.unwrap().into_envelope();
+                let push: ConstMailboxReadWriteMessage = match first {
+                    Envelope::ReadWrite(message) => message,
+                    _ => panic!("expected push"),
+                };
+                match push {
+                    ConstMailboxReadWriteMessage::Push { value } => assert_eq!(value, 3),
+                }
+
+                let (_, second) = receiver.recv().await.unwrap().into_envelope();
+                match second {
+                    Envelope::ReadOnly(ConstMailboxReadOnlyMessage::Get { response }) => {
+                        response.send([7u8; 4]).unwrap();
+                    }
+                    _ => panic!("expected get"),
+                }
+            };
+            let (got, ()) = futures::join!(mailbox.get_internal(), responder);
+            assert_eq!(got.unwrap(), [7u8; 4]);
+        });
+    }
+
+    #[test]
+    fn log_shape_readonly_enum_drops_unused_generic() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("log_shape"), NZUsize!(2));
+            let mailbox = LogShapeMailbox::<u64>::from(Mailbox::new(sender));
+
+            let responder = async move {
+                let (_, first) = receiver.recv().await.unwrap().into_envelope();
+                match first {
+                    Envelope::ReadWrite(LogShapeMailboxReadWriteMessage::Propose { response }) => {
+                        response.send(9).unwrap();
+                    }
+                    _ => panic!("expected propose"),
+                }
+
+                // The read-only enum is named without generics.
+                let (_, second) = receiver.recv().await.unwrap().into_envelope();
+                let verify: LogShapeMailboxReadOnlyMessage = match second {
+                    Envelope::ReadOnly(message) => message,
+                    _ => panic!("expected verify"),
+                };
+                match verify {
+                    LogShapeMailboxReadOnlyMessage::Verify { response } => {
+                        response.send(true).unwrap();
+                    }
+                }
+            };
+
+            let proposed = mailbox.propose_internal();
+            let verified = mailbox.verify_internal();
+            let (proposed, verified, ()) = futures::join!(proposed, verified, responder);
+            assert_eq!(proposed.unwrap(), 9);
+            assert!(verified.unwrap());
+        });
+    }
+
+    #[test]
+    fn split_generics_route_to_each_branch() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("split"), NZUsize!(2));
+            let mailbox = SplitMailbox::<u64, bool>::from(Mailbox::new(sender));
+
+            assert_eq!(mailbox.left_internal(5), Feedback::Ok);
+            let responder = async move {
+                // Each sub-enum keeps exactly the one parameter its branch uses.
+                let (_, first) = receiver.recv().await.unwrap().into_envelope();
+                let left: SplitMailboxReadWriteMessage<u64> = match first {
+                    Envelope::ReadWrite(message) => message,
+                    _ => panic!("expected left"),
+                };
+                match left {
+                    SplitMailboxReadWriteMessage::Left { value } => assert_eq!(value, 5),
+                }
+
+                let (_, second) = receiver.recv().await.unwrap().into_envelope();
+                let right: SplitMailboxReadOnlyMessage<bool> = match second {
+                    Envelope::ReadOnly(message) => message,
+                    _ => panic!("expected right"),
+                };
+                match right {
+                    SplitMailboxReadOnlyMessage::Right { response } => response.send(true).unwrap(),
+                }
+            };
+
+            let (right, ()) = futures::join!(mailbox.right_internal(), responder);
+            assert!(right.unwrap());
+        });
+    }
+
+    #[test]
+    fn all_tell_generic_mailbox_has_uninhabited_readonly_enum() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("all_tell"), NZUsize!(1));
+            let mailbox = AllTellMailbox::<u64>::from(Mailbox::new(sender));
+
+            assert_eq!(mailbox.store_internal(7), Feedback::Ok);
+            let (_, event) = receiver.recv().await.unwrap().into_envelope();
+            match event {
+                Envelope::ReadWrite(AllTellMailboxReadWriteMessage::Store { value }) => {
+                    assert_eq!(value, 7);
+                }
+                // The read-only enum is uninhabited, so this arm is unreachable.
+                Envelope::ReadOnly(message) => match message {},
+            }
+        });
+    }
+
+    #[test]
+    fn generated_policy_skips_closed_response_in_overflow() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(1));
+            let mailbox = GeneratedMailbox::from(Mailbox::new(sender));
+
+            assert_eq!(mailbox.ping_internal(1), Feedback::Ok);
+            let response = mailbox.watch_internal();
+            drop(response);
+
+            let (_, first) = receiver.try_recv().unwrap().into_envelope();
+            assert!(matches!(
+                first,
+                Envelope::ReadWrite(GeneratedMailboxReadWriteMessage::Ping { value: 1 })
+            ));
+            match receiver.try_recv() {
+                Err(TryRecvError::Empty) => {}
+                Ok(_) => panic!("closed response should be skipped"),
+                Err(err) => panic!("unexpected error: {err:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn custom_policy_coalesces_overflow() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(1));
+            let mailbox = CoalescingMailbox::from(Mailbox::new(sender));
+
+            assert_eq!(mailbox.set2_internal(1), Feedback::Ok);
+            assert_eq!(mailbox.set2_internal(2), Feedback::Backoff);
+            assert_eq!(mailbox.set2_internal(3), Feedback::Backoff);
+
+            let (_, first) = receiver.try_recv().unwrap().into_envelope();
+            match first {
+                Envelope::ReadWrite(CoalescingMailboxReadWriteMessage::Set2 { value }) => {
+                    assert_eq!(value, 1);
+                }
+                _ => panic!("expected set"),
+            }
+            let (_, second) = receiver.try_recv().unwrap().into_envelope();
+            match second {
+                Envelope::ReadWrite(CoalescingMailboxReadWriteMessage::Set2 { value }) => {
+                    assert_eq!(value, 3);
+                }
+                _ => panic!("expected coalesced set"),
+            }
+            assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
+        });
+    }
+
+    #[test]
+    fn custom_unreliable_policy_rejects_overflow() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, _receiver) =
+                mailbox::new_unreliable(context.child("mailbox"), NZUsize!(1));
+            let mailbox = DroppyMailbox::from(UnreliableMailbox::new(sender));
+
+            assert_eq!(mailbox.poke_internal(), Unreliable::new(Feedback::Ok));
+            assert_eq!(mailbox.poke_internal(), Unreliable::Rejected);
+        });
+    }
+
+    #[test]
+    fn generated_unreliable_policy_rejects_overflow() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (sender, _receiver) =
+                mailbox::new_unreliable(context.child("mailbox"), NZUsize!(1));
+            let mailbox = LossyMailbox::from(UnreliableMailbox::new(sender));
+
+            assert_eq!(mailbox.pulse_internal(), Unreliable::new(Feedback::Ok));
+            let (feedback, pending) = mailbox.enqueue_fetch_internal();
+            assert_eq!(feedback, Unreliable::Rejected);
+            assert!(pending.await.is_err());
+        });
+    }
+}

--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -1,5 +1,54 @@
 //! Safely coordinate concurrent components.
 //!
+//! An actor is a task that owns mutable state and processes messages sent by
+//! other components. Getting that pattern right by hand is subtle: senders
+//! need backpressure that never blocks them, request/response needs typing and
+//! tracing, reads want to run concurrently while writes stay exclusive, and
+//! shutdown must not strand callers awaiting a response. This crate packages
+//! the pattern into three layers, each usable without the ones above it:
+//!
+//! ```text
+//!   callers
+//!      |  tell / ask / subscribe        typed methods from ingress!
+//!      v
+//!   +--------------------------+
+//!   |    mailbox (per lane)    |        bounded ready queue + policy overflow
+//!   +--------------------------+
+//!      |
+//!      v
+//!   +--------------------------+        read-only  --> read pool (snapshots)
+//!   |       service loop       |
+//!   +--------------------------+        read-write --> control loop (serial)
+//!      |
+//!      v
+//!   actor hooks (on_read_only, on_read_write, ...)
+//! ```
+//!
+//! # Mailbox
+//!
+//! [`mailbox`] provides a bounded, non-blocking queue. Sends never block: when
+//! the ready queue is full, the message is handed to a caller-defined
+//! [`mailbox::Policy`] that can retain, coalesce, replace, or deliberately
+//! drop it. Backpressure behavior is part of an actor's message type rather
+//! than a property discovered under load.
+//!
+//! # Ingress
+//!
+//! [`ingress!`] turns message declarations into typed enums and a mailbox
+//! wrapper with `tell` (fire-and-forget), `ask` (request/response), and
+//! `subscribe` (enqueue now, await later) methods. Each declaration routes to
+//! a read-only or read-write handler, and generated methods carry tracing
+//! spans across the channel so a request's trace follows it between actors.
+//!
+//! # Service
+//!
+//! [`service::Builder`] runs an [`Actor`] on a managed control loop.
+//! Read-only ingress is dispatched concurrently to a bounded worker pool,
+//! each handler executing on a snapshot of actor state captured at admission.
+//! Read-write ingress runs serially on the control loop, ordered against
+//! in-flight reads by a configurable [`service::FenceMode`]. See [`service`]
+//! for the concurrency model and its ordering guarantees.
+//!
 //! # Status
 //!
 //! Stability varies by primitive. See [README](https://github.com/commonwarexyz/monorepo#stability) for details.
@@ -8,6 +57,13 @@
     html_logo_url = "https://commonware.xyz/imgs/rustdoc_logo.svg",
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
+
+// Macro expansions use one stable path in this crate, doctests, and downstream crates.
+#[allow(unused_extern_crates)]
+extern crate self as commonware_actor;
+
+#[cfg(test)]
+mod mocks;
 
 commonware_macros::stability_scope!(BETA {
     /// Feedback from submitting work to a bounded endpoint.
@@ -73,4 +129,323 @@ commonware_macros::stability_scope!(BETA {
     }
 
     pub mod mailbox;
+});
+
+commonware_macros::stability_scope!(ALPHA {
+    use std::{
+        fmt::{Debug, Display},
+        future::Future,
+        num::NonZeroUsize,
+    };
+
+    pub mod ingress;
+    pub mod service;
+
+    pub use commonware_actor_macros::ingress;
+    #[doc(hidden)]
+    pub use commonware_utils::channel::oneshot;
+    #[doc(hidden)]
+    pub use tracing;
+
+    /// Stateful task driven by the actor service loop.
+    ///
+    /// See [`service`] for the loop's concurrency model and ordering
+    /// guarantees.
+    ///
+    /// # Lifecycle
+    ///
+    /// In driver mode ([`service::Builder`]), hooks run in this order:
+    ///
+    /// 1. `on_startup` once (receives [`Actor::Args`] data).
+    /// 2. Per iteration: `preprocess`, then [`Actor::next_event`] selects
+    ///    one event (with runtime shutdown and read failures checked by the
+    ///    service loop). If a lane message is selected, the service may drain
+    ///    additional ready messages from that same lane, up to
+    ///    [`Actor::max_lane_batch`]. Each message is dispatched to
+    ///    `on_read_only` (concurrent) or `on_read_write` (serial). After at
+    ///    least one message is dispatched, `postprocess` runs once.
+    /// 3. `on_shutdown` once, on graceful exit (runtime stop,
+    ///    [`service::Event::Stop`], or a fatal handler error).
+    ///
+    /// Returning `Err` from `on_read_only` or `on_read_write` is fatal: the
+    /// error is logged and `on_shutdown` is called before the loop exits.
+    ///
+    /// # Shutdown
+    ///
+    /// Shutdown is prompt: in-flight read-only handlers are aborted before
+    /// [`Actor::on_shutdown`] runs, and their pending askers observe
+    /// [`ingress::Cancelled`]. A read-only handler must not be relied upon to
+    /// run to completion across shutdown.
+    pub trait Actor<E>: Send + 'static {
+        /// Typed mailbox returned by the service builder.
+        ///
+        /// Set this to the mailbox wrapper generated by [`ingress!`] so that
+        /// [`service::Builder::build`] returns the typed mailbox
+        /// directly.
+        type Mailbox: Send + Clone + 'static;
+
+        /// Envelope ingress type consumed by the service mailbox.
+        ///
+        /// Generated mailbox wrappers from [`ingress!`] set this to
+        /// `<MailboxName>Message`.
+        ///
+        /// Service builders choose whether lanes are backed by reliable or
+        /// unreliable mailbox endpoints.
+        type Ingress: service::Ingress;
+
+        /// Fatal error type returned by [`Actor::on_read_only`] and
+        /// [`Actor::on_read_write`].
+        ///
+        /// Returning `Err` from read or write handlers logs the error and
+        /// stops the actor.
+        type Error: Debug + Display + Send + 'static;
+
+        /// Snapshot type used by concurrent read-only ingress handlers.
+        ///
+        /// Must be cheap to create and clone because the service captures or
+        /// clones one snapshot for each read-only message.
+        type Snapshot: Clone + Send + 'static;
+
+        /// Data provided to the service on start up.
+        ///
+        /// Use `()` for actors that do not need external start-up data.
+        /// Actors with non-unit `Args` must be started via
+        /// [`service::Reliable::start_with`].
+        type Args: Send + 'static;
+
+        /// Maximum number of messages to process from a winning lane in one
+        /// iteration.
+        ///
+        /// After the loop receives a mailbox event from a lane, it may
+        /// non-blockingly drain additional ready messages from that same lane
+        /// until this cap is reached.
+        ///
+        /// Tradeoff:
+        /// - lower values improve fairness across lanes and reduce tail
+        ///   latency for events waiting on other lanes.
+        /// - higher values improve throughput by reducing loop overhead and
+        ///   enabling batching on hot lanes.
+        ///
+        /// Raising this value can temporarily starve colder lanes and delay
+        /// processing of actor-owned sources while a hot lane is being drained.
+        /// [`Actor::next_event`] chooses the first event in an iteration; batch
+        /// draining does not re-enter that selection until the batch ends.
+        ///
+        /// A batch does not always reach this cap. It ends early when the
+        /// lane has no ready message or when the read-only concurrency limit
+        /// fills; remaining lane messages wait for a later iteration and can
+        /// lose the next [`Actor::next_event`] selection to another source.
+        /// A read-write message inside a batch is also not free: under
+        /// [`service::FenceMode::Linearizable`] it drains every in-flight
+        /// read-only handler before running, so a batch mixing reads and
+        /// writes re-serializes at each write instead of streaming through.
+        ///
+        /// The default is `1`, which preserves single-message iteration
+        /// behavior.
+        fn max_lane_batch(&self, _args: &Self::Args) -> NonZeroUsize {
+            NonZeroUsize::MIN
+        }
+
+        /// Create a snapshot for handling read-only ingress concurrently.
+        ///
+        /// The service loop captures a snapshot when a read-only message is
+        /// admitted, then executes [`Actor::on_read_only`] on a read worker.
+        /// Consecutive read-only messages admitted without an intervening
+        /// `&mut self` hook share one snapshot: the service calls this once
+        /// and clones the result for the rest of the run.
+        ///
+        /// This must be cheap to create and clone. Prefer `Arc`-backed
+        /// structures or `Copy` types. Avoid copying large data structures.
+        fn snapshot(&self, args: &Self::Args) -> Self::Snapshot;
+
+        /// Runs once when the control loop starts.
+        ///
+        /// `args` carries externally-provided data that the actor needs
+        /// before processing messages (e.g., connection handles, peer
+        /// identity).
+        fn on_startup(
+            &mut self,
+            _context: &mut E,
+            _args: &mut Self::Args,
+        ) -> impl Future<Output = ()> + Send {
+            async {}
+        }
+
+        /// Runs once when the control loop stops gracefully.
+        ///
+        /// Called on: runtime shutdown signal, [`service::Event::Stop`], or
+        /// after a fatal handler error from [`Actor::on_read_only`] or
+        /// [`Actor::on_read_write`]. In-flight read-only handlers are
+        /// aborted before this hook runs, so no read-only handler executes
+        /// concurrently with it or responds after it.
+        fn on_shutdown(
+            &mut self,
+            _context: &mut E,
+            _args: &mut Self::Args,
+        ) -> impl Future<Output = ()> + Send {
+            async {}
+        }
+
+        /// Runs at the beginning of each iteration, before polling for events.
+        ///
+        /// Use this for periodic housekeeping that should run every loop
+        /// iteration regardless of which event fires (e.g., cleaning stale
+        /// subscriptions, refreshing state).
+        ///
+        /// Iterations are not one-to-one with dispatched messages. An
+        /// iteration also occurs when [`Actor::next_event`] returns
+        /// [`service::Event::Continue`] and each time the loop resumes after
+        /// waiting for read capacity, so `preprocess` can run many times
+        /// between two dispatched messages and is not paired with
+        /// [`Actor::postprocess`]. Keep it cheap and do not treat a call as
+        /// evidence that a message was processed.
+        fn preprocess(
+            &mut self,
+            _context: &mut E,
+            _args: &mut Self::Args,
+        ) -> impl Future<Output = ()> + Send {
+            async {}
+        }
+
+        /// Runs at the end of each iteration that dispatched ingress.
+        ///
+        /// Only called when at least one message was dispatched in the
+        /// iteration, from a lane or as [`service::Event::External`]. Skipped
+        /// when the loop merely waited for read capacity or observed
+        /// [`service::Event::Continue`], so it is not paired with
+        /// [`Actor::preprocess`], which runs on every iteration.
+        /// When a lane batch is enabled via [`Actor::max_lane_batch`],
+        /// `postprocess` runs once after the full batch completes.
+        fn postprocess(
+            &mut self,
+            _context: &mut E,
+            _args: &mut Self::Args,
+        ) -> impl Future<Output = ()> + Send {
+            async {}
+        }
+
+        /// Handle one read-only ingress message.
+        ///
+        /// Read-only handlers execute concurrently on read workers, receive
+        /// only the captured `snapshot`, and must not mutate actor state. The
+        /// `context` parameter is a child of the actor's runtime context,
+        /// suitable for spawning sub-tasks, accessing metrics, etc.
+        ///
+        /// Returning `Err` is fatal: the service loop logs the error and
+        /// calls [`Actor::on_shutdown`] before exiting. Other in-flight
+        /// reads are aborted before [`Actor::on_shutdown`] runs.
+        ///
+        /// Do not send ingress to the same actor from a read-only handler.
+        /// Read-write handlers fence behind earlier reads, so a read-only
+        /// handler waiting on its own actor can deadlock the service.
+        fn on_read_only(
+            _context: E,
+            _snapshot: Self::Snapshot,
+            _message: <Self::Ingress as ingress::IntoEnvelope>::ReadOnlyMessage,
+        ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+            async {
+                panic!(
+                    "Actor::on_read_only must be implemented when read-only ingress is dispatched"
+                )
+            }
+        }
+
+        /// Handle one ingress message that may mutate actor state.
+        ///
+        /// Read-write handlers execute serially on the actor loop. Under the
+        /// default [`service::FenceMode::Linearizable`], they are fenced
+        /// behind in-flight read-only handlers that were dispatched before
+        /// the write arrived; reads dispatched after are not waited on. Under
+        /// [`service::FenceMode::Snapshot`], they run immediately,
+        /// concurrently with in-flight reads.
+        ///
+        /// Returning `Err` is fatal: the service loop logs the error and
+        /// calls [`Actor::on_shutdown`] before exiting.
+        fn on_read_write(
+            &mut self,
+            _context: &mut E,
+            _args: &mut Self::Args,
+            _message: <Self::Ingress as ingress::IntoEnvelope>::ReadWriteMessage,
+        ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+            async {
+                panic!(
+                    "Actor::on_read_write must be implemented when read-write ingress is dispatched"
+                )
+            }
+        }
+
+        /// Select the next event for one service-loop iteration.
+        ///
+        /// The default implementation serves lanes only and stops when a
+        /// lane closes. Override this to race self-owned sources directly
+        /// against [`service::LaneSet::recv`]. The order of arms in
+        /// `commonware_macros::select!` is the actor's priority order, so
+        /// actors can place internal sources before lanes and lower-priority
+        /// sources after lanes without boxing futures or registering sources
+        /// with the driver.
+        ///
+        /// Source exhaustion policy belongs in the select arm that observed
+        /// it. For example, a closed peer receiver can set a flag and return
+        /// [`service::Event::Continue`] so future iterations replace only
+        /// that arm with [`commonware_utils::futures::OptionFuture`], while a
+        /// closed task handle can return [`service::Event::Stop`]. Always mute
+        /// an immediately-ready source before returning
+        /// [`service::Event::Continue`], or the service loop will keep
+        /// selecting it. If every source has closed, return
+        /// [`service::Event::Stop`]; [`service::LaneSet::recv`] never resolves
+        /// once every lane has closed.
+        ///
+        /// This future is short-lived: it is rebuilt after every selected
+        /// event. Relative timers such as `context.sleep(interval)` restart
+        /// each time and can starve under steady mailbox traffic. Store an
+        /// absolute deadline in `self` or `args`, then await `sleep_until`.
+        ///
+        /// If a non-replayable source such as [`service::LaneSet::recv`] wins,
+        /// return the selected [`service::Event`] without awaiting again. Any
+        /// `.await` after receiving from such a source creates a cancellation
+        /// point where the consumed message or one-shot closure event can be
+        /// lost if shutdown or a read-handler failure wins the driver race.
+        ///
+        /// When the read-only concurrency limit is full, the service waits for
+        /// read capacity before calling `next_event` again. Actor-owned sources
+        /// are not polled during that wait.
+        ///
+        /// # Cancellation safety
+        ///
+        /// This future is dropped and recreated whenever runtime shutdown or
+        /// a read-handler failure wins the race. Implementations must be
+        /// **cancellation-safe**: any work done before an internal `.await`
+        /// point may be lost if the future is cancelled at that point. Hold
+        /// intermediate state in `self` or `args` rather than in local
+        /// variables across `.await` boundaries.
+        ///
+        /// Cancellation does not roll anything back: mutations made through
+        /// `self` or `args` before the cancellation point persist and are
+        /// observed by every later hook. A cancelled `next_event` that
+        /// dequeued from an internal source and then awaited something else
+        /// loses that item unless it was stashed in `self` or `args` first.
+        fn next_event<R>(
+            &mut self,
+            _context: &mut E,
+            _args: &mut Self::Args,
+            mut lanes: service::LaneSet<'_, Self::Ingress, R>,
+        ) -> impl Future<
+            Output = service::Event<
+                Self::Ingress,
+                <Self::Ingress as ingress::IntoEnvelope>::ReadWriteMessage,
+            >,
+        > + Send
+        where
+            R: service::LaneReceiver<Self::Ingress>,
+        {
+            async move {
+                match lanes.recv().await {
+                    service::LaneEvent::Message { lane, message } => {
+                        service::Event::Ingress { lane, message }
+                    }
+                    service::LaneEvent::Closed { .. } => service::Event::Stop,
+                }
+            }
+        }
+    }
 });

--- a/actor/src/mailbox.rs
+++ b/actor/src/mailbox.rs
@@ -316,6 +316,21 @@ impl<T: Policy> Receiver<T> {
         recv_from(&self.state).await
     }
 
+    /// Poll to receive the next message.
+    ///
+    /// Returns `Ready(None)` after all senders are dropped and all buffered
+    /// messages have been drained.
+    #[cfg(not(any(
+        commonware_stability_BETA,
+        commonware_stability_GAMMA,
+        commonware_stability_DELTA,
+        commonware_stability_EPSILON,
+        commonware_stability_RESERVED
+    )))] // ALPHA
+    pub(crate) fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        self.state.poll_recv(cx)
+    }
+
     /// Try to receive the next message without waiting.
     ///
     /// Returns [`TryRecvError::Disconnected`] after all senders are dropped and
@@ -332,6 +347,21 @@ impl<T: UnreliablePolicy> UnreliableReceiver<T> {
     /// have been drained.
     pub async fn recv(&mut self) -> Option<T> {
         recv_from(&self.state).await
+    }
+
+    /// Poll to receive the next message.
+    ///
+    /// Returns `Ready(None)` after all senders are dropped and all buffered
+    /// messages have been drained.
+    #[cfg(not(any(
+        commonware_stability_BETA,
+        commonware_stability_GAMMA,
+        commonware_stability_DELTA,
+        commonware_stability_EPSILON,
+        commonware_stability_RESERVED
+    )))] // ALPHA
+    pub(crate) fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        self.state.poll_recv(cx)
     }
 
     /// Try to receive the next message without waiting.

--- a/actor/src/mocks.rs
+++ b/actor/src/mocks.rs
@@ -1,0 +1,174 @@
+//! Shared test-only tracing subscriber that records span topology.
+//!
+//! Used by ingress and service tests to assert parentage and `follows_from`
+//! edges without exposing a public API.
+
+use commonware_utils::sync::Mutex;
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+use tracing::{
+    Event, Metadata, Subscriber,
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+};
+use tracing_core::span::Current;
+
+/// A span observed by [`TraceRecorder`].
+#[derive(Clone, Debug)]
+pub(crate) struct RecordedSpan {
+    pub(crate) id: u64,
+    pub(crate) name: &'static str,
+    /// The resolved parent: explicit parents are taken from the span
+    /// attributes, contextual parents from the enter/exit stack, and
+    /// explicit roots record `None`.
+    pub(crate) parent: Option<u64>,
+    /// Span ids recorded via `Span::follows_from`.
+    pub(crate) follows: Vec<u64>,
+    /// Field values recorded at span creation, debug-formatted.
+    pub(crate) fields: Vec<(&'static str, String)>,
+    metadata: &'static Metadata<'static>,
+}
+
+impl RecordedSpan {
+    /// Return the recorded value for `name`, panicking when absent.
+    pub(crate) fn field(&self, name: &str) -> &str {
+        self.fields
+            .iter()
+            .find(|(field, _)| *field == name)
+            .map(|(_, value)| value.as_str())
+            .unwrap_or_else(|| panic!("missing field {name}"))
+    }
+}
+
+/// Captures span fields into debug-formatted strings.
+///
+/// `%value` and `?value` recordings both arrive through `record_debug`.
+struct FieldCapture(Vec<(&'static str, String)>);
+
+impl Visit for FieldCapture {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.0.push((field.name(), format!("{value:?}")));
+    }
+}
+
+/// Shared state inspected by tests after a recorded run.
+#[derive(Default)]
+pub(crate) struct TraceState {
+    next: AtomicU64,
+    spans: Mutex<Vec<RecordedSpan>>,
+    stack: Mutex<Vec<u64>>,
+}
+
+impl TraceState {
+    /// Return the first recorded span with `name`, panicking when absent.
+    pub(crate) fn span(&self, name: &str) -> RecordedSpan {
+        self.spans
+            .lock()
+            .iter()
+            .find(|span| span.name == name)
+            .unwrap_or_else(|| panic!("missing span {name}"))
+            .clone()
+    }
+
+    /// Return every recorded span with `name`.
+    pub(crate) fn spans_named(&self, name: &str) -> Vec<RecordedSpan> {
+        self.spans
+            .lock()
+            .iter()
+            .filter(|span| span.name == name)
+            .cloned()
+            .collect()
+    }
+}
+
+/// Minimal [`Subscriber`] that records span creation, parentage, and
+/// `follows_from` edges for assertions.
+pub(crate) struct TraceRecorder {
+    state: Arc<TraceState>,
+}
+
+impl TraceRecorder {
+    pub(crate) fn new() -> (Self, Arc<TraceState>) {
+        let state = Arc::new(TraceState::default());
+        (
+            Self {
+                state: state.clone(),
+            },
+            state,
+        )
+    }
+}
+
+impl Subscriber for TraceRecorder {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        let id = self.state.next.fetch_add(1, Ordering::SeqCst) + 1;
+        let parent = if attrs.is_root() {
+            None
+        } else if attrs.is_contextual() {
+            self.state.stack.lock().last().copied()
+        } else {
+            attrs.parent().map(|id| id.into_u64())
+        };
+
+        let mut fields = FieldCapture(Vec::new());
+        attrs.record(&mut fields);
+
+        self.state.spans.lock().push(RecordedSpan {
+            id,
+            name: attrs.metadata().name(),
+            parent,
+            follows: Vec::new(),
+            fields: fields.0,
+            metadata: attrs.metadata(),
+        });
+        Id::from_u64(id)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, span: &Id, follows: &Id) {
+        let mut spans = self.state.spans.lock();
+        let recorded = spans
+            .iter_mut()
+            .find(|recorded| recorded.id == span.into_u64())
+            .expect("follows_from on unknown span");
+        recorded.follows.push(follows.into_u64());
+    }
+
+    fn event(&self, _event: &Event<'_>) {}
+
+    fn enter(&self, span: &Id) {
+        self.state.stack.lock().push(span.into_u64());
+    }
+
+    fn exit(&self, span: &Id) {
+        let mut stack = self.state.stack.lock();
+        if let Some(position) = stack.iter().rposition(|id| *id == span.into_u64()) {
+            stack.remove(position);
+        }
+    }
+
+    fn current_span(&self) -> Current {
+        let stack = self.state.stack.lock();
+        let Some(id) = stack.last().copied() else {
+            return Current::none();
+        };
+        drop(stack);
+
+        let spans = self.state.spans.lock();
+        let recorded = spans
+            .iter()
+            .find(|span| span.id == id)
+            .expect("current span was recorded");
+        Current::new(Id::from_u64(id), recorded.metadata)
+    }
+}

--- a/actor/src/service/builder.rs
+++ b/actor/src/service/builder.rs
@@ -1,0 +1,334 @@
+use super::{
+    DEFAULT_MAILBOX_CAPACITY, DEFAULT_MAX_INFLIGHT_READS, FenceMode,
+    driver::Service,
+    reliable::Reliable,
+    types::{DuplicateLaneError, Lanes},
+    unreliable::Unreliable,
+};
+use crate::{
+    Actor,
+    ingress::{Mailbox, UnreliableMailbox},
+    mailbox::{self, Policy, Receiver, UnreliablePolicy, UnreliableReceiver},
+};
+use commonware_runtime::{Metrics as RuntimeMetrics, Spawner};
+use std::{collections::BTreeMap, num::NonZeroUsize};
+
+type SingleLaneBuildOutput<E, A> = (<A as Actor<E>>::Mailbox, Reliable<E, A>);
+
+type MultiLaneBuildOutput<E, A, L> = (Lanes<L, <A as Actor<E>>::Mailbox>, Reliable<E, A>);
+
+type SingleLaneUnreliableBuildOutput<E, A> = (<A as Actor<E>>::Mailbox, Unreliable<E, A>);
+
+type MultiLaneUnreliableBuildOutput<E, A, L> =
+    (Lanes<L, <A as Actor<E>>::Mailbox>, Unreliable<E, A>);
+
+fn validate_unique_lanes<'a, L>(
+    lanes: impl IntoIterator<Item = &'a L>,
+) -> Result<(), DuplicateLaneError>
+where
+    L: Ord + 'a,
+{
+    let mut seen = std::collections::BTreeSet::new();
+    for lane in lanes {
+        if !seen.insert(lane) {
+            return Err(DuplicateLaneError);
+        }
+    }
+    Ok(())
+}
+
+fn build_reliable_service<E, A>(
+    context: E,
+    actor: A,
+    lanes: Vec<Receiver<A::Ingress>>,
+    max_inflight_reads: NonZeroUsize,
+    fence_mode: FenceMode,
+) -> Reliable<E, A>
+where
+    E: RuntimeMetrics + Spawner,
+    A: Actor<E>,
+    A::Ingress: Policy<Overflow: Send> + Send + 'static,
+{
+    Reliable::new(Service::new(
+        context,
+        actor,
+        lanes,
+        max_inflight_reads,
+        fence_mode,
+    ))
+}
+
+fn build_unreliable_service<E, A>(
+    context: E,
+    actor: A,
+    lanes: Vec<UnreliableReceiver<A::Ingress>>,
+    max_inflight_reads: NonZeroUsize,
+    fence_mode: FenceMode,
+) -> Unreliable<E, A>
+where
+    E: RuntimeMetrics + Spawner,
+    A: Actor<E>,
+    A::Ingress: UnreliablePolicy<Overflow: Send> + Send + 'static,
+{
+    Unreliable::new(Service::new(
+        context,
+        actor,
+        lanes,
+        max_inflight_reads,
+        fence_mode,
+    ))
+}
+
+/// Configures an actor service loop before lane type is selected.
+///
+/// Polling is biased and deterministic:
+/// - lane polling is declaration-order biased
+/// - actor-defined source ordering lives in [`Actor::next_event`]
+///
+/// Runtime shutdown and read-only handler completion can cancel and restart
+/// [`Actor::next_event`]. Under sustained load, earlier lanes can starve later
+/// lanes because the first ready lane is always selected.
+///
+/// [`Builder::build`] creates reliable lanes backed by
+/// [`crate::mailbox::Policy`]. [`Builder::build_unreliable`] creates
+/// unreliable lanes backed by [`crate::mailbox::UnreliablePolicy`].
+pub struct Builder<A> {
+    actor: A,
+    max_inflight_reads: NonZeroUsize,
+    fence_mode: FenceMode,
+}
+
+impl<A> Builder<A> {
+    /// Create a new service builder for `actor`.
+    pub const fn new(actor: A) -> Self {
+        Self {
+            actor,
+            max_inflight_reads: DEFAULT_MAX_INFLIGHT_READS,
+            fence_mode: FenceMode::Linearizable,
+        }
+    }
+
+    /// Configure the maximum number of in-flight read-only handlers.
+    ///
+    /// The default is [`DEFAULT_MAX_INFLIGHT_READS`].
+    pub const fn with_read_concurrency(mut self, max_inflight_reads: NonZeroUsize) -> Self {
+        self.max_inflight_reads = max_inflight_reads;
+        self
+    }
+
+    /// Configure how read-write handlers order against in-flight reads.
+    ///
+    /// The default is [`FenceMode::Linearizable`].
+    pub const fn with_fence_mode(mut self, fence_mode: FenceMode) -> Self {
+        self.fence_mode = fence_mode;
+        self
+    }
+
+    /// Add a bounded lane, transitioning to a [`MultiLaneBuilder`].
+    ///
+    /// `capacity` is per-lane ready-queue depth; overflow beyond it is
+    /// managed by the ingress policy.
+    pub fn with_lane<L>(self, lane: L, capacity: NonZeroUsize) -> MultiLaneBuilder<A, L>
+    where
+        L: Ord,
+    {
+        MultiLaneBuilder {
+            actor: self.actor,
+            lanes: vec![(lane, capacity)],
+            max_inflight_reads: self.max_inflight_reads,
+            fence_mode: self.fence_mode,
+        }
+    }
+
+    /// Build a single-lane service with [`DEFAULT_MAILBOX_CAPACITY`].
+    pub fn build<E>(self, context: E) -> SingleLaneBuildOutput<E, A>
+    where
+        E: RuntimeMetrics + Spawner,
+        A: Actor<E>,
+        A::Ingress: Policy<Overflow: Send>,
+        A::Mailbox: From<Mailbox<A::Ingress>>,
+    {
+        self.build_with_capacity(context, DEFAULT_MAILBOX_CAPACITY)
+    }
+
+    /// Build a single-lane service with the provided mailbox capacity.
+    ///
+    /// `capacity` is the ready-queue depth; overflow beyond it is managed by
+    /// the ingress policy.
+    pub fn build_with_capacity<E>(
+        self,
+        context: E,
+        capacity: NonZeroUsize,
+    ) -> SingleLaneBuildOutput<E, A>
+    where
+        E: RuntimeMetrics + Spawner,
+        A: Actor<E>,
+        A::Ingress: Policy<Overflow: Send>,
+        A::Mailbox: From<Mailbox<A::Ingress>>,
+    {
+        let (sender, receiver) = mailbox::new(context.child("mailbox"), capacity);
+        let mailbox = A::Mailbox::from(Mailbox::new(sender));
+        let service = build_reliable_service(
+            context,
+            self.actor,
+            vec![receiver],
+            self.max_inflight_reads,
+            self.fence_mode,
+        );
+
+        (mailbox, service)
+    }
+
+    /// Build a single-lane unreliable service with [`DEFAULT_MAILBOX_CAPACITY`].
+    pub fn build_unreliable<E>(self, context: E) -> SingleLaneUnreliableBuildOutput<E, A>
+    where
+        E: RuntimeMetrics + Spawner,
+        A: Actor<E>,
+        A::Ingress: UnreliablePolicy<Overflow: Send>,
+        A::Mailbox: From<UnreliableMailbox<A::Ingress>>,
+    {
+        self.build_unreliable_with_capacity(context, DEFAULT_MAILBOX_CAPACITY)
+    }
+
+    /// Build a single-lane unreliable service with the provided mailbox capacity.
+    ///
+    /// `capacity` is the ready-queue depth; overflow beyond it is managed by
+    /// the unreliable ingress policy and may reject submitted work.
+    pub fn build_unreliable_with_capacity<E>(
+        self,
+        context: E,
+        capacity: NonZeroUsize,
+    ) -> SingleLaneUnreliableBuildOutput<E, A>
+    where
+        E: RuntimeMetrics + Spawner,
+        A: Actor<E>,
+        A::Ingress: UnreliablePolicy<Overflow: Send>,
+        A::Mailbox: From<UnreliableMailbox<A::Ingress>>,
+    {
+        let (sender, receiver) = mailbox::new_unreliable(context.child("mailbox"), capacity);
+        let mailbox = A::Mailbox::from(UnreliableMailbox::new(sender));
+        let service = build_unreliable_service(
+            context,
+            self.actor,
+            vec![receiver],
+            self.max_inflight_reads,
+            self.fence_mode,
+        );
+
+        (mailbox, service)
+    }
+}
+
+/// Configures a multi-lane actor service loop with bounded lanes.
+pub struct MultiLaneBuilder<A, L>
+where
+    L: Ord,
+{
+    actor: A,
+    lanes: Vec<(L, NonZeroUsize)>,
+    max_inflight_reads: NonZeroUsize,
+    fence_mode: FenceMode,
+}
+
+impl<A, L> MultiLaneBuilder<A, L>
+where
+    L: Ord,
+{
+    /// Add another bounded lane.
+    ///
+    /// `capacity` is per-lane ready-queue depth; overflow beyond it is
+    /// managed by the ingress policy.
+    pub fn with_lane(mut self, lane: L, capacity: NonZeroUsize) -> Self {
+        self.lanes.push((lane, capacity));
+        self
+    }
+
+    /// Configure the maximum number of in-flight read-only handlers.
+    ///
+    /// The default is [`DEFAULT_MAX_INFLIGHT_READS`].
+    pub const fn with_read_concurrency(mut self, max_inflight_reads: NonZeroUsize) -> Self {
+        self.max_inflight_reads = max_inflight_reads;
+        self
+    }
+
+    /// Configure how read-write handlers order against in-flight reads.
+    ///
+    /// The default is [`FenceMode::Linearizable`].
+    pub const fn with_fence_mode(mut self, fence_mode: FenceMode) -> Self {
+        self.fence_mode = fence_mode;
+        self
+    }
+
+    /// Finalize construction, returning per-lane mailboxes and control loop driver.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DuplicateLaneError`] when the same lane key is added more than once.
+    pub fn build<E>(self, context: E) -> Result<MultiLaneBuildOutput<E, A, L>, DuplicateLaneError>
+    where
+        E: RuntimeMetrics + Spawner,
+        A: Actor<E>,
+        A::Ingress: Policy<Overflow: Send>,
+        A::Mailbox: From<Mailbox<A::Ingress>>,
+    {
+        validate_unique_lanes(self.lanes.iter().map(|(lane, _)| lane))?;
+
+        let mut mailboxes = BTreeMap::new();
+        let mut receivers = Vec::with_capacity(self.lanes.len());
+
+        for (index, (lane, capacity)) in self.lanes.into_iter().enumerate() {
+            let lane_context = context.child("mailbox").with_attribute("lane", index);
+            let (sender, receiver) = mailbox::new(lane_context, capacity);
+            mailboxes.insert(lane, A::Mailbox::from(Mailbox::new(sender)));
+            receivers.push(receiver);
+        }
+
+        let service = build_reliable_service(
+            context,
+            self.actor,
+            receivers,
+            self.max_inflight_reads,
+            self.fence_mode,
+        );
+
+        Ok((Lanes { mailboxes }, service))
+    }
+
+    /// Finalize construction with unreliable lanes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DuplicateLaneError`] when the same lane key is added more than once.
+    pub fn build_unreliable<E>(
+        self,
+        context: E,
+    ) -> Result<MultiLaneUnreliableBuildOutput<E, A, L>, DuplicateLaneError>
+    where
+        E: RuntimeMetrics + Spawner,
+        A: Actor<E>,
+        A::Ingress: UnreliablePolicy<Overflow: Send>,
+        A::Mailbox: From<UnreliableMailbox<A::Ingress>>,
+    {
+        validate_unique_lanes(self.lanes.iter().map(|(lane, _)| lane))?;
+
+        let mut mailboxes = BTreeMap::new();
+        let mut receivers = Vec::with_capacity(self.lanes.len());
+
+        for (index, (lane, capacity)) in self.lanes.into_iter().enumerate() {
+            let lane_context = context.child("mailbox").with_attribute("lane", index);
+            let (sender, receiver) = mailbox::new_unreliable(lane_context, capacity);
+            mailboxes.insert(lane, A::Mailbox::from(UnreliableMailbox::new(sender)));
+            receivers.push(receiver);
+        }
+
+        let service = build_unreliable_service(
+            context,
+            self.actor,
+            receivers,
+            self.max_inflight_reads,
+            self.fence_mode,
+        );
+
+        Ok((Lanes { mailboxes }, service))
+    }
+}

--- a/actor/src/service/driver.rs
+++ b/actor/src/service/driver.rs
@@ -1,0 +1,749 @@
+use super::{
+    FenceMode, metrics,
+    types::{Event, Lane, LaneReceiver, LaneSet},
+};
+use crate::{
+    Actor,
+    ingress::{Envelope, IntoEnvelope},
+};
+use commonware_macros::select;
+use commonware_runtime::{
+    ContextCell, Error as RuntimeError, Handle, Metrics as RuntimeMetrics, Spawner,
+    signal::{Signal, Signaler},
+};
+use commonware_utils::channel::mpsc;
+use crossbeam_queue::ArrayQueue;
+use futures_util::{StreamExt, future::FutureExt, stream::FuturesUnordered, task::AtomicWaker};
+use std::{
+    future::poll_fn,
+    num::NonZeroUsize,
+    pin::pin,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+        mpsc::TryRecvError,
+    },
+    task::Poll,
+};
+use thiserror::Error as ThisError;
+use tracing::{Instrument as _, Span, debug, debug_span, error};
+
+type ReadMessage<E, A> = <<A as Actor<E>>::Ingress as IntoEnvelope>::ReadOnlyMessage;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ThisError)]
+enum Stop {
+    #[error("shutdown signal received")]
+    Shutdown,
+    #[error("actor requested stop")]
+    Actor,
+    #[error(transparent)]
+    Read(ReadStop),
+    #[error(transparent)]
+    Write(WriteStop),
+    #[error(transparent)]
+    Worker(WorkerStop),
+    #[error(transparent)]
+    Dispatch(DispatchStop),
+}
+
+impl Stop {
+    const fn reason(self) -> metrics::StopReason {
+        match self {
+            Self::Shutdown => metrics::StopReason::Shutdown,
+            Self::Actor => metrics::StopReason::Actor,
+            Self::Read(_) => metrics::StopReason::Read,
+            Self::Write(_) => metrics::StopReason::Write,
+            Self::Worker(_) => metrics::StopReason::Worker,
+            Self::Dispatch(_) => metrics::StopReason::Dispatch,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ThisError)]
+enum ReadStop {
+    #[error("fatal read detected")]
+    Fatal,
+    #[error("read failure channel closed")]
+    FailureChannelClosed,
+    #[error("read workers exhausted")]
+    WorkersExhausted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ThisError)]
+enum WriteStop {
+    #[error("fatal write detected")]
+    Fatal,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ThisError)]
+enum WorkerStop {
+    #[error("read worker stopped")]
+    Stopped,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ThisError)]
+enum DispatchStop {
+    #[error("read dispatched without available worker")]
+    ReadWithoutWorker,
+    #[error("read worker unavailable")]
+    ReadWorkerUnavailable,
+}
+
+struct ReadJob<E, A>
+where
+    E: Spawner,
+    A: Actor<E>,
+{
+    snapshot: A::Snapshot,
+    message: ReadMessage<E, A>,
+    process: Span,
+}
+
+/// Coordination state shared between the control loop and read workers.
+///
+/// Workers retire their own completions: each returns itself to `idle`,
+/// decrements `inflight`, and wakes any registered waiter. Successful reads
+/// therefore never wake the control loop; it only hears about failures.
+struct ReadShared {
+    /// Workers ready to accept a job.
+    idle: ArrayQueue<usize>,
+    /// Reads dispatched but not yet completed.
+    inflight: AtomicUsize,
+    /// Woken when `inflight` reaches zero (write fence).
+    drained: AtomicWaker,
+    /// Woken when a worker becomes idle (capacity wait).
+    capacity: AtomicWaker,
+}
+
+/// Pre-spawned read workers with a bounded number of active handlers.
+struct ReadPool<E, A>
+where
+    E: Spawner,
+    A: Actor<E>,
+{
+    workers: Vec<mpsc::Sender<ReadJob<E, A>>>,
+    shared: Arc<ReadShared>,
+    failures: mpsc::Receiver<A::Error>,
+    handles: FuturesUnordered<Handle<()>>,
+    shutdown: Option<Signaler>,
+    metrics: metrics::Metrics,
+}
+
+impl<E, A> ReadPool<E, A>
+where
+    E: Spawner,
+    A: Actor<E>,
+{
+    fn new(context: &E, max_inflight: NonZeroUsize, metrics: metrics::Metrics) -> Self {
+        let max_inflight = max_inflight.get();
+        let (failure_sender, failures) = mpsc::channel(max_inflight);
+        let (signaler, signal) = Signaler::new();
+        let shared = Arc::new(ReadShared {
+            idle: ArrayQueue::new(max_inflight),
+            inflight: AtomicUsize::new(0),
+            drained: AtomicWaker::new(),
+            capacity: AtomicWaker::new(),
+        });
+        let mut workers = Vec::with_capacity(max_inflight);
+        let handles = FuturesUnordered::new();
+        metrics.set_read_workers(max_inflight);
+        metrics.set_inflight_reads(0);
+
+        for worker in 0..max_inflight {
+            let (sender, receiver) = mpsc::channel(1);
+            let failures = failure_sender.clone();
+            let signal = signal.clone();
+            let worker_shared = shared.clone();
+            let metrics = metrics.clone();
+            let handle = context
+                .child("read_worker")
+                .with_attribute("worker", worker)
+                .spawn(move |context| {
+                    Self::run_worker(
+                        worker,
+                        context,
+                        receiver,
+                        worker_shared,
+                        failures,
+                        metrics,
+                        signal,
+                    )
+                });
+            workers.push(sender);
+            let _ = shared.idle.push(worker);
+            handles.push(handle);
+        }
+
+        Self {
+            workers,
+            shared,
+            failures,
+            handles,
+            shutdown: Some(signaler),
+            metrics,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.shared.inflight.load(Ordering::Acquire)
+    }
+
+    fn is_full(&self) -> bool {
+        self.shared.idle.is_empty()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn dispatch(&mut self, job: ReadJob<E, A>) -> Result<(), DispatchStop> {
+        let Some(worker) = self.shared.idle.pop() else {
+            return Err(DispatchStop::ReadWithoutWorker);
+        };
+
+        // Count the read before handing it off so a completing worker can
+        // never observe an in-flight read that was not yet counted.
+        let inflight = self.shared.inflight.fetch_add(1, Ordering::AcqRel) + 1;
+        self.metrics.set_inflight_reads(inflight);
+        if self.workers[worker].try_send(job).is_err() {
+            return Err(DispatchStop::ReadWorkerUnavailable);
+        }
+        Ok(())
+    }
+
+    /// Await a fatal read failure or an unexpected worker stop.
+    ///
+    /// Successful completions retire on the worker and never resolve this
+    /// future.
+    async fn failed(&mut self) -> Stop {
+        select! {
+            err = self.failures.recv() => {
+                let Some(err) = err else {
+                    return Stop::Read(ReadStop::FailureChannelClosed);
+                };
+                error!(%err, "actor failed");
+                Stop::Read(ReadStop::Fatal)
+            },
+            result = self.handles.next() => {
+                let Some(result) = result else {
+                    return Stop::Read(ReadStop::WorkersExhausted);
+                };
+                self.metrics.read_worker_stops.inc();
+                Self::worker_stopped(result)
+            },
+        }
+    }
+
+    /// Await a stop condition (shutdown, fatal read, or worker stop).
+    async fn stop_or_shutdown(&mut self, shutdown: &mut Signal) -> Stop {
+        select! {
+            _ = shutdown => Stop::Shutdown,
+            reason = self.failed() => reason,
+        }
+    }
+
+    /// Await read capacity, returning a stop reason if one occurs first.
+    async fn capacity_or_stop(&mut self, shutdown: &mut Signal) -> Option<Stop> {
+        let shared = self.shared.clone();
+        select! {
+            _ = shutdown => Some(Stop::Shutdown),
+            reason = self.failed() => Some(reason),
+            _ = poll_fn(|cx| {
+                // Register before checking so a worker that frees itself
+                // between the check and the pending return still wakes us.
+                shared.capacity.register(cx.waker());
+                if shared.idle.is_empty() {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            }) => None,
+        }
+    }
+
+    /// Await zero in-flight reads, returning a stop reason if one occurs first.
+    async fn drained_or_stop(&mut self, shutdown: &mut Signal) -> Option<Stop> {
+        let shared = self.shared.clone();
+        select! {
+            _ = shutdown => Some(Stop::Shutdown),
+            reason = self.failed() => Some(reason),
+            _ = poll_fn(|cx| {
+                // Register before checking so a worker that retires between
+                // the check and the pending return still wakes us.
+                shared.drained.register(cx.waker());
+                if shared.inflight.load(Ordering::Acquire) == 0 {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            }) => None,
+        }
+    }
+
+    async fn shutdown(&mut self) {
+        self.workers.clear();
+        let shutdown = self.shutdown.take().map(|signaler| signaler.signal(0));
+        while let Some(result) = self.handles.next().await {
+            let _ = result;
+        }
+        if let Some(shutdown) = shutdown {
+            let _ = shutdown.await;
+        }
+        self.shared.inflight.store(0, Ordering::Release);
+        self.metrics.set_inflight_reads(0);
+    }
+
+    async fn run_worker(
+        worker: usize,
+        context: E,
+        mut receiver: mpsc::Receiver<ReadJob<E, A>>,
+        shared: Arc<ReadShared>,
+        failures: mpsc::Sender<A::Error>,
+        metrics: metrics::Metrics,
+        mut shutdown: Signal,
+    ) {
+        loop {
+            let job = select! {
+                _ = &mut shutdown => return,
+                job = receiver.recv() => {
+                    let Some(job) = job else {
+                        return;
+                    };
+                    job
+                },
+            };
+
+            let read = A::on_read_only(context.child("read"), job.snapshot, job.message)
+                .instrument(job.process);
+            let read = pin!(read);
+            let result = select! {
+                _ = &mut shutdown => return,
+                result = read => result,
+            };
+
+            // Publish any failure before retiring so a fence that observes
+            // zero in-flight reads also observes the failure.
+            if let Err(err) = result {
+                metrics.read_failures.inc();
+                if failures.try_send(err).is_err() {
+                    return;
+                }
+            }
+            metrics.reads.inc();
+            if shared.idle.push(worker).is_err() {
+                return;
+            }
+            let remaining = shared.inflight.fetch_sub(1, Ordering::AcqRel) - 1;
+            metrics.set_inflight_reads(remaining);
+            if remaining == 0 {
+                shared.drained.wake();
+            }
+            shared.capacity.wake();
+        }
+    }
+
+    fn worker_stopped(result: Result<(), RuntimeError>) -> Stop {
+        match result {
+            Ok(()) => error!("read worker exited"),
+            Err(err) => error!(?err, "read worker failed"),
+        }
+        Stop::Worker(WorkerStop::Stopped)
+    }
+}
+
+enum NextEvent<I, W> {
+    Actor(Event<I, W>),
+    Stop(Stop),
+}
+
+struct Batch {
+    messages: usize,
+    stopped: bool,
+}
+
+/// Framework-managed actor loop used by [`crate::service::Builder`].
+///
+/// The loop dispatches read-only ingress concurrently on snapshots and
+/// read-write ingress serially on the control loop. Under
+/// [`FenceMode::Linearizable`], every in-flight read-only handler is drained
+/// to completion before a read-write handler runs; under
+/// [`FenceMode::Snapshot`], read-write handlers run immediately.
+///
+/// Shutdown is prompt: in-flight read-only handlers are aborted before
+/// [`Actor::on_shutdown`] runs.
+pub struct Service<E, A, R>
+where
+    E: Spawner,
+    A: Actor<E>,
+    R: LaneReceiver<A::Ingress>,
+{
+    pub(super) context: ContextCell<E>,
+    pub(super) actor: A,
+    pub(super) lanes: Vec<Option<R>>,
+    pub(super) shutdown: Signal,
+    pub(super) max_inflight_reads: NonZeroUsize,
+    pub(super) fence_mode: FenceMode,
+    pub(super) cached_snapshot: Option<A::Snapshot>,
+    pub(super) metrics: metrics::Metrics,
+}
+
+impl<E, A, R> Service<E, A, R>
+where
+    E: RuntimeMetrics + Spawner,
+    A: Actor<E>,
+    R: LaneReceiver<A::Ingress> + 'static,
+{
+    pub(super) fn new(
+        context: E,
+        actor: A,
+        lanes: Vec<R>,
+        max_inflight_reads: NonZeroUsize,
+        fence_mode: FenceMode,
+    ) -> Self {
+        let shutdown = context.stopped();
+        let metrics = metrics::Metrics::init(&context, lanes.len());
+        Self {
+            context: ContextCell::new(context),
+            actor,
+            lanes: lanes.into_iter().map(Some).collect(),
+            shutdown,
+            max_inflight_reads,
+            fence_mode,
+            cached_snapshot: None,
+            metrics,
+        }
+    }
+}
+
+impl<E, A, R> Service<E, A, R>
+where
+    E: Spawner,
+    A: Actor<E>,
+    R: LaneReceiver<A::Ingress> + 'static,
+{
+    /// Spawn the control loop, passing `args` data to [`Actor::on_startup`].
+    pub fn start_with(mut self, args: A::Args) -> Handle<()> {
+        let context = self.context.take();
+        context.spawn(move |context| async move {
+            self.context.restore(context);
+            self.enter(args).await
+        })
+    }
+
+    /// Run the actor loop until shutdown, fatal handler failure, or [`Event::Stop`].
+    async fn enter(mut self, mut args: A::Args) {
+        debug!(lanes = self.lanes.len(), "actor service started");
+        self.actor
+            .on_startup(self.context.as_present_mut(), &mut args)
+            .await;
+
+        let mut reads = ReadPool::<E, A>::new(
+            self.context.as_present(),
+            self.max_inflight_reads,
+            self.metrics.clone(),
+        );
+
+        loop {
+            self.actor
+                .preprocess(self.context.as_present_mut(), &mut args)
+                .await;
+
+            if reads.is_full() {
+                if self.wait_for_read_capacity(&mut args, &mut reads).await {
+                    return;
+                }
+                continue;
+            }
+
+            // When the failure or shutdown arm wins, `next` is dropped mid-poll.
+            // This is the cancellation described in [`Actor::next_event`]'s
+            // "Cancellation safety" contract: the actor must tolerate losing
+            // the future here, and any state it mutated before the
+            // cancellation point persists.
+            let event = {
+                let lanes = LaneSet::new(&mut self.lanes);
+                let next = self
+                    .actor
+                    .next_event(self.context.as_present_mut(), &mut args, lanes);
+                let next = pin!(next);
+                select! {
+                    reason = reads.stop_or_shutdown(&mut self.shutdown) => NextEvent::Stop(reason),
+                    event = next => NextEvent::Actor(event),
+                }
+            };
+            // Every `&mut` actor hook since the last dispatch (preprocess,
+            // postprocess, next_event) has run by this point, and no read
+            // dispatches before it in an iteration.
+            self.cached_snapshot = None;
+            match event {
+                NextEvent::Stop(reason) => {
+                    self.shutdown_gracefully(&mut args, &mut reads, reason)
+                        .await;
+                    return;
+                }
+                NextEvent::Actor(Event::Continue) => continue,
+                NextEvent::Actor(Event::Stop) => {
+                    self.shutdown_gracefully(&mut args, &mut reads, Stop::Actor)
+                        .await;
+                    return;
+                }
+                NextEvent::Actor(Event::Ingress { lane, message }) => {
+                    self.metrics.record_lane_message(lane.index());
+                    if self.dispatch_ingress(&mut args, &mut reads, message).await {
+                        self.metrics.observe_lane_batch(1);
+                        return;
+                    }
+                    let batch = self.drain_lane_batch(&mut args, &mut reads, lane).await;
+                    self.metrics.observe_lane_batch(batch.messages);
+                    if batch.stopped {
+                        return;
+                    }
+                }
+                NextEvent::Actor(Event::External(message)) => {
+                    if self
+                        .handle_read_write(&mut args, &mut reads, None, message)
+                        .await
+                    {
+                        return;
+                    }
+                }
+            }
+
+            self.actor
+                .postprocess(self.context.as_present_mut(), &mut args)
+                .await;
+        }
+    }
+
+    /// Close mailboxes, abort in-flight read-only handlers, run
+    /// [`Actor::on_shutdown`], and exit promptly.
+    ///
+    /// Reads abort before the hook runs so no handler can respond with
+    /// pre-shutdown state after the hook mutates the actor. Pending askers
+    /// observe a cancelled response.
+    async fn shutdown_gracefully(
+        &mut self,
+        args: &mut A::Args,
+        reads: &mut ReadPool<E, A>,
+        reason: Stop,
+    ) {
+        let inflight_reads = reads.len();
+        self.metrics.record_stop(reason.reason());
+        debug!(%reason, inflight_reads, "actor shutting down");
+        self.lanes.clear();
+        reads.shutdown().await;
+        self.actor
+            .on_shutdown(self.context.as_present_mut(), args)
+            .await;
+        debug!("actor service stopped");
+    }
+
+    /// Wait until read-only capacity is available or the service must stop.
+    async fn wait_for_read_capacity(
+        &mut self,
+        args: &mut A::Args,
+        reads: &mut ReadPool<E, A>,
+    ) -> bool {
+        debug_assert!(!reads.is_empty(), "wait requires in-flight reads");
+        self.metrics.read_capacity_waits.inc();
+
+        if let Some(reason) = reads.capacity_or_stop(&mut self.shutdown).await {
+            self.shutdown_gracefully(args, reads, reason).await;
+            return true;
+        }
+
+        false
+    }
+
+    /// Drain all reads that must complete before a read-write handler runs.
+    async fn drain_reads_or_shutdown(
+        &mut self,
+        args: &mut A::Args,
+        reads: &mut ReadPool<E, A>,
+    ) -> bool {
+        if reads.is_empty() {
+            return false;
+        }
+        if let Some(reason) = reads.drained_or_stop(&mut self.shutdown).await {
+            self.shutdown_gracefully(args, reads, reason).await;
+            return true;
+        }
+        false
+    }
+
+    /// Dispatch one ingress message according to its read-only or read-write envelope.
+    async fn dispatch_ingress(
+        &mut self,
+        args: &mut A::Args,
+        reads: &mut ReadPool<E, A>,
+        message: A::Ingress,
+    ) -> bool {
+        let (span, envelope) = message.into_envelope();
+        match envelope {
+            Envelope::ReadOnly(message) => {
+                let process = debug_span!(parent: &span, "actor.process");
+                if let Err(reason) = self.handle_read_only(args, reads, process, message) {
+                    error!(%reason, "read dispatch failed");
+                    self.shutdown_gracefully(args, reads, Stop::Dispatch(reason))
+                        .await;
+                    return true;
+                }
+                false
+            }
+            Envelope::ReadWrite(message) => {
+                self.handle_read_write(args, reads, Some(span), message)
+                    .await
+            }
+        }
+    }
+
+    /// Drain additional ready messages from the lane that won this iteration.
+    ///
+    /// The batch ends before [`Actor::max_lane_batch`] when the lane has no
+    /// ready message or read capacity fills. Other lanes are not polled while
+    /// the batch runs, which biases throughput toward the winning lane.
+    async fn drain_lane_batch(
+        &mut self,
+        args: &mut A::Args,
+        reads: &mut ReadPool<E, A>,
+        lane: Lane,
+    ) -> Batch {
+        let mut remaining = self.actor.max_lane_batch(args).get().saturating_sub(1);
+        let mut messages = 1;
+        while remaining > 0 {
+            if (&mut self.shutdown).now_or_never().is_some() {
+                self.shutdown_gracefully(args, reads, Stop::Shutdown).await;
+                return Batch {
+                    messages,
+                    stopped: true,
+                };
+            }
+
+            if reads.is_full() {
+                return Batch {
+                    messages,
+                    stopped: false,
+                };
+            }
+
+            let next = self
+                .lanes
+                .get_mut(lane.index())
+                .and_then(|slot| slot.as_mut())
+                .map(|receiver| receiver.try_recv());
+            match next {
+                Some(Ok(message)) => {
+                    self.metrics.record_lane_message(lane.index());
+                    messages += 1;
+                    if self.dispatch_ingress(args, reads, message).await {
+                        return Batch {
+                            messages,
+                            stopped: true,
+                        };
+                    }
+                    remaining -= 1;
+                }
+                Some(Err(TryRecvError::Empty | TryRecvError::Disconnected)) | None => {
+                    return Batch {
+                        messages,
+                        stopped: false,
+                    };
+                }
+            }
+        }
+        Batch {
+            messages,
+            stopped: false,
+        }
+    }
+
+    /// Dispatch a read-only handler to an idle worker using the current actor snapshot.
+    ///
+    /// Consecutive read-only dispatches clone one cached snapshot instead of
+    /// capturing a new one per message.
+    fn handle_read_only(
+        &mut self,
+        args: &A::Args,
+        reads: &mut ReadPool<E, A>,
+        process: Span,
+        message: <A::Ingress as IntoEnvelope>::ReadOnlyMessage,
+    ) -> Result<(), DispatchStop> {
+        let actor = &self.actor;
+        let snapshot = self
+            .cached_snapshot
+            .get_or_insert_with(|| actor.snapshot(args))
+            .clone();
+        reads.dispatch(ReadJob {
+            snapshot,
+            message,
+            process,
+        })
+    }
+
+    /// Fence behind in-flight reads per [`FenceMode`], then run one
+    /// read-write handler.
+    ///
+    /// `enqueue_span` is the span carried by a mailbox message; external
+    /// events pass `None` and are processed under a distinct span name. The
+    /// processing span is created after the read fence so the fence wait is
+    /// not attributed to handler work.
+    async fn handle_read_write(
+        &mut self,
+        args: &mut A::Args,
+        reads: &mut ReadPool<E, A>,
+        enqueue_span: Option<Span>,
+        message: <A::Ingress as IntoEnvelope>::ReadWriteMessage,
+    ) -> bool {
+        if self.fence_mode == FenceMode::Linearizable
+            && self.drain_reads_or_shutdown(args, reads).await
+        {
+            return true;
+        }
+
+        let process = enqueue_span.as_ref().map_or_else(
+            || debug_span!("actor.process.external"),
+            |span| debug_span!(parent: span, "actor.process"),
+        );
+        let result = self
+            .actor
+            .on_read_write(self.context.as_present_mut(), args, message)
+            .instrument(process)
+            .await;
+        self.cached_snapshot = None;
+        self.metrics.writes.inc();
+        if let Err(err) = result {
+            self.metrics.write_failures.inc();
+            error!(%err, "actor failed");
+            self.shutdown_gracefully(args, reads, Stop::Write(WriteStop::Fatal))
+                .await;
+            return true;
+        }
+
+        false
+    }
+}
+
+impl<E, A, R> Service<E, A, R>
+where
+    E: Spawner,
+    A: Actor<E, Args = ()>,
+    R: LaneReceiver<A::Ingress> + 'static,
+{
+    /// Spawn the control loop for actors whose [`Actor::Args`] is `()`.
+    pub fn start(self) -> Handle<()> {
+        self.start_with(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_failure_channel_closed_records_read_stop() {
+        assert_eq!(
+            Stop::Read(ReadStop::FailureChannelClosed).reason(),
+            metrics::StopReason::Read
+        );
+    }
+}

--- a/actor/src/service/metrics.rs
+++ b/actor/src/service/metrics.rs
@@ -1,0 +1,118 @@
+use commonware_runtime::{
+    Metrics as RuntimeMetrics,
+    telemetry::metrics::{
+        Counter, CounterFamily, EncodeLabelValue, EncodeStruct, Gauge, Histogram, MetricsExt as _,
+        raw,
+    },
+};
+use std::{fmt, sync::Arc};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeStruct)]
+pub(super) struct Lane {
+    pub lane: usize,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, EncodeLabelValue)]
+pub(super) enum StopReason {
+    Shutdown,
+    Actor,
+    Read,
+    Write,
+    Worker,
+    Dispatch,
+}
+
+impl fmt::Display for StopReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let reason = match self {
+            Self::Shutdown => "shutdown",
+            Self::Actor => "actor",
+            Self::Read => "read",
+            Self::Write => "write",
+            Self::Worker => "worker",
+            Self::Dispatch => "dispatch",
+        };
+        f.write_str(reason)
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeStruct)]
+pub(super) struct Stop {
+    pub reason: StopReason,
+}
+
+#[derive(Clone)]
+pub(super) struct Metrics {
+    pub inflight_reads: Gauge,
+    pub read_workers: Gauge,
+    pub reads: Counter,
+    pub read_failures: Counter,
+    pub writes: Counter,
+    pub write_failures: Counter,
+    pub read_capacity_waits: Counter,
+    pub read_worker_stops: Counter,
+    pub stops: CounterFamily<Stop>,
+    pub lane_batch_size: Histogram,
+    /// Per-lane counter handles resolved at construction.
+    ///
+    /// Family lookups take a lock and hash the label set, so the hot path
+    /// indexes this slice instead. The family is kept alive alongside the
+    /// handles so the metric stays registered.
+    lane_messages: Arc<[raw::Counter]>,
+    _lane_messages_family: CounterFamily<Lane>,
+}
+
+impl Metrics {
+    pub fn init(context: &impl RuntimeMetrics, lanes: usize) -> Self {
+        let lane_messages_family: CounterFamily<Lane> =
+            context.family("lane_messages", "Number of messages selected by lane");
+        let lane_messages = (0..lanes)
+            .map(|lane| lane_messages_family.get_or_create(&Lane { lane }).clone())
+            .collect();
+        Self {
+            inflight_reads: context.gauge("inflight_reads", "Number of active read-only handlers"),
+            read_workers: context.gauge("read_workers", "Number of provisioned read workers"),
+            reads: context.counter("reads", "Number of read-only handlers completed"),
+            read_failures: context.counter("read_failures", "Number of failed read-only handlers"),
+            writes: context.counter("writes", "Number of read-write handlers completed"),
+            write_failures: context
+                .counter("write_failures", "Number of failed read-write handlers"),
+            read_capacity_waits: context.counter(
+                "read_capacity_waits",
+                "Number of times the service waited for read capacity",
+            ),
+            read_worker_stops: context.counter(
+                "read_worker_stops",
+                "Number of read workers that stopped unexpectedly",
+            ),
+            lane_messages,
+            stops: context.family("stops", "Number of service stops by reason"),
+            lane_batch_size: context.histogram(
+                "lane_batch_size",
+                "Number of lane messages processed in one service-loop iteration",
+                [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0],
+            ),
+            _lane_messages_family: lane_messages_family,
+        }
+    }
+
+    pub fn set_read_workers(&self, workers: usize) {
+        self.read_workers.set(workers as _);
+    }
+
+    pub fn set_inflight_reads(&self, reads: usize) {
+        self.inflight_reads.set(reads as _);
+    }
+
+    pub fn record_lane_message(&self, lane: usize) {
+        self.lane_messages[lane].inc();
+    }
+
+    pub fn record_stop(&self, reason: StopReason) {
+        self.stops.get_or_create(&Stop { reason }).inc();
+    }
+
+    pub fn observe_lane_batch(&self, size: usize) {
+        self.lane_batch_size.observe(size as f64);
+    }
+}

--- a/actor/src/service/mod.rs
+++ b/actor/src/service/mod.rs
@@ -1,0 +1,131 @@
+//! Shared service loop primitive for actors.
+//!
+//! [`Builder`] runs an [`Actor`](crate::Actor) on a managed control loop: a
+//! single task that owns the actor and dispatches ingress to its hooks. Each
+//! message is declared read-only or read-write by the
+//! [`ingress!`](crate::ingress!) declaration that produced it, and the loop
+//! gives each class a different execution mode.
+//!
+//! # Concurrency Model
+//!
+//! Read-only ingress is dispatched to a pool of pre-spawned read workers,
+//! bounded by [`Builder::with_read_concurrency`]. Each handler receives a
+//! snapshot of actor state captured when its message was admitted, so it
+//! never observes a partially-applied write. Consecutive reads admitted
+//! without an intervening actor mutation share one snapshot capture.
+//!
+//! Read-write ingress runs serially on the control loop itself. While a
+//! write runs, no new ingress of either class is admitted.
+//!
+//! ```text
+//!                          +--> read worker (snapshot)
+//!                          |
+//!   lanes --> control -----+--> read worker (snapshot)
+//!             loop         |
+//!               |          +--> read worker (snapshot)
+//!               |
+//!               +--> on_read_write (serial, ordered by FenceMode)
+//! ```
+//!
+//! # Ordering
+//!
+//! Reads never observe writes admitted after them: a snapshot is fixed at
+//! admission. [`FenceMode`] controls the reverse direction, whether a write
+//! waits for reads admitted before it:
+//!
+//! - [`FenceMode::Linearizable`] (default) drains every in-flight read before
+//!   a write runs. A read admitted before a write always responds before that
+//!   write executes, so no caller can observe a pre-write response arrive
+//!   after the write has been acknowledged. The cost is that one slow read
+//!   stalls the write and all ingress behind it.
+//! - [`FenceMode::Snapshot`] runs writes immediately, concurrently with
+//!   in-flight reads. Reads still respond with the snapshot captured at
+//!   admission, so responses are always self-consistent, but they can be
+//!   stale relative to acknowledged writes.
+//!
+//! Within one lane, messages are processed in enqueue order. Across lanes,
+//! selection is declaration-order biased (see [`Builder`]).
+//!
+//! # Shutdown
+//!
+//! Shutdown (runtime stop, [`Event::Stop`], or a fatal handler error) is
+//! prompt: in-flight read-only handlers are aborted before
+//! [`Actor::on_shutdown`](crate::Actor::on_shutdown) runs, and their pending
+//! askers observe [`Cancelled`](crate::ingress::Cancelled).
+//!
+//! # Event Sources
+//!
+//! Actors that only need mailbox input can use the default
+//! [`Actor::next_event`](crate::Actor::next_event). Actors with timers,
+//! network receivers, or other unboxed sources can override `next_event` and
+//! race those sources directly against [`LaneSet::recv`]. Source ordering and
+//! source exhaustion policy live in that hook.
+
+use crate::ingress::IntoEnvelope;
+use commonware_utils::NZUsize;
+use std::num::NonZeroUsize;
+
+mod builder;
+pub use builder::{Builder, MultiLaneBuilder};
+
+mod driver;
+
+mod metrics;
+
+mod reliable;
+pub use reliable::Reliable;
+
+mod types;
+pub use types::{DuplicateLaneError, Event, Lane, LaneEvent, LaneReceiver, LaneSet, Lanes};
+
+mod unreliable;
+pub use unreliable::Unreliable;
+
+/// Default mailbox capacity for single-lane services.
+pub const DEFAULT_MAILBOX_CAPACITY: NonZeroUsize = NZUsize!(1024);
+
+/// Ordering between read-write handlers and in-flight read-only handlers.
+///
+/// Read-only handlers always execute on a snapshot captured when the message
+/// was admitted, so they never observe a partially-applied write. The fence
+/// mode controls the reverse direction: whether a read-write handler waits
+/// for read-only handlers that were admitted before it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FenceMode {
+    /// Drain every in-flight read-only handler before each read-write
+    /// handler runs.
+    ///
+    /// A read admitted before a write always responds before that write
+    /// executes, so no asker can observe a pre-write response arrive after
+    /// the write has been acknowledged. This is the strongest ordering and
+    /// the default. Its cost is that one slow read stalls the write and all
+    /// ingress behind it.
+    #[default]
+    Linearizable,
+    /// Run read-write handlers immediately, concurrently with in-flight
+    /// read-only handlers.
+    ///
+    /// Reads admitted before a write may respond after that write completes,
+    /// using the snapshot captured at admission. Responses are always
+    /// snapshot-consistent but can be stale relative to acknowledged writes.
+    ///
+    /// Only use this mode when [`crate::Actor::Snapshot`] is an owned or
+    /// immutable view of actor state. If the snapshot aliases state the
+    /// write mutates (e.g. through a shared lock), a concurrent read can
+    /// observe a partially-applied write.
+    Snapshot,
+}
+
+/// Default maximum number of in-flight read-only handlers.
+pub const DEFAULT_MAX_INFLIGHT_READS: NonZeroUsize = NZUsize!(16);
+
+/// Ingress accepted by the actor service loop.
+///
+/// Builders select whether lanes are backed by [`crate::mailbox::Policy`] or
+/// [`crate::mailbox::UnreliablePolicy`].
+pub trait Ingress: IntoEnvelope {}
+
+impl<I> Ingress for I where I: IntoEnvelope {}
+
+#[cfg(test)]
+mod tests;

--- a/actor/src/service/reliable.rs
+++ b/actor/src/service/reliable.rs
@@ -1,0 +1,44 @@
+use super::driver::Service;
+use crate::{
+    Actor,
+    mailbox::{Policy, Receiver},
+};
+use commonware_runtime::{Handle, Spawner};
+
+/// Actor service backed by reliable mailbox lanes.
+pub struct Reliable<E, A>
+where
+    E: Spawner,
+    A: Actor<E>,
+    A::Ingress: Policy<Overflow: Send> + Send + 'static,
+{
+    inner: Service<E, A, Receiver<A::Ingress>>,
+}
+
+impl<E, A> Reliable<E, A>
+where
+    E: Spawner,
+    A: Actor<E>,
+    A::Ingress: Policy<Overflow: Send> + Send + 'static,
+{
+    pub(super) const fn new(inner: Service<E, A, Receiver<A::Ingress>>) -> Self {
+        Self { inner }
+    }
+
+    /// Spawn the control loop, passing `args` data to [`Actor::on_startup`].
+    pub fn start_with(self, args: A::Args) -> Handle<()> {
+        self.inner.start_with(args)
+    }
+}
+
+impl<E, A> Reliable<E, A>
+where
+    E: Spawner,
+    A: Actor<E, Args = ()>,
+    A::Ingress: Policy<Overflow: Send> + Send + 'static,
+{
+    /// Spawn the control loop for actors whose [`Actor::Args`] is `()`.
+    pub fn start(self) -> Handle<()> {
+        self.inner.start()
+    }
+}

--- a/actor/src/service/tests.rs
+++ b/actor/src/service/tests.rs
@@ -1,0 +1,1502 @@
+use super::*;
+use crate::{Actor, Feedback, Unreliable, ingress, ingress::Cancelled, mocks::TraceRecorder};
+use commonware_runtime::{Clock, Metrics, Runner as _, Spawner, Supervisor as _, deterministic};
+use commonware_utils::{
+    NZUsize,
+    channel::{mpsc, oneshot},
+    futures::OptionFuture,
+    sync::Mutex,
+};
+use futures_util::FutureExt as _;
+use std::{
+    collections::VecDeque,
+    convert::Infallible,
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    time::{Duration, SystemTime},
+};
+use tracing::Instrument as _;
+
+struct CounterActor {
+    value: u64,
+}
+
+ingress! {
+    CounterMailbox,
+
+    pub tell Seed { value: u64 };
+    pub ask read_write BumpAndGet { delta: u64 } -> u64;
+    pub ask Get -> u64;
+}
+
+impl<E: Spawner> Actor<E> for CounterActor {
+    type Mailbox = CounterMailbox;
+    type Ingress = CounterMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = u64;
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {
+        self.value
+    }
+
+    async fn on_read_only(
+        _context: E,
+        snapshot: Self::Snapshot,
+        message: CounterMailboxReadOnlyMessage,
+    ) -> Result<(), Self::Error> {
+        match message {
+            CounterMailboxReadOnlyMessage::Get { response } => {
+                let _ = response.send(snapshot);
+                Ok(())
+            }
+        }
+    }
+
+    async fn on_read_write(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        message: CounterMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        match message {
+            CounterMailboxReadWriteMessage::Seed { value } => {
+                self.value = value;
+            }
+            CounterMailboxReadWriteMessage::BumpAndGet { delta, response } => {
+                self.value += delta;
+                let _ = response.send(self.value);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Actor whose [`Actor::Args`] seeds the initial value on startup.
+struct ArgsActor {
+    value: u64,
+}
+
+impl<E: Spawner> Actor<E> for ArgsActor {
+    type Mailbox = CounterMailbox;
+    type Ingress = CounterMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = u64;
+    type Args = u64;
+
+    async fn on_startup(&mut self, _context: &mut E, args: &mut Self::Args) {
+        self.value = *args;
+    }
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {
+        self.value
+    }
+
+    async fn on_read_only(
+        _context: E,
+        snapshot: Self::Snapshot,
+        message: CounterMailboxReadOnlyMessage,
+    ) -> Result<(), Self::Error> {
+        match message {
+            CounterMailboxReadOnlyMessage::Get { response } => {
+                let _ = response.send(snapshot);
+                Ok(())
+            }
+        }
+    }
+
+    async fn on_read_write(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        message: CounterMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        match message {
+            CounterMailboxReadWriteMessage::Seed { value } => {
+                self.value = value;
+            }
+            CounterMailboxReadWriteMessage::BumpAndGet { delta, response } => {
+                self.value += delta;
+                let _ = response.send(self.value);
+            }
+        }
+        Ok(())
+    }
+}
+
+ingress! {
+    HookMailbox,
+
+    pub tell Note { value: u64 };
+    pub ask read_write Fence -> u64;
+}
+
+ingress! {
+    unreliable,
+    UnreliableHookMailbox,
+
+    pub tell Hit;
+    pub ask Count -> u64;
+}
+
+/// Actor recording hook activity and processed message order.
+#[derive(Clone)]
+struct HookActor {
+    batch: NonZeroUsize,
+    processed: Arc<Mutex<Vec<u64>>>,
+    preprocess: Arc<AtomicUsize>,
+    postprocess: Arc<AtomicUsize>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl HookActor {
+    fn new(batch: NonZeroUsize) -> Self {
+        Self {
+            batch,
+            processed: Arc::new(Mutex::new(Vec::new())),
+            preprocess: Arc::new(AtomicUsize::new(0)),
+            postprocess: Arc::new(AtomicUsize::new(0)),
+            shutdown: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn apply(&self, message: HookMailboxReadWriteMessage) {
+        match message {
+            HookMailboxReadWriteMessage::Note { value } => {
+                self.processed.lock().push(value);
+            }
+            HookMailboxReadWriteMessage::Fence { response } => {
+                let _ = response.send(self.processed.lock().len() as u64);
+            }
+        }
+    }
+}
+
+impl<E: Spawner> Actor<E> for HookActor {
+    type Mailbox = HookMailbox;
+    type Ingress = HookMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = ();
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {}
+
+    fn max_lane_batch(&self, _args: &Self::Args) -> NonZeroUsize {
+        self.batch
+    }
+
+    async fn preprocess(&mut self, _context: &mut E, _args: &mut Self::Args) {
+        self.preprocess.fetch_add(1, Ordering::SeqCst);
+    }
+
+    async fn postprocess(&mut self, _context: &mut E, _args: &mut Self::Args) {
+        self.postprocess.fetch_add(1, Ordering::SeqCst);
+    }
+
+    async fn on_shutdown(&mut self, _context: &mut E, _args: &mut Self::Args) {
+        self.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    async fn on_read_write(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        message: HookMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        self.apply(message);
+        Ok(())
+    }
+}
+
+struct UnreliableHookActor {
+    value: u64,
+}
+
+impl<E: Spawner> Actor<E> for UnreliableHookActor {
+    type Mailbox = UnreliableHookMailbox;
+    type Ingress = UnreliableHookMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = u64;
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {
+        self.value
+    }
+
+    async fn on_read_only(
+        _context: E,
+        snapshot: Self::Snapshot,
+        message: UnreliableHookMailboxReadOnlyMessage,
+    ) -> Result<(), Self::Error> {
+        let UnreliableHookMailboxReadOnlyMessage::Count { response } = message;
+        let _ = response.send(snapshot);
+        Ok(())
+    }
+
+    async fn on_read_write(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        message: UnreliableHookMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        let UnreliableHookMailboxReadWriteMessage::Hit = message;
+        self.value += 1;
+        Ok(())
+    }
+}
+
+struct StopBatchActor {
+    processed: Arc<Mutex<Vec<u64>>>,
+}
+
+impl<E: Spawner> Actor<E> for StopBatchActor {
+    type Mailbox = HookMailbox;
+    type Ingress = HookMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = ();
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {}
+
+    fn max_lane_batch(&self, _args: &Self::Args) -> NonZeroUsize {
+        NZUsize!(8)
+    }
+
+    async fn on_read_write(
+        &mut self,
+        context: &mut E,
+        _args: &mut Self::Args,
+        message: HookMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        let HookMailboxReadWriteMessage::Note { value } = message else {
+            return Ok(());
+        };
+
+        self.processed.lock().push(value);
+        if value == 1 {
+            let _ = context.child("stop").stop(0, None).now_or_never();
+        }
+        Ok(())
+    }
+}
+
+/// Same as [`StopBatchActor`] but with the default `max_lane_batch` of 1.
+struct StopSingleActor {
+    processed: Arc<Mutex<Vec<u64>>>,
+}
+
+impl<E: Spawner> Actor<E> for StopSingleActor {
+    type Mailbox = HookMailbox;
+    type Ingress = HookMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = ();
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {}
+
+    async fn on_read_write(
+        &mut self,
+        context: &mut E,
+        _args: &mut Self::Args,
+        message: HookMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        let HookMailboxReadWriteMessage::Note { value } = message else {
+            return Ok(());
+        };
+
+        self.processed.lock().push(value);
+        if value == 1 {
+            let _ = context.child("stop").stop(0, None).now_or_never();
+        }
+        Ok(())
+    }
+}
+
+/// Actor selecting pre-lane events, mailbox lanes, and post-lane p2p events
+/// without driver-owned source policy.
+struct SelectActor {
+    pre: VecDeque<u64>,
+    timeouts_remaining: usize,
+    timeout_deadline: Option<SystemTime>,
+    p2p_closed: bool,
+    inner: HookActor,
+}
+
+impl SelectActor {
+    fn new() -> Self {
+        Self {
+            pre: VecDeque::new(),
+            timeouts_remaining: 0,
+            timeout_deadline: None,
+            p2p_closed: false,
+            inner: HookActor::new(NonZeroUsize::MIN),
+        }
+    }
+}
+
+impl<E: Spawner + Clock> Actor<E> for SelectActor {
+    type Mailbox = HookMailbox;
+    type Ingress = HookMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = ();
+    type Args = mpsc::Receiver<u64>;
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {}
+
+    async fn on_shutdown(&mut self, _context: &mut E, _args: &mut Self::Args) {
+        self.inner.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    async fn next_event<R>(
+        &mut self,
+        context: &mut E,
+        args: &mut Self::Args,
+        mut lanes: LaneSet<'_, Self::Ingress, R>,
+    ) -> Event<Self::Ingress, HookMailboxReadWriteMessage>
+    where
+        R: LaneReceiver<Self::Ingress>,
+    {
+        if self.pre.is_empty()
+            && self.timeouts_remaining == 0
+            && self.p2p_closed
+            && lanes.is_exhausted()
+        {
+            return Event::Stop;
+        }
+
+        if let Some(value) = self.pre.pop_front() {
+            return Event::External(HookMailboxReadWriteMessage::Note { value });
+        }
+
+        let timeout = OptionFuture::from((self.timeouts_remaining > 0).then(|| {
+            let deadline = *self
+                .timeout_deadline
+                .get_or_insert_with(|| context.current() + Duration::from_millis(1));
+            context.sleep_until(deadline)
+        }));
+        let p2p = OptionFuture::from((!self.p2p_closed).then(|| args.recv()));
+
+        commonware_macros::select! {
+            _ = timeout => {
+                self.timeouts_remaining -= 1;
+                self.timeout_deadline = None;
+                Event::External(HookMailboxReadWriteMessage::Note { value: 100 })
+            },
+            event = lanes.recv() => match event {
+                LaneEvent::Message { lane, message } => Event::Ingress { lane, message },
+                LaneEvent::Closed { .. } => Event::Continue,
+            },
+            value = p2p => match value {
+                Some(value) => Event::External(HookMailboxReadWriteMessage::Note { value }),
+                None => {
+                    self.p2p_closed = true;
+                    Event::Continue
+                },
+            },
+        }
+    }
+
+    async fn on_read_write(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        message: HookMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        self.inner.apply(message);
+        Ok(())
+    }
+}
+
+ingress! {
+    FailMailbox,
+
+    pub ask read_write Halt -> ();
+    pub ask Snap -> u64;
+    pub ask Crash -> u64;
+    pub ask Hang {
+        release: commonware_utils::channel::oneshot::Receiver<()>,
+    } -> u64;
+}
+
+/// Actor whose handlers fail or block to exercise the fatal shutdown paths.
+struct FailingActor {
+    shutdown: Arc<AtomicBool>,
+    hanging: Arc<AtomicUsize>,
+}
+
+impl FailingActor {
+    fn new() -> Self {
+        Self {
+            shutdown: Arc::new(AtomicBool::new(false)),
+            hanging: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl<E: Spawner> Actor<E> for FailingActor {
+    type Mailbox = FailMailbox;
+    type Ingress = FailMailboxMessage;
+    type Error = &'static str;
+    type Snapshot = Arc<AtomicUsize>;
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {
+        self.hanging.clone()
+    }
+
+    async fn on_shutdown(&mut self, _context: &mut E, _args: &mut Self::Args) {
+        self.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    async fn on_read_only(
+        _context: E,
+        snapshot: Self::Snapshot,
+        message: FailMailboxReadOnlyMessage,
+    ) -> Result<(), Self::Error> {
+        match message {
+            FailMailboxReadOnlyMessage::Snap { .. } => Err("read failed"),
+            FailMailboxReadOnlyMessage::Crash { .. } => panic!("read panicked"),
+            FailMailboxReadOnlyMessage::Hang { release, response } => {
+                snapshot.fetch_add(1, Ordering::SeqCst);
+                let _ = release.await;
+                let _ = response.send(1);
+                Ok(())
+            }
+        }
+    }
+
+    async fn on_read_write(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        message: FailMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        match message {
+            FailMailboxReadWriteMessage::Halt { .. } => Err("write failed"),
+        }
+    }
+}
+
+#[test]
+fn routes_read_write_ask_and_read_only_ask() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let (mailbox, service) =
+            Builder::new(CounterActor { value: 0 }).build(context.child("counter"));
+        let handle = service.start();
+
+        assert_eq!(mailbox.seed_internal(10), Feedback::Ok);
+        assert_eq!(
+            mailbox
+                .bump_and_get_internal(5)
+                .await
+                .expect("bump response"),
+            15
+        );
+        assert_eq!(mailbox.get_internal().await.expect("get response"), 15);
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn unreliable_service_routes_messages() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let (mailbox, service) = Builder::new(UnreliableHookActor { value: 0 })
+            .build_unreliable(context.child("unreliable"));
+        let handle = service.start();
+
+        assert_eq!(mailbox.hit_internal(), Unreliable::new(Feedback::Ok));
+        assert_eq!(mailbox.count_internal().await.expect("count response"), 1);
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn service_metrics_track_activity() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let (mailbox, service) =
+            Builder::new(CounterActor { value: 0 }).build(context.child("metrics"));
+        let handle = service.start();
+
+        assert_eq!(mailbox.get_internal().await.expect("get response"), 0);
+        assert_eq!(
+            mailbox
+                .bump_and_get_internal(1)
+                .await
+                .expect("bump response"),
+            1
+        );
+
+        let buffer = context.encode();
+        assert!(buffer.contains("metrics_reads_total 1"), "{buffer}");
+        assert!(buffer.contains("metrics_writes_total 1"), "{buffer}");
+        assert!(
+            buffer.contains("metrics_lane_messages_total{lane=\"0\"} 2"),
+            "{buffer}"
+        );
+        assert!(buffer.contains("metrics_inflight_reads 0"), "{buffer}");
+        assert!(buffer.contains("metrics_read_workers 16"), "{buffer}");
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn start_with_seeds_args() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let (mailbox, service) = Builder::new(ArgsActor { value: 0 }).build(context.child("args"));
+        let handle = service.start_with(41);
+
+        assert_eq!(
+            mailbox
+                .bump_and_get_internal(1)
+                .await
+                .expect("bump response"),
+            42
+        );
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn spans_follow_messages_across_the_mailbox() {
+    let (recorder, state) = TraceRecorder::new();
+    tracing::subscriber::with_default(recorder, || {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (mailbox, service) =
+                Builder::new(CounterActor { value: 0 }).build(context.child("spans"));
+            let handle = service.start();
+
+            let caller = tracing::info_span!("test.actor.caller");
+            {
+                let _guard = caller.enter();
+                assert_eq!(mailbox.seed_internal(11), Feedback::Ok);
+            }
+            let bumped = mailbox
+                .bump_and_get_internal(1)
+                .instrument(caller.clone())
+                .await
+                .expect("bump response");
+            assert_eq!(bumped, 12);
+
+            drop(mailbox);
+            handle.await.expect("service stopped cleanly");
+        });
+    });
+
+    // Tells start a new root that follows from the caller, even while the
+    // caller's span is active. This is what keeps tell ping/pong loops from
+    // growing one trace without bound.
+    let caller = state.span("test.actor.caller");
+    let seed = state.span("actor.counter_mailbox.seed");
+    assert_eq!(seed.parent, None);
+    assert_eq!(seed.follows, vec![caller.id]);
+
+    // Asks stay inside the caller's trace: depth is bounded by the request
+    // chain because the caller awaits the response.
+    let bump = state.span("actor.counter_mailbox.bump_and_get");
+    assert_eq!(bump.parent, Some(caller.id));
+    assert!(bump.follows.is_empty());
+
+    // Dispatch re-enters the carried span via an `actor.process` child.
+    let process = state.spans_named("actor.process");
+    assert!(process.iter().any(|span| span.parent == Some(seed.id)));
+    assert!(process.iter().any(|span| span.parent == Some(bump.id)));
+}
+
+#[test]
+fn external_events_route_and_exhaustion_stops_actor() {
+    let (recorder, state) = TraceRecorder::new();
+    tracing::subscriber::with_default(recorder, || {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let actor = SelectActor::new();
+            let processed = actor.inner.processed.clone();
+            let shutdown = actor.inner.shutdown.clone();
+            let (external, receiver) = mpsc::channel(8);
+            let (mailbox, service) = Builder::new(actor).build(context.child("external"));
+            let handle = service.start_with(receiver);
+
+            external.send(7).await.expect("send external");
+            external.send(8).await.expect("send external");
+            while processed.lock().len() < 2 {
+                context.sleep(Duration::from_millis(1)).await;
+            }
+            assert_eq!(*processed.lock(), vec![7, 8]);
+            assert_eq!(mailbox.fence_internal().await.expect("fence response"), 2);
+
+            // Closing the p2p source only disables that arm. The actor stops
+            // after the mailbox lane also closes.
+            drop(external);
+            drop(mailbox);
+            handle.await.expect("service stopped cleanly");
+            assert!(shutdown.load(Ordering::SeqCst));
+        });
+    });
+
+    // External events carry no enqueue span; they are processed under a
+    // distinct root span name.
+    assert!(!state.spans_named("actor.process.external").is_empty());
+}
+
+#[test]
+fn actor_select_can_sandwich_lane_between_external_sources() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let mut actor = SelectActor::new();
+        actor.pre = VecDeque::from([1]);
+        let processed = actor.inner.processed.clone();
+        let (external, receiver) = mpsc::channel(8);
+        let (mailbox, service) = Builder::new(actor).build(context.child("sandwich"));
+
+        // Every source is ready when the actor starts. The actor's select
+        // places `pre` before lanes and p2p after lanes.
+        assert_eq!(mailbox.note_internal(2), Feedback::Ok);
+        external.send(3).await.expect("send external");
+        let handle = service.start_with(receiver);
+
+        while processed.lock().len() < 3 {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(*processed.lock(), vec![1, 2, 3]);
+
+        drop(external);
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn lane_close_can_keep_serving_external_sources() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let actor = SelectActor::new();
+        let processed = actor.inner.processed.clone();
+        let shutdown = actor.inner.shutdown.clone();
+        let (external, receiver) = mpsc::channel(8);
+        let (mailbox, service) = Builder::new(actor).build(context.child("disable"));
+
+        // Drain and close the mailbox lane before the loop starts: the
+        // actor disables the lane and keeps serving external events.
+        assert_eq!(mailbox.note_internal(1), Feedback::Ok);
+        drop(mailbox);
+        let handle = service.start_with(receiver);
+
+        external.send(2).await.expect("send external");
+        while processed.lock().len() < 2 {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(*processed.lock(), vec![1, 2]);
+        assert!(!shutdown.load(Ordering::SeqCst));
+
+        // Exhausting the external source leaves no live source, so the actor
+        // stops on the next iteration.
+        drop(external);
+        handle.await.expect("service stopped cleanly");
+        assert!(shutdown.load(Ordering::SeqCst));
+    });
+}
+
+#[test]
+fn p2p_close_can_be_omitted_while_timeout_and_lane_continue() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let mut actor = SelectActor::new();
+        actor.timeouts_remaining = 1;
+        let processed = actor.inner.processed.clone();
+        let shutdown = actor.inner.shutdown.clone();
+        let (external, receiver) = mpsc::channel::<u64>(8);
+        let (mailbox, service) = Builder::new(actor).build(context.child("p2p_closed"));
+
+        // Closing p2p should only remove that arm. Timeout and lanes still
+        // produce events.
+        drop(external);
+        assert_eq!(mailbox.note_internal(2), Feedback::Ok);
+        let handle = service.start_with(receiver);
+
+        while processed.lock().len() < 2 {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(*processed.lock(), vec![2, 100]);
+        assert!(!shutdown.load(Ordering::SeqCst));
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+        assert!(shutdown.load(Ordering::SeqCst));
+    });
+}
+
+#[test]
+fn fatal_write_stops_actor() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let actor = FailingActor::new();
+        let shutdown = actor.shutdown.clone();
+        let (mailbox, service) = Builder::new(actor).build(context.child("fatal_write"));
+        let handle = service.start();
+
+        assert_eq!(mailbox.halt_internal().await.unwrap_err(), Cancelled);
+        handle.await.expect("service stopped cleanly");
+        assert!(shutdown.load(Ordering::SeqCst));
+    });
+}
+
+#[test]
+fn fatal_read_stops_actor() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let actor = FailingActor::new();
+        let shutdown = actor.shutdown.clone();
+        let (mailbox, service) = Builder::new(actor).build(context.child("fatal_read"));
+        let handle = service.start();
+
+        assert_eq!(mailbox.snap_internal().await.unwrap_err(), Cancelled);
+        handle.await.expect("service stopped cleanly");
+        assert!(shutdown.load(Ordering::SeqCst));
+    });
+}
+
+#[test]
+fn panic_read_stops_actor() {
+    let cfg = deterministic::Config::default().with_catch_panics(true);
+    let runner = deterministic::Runner::new(cfg);
+    runner.start(|context| async move {
+        let actor = FailingActor::new();
+        let shutdown = actor.shutdown.clone();
+        let (mailbox, service) = Builder::new(actor).build(context.child("panic_read"));
+        let handle = service.start();
+
+        assert_eq!(mailbox.crash_internal().await.unwrap_err(), Cancelled);
+        handle.await.expect("service stopped cleanly");
+        assert!(shutdown.load(Ordering::SeqCst));
+    });
+}
+
+#[test]
+fn fatal_read_aborts_blocked_reads() {
+    let runner = deterministic::Runner::timed(Duration::from_secs(10));
+    runner.start(|context| async move {
+        let actor = FailingActor::new();
+        let shutdown = actor.shutdown.clone();
+        let hanging = actor.hanging.clone();
+        let (mailbox, service) = Builder::new(actor).build(context.child("fatal_hang"));
+        let handle = service.start();
+
+        // Park one read on a channel that never releases.
+        let (release, wait) = oneshot::channel();
+        let hang_mailbox = mailbox.clone();
+        let hang = context
+            .child("hang")
+            .spawn(move |_context| async move { hang_mailbox.hang_internal(wait).await });
+        while hanging.load(Ordering::SeqCst) < 1 {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+
+        // A fatal read must stop the actor without draining the parked read.
+        assert_eq!(mailbox.snap_internal().await.unwrap_err(), Cancelled);
+        handle.await.expect("service stopped cleanly");
+        assert!(shutdown.load(Ordering::SeqCst));
+        assert_eq!(hang.await.expect("hang task joined"), Err(Cancelled));
+        drop(release);
+    });
+}
+
+#[test]
+fn lane_batch_processes_up_to_cap_with_single_postprocess() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let actor = HookActor::new(NZUsize!(4));
+        let processed = actor.processed.clone();
+        let postprocess = actor.postprocess.clone();
+        let (mailbox, service) =
+            Builder::new(actor.clone()).build_with_capacity(context.child("batch"), NZUsize!(8));
+
+        // Buffer a full batch before the loop starts: one iteration should
+        // drain all four messages and run postprocess once.
+        for value in 1..=4 {
+            assert_eq!(mailbox.note_internal(value), Feedback::Ok);
+        }
+        let handle = service.start();
+
+        assert_eq!(mailbox.fence_internal().await.expect("fence response"), 4);
+        assert_eq!(*processed.lock(), vec![1, 2, 3, 4]);
+        // One postprocess for the batched notes, one for the fence. The
+        // fence's postprocess runs after its response is delivered, so wait
+        // for the loop to finish the iteration.
+        while postprocess.load(Ordering::SeqCst) < 2 {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(postprocess.load(Ordering::SeqCst), 2);
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn overflow_messages_are_processed_in_order() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let actor = HookActor::new(NonZeroUsize::MIN);
+        let processed = actor.processed.clone();
+        let (mailbox, service) =
+            Builder::new(actor).build_with_capacity(context.child("overflow"), NZUsize!(1));
+
+        // Only the first message fits the ready queue; the rest ride the
+        // generated FIFO overflow policy and must still arrive in order.
+        assert_eq!(mailbox.note_internal(1), Feedback::Ok);
+        for value in 2..=10 {
+            assert_eq!(mailbox.note_internal(value), Feedback::Backoff);
+        }
+        let handle = service.start();
+
+        assert_eq!(mailbox.fence_internal().await.expect("fence response"), 10);
+        assert_eq!(*processed.lock(), (1..=10).collect::<Vec<_>>());
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn lane_close_mid_batch_postprocesses_then_shuts_down() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let actor = HookActor::new(NZUsize!(8));
+        let processed = actor.processed.clone();
+        let postprocess = actor.postprocess.clone();
+        let shutdown = actor.shutdown.clone();
+        let (mailbox, service) =
+            Builder::new(actor).build_with_capacity(context.child("close"), NZUsize!(4));
+
+        for value in 1..=3 {
+            assert_eq!(mailbox.note_internal(value), Feedback::Ok);
+        }
+        drop(mailbox);
+        let handle = service.start();
+        handle.await.expect("service stopped cleanly");
+
+        assert_eq!(*processed.lock(), vec![1, 2, 3]);
+        assert_eq!(postprocess.load(Ordering::SeqCst), 1);
+        assert!(shutdown.load(Ordering::SeqCst));
+    });
+}
+
+#[test]
+fn runtime_stop_interrupts_lane_batch() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let processed = Arc::new(Mutex::new(Vec::new()));
+        let actor = StopBatchActor {
+            processed: processed.clone(),
+        };
+        let (mailbox, service) =
+            Builder::new(actor).build_with_capacity(context.child("stop_batch"), NZUsize!(4));
+
+        for value in 1..=4 {
+            assert_eq!(mailbox.note_internal(value), Feedback::Ok);
+        }
+
+        let handle = service.start();
+        handle.await.expect("service stopped cleanly");
+        assert_eq!(*processed.lock(), vec![1]);
+        drop(mailbox);
+    });
+}
+
+#[test]
+fn runtime_stop_interrupts_busy_lane_without_batching() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let processed = Arc::new(Mutex::new(Vec::new()));
+        let actor = StopSingleActor {
+            processed: processed.clone(),
+        };
+        let (mailbox, service) =
+            Builder::new(actor).build_with_capacity(context.child("stop_single"), NZUsize!(4));
+
+        for value in 1..=4 {
+            assert_eq!(mailbox.note_internal(value), Feedback::Ok);
+        }
+
+        let handle = service.start();
+        handle.await.expect("service stopped cleanly");
+        assert_eq!(*processed.lock(), vec![1]);
+        drop(mailbox);
+    });
+}
+
+#[test]
+fn runtime_stop_triggers_graceful_shutdown() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let actor = HookActor::new(NonZeroUsize::MIN);
+        let shutdown = actor.shutdown.clone();
+        let (mailbox, service) = Builder::new(actor).build(context.child("stop"));
+        let handle = service.start();
+
+        assert_eq!(mailbox.fence_internal().await.expect("fence response"), 0);
+        context
+            .stop(0, None)
+            .await
+            .expect("runtime stopped cleanly");
+        handle.await.expect("service stopped cleanly");
+        assert!(shutdown.load(Ordering::SeqCst));
+        drop(mailbox);
+    });
+}
+
+#[test]
+fn multi_lane_declaration_order_bias() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let actor = HookActor::new(NonZeroUsize::MIN);
+        let processed = actor.processed.clone();
+        let (lanes, service) = Builder::new(actor)
+            .with_lane("hi", NZUsize!(4))
+            .with_lane("lo", NZUsize!(4))
+            .build(context.child("lanes"))
+            .expect("unique lanes");
+        let mailboxes = lanes.into_inner();
+        let hi = mailboxes.get(&"hi").expect("hi lane").clone();
+        let lo = mailboxes.get(&"lo").expect("lo lane").clone();
+        drop(mailboxes);
+
+        // Enqueue on the later lane first: declaration order still wins.
+        assert_eq!(lo.note_internal(2), Feedback::Ok);
+        assert_eq!(hi.note_internal(1), Feedback::Ok);
+        let handle = service.start();
+
+        while processed.lock().len() < 2 {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(*processed.lock(), vec![1, 2]);
+
+        drop(hi);
+        drop(lo);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn duplicate_lanes_are_rejected() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let result = Builder::new(CounterActor { value: 0 })
+            .with_lane("same", NZUsize!(1))
+            .with_lane("same", NZUsize!(1))
+            .build(context.child("duplicates"));
+
+        assert!(matches!(result, Err(DuplicateLaneError)));
+    });
+}
+
+struct FencedActor {
+    value: u64,
+    active_reads: Arc<AtomicUsize>,
+    writes: Arc<AtomicUsize>,
+}
+
+ingress! {
+    FencedMailbox,
+
+    pub tell Bump;
+    pub ask BlockOn {
+        release: commonware_utils::channel::oneshot::Receiver<()>,
+    } -> u64;
+    pub ask GetFenced -> u64;
+}
+
+impl<E: Spawner> Actor<E> for FencedActor {
+    type Mailbox = FencedMailbox;
+    type Ingress = FencedMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = (u64, Arc<AtomicUsize>);
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {
+        (self.value, self.active_reads.clone())
+    }
+
+    async fn on_read_only(
+        _context: E,
+        snapshot: Self::Snapshot,
+        message: FencedMailboxReadOnlyMessage,
+    ) -> Result<(), Self::Error> {
+        let (value, active_reads) = snapshot;
+        match message {
+            FencedMailboxReadOnlyMessage::BlockOn { release, response } => {
+                active_reads.fetch_add(1, Ordering::SeqCst);
+                let _ = release.await;
+                active_reads.fetch_sub(1, Ordering::SeqCst);
+                let _ = response.send(value);
+            }
+            FencedMailboxReadOnlyMessage::GetFenced { response } => {
+                let _ = response.send(value);
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_read_write(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        message: FencedMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        match message {
+            FencedMailboxReadWriteMessage::Bump => {
+                self.value += 1;
+                self.writes.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+    }
+}
+
+#[test]
+fn read_write_waits_for_inflight_reads() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let active_reads = Arc::new(AtomicUsize::new(0));
+        let writes = Arc::new(AtomicUsize::new(0));
+        let actor = FencedActor {
+            value: 7,
+            active_reads: active_reads.clone(),
+            writes: writes.clone(),
+        };
+        let (mailbox, service) = Builder::new(actor)
+            .with_read_concurrency(NonZeroUsize::new(2).expect("non-zero"))
+            .build(context.child("fenced"));
+        let handle = service.start();
+
+        let (release, wait) = oneshot::channel();
+        let read_mailbox = mailbox.clone();
+        let read = context.child("read").spawn(move |_context| async move {
+            read_mailbox
+                .block_on_internal(wait)
+                .await
+                .expect("read response")
+        });
+
+        for _ in 0..10 {
+            if active_reads.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            context.sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(active_reads.load(Ordering::SeqCst), 1);
+
+        assert_eq!(mailbox.bump_internal(), Feedback::Ok);
+        context.sleep(Duration::from_millis(1)).await;
+        assert_eq!(writes.load(Ordering::SeqCst), 0);
+        assert_eq!(active_reads.load(Ordering::SeqCst), 1);
+
+        release.send(()).expect("release read");
+        assert_eq!(read.await.expect("read task joined"), 7);
+
+        for _ in 0..10 {
+            if writes.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            context.sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(writes.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            mailbox.get_fenced_internal().await.expect("get response"),
+            8
+        );
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn snapshot_fence_mode_runs_writes_during_reads() {
+    let runner = deterministic::Runner::timed(Duration::from_secs(10));
+    runner.start(|context| async move {
+        let active_reads = Arc::new(AtomicUsize::new(0));
+        let writes = Arc::new(AtomicUsize::new(0));
+        let actor = FencedActor {
+            value: 7,
+            active_reads: active_reads.clone(),
+            writes: writes.clone(),
+        };
+        let (mailbox, service) = Builder::new(actor)
+            .with_fence_mode(FenceMode::Snapshot)
+            .build(context.child("unfenced"));
+        let handle = service.start();
+
+        // Park one read on a channel released only after the write lands.
+        let (release, wait) = oneshot::channel();
+        let read_mailbox = mailbox.clone();
+        let read = context.child("read").spawn(move |_context| async move {
+            read_mailbox
+                .block_on_internal(wait)
+                .await
+                .expect("read response")
+        });
+        while active_reads.load(Ordering::SeqCst) < 1 {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+
+        // The write must complete while the read is still parked.
+        assert_eq!(mailbox.bump_internal(), Feedback::Ok);
+        while writes.load(Ordering::SeqCst) < 1 {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(active_reads.load(Ordering::SeqCst), 1);
+
+        // The read still responds with the snapshot captured at admission.
+        release.send(()).expect("release read");
+        assert_eq!(read.await.expect("read task joined"), 7);
+        assert_eq!(
+            mailbox.get_fenced_internal().await.expect("get response"),
+            8
+        );
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn runtime_stop_aborts_blocked_reads() {
+    let runner = deterministic::Runner::timed(Duration::from_secs(10));
+    runner.start(|context| async move {
+        let active_reads = Arc::new(AtomicUsize::new(0));
+        let writes = Arc::new(AtomicUsize::new(0));
+        let actor = FencedActor {
+            value: 7,
+            active_reads: active_reads.clone(),
+            writes,
+        };
+        let (mailbox, service) = Builder::new(actor).build(context.child("stop_abort"));
+        let handle = service.start();
+
+        // Park one read on a channel that never releases.
+        let (release, wait) = oneshot::channel();
+        let read_mailbox = mailbox.clone();
+        let read = context
+            .child("read")
+            .spawn(move |_context| async move { read_mailbox.block_on_internal(wait).await });
+        while active_reads.load(Ordering::SeqCst) < 1 {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+
+        // Runtime shutdown must not wait for the parked read; supervision
+        // aborts it and the asker observes a cancelled response.
+        context
+            .stop(0, None)
+            .await
+            .expect("runtime stopped cleanly");
+        handle.await.expect("service stopped cleanly");
+        assert_eq!(read.await.expect("read task joined"), Err(Cancelled));
+        drop(release);
+        drop(mailbox);
+    });
+}
+
+ingress! {
+    OrderedMailbox,
+
+    pub ask Park {
+        release: commonware_utils::channel::oneshot::Receiver<()>,
+    } -> u64;
+}
+
+/// Records the drop of a parked read-only handler.
+struct DropLog {
+    events: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl Drop for DropLog {
+    fn drop(&mut self) {
+        self.events.lock().push("read_dropped");
+    }
+}
+
+/// Actor recording the order of read aborts and the shutdown hook.
+struct OrderedShutdownActor {
+    events: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl<E: Spawner> Actor<E> for OrderedShutdownActor {
+    type Mailbox = OrderedMailbox;
+    type Ingress = OrderedMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = Arc<Mutex<Vec<&'static str>>>;
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {
+        self.events.clone()
+    }
+
+    async fn on_shutdown(&mut self, _context: &mut E, _args: &mut Self::Args) {
+        self.events.lock().push("on_shutdown");
+    }
+
+    async fn on_read_only(
+        _context: E,
+        snapshot: Self::Snapshot,
+        message: OrderedMailboxReadOnlyMessage,
+    ) -> Result<(), Self::Error> {
+        let OrderedMailboxReadOnlyMessage::Park { release, response } = message;
+        let _guard = DropLog {
+            events: snapshot.clone(),
+        };
+        snapshot.lock().push("read_parked");
+        let _ = release.await;
+        let _ = response.send(1);
+        Ok(())
+    }
+}
+
+#[test]
+fn reads_abort_before_on_shutdown() {
+    let runner = deterministic::Runner::timed(Duration::from_secs(10));
+    runner.start(|context| async move {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let actor = OrderedShutdownActor {
+            events: events.clone(),
+        };
+        let (mailbox, service) = Builder::new(actor).build(context.child("ordered"));
+        let handle = service.start();
+
+        // Park one read on a channel that never releases.
+        let (release, wait) = oneshot::channel();
+        let read_mailbox = mailbox.clone();
+        let read = context
+            .child("read")
+            .spawn(move |_context| async move { read_mailbox.park_internal(wait).await });
+        while events.lock().is_empty() {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+
+        // The parked read must be aborted before on_shutdown runs, so the
+        // hook can never race a handler holding a pre-shutdown snapshot.
+        context
+            .stop(0, None)
+            .await
+            .expect("runtime stopped cleanly");
+        handle.await.expect("service stopped cleanly");
+        assert_eq!(
+            *events.lock(),
+            vec!["read_parked", "read_dropped", "on_shutdown"]
+        );
+        assert_eq!(read.await.expect("read task joined"), Err(Cancelled));
+        drop(release);
+        drop(mailbox);
+    });
+}
+
+ingress! {
+    ShutdownMailbox,
+
+    pub tell Submit;
+}
+
+/// Actor that pauses in its shutdown hook.
+struct ShutdownActor {
+    started: Arc<AtomicBool>,
+    release: Option<oneshot::Receiver<()>>,
+}
+
+impl<E: Spawner> Actor<E> for ShutdownActor {
+    type Mailbox = ShutdownMailbox;
+    type Ingress = ShutdownMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = ();
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {}
+
+    async fn on_shutdown(&mut self, _context: &mut E, _args: &mut Self::Args) {
+        self.started.store(true, Ordering::SeqCst);
+        let _ = self.release.take().expect("shutdown runs once").await;
+    }
+
+    async fn next_event<R>(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        _lanes: LaneSet<'_, Self::Ingress, R>,
+    ) -> Event<Self::Ingress, ShutdownMailboxReadWriteMessage>
+    where
+        R: LaneReceiver<Self::Ingress>,
+    {
+        Event::Stop
+    }
+}
+
+#[test]
+fn shutdown_closes_mailbox_before_on_shutdown() {
+    let runner = deterministic::Runner::timed(Duration::from_secs(10));
+    runner.start(|context| async move {
+        let started = Arc::new(AtomicBool::new(false));
+        let (release, wait) = oneshot::channel();
+        let actor = ShutdownActor {
+            started: started.clone(),
+            release: Some(wait),
+        };
+        let (mailbox, service) = Builder::new(actor).build(context.child("shutdown_mailbox"));
+        let handle = service.start();
+
+        while !started.load(Ordering::SeqCst) {
+            context.sleep(Duration::from_millis(1)).await;
+        }
+
+        assert_eq!(mailbox.submit_internal(), Feedback::Closed);
+        release.send(()).expect("release shutdown");
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+ingress! {
+    CachedMailbox,
+
+    pub tell Bump;
+    pub subscribe Peek -> u64;
+}
+
+/// Actor counting how many snapshots the service captures.
+struct CachingActor {
+    value: u64,
+    snapshots: Arc<AtomicUsize>,
+}
+
+impl<E: Spawner> Actor<E> for CachingActor {
+    type Mailbox = CachedMailbox;
+    type Ingress = CachedMailboxMessage;
+    type Error = Infallible;
+    type Snapshot = u64;
+    type Args = ();
+
+    fn snapshot(&self, _args: &Self::Args) -> Self::Snapshot {
+        self.snapshots.fetch_add(1, Ordering::SeqCst);
+        self.value
+    }
+
+    fn max_lane_batch(&self, _args: &Self::Args) -> NonZeroUsize {
+        NZUsize!(8)
+    }
+
+    async fn on_read_only(
+        _context: E,
+        snapshot: Self::Snapshot,
+        message: CachedMailboxReadOnlyMessage,
+    ) -> Result<(), Self::Error> {
+        let CachedMailboxReadOnlyMessage::Peek { response } = message;
+        let _ = response.send(snapshot);
+        Ok(())
+    }
+
+    async fn on_read_write(
+        &mut self,
+        _context: &mut E,
+        _args: &mut Self::Args,
+        message: CachedMailboxReadWriteMessage,
+    ) -> Result<(), Self::Error> {
+        let CachedMailboxReadWriteMessage::Bump = message;
+        self.value += 1;
+        Ok(())
+    }
+}
+
+#[test]
+fn consecutive_reads_share_one_snapshot() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let snapshots = Arc::new(AtomicUsize::new(0));
+        let actor = CachingActor {
+            value: 3,
+            snapshots: snapshots.clone(),
+        };
+        let (mailbox, service) = Builder::new(actor).build(context.child("cached"));
+
+        // Buffer a full batch of reads before the loop starts: one snapshot
+        // capture must serve the whole batch.
+        let peeks: Vec<_> = (0..4).map(|_| mailbox.peek_internal()).collect();
+        let handle = service.start();
+
+        for peek in peeks {
+            assert_eq!(peek.await.expect("peek response"), 3);
+        }
+        assert_eq!(snapshots.load(Ordering::SeqCst), 1);
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+#[test]
+fn write_invalidates_cached_snapshot() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let snapshots = Arc::new(AtomicUsize::new(0));
+        let actor = CachingActor {
+            value: 0,
+            snapshots: snapshots.clone(),
+        };
+        let (mailbox, service) = Builder::new(actor).build(context.child("invalidate"));
+
+        // A write between two reads in one batch must split the cache: the
+        // second read observes the write, not the first read's snapshot.
+        let before = mailbox.peek_internal();
+        assert_eq!(mailbox.bump_internal(), Feedback::Ok);
+        let after = mailbox.peek_internal();
+        let handle = service.start();
+
+        assert_eq!(before.await.expect("peek response"), 0);
+        assert_eq!(after.await.expect("peek response"), 1);
+        assert_eq!(snapshots.load(Ordering::SeqCst), 2);
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+    });
+}
+
+/// Drive a mixed read/write workload and return the runtime auditor state.
+fn mixed_workload_state(seed: u64) -> String {
+    let runner = deterministic::Runner::seeded(seed);
+    runner.start(|context| async move {
+        let (mailbox, service) = Builder::new(CounterActor { value: 0 })
+            .with_read_concurrency(NZUsize!(4))
+            .build(context.child("determinism"));
+        let handle = service.start();
+
+        assert_eq!(mailbox.seed_internal(1), Feedback::Ok);
+        let (a, b, c) = futures::join!(
+            mailbox.get_internal(),
+            mailbox.bump_and_get_internal(2),
+            mailbox.get_internal()
+        );
+        a.expect("get response");
+        b.expect("bump response");
+        c.expect("get response");
+
+        drop(mailbox);
+        handle.await.expect("service stopped cleanly");
+        context.auditor().state()
+    })
+}
+
+#[test]
+fn deterministic_across_identical_runs() {
+    assert_eq!(mixed_workload_state(42), mixed_workload_state(42));
+}

--- a/actor/src/service/types.rs
+++ b/actor/src/service/types.rs
@@ -1,0 +1,234 @@
+use super::Ingress;
+use crate::mailbox::{Policy, Receiver, UnreliablePolicy, UnreliableReceiver};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    future::poll_fn,
+    task::{Context, Poll},
+};
+use thiserror::Error;
+
+/// Receives messages for one service lane.
+pub trait LaneReceiver<I>: Send {
+    #[doc(hidden)]
+    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<I>>;
+    #[doc(hidden)]
+    fn try_recv(&mut self) -> Result<I, std::sync::mpsc::TryRecvError>;
+}
+
+impl<I> LaneReceiver<I> for Receiver<I>
+where
+    I: Policy + Send + 'static,
+    I::Overflow: Send,
+{
+    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<I>> {
+        self.poll_recv(cx)
+    }
+
+    fn try_recv(&mut self) -> Result<I, std::sync::mpsc::TryRecvError> {
+        self.try_recv()
+    }
+}
+
+impl<I> LaneReceiver<I> for UnreliableReceiver<I>
+where
+    I: UnreliablePolicy + Send + 'static,
+    I::Overflow: Send,
+{
+    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<I>> {
+        self.poll_recv(cx)
+    }
+
+    fn try_recv(&mut self) -> Result<I, std::sync::mpsc::TryRecvError> {
+        self.try_recv()
+    }
+}
+
+/// Returned when the same lane key is configured more than once.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+#[error("duplicate lane configured")]
+pub struct DuplicateLaneError;
+
+/// Per-lane mailboxes returned by [`crate::service::MultiLaneBuilder::build`].
+pub struct Lanes<L, M>
+where
+    L: Ord,
+{
+    pub(super) mailboxes: BTreeMap<L, M>,
+}
+
+impl<L, M> Clone for Lanes<L, M>
+where
+    L: Ord + Clone,
+    M: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            mailboxes: self.mailboxes.clone(),
+        }
+    }
+}
+
+impl<L, M> fmt::Debug for Lanes<L, M>
+where
+    L: Ord + fmt::Debug,
+    M: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Lanes")
+            .field("mailboxes", &self.mailboxes)
+            .finish()
+    }
+}
+
+impl<L, M> Lanes<L, M>
+where
+    L: Ord,
+{
+    /// Returns the number of lanes.
+    pub fn len(&self) -> usize {
+        self.mailboxes.len()
+    }
+
+    /// Returns `true` if there are no lanes.
+    pub fn is_empty(&self) -> bool {
+        self.mailboxes.is_empty()
+    }
+
+    /// Returns a reference to the mailbox for `lane`.
+    pub fn lane(&self, lane: &L) -> Option<&M> {
+        self.mailboxes.get(lane)
+    }
+
+    /// Consume and return all lane mailboxes.
+    pub fn into_inner(self) -> BTreeMap<L, M> {
+        self.mailboxes
+    }
+}
+
+impl<L, M> IntoIterator for Lanes<L, M>
+where
+    L: Ord,
+{
+    type Item = (L, M);
+    type IntoIter = std::collections::btree_map::IntoIter<L, M>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.mailboxes.into_iter()
+    }
+}
+
+/// Opaque declaration index for a service lane.
+///
+/// Values are produced by [`LaneSet`] and should be passed back unchanged when
+/// returning [`Event::Ingress`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Lane {
+    index: usize,
+}
+
+impl Lane {
+    const fn new(index: usize) -> Self {
+        Self { index }
+    }
+
+    /// Returns the lane's declaration index.
+    pub const fn index(self) -> usize {
+        self.index
+    }
+}
+
+/// Event selected by an actor for one service-loop iteration.
+pub enum Event<I, W> {
+    /// Dispatch an ingress message received from `lane`.
+    Ingress {
+        /// Lane that produced `message`.
+        ///
+        /// Use the lane returned with the same [`LaneEvent::Message`]. The
+        /// driver uses this token to batch additional ready messages from that
+        /// lane.
+        lane: Lane,
+        /// Ingress message to dispatch.
+        message: I,
+    },
+    /// Dispatch an actor-owned event as read-write ingress.
+    External(W),
+    /// No message was selected; start the next service-loop iteration.
+    ///
+    /// Sources that are immediately ready must be muted before returning this,
+    /// otherwise the actor will select the same source again immediately.
+    Continue,
+    /// Stop the actor, run shutdown, and exit.
+    Stop,
+}
+
+/// Result of polling actor mailbox lanes.
+pub enum LaneEvent<I> {
+    /// A lane produced a message.
+    Message {
+        /// Lane that produced the message.
+        lane: Lane,
+        /// Message received from the lane.
+        message: I,
+    },
+    /// A lane closed and will not be polled again.
+    Closed {
+        /// Lane that closed.
+        lane: Lane,
+    },
+}
+
+/// Borrowed view over service mailbox lanes.
+pub struct LaneSet<'a, I: Ingress, R> {
+    pub(super) lanes: &'a mut [Option<R>],
+    _ingress: std::marker::PhantomData<I>,
+}
+
+impl<'a, I, R> LaneSet<'a, I, R>
+where
+    I: Ingress,
+    R: LaneReceiver<I>,
+{
+    pub(super) const fn new(lanes: &'a mut [Option<R>]) -> Self {
+        Self {
+            lanes,
+            _ingress: std::marker::PhantomData,
+        }
+    }
+
+    /// Returns `true` when every lane has closed.
+    pub fn is_exhausted(&self) -> bool {
+        self.lanes.iter().all(Option::is_none)
+    }
+
+    /// Await the next lane message or lane closure.
+    ///
+    /// Polling is declaration-order biased. Closed lanes are reported once
+    /// and then disabled. Once every lane has closed, this future never
+    /// resolves again; use [`LaneSet::is_exhausted`] to choose another event
+    /// or stop the actor.
+    pub async fn recv(&mut self) -> LaneEvent<I> {
+        poll_fn(|cx| self.poll_recv(cx)).await
+    }
+
+    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<LaneEvent<I>> {
+        for (lane, slot) in self.lanes.iter_mut().enumerate() {
+            let Some(receiver) = slot.as_mut() else {
+                continue;
+            };
+            match receiver.poll_recv(cx) {
+                Poll::Ready(Some(message)) => {
+                    let lane = Lane::new(lane);
+                    return Poll::Ready(LaneEvent::Message { lane, message });
+                }
+                Poll::Ready(None) => {
+                    *slot = None;
+                    let lane = Lane::new(lane);
+                    return Poll::Ready(LaneEvent::Closed { lane });
+                }
+                Poll::Pending => {}
+            }
+        }
+        Poll::Pending
+    }
+}

--- a/actor/src/service/unreliable.rs
+++ b/actor/src/service/unreliable.rs
@@ -1,0 +1,44 @@
+use super::driver::Service;
+use crate::{
+    Actor,
+    mailbox::{UnreliablePolicy, UnreliableReceiver},
+};
+use commonware_runtime::{Handle, Spawner};
+
+/// Actor service backed by unreliable mailbox lanes.
+pub struct Unreliable<E, A>
+where
+    E: Spawner,
+    A: Actor<E>,
+    A::Ingress: UnreliablePolicy<Overflow: Send> + Send + 'static,
+{
+    inner: Service<E, A, UnreliableReceiver<A::Ingress>>,
+}
+
+impl<E, A> Unreliable<E, A>
+where
+    E: Spawner,
+    A: Actor<E>,
+    A::Ingress: UnreliablePolicy<Overflow: Send> + Send + 'static,
+{
+    pub(super) const fn new(inner: Service<E, A, UnreliableReceiver<A::Ingress>>) -> Self {
+        Self { inner }
+    }
+
+    /// Spawn the control loop, passing `args` data to [`Actor::on_startup`].
+    pub fn start_with(self, args: A::Args) -> Handle<()> {
+        self.inner.start_with(args)
+    }
+}
+
+impl<E, A> Unreliable<E, A>
+where
+    E: Spawner,
+    A: Actor<E, Args = ()>,
+    A::Ingress: UnreliablePolicy<Overflow: Send> + Send + 'static,
+{
+    /// Spawn the control loop for actors whose [`Actor::Args`] is `()`.
+    pub fn start(self) -> Handle<()> {
+        self.inner.start()
+    }
+}


### PR DESCRIPTION
## Overview

Builds out `commonware-actor` beyond the policy mailbox with two layers: typed ingress generation and a framework-managed service loop. Each layer is usable without the ones above it. Supersedes #3077.

### Ingress (`ingress!`)

Adds a `commonware-actor-macros` crate providing the `ingress!` macro. A message declaration generates typed message enums and a mailbox wrapper with `tell` (fire-and-forget), `ask` (request/response), and `subscribe` (enqueue now, await later) methods, with each item routed to a read-only or read-write handler. Generated methods carry debug-level enqueue spans across the channel: `tell` starts a new root that `follows_from` the caller (so tell ping-pong loops link traces instead of growing one without bound), while `ask`/`subscribe` remain children of the caller's span. Reliable ingress defaults to FIFO overflow that drops requests whose response channel has closed; `custom_policy` and `unreliable` headers override this.

### Service loop (`service::Builder`)

Runs an `Actor` on a single control loop with lifecycle hooks (`on_startup`, `preprocess`, `next_event`, `on_read_only`, `on_read_write`, `postprocess`, `on_shutdown`).

- **Read/write split**: read-only ingress dispatches to a bounded pool of pre-spawned workers, each handler executing on a snapshot captured at admission; read-write ingress runs serially on the control loop.
- **Fence modes**: `FenceMode::Linearizable` (default) drains in-flight reads before each write, so a read admitted before a write always responds before that write executes. `FenceMode::Snapshot` runs writes immediately, for actors that tolerate stale (but snapshot-consistent) read responses in exchange for writes that never stall behind slow reads.
- **Snapshot caching**: `Actor::Snapshot: Clone`; consecutive reads with no intervening actor mutation share one snapshot capture.
- **Lanes**: multi-lane builders with declaration-order-biased selection; the winning lane drains up to `Actor::max_lane_batch` ready messages per iteration. Actors override `next_event` to race their own sources (timers, network receivers) against lanes.
- **Shutdown**: prompt. In-flight reads are aborted before `on_shutdown` runs, so the hook never races a handler holding a pre-shutdown snapshot; pending askers observe `Cancelled`. Fatal handler errors stop the actor through the same path.
- **Observability**: metrics for reads, writes, failures, in-flight reads, lane batch sizes, and stop reasons; processing spans re-enter the enqueue span carried by each message.

### Testing

Deterministic tests cover routing, fence ordering in both modes, snapshot cache sharing and invalidation, shutdown ordering (via drop-guard event sequencing), lane fairness and batching, overflow ordering, fatal read/write/panic paths, span propagation, and cross-run determinism. Includes mailbox and service throughput benches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #1110 