### PR TITLE
[runtime] [storage] Dispatch page-cache retention via an internal enum instead of a PageCache trait

### DIFF
--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -20,10 +20,7 @@ use tracing::{error, trace};
 
 /// Shared future for one logical page fetch. The output uses `Arc<Error>` because `Shared`
 /// requires cloneable results. The `IoBuf` contains only the logical, validated page bytes.
-///
-/// `Shared` also makes the future `Sync` and cloneable, so a caching implementation can hand one
-/// fetch generation to every concurrent reader of the same page.
-pub type PageFetchFuture = Shared<Pin<Box<dyn Future<Output = Result<IoBuf, Arc<Error>>> + Send>>>;
+type PageFetchFuture = Shared<Pin<Box<dyn Future<Output = Result<IoBuf, Arc<Error>>> + Send>>>;
 
 /// Shared handle to one in-flight fetch generation. The cache keeps one copy in `page_fetches`,
 /// and each waiter clones the `Arc` while it is still interested in the result.
@@ -117,251 +114,21 @@ struct Cache {
     page_fetches: AHashMap<(u64, u64), PageFetchEntry>,
 }
 
-/// A cache of logical [Blob] pages, shared by every blob registered with a [CacheRef].
-/// Implementations decide what (if anything) to retain; [CacheRef] drives all reads, insertions,
-/// and invalidations through this trait.
-pub trait PageCache: Clone + Send + Sync + 'static {
-    /// Copy cached bytes starting at `offset` into `buf`, returning the number of bytes copied.
-    /// May stop early at any page boundary; `0` means the first page was not cached.
-    fn read_at(&self, blob_id: u64, buf: &mut [u8], offset: u64) -> usize;
-
-    /// Read multiple disjoint byte ranges. Fully cached ranges are filled and removed from
-    /// `ranges`; entries left behind are (at least partially) uncached.
-    fn read_many(&self, blob_id: u64, ranges: &mut Vec<(&mut [u8], u64)>);
-
-    /// Store the whole `page_size`-sized pages of `buf` as consecutive pages starting at
-    /// `first_page`, ignoring any trailing partial page.
-    fn cache(&self, blob_id: u64, page_size: usize, buf: &[u8], first_page: u64);
-
-    /// Drop any cached pages for `blob_id` at `page_num >= start_page`.
-    fn invalidate_from(&self, blob_id: u64, start_page: u64);
-
-    /// Resolve a page fault for `(blob_id, page_num)`: `fetch` reads and validates the logical
-    /// page from the underlying blob. Copies the requested bytes (from `offset` onward, to the
-    /// end of the page at most) into `buf`, returning the number of bytes copied.
-    /// Implementations may join concurrent fetches of the same page and may retain the fetched
-    /// page for future reads.
-    fn fault<'a>(
-        &'a self,
-        blob_id: u64,
-        page_num: u64,
-        offset: u64,
-        buf: &'a mut [u8],
-        fetch: PageFetchFuture,
-    ) -> impl Future<Output = Result<usize, Error>> + Send + Sync + 'a;
-}
-
-/// A [PageCache] with bounded capacity and Clock (second-chance) eviction that deduplicates
-/// concurrent fetches of the same page.
+/// Retention policy backing a [CacheRef].
 #[derive(Clone)]
