### PR TITLE
Improve simplex and marshal fuzzing

### DIFF
--- a/consensus/fuzz/Cargo.toml
+++ b/consensus/fuzz/Cargo.toml
@@ -429,6 +429,20 @@ doc = false
 bench = false
 
 [[bin]]
+name = "marshal_inline"
+path = "fuzz_targets/marshal_inline.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "marshal_store"
+path = "fuzz_targets/marshal_store.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "marshal_liveness_standard"
 path = "fuzz_targets/marshal_liveness_standard.rs"
 test = false

--- a/consensus/fuzz/fuzz_targets/marshal_inline.rs
+++ b/consensus/fuzz/fuzz_targets/marshal_inline.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+#[cfg(feature = "mocks")]
+mod fuzz {
+    use commonware_consensus_fuzz::marshal::{fuzz_marshal_inline, MarshalInlineInput};
+    use libfuzzer_sys::fuzz_target;
+
+    fuzz_target!(|input: MarshalInlineInput| {
+        fuzz_marshal_inline(input);
+    });
+}

--- a/consensus/fuzz/fuzz_targets/marshal_standard.rs
+++ b/consensus/fuzz/fuzz_targets/marshal_standard.rs
@@ -2,10 +2,11 @@
 
 #[cfg(feature = "mocks")]
 mod fuzz {
-    use commonware_consensus_fuzz::marshal::{fuzz_marshal_standard, MarshalStandardInput};
+    use commonware_consensus::marshal::mocks::harness::StandardHarness;
+    use commonware_consensus_fuzz::marshal::{fuzz_marshal, MarshalFuzzInput};
     use libfuzzer_sys::fuzz_target;
 
-    fuzz_target!(|input: MarshalStandardInput| {
-        fuzz_marshal_standard(input);
+    fuzz_target!(|input: MarshalFuzzInput| {
+        fuzz_marshal::<StandardHarness>(input);
     });
 }

--- a/consensus/fuzz/fuzz_targets/marshal_store.rs
+++ b/consensus/fuzz/fuzz_targets/marshal_store.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+#[cfg(feature = "mocks")]
+mod fuzz {
+    use commonware_consensus_fuzz::marshal::{fuzz_marshal_store, MarshalStoreInput};
+    use libfuzzer_sys::fuzz_target;
+
+    fuzz_target!(|input: MarshalStoreInput| {
+        fuzz_marshal_store(input);
+    });
+}

--- a/consensus/fuzz/src/byzzfuzz/runner.rs
+++ b/consensus/fuzz/src/byzzfuzz/runner.rs
@@ -258,6 +258,8 @@ where
             relay.clone(),
             Duration::from_secs(1),
             Duration::from_secs(2),
+            input.mailbox_size,
+            input.fetch_concurrent,
             input.forwarding,
             (vote_primary, vote_receiver),
             (cert_primary, cert_receiver),

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -116,6 +116,31 @@ pub(crate) const FAULT_PHASE: Duration = Duration::from_secs(30);
 pub(crate) const POST_GST_WINDOW: Duration = Duration::from_secs(360);
 const NAMESPACE: &[u8] = b"consensus_fuzz";
 const MAX_RAW_BYTES: usize = 32_768;
+const DEFAULT_MAILBOX_SIZE: NonZeroUsize = NZUsize!(1024);
+const DEFAULT_FETCH_CONCURRENT: NonZeroUsize = NZUsize!(1);
+
+pub(crate) fn fuzz_mailbox_size(
+    u: &mut arbitrary::Unstructured<'_>,
+) -> arbitrary::Result<NonZeroUsize> {
+    Ok(match u.int_in_range(0..=99)? {
+        0..=49 => DEFAULT_MAILBOX_SIZE,
+        50..=74 => NZUsize!(1),
+        75..=89 => NZUsize!(2),
+        90..=96 => NZUsize!(4),
+        _ => NZUsize!(8),
+    })
+}
+
+pub(crate) fn fuzz_fetch_concurrent(
+    u: &mut arbitrary::Unstructured<'_>,
+) -> arbitrary::Result<NonZeroUsize> {
+    Ok(match u.int_in_range(0..=99)? {
+        0..=49 => DEFAULT_FETCH_CONCURRENT,
+        50..=74 => NZUsize!(2),
+        75..=89 => NZUsize!(4),
+        _ => NZUsize!(8),
+    })
+}
 
 /// Network configuration for fuzz testing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -303,6 +328,8 @@ impl fmt::Debug for FuzzInputDebug<'_> {
             .field("partition", &input.partition)
             .field("strategy", &input.strategy)
             .field("messaging_faults", &input.messaging_faults)
+            .field("mailbox_size", &input.mailbox_size)
+            .field("fetch_concurrent", &input.fetch_concurrent)
             .field("forwarding", &input.forwarding)
             .field("certify", &input.certify)
             .field("reporting", &input.reporting)
@@ -318,6 +345,8 @@ impl fmt::Debug for NodeFuzzInputDebug<'_> {
         f.debug_struct("NodeFuzzInput")
             .field("raw_bytes_len", &input.raw_bytes.len())
             .field("events", &input.events)
+            .field("mailbox_size", &input.mailbox_size)
+            .field("fetch_concurrent", &input.fetch_concurrent)
             .field("forwarding", &input.forwarding)
             .field("certify", &input.certify)
             .field("reporting", &input.reporting)
@@ -356,6 +385,10 @@ pub struct FuzzInput {
     /// `rate%` honest-message drop while the reference reporter is in `view`;
     /// the rate reverts to 0 outside scheduled views.
     pub messaging_faults: Vec<(View, u8)>,
+    /// Per-iteration mailbox capacity threaded into every honest engine.
+    pub mailbox_size: NonZeroUsize,
+    /// Per-iteration resolver fetch concurrency threaded into every honest engine.
+    pub fetch_concurrent: NonZeroUsize,
     /// Per-iteration forwarding policy threaded into every engine the harness
     /// spawns. Sampling lets the fuzzer drive coverage of all three arms of
     /// `batcher::forward_targets` instead of pinning to `Disabled`.
@@ -435,6 +468,9 @@ impl Arbitrary<'_> for FuzzInput {
 
         let reporting = ReporterWiring::arbitrary(u)?;
 
+        let mailbox_size = fuzz_mailbox_size(u)?;
+        let fetch_concurrent = fuzz_fetch_concurrent(u)?;
+
         // Collect bytes for RNG
         let remaining = u.len().min(MAX_RAW_BYTES);
         let raw_bytes = u.bytes(remaining)?.to_vec();
@@ -451,6 +487,8 @@ impl Arbitrary<'_> for FuzzInput {
             required_containers,
             strategy,
             messaging_faults: Vec::new(),
+            mailbox_size,
+            fetch_concurrent,
             forwarding,
             certify,
             reporting,
@@ -675,6 +713,8 @@ pub(crate) fn spawn_honest_validator<
     relay: Arc<relay::Relay<Sha256Digest, PublicKeyOf<P>>>,
     leader_timeout: Duration,
     certification_timeout: Duration,
+    mailbox_size: NonZeroUsize,
+    fetch_concurrent: NonZeroUsize,
     forwarding: ForwardingPolicy,
     pending: (PendingSender, PendingReceiver),
     recovered: (RecoveredSender, RecoveredReceiver),
@@ -728,7 +768,7 @@ where
         relay: application.clone(),
         reporter: wiring.wire(reporter.clone()),
         partition: validator.to_string(),
-        mailbox_size: NZUsize!(1024),
+        mailbox_size,
         epoch: Epoch::new(EPOCH),
         floor: Floor::Genesis(application::genesis::<Sha256>(Epoch::new(EPOCH))),
         leader_timeout,
@@ -737,7 +777,7 @@ where
         fetch_timeout: Duration::from_secs(1),
         activity_timeout: Delta::new(10),
         skip_timeout: Delta::new(5),
-        fetch_concurrent: NZUsize!(1),
+        fetch_concurrent,
         replay_buffer: NZUsize!(1024 * 1024),
         write_buffer: NZUsize!(1024 * 1024),
         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
@@ -765,6 +805,8 @@ fn spawn_honest_validator_in_faulty_messaging<P: simplex::Simplex>(
     relay: Arc<relay::Relay<Sha256Digest, PublicKeyOf<P>>>,
     leader_timeout: Duration,
     certification_timeout: Duration,
+    mailbox_size: NonZeroUsize,
+    fetch_concurrent: NonZeroUsize,
     forwarding: ForwardingPolicy,
     channels: NetworkChannels<PublicKeyOf<P>>,
     certify: CertifyChoice,
@@ -807,6 +849,8 @@ fn spawn_honest_validator_in_faulty_messaging<P: simplex::Simplex>(
         relay,
         leader_timeout,
         certification_timeout,
+        mailbox_size,
+        fetch_concurrent,
         forwarding,
         (vote_sender, vote_receiver),
         (certificate_sender, certificate_receiver),
@@ -1135,6 +1179,8 @@ fn run_standard_once<P: simplex::Simplex>(
                 relay.clone(),
                 Duration::from_secs(1),
                 Duration::from_secs(2),
+                input.mailbox_size,
+                input.fetch_concurrent,
                 input.forwarding,
                 pending,
                 recovered,
@@ -1290,6 +1336,8 @@ fn run_with_faulty_messaging<P: simplex::Simplex>(mut input: FuzzInput) {
                 relay.clone(),
                 Duration::from_secs(1),
                 Duration::from_secs(2),
+                input.mailbox_size,
+                input.fetch_concurrent,
                 input.forwarding,
                 channels,
                 input.certify,
@@ -1600,7 +1648,7 @@ fn run_twins<P: simplex::Simplex>(mut input: FuzzInput, role: TwinsRole, state_c
                     relay: application.clone(),
                     reporter: reporter.clone(),
                     partition: format!("twin_{idx}_primary"),
-                    mailbox_size: NZUsize!(1024),
+                    mailbox_size: input.mailbox_size,
                     epoch: Epoch::new(EPOCH),
                     floor: Floor::Genesis(application::genesis::<Sha256>(Epoch::new(EPOCH))),
                     leader_timeout: Duration::from_secs(1),
@@ -1609,7 +1657,7 @@ fn run_twins<P: simplex::Simplex>(mut input: FuzzInput, role: TwinsRole, state_c
                     fetch_timeout: Duration::from_secs(1),
                     activity_timeout: Delta::new(10),
                     skip_timeout: Delta::new(5),
-                    fetch_concurrent: NZUsize!(1),
+                    fetch_concurrent: input.fetch_concurrent,
                     replay_buffer: NZUsize!(1024 * 1024),
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&primary_context, PAGE_SIZE, PAGE_CACHE_SIZE),
@@ -1685,7 +1733,7 @@ fn run_twins<P: simplex::Simplex>(mut input: FuzzInput, role: TwinsRole, state_c
                             relay: secondary_application.clone(),
                             reporter: secondary_reporter,
                             partition: secondary_label,
-                            mailbox_size: NZUsize!(1024),
+                            mailbox_size: input.mailbox_size,
                             epoch: Epoch::new(EPOCH),
                             floor: Floor::Genesis(application::genesis::<Sha256>(Epoch::new(
                                 EPOCH,
@@ -1696,7 +1744,7 @@ fn run_twins<P: simplex::Simplex>(mut input: FuzzInput, role: TwinsRole, state_c
                             fetch_timeout: Duration::from_secs(1),
                             activity_timeout: Delta::new(10),
                             skip_timeout: Delta::new(5),
-                            fetch_concurrent: NZUsize!(1),
+                            fetch_concurrent: input.fetch_concurrent,
                             replay_buffer: NZUsize!(1024 * 1024),
                             write_buffer: NZUsize!(1024 * 1024),
                             page_cache: CacheRef::from_pooler(
@@ -1743,6 +1791,8 @@ fn run_twins<P: simplex::Simplex>(mut input: FuzzInput, role: TwinsRole, state_c
                     relay.clone(),
                     Duration::from_secs(1),
                     Duration::from_millis(1_500),
+                    input.mailbox_size,
+                    input.fetch_concurrent,
                     input.forwarding,
                     pending,
                     recovered,
@@ -1834,6 +1884,8 @@ where
     let rng = FuzzRng::new(input.raw_bytes.clone());
     let cfg = deterministic::Config::new().with_rng(Box::new(rng));
     let executor = deterministic::Runner::new(cfg);
+    let mailbox_size = input.mailbox_size;
+    let fetch_concurrent = input.fetch_concurrent;
     let forwarding = input.forwarding;
     let certify = input.certify;
     let reporting = input.reporting;
@@ -1853,6 +1905,8 @@ where
                 checkpoint,
                 participants,
                 schemes,
+                mailbox_size,
+                fetch_concurrent,
                 forwarding,
                 certify,
                 reporting,
@@ -2119,6 +2173,8 @@ mod tests {
             partition: Partition::Connected,
             strategy: StrategyChoice::AnyScope,
             messaging_faults: Vec::new(),
+            mailbox_size: DEFAULT_MAILBOX_SIZE,
+            fetch_concurrent: DEFAULT_FETCH_CONCURRENT,
             forwarding: ForwardingPolicy::Disabled,
             certify: CertifyChoice::Always,
             reporting: ReporterWiring::Solo,

--- a/consensus/fuzz/src/marshal/mod.rs
+++ b/consensus/fuzz/src/marshal/mod.rs
@@ -1,17 +1,24 @@
 //! Fuzz harnesses for the marshal mechanism.
 //!
-//! Two complementary methods, each generic over the marshal variant
-//! (`StandardHarness` / `CodingHarness`), mirroring how marshal itself splits
-//! into `standard` and `coding`:
+//! Each driver is its own libFuzzer target so a single mode's input format
+//! owns its whole byte tape and its own corpus (no top-level enum splitting
+//! bytes across modes). The drivers:
 //!
 //! - [`single_node`]: drives one marshal actor in isolation by synthesizing
 //!   every input it would receive (blocks, notarizations, finalizations,
-//!   restarts) and asserting per-actor delivery invariants.
+//!   restarts) and asserting per-actor delivery invariants. Generic over the
+//!   marshal variant (`StandardHarness` / `CodingHarness`), mirroring how
+//!   marshal itself splits into `standard` and `coding`. Targets:
+//!   `marshal_standard`, `marshal_coding`.
 //! - [`multi_node`]: runs a live `N4F1C3` cluster (three honest nodes
 //!   plus one byzantine `Disrupter`) wired to real simplex consensus, and
 //!   checks marshal liveness (every honest node delivers a target number of
 //!   ordered finalized blocks sampled within a single-epoch bound) plus
-//!   cross-node agreement.
+//!   cross-node agreement. Also per-variant. Targets:
+//!   `marshal_liveness_standard`, `marshal_liveness_coding`.
+//! - [`inline`]: drives the standard inline block path. Target: `marshal_inline`.
+//! - [`store`]: drives the marshal block/certificate store directly. Target:
+//!   `marshal_store`.
 //!
 //! # Goals, pros, and cons
 //!
@@ -26,9 +33,6 @@
 //!   - Con: heavier (fewer iterations) and only valid
 //!     consensus orderings.
 
-use arbitrary::Arbitrary;
-use commonware_consensus::marshal::mocks::harness::StandardHarness;
-
 pub mod inline;
 pub mod multi_node;
 pub mod single_node;
@@ -38,28 +42,3 @@ pub use inline::{fuzz_marshal_inline, MarshalInlineInput};
 pub use multi_node::{fuzz_marshal_liveness, MarshalLivenessInput};
 pub use single_node::{fuzz_marshal, MarshalEvent, MarshalFuzzInput, VariantPublish};
 pub use store::{fuzz_marshal_store, MarshalStoreInput};
-
-#[derive(Debug, Clone)]
-pub enum MarshalStandardInput {
-    Actor(MarshalFuzzInput),
-    Inline(MarshalInlineInput),
-    Store(MarshalStoreInput),
-}
-
-impl Arbitrary<'_> for MarshalStandardInput {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        Ok(match u.int_in_range(0..=99)? {
-            0..=69 => Self::Actor(MarshalFuzzInput::arbitrary(u)?),
-            70..=89 => Self::Inline(MarshalInlineInput::arbitrary(u)?),
-            _ => Self::Store(MarshalStoreInput::arbitrary(u)?),
-        })
-    }
-}
-
-pub fn fuzz_marshal_standard(input: MarshalStandardInput) {
-    match input {
-        MarshalStandardInput::Actor(input) => fuzz_marshal::<StandardHarness>(input),
-        MarshalStandardInput::Inline(input) => fuzz_marshal_inline(input),
-        MarshalStandardInput::Store(input) => fuzz_marshal_store(input),
-    }
-}

--- a/consensus/fuzz/src/marshal/single_node/runner.rs
+++ b/consensus/fuzz/src/marshal/single_node/runner.rs
@@ -122,6 +122,34 @@ fn block_available(
     durable_available.contains(&height) || variant_available.contains(&height)
 }
 
+/// Queue the acks orphaned by a same-segment floor install so the strict
+/// segment-ordering check ignores them.
+///
+/// When marshal ingests a floor anchor mid-segment it clears its pending-ack
+/// waiters and re-dispatches from the floor (`ingest` -> `pending_acks.clear`).
+/// Every ready height at or above the reinstalled floor is therefore delivered
+/// twice within the same mailbox drain: once before the clear (now orphaned,
+/// its waiter gone exactly like a restart-stale ack) and once after. The
+/// pre-clear copies are dispatched first, so queue them as stale in ascending
+/// order; only the live post-clear deliveries remain for the in-order check.
+///
+/// The orphaned heights are `floor_height..=ready_prefix`: `ready_prefix` is
+/// the contiguous finalized prefix, so those are exactly the heights marshal
+/// can dispatch above the floor. The caller's `current_segment_empty` /
+/// `only_genesis_pending` guards ensure none of them were dispatched before
+/// this event, so each is orphaned in this drain rather than pre-existing.
+/// When `ready_prefix < floor_height` nothing is ready above the floor and the
+/// range is empty (no duplicate dispatch occurs).
+fn queue_floor_orphaned_acks(
+    stale_to_skip: &mut VecDeque<Height>,
+    floor_height: u64,
+    ready_prefix: u64,
+) {
+    for h in floor_height..=ready_prefix {
+        stale_to_skip.push_back(Height::new(h));
+    }
+}
+
 fn application_block<H: TestHarness>(block: &H::TestBlock) -> H::ApplicationBlock {
     <H::Variant as Variant>::into_inner(block.clone().into())
 }
@@ -1001,6 +1029,14 @@ where
                             });
                         }
                         durable_available.insert(floor_height.get());
+                        // Any height already ready above the reinstalled floor
+                        // was dispatched before marshal's floor ingest cleared
+                        // its ack waiters; those pre-clear deliveries are stale.
+                        queue_floor_orphaned_acks(
+                            &mut stale_to_skip,
+                            floor_height.get(),
+                            ready_prefix,
+                        );
                         repair_wake |= apply_pending_floor(
                             &mut pending_floor,
                             floor_height,
@@ -1039,6 +1075,10 @@ where
                         stale_to_skip.extend(live_pending_acks.iter().copied());
                         pending_floor = Some(h);
                         if block_available(&durable_available, &variant_available, h) {
+                            // Heights already ready above this floor are
+                            // re-dispatched after marshal clears its ack
+                            // waiters; their pre-clear deliveries are stale.
+                            queue_floor_orphaned_acks(&mut stale_to_skip, h, ready_prefix);
                             repair_wake |= apply_pending_floor(
                                 &mut pending_floor,
                                 height,

--- a/consensus/fuzz/src/marshal/single_node/runner.rs
+++ b/consensus/fuzz/src/marshal/single_node/runner.rs
@@ -141,10 +141,11 @@ fn block_available(
 /// must NOT call this or it would mark the sole live delivery stale.
 ///
 /// The orphaned heights are `floor_height..=ready_prefix`: `ready_prefix` is
-/// the contiguous finalized prefix, so those are exactly the heights marshal
-/// can dispatch above the floor. The caller's `current_segment_empty` /
-/// `only_genesis_pending` guards ensure none of them were dispatched before
-/// this event, so each is orphaned in this drain rather than pre-existing.
+/// the contiguous finalized prefix after all same-event floor and repair shadow
+/// updates, so those are exactly the heights marshal can dispatch above the
+/// floor. The caller's `current_segment_empty` / `only_genesis_pending` guards
+/// ensure none of them were dispatched before this event, so each is orphaned
+/// in this drain rather than pre-existing.
 /// When `ready_prefix < floor_height` nothing is ready above the floor and the
 /// range is empty (no duplicate dispatch occurs).
 fn queue_floor_orphaned_acks(
@@ -522,6 +523,7 @@ where
             // This mirrors actor.rs gating try_repair_gaps on
             // store_finalization's return value.
             let mut repair_wake = false;
+            let mut floor_orphaned_from = None;
             match event {
                 MarshalEvent::Propose { block_idx } => {
                     let block = &canonical[block_index(block_idx)];
@@ -1036,14 +1038,7 @@ where
                             });
                         }
                         durable_available.insert(floor_height.get());
-                        // Any height already ready above the reinstalled floor
-                        // was dispatched before marshal's floor ingest cleared
-                        // its ack waiters; those pre-clear deliveries are stale.
-                        queue_floor_orphaned_acks(
-                            &mut stale_to_skip,
-                            floor_height.get(),
-                            ready_prefix,
-                        );
+                        floor_orphaned_from = Some(floor_height.get());
                         repair_wake |= apply_pending_floor(
                             &mut pending_floor,
                             floor_height,
@@ -1293,6 +1288,14 @@ where
                     &mut finalized_available,
                     &mut ready_prefix,
                 );
+            }
+
+            if let Some(floor_height) = floor_orphaned_from {
+                // A MailboxBurst floor shares a drain with earlier dispatches.
+                // The same event can then apply the floor and repair gaps before
+                // marshal settles, so queue stale pre-clear copies using the final
+                // ready prefix for this event.
+                queue_floor_orphaned_acks(&mut stale_to_skip, floor_height, ready_prefix);
             }
 
             context.sleep(EVENT_SETTLE).await;

--- a/consensus/fuzz/src/marshal/single_node/runner.rs
+++ b/consensus/fuzz/src/marshal/single_node/runner.rs
@@ -127,27 +127,29 @@ fn block_available(
 ///
 /// Only for a floor install that shares a mailbox drain with an independent
 /// dispatch pass (the `MailboxBurst` event, which enqueues many actions at
-/// once). There, marshal first dispatches the ready heights above the floor,
-/// then the floor anchor's `ingest` clears its pending-ack waiters and
-/// re-dispatches from the floor (`ingest` -> `pending_acks.clear`). Each ready
+/// once). There, heights already dispatchable before this event are dispatched
+/// in the drain, then the floor anchor's `ingest` clears its pending-ack waiters
+/// and re-dispatches from the floor (`ingest` -> `pending_acks.clear`). Each such
 /// height at or above the reinstalled floor is delivered twice in that drain:
 /// once before the clear (now orphaned, its waiter gone exactly like a
-/// restart-stale ack) and once after. The pre-clear copies are dispatched
-/// first, so queue them as stale in ascending order; only the live post-clear
-/// deliveries remain for the in-order check.
+/// restart-stale ack) and once after. The pre-clear copies are dispatched first,
+/// so queue them as stale in ascending order; only the live post-clear deliveries
+/// remain for the in-order check.
 ///
 /// A standalone `SetFloor` posts a single `set_floor` message: marshal ingests
 /// once and dispatches each ready height once (no pre-clear pass), so that path
 /// must NOT call this or it would mark the sole live delivery stale.
 ///
-/// The orphaned heights are `floor_height..=ready_prefix`: `ready_prefix` is
-/// the contiguous finalized prefix after all same-event floor and repair shadow
-/// updates, so those are exactly the heights marshal can dispatch above the
-/// floor. The caller's `current_segment_empty` / `only_genesis_pending` guards
-/// ensure none of them were dispatched before this event, so each is orphaned
-/// in this drain rather than pre-existing.
-/// When `ready_prefix < floor_height` nothing is ready above the floor and the
-/// range is empty (no duplicate dispatch occurs).
+/// The orphaned heights are `floor_height..=ready_prefix`, where `ready_prefix`
+/// is the contiguous finalized prefix as of the END of the previous event (the
+/// pre-event value), NOT the post-floor/post-repair value. Only heights already
+/// dispatchable before this event get a pre-clear copy; heights the floor
+/// install itself makes ready are dispatched once (live) and must not be marked
+/// stale. The caller's `current_segment_empty` / `only_genesis_pending` guards
+/// ensure none of the pre-event-ready heights were dispatched before this event,
+/// so each is orphaned in this drain rather than pre-existing. When the pre-event
+/// `ready_prefix < floor_height` nothing above the floor was ready and the range
+/// is empty (single live dispatch, no orphans).
 fn queue_floor_orphaned_acks(
     stale_to_skip: &mut VecDeque<Height>,
     floor_height: u64,
@@ -524,6 +526,11 @@ where
             // store_finalization's return value.
             let mut repair_wake = false;
             let mut floor_orphaned_from = None;
+            // Ready prefix as of the end of the previous event. A same-event floor
+            // install only orphans heights that were ALREADY dispatchable (pre-clear
+            // pass); heights the floor itself makes ready are dispatched once (live),
+            // so the orphan set must use this pre-event value, not the post-repair one.
+            let ready_prefix_before = ready_prefix;
             match event {
                 MarshalEvent::Propose { block_idx } => {
                     let block = &canonical[block_index(block_idx)];
@@ -1291,11 +1298,12 @@ where
             }
 
             if let Some(floor_height) = floor_orphaned_from {
-                // A MailboxBurst floor shares a drain with earlier dispatches.
-                // The same event can then apply the floor and repair gaps before
-                // marshal settles, so queue stale pre-clear copies using the final
-                // ready prefix for this event.
-                queue_floor_orphaned_acks(&mut stale_to_skip, floor_height, ready_prefix);
+                // A MailboxBurst floor shares a drain with earlier dispatches. Only
+                // heights already dispatchable before this event get a pre-clear copy
+                // (orphaned); heights the floor newly makes ready are dispatched once
+                // (live). Bound the orphan set by the pre-event ready prefix so the
+                // floor's own newly-ready heights are not marked stale.
+                queue_floor_orphaned_acks(&mut stale_to_skip, floor_height, ready_prefix_before);
             }
 
             context.sleep(EVENT_SETTLE).await;

--- a/consensus/fuzz/src/marshal/single_node/runner.rs
+++ b/consensus/fuzz/src/marshal/single_node/runner.rs
@@ -125,13 +125,20 @@ fn block_available(
 /// Queue the acks orphaned by a same-segment floor install so the strict
 /// segment-ordering check ignores them.
 ///
-/// When marshal ingests a floor anchor mid-segment it clears its pending-ack
-/// waiters and re-dispatches from the floor (`ingest` -> `pending_acks.clear`).
-/// Every ready height at or above the reinstalled floor is therefore delivered
-/// twice within the same mailbox drain: once before the clear (now orphaned,
-/// its waiter gone exactly like a restart-stale ack) and once after. The
-/// pre-clear copies are dispatched first, so queue them as stale in ascending
-/// order; only the live post-clear deliveries remain for the in-order check.
+/// Only for a floor install that shares a mailbox drain with an independent
+/// dispatch pass (the `MailboxBurst` event, which enqueues many actions at
+/// once). There, marshal first dispatches the ready heights above the floor,
+/// then the floor anchor's `ingest` clears its pending-ack waiters and
+/// re-dispatches from the floor (`ingest` -> `pending_acks.clear`). Each ready
+/// height at or above the reinstalled floor is delivered twice in that drain:
+/// once before the clear (now orphaned, its waiter gone exactly like a
+/// restart-stale ack) and once after. The pre-clear copies are dispatched
+/// first, so queue them as stale in ascending order; only the live post-clear
+/// deliveries remain for the in-order check.
+///
+/// A standalone `SetFloor` posts a single `set_floor` message: marshal ingests
+/// once and dispatches each ready height once (no pre-clear pass), so that path
+/// must NOT call this or it would mark the sole live delivery stale.
 ///
 /// The orphaned heights are `floor_height..=ready_prefix`: `ready_prefix` is
 /// the contiguous finalized prefix, so those are exactly the heights marshal
@@ -1075,10 +1082,6 @@ where
                         stale_to_skip.extend(live_pending_acks.iter().copied());
                         pending_floor = Some(h);
                         if block_available(&durable_available, &variant_available, h) {
-                            // Heights already ready above this floor are
-                            // re-dispatched after marshal clears its ack
-                            // waiters; their pre-clear deliveries are stale.
-                            queue_floor_orphaned_acks(&mut stale_to_skip, h, ready_prefix);
                             repair_wake |= apply_pending_floor(
                                 &mut pending_floor,
                                 height,

--- a/consensus/fuzz/src/simplex.rs
+++ b/consensus/fuzz/src/simplex.rs
@@ -304,6 +304,8 @@ mod tests {
             degraded_network: false,
             strategy: StrategyChoice::AnyScope,
             messaging_faults: Vec::new(),
+            mailbox_size: crate::DEFAULT_MAILBOX_SIZE,
+            fetch_concurrent: crate::DEFAULT_FETCH_CONCURRENT,
             forwarding: ForwardingPolicy::Disabled,
             certify: CertifyChoice::Always,
             reporting: ReporterWiring::Solo,

--- a/consensus/fuzz/src/simplex_node.rs
+++ b/consensus/fuzz/src/simplex_node.rs
@@ -1610,6 +1610,7 @@ where
     (participants, schemes)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run_recovery<P: simplex::Simplex>(
     checkpoint: deterministic::Checkpoint,
     participants: Vec<PublicKeyOf<P>>,

--- a/consensus/fuzz/src/simplex_node.rs
+++ b/consensus/fuzz/src/simplex_node.rs
@@ -29,6 +29,7 @@ use futures::FutureExt;
 use rand::Rng;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    num::NonZeroUsize,
     time::Duration,
 };
 
@@ -66,6 +67,8 @@ pub struct NodeEvent {
 pub struct NodeFuzzInput {
     pub raw_bytes: Vec<u8>,
     pub events: Vec<NodeEvent>,
+    pub mailbox_size: NonZeroUsize,
+    pub fetch_concurrent: NonZeroUsize,
     pub forwarding: ForwardingPolicy,
     pub certify: crate::CertifyChoice,
     pub reporting: crate::ReporterWiring,
@@ -92,6 +95,8 @@ impl Arbitrary<'_> for NodeFuzzInput {
         let certify = crate::CertifyChoice::Always;
 
         let reporting = crate::ReporterWiring::arbitrary(u)?;
+        let mailbox_size = crate::fuzz_mailbox_size(u)?;
+        let fetch_concurrent = crate::fuzz_fetch_concurrent(u)?;
 
         let remaining = u.len().min(crate::MAX_RAW_BYTES);
         let raw_bytes = if remaining == 0 {
@@ -103,6 +108,8 @@ impl Arbitrary<'_> for NodeFuzzInput {
         Ok(Self {
             raw_bytes,
             events,
+            mailbox_size,
+            fetch_concurrent,
             forwarding,
             certify,
             reporting,
@@ -1507,6 +1514,8 @@ where
             fault_rounds_bound: 1,
         },
         messaging_faults: Vec::new(),
+        mailbox_size: input.mailbox_size,
+        fetch_concurrent: input.fetch_concurrent,
         forwarding: input.forwarding,
         certify: input.certify,
         reporting: input.reporting,
@@ -1561,6 +1570,8 @@ where
         relay.clone(),
         Duration::from_secs(1),
         Duration::from_secs(2),
+        input.mailbox_size,
+        input.fetch_concurrent,
         base.forwarding,
         pending,
         recovered,
@@ -1603,6 +1614,8 @@ pub(crate) fn run_recovery<P: simplex::Simplex>(
     checkpoint: deterministic::Checkpoint,
     participants: Vec<PublicKeyOf<P>>,
     schemes: Vec<P::Scheme>,
+    mailbox_size: NonZeroUsize,
+    fetch_concurrent: NonZeroUsize,
     forwarding: ForwardingPolicy,
     certify: crate::CertifyChoice,
     wiring: crate::ReporterWiring,
@@ -1638,6 +1651,8 @@ pub(crate) fn run_recovery<P: simplex::Simplex>(
             relay,
             Duration::from_secs(1),
             Duration::from_secs(2),
+            mailbox_size,
+            fetch_concurrent,
             forwarding,
             pending,
             recovered,
@@ -1676,6 +1691,8 @@ mod tests {
                     event: Event::OnFinalization,
                 },
             ],
+            mailbox_size: NZUsize!(1024),
+            fetch_concurrent: NZUsize!(1),
             forwarding: ForwardingPolicy::Disabled,
             certify: crate::CertifyChoice::Always,
             reporting: crate::ReporterWiring::Solo,
@@ -1702,6 +1719,8 @@ mod tests {
                     event: Event::OnFinalization,
                 },
             ],
+            mailbox_size: NZUsize!(1024),
+            fetch_concurrent: NZUsize!(1),
             forwarding: ForwardingPolicy::Disabled,
             certify: crate::CertifyChoice::Always,
             reporting: crate::ReporterWiring::Solo,

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -273,6 +273,8 @@ impl Freelist {
     /// finally dropped, otherwise the buffer leaks.
     #[inline(always)]
     pub(super) fn try_create(&self, zeroed: bool) -> Option<(u32, PooledBuffer)> {
+        // TODO: migrate to `try_update` once MSRV is >= 1.95
+        #[allow(deprecated)]
         let slot = self
             .created
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |created| {

--- a/utils/src/concurrency.rs
+++ b/utils/src/concurrency.rs
@@ -25,6 +25,8 @@ impl Limiter {
 
     /// Attempt to reserve a slot. Returns `None` when the limiter is saturated.
     pub fn try_acquire(&self) -> Option<Reservation> {
+        // TODO: migrate to `try_update` once MSRV is >= 1.95
+        #[allow(deprecated)]
         self.current
             .fetch_update(Ordering::AcqRel, Ordering::Relaxed, |current| {
                 (current < self.max).then_some(current + 1)


### PR DESCRIPTION
This PR:
- fixes a false positive in the marshal inline fuzz target logic
- restruturizes marshal fuzz targets
- adds `mailbox_size` and `fetch_concurrent` into fuzz input