### PR TITLE
[runtime, utils] allow deprecated `fetch_update`

### DIFF
--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -273,6 +273,8 @@ impl Freelist {
     /// finally dropped, otherwise the buffer leaks.
     #[inline(always)]
     pub(super) fn try_create(&self, zeroed: bool) -> Option<(u32, PooledBuffer)> {
+        // TODO: migrate to `try_update` once MSRV is >= 1.95
+        #[allow(deprecated)]
         let slot = self
             .created
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |created| {

--- a/utils/src/concurrency.rs
+++ b/utils/src/concurrency.rs
@@ -25,6 +25,8 @@ impl Limiter {
 
     /// Attempt to reserve a slot. Returns `None` when the limiter is saturated.
     pub fn try_acquire(&self) -> Option<Reservation> {
+        // TODO: migrate to `try_update` once MSRV is >= 1.95
+        #[allow(deprecated)]
         self.current
             .fetch_update(Ordering::AcqRel, Ordering::Relaxed, |current| {
                 (current < self.max).then_some(current + 1)


### PR DESCRIPTION
`fetch_update` was renamed to `try_update` and deprecated in 1.95.0. Since our MSRV is currently set to 1.91.1 we can't migrate to `try_update`.