### PR TITLE
[storage/journal] Read `read_many` per-blob groups concurrently

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1429,6 +1429,16 @@ mod tests {
         format!("{}-blobs", cfg.partition)
     }
 
+    /// Extract a metric counter's value from encoded metrics output.
+    fn counter(buffer: &str, name: &str) -> u64 {
+        buffer
+            .lines()
+            .find(|l| l.contains(name) && !l.starts_with('#'))
+            .and_then(|l| l.split_whitespace().last())
+            .and_then(|v| v.parse().ok())
+            .expect("counter missing")
+    }
+
     impl<E: crate::Context, A: CodecFixedShared> Journal<E, A> {
         /// Test helper: Get the oldest blob from the blob store.
         pub(crate) const fn test_oldest_blob(&self) -> Option<u64> {
@@ -4845,15 +4855,6 @@ mod tests {
 
             let reader = journal.snapshot().await.unwrap();
 
-            fn counter(buffer: &str, name: &str) -> u64 {
-                buffer
-                    .lines()
-                    .find(|l| l.contains(name) && !l.starts_with('#'))
-                    .and_then(|l| l.split_whitespace().last())
-                    .and_then(|v| v.parse().ok())
-                    .expect("counter missing")
-            }
-
             // Sparse subset spanning multiple blobs, including the pruning boundary.
             // `try_read_sync` probes do not populate the cache, so the cached subset is
             // whatever the append path left resident; derive the expected hit count from
@@ -4888,6 +4889,72 @@ mod tests {
             let batch = reader.read_many(&all).await.unwrap();
             for (i, &pos) in all.iter().enumerate() {
                 assert_eq!(batch[i], reader.read(pos).await.unwrap());
+            }
+            drop(reader);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_read_many_cold_blob_groups() {
+        // Read a batch whose positions are all cache misses spread over four blobs, so the whole
+        // batch is served by per-blob group reads into disjoint slices of the shared output
+        // buffer. Each digest encodes its position, so a group read into the wrong slice fails
+        // the value assertions.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(8));
+            cfg.page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(32));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Reopen with a fresh page cache so every full page is cold. The positions avoid
+            // each blob's trailing bytes, which sealed blobs keep in memory and always serve
+            // synchronously.
+            cfg.page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(32));
+            let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            let reader = journal.snapshot().await.unwrap();
+            let positions = [1, 5, 10, 14, 17, 22, 25, 30];
+            for pos in positions {
+                assert!(reader.try_read_sync(pos).is_none(), "position {pos}");
+            }
+
+            // Every item requires a blob read, split into four groups of two.
+            let before = context.encode();
+            let batch = reader.read_many(&positions).await.unwrap();
+            let after = context.encode();
+            assert_eq!(
+                counter(&after, "second_cache_misses") - counter(&before, "second_cache_misses"),
+                positions.len() as u64
+            );
+            assert_eq!(
+                counter(&after, "second_cache_hits"),
+                counter(&before, "second_cache_hits")
+            );
+            for (i, &pos) in positions.iter().enumerate() {
+                assert_eq!(batch[i], test_digest(pos), "position {pos}");
+            }
+
+            // The first pass cached every page it faulted, so a second pass is all hits and must
+            // return the same items.
+            let before = context.encode();
+            let batch = reader.read_many(&positions).await.unwrap();
+            let after = context.encode();
+            assert_eq!(
+                counter(&after, "second_cache_hits") - counter(&before, "second_cache_hits"),
+                positions.len() as u64
+            );
+            for (i, &pos) in positions.iter().enumerate() {
+                assert_eq!(batch[i], test_digest(pos), "position {pos}");
             }
             drop(reader);
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1228,8 +1228,7 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Reader<'_, E, A> {
         let mut reusable_buf = vec![0u8; positions.len() * chunk_size];
 
         // The buffer is pre-sized for every position, so each group can own a disjoint slice and
-        // all groups can read concurrently: the whole batch becomes one I/O wave instead of one
-        // wave per blob (misses within a group already read concurrently).
+        // all groups can read concurrently.
         let mut reads = Vec::new();
         let mut remaining_buf = reusable_buf.as_mut_slice();
         for group in positions.chunk_by(|a, b| {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -112,7 +112,7 @@ use commonware_runtime::{
     buffer::paged::{CacheRef, Writer},
     Blob as RBlob, Buf, IoBuf,
 };
-use futures::Stream;
+use futures::{future::try_join_all, Stream};
 use std::{
     collections::BTreeMap,
     future::Future,
@@ -1226,7 +1226,12 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Reader<'_, E, A> {
         // true misses from the blob (concurrently).
         let mut result: Vec<A> = Vec::with_capacity(positions.len());
         let mut reusable_buf = vec![0u8; positions.len() * chunk_size];
-        let mut hits = 0u64;
+
+        // The buffer is pre-sized for every position, so each group can own a disjoint slice and
+        // all groups can read concurrently: the whole batch becomes one I/O wave instead of one
+        // wave per blob (misses within a group already read concurrently).
+        let mut reads = Vec::new();
+        let mut remaining_buf = reusable_buf.as_mut_slice();
         for group in positions.chunk_by(|a, b| {
             super::position_to_blob(*a, items_per_blob)
                 == super::position_to_blob(*b, items_per_blob)
@@ -1242,15 +1247,21 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Reader<'_, E, A> {
                 .blobs
                 .get(blob)
                 .expect("positions in bounds map to a retained blob");
-            let buf = &mut reusable_buf[..group.len() * chunk_size];
-            let group_hits = blob
-                .read_many_into(buf, &blob_offsets, Journal::<E, A>::CHUNK_SIZE)
-                .await?;
-            hits += group_hits as u64;
+            let (buf, rest) = remaining_buf.split_at_mut(group.len() * chunk_size);
+            remaining_buf = rest;
+            reads.push(async move {
+                blob.read_many_into(buf, &blob_offsets, Journal::<E, A>::CHUNK_SIZE)
+                    .await
+            });
+        }
+        let hits: u64 = try_join_all(reads)
+            .await?
+            .into_iter()
+            .map(|group_hits| group_hits as u64)
+            .sum();
 
-            for slice in buf.chunks_exact(chunk_size) {
-                result.push(A::decode(slice).map_err(Error::Codec)?);
-            }
+        for slice in reusable_buf.chunks_exact(chunk_size) {
+            result.push(A::decode(slice).map_err(Error::Codec)?);
         }
 
         self.metrics.record_cache_hits(hits);

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -29,7 +29,7 @@ use commonware_runtime::{
     Blob as RBlob, Buf, IoBuf,
 };
 use commonware_utils::NZUsize;
-use futures::Stream;
+use futures::{future::try_join_all, Stream};
 use std::{
     collections::BTreeMap,
     io::Cursor,
@@ -740,9 +740,11 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
                 other => other,
             })?;
 
-        // Group runs of consecutive positions that fall into the same blob and perform a consecutive
-        // read for each run.
+        // Group runs of consecutive positions that fall into the same blob, then read all runs
+        // concurrently: uniform access makes most runs a single item, so reading them
+        // sequentially would serialize one I/O per miss.
         let items_per_blob = self.items_per_blob.get();
+        let mut runs = Vec::new();
         let mut group_start = 0;
         while group_start < miss_positions.len() {
             let blob = position_to_blob(miss_positions[group_start], items_per_blob);
@@ -767,17 +769,20 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
                 {
                     run_end += 1;
                 }
-
-                let items = self
-                    .read_consecutive(&blob_handle, blob, &miss_offsets[run_start..run_end])
-                    .await?;
-
-                for (item, &miss_idx) in items.into_iter().zip(&miss_indices[run_start..run_end]) {
-                    result[miss_idx] = Some(item);
-                }
+                runs.push((run_start, run_end, blob, blob_handle.clone()));
                 run_start = run_end;
             }
             group_start = group_end;
+        }
+
+        let run_items = try_join_all(runs.iter().map(|(run_start, run_end, blob, handle)| {
+            self.read_consecutive(handle, *blob, &miss_offsets[*run_start..*run_end])
+        }))
+        .await?;
+        for ((run_start, run_end, _, _), items) in runs.iter().zip(run_items) {
+            for (item, &miss_idx) in items.into_iter().zip(&miss_indices[*run_start..*run_end]) {
+                result[miss_idx] = Some(item);
+            }
         }
 
         self.metrics.items_read.inc_by(positions.len() as u64);

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2332,6 +2332,83 @@ mod tests {
         });
     }
 
+    #[test_traced]
+    fn test_variable_read_many_scattered_single_runs_across_blobs() {
+        // Read a batch where cache hits are interleaved with non-consecutive misses spanning
+        // several blobs. The misses split into many small runs that are fetched separately, and
+        // each run's items must land in the correct result slots between the cached items. Every
+        // item's payload encodes its position, so a wrong run boundary or a misplaced result
+        // fails the value assertions.
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "read-many-scattered-runs".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(16)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            // Each item's frame is 302 bytes, so a 5-item blob spans two full 512-byte pages plus
+            // a partial page. Full pages are served through the page cache and go cold on reopen,
+            // which is what lets this test stage misses at all.
+            let items = (0..30)
+                .map(|i| FixedBytes::new([i as u8; 300]))
+                .collect::<Vec<_>>();
+            let mut journal =
+                Journal::<_, FixedBytes<300>>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+            for item in &items {
+                journal.append(item).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // Reopen with a fresh page cache so sealed-blob full pages are cold.
+            let cfg = Config {
+                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(16)),
+                ..cfg
+            };
+            let mut journal = Journal::<_, FixedBytes<300>>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            let reader = journal.snapshot().await.unwrap();
+
+            // Warm blobs 1 (positions 5..10) and 3 (positions 15..20) with one read each. The
+            // faulted pages cover the neighboring positions asserted below.
+            reader.read(6).await.unwrap();
+            reader.read(16).await.unwrap();
+
+            // Prove the interleave the batch will see: warm-blob positions are sync hits, and the
+            // scattered positions in blobs 0, 2, and 4 are misses. The hit pass in read_many runs
+            // before any miss I/O, so this is exactly the hit/miss split the call resolves.
+            for hit in [5, 6, 15, 17] {
+                assert!(reader.try_read_sync(hit).is_some(), "position {hit}");
+            }
+            let misses = [0, 3, 10, 12, 20, 21, 23];
+            for miss in misses {
+                assert!(reader.try_read_sync(miss).is_none(), "position {miss}");
+            }
+
+            // The misses decompose into runs [0], [3], [10], [12], [20, 21], [23]: four single-item
+            // runs and one consecutive pair across three blobs, with hits interleaved between them.
+            let positions = [0, 3, 5, 6, 10, 12, 15, 17, 20, 21, 23];
+            let expected: Vec<_> = positions
+                .iter()
+                .map(|&p| items[p as usize].clone())
+                .collect();
+            assert_eq!(reader.read_many(&positions).await.unwrap(), expected);
+
+            // A second pass serves the now-cached positions through the hit path and must agree.
+            assert_eq!(reader.read_many(&positions).await.unwrap(), expected);
+            drop(reader);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test that complete offsets partition loss after pruning is detected as unrecoverable.
     ///
     /// When the offsets partition is completely lost and the data has been pruned, we cannot

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -741,8 +741,7 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
             })?;
 
         // Group runs of consecutive positions that fall into the same blob, then read all runs
-        // concurrently: uniform access makes most runs a single item, so reading them
-        // sequentially would serialize one I/O per miss.
+        // concurrently.
         let items_per_blob = self.items_per_blob.get();
         let mut runs = Vec::new();
         let mut group_start = 0;


### PR DESCRIPTION
## Summary

Both contiguous journals batch their `read_many` I/O less than they appear to. The **fixed**
journal groups its (sorted) positions by blob and reads each blob's batch with one call — but
awaits those group reads **sequentially**: for example, for 1M items per blob, a uniform
256-key batch over a multi-blob region scatters into ~64 groups of ~4 keys, so a single
`get_many` call runs at an effective I/O depth of ~3. The **variable** journal is worse: after
its offsets lookup, it awaits each *consecutive run* of positions sequentially, and uniform
access makes nearly every run a single item — one serialized I/O per cache miss, so batching
bought almost nothing over point gets.

This PR makes both concurrent. Fixed (first commit): the output buffer is already pre-sized
for every position, so each blob group takes a disjoint slice (`split_at_mut`) and all groups
run under one `try_join_all` — the whole batch becomes a single I/O wave. Variable (second
commit): run descriptors are collected first, then all runs — across and within blobs — are
joined the same way. Decoding and result ordering are unchanged; blob reads are `&self`, so no
locking changes.

## Measured

Cold uniform-random `get_many` (256-key batches) through the full qmdb stack, 50M-key /
250M-update database, Linux (`x86_64`, AMD EPYC 9354P, ext4 on md-RAID NVMe), OS cache dropped
per pass, benchmark from #4170:

Fixed journal (first commit):

| cold | before | after | speedup |
|---|---|---|---|
| 16 KiB pages, 1 caller | 80.4 us/get (12.4K gets/s) | 9.5 us/get (105K gets/s) | **8.5x** |
| 4 KiB pages, 1 caller | 44.8 us/get (22.3K gets/s) | 6.7 us/get (151K gets/s) | **6.7x** |
| 16 KiB pages, 8 callers | 12.2 us/get | 5.0 us/get | 2.4x |

Variable journal (second commit; digest values, same database shape):

| cold | before | after | speedup |
|---|---|---|---|
| 16 KiB pages, 1 caller | 265.6 us/get (3.8K gets/s) | 18.9 us/get (52.9K gets/s) | **14.0x** |
| 4 KiB pages, 1 caller | 187.4 us/get (5.3K gets/s) | 17.2 us/get (58.1K gets/s) | **10.9x** |
| 16 KiB pages, 8 callers | 33.5 us/get | 13.7 us/get | 2.4x |

Before the fix, a batched variable-journal `get_many` (265.6 us/get) was barely faster than
one-at-a-time point gets (298.5 us/get): run-level serialization issued one awaited I/O per
cache miss, so batching bought almost nothing.

The single-caller case is the production commit-path shape (`get_many`-driven load phase); the
fixed journal moves from ~22x below device capability to within ~2x of it. Results are
byte-identical before and after on both journal kinds.

## Notes

- **Conflicts with, but is complementary to, #4144**: that PR restructures the same function
  into cache/miss passes (`read_many_impl`) while keeping the sequential per-blob loop; this
  change parallelizes whatever reads survive to the blob stage. Whichever lands second ports
  cleanly — the transform (disjoint buffer slices + joined group reads) applies the same way to
  the refactored shape. Draft until sequencing is settled.
- At already-saturated external concurrency (32 callers), unbounded fan-out shows a small
  regression (~13% cold at 4 KiB pages) from blocking-pool contention; a follow-up will sweep a
  concurrency bound (`buffer_unordered(N)`) before this leaves draft.
- The variable journal's `read_many` gets the same treatment (second commit): its data reads
  awaited one *consecutive run* at a time, and uniform access makes most runs a single item —
  one serialized I/O per cache miss. Runs are now collected and joined concurrently. (Its
  offsets lookup is a fixed journal, so it also inherits the first commit's fix.)
- Within-blob misses were already concurrent for the fixed journal (the paged view issues them
  via `FuturesUnordered`), so single-blob batches were never affected; the pathology was
  many-blobs-few-keys, which uniform access over a multi-blob region maximizes.
- Reproduction needs the `get_many` mode of the `scale` benchmark from #4170 (variable-journal
  support via its `kind` argument).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSarn1C4iMrjHQHrVcanFo