-pub struct ClockCache {
-    inner: Arc<RwLock<Cache>>,
-}
-
-impl ClockCache {
-    /// Create a cache storing at most `capacity` pages, each exactly `page_size` bytes, eagerly
-    /// allocated from `pool`.
-    pub fn new(pool: BufferPool, page_size: NonZeroU16, capacity: NonZeroUsize) -> Self {
-        Self {
-            inner: Arc::new(RwLock::new(Cache::new(pool, page_size, capacity))),
-        }
-    }
-}
-
-impl PageCache for ClockCache {
-    fn read_at(&self, blob_id: u64, mut buf: &mut [u8], mut offset: u64) -> usize {
-        let original_len = buf.len();
-        let cache = self.inner.read();
-        while !buf.is_empty() {
-            let count = cache.read_at(blob_id, buf, offset);
-            if count == 0 {
-                break;
-            }
-            offset += count as u64;
-            buf = &mut buf[count..];
-        }
-        original_len - buf.len()
-    }
-
-    fn read_many(&self, blob_id: u64, ranges: &mut Vec<(&mut [u8], u64)>) {
-        let cache = self.inner.read();
-        ranges.retain_mut(|(buf, logical_offset)| {
-            let mut remaining = buf.len();
-            let mut offset = *logical_offset;
-            let mut dst = 0;
-            while remaining > 0 {
-                let count = cache.read_at(blob_id, &mut buf[dst..], offset);
-                if count == 0 {
-                    break;
-                }
-                offset += count as u64;
-                dst += count;
-                remaining -= count;
-            }
-
-            // Keep cache misses in `ranges`; drop fully-cached entries.
-            remaining > 0
-        });
-    }
-
-    fn cache(&self, blob_id: u64, page_size: usize, mut buf: &[u8], mut first_page: u64) {
-        let mut cache = self.inner.write();
-        while buf.len() >= page_size {
-            cache.cache(blob_id, &buf[..page_size], first_page);
-            buf = &buf[page_size..];
-            first_page = match first_page.checked_add(1) {
-                Some(next) => next,
-                None => break,
-            };
-        }
-    }
-
-    fn invalidate_from(&self, blob_id: u64, start_page: u64) {
-        self.inner.write().invalidate_from(blob_id, start_page);
-    }
-
-    async fn fault(
-        &self,
-        blob_id: u64,
-        page_num: u64,
-        offset: u64,
-        buf: &mut [u8],
-        fetch: PageFetchFuture,
-    ) -> Result<usize, Error> {
-        // Create or clone a future that resolves the fetch. This requires a write lock on the
-        // cache since we may need to modify `page_fetches` if this task is the first fetcher.
-        let (fetch_future, mut fetch_guard) = {
-            let mut cache = self.inner.write();
-
-            // There's a (small) chance the page was fetched & buffered by another task before
-            // we were able to acquire the write lock, so check the cache before anything else.
-            let count = cache.read_at(blob_id, buf, offset);
-            if count != 0 {
-                return Ok(count);
-            }
-
-            let key = (blob_id, page_num);
-            match cache.page_fetches.entry(key) {
-                Entry::Occupied(o) => {
-                    // Another task is already fetching this page, so clone its existing
-                    // future.
-                    let entry = o.into_mut();
-                    entry.waiters += 1;
-                    let fetch_future = entry.fetch.as_ref().clone();
-                    let fetch = Arc::clone(&entry.fetch);
-                    (
-                        fetch_future,
-                        PageFetchGuard::new(Arc::clone(&self.inner), key, fetch),
-                    )
-                }
-                Entry::Vacant(v) => {
-                    // Nobody is currently fetching this page, so wrap the provided fetch in a
-                    // future that also caches the result and clears the in-flight marker.
-                    let inner = Arc::clone(&self.inner);
-                    let future = async move {
-                        let result = fetch.await;
-                        if let Err(err) = &result {
-                            error!(page_num, ?err, "Page fetch failed");
-                        }
-
-                        // This shared future still owns `page_fetches[key]`. As long as at
-                        // least one waiter remains armed, that entry pins this generation in
-                        // place, so a replacement fetch for the same page cannot be inserted
-                        // before we cache the successful result below. Only when every waiter
-                        // cancels can the last guard remove the entry and let a later reader
-                        // start a new generation.
-                        let mut cache = inner.write();
-                        if let Ok(page) = &result {
-                            cache.cache(blob_id, page.as_ref(), page_num);
-                        }
-                        let _ = cache.page_fetches.remove(&key);
-                        result
-                    };
-
-                    // Make the future shareable and insert it into the map.
-                    let fetch_future = future.boxed().shared();
-                    let fetch = Arc::new(fetch_future.clone());
-                    v.insert(PageFetchEntry {
-                        fetch: Arc::clone(&fetch),
-                        waiters: 1,
-                    });
-
-                    (
-                        fetch_future,
-                        PageFetchGuard::new(Arc::clone(&self.inner), key, fetch),
-                    )
-                }
-            }
-        };
-
-        // Await the shared fetch. The future itself logs failures, caches the resolved page,
-        // and removes the in-flight marker before it returns, so waiters only need
-        // cancellation cleanup while the fetch is still unresolved.
-        let fetch_result = fetch_future.await;
-        fetch_guard.disarm();
-        let page_buf = match fetch_result {
-            Ok(page_buf) => page_buf,
-            Err(_) => return Err(Error::ReadFailed),
-        };
-
-        // Copy the requested portion of the page into the buffer.
-        let offset_in_page = (offset % page_buf.len() as u64) as usize;
-        let bytes_to_copy = std::cmp::min(buf.len(), page_buf.len() - offset_in_page);
-        buf[..bytes_to_copy]
-            .copy_from_slice(&page_buf.as_ref()[offset_in_page..offset_in_page + bytes_to_copy]);
-
-        Ok(bytes_to_copy)
-    }
-}
-
-/// A [PageCache] that retains nothing: every read is a fault, and every fault fetches directly
-/// from the blob (with the same integrity validation as a caching implementation).
-///
-/// Useful when an external cache (e.g. the OS page cache under buffered I/O) already holds hot
-/// pages and in-process caching would duplicate it, or to measure uncached read cost. Unlike a
-/// caching implementation, concurrent readers of the same page each perform their own fetch.
-#[derive(Clone, Copy)]
-pub struct NoCache;
-
-impl PageCache for NoCache {
-    fn read_at(&self, _blob_id: u64, _buf: &mut [u8], _offset: u64) -> usize {
-        0
-    }
-
-    fn read_many(&self, _blob_id: u64, _ranges: &mut Vec<(&mut [u8], u64)>) {}
-
-    fn cache(&self, _blob_id: u64, _page_size: usize, _buf: &[u8], _first_page: u64) {}
-
-    fn invalidate_from(&self, _blob_id: u64, _start_page: u64) {}
-
-    async fn fault(
-        &self,
-        _blob_id: u64,
-        page_num: u64,
-        offset: u64,
-        buf: &mut [u8],
-        fetch: PageFetchFuture,
-    ) -> Result<usize, Error> {
-        let page_buf = match fetch.await {
-            Ok(page_buf) => page_buf,
-            Err(err) => {
-                error!(page_num, ?err, "Page fetch failed");
-                return Err(Error::ReadFailed);
-            }
-        };
-        let offset_in_page = (offset % page_buf.len() as u64) as usize;
-        let bytes_to_copy = std::cmp::min(buf.len(), page_buf.len() - offset_in_page);
-        buf[..bytes_to_copy]
-            .copy_from_slice(&page_buf.as_ref()[offset_in_page..offset_in_page + bytes_to_copy]);
-        Ok(bytes_to_copy)
-    }
+enum CacheImpl {
+    /// A bounded cache with Clock (second-chance) eviction that deduplicates concurrent fetches
+    /// of the same page.
+    Clock(Arc<RwLock<Cache>>),
+    /// Retains nothing: every read fetches directly from the blob.
+    None,
 }
 
 /// A reference to a page cache that can be shared across threads via cloning, along with the page
 /// size that will be used with it. Provides the API for interacting with the page cache in a
 /// thread-safe manner.
 #[derive(Clone)]
-pub struct CacheRef<P: PageCache = ClockCache> {
+pub struct CacheRef {
     /// The size of each page in the underlying blobs managed by this page cache.
     ///
     /// # Warning
@@ -373,21 +140,31 @@ pub struct CacheRef<P: PageCache = ClockCache> {
     /// The next id to assign to a blob that will be managed by this cache.
     next_id: Arc<AtomicU64>,
 
-    /// The [PageCache] implementation backing this handle.
-    cache: P,
+    /// The retention policy and its state.
+    cache: CacheImpl,
 
     /// Pool used for page-cache and associated buffer allocations.
     pool: BufferPool,
 }
 
-impl CacheRef<ClockCache> {
-    /// Create a shared page-cache handle backed by a [ClockCache] allocated from `pool`.
+impl CacheRef {
+    /// Create a shared page-cache handle backed by `pool`.
     ///
     /// The cache stores at most `capacity` pages, each exactly `page_size` bytes.
     /// Initialization eagerly allocates and zeroes all cache slots from `pool`.
     pub fn new(pool: BufferPool, page_size: NonZeroU16, capacity: NonZeroUsize) -> Self {
-        let cache = ClockCache::new(pool.clone(), page_size, capacity);
-        Self::with_cache(pool, page_size, cache)
+        let page_size_u64 = page_size.get() as u64;
+
+        Self {
+            page_size: page_size_u64,
+            next_id: Arc::new(AtomicU64::new(0)),
+            cache: CacheImpl::Clock(Arc::new(RwLock::new(Cache::new(
+                pool.clone(),
+                page_size,
+                capacity,
+            )))),
+            pool,
+        }
     }
 
     /// Create a shared page-cache handle, extracting the storage [BufferPool] from a
@@ -399,30 +176,26 @@ impl CacheRef<ClockCache> {
     ) -> Self {
         Self::new(pooler.storage_buffer_pool().clone(), page_size, capacity)
     }
-}
 
-impl CacheRef<NoCache> {
-    /// Create a handle backed by [NoCache], performing no in-process caching.
+    /// Create a handle that performs no in-process caching: every read fetches directly from the
+    /// blob (with the same integrity validation), and concurrent readers of the same page each
+    /// perform their own fetch.
+    ///
+    /// Useful when an external cache (e.g. the OS page cache under buffered I/O) already holds
+    /// hot pages and in-process caching would duplicate it, or to measure uncached read cost.
     pub fn no_cache(pool: BufferPool, page_size: NonZeroU16) -> Self {
-        Self::with_cache(pool, page_size, NoCache)
-    }
-
-    /// Create a handle backed by [NoCache], extracting the storage [BufferPool] from a
-    /// [BufferPooler].
-    pub fn no_cache_from_pooler(pooler: &impl BufferPooler, page_size: NonZeroU16) -> Self {
-        Self::no_cache(pooler.storage_buffer_pool().clone(), page_size)
-    }
-}
-
-impl<P: PageCache> CacheRef<P> {
-    /// Create a handle backed by the given [PageCache] implementation.
-    pub fn with_cache(pool: BufferPool, page_size: NonZeroU16, cache: P) -> Self {
         Self {
             page_size: page_size.get() as u64,
             next_id: Arc::new(AtomicU64::new(0)),
-            cache,
+            cache: CacheImpl::None,
             pool,
         }
+    }
+
+    /// Create a [CacheRef::no_cache] handle, extracting the storage [BufferPool] from a
+    /// [BufferPooler].
+    pub fn no_cache_from_pooler(pooler: &impl BufferPooler, page_size: NonZeroU16) -> Self {
+        Self::no_cache(pooler.storage_buffer_pool().clone(), page_size)
     }
 
     /// The page size used by this page cache.
@@ -450,23 +223,62 @@ impl<P: PageCache> CacheRef<P> {
 
     /// Try to read the specified bytes from the page cache only. Returns the number of bytes
     /// successfully read from cache and copied to `buf` before a page fault, if any.
-    pub(super) fn read_cached(&self, blob_id: u64, buf: &mut [u8], logical_offset: u64) -> usize {
-        self.cache.read_at(blob_id, buf, logical_offset)
+    pub(super) fn read_cached(
+        &self,
+        blob_id: u64,
+        mut buf: &mut [u8],
+        mut logical_offset: u64,
+    ) -> usize {
+        let CacheImpl::Clock(cache) = &self.cache else {
+            return 0;
+        };
+        let original_len = buf.len();
+        let page_cache = cache.read();
+        while !buf.is_empty() {
+            let count = page_cache.read_at(blob_id, buf, logical_offset);
+            if count == 0 {
+                // Cache miss - return how many bytes we successfully read
+                break;
+            }
+            logical_offset += count as u64;
+            buf = &mut buf[count..];
+        }
+        original_len - buf.len()
     }
 
-    /// Read multiple disjoint byte ranges from the page cache.
+    /// Read multiple disjoint byte ranges from the page cache in a single lock acquisition.
     ///
     /// Each element of `ranges` is `(dest_slice, logical_offset)`. Fully-cached ranges have
     /// their data written to the destination slice and are removed from `ranges`. Entries left
     /// in `ranges` correspond to cache misses that the caller must read from the underlying
     /// blob.
     pub(super) fn read_cached_many(&self, blob_id: u64, ranges: &mut Vec<(&mut [u8], u64)>) {
-        self.cache.read_many(blob_id, ranges);
+        let CacheImpl::Clock(cache) = &self.cache else {
+            return;
+        };
+        let page_cache = cache.read();
+        ranges.retain_mut(|(buf, logical_offset)| {
+            let mut remaining = buf.len();
+            let mut offset = *logical_offset;
+            let mut dst = 0;
+            while remaining > 0 {
+                let count = page_cache.read_at(blob_id, &mut buf[dst..], offset);
+                if count == 0 {
+                    break;
+                }
+                offset += count as u64;
+                dst += count;
+                remaining -= count;
+            }
+
+            // Keep cache misses in `ranges`; drop fully-cached entries.
+            remaining > 0
+        });
     }
 
     /// Read the specified bytes, preferentially from the page cache. Bytes not found in the cache
-    /// will be read from the provided `blob` and (depending on the [PageCache] implementation)
-    /// cached for future reads.
+    /// will be read from the provided `blob` and, unless this handle was created with
+    /// [CacheRef::no_cache], cached for future reads.
     pub(super) async fn read<B: Blob>(
         &self,
         blob: &B,
@@ -477,6 +289,7 @@ impl<P: PageCache> CacheRef<P> {
         // Read up to a page worth of data at a time from either the page cache or the `blob`,
         // until the requested data is fully read.
         while !buf.is_empty() {
+            // See if we can get (some of) the data from the page cache.
             let count = self.read_cached(blob_id, buf, offset);
             if count != 0 {
                 offset += count as u64;
@@ -495,9 +308,9 @@ impl<P: PageCache> CacheRef<P> {
         Ok(())
     }
 
-    /// Fetch the requested page after encountering a page fault, delegating dedup and retention
-    /// to the [PageCache] implementation. Returns the number of bytes read, which should always
-    /// be non-zero.
+    /// Fetch the requested page after encountering a page fault, which may involve retrieving it
+    /// from `blob` & caching the result in the page cache. Returns the number of bytes read, which
+    /// should always be non-zero.
     pub(super) async fn read_after_page_fault<B: Blob>(
         &self,
         blob: &B,
@@ -507,21 +320,112 @@ impl<P: PageCache> CacheRef<P> {
     ) -> Result<usize, Error> {
         assert!(!buf.is_empty());
 
-        let (page_num, _) = Cache::offset_to_page(self.page_size, offset);
+        let (page_num, offset_in_page) = Cache::offset_to_page(self.page_size, offset);
+        let offset_in_page = offset_in_page as usize;
         trace!(page_num, blob_id, "page fault");
 
-        // Build a type-erased fetch of the page. get_page_from_blob handles CRC validation and
-        // returns only logical bytes.
-        let blob = blob.clone();
-        let page_size = self.page_size;
-        let fetch: PageFetchFuture =
-            async move { fetch_cacheable_page(&blob, page_num, page_size).await }
-                .boxed()
-                .shared();
+        // Without a cache there is nothing to consult, insert into, or deduplicate against:
+        // fetch the page directly from the blob. `Shared` makes the fetch future `Sync`, which
+        // callers require of the read path (blob read futures are only `Send`).
+        let CacheImpl::Clock(shared) = &self.cache else {
+            let fetch = fetch_cacheable_page(blob, page_num, self.page_size).shared();
+            let page_buf = match fetch.await {
+                Ok(page_buf) => page_buf,
+                Err(err) => {
+                    error!(page_num, ?err, "Page fetch failed");
+                    return Err(Error::ReadFailed);
+                }
+            };
+            let bytes_to_copy = std::cmp::min(buf.len(), page_buf.len() - offset_in_page);
+            buf[..bytes_to_copy].copy_from_slice(
+                &page_buf.as_ref()[offset_in_page..offset_in_page + bytes_to_copy],
+            );
+            return Ok(bytes_to_copy);
+        };
 
-        self.cache
-            .fault(blob_id, page_num, offset, buf, fetch)
-            .await
+        // Create or clone a future that retrieves the desired page from the underlying blob. This
+        // requires a write lock on the page cache since we may need to modify `page_fetches` if
+        // this task is the first fetcher.
+        let (fetch_future, mut fetch_guard) = {
+            let mut cache = shared.write();
+
+            // There's a (small) chance the page was fetched & buffered by another task before we
+            // were able to acquire the write lock, so check the cache before doing anything else.
+            let count = cache.read_at(blob_id, buf, offset);
+            if count != 0 {
+                return Ok(count);
+            }
+
+            let key = (blob_id, page_num);
+            match cache.page_fetches.entry(key) {
+                Entry::Occupied(o) => {
+                    // Another thread is already fetching this page, so clone its existing future.
+                    let entry = o.into_mut();
+                    entry.waiters += 1;
+                    let fetch_future = entry.fetch.as_ref().clone();
+                    let fetch = Arc::clone(&entry.fetch);
+                    (
+                        fetch_future,
+                        PageFetchGuard::new(Arc::clone(shared), key, fetch),
+                    )
+                }
+                Entry::Vacant(v) => {
+                    // Nobody is currently fetching this page, so create a future that will do the
+                    // work. get_page_from_blob handles CRC validation and returns only logical bytes.
+                    let blob = blob.clone();
+                    let cache = Arc::clone(shared);
+                    let page_size = self.page_size;
+                    let future = async move {
+                        let result = fetch_cacheable_page(&blob, page_num, page_size).await;
+                        if let Err(err) = &result {
+                            error!(page_num, ?err, "Page fetch failed");
+                        }
+
+                        // This shared future still owns `page_fetches[key]`. As long as at least
+                        // one waiter remains armed, that entry pins this generation in place, so a
+                        // replacement fetch for the same page cannot be inserted before we cache
+                        // the successful result below. Only when every waiter cancels can the last
+                        // guard remove the entry and let a later reader start a new generation.
+                        let mut cache = cache.write();
+                        if let Ok(page) = &result {
+                            cache.cache(blob_id, page.as_ref(), page_num);
+                        }
+                        let _ = cache.page_fetches.remove(&key);
+                        result
+                    };
+
+                    // Make the future shareable and insert it into the map.
+                    let fetch_future = future.boxed().shared();
+                    let fetch = Arc::new(fetch_future.clone());
+                    v.insert(PageFetchEntry {
+                        fetch: Arc::clone(&fetch),
+                        waiters: 1,
+                    });
+
+                    (
+                        fetch_future,
+                        PageFetchGuard::new(Arc::clone(shared), key, fetch),
+                    )
+                }
+            }
+        };
+
+        // Await the shared fetch. The future itself logs failures, caches the resolved page, and
+        // removes the in-flight marker before it returns, so waiters only need cancellation
+        // cleanup while the fetch is still unresolved.
+        let fetch_result = fetch_future.await;
+        fetch_guard.disarm();
+        let page_buf = match fetch_result {
+            Ok(page_buf) => page_buf,
+            Err(_) => return Err(Error::ReadFailed),
+        };
+
+        // Copy the requested portion of the page into the buffer.
+        let bytes_to_copy = std::cmp::min(buf.len(), page_buf.len() - offset_in_page);
+        buf[..bytes_to_copy]
+            .copy_from_slice(&page_buf.as_ref()[offset_in_page..offset_in_page + bytes_to_copy]);
+
+        Ok(bytes_to_copy)
     }
 
     /// Cache the provided pages of data in the page cache, returning the remaining bytes that
@@ -529,20 +433,38 @@ impl<P: PageCache> CacheRef<P> {
     ///
     /// # Panics
     ///
-    /// Panics if `offset` is not page aligned.
-    pub fn cache(&self, blob_id: u64, buf: &[u8], offset: u64) -> usize {
-        let (page_num, offset_in_page) = self.offset_to_page(offset);
+    /// - Panics if `offset` is not page aligned.
+    /// - If the buffer is not the size of a page.
+    pub fn cache(&self, blob_id: u64, mut buf: &[u8], offset: u64) -> usize {
+        let (mut page_num, offset_in_page) = self.offset_to_page(offset);
         assert_eq!(offset_in_page, 0);
         let page_size = self.page_size as usize;
-        self.cache.cache(blob_id, page_size, buf, page_num);
-        buf.len() % page_size
+        let CacheImpl::Clock(cache) = &self.cache else {
+            return buf.len() % page_size;
+        };
+        {
+            // Write lock the page cache.
+            let mut page_cache = cache.write();
+            while buf.len() >= page_size {
+                page_cache.cache(blob_id, &buf[..page_size], page_num);
+                buf = &buf[page_size..];
+                page_num = match page_num.checked_add(1) {
+                    Some(next) => next,
+                    None => break,
+                };
+            }
+        }
+
+        buf.len()
     }
 
     /// Drop any cached pages for `blob_id` at `page_num >= start_page`. Used after a blob is
     /// truncated so subsequent reads can't observe pre-truncation bytes in a page that the tip
     /// buffer (or future writes) now owns.
     pub(super) fn invalidate_from(&self, blob_id: u64, start_page: u64) {
-        self.cache.invalidate_from(blob_id, start_page);
+        if let CacheImpl::Clock(cache) = &self.cache {
+            cache.write().invalidate_from(blob_id, start_page);
+        }
     }
 }
 
@@ -658,19 +580,12 @@ mod tests {
         BufferPool::new(BufferPoolConfig::for_storage(), &mut registry)
     }
 
-    /// Build a [CacheRef] backed by a [ClockCache], returning both so tests can probe the
-    /// concrete cache state behind the trait.
-    fn clocked(
-        pooler: &impl BufferPooler,
-        page_size: NonZeroU16,
-        capacity: NonZeroUsize,
-    ) -> (CacheRef, Arc<ClockCache>) {
-        let pool = pooler.storage_buffer_pool().clone();
-        let clock = Arc::new(ClockCache::new(pool.clone(), page_size, capacity));
-        (
-            CacheRef::with_cache(pool, page_size, clock.as_ref().clone()),
-            clock,
-        )
+    /// Extract the clock cache behind `cache_ref` so tests can probe its internal state.
+    fn clock(cache_ref: &CacheRef) -> &Arc<RwLock<Cache>> {
+        match &cache_ref.cache {
+            CacheImpl::Clock(cache) => cache,
+            CacheImpl::None => panic!("expected a caching handle"),
+        }
     }
 
     // Logical page size (what CacheRef uses and what gets cached).
@@ -989,7 +904,7 @@ mod tests {
 
             // Populate a blob with 3 consecutive pages of CRC-protected data.
             let (blob, _) = context
-                .open("test", "passthrough_blob".as_bytes())
+                .open("test", "no_cache_blob".as_bytes())
                 .await
                 .expect("Failed to open blob");
             for i in 0..3 {
@@ -1020,14 +935,9 @@ mod tests {
                 .read(&blob, 0, &mut buf, PAGE_SIZE_U64 / 2)
                 .await
                 .unwrap();
-            assert_eq!(
-                &buf[..(PAGE_SIZE.get() / 2) as usize],
-                &[0u8; PAGE_SIZE.get() as usize][..(PAGE_SIZE.get() / 2) as usize]
-            );
-            assert_eq!(
-                &buf[(PAGE_SIZE.get() / 2) as usize..],
-                &[1u8; PAGE_SIZE.get() as usize][..(PAGE_SIZE.get() / 2) as usize]
-            );
+            let half = (PAGE_SIZE.get() / 2) as usize;
+            assert!(buf[..half].iter().all(|b| *b == 0));
+            assert!(buf[half..].iter().all(|b| *b == 1));
 
             // Nothing is retained: cached probes always miss, and insertion is a no-op that
             // still reports the leftover partial-page bytes.
@@ -1050,7 +960,7 @@ mod tests {
     fn test_cache_max_page() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cache_ref, clock) = clocked(&context, PAGE_SIZE, NZUsize!(2));
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(2));
 
             // Use the largest page-aligned offset representable for the configured PAGE_SIZE.
             let aligned_max_offset = u64::MAX - (u64::MAX % PAGE_SIZE_U64);
@@ -1064,7 +974,7 @@ mod tests {
 
             // Reading from the cache should return the logical bytes.
             let mut buf = vec![0u8; PAGE_SIZE.get() as usize];
-            let page_cache = clock.inner.read();
+            let page_cache = clock(&cache_ref).read();
             let bytes_read = page_cache.read_at(0, &mut buf, aligned_max_offset);
             assert_eq!(bytes_read, PAGE_SIZE.get() as usize);
             assert!(buf.iter().all(|b| *b == 42));
@@ -1077,7 +987,8 @@ mod tests {
         executor.start(|context| async move {
             // Use the minimum page size (CHECKSUM_SIZE + 1 = 13) with high offset.
             const MIN_PAGE_SIZE: u64 = CHECKSUM_SIZE + 1;
-            let (cache_ref, clock) = clocked(&context, NZU16!(MIN_PAGE_SIZE as u16), NZUsize!(2));
+            let cache_ref =
+                CacheRef::from_pooler(&context, NZU16!(MIN_PAGE_SIZE as u16), NZUsize!(2));
 
             // Create two pages worth of logical data (no CRCs - CacheRef::cache expects logical
             // only).
@@ -1093,7 +1004,7 @@ mod tests {
 
             // Verify the first page was cached correctly.
             let mut buf = vec![0u8; MIN_PAGE_SIZE as usize];
-            let page_cache = clock.inner.read();
+            let page_cache = clock(&cache_ref).read();
             assert_eq!(
                 page_cache.read_at(0, &mut buf, high_offset),
                 MIN_PAGE_SIZE as usize
@@ -1115,7 +1026,7 @@ mod tests {
         executor.start(|context| async move {
             // Set up a small cache and a blob whose read never completes once started.
             let blob_id = 0;
-            let (cache_ref, clock) = clocked(&context, PAGE_SIZE, NZUsize!(10));
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(10));
             let (started_tx, started_rx) = oneshot::channel();
             let blob = BlockingBlob {
                 started: Arc::new(Mutex::new(Some(started_tx))),
@@ -1134,7 +1045,7 @@ mod tests {
             // Wait until the underlying read has started, ensuring the in-flight marker exists.
             started_rx.await.expect("blocking read never started");
             {
-                let page_cache = clock.inner.read();
+                let page_cache = clock(&cache_ref).read();
                 assert!(page_cache.page_fetches.contains_key(&(blob_id, 0)));
             }
 
@@ -1143,7 +1054,7 @@ mod tests {
             assert!(matches!(handle.await, Err(Error::Closed)));
 
             // The guard drop path should have removed the stale in-flight entry.
-            let page_cache = clock.inner.read();
+            let page_cache = clock(&cache_ref).read();
             assert!(
                 !page_cache.page_fetches.contains_key(&(blob_id, 0)),
                 "cancelled first fetcher should not leave stale page_fetches entry"
@@ -1156,7 +1067,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let blob_id = 0;
-            let (cache_ref, clock) = clocked(&context, PAGE_SIZE, NZUsize!(10));
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(10));
 
             // Return one valid full page, but hold the underlying read until the test releases it.
             let logical_page = vec![7u8; PAGE_SIZE.get() as usize];
@@ -1199,7 +1110,7 @@ mod tests {
             // Wait until both tasks are registered against the same in-flight fetch.
             loop {
                 let joined = {
-                    let page_cache = clock.inner.read();
+                    let page_cache = clock(&cache_ref).read();
                     page_cache
                         .page_fetches
                         .get(&(blob_id, 0))
@@ -1233,7 +1144,7 @@ mod tests {
             // blob read.
             loop {
                 let third_entered = {
-                    let page_cache = clock.inner.read();
+                    let page_cache = clock(&cache_ref).read();
                     reads.load(Ordering::Relaxed) > 1
                         || page_cache
                             .page_fetches
@@ -1274,7 +1185,7 @@ mod tests {
             assert_eq!(fourth_buf, logical_page);
             assert_eq!(reads.load(Ordering::Relaxed), 1);
 
-            let page_cache = clock.inner.read();
+            let page_cache = clock(&cache_ref).read();
             assert!(
                 !page_cache.page_fetches.contains_key(&(blob_id, 0)),
                 "completed fetch should leave no stale page_fetches entry"
@@ -1287,7 +1198,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let blob_id = 0;
-            let (cache_ref, clock) = clocked(&context, PAGE_SIZE, NZUsize!(10));
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(10));
 
             // Hold one shared fetch in flight, then make the underlying read fail.
             let (started_tx, started_rx) = oneshot::channel();
@@ -1324,7 +1235,7 @@ mod tests {
             // Wait until both tasks share the same in-flight fetch entry.
             loop {
                 let joined = {
-                    let page_cache = clock.inner.read();
+                    let page_cache = clock(&cache_ref).read();
                     page_cache
                         .page_fetches
                         .get(&(blob_id, 0))
@@ -1347,7 +1258,7 @@ mod tests {
 
             // The failed generation must remove its in-flight entry and avoid caching data.
             {
-                let page_cache = clock.inner.read();
+                let page_cache = clock(&cache_ref).read();
                 assert!(
                     !page_cache.page_fetches.contains_key(&(blob_id, 0)),
                     "erroring fetch should leave no stale page_fetches entry"
@@ -1369,15 +1280,14 @@ mod tests {
     #[test_traced]
     fn test_read_cached_many_all_cached() {
         let pool = test_pool();
-        let clock = Arc::new(ClockCache::new(pool.clone(), PAGE_SIZE, NZUsize!(10)));
-        let cache_ref = CacheRef::with_cache(pool, PAGE_SIZE, clock.as_ref().clone());
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
         let blob_id = cache_ref.next_id();
         let page0 = vec![0xAA; PAGE_SIZE.get() as usize];
         let page1 = vec![0xBB; PAGE_SIZE.get() as usize];
 
         // Populate two pages with distinct data.
         {
-            let mut cache = clock.inner.write();
+            let mut cache = clock(&cache_ref).write();
             cache.cache(blob_id, &page0, 0);
             cache.cache(blob_id, &page1, 1);
         }
@@ -1400,8 +1310,7 @@ mod tests {
     #[test_traced]
     fn test_read_cached_many_none_cached() {
         let pool = test_pool();
-        let clock = Arc::new(ClockCache::new(pool.clone(), PAGE_SIZE, NZUsize!(10)));
-        let cache_ref = CacheRef::with_cache(pool, PAGE_SIZE, clock.as_ref().clone());
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
         let blob_id = cache_ref.next_id();
 
         let mut buf0 = vec![0u8; PAGE_SIZE_U64 as usize];
@@ -1420,14 +1329,13 @@ mod tests {
         // Verify that read_cached_many checks ALL ranges, not just up to the
         // first miss. Pages 0 and 2 are cached, page 1 is not.
         let pool = test_pool();
-        let clock = Arc::new(ClockCache::new(pool.clone(), PAGE_SIZE, NZUsize!(10)));
-        let cache_ref = CacheRef::with_cache(pool, PAGE_SIZE, clock.as_ref().clone());
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
         let blob_id = cache_ref.next_id();
 
         let page0 = vec![0x11; PAGE_SIZE.get() as usize];
         let page2 = vec![0x33; PAGE_SIZE.get() as usize];
         {
-            let mut cache = clock.inner.write();
+            let mut cache = clock(&cache_ref).write();
             cache.cache(blob_id, &page0, 0);
             // page 1 deliberately not cached
             cache.cache(blob_id, &page2, 2);
@@ -1470,14 +1378,13 @@ mod tests {
         #[case] expected_count: usize,
     ) {
         let pool = test_pool();
-        let clock = Arc::new(ClockCache::new(pool.clone(), PAGE_SIZE, NZUsize!(10)));
-        let cache_ref = CacheRef::with_cache(pool, PAGE_SIZE, clock.as_ref().clone());
+        let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(10));
         let blob_id = cache_ref.next_id();
         let sentinel = 0xEE;
         let page_size = PAGE_SIZE.get() as usize;
 
         {
-            let mut cache = clock.inner.write();
+            let mut cache = clock(&cache_ref).write();
             for page in cached_pages {
                 // Use a distinct byte per page so cross-page reads prove both halves were copied.
                 cache.cache(blob_id, &vec![page as u8 + 1; page_size], page);

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -34,7 +34,7 @@ mod sealed;
 mod view;
 mod writer;
 
-pub use cache::{CacheRef, ClockCache, NoCache, PageCache, PageFetchFuture};
+pub use cache::CacheRef;
 pub use read::Replay;
 pub use sealed::Sealed;
 use tracing::{debug, error};

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -15,7 +15,7 @@
 //! any lock; they share the underlying [`Blob`] handle (which provides its own synchronization)
 //! and the page cache.
 
-use super::{read::PageReader, view::View, CacheRef, ClockCache, PageCache, Replay, CHECKSUM_SIZE};
+use super::{read::PageReader, view::View, CacheRef, Replay, CHECKSUM_SIZE};
 use crate::{Blob, Error, IoBuf, IoBufMut, IoBufs};
 use std::{
     num::{NonZeroU16, NonZeroUsize},
@@ -24,11 +24,11 @@ use std::{
 
 /// An immutable, page-cache-backed read handle for a [Blob]. The read-only counterpart to
 /// [`super::Writer`].
-pub struct Sealed<B: Blob, P: PageCache = ClockCache> {
-    inner: Arc<SealedInner<B, P>>,
+pub struct Sealed<B: Blob> {
+    inner: Arc<SealedInner<B>>,
 }
 
-impl<B: Blob, P: PageCache> Clone for Sealed<B, P> {
+impl<B: Blob> Clone for Sealed<B> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -36,7 +36,7 @@ impl<B: Blob, P: PageCache> Clone for Sealed<B, P> {
     }
 }
 
-struct SealedInner<B: Blob, P: PageCache> {
+struct SealedInner<B: Blob> {
     /// The underlying blob being wrapped.
     blob: B,
 
@@ -49,7 +49,7 @@ struct SealedInner<B: Blob, P: PageCache> {
     partial_page: Option<IoBuf>,
 
     /// Reference to the page cache used for reads of full pages.
-    cache_ref: CacheRef<P>,
+    cache_ref: CacheRef,
 
     /// Page-cache id. [`super::Writer::seal`] preserves the writer id so hot full pages remain
     /// valid across the transition. [`super::Writer::snapshot`] uses a fresh id because the writer
@@ -57,13 +57,13 @@ struct SealedInner<B: Blob, P: PageCache> {
     id: u64,
 }
 
-impl<B: Blob, P: PageCache> Sealed<B, P> {
+impl<B: Blob> Sealed<B> {
     /// Construct a [`Sealed`] from already-validated parts. Invoked by [`super::Writer::seal`].
     pub(super) fn new(
         blob: B,
         size: u64,
         partial_page: Option<IoBuf>,
-        cache_ref: CacheRef<P>,
+        cache_ref: CacheRef,
         id: u64,
     ) -> Self {
         Self {
@@ -99,7 +99,7 @@ impl<B: Blob, P: PageCache> Sealed<B, P> {
     }
 
     /// Returns a borrowed view over this blob.
-    fn view(&self) -> View<'_, B, P> {
+    fn view(&self) -> View<'_, B> {
         View {
             blob: &self.inner.blob,
             cache_ref: &self.inner.cache_ref,

--- a/runtime/src/utils/buffer/paged/view.rs
+++ b/runtime/src/utils/buffer/paged/view.rs
@@ -6,17 +6,17 @@
 //! to a blob read. Each type exposes itself as a borrowed [`View`] so this algorithm lives in
 //! exactly one place.
 
-use super::{CacheRef, PageCache};
+use super::CacheRef;
 use crate::{Blob, Error, IoBufMut, IoBufs};
 use futures::stream::{FuturesUnordered, StreamExt};
 use std::num::NonZeroUsize;
 
 /// A borrowed view over a paged blob.
-pub struct View<'a, B: Blob, P: PageCache> {
+pub struct View<'a, B: Blob> {
     /// Underlying blob, used for bytes below `tail_offset` not resident in the cache.
     pub(super) blob: &'a B,
     /// Page cache used for bytes below `tail_offset`.
-    pub(super) cache_ref: &'a CacheRef<P>,
+    pub(super) cache_ref: &'a CacheRef,
     /// Page-cache id of the originating blob.
     pub(super) id: u64,
     /// Size of the blob, in bytes.
@@ -27,15 +27,15 @@ pub struct View<'a, B: Blob, P: PageCache> {
     pub(super) tail: &'a [u8],
 }
 
-impl<B: Blob, P: PageCache> Clone for View<'_, B, P> {
+impl<B: Blob> Clone for View<'_, B> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<B: Blob, P: PageCache> Copy for View<'_, B, P> {}
+impl<B: Blob> Copy for View<'_, B> {}
 
-impl<B: Blob, P: PageCache> View<'_, B, P> {
+impl<B: Blob> View<'_, B> {
     /// Copy any in-memory tail overlap into `buf`, returning the remaining prefix length.
     fn copy_tail_overlap(&self, buf: &mut [u8], offset: u64) -> usize {
         let tail_start = self.tail_offset.max(offset);

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -36,7 +36,6 @@
 //! invalidate checksum recovery.
 
 use super::{
-    cache::{ClockCache, PageCache},
     read::{PageReader, Replay},
     view::View,
 };
@@ -94,7 +93,7 @@ const fn too_big_for_buffer(
 }
 
 /// Unique writer to a cache-wrapped [Blob].
-pub struct Writer<B: Blob, P: PageCache = ClockCache> {
+pub struct Writer<B: Blob> {
     /// The underlying blob being wrapped.
     blob: B,
 
@@ -112,14 +111,14 @@ pub struct Writer<B: Blob, P: PageCache = ClockCache> {
     id: u64,
 
     /// A reference to the page cache that manages read caching for this blob.
-    cache_ref: CacheRef<P>,
+    cache_ref: CacheRef,
 
     /// The write buffer containing any logical bytes following the last full page boundary in the
     /// underlying blob.
     buffer: Buffer,
 }
 
-impl<B: Blob, P: PageCache> Writer<B, P> {
+impl<B: Blob> Writer<B> {
     /// Write bytes to the underlying blob and mark them as needing sync.
     async fn write_at(&mut self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
         self.sync_state.write_at(&self.blob, offset, bufs).await
@@ -160,7 +159,7 @@ impl<B: Blob, P: PageCache> Writer<B, P> {
         blob: B,
         original_blob_size: u64,
         capacity: usize,
-        cache_ref: CacheRef<P>,
+        cache_ref: CacheRef,
     ) -> Result<Self, Error> {
         let (partial_page_state, pages, invalid_data_found) =
             Self::read_last_valid_page(&blob, original_blob_size, cache_ref.page_size()).await?;
@@ -574,7 +573,7 @@ impl<B: Blob, P: PageCache> Writer<B, P> {
     }
 
     /// Returns a borrowed view over this blob.
-    fn view(&self) -> View<'_, B, P> {
+    fn view(&self) -> View<'_, B> {
         View {
             blob: &self.blob,
             cache_ref: &self.cache_ref,
@@ -914,7 +913,7 @@ impl<B: Blob, P: PageCache> Writer<B, P> {
     ///
     /// If this writer later rewinds or truncates into the returned handle's range, reads from that
     /// handle may observe unspecified contents.
-    pub async fn snapshot(&mut self) -> Result<super::Sealed<B, P>, Error> {
+    pub async fn snapshot(&mut self) -> Result<super::Sealed<B>, Error> {
         self.flush_internal(true, false).await?;
         Ok(self.sealed_handle(self.cache_ref.next_id()))
     }
@@ -1093,7 +1092,7 @@ impl<B: Blob, P: PageCache> Writer<B, P> {
     }
 
     /// Construct an immutable read handle for the current blob state.
-    fn sealed_handle(&self, id: u64) -> super::Sealed<B, P> {
+    fn sealed_handle(&self, id: u64) -> super::Sealed<B> {
         let logical_page_size = self.cache_ref.page_size();
         let full_pages = self.current_page;
         assert_eq!(
@@ -1121,7 +1120,7 @@ impl<B: Blob, P: PageCache> Writer<B, P> {
     /// Buffered bytes (full and partial pages) are written to the underlying blob, but the blob is
     /// not fsynced. The returned [`super::Sealed`] handle can be made durable later via
     /// [`super::Sealed::sync`].
-    pub async fn seal(mut self) -> Result<super::Sealed<B, P>, Error> {
+    pub async fn seal(mut self) -> Result<super::Sealed<B>, Error> {
         self.sync_state.wait_for_pending().await?;
         self.flush_internal(true, false).await?;
         Ok(self.sealed_handle(self.id))

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -24,7 +24,6 @@ use commonware_codec::{CodecFixedShared, CodecShared, Encode, EncodeShared};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use commonware_runtime::buffer::paged::PageCache;
 use core::{
     num::{NonZeroU64, NonZeroUsize},
     ops::Range,
@@ -244,7 +243,7 @@ where
 {
     /// Merkle structure where each leaf is an item digest.
     /// Invariant: leaf i corresponds to item i in the journal.
-    pub(crate) merkle: Merkle<F, E, H::Digest, S, C::PageCache>,
+    pub(crate) merkle: Merkle<F, E, H::Digest, S>,
 
     /// Journal of items.
     /// Invariant: item i corresponds to leaf i in the Merkle structure.
@@ -355,7 +354,7 @@ where
     /// Create a new [Journal] from the given components after aligning the Merkle structure with
     /// the journal.
     pub async fn from_components(
-        mut merkle: Merkle<F, E, H::Digest, S, C::PageCache>,
+        mut merkle: Merkle<F, E, H::Digest, S>,
         journal: C,
         hasher: StandardHasher<H>,
         apply_batch_size: u64,
@@ -379,7 +378,7 @@ where
     /// memory use: each batch's items are buffered in memory so their leaves can be hashed
     /// across the strategy.
     async fn align(
-        merkle: &mut Merkle<F, E, H::Digest, S, C::PageCache>,
+        merkle: &mut Merkle<F, E, H::Digest, S>,
         journal: &C,
         hasher: &StandardHasher<H>,
         apply_batch_size: u64,
@@ -667,14 +666,13 @@ const APPLY_BATCH_SIZE: u64 = 1 << 16;
 /// journal type.
 macro_rules! impl_journal_new {
     ($journal_mod:ident, $cfg_ty:ty, $codec_bound:path) => {
-        impl<F, E, O, H, S, P> Journal<F, E, $journal_mod::Journal<E, O, P>, H, S>
+        impl<F, E, O, H, S> Journal<F, E, $journal_mod::Journal<E, O>, H, S>
         where
             F: Family,
             E: Context,
             O: $codec_bound,
             H: Hasher,
             S: Strategy,
-            P: PageCache,
         {
             /// Create a new authenticated [Journal].
             ///
@@ -683,7 +681,7 @@ macro_rules! impl_journal_new {
             #[boxed]
             pub async fn new(
                 context: E,
-                merkle_cfg: merkle::full::Config<S, P>,
+                merkle_cfg: merkle::full::Config<S>,
                 journal_cfg: $cfg_ty,
                 rewind_predicate: fn(&O) -> bool,
                 bagging: merkle::Bagging,
@@ -709,8 +707,8 @@ macro_rules! impl_journal_new {
     };
 }
 
-impl_journal_new!(fixed, fixed::Config<P>, CodecFixedShared);
-impl_journal_new!(variable, variable::Config<O::Cfg, P>, CodecShared);
+impl_journal_new!(fixed, fixed::Config, CodecFixedShared);
+impl_journal_new!(variable, variable::Config<O::Cfg>, CodecShared);
 
 impl<F, E, C, H, S> Contiguous for Journal<F, E, C, H, S>
 where
@@ -720,7 +718,6 @@ where
     H: Hasher,
     S: Strategy,
 {
-    type PageCache = C::PageCache;
     type Item = C::Item;
 
     fn bounds(&self) -> Range<u64> {
@@ -800,7 +797,7 @@ pub trait Inner<E: Context>: Mutable {
     /// Initialize an authenticated [Journal] backed by this journal type.
     fn init<F: Family, H: Hasher, S: Strategy>(
         context: E,
-        merkle_cfg: merkle::full::Config<S, Self::PageCache>,
+        merkle_cfg: merkle::full::Config<S>,
         journal_cfg: Self::Config,
         rewind_predicate: fn(&Self::Item) -> bool,
         bagging: merkle::Bagging,

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use commonware_formatting::hex;
 use commonware_runtime::{
-    buffer::paged::{CacheRef, PageCache, Replay as PagedReplay, Sealed, Writer},
+    buffer::paged::{CacheRef, Replay as PagedReplay, Sealed, Writer},
     telemetry::metrics::{Counter, Gauge, GaugeExt as _, MetricsExt as _},
     Blob as RBlob, Buf, Error as RError, IoBufMut, IoBufs,
 };
@@ -31,22 +31,19 @@ impl Metrics {
     }
 }
 
-/// A shared snapshot of a journal's sealed blobs.
-type SealedSnapshot<B, P> = Arc<[Sealed<B, P>]>;
-
 /// A storage partition holding blobs.
-pub(super) struct Partition<E: Context, P: PageCache> {
+pub(super) struct Partition<E: Context> {
     context: E,
     name: String,
-    page_cache: CacheRef<P>,
+    page_cache: CacheRef,
     write_buffer: NonZeroUsize,
 }
 
-impl<E: Context, P: PageCache> Partition<E, P> {
+impl<E: Context> Partition<E> {
     pub(super) const fn new(
         context: E,
         name: String,
-        page_cache: CacheRef<P>,
+        page_cache: CacheRef,
         write_buffer: NonZeroUsize,
     ) -> Self {
         Self {
@@ -58,7 +55,7 @@ impl<E: Context, P: PageCache> Partition<E, P> {
     }
 
     /// Open the given blob as a [`Writer`], creating it if it does not exist.
-    pub(super) async fn open(&self, blob: u64) -> Result<Writer<E::Blob, P>, Error> {
+    pub(super) async fn open(&self, blob: u64) -> Result<Writer<E::Blob>, Error> {
         let name = blob.to_be_bytes();
         let (blob, size) = self
             .context
@@ -80,7 +77,7 @@ impl<E: Context, P: PageCache> Partition<E, P> {
     }
 
     /// Scan the partition and open every existing blob as a [`Writer`], keyed by blob index.
-    pub(super) async fn open_all(&self) -> Result<BTreeMap<u64, Writer<E::Blob, P>>, Error> {
+    pub(super) async fn open_all(&self) -> Result<BTreeMap<u64, Writer<E::Blob>>, Error> {
         let stored = Self::scan_names(&self.context, &self.name).await?;
 
         let mut blobs = BTreeMap::new();
@@ -137,24 +134,24 @@ impl<E: Context, P: PageCache> Partition<E, P> {
 }
 
 /// A journal's blobs: contiguous sealed blobs ending in one writable tail.
-pub(super) struct Writable<E: Context, P: PageCache> {
-    partition: Partition<E, P>,
+pub(super) struct Writable<E: Context> {
+    partition: Partition<E>,
     metrics: Metrics,
 
     /// The writable tail.
-    tail: Writer<E::Blob, P>,
+    tail: Writer<E::Blob>,
 
     /// Index of the first blob in [Self::sealed].
     oldest_blob_index: u64,
 
     /// Sealed historical blobs.
-    sealed: Vec<Sealed<E::Blob, P>>,
+    sealed: Vec<Sealed<E::Blob>>,
 
     /// Cached owned snapshot of [Self::sealed].
-    sealed_snapshot: Option<SealedSnapshot<E::Blob, P>>,
+    sealed_snapshot: Option<Arc<[Sealed<E::Blob>]>>,
 }
 
-impl<E: Context, P: PageCache> Writable<E, P> {
+impl<E: Context> Writable<E> {
     /// Build from recovered writers: seal every blob below `tail_blob` and install the tail,
     /// opening an empty one if absent.
     ///
@@ -164,8 +161,8 @@ impl<E: Context, P: PageCache> Writable<E, P> {
     /// - No blob may exceed `tail_blob`.
     /// - Any blobs present must end at `tail_blob`.
     pub(super) async fn recover(
-        partition: Partition<E, P>,
-        pending: BTreeMap<u64, Writer<E::Blob, P>>,
+        partition: Partition<E>,
+        pending: BTreeMap<u64, Writer<E::Blob>>,
         tail_blob: u64,
     ) -> Result<Self, Error> {
         if let Some(&newest) = pending.keys().next_back() {
@@ -177,7 +174,7 @@ impl<E: Context, P: PageCache> Writable<E, P> {
         }
         let oldest = pending.keys().next().copied();
         let mut sealed = Vec::with_capacity(pending.len());
-        let mut tail: Option<Writer<E::Blob, P>> = None;
+        let mut tail: Option<Writer<E::Blob>> = None;
         let mut expected = oldest;
         for (blob, writer) in pending {
             if expected != Some(blob) {
@@ -229,12 +226,12 @@ impl<E: Context, P: PageCache> Writable<E, P> {
     }
 
     /// A write handle for the tail.
-    pub(super) const fn tail_writer(&mut self) -> &mut Writer<E::Blob, P> {
+    pub(super) const fn tail_writer(&mut self) -> &mut Writer<E::Blob> {
         &mut self.tail
     }
 
     /// Borrow the current blobs for a live reader.
-    pub(super) fn reader(&self) -> Blobs<'_, E::Blob, P> {
+    pub(super) fn reader(&self) -> Blobs<'_, E::Blob> {
         Blobs {
             oldest_blob_index: self.oldest_blob_index,
             sealed: SealedBlobs::Borrowed(&self.sealed),
@@ -243,11 +240,11 @@ impl<E: Context, P: PageCache> Writable<E, P> {
     }
 
     /// Capture owned blob handles for a snapshot reader.
-    pub(super) async fn snapshot(&mut self) -> Result<Blobs<'static, E::Blob, P>, Error> {
+    pub(super) async fn snapshot(&mut self) -> Result<Blobs<'static, E::Blob>, Error> {
         let sealed = match &self.sealed_snapshot {
             Some(sealed) => sealed.clone(),
             None => {
-                let sealed: SealedSnapshot<E::Blob, P> = self.sealed.clone().into();
+                let sealed: Arc<[Sealed<E::Blob>]> = self.sealed.clone().into();
                 self.sealed_snapshot = Some(sealed.clone());
                 sealed
             }
@@ -406,32 +403,32 @@ impl<E: Context, P: PageCache> Writable<E, P> {
         for blob in self.oldest_blob_index..=tail_blob {
             self.partition.remove(blob).await?;
         }
-        Partition::<E, P>::remove_all(&self.partition.context, &self.partition.name).await
+        Partition::remove_all(&self.partition.context, &self.partition.name).await
     }
 }
 
 /// Blob handles for a contiguous journal view.
 ///
 /// Stores sealed history separately from the tail because the tail can use a different read path.
-pub(super) struct Blobs<'a, B: RBlob, P: PageCache> {
+pub(super) struct Blobs<'a, B: RBlob> {
     /// Index of the first sealed blob.
     oldest_blob_index: u64,
     /// Sealed historical blobs.
-    sealed: SealedBlobs<'a, B, P>,
+    sealed: SealedBlobs<'a, B>,
     /// Tail blob.
-    tail: Blob<'a, B, P>,
+    tail: Blob<'a, B>,
 }
 
 /// Storage for the sealed history slice.
-enum SealedBlobs<'a, B: RBlob, P: PageCache> {
+enum SealedBlobs<'a, B: RBlob> {
     /// Borrowed sealed slice.
-    Borrowed(&'a [Sealed<B, P>]),
+    Borrowed(&'a [Sealed<B>]),
     /// Owned sealed slice.
-    Owned(Arc<[Sealed<B, P>]>),
+    Owned(Arc<[Sealed<B>]>),
 }
 
-impl<B: RBlob, P: PageCache> SealedBlobs<'_, B, P> {
-    fn as_slice(&self) -> &[Sealed<B, P>] {
+impl<B: RBlob> SealedBlobs<'_, B> {
+    fn as_slice(&self) -> &[Sealed<B>] {
         match self {
             Self::Borrowed(sealed) => sealed,
             Self::Owned(sealed) => sealed,
@@ -440,14 +437,14 @@ impl<B: RBlob, P: PageCache> SealedBlobs<'_, B, P> {
 }
 
 /// A read handle for one journal blob.
-pub(super) enum Blob<'a, B: RBlob, P: PageCache> {
+pub(super) enum Blob<'a, B: RBlob> {
     /// Writable tail, read through the writer's cache-aware logical view.
-    Writer(&'a Writer<B, P>),
+    Writer(&'a Writer<B>),
     /// Immutable historical blob.
-    Sealed(Sealed<B, P>),
+    Sealed(Sealed<B>),
 }
 
-impl<B: RBlob, P: PageCache> Clone for Blob<'_, B, P> {
+impl<B: RBlob> Clone for Blob<'_, B> {
     fn clone(&self) -> Self {
         match self {
             Self::Writer(writer) => Self::Writer(writer),
@@ -456,7 +453,7 @@ impl<B: RBlob, P: PageCache> Clone for Blob<'_, B, P> {
     }
 }
 
-impl<'a, B: RBlob, P: PageCache> Blob<'a, B, P> {
+impl<'a, B: RBlob> Blob<'a, B> {
     /// Return the blob's logical size.
     pub(super) fn size(&self) -> u64 {
         match self {
@@ -512,7 +509,7 @@ impl<'a, B: RBlob, P: PageCache> Blob<'a, B, P> {
         self,
         offset: u64,
         buffer_size: NonZeroUsize,
-    ) -> Result<Replay<'a, B, P>, Error> {
+    ) -> Result<Replay<'a, B>, Error> {
         match self {
             Self::Writer(writer) => Replay::view(Self::Writer(writer), offset, buffer_size),
             Self::Sealed(sealed) => {
@@ -543,7 +540,7 @@ impl<'a, B: RBlob, P: PageCache> Blob<'a, B, P> {
     }
 }
 
-impl<B: RBlob, P: PageCache> FrameReader for Blob<'_, B, P> {
+impl<B: RBlob> FrameReader for Blob<'_, B> {
     async fn read_up_to(
         &self,
         offset: u64,
@@ -559,19 +556,19 @@ impl<B: RBlob, P: PageCache> FrameReader for Blob<'_, B, P> {
 }
 
 /// Sequential replay over either a sealed paged blob or a live writer view.
-pub(super) struct Replay<'a, B: RBlob, P: PageCache> {
-    inner: ReplayInner<'a, B, P>,
+pub(super) struct Replay<'a, B: RBlob> {
+    inner: ReplayInner<'a, B>,
 }
 
 /// Backing strategy for sequential blob replay.
-enum ReplayInner<'a, B: RBlob, P: PageCache> {
+enum ReplayInner<'a, B: RBlob> {
     /// Paged replay over sealed data. CRC bytes are validated and skipped by the runtime buffer.
     Paged(PagedReplay<B>),
     /// Logical replay over a live writer or any other blob view.
-    View(ViewReplay<'a, B, P>),
+    View(ViewReplay<'a, B>),
 }
 
-impl<'a, B: RBlob, P: PageCache> Replay<'a, B, P> {
+impl<'a, B: RBlob> Replay<'a, B> {
     /// Wrap a paged replay handle.
     const fn paged(replay: PagedReplay<B>) -> Self {
         Self {
@@ -580,7 +577,7 @@ impl<'a, B: RBlob, P: PageCache> Replay<'a, B, P> {
     }
 
     /// Build a replay handle over a logical blob view.
-    fn view(blob: Blob<'a, B, P>, offset: u64, buffer_size: NonZeroUsize) -> Result<Self, Error> {
+    fn view(blob: Blob<'a, B>, offset: u64, buffer_size: NonZeroUsize) -> Result<Self, Error> {
         Ok(Self {
             inner: ReplayInner::View(ViewReplay::new(blob, offset, buffer_size)?),
         })
@@ -605,7 +602,7 @@ impl<'a, B: RBlob, P: PageCache> Replay<'a, B, P> {
     }
 }
 
-impl<B: RBlob, P: PageCache> Buf for Replay<'_, B, P> {
+impl<B: RBlob> Buf for Replay<'_, B> {
     fn remaining(&self) -> usize {
         match &self.inner {
             ReplayInner::Paged(replay) => replay.remaining(),
@@ -629,9 +626,9 @@ impl<B: RBlob, P: PageCache> Buf for Replay<'_, B, P> {
 }
 
 /// Sequential read buffer over a live journal blob view.
-struct ViewReplay<'a, B: RBlob, P: PageCache> {
+struct ViewReplay<'a, B: RBlob> {
     /// The source blob view.
-    blob: Blob<'a, B, P>,
+    blob: Blob<'a, B>,
     /// Next logical offset to read from `blob`.
     offset: u64,
     /// Minimum read size when more bytes are needed.
@@ -644,9 +641,9 @@ struct ViewReplay<'a, B: RBlob, P: PageCache> {
     exhausted: bool,
 }
 
-impl<'a, B: RBlob, P: PageCache> ViewReplay<'a, B, P> {
+impl<'a, B: RBlob> ViewReplay<'a, B> {
     /// Create a view replay positioned at `offset`.
-    fn new(blob: Blob<'a, B, P>, offset: u64, buffer_size: NonZeroUsize) -> Result<Self, Error> {
+    fn new(blob: Blob<'a, B>, offset: u64, buffer_size: NonZeroUsize) -> Result<Self, Error> {
         if offset > blob.size() {
             return Err(Error::Runtime(RError::BlobInsufficientLength));
         }
@@ -719,7 +716,7 @@ impl<'a, B: RBlob, P: PageCache> ViewReplay<'a, B, P> {
     }
 }
 
-impl<B: RBlob, P: PageCache> Buf for ViewReplay<'_, B, P> {
+impl<B: RBlob> Buf for ViewReplay<'_, B> {
     fn remaining(&self) -> usize {
         self.buf.len() - self.cursor
     }
@@ -737,14 +734,14 @@ impl<B: RBlob, P: PageCache> Buf for ViewReplay<'_, B, P> {
     }
 }
 
-impl<'a, B: RBlob, P: PageCache> Blobs<'a, B, P> {
+impl<'a, B: RBlob> Blobs<'a, B> {
     /// Index of the newest blob (the tail).
     pub(super) fn tail_blob_index(&self) -> u64 {
         self.oldest_blob_index + self.sealed.as_slice().len() as u64
     }
 
     /// Resolve a blob, if retained.
-    pub(super) fn get(&self, blob: u64) -> Option<Blob<'a, B, P>> {
+    pub(super) fn get(&self, blob: u64) -> Option<Blob<'a, B>> {
         if blob == self.tail_blob_index() {
             return Some(self.tail.clone());
         }
@@ -769,10 +766,10 @@ mod tests {
         ));
     }
 
-    impl<E: Context, P: PageCache> Writable<E, P> {
+    impl<E: Context> Writable<E> {
         /// Open `blob` as an independent writer, outside this journal's tracking
         /// (simulates a crash-artifact blob).
-        pub(crate) async fn open_blob(&self, blob: u64) -> Result<Writer<E::Blob, P>, Error> {
+        pub(crate) async fn open_blob(&self, blob: u64) -> Result<Writer<E::Blob>, Error> {
             self.partition.open(blob).await
         }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -109,7 +109,7 @@ use crate::{
 };
 use commonware_codec::{CodecFixedShared, DecodeExt as _, ReadExt as _};
 use commonware_runtime::{
-    buffer::paged::{CacheRef, ClockCache, PageCache, Writer},
+    buffer::paged::{CacheRef, Writer},
     Blob as RBlob, Buf, IoBuf,
 };
 use futures::Stream;
@@ -142,13 +142,13 @@ fn first_in_blob(pruning_boundary: u64, blob: u64, items_per_blob: u64) -> Resul
 /// The stream is split into one state per blob so replay can start at a mid-blob pruning boundary,
 /// stop at the journal's logical end, and avoid reading across blob files. `buffer` is a byte
 /// budget for each blob replay, not an item count.
-fn replay_stream<'a, B: RBlob, A: CodecFixedShared, P: PageCache>(
-    blobs: &Blobs<'a, B, P>,
+fn replay_stream<'a, B: RBlob, A: CodecFixedShared>(
+    blobs: &Blobs<'a, B>,
     bounds: Range<u64>,
     items_per_blob: NonZeroU64,
     start_pos: u64,
     buffer: NonZeroUsize,
-) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send + use<'a, B, A, P>, Error> {
+) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send + use<'a, B, A>, Error> {
     if start_pos > bounds.end {
         return Err(Error::ItemOutOfRange(start_pos));
     }
@@ -180,7 +180,7 @@ fn replay_stream<'a, B: RBlob, A: CodecFixedShared, P: PageCache>(
                 .get(blob)
                 .expect("positions in bounds map to a retained blob");
 
-            states.push(FixedReplayState::<B, A, P> {
+            states.push(FixedReplayState::<B, A> {
                 replay: blob.replay_from(offset, buffer)?,
                 pos: first_pos,
                 end_pos: blob_end,
@@ -194,9 +194,9 @@ fn replay_stream<'a, B: RBlob, A: CodecFixedShared, P: PageCache>(
 }
 
 /// Replay state for one fixed-size blob.
-struct FixedReplayState<'a, B: RBlob, A, P: PageCache> {
+struct FixedReplayState<'a, B: RBlob, A> {
     /// Sequential logical bytes for this blob.
-    replay: BlobReplay<'a, B, P>,
+    replay: BlobReplay<'a, B>,
     /// Next position to yield.
     pos: u64,
     /// Exclusive end position within this blob.
@@ -206,9 +206,7 @@ struct FixedReplayState<'a, B: RBlob, A, P: PageCache> {
     _marker: PhantomData<A>,
 }
 
-impl<B: RBlob, A: CodecFixedShared, P: PageCache> super::ReplayBatchState
-    for FixedReplayState<'_, B, A, P>
-{
+impl<B: RBlob, A: CodecFixedShared> super::ReplayBatchState for FixedReplayState<'_, B, A> {
     type Item = A;
 
     /// Decode the next batch of fixed-size items from this blob.
@@ -288,7 +286,7 @@ struct RecoveredBounds {
 
 /// Configuration for `Journal` storage.
 #[derive(Clone)]
-pub struct Config<P: PageCache = ClockCache> {
+pub struct Config {
     /// Prefix for the journal partitions.
     ///
     /// Blobs are stored in `partition` (legacy) if it contains data, otherwise in
@@ -303,7 +301,7 @@ pub struct Config<P: PageCache = ClockCache> {
     pub items_per_blob: NonZeroU64,
 
     /// The page cache to use for caching data.
-    pub page_cache: CacheRef<P>,
+    pub page_cache: CacheRef,
 
     /// The size of the write buffer to use for each blob.
     pub write_buffer: NonZeroUsize,
@@ -319,9 +317,9 @@ pub struct Config<P: PageCache = ClockCache> {
 /// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
 /// the first invalid data read will be considered the new end of the journal (and the
 /// underlying blob will be truncated to the last valid item). Repair is performed during init.
-pub struct Journal<E: Context, A, P: PageCache = ClockCache> {
+pub struct Journal<E: Context, A> {
     /// The blobs that comprise the journal.
-    blobs: Writable<E, P>,
+    blobs: Writable<E>,
 
     /// The durable recovery checkpoint.
     checkpoint: Checkpoint<E>,
@@ -341,7 +339,7 @@ pub struct Journal<E: Context, A, P: PageCache = ClockCache> {
     _phantom: PhantomData<A>,
 }
 
-impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
+impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Size of each entry in bytes. Evaluating this rejects zero-size item types at compile
     /// time, which would otherwise divide by zero in the chunk math.
     pub const CHUNK_SIZE: NonZeroUsize = match NonZeroUsize::new(A::SIZE) {
@@ -369,7 +367,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
 
     /// Construct a journal from recovered blobs.
     fn from_blobs(
-        blobs: Writable<E, P>,
+        blobs: Writable<E>,
         checkpoint: Checkpoint<E>,
         bounds: Range<u64>,
         dirty_from_blob: Option<u64>,
@@ -391,7 +389,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     ///
     /// All backing blobs are opened but not read during initialization. The `replay` method can be
     /// used to iterate over all items in the `Journal`.
-    pub async fn init(context: E, cfg: Config<P>) -> Result<Self, Error> {
+    pub async fn init(context: E, cfg: Config) -> Result<Self, Error> {
         let checkpoint = Checkpoint::open(context.child("meta"), &cfg.partition).await?;
         Self::init_with_checkpoint(context, cfg, checkpoint).await
     }
@@ -399,7 +397,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     /// Finish initialization using an already-open checkpoint.
     async fn init_with_checkpoint(
         context: E,
-        cfg: Config<P>,
+        cfg: Config,
         mut checkpoint: Checkpoint<E>,
     ) -> Result<Self, Error> {
         // A staged clear intent means all old blob data is about to be discarded. Honor it before
@@ -408,7 +406,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
             return Self::complete_staged_clear(context, cfg, checkpoint, clear_target).await;
         }
 
-        let blob_partition = Partition::<E, P>::select(&context, &cfg.partition).await?;
+        let blob_partition = Partition::select(&context, &cfg.partition).await?;
         let partition = Partition::new(
             context.child("blobs"),
             blob_partition,
@@ -503,14 +501,14 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     /// `clear_target`, then finalize the checkpoint the crashed clear left staged.
     async fn complete_staged_clear(
         context: E,
-        cfg: Config<P>,
+        cfg: Config,
         mut checkpoint: Checkpoint<E>,
         clear_target: u64,
     ) -> Result<Self, Error> {
         warn!(clear_target, "crash repair: completing interrupted clear");
         let new_partition = format!("{}-blobs", cfg.partition);
-        Partition::<E, P>::remove_all(&context, &cfg.partition).await?;
-        Partition::<E, P>::remove_all(&context, &new_partition).await?;
+        Partition::<E>::remove_all(&context, &cfg.partition).await?;
+        Partition::<E>::remove_all(&context, &new_partition).await?;
         let partition = Partition::new(
             context.child("blobs"),
             new_partition,
@@ -541,7 +539,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     /// blob state or a watermark beyond the recovered size is corruption. The caller persists the
     /// checkpoint before applying the returned repair (see comment at the call site).
     fn recover_bounds(
-        pending: &BTreeMap<u64, Writer<E::Blob, P>>,
+        pending: &BTreeMap<u64, Writer<E::Blob>>,
         items_per_blob: u64,
         boundary_hint: Option<u64>,
         watermark_hint: Option<u64>,
@@ -643,7 +641,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     /// Classify a blob's untrusted on-disk length against its capacity. A missing blob counts
     /// as zero length, surfacing as a gap.
     fn classify_fill(
-        pending: &BTreeMap<u64, Writer<E::Blob, P>>,
+        pending: &BTreeMap<u64, Writer<E::Blob>>,
         items_per_blob: u64,
         pruning_boundary: u64,
         blob: u64,
@@ -670,7 +668,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     /// lengths are untrusted disk state. The returned size is chunk-exact and the retained
     /// prefix is contiguous.
     fn recover_by_walking_lengths(
-        pending: &BTreeMap<u64, Writer<E::Blob, P>>,
+        pending: &BTreeMap<u64, Writer<E::Blob>>,
         items_per_blob: u64,
         pruning_boundary: u64,
     ) -> Result<(u64, Option<u64>), Error> {
@@ -719,9 +717,9 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     /// In the event of a crash during this call, upon restart recovery will ensure the journal is
     /// either still in its prior state, or has bounds `size..size`.
     #[commonware_macros::stability(ALPHA)]
-    pub async fn init_at_size(context: E, cfg: Config<P>, size: u64) -> Result<Self, Error> {
+    pub async fn init_at_size(context: E, cfg: Config, size: u64) -> Result<Self, Error> {
         // Fail before writing intent if existing blob partitions are already inconsistent.
-        Partition::<E, P>::select(&context, &cfg.partition).await?;
+        Partition::select(&context, &cfg.partition).await?;
         Self::init_at_size_cleared(context, cfg, size, || async { Ok(()) }).await
     }
 
@@ -734,7 +732,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     #[commonware_macros::stability(ALPHA)]
     pub(in crate::journal::contiguous) async fn init_at_size_cleared<F, Fut>(
         context: E,
-        cfg: Config<P>,
+        cfg: Config,
         size: u64,
         clear_dependents: F,
     ) -> Result<Self, Error>
@@ -764,7 +762,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     /// staged reset this behaves exactly like [Self::init].
     pub(in crate::journal::contiguous) async fn init_cleared<F, Fut>(
         context: E,
-        cfg: Config<P>,
+        cfg: Config,
         clear_dependents: F,
     ) -> Result<Self, Error>
     where
@@ -822,7 +820,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     ///
     /// If the journal later rewinds or truncates into the returned reader's range, subsequent reads
     /// from that range may observe unspecified contents.
-    pub async fn snapshot(&mut self) -> Result<Reader<'static, E, A, P>, Error> {
+    pub async fn snapshot(&mut self) -> Result<Reader<'static, E, A>, Error> {
         Ok(Reader {
             blobs: self.blobs.snapshot().await?,
             bounds: self.bounds.clone(),
@@ -833,7 +831,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
     }
 
     /// A reader borrowing the journal's live state.
-    pub(super) fn reader(&self) -> Reader<'_, E, A, P> {
+    pub(super) fn reader(&self) -> Reader<'_, E, A> {
         Reader {
             blobs: self.blobs.reader(),
             bounds: self.bounds.clone(),
@@ -1132,15 +1130,15 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Journal<E, A, P> {
 }
 
 /// A reader over a fixed journal.
-pub struct Reader<'a, E: Context, A, P: PageCache = ClockCache> {
-    blobs: Blobs<'a, E::Blob, P>,
+pub struct Reader<'a, E: Context, A> {
+    blobs: Blobs<'a, E::Blob>,
     bounds: Range<u64>,
     items_per_blob: NonZeroU64,
     metrics: Arc<Metrics<E>>,
     _phantom: PhantomData<A>,
 }
 
-impl<E: Context, A: CodecFixedShared, P: PageCache> Reader<'_, E, A, P> {
+impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
     /// Validate a position to be read: must lie within `bounds`.
     const fn validate_readable(&self, pos: u64) -> Result<(), Error> {
         if pos >= self.bounds.end {
@@ -1153,7 +1151,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Reader<'_, E, A, P> {
     }
 
     /// Resolve `pos` to its blob and byte offset within the blob.
-    fn locate(&self, pos: u64) -> Result<(Blob<'_, E::Blob, P>, u64), Error> {
+    fn locate(&self, pos: u64) -> Result<(Blob<'_, E::Blob>, u64), Error> {
         self.validate_readable(pos)?;
         let items_per_blob = self.items_per_blob.get();
         let blob = super::position_to_blob(pos, items_per_blob);
@@ -1177,9 +1175,8 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Reader<'_, E, A, P> {
     }
 }
 
-impl<E: Context, A: CodecFixedShared, P: PageCache> super::Contiguous for Reader<'_, E, A, P> {
+impl<E: Context, A: CodecFixedShared> super::Contiguous for Reader<'_, E, A> {
     type Item = A;
-    type PageCache = P;
 
     fn bounds(&self) -> Range<u64> {
         self.bounds.clone()
@@ -1293,9 +1290,8 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> super::Contiguous for Reader
     }
 }
 
-impl<E: Context, A: CodecFixedShared, P: PageCache> super::Contiguous for Journal<E, A, P> {
+impl<E: Context, A: CodecFixedShared> super::Contiguous for Journal<E, A> {
     type Item = A;
-    type PageCache = P;
 
     fn bounds(&self) -> Range<u64> {
         self.bounds.clone()
@@ -1329,7 +1325,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> super::Contiguous for Journa
     }
 }
 
-impl<E: Context, A: CodecFixedShared, P: PageCache> Mutable for Journal<E, A, P> {
+impl<E: Context, A: CodecFixedShared> Mutable for Journal<E, A> {
     async fn append(&mut self, item: &Self::Item) -> Result<u64, Error> {
         Self::append(self, item).await
     }
@@ -1360,8 +1356,8 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> Mutable for Journal<E, A, P>
 }
 
 #[commonware_macros::stability(ALPHA)]
-impl<E: Context, A: CodecFixedShared, P: PageCache> authenticated::Inner<E> for Journal<E, A, P> {
-    type Config = Config<P>;
+impl<E: Context, A: CodecFixedShared> authenticated::Inner<E> for Journal<E, A> {
+    type Config = Config;
 
     async fn init<
         F: merkle::Family,
@@ -1369,7 +1365,7 @@ impl<E: Context, A: CodecFixedShared, P: PageCache> authenticated::Inner<E> for 
         S: commonware_parallel::Strategy,
     >(
         context: E,
-        merkle_cfg: merkle::full::Config<S, P>,
+        merkle_cfg: merkle::full::Config<S>,
         journal_cfg: Self::Config,
         rewind_predicate: fn(&A) -> bool,
         bagging: merkle::Bagging,

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -8,7 +8,6 @@
 //! leave its in-memory state inconsistent with the underlying storage.
 
 use super::Error;
-use commonware_runtime::buffer::paged::PageCache;
 use futures::{stream, Stream, StreamExt as _};
 use std::{future::Future, num::NonZeroUsize, ops::Range};
 use tracing::warn;
@@ -156,9 +155,6 @@ where
 pub trait Contiguous: Send + Sync {
     /// The type of items stored in the journal.
     type Item: Send;
-
-    /// The page cache implementation this journal reads through.
-    type PageCache: PageCache;
 
     /// Returns [start, end) with a guaranteed stable pruning boundary.
     fn bounds(&self) -> Range<u64>;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -25,7 +25,7 @@ use crate::{
 use commonware_codec::{varint::MAX_U32_VARINT_SIZE, Codec, CodecShared};
 use commonware_macros::boxed;
 use commonware_runtime::{
-    buffer::paged::{CacheRef, ClockCache, PageCache, Replay, Writer},
+    buffer::paged::{CacheRef, Replay, Writer},
     Blob as RBlob, Buf, IoBuf,
 };
 use commonware_utils::NZUsize;
@@ -164,11 +164,11 @@ struct BlobScan {
 ///
 /// Unlike fixed replay, each yielded item must first decode a varint frame length. The byte
 /// `budget` caps how much frame data this state emits in one stream batch.
-struct ReplayState<'a, B: RBlob, V: Codec, P: PageCache> {
+struct ReplayState<'a, B: RBlob, V: Codec> {
     /// Blob index, used in corruption messages.
     blob: u64,
     /// Sequential logical bytes for this blob.
-    replay: BlobReplay<'a, B, P>,
+    replay: BlobReplay<'a, B>,
     /// Target maximum number of encoded bytes decoded per batch.
     budget: u64,
     /// Next position to yield.
@@ -184,7 +184,7 @@ struct ReplayState<'a, B: RBlob, V: Codec, P: PageCache> {
     _marker: PhantomData<V>,
 }
 
-impl<B: RBlob, V: CodecShared, P: PageCache> super::ReplayBatchState for ReplayState<'_, B, V, P> {
+impl<B: RBlob, V: CodecShared> super::ReplayBatchState for ReplayState<'_, B, V> {
     type Item = V;
 
     /// Decode the next batch of varint-framed items from this blob.
@@ -312,7 +312,7 @@ impl<B: RBlob, V: CodecShared, P: PageCache> super::ReplayBatchState for ReplayS
 
 /// Configuration for a [Journal].
 #[derive(Clone)]
-pub struct Config<C, P: PageCache = ClockCache> {
+pub struct Config<C> {
     /// Base partition name. Sub-partitions will be created by appending DATA_SUFFIX and OFFSETS_SUFFIX.
     pub partition: String,
 
@@ -329,13 +329,13 @@ pub struct Config<C, P: PageCache = ClockCache> {
     pub codec_config: C,
 
     /// Page cache for buffering reads from the underlying storage.
-    pub page_cache: CacheRef<P>,
+    pub page_cache: CacheRef,
 
     /// Write buffer size for each blob.
     pub write_buffer: NonZeroUsize,
 }
 
-impl<C, P: PageCache> Config<C, P> {
+impl<C> Config<C> {
     /// Returns the partition name for the data blobs.
     fn data_partition(&self) -> String {
         format!("{}{}", self.partition, DATA_SUFFIX)
@@ -388,13 +388,13 @@ impl<C, P: PageCache> Config<C, P> {
 /// below the recovered offsets start or beyond the retained data prefix, init falls back to the
 /// offsets start. Replay after the anchor stops at the first short data blob and truncates newer
 /// blobs so the recovered journal remains a contiguous prefix.
-pub struct Journal<E: Context, V: Codec, P: PageCache = ClockCache> {
+pub struct Journal<E: Context, V: Codec> {
     /// The data blobs: sealed history plus the writable tail.
-    blobs: Writable<E, P>,
+    blobs: Writable<E>,
 
     /// Index mapping positions to byte offsets within their data blob. Its checkpoint is also
     /// this journal's durable recovery record.
-    offsets: fixed::Journal<E, u64, P>,
+    offsets: fixed::Journal<E, u64>,
 
     /// The readable positions; `bounds.end` is the next append position.
     bounds: Range<u64>,
@@ -421,15 +421,15 @@ pub struct Journal<E: Context, V: Codec, P: PageCache = ClockCache> {
 }
 
 /// A reader over a variable journal.
-pub struct Reader<'a, E: Context, V: Codec, P: PageCache = ClockCache> {
+pub struct Reader<'a, E: Context, V: Codec> {
     /// The journal's data blobs.
-    data: Blobs<'a, E::Blob, P>,
+    data: Blobs<'a, E::Blob>,
 
     /// The readable position range `[start, end)`.
     bounds: Range<u64>,
 
     /// Maps positions to byte offsets within the data blobs.
-    offsets: fixed::Reader<'a, E, u64, P>,
+    offsets: fixed::Reader<'a, E, u64>,
 
     /// The number of items in each blob.
     items_per_blob: NonZeroU64,
@@ -444,7 +444,7 @@ pub struct Reader<'a, E: Context, V: Codec, P: PageCache = ClockCache> {
     metrics: Arc<Metrics<E>>,
 }
 
-impl<'a, E: Context, V: CodecShared, P: PageCache> Reader<'a, E, V, P> {
+impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
     /// Validate a position to be read: must lie within `bounds`.
     const fn validate_readable(&self, position: u64) -> Result<(), Error> {
         if position >= self.bounds.end {
@@ -457,7 +457,7 @@ impl<'a, E: Context, V: CodecShared, P: PageCache> Reader<'a, E, V, P> {
     }
 
     /// Read the varint-framed item at byte `offset` via `blob`.
-    async fn read_at_offset(&self, blob: &Blob<'_, E::Blob, P>, offset: u64) -> Result<V, Error> {
+    async fn read_at_offset(&self, blob: &Blob<'_, E::Blob>, offset: u64) -> Result<V, Error> {
         read_frame_at(blob, offset, &self.codec_config, self.compressed)
             .await
             .map(|(_, _, item)| item)
@@ -471,7 +471,7 @@ impl<'a, E: Context, V: CodecShared, P: PageCache> Reader<'a, E, V, P> {
     /// strictly increasing.
     async fn read_consecutive(
         &self,
-        blob_handle: &Blob<'_, E::Blob, P>,
+        blob_handle: &Blob<'_, E::Blob>,
         blob: u64,
         offsets: &[u64],
     ) -> Result<Vec<V>, Error> {
@@ -607,7 +607,7 @@ impl<'a, E: Context, V: CodecShared, P: PageCache> Reader<'a, E, V, P> {
         &self,
         start_pos: u64,
         buffer: NonZeroUsize,
-    ) -> Result<Vec<ReplayState<'a, E::Blob, V, P>>, Error> {
+    ) -> Result<Vec<ReplayState<'a, E::Blob, V>>, Error> {
         let bounds = self.bounds();
         if start_pos > bounds.end {
             return Err(Error::ItemOutOfRange(start_pos));
@@ -641,7 +641,7 @@ impl<'a, E: Context, V: CodecShared, P: PageCache> Reader<'a, E, V, P> {
 
                 // Store codec settings in the state because the stream owns states across await
                 // points and cannot borrow `self`.
-                states.push(ReplayState::<E::Blob, V, P> {
+                states.push(ReplayState::<E::Blob, V> {
                     blob,
                     replay: blob_handle.replay_from(offset, buffer)?,
                     budget: buffer.get() as u64,
@@ -659,9 +659,8 @@ impl<'a, E: Context, V: CodecShared, P: PageCache> Reader<'a, E, V, P> {
     }
 }
 
-impl<E: Context, V: CodecShared, P: PageCache> super::Contiguous for Reader<'_, E, V, P> {
+impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
     type Item = V;
-    type PageCache = P;
 
     fn bounds(&self) -> Range<u64> {
         self.bounds.clone()
@@ -804,7 +803,7 @@ impl<E: Context, V: CodecShared, P: PageCache> super::Contiguous for Reader<'_, 
     }
 }
 
-impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
+impl<E: Context, V: CodecShared> Journal<E, V> {
     /// Mark all data blobs from `blob` onward as dirty.
     fn mark_dirty_from(&mut self, blob: u64) {
         self.dirty_from_blob = Some(
@@ -820,7 +819,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     /// The data blobs are the source of truth. If the offsets journal is inconsistent
     /// it will be updated to match the data blobs.
     #[boxed]
-    pub async fn init(context: E, cfg: Config<V::Cfg, P>) -> Result<Self, Error> {
+    pub async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
         let items_per_blob = cfg.items_per_section.get();
         let data_partition = cfg.data_partition();
         let data_context = context.child("data");
@@ -828,7 +827,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
         // If a prior `init_at_size`/`clear_to_size` crashed mid-reset, the offsets journal
         // carries a staged clear. `init_cleared` discards the data partition before finishing
         // that reset so stale data is never replayed past the reset size.
-        let mut offsets = fixed::Journal::<E, u64, P>::init_cleared(
+        let mut offsets = fixed::Journal::<E, u64>::init_cleared(
             context.child("offsets"),
             fixed::Config {
                 partition: cfg.offsets_partition(),
@@ -836,7 +835,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
                 page_cache: cfg.page_cache.clone(),
                 write_buffer: cfg.write_buffer,
             },
-            || Partition::<E, P>::remove_all(&data_context, &data_partition),
+            || Partition::<E>::remove_all(&data_context, &data_partition),
         )
         .await?;
 
@@ -891,11 +890,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     /// Returns a journal with journal.bounds() == Range{start: size, end: size}
     /// and next append at position `size`.
     #[commonware_macros::stability(ALPHA)]
-    pub async fn init_at_size(
-        context: E,
-        cfg: Config<V::Cfg, P>,
-        size: u64,
-    ) -> Result<Self, Error> {
+    pub async fn init_at_size(context: E, cfg: Config<V::Cfg>, size: u64) -> Result<Self, Error> {
         let items_per_blob = cfg.items_per_section.get();
         let data_partition = cfg.data_partition();
         let data_context = context.child("data");
@@ -903,7 +898,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
         // `init_at_size_cleared` durably stages the offsets reset, clears the data partition,
         // then completes the reset. A crash at any point leaves a staged clear that the next
         // `init` (via `init_cleared`) finishes, so stale data can never outlive the reset.
-        let offsets = fixed::Journal::<E, u64, P>::init_at_size_cleared(
+        let offsets = fixed::Journal::<E, u64>::init_at_size_cleared(
             context.child("offsets"),
             fixed::Config {
                 partition: cfg.offsets_partition(),
@@ -912,7 +907,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
                 write_buffer: cfg.write_buffer,
             },
             size,
-            || Partition::<E, P>::remove_all(&data_context, &data_partition),
+            || Partition::<E>::remove_all(&data_context, &data_partition),
         )
         .await?;
 
@@ -972,7 +967,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     #[commonware_macros::stability(ALPHA)]
     pub(crate) async fn init_sync(
         context: E,
-        cfg: Config<V::Cfg, P>,
+        cfg: Config<V::Cfg>,
         range: Range<u64>,
     ) -> Result<Self, Error> {
         assert!(!range.is_empty(), "range must not be empty");
@@ -1260,7 +1255,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     ///
     /// If the journal later rewinds into the returned reader's range, subsequent reads
     /// from that range may observe unspecified contents.
-    pub async fn snapshot(&mut self) -> Result<Reader<'static, E, V, P>, Error> {
+    pub async fn snapshot(&mut self) -> Result<Reader<'static, E, V>, Error> {
         Ok(Reader {
             data: self.blobs.snapshot().await?,
             bounds: self.bounds.clone(),
@@ -1273,7 +1268,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     }
 
     /// A reader borrowing the journal's live state.
-    fn reader(&self) -> Reader<'_, E, V, P> {
+    fn reader(&self) -> Reader<'_, E, V> {
         Reader {
             data: self.blobs.reader(),
             bounds: self.bounds.clone(),
@@ -1403,7 +1398,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
 
     /// Scan every frame in `writer`, returning the item count and valid prefix.
     async fn scan_blob(
-        writer: &mut Writer<E::Blob, P>,
+        writer: &mut Writer<E::Blob>,
         codec_config: &V::Cfg,
         compressed: bool,
     ) -> Result<BlobScan, Error> {
@@ -1436,9 +1431,9 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     ///
     /// Returns the recovered bounds (`pruning_boundary..size`).
     async fn align(
-        partition: &Partition<E, P>,
-        pending: &mut BTreeMap<u64, Writer<E::Blob, P>>,
-        offsets: &mut fixed::Journal<E, u64, P>,
+        partition: &Partition<E>,
+        pending: &mut BTreeMap<u64, Writer<E::Blob>>,
+        offsets: &mut fixed::Journal<E, u64>,
         items_per_blob: u64,
         codec_config: &V::Cfg,
         compressed: bool,
@@ -1621,9 +1616,9 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     /// is legitimate after a clean restart, or the artifact of a rewind, prune-all, or
     /// first-append crash.
     async fn align_empty(
-        partition: &Partition<E, P>,
-        pending: &mut BTreeMap<u64, Writer<E::Blob, P>>,
-        offsets: &mut fixed::Journal<E, u64, P>,
+        partition: &Partition<E>,
+        pending: &mut BTreeMap<u64, Writer<E::Blob>>,
+        offsets: &mut fixed::Journal<E, u64>,
         items_per_blob: u64,
     ) -> Result<Range<u64>, Error> {
         let offsets_bounds = offsets.pruning_boundary()..offsets.size();
@@ -1666,7 +1661,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     /// Choose the position to rebuild offsets from: the persisted recovery watermark when it is
     /// usable, otherwise the offsets pruning boundary.
     fn recovery_anchor(
-        offsets: &fixed::Journal<E, u64, P>,
+        offsets: &fixed::Journal<E, u64>,
         offsets_bounds: &Range<u64>,
         retained_data_end_bound: u64,
     ) -> Result<u64, Error> {
@@ -1695,7 +1690,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
 
     /// Sync data blobs backing rebuilt offsets before the offsets are made durable.
     async fn sync_data_range(
-        pending: &mut BTreeMap<u64, Writer<E::Blob, P>>,
+        pending: &mut BTreeMap<u64, Writer<E::Blob>>,
         start_position: u64,
         end_position: u64,
         items_per_blob: u64,
@@ -1722,9 +1717,9 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     /// earlier point. If replay finds a short blob after the anchor, recovery truncates newer
     /// blobs and returns the contiguous data-backed size.
     async fn rebuild_offsets_from_anchor(
-        partition: &Partition<E, P>,
-        pending: &mut BTreeMap<u64, Writer<E::Blob, P>>,
-        offsets: &mut fixed::Journal<E, u64, P>,
+        partition: &Partition<E>,
+        pending: &mut BTreeMap<u64, Writer<E::Blob>>,
+        offsets: &mut fixed::Journal<E, u64>,
         items_per_blob: u64,
         anchor: u64,
         codec_config: &V::Cfg,
@@ -1839,8 +1834,8 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
 
     /// Remove every blob newer than `blob`, newest-first so a crash leaves a contiguous prefix.
     async fn remove_blobs_after(
-        partition: &Partition<E, P>,
-        pending: &mut BTreeMap<u64, Writer<E::Blob, P>>,
+        partition: &Partition<E>,
+        pending: &mut BTreeMap<u64, Writer<E::Blob>>,
         blob: u64,
     ) -> Result<(), Error> {
         while let Some((&newest, _)) = pending.last_key_value() {
@@ -1854,9 +1849,8 @@ impl<E: Context, V: CodecShared, P: PageCache> Journal<E, V, P> {
     }
 }
 
-impl<E: Context, V: CodecShared, P: PageCache> Contiguous for Journal<E, V, P> {
+impl<E: Context, V: CodecShared> Contiguous for Journal<E, V> {
     type Item = V;
-    type PageCache = P;
 
     fn bounds(&self) -> Range<u64> {
         self.bounds.clone()
@@ -1886,7 +1880,7 @@ impl<E: Context, V: CodecShared, P: PageCache> Contiguous for Journal<E, V, P> {
     }
 }
 
-impl<E: Context, V: CodecShared, P: PageCache> Mutable for Journal<E, V, P> {
+impl<E: Context, V: CodecShared> Mutable for Journal<E, V> {
     async fn append(&mut self, item: &Self::Item) -> Result<u64, Error> {
         Self::append(self, item).await
     }
@@ -1917,8 +1911,8 @@ impl<E: Context, V: CodecShared, P: PageCache> Mutable for Journal<E, V, P> {
 }
 
 #[commonware_macros::stability(ALPHA)]
-impl<E: Context, V: CodecShared, P: PageCache> authenticated::Inner<E> for Journal<E, V, P> {
-    type Config = Config<V::Cfg, P>;
+impl<E: Context, V: CodecShared> authenticated::Inner<E> for Journal<E, V> {
+    type Config = Config<V::Cfg>;
 
     async fn init<
         F: merkle::Family,
@@ -1926,7 +1920,7 @@ impl<E: Context, V: CodecShared, P: PageCache> authenticated::Inner<E> for Journ
         S: commonware_parallel::Strategy,
     >(
         context: E,
-        merkle_cfg: merkle::full::Config<S, P>,
+        merkle_cfg: merkle::full::Config<S>,
         journal_cfg: Self::Config,
         rewind_predicate: fn(&V) -> bool,
         bagging: merkle::Bagging,
@@ -2609,7 +2603,7 @@ mod tests {
                 let mut states = Vec::new();
                 for (blob_index, writer) in writers.iter().enumerate() {
                     let blob = blob_index as u64;
-                    states.push(ReplayState::<_, u64, _> {
+                    states.push(ReplayState::<_, u64> {
                         blob,
                         replay: Blob::Writer(writer).replay_from(0, NZUsize!(1024)).unwrap(),
                         budget: 1024,
@@ -3817,7 +3811,7 @@ mod tests {
             assert!(result.is_none());
 
             drop(pending);
-            Partition::<deterministic::Context, ClockCache>::remove_all(
+            Partition::<deterministic::Context>::remove_all(
                 &context,
                 "rebuild-anchor-outside-data",
             )
@@ -4855,7 +4849,7 @@ mod tests {
                 .unwrap();
 
                 if clear_data {
-                    Partition::<deterministic::Context, ClockCache>::remove_all(
+                    Partition::<deterministic::Context>::remove_all(
                         &context,
                         &cfg.data_partition(),
                     )
@@ -5137,12 +5131,9 @@ mod tests {
 
             // Simulate crash after data was cleared but before offsets were pruned.
             drop(journal);
-            Partition::<deterministic::Context, ClockCache>::remove_all(
-                &context,
-                &cfg.data_partition(),
-            )
-            .await
-            .unwrap();
+            Partition::<deterministic::Context>::remove_all(&context, &cfg.data_partition())
+                .await
+                .unwrap();
 
             // Phase 2: Init triggers data-empty repair and should treat journal as fully pruned at size 7.
             let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -25,10 +25,7 @@ use crate::{
 use commonware_codec::{DecodeExt, Write};
 use commonware_cryptography::Digest;
 use commonware_parallel::Strategy;
-use commonware_runtime::{
-    buffer::paged::{CacheRef, ClockCache, PageCache},
-    Clock, Metrics, Storage as RStorage,
-};
+use commonware_runtime::{buffer::paged::CacheRef, Clock, Metrics, Storage as RStorage};
 use commonware_utils::{range::NonEmptyRange, sequence::prefixed_u64::U64};
 use std::{
     collections::BTreeMap,
@@ -97,7 +94,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 
 /// Configuration for a journal-backed Merkle structure.
 #[derive(Clone)]
-pub struct Config<S: Strategy, P: PageCache = ClockCache> {
+pub struct Config<S: Strategy> {
     /// The name of the `commonware-runtime::Storage` storage partition used for the journal storing
     /// the nodes.
     pub journal_partition: String,
@@ -117,7 +114,7 @@ pub struct Config<S: Strategy, P: PageCache = ClockCache> {
     pub strategy: S,
 
     /// The page cache to use for caching data.
-    pub page_cache: CacheRef<P>,
+    pub page_cache: CacheRef,
 }
 
 /// Configuration for initializing a full Merkle structure for synchronization.
@@ -126,9 +123,9 @@ pub struct Config<S: Strategy, P: PageCache = ClockCache> {
 /// - **Fresh Start**: Existing data < range start -> discard and start fresh
 /// - **Prune and Reuse**: range contains existing data -> prune and reuse
 /// - **Error**: existing data > range end
-pub struct SyncConfig<F: Family, D: Digest, S: Strategy, P: PageCache = ClockCache> {
+pub struct SyncConfig<F: Family, D: Digest, S: Strategy> {
     /// Base configuration (journal, metadata, etc.)
-    pub config: Config<S, P>,
+    pub config: Config<S>,
 
     /// Sync range expressed as leaf-aligned bounds.
     pub range: NonEmptyRange<Location<F>>,
@@ -140,13 +137,7 @@ pub struct SyncConfig<F: Family, D: Digest, S: Strategy, P: PageCache = ClockCac
 }
 
 /// A Merkle structure backed by a fixed-item-length journal.
-pub struct Merkle<
-    F: Family,
-    E: RStorage + Clock + Metrics,
-    D: Digest,
-    S: Strategy,
-    P: PageCache = ClockCache,
-> {
+pub struct Merkle<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> {
     /// A memory resident Merkle structure used to build the structure and cache updates. It caches
     /// all un-synced nodes, and the pinned node set as derived from both its own pruning boundary
     /// and the full structure's pruning boundary.
@@ -157,7 +148,7 @@ pub struct Merkle<
     pub(crate) pruned_to_pos: Position<F>,
 
     /// Stores all unpruned nodes.
-    pub(crate) journal: Journal<E, D, P>,
+    pub(crate) journal: Journal<E, D>,
 
     /// Stores the pinned nodes for the current pruning boundary, and the corresponding pruning
     /// boundary used to generate them. The metadata remains empty until pruning is invoked, and its
@@ -177,9 +168,7 @@ const NODE_PREFIX: u8 = 0;
 /// Prefix used for the key storing the pruning boundary (as a leaf index) in the metadata.
 pub(crate) const PRUNED_TO_PREFIX: u8 = 1;
 
-impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy, P: PageCache>
-    Merkle<F, E, D, S, P>
-{
+impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// Return the total number of nodes in the structure, irrespective of any pruning. The next
     /// added element's position will have this value.
     pub fn size(&self) -> Position<F> {
@@ -196,7 +185,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy, P: PageCa
     /// error otherwise.
     async fn get_from_metadata_or_journal(
         metadata: &Metadata<E, U64, Vec<u8>>,
-        journal: &Journal<E, D, P>,
+        journal: &Journal<E, D>,
         pos: Position<F>,
     ) -> Result<D, Error<F>> {
         if let Some(bytes) = metadata.get(&U64::new(NODE_PREFIX, *pos)) {
@@ -238,7 +227,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy, P: PageCa
     async fn add_extra_pinned_nodes(
         mem: &mut Mem<F, D>,
         metadata: &Metadata<E, U64, Vec<u8>>,
-        journal: &Journal<E, D, P>,
+        journal: &Journal<E, D>,
         prune_pos: Position<F>,
     ) -> Result<(), Error<F>> {
         let prune_loc = Location::try_from(prune_pos).expect("valid prune_pos");
@@ -256,7 +245,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy, P: PageCa
     pub async fn init(
         context: E,
         hasher: &impl Hasher<F, Digest = D>,
-        cfg: Config<S, P>,
+        cfg: Config<S>,
     ) -> Result<Self, Error<F>> {
         let journal_cfg = JConfig {
             partition: cfg.journal_partition,
@@ -265,7 +254,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy, P: PageCa
             write_buffer: cfg.write_buffer,
         };
         let mut journal =
-            Journal::<E, D, P>::init(context.child("merkle_journal"), journal_cfg).await?;
+            Journal::<E, D>::init(context.child("merkle_journal"), journal_cfg).await?;
         let mut journal_size = Position::<F>::new(journal.size());
 
         let metadata_cfg = MConfig {
@@ -435,7 +424,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy, P: PageCa
     ///
     /// 3. **Error**: existing_size > range.end
     ///    - Returns [crate::journal::Error::ItemOutOfRange]
-    pub async fn init_sync(context: E, cfg: SyncConfig<F, D, S, P>) -> Result<Self, Error<F>> {
+    pub async fn init_sync(context: E, cfg: SyncConfig<F, D, S>) -> Result<Self, Error<F>> {
         let prune_pos = Position::try_from(cfg.range.start())?;
         let end_pos = Position::try_from(cfg.range.end())?;
         let journal_cfg = JConfig {
@@ -446,7 +435,7 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy, P: PageCa
         };
 
         // Open the journal, performing a rewind if necessary for crash recovery.
-        let mut journal: Journal<E, D, P> =
+        let mut journal: Journal<E, D> =
             Journal::init(context.child("merkle_journal"), journal_cfg).await?;
         let mut journal_size = Position::<F>::new(journal.size());
 
@@ -907,8 +896,8 @@ impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Readable
     }
 }
 
-impl<F: Family, E: RStorage + Clock + Metrics + Sync, D: Digest, S: Strategy, P: PageCache>
-    crate::merkle::storage::Storage<F> for Merkle<F, E, D, S, P>
+impl<F: Family, E: RStorage + Clock + Metrics + Sync, D: Digest, S: Strategy>
+    crate::merkle::storage::Storage<F> for Merkle<F, E, D, S>
 {
     type Digest = D;
 
@@ -921,9 +910,7 @@ impl<F: Family, E: RStorage + Clock + Metrics + Sync, D: Digest, S: Strategy, P:
     }
 }
 
-impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy, P: PageCache>
-    Merkle<F, E, D, S, P>
-{
+impl<F: Family, E: RStorage + Clock + Metrics, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// Return an inclusion proof for the element at the location `loc` against a historical
     /// state with `leaves` leaves.
     ///

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -83,7 +83,6 @@ use commonware_codec::CodecShared;
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use commonware_runtime::buffer::paged::{ClockCache, PageCache};
 use core::num::NonZeroUsize;
 use std::sync::Arc;
 use tracing::warn;
@@ -103,9 +102,9 @@ pub(crate) const BITMAP_CHUNK_BYTES: usize = 64;
 
 /// Configuration for an `Any` authenticated db.
 #[derive(Clone)]
-pub struct Config<T: Translator, J, S: Strategy, P: PageCache = ClockCache> {
+pub struct Config<T: Translator, J, S: Strategy> {
     /// Configuration for the Merkle structure backing the authenticated journal.
-    pub merkle_config: MerkleConfig<S, P>,
+    pub merkle_config: MerkleConfig<S>,
 
     /// Configuration for the operations log journal.
     pub journal_config: J,
@@ -119,15 +118,15 @@ pub struct Config<T: Translator, J, S: Strategy, P: PageCache = ClockCache> {
 }
 
 /// Configuration for an `Any` authenticated db with fixed-size values.
-pub type FixedConfig<T, S, P = ClockCache> = Config<T, FConfig<P>, S, P>;
+pub type FixedConfig<T, S> = Config<T, FConfig, S>;
 
 /// Configuration for an `Any` authenticated db with variable-sized values.
-pub type VariableConfig<T, C, S, P = ClockCache> = Config<T, VConfig<C, P>, S, P>;
+pub type VariableConfig<T, C, S> = Config<T, VConfig<C>, S>;
 
 /// Initialize an `Any` authenticated db from the given config.
 pub async fn init<F, E, U, H, T, I, J, S>(
     context: E,
-    cfg: Config<T, J::Config, S, J::PageCache>,
+    cfg: Config<T, J::Config, S>,
 ) -> Result<db::Db<F, E, J, I, H, U, BITMAP_CHUNK_BYTES, S>, crate::qmdb::Error<F>>
 where
     F: Family,
@@ -148,7 +147,7 @@ where
 #[boxed]
 pub(crate) async fn init_with_bitmap<F, E, U, H, T, I, J, S, const N: usize>(
     context: E,
-    cfg: Config<T, J::Config, S, J::PageCache>,
+    cfg: Config<T, J::Config, S>,
     bitmap: Option<Arc<Shared<N>>>,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use commonware_runtime::buffer::paged::{ClockCache, PageCache};
 use commonware_utils::Array;
 
 pub type Update<K, V> = ordered::Update<K, FixedEncoding<V>>;
@@ -25,10 +24,10 @@ pub type Operation<F, K, V> = ordered::Operation<F, K, FixedEncoding<V>>;
 
 /// A key-value QMDB based on an authenticated log of operations, supporting authentication of any
 /// value ever associated with a key.
-pub type Db<F, E, K, V, H, T, S, P = ClockCache> = super::Db<
+pub type Db<F, E, K, V, H, T, S> = super::Db<
     F,
     E,
-    Journal<E, Operation<F, K, V>, P>,
+    Journal<E, Operation<F, K, V>>,
     Index<T, Location<F>>,
     H,
     Update<K, V>,
@@ -36,20 +35,12 @@ pub type Db<F, E, K, V, H, T, S, P = ClockCache> = super::Db<
     S,
 >;
 
-impl<
-        F: Family,
-        E: Context,
-        K: Array,
-        V: FixedValue,
-        H: Hasher,
-        T: Translator,
-        S: Strategy,
-        P: PageCache,
-    > Db<F, E, K, V, H, T, S, P>
+impl<F: Family, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator, S: Strategy>
+    Db<F, E, K, V, H, T, S>
 {
     /// Returns a [Db] qmdb initialized from `cfg`. Any uncommitted log operations will be
     /// discarded and the state of the db will be as of the last committed operation.
-    pub async fn init(context: E, cfg: Config<T, S, P>) -> Result<Self, Error<F>> {
+    pub async fn init(context: E, cfg: Config<T, S>) -> Result<Self, Error<F>> {
         crate::qmdb::any::init(context, cfg).await
     }
 }

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -55,7 +55,7 @@ pub(crate) mod tests;
 #[allow(clippy::too_many_arguments)]
 async fn build_db<F, E, U, I, H, C, T, S>(
     context: E,
-    merkle_config: full::Config<S, C::PageCache>,
+    merkle_config: full::Config<S>,
     log: C,
     translator: T,
     pinned_nodes: Option<Vec<H::Digest>>,
@@ -76,7 +76,7 @@ where
 {
     let hasher = qmdb::hasher::<H>();
 
-    let merkle = full::Merkle::<F, _, _, S, _>::init_sync(
+    let merkle = full::Merkle::<F, _, _, S>::init_sync(
         context.child("merkle"),
         full::SyncConfig {
             config: merkle_config,

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -3,11 +3,7 @@
 
 use commonware_cryptography::{DigestOf, Hasher as _, Sha256};
 use commonware_parallel::Rayon;
-use commonware_runtime::{
-    buffer::paged::{CacheRef, ClockCache, PageCache},
-    tokio::Context,
-    BufferPooler, ThreadPooler,
-};
+use commonware_runtime::{buffer::paged::CacheRef, tokio::Context, BufferPooler, ThreadPooler};
 use commonware_storage::{
     journal::contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     merkle::{self, full::Config as MerkleConfig, Family},
@@ -54,8 +50,7 @@ pub const INIT_CACHE_SIZE: Option<NonZeroUsize> = Some(NZUsize!(1 << 18));
 // -- Fixed value (Digest), fixed storage layout --
 
 pub type AnyUFixDb<F> = UFixed<F, Context, Digest, Digest, Sha256, EightCap, Rayon>;
-pub type AnyOFixDb<F, P = ClockCache> =
-    OFixed<F, Context, Digest, Digest, Sha256, EightCap, Rayon, P>;
+pub type AnyOFixDb<F> = OFixed<F, Context, Digest, Digest, Sha256, EightCap, Rayon>;
 /// Ordered "any" DB with a partitioned snapshot index (256 partitions, P=1). Exercises the
 /// partitioned ordered index's cursor (get_mut/find/update) on apply.
 pub type AnyOFixP256Db<F> = OFixP256<F, Context, Digest, Digest, Sha256, EightCap, Rayon>;
@@ -102,12 +97,12 @@ const PARTITION_VAR: &str = "bench-variable";
 const PARTITION_KEYLESS: &str = "bench-keyless";
 const PARTITION_IMM: &str = "bench-immutable";
 
-fn merkle_cfg<P: PageCache>(
+fn merkle_cfg(
     suffix: &str,
     ctx: &(impl BufferPooler + ThreadPooler),
-    page_cache: CacheRef<P>,
+    page_cache: CacheRef,
     items_per_blob: NonZeroU64,
-) -> MerkleConfig<Rayon, P> {
+) -> MerkleConfig<Rayon> {
     MerkleConfig {
         journal_partition: format!("journal-{suffix}"),
         metadata_partition: format!("metadata-{suffix}"),
@@ -118,11 +113,7 @@ fn merkle_cfg<P: PageCache>(
     }
 }
 
-fn fix_log_cfg<P: PageCache>(
-    suffix: &str,
-    page_cache: CacheRef<P>,
-    items_per_blob: NonZeroU64,
-) -> FConfig<P> {
+fn fix_log_cfg(suffix: &str, page_cache: CacheRef, items_per_blob: NonZeroU64) -> FConfig {
     FConfig {
         partition: format!("log-journal-{suffix}"),
         items_per_blob,
@@ -154,11 +145,11 @@ pub fn any_fix_cfg(ctx: &(impl BufferPooler + ThreadPooler)) -> AnyFixedConfig<E
 
 /// [any_fix_cfg], with explicit blob sizing and page cache (a database must be reopened with the
 /// page size it was written with).
-pub fn any_fix_cfg_with<P: PageCache>(
+pub fn any_fix_cfg_with(
     ctx: &(impl BufferPooler + ThreadPooler),
     items_per_blob: NonZeroU64,
-    page_cache: CacheRef<P>,
-) -> AnyFixedConfig<EightCap, Rayon, P> {
+    page_cache: CacheRef,
+) -> AnyFixedConfig<EightCap, Rayon> {
     AnyFixedConfig {
         merkle_config: merkle_cfg(PARTITION_FIX, ctx, page_cache.clone(), items_per_blob),
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),

--- a/storage/src/qmdb/benches/scale.rs
+++ b/storage/src/qmdb/benches/scale.rs
@@ -38,9 +38,9 @@
 //! the OS page cache in-process (init's replay warms it) and runs a cold pass of `num_gets`
 //! uniform-random gets across that many spawned reader tasks, followed by a warm pass over the same
 //! keys as a control. Keys are sampled the same way `generate` derives them (`Sha256(index)` over
-//! the keyspace), so nearly all gets hit a live key. By default this mode uses `NoCache` (no
-//! in-process caching) so reads always reach the storage layer; pass a non-zero `cache_pages` to
-//! measure through an in-process cache of that many pages instead.
+//! the keyspace), so nearly all gets hit a live key. By default this mode performs no in-process
+//! caching so reads always reach the storage layer; pass a non-zero `cache_pages` to measure
+//! through an in-process cache of that many pages instead.
 
 #[allow(dead_code, unused_imports, unused_macros)]
 #[path = "common.rs"]
@@ -49,7 +49,7 @@ mod common;
 use common::{any_fix_cfg_with, gen_random_kv, make_fixed_value, AnyOFixDb, PAGE_SIZE};
 use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_runtime::{
-    buffer::paged::{CacheRef, PageCache},
+    buffer::paged::CacheRef,
     tokio::{Config, Context, Runner},
     Runner as _, Spawner as _, Supervisor as _,
 };
@@ -150,8 +150,8 @@ fn main() {
                     usage();
                     return;
                 };
-                // Optional in-process page cache size (7th arg): omitted or `0` selects
-                // `NoCache`, so reads always reach the storage layer.
+                // Optional in-process page cache size (7th arg): omitted or `0` disables
+                // in-process caching, so reads always reach the storage layer.
                 let cache_pages = match argv.get(6).map(|a| a.parse::<usize>()) {
                     None => None,
                     Some(Ok(n)) => NonZeroUsize::new(n),
@@ -296,47 +296,27 @@ fn get_bench(
         );
         return;
     }
-    // `NoCache` by default so point reads reach the storage layer instead of the in-process
-    // cache, which is what the cold-read measurement is about. The cache implementation is a
-    // type parameter, so each choice instantiates its own database type.
-    match cache_pages {
-        None => run_get_bench(
-            folder,
-            keyspace,
-            num_gets,
-            concurrencies,
-            page_size,
-            move |ctx: &Context| CacheRef::no_cache_from_pooler(ctx, page_size),
-            "none".to_string(),
-        ),
-        Some(pages) => run_get_bench(
-            folder,
-            keyspace,
-            num_gets,
-            concurrencies,
-            page_size,
-            move |ctx: &Context| CacheRef::from_pooler(ctx, page_size, pages),
-            format!("{pages} pages"),
-        ),
-    }
-}
-
-/// [get_bench], instantiated for one [PageCache] implementation.
-#[allow(clippy::too_many_arguments)]
-fn run_get_bench<P: PageCache>(
-    folder: &str,
-    keyspace: u64,
-    num_gets: u64,
-    concurrencies: Vec<u64>,
-    page_size: NonZeroU16,
-    make_cache: impl FnOnce(&Context) -> CacheRef<P> + Send + 'static,
-    cache_mode: String,
-) {
     let cfg = Config::default().with_storage_directory(folder);
     Runner::new(cfg).start(|ctx| async move {
-        let config = any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, make_cache(&ctx));
+        // No caching by default so point reads reach the storage layer instead of the
+        // in-process cache, which is what the cold-read measurement is about.
+        let (page_cache, cache_mode) = cache_pages.map_or_else(
+            || {
+                (
+                    CacheRef::no_cache_from_pooler(&ctx, page_size),
+                    "none".to_string(),
+                )
+            },
+            |pages| {
+                (
+                    CacheRef::from_pooler(&ctx, page_size, pages),
+                    format!("{pages} pages"),
+                )
+            },
+        );
+        let config = any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, page_cache);
         let open_start = Instant::now();
-        let db = AnyOFixDb::<Mmr, P>::init(ctx.child("storage"), config)
+        let db = AnyOFixDb::<Mmr>::init(ctx.child("storage"), config)
             .await
             .unwrap();
         let opened = open_start.elapsed();
@@ -375,9 +355,9 @@ fn run_get_bench<P: PageCache>(
 /// reader tasks (the first `num_gets % concurrency` readers take one extra), each consuming its
 /// own deterministic key stream (so a repeat pass replays the same keys). Returns the elapsed
 /// time, the number of gets issued, and how many found a value.
-async fn run_gets<P: PageCache>(
+async fn run_gets(
     ctx: &Context,
-    db: Arc<AnyOFixDb<Mmr, P>>,
+    db: Arc<AnyOFixDb<Mmr>>,
     keyspace: u64,
     num_gets: u64,
     concurrency: u64,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -347,7 +347,6 @@ use commonware_codec::{CodecShared, FixedSize};
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use commonware_runtime::buffer::paged::{ClockCache, PageCache};
 use commonware_utils::bitmap::Prunable as BitMap;
 use core::num::NonZeroUsize;
 use std::sync::Arc;
@@ -365,9 +364,9 @@ use self::db::Metrics;
 
 /// Configuration for a `Current` authenticated db.
 #[derive(Clone)]
-pub struct Config<T: Translator, J, S: Strategy, P: PageCache = ClockCache> {
+pub struct Config<T: Translator, J, S: Strategy> {
     /// Configuration for the Merkle structure backing the authenticated journal.
-    pub merkle_config: MerkleConfig<S, P>,
+    pub merkle_config: MerkleConfig<S>,
 
     /// Configuration for the operations log journal.
     pub journal_config: J,
@@ -383,10 +382,8 @@ pub struct Config<T: Translator, J, S: Strategy, P: PageCache = ClockCache> {
     pub init_cache_size: Option<NonZeroUsize>,
 }
 
-impl<T: Translator, J, S: Strategy, P: PageCache> From<Config<T, J, S, P>>
-    for AnyConfig<T, J, S, P>
-{
-    fn from(cfg: Config<T, J, S, P>) -> Self {
+impl<T: Translator, J, S: Strategy> From<Config<T, J, S>> for AnyConfig<T, J, S> {
+    fn from(cfg: Config<T, J, S>) -> Self {
         Self {
             merkle_config: cfg.merkle_config,
             journal_config: cfg.journal_config,
@@ -406,7 +403,7 @@ pub type VariableConfig<T, C, S> = Config<T, VConfig<C>, S>;
 #[boxed]
 pub(super) async fn init<F, E, U, H, T, I, J, const N: usize, S>(
     context: E,
-    config: Config<T, J::Config, S, J::PageCache>,
+    config: Config<T, J::Config, S>,
 ) -> Result<db::Db<F, E, J, I, H, U, N, S>, crate::qmdb::Error<F>>
 where
     F: merkle::Graftable,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -70,7 +70,6 @@ use crate::{
 use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_parallel::Strategy;
-use commonware_runtime::buffer::paged::PageCache;
 use commonware_utils::{bitmap::Prunable as BitMap, channel::oneshot, range::NonEmptyRange, Array};
 use core::num::NonZeroUsize;
 use std::sync::Arc;
@@ -78,7 +77,7 @@ use std::sync::Arc;
 #[cfg(test)]
 pub(crate) mod tests;
 
-impl<T: Translator, J: Clone, S: Strategy, P: PageCache> Config for super::Config<T, J, S, P> {
+impl<T: Translator, J: Clone, S: Strategy> Config for super::Config<T, J, S> {
     type JournalConfig = J;
 
     fn journal_config(&self) -> Self::JournalConfig {
@@ -96,7 +95,7 @@ impl<T: Translator, J: Clone, S: Strategy, P: PageCache> Config for super::Confi
 #[allow(clippy::too_many_arguments)]
 async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
     context: E,
-    merkle_config: full::Config<S, J::PageCache>,
+    merkle_config: full::Config<S>,
     log: J,
     translator: T,
     pinned_nodes: Option<Vec<H::Digest>>,
@@ -118,7 +117,7 @@ where
     Operation<F, U>: Codec + Committable + CodecShared,
 {
     // Build authenticated log.
-    let merkle = Merkle::<F, _, _, S, _>::init_sync(
+    let merkle = Merkle::<F, _, _, S>::init_sync(
         context.child("merkle"),
         full::SyncConfig {
             config: merkle_config,
@@ -310,7 +309,7 @@ macro_rules! impl_current_sync_database {
                 .await?;
 
                 let hasher = qmdb::hasher::<H>();
-                let merkle = Merkle::<F, _, _, S, _>::init(
+                let merkle = Merkle::<F, _, _, S>::init(
                     context.child("local_boundary_merkle"),
                     &hasher,
                     config.merkle_config.clone(),

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -99,7 +99,6 @@ use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use commonware_runtime::buffer::paged::{ClockCache, PageCache};
 use core::num::{NonZeroU64, NonZeroUsize};
 use std::{ops::Range, sync::Arc};
 use tracing::warn;
@@ -141,9 +140,9 @@ pub use operation::Operation;
 
 /// Configuration for an [Immutable] authenticated db.
 #[derive(Clone)]
-pub struct Config<T: Translator, J, S: Strategy, P: PageCache = ClockCache> {
+pub struct Config<T: Translator, J, S: Strategy> {
     /// Configuration for the Merkle structure backing the authenticated journal.
-    pub merkle_config: MerkleConfig<S, P>,
+    pub merkle_config: MerkleConfig<S>,
 
     /// Configuration for the operations log journal.
     pub log: J,

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -39,7 +39,7 @@ where
     type Op = Operation<F, K, V>;
     type Journal = C;
     type Hasher = H;
-    type Config = immutable::Config<T, C::Config, S, C::PageCache>;
+    type Config = immutable::Config<T, C::Config, S>;
     type Digest = H::Digest;
     type Context = E;
 
@@ -70,7 +70,7 @@ where
         let hasher = qmdb::hasher::<H>();
 
         // Initialize Merkle structure for sync
-        let merkle = Merkle::<F, _, _, S, _>::init_sync(
+        let merkle = Merkle::<F, _, _, S>::init_sync(
             context.child("merkle"),
             full::SyncConfig {
                 config: db_config.merkle_config.clone(),

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -61,7 +61,6 @@ use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use commonware_runtime::buffer::paged::{ClockCache, PageCache};
 use std::{num::NonZeroU64, sync::Arc};
 use tracing::{debug, warn};
 
@@ -101,9 +100,9 @@ pub use operation::Operation;
 
 /// Configuration for a [Keyless] authenticated db.
 #[derive(Clone)]
-pub struct Config<J, S: Strategy, P: PageCache = ClockCache> {
+pub struct Config<J, S: Strategy> {
     /// Configuration for the Merkle structure backing the authenticated journal.
-    pub merkle: MerkleConfig<S, P>,
+    pub merkle: MerkleConfig<S>,
 
     /// Configuration for the operations log journal.
     pub log: J,

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -35,7 +35,7 @@ where
     type Op = Operation<F, V>;
     type Journal = C;
     type Hasher = H;
-    type Config = super::Config<C::Config, S, C::PageCache>;
+    type Config = super::Config<C::Config, S>;
     type Digest = H::Digest;
     type Context = E;
 
@@ -64,7 +64,7 @@ where
     ) -> Result<Self, qmdb::Error<F>> {
         let hasher = qmdb::hasher::<H>();
 
-        let merkle = Merkle::<F, _, _, S, _>::init_sync(
+        let merkle = Merkle::<F, _, _, S>::init_sync(
             context.child("merkle"),
             full::SyncConfig {
                 config: config.merkle.clone(),

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use commonware_cryptography::Digest;
 use commonware_parallel::Strategy;
-use commonware_runtime::buffer::paged::PageCache;
 use commonware_utils::range::NonEmptyRange;
 use std::future::Future;
 
@@ -14,9 +13,7 @@ pub trait Config {
     fn journal_config(&self) -> Self::JournalConfig;
 }
 
-impl<T: Translator, J: Clone, S: Strategy, P: PageCache> Config
-    for crate::qmdb::any::Config<T, J, S, P>
-{
+impl<T: Translator, J: Clone, S: Strategy> Config for crate::qmdb::any::Config<T, J, S> {
     type JournalConfig = J;
 
     fn journal_config(&self) -> Self::JournalConfig {
@@ -24,9 +21,7 @@ impl<T: Translator, J: Clone, S: Strategy, P: PageCache> Config
     }
 }
 
-impl<T: Translator, C: Clone, S: Strategy, P: PageCache> Config
-    for crate::qmdb::immutable::Config<T, C, S, P>
-{
+impl<T: Translator, C: Clone, S: Strategy> Config for crate::qmdb::immutable::Config<T, C, S> {
     type JournalConfig = C;
 
     fn journal_config(&self) -> Self::JournalConfig {
@@ -34,7 +29,7 @@ impl<T: Translator, C: Clone, S: Strategy, P: PageCache> Config
     }
 }
 
-impl<J: Clone, S: Strategy, P: PageCache> Config for crate::qmdb::keyless::Config<J, S, P> {
+impl<J: Clone, S: Strategy> Config for crate::qmdb::keyless::Config<J, S> {
     type JournalConfig = J;
 
     fn journal_config(&self) -> Self::JournalConfig {


### PR DESCRIPTION
## Summary

The base branch lets `CacheRef` skip in-process caching, so the `scale` bench's `get`/`get_many` modes measure cold reads honestly (and deployments can avoid double-caching under the OS page cache). It delivers this with a `PageCache` trait, threading `P: PageCache` through `Writer`/`Sealed`/`View`, the contiguous journals, and every qmdb config and `Db` alias -- 21 files.

But none of those types use `P`; they only store or pass a `CacheRef<P>`. So this PR hides the choice inside a non-generic `CacheRef` instead:

```rust
enum CacheImpl {
    Clock(Arc<RwLock<Cache>>), // the existing bounded cache with fetch dedup
    None,                      // retains nothing; every read fetches from the blob
}
```

All 20 downstream files revert to `main` byte for byte, and the clock path provably keeps its behavior because its code does not move: each read/insert/invalidate method takes a `let ... else` guard, and the fault path gains an early-exit arm that fetches straight from the blob. `CacheRef::new` and every existing caller are untouched; the new mode is `CacheRef::no_cache[_from_pooler](pool, page_size)`.

## Costs

- **Dispatch:** a predicted two-variant branch, ahead of an `RwLock` acquire + page memcpy (hit) or blob I/O (miss). The warm pass of `scale -- get` can A/B this against the trait version if we want proof.
- **Allocation parity:** the no-cache fault still wraps its fetch in `Shared`, because `Contiguous::read` requires `Sync` futures and blob reads are only `Send`. (That bound is why the trait boxed every fetch.)
- **Closed set:** external `PageCache` impls can no longer plug in. A new retention policy is an enum variant; if out-of-tree impls ever matter, a `Custom(Arc<dyn ...>)` variant fits without signature changes.