### PR TITLE
[workspace] Bump `rand` & ecosystem to 0.10

### DIFF
--- a/.github/scripts/check_dependency_cooldown.sh
+++ b/.github/scripts/check_dependency_cooldown.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+check_cooldown() {
+  cargo cooldown --workspace --all-features check
+}
+
+check_lockfile() {
+  git diff --exit-code Cargo.lock
+}
+
+if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
+  check_cooldown
+  check_lockfile
+  exit 0
+fi
+
+base_ref="${COOLDOWN_BASE_REF:-}"
+head_sha="${COOLDOWN_HEAD_SHA:-}"
+if [[ -z "${base_ref}" || -z "${head_sha}" ]]; then
+  echo "COOLDOWN_BASE_REF and COOLDOWN_HEAD_SHA are required for pull_request cooldown checks" >&2
+  exit 1
+fi
+
+git fetch --no-tags origin "refs/heads/${base_ref}:refs/remotes/origin/${base_ref}"
+base_rev="refs/remotes/origin/${base_ref}"
+merge_base="$(git merge-base "${base_rev}" "${head_sha}")"
+
+if git diff --quiet "${merge_base}" "${head_sha}" -- Cargo.lock; then
+  echo "Cargo.lock did not change; skipping cargo-cooldown."
+  exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+cp Cargo.lock "${tmpdir}/pr.Cargo.lock"
+cleanup() {
+  status=$?
+  cp "${tmpdir}/pr.Cargo.lock" Cargo.lock
+  rm -rf "${tmpdir}"
+  exit "${status}"
+}
+trap cleanup EXIT
+
+git show "${base_rev}:Cargo.lock" > Cargo.lock
+
+check_cooldown
+
+if ! cmp --silent Cargo.lock "${tmpdir}/pr.Cargo.lock"; then
+  echo "Cargo.lock differs after applying the cooldown baseline." >&2
+  echo "Regenerate Cargo.lock after the upgraded dependencies satisfy cooldown." >&2
+  exit 1
+fi

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -261,6 +261,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      with:
+        fetch-depth: 0
     - name: Run setup
       uses: ./.github/actions/setup
       with:
@@ -270,6 +272,9 @@ jobs:
       with:
         tool: just@1.43.0,cargo-cooldown@${{ env.CARGO_COOLDOWN_VERSION }}
     - name: Check dependency cooldown
+      env:
+        COOLDOWN_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        COOLDOWN_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: just cooldown
 
   Lock:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,6 @@ dependencies = [
  "num-rational",
  "rand 0.10.2",
  "rand_chacha 0.10.0",
- "rand_core 0.10.1",
  "rayon",
  "thiserror 2.0.17",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,6 +2347,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,13 +414,13 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint",
+ "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
  "http 1.3.1",
- "p256",
+ "p256 0.13.2",
  "percent-encoding",
  "sha2 0.11.0",
  "subtle",
@@ -723,6 +723,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,13 +922,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1099,8 +1116,8 @@ dependencies = [
  "commonware-storage",
  "commonware-stream",
  "commonware-utils",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1134,7 +1151,7 @@ dependencies = [
  "commonware-utils",
  "futures",
  "libfuzzer-sys",
- "rand 0.8.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1169,8 +1186,8 @@ dependencies = [
  "commonware-macros",
  "paste",
  "proptest",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
  "thiserror 2.0.17",
 ]
 
@@ -1214,9 +1231,9 @@ dependencies = [
  "commonware-utils",
  "criterion",
  "num-rational",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "rayon",
  "thiserror 2.0.17",
 ]
@@ -1231,7 +1248,7 @@ dependencies = [
  "commonware-parallel",
  "commonware-utils",
  "libfuzzer-sys",
- "rand_chacha 0.3.1",
+ "rand_chacha 0.10.0",
 ]
 
 [[package]]
@@ -1246,7 +1263,7 @@ dependencies = [
  "commonware-runtime",
  "commonware-stream",
  "commonware-utils",
- "rand 0.8.5",
+ "rand 0.10.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1265,7 +1282,7 @@ dependencies = [
  "commonware-utils",
  "futures",
  "libfuzzer-sys",
- "rand 0.8.5",
+ "rand 0.10.2",
  "thiserror 2.0.17",
 ]
 
@@ -1317,9 +1334,9 @@ dependencies = [
  "futures",
  "paste",
  "pin-project",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "rand_distr",
  "rayon",
  "rstest",
@@ -1345,8 +1362,8 @@ dependencies = [
  "futures",
  "libfuzzer-sys",
  "proptest",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1378,17 +1395,18 @@ dependencies = [
  "criterion",
  "ctutils 0.3.1",
  "curve25519-dalek",
- "ecdsa",
+ "ecdsa 0.17.0",
  "fixedbitset",
  "getrandom 0.2.16",
+ "getrandom 0.4.3",
  "hashbrown 0.16.1",
  "num-rational",
  "num-traits",
  "once_cell",
- "p256",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "p256 0.14.0",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "rayon",
  "rstest",
  "sha2 0.11.0",
@@ -1411,11 +1429,10 @@ dependencies = [
  "commonware-utils",
  "crc",
  "ed25519-consensus",
- "ed25519-zebra",
  "libfuzzer-sys",
  "num-rational",
- "p256",
- "rand 0.8.5",
+ "p256 0.14.0",
+ "rand 0.10.2",
  "sha2 0.11.0",
  "zeroize",
 ]
@@ -1456,7 +1473,7 @@ dependencies = [
  "commonware-runtime",
  "commonware-utils",
  "futures",
- "rand 0.8.5",
+ "rand 0.10.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -1478,7 +1495,7 @@ dependencies = [
  "commonware-runtime",
  "commonware-utils",
  "futures",
- "rand 0.8.5",
+ "rand 0.10.2",
  "serde",
  "serde_yaml",
  "tracing",
@@ -1493,7 +1510,7 @@ dependencies = [
  "commonware-macros",
  "const-hex",
  "criterion",
- "rand 0.8.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1518,8 +1535,8 @@ dependencies = [
  "commonware-utils",
  "futures",
  "prometheus-client",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "thiserror 2.0.17",
  "tracing",
  "tracing-subscriber",
@@ -1532,9 +1549,9 @@ dependencies = [
  "arbitrary",
  "commonware-formatting",
  "commonware-macros",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "rstest",
 ]
 
@@ -1555,7 +1572,7 @@ dependencies = [
  "commonware-storage",
  "commonware-utils",
  "crossterm 0.29.0",
- "rand 0.8.5",
+ "rand 0.10.2",
  "ratatui",
  "serde_json",
  "tracing",
@@ -1598,9 +1615,9 @@ dependencies = [
  "commonware-parallel",
  "commonware-utils",
  "criterion",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1633,8 +1650,8 @@ dependencies = [
  "num-integer",
  "num-rational",
  "num-traits",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rand_distr",
  "thiserror 2.0.17",
  "tracing",
@@ -1654,7 +1671,7 @@ dependencies = [
  "commonware-utils",
  "futures",
  "libfuzzer-sys",
- "rand 0.8.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1690,8 +1707,8 @@ dependencies = [
  "commonware-storage",
  "commonware-utils",
  "futures",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1716,7 +1733,7 @@ dependencies = [
  "commonware-stream",
  "commonware-utils",
  "futures",
- "rand 0.8.5",
+ "rand 0.10.2",
  "thiserror 2.0.17",
  "tracing",
  "tracing-subscriber",
@@ -1746,6 +1763,7 @@ dependencies = [
  "crossbeam-utils",
  "futures",
  "getrandom 0.2.16",
+ "getrandom 0.4.3",
  "governor",
  "io-uring",
  "libc",
@@ -1755,8 +1773,8 @@ dependencies = [
  "opentelemetry_sdk",
  "pin-project",
  "prometheus-client",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rayon",
  "rstest",
  "serde_json",
@@ -1814,7 +1832,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "paste",
- "rand 0.8.5",
+ "rand 0.10.2",
  "rand_distr",
  "rstest",
  "thiserror 2.0.17",
@@ -1836,7 +1854,7 @@ dependencies = [
  "commonware-utils",
  "futures",
  "libfuzzer-sys",
- "rand 0.8.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -1852,8 +1870,8 @@ dependencies = [
  "commonware-utils",
  "criterion",
  "futures",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "thiserror 2.0.17",
  "x25519-dalek",
  "zeroize",
@@ -1872,7 +1890,7 @@ dependencies = [
  "commonware-utils",
  "futures",
  "libfuzzer-sys",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1889,7 +1907,7 @@ dependencies = [
  "commonware-stream",
  "commonware-utils",
  "futures",
- "rand 0.8.5",
+ "rand 0.10.2",
  "rstest",
  "thiserror 2.0.17",
  "tokio",
@@ -1914,6 +1932,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hashbrown 0.16.1",
  "num-bigint",
  "num-integer",
@@ -1922,7 +1941,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "proptest",
- "rand 0.8.5",
+ "rand 0.10.2",
  "roaring",
  "rstest",
  "thiserror 2.0.17",
@@ -1944,7 +1963,7 @@ dependencies = [
  "libfuzzer-sys",
  "num-bigint",
  "num-rational",
- "rand 0.8.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -2066,6 +2085,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -2257,6 +2282,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils 0.4.2",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,7 +2314,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2292,18 +2335,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov 0.5.4",
+ "subtle",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2391,6 +2434,16 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -2506,23 +2559,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
+name = "ecdsa"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "pkcs8",
- "serde",
- "signature",
+ "der 0.8.0",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2541,23 +2598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-zebra"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "hashbrown 0.15.5",
- "pkcs8",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,16 +2609,36 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -2625,10 +2685,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
+name = "ff"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -2828,8 +2898,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -2841,9 +2925,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "governor"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e23d5986fd4364c2fb7498523540618b4b8d92eec6c36a02e565f66748e2f79"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
 dependencies = [
  "cfg-if",
  "dashmap",
@@ -2868,8 +2952,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -3056,11 +3151,13 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -3825,10 +3922,23 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3913,8 +4023,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3993,12 +4113,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -4044,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -4186,15 +4333,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -4207,13 +4349,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4224,6 +4367,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4245,13 +4398,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -4413,6 +4572,16 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4644,10 +4813,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils 0.4.2",
+ "der 0.8.0",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -4770,6 +4953,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4882,6 +5075,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4947,7 +5150,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -6140,6 +6353,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6147,13 +6371,12 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
- "serde",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,17 +146,16 @@ crossbeam-queue = "0.3.12"
 crossbeam-utils = "0.8.21"
 crossterm = "0.29.0"
 ctutils = "0.3.1"
-curve25519-dalek = "4.1.3"
+curve25519-dalek = "5.0.0"
 dashmap = "6.1.0"
-ecdsa = { version = "0.16.9", default-features = false }
+ecdsa = { version = "0.17.0", default-features = false }
 ed25519-consensus = "2.1.0"
-ed25519-zebra = "4.1.0"
 either = "1.13.0"
 fixedbitset = { version = "0.5.7", default-features = false }
 futures = "0.3.31"
 futures-timer = "3.0.3"
 futures-util = { version = "0.3.31", default-features = false, features = ["std"] }
-governor = "0.10.2"
+governor = "0.10.4"
 hashbrown = { version = "0.16.1", default-features = false, features = ["default-hasher"] }
 io-uring = "0.7.4"
 libc = "0.2.172"
@@ -170,21 +169,21 @@ once_cell = { version = "1.21.3", default-features = false }
 opentelemetry = "0.32.0"
 opentelemetry-otlp = "0.32.0"
 opentelemetry_sdk = "0.32.0"
-p256 = { version = "0.13.2", default-features = false }
+p256 = { version = "0.14.0", default-features = false }
 parking_lot = "0.12.5"
 paste = "1.0.15"
 pin-project = "1.1.10"
 proc-macro-crate = "3.4.0"
 proc-macro2 = "1.0"
 prometheus-client = "0.24.0"
-proptest = "1.8.0"
+proptest = "1.11.0"
 prost = "0.14.1"
 prost-build = "0.14.1"
 quote = "1.0"
-rand = { version = "0.8.5", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
-rand_core = "0.6.4"
-rand_distr = "0.4.3"
+rand = { version = "0.10.2", default-features = false }
+rand_chacha = { version = "0.10.0", default-features = false }
+rand_core = { version = "0.10.1", default-features = false }
+rand_distr = "0.6.0"
 ratatui = "0.29.0"
 rayon = { version = "1.10.0", default-features = false }
 reqwest = "0.13.4"
@@ -202,7 +201,7 @@ tracing = "0.1.41"
 tracing-opentelemetry = "0.33.0"
 tracing-subscriber = "0.3.19"
 uuid = "1.15.1"
-x25519-dalek = "2.0.1"
+x25519-dalek = "3.0.0"
 zeroize = "1.5.7"
 zstd = "0.13.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ crossbeam-queue = "0.3.12"
 crossbeam-utils = "0.8.21"
 crossterm = "0.29.0"
 ctutils = "0.3.1"
-curve25519-dalek = "5.0.0"
+curve25519-dalek = { version = "5.0.0", features = ["digest"] }
 dashmap = "6.1.0"
 ecdsa = { version = "0.17.0", default-features = false }
 ed25519-consensus = "2.1.0"

--- a/codec/src/conformance.rs
+++ b/codec/src/conformance.rs
@@ -7,7 +7,7 @@
 use crate::Encode;
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_conformance::Conformance;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt as _, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::{fmt::Debug, marker::PhantomData};
 

--- a/coding/Cargo.toml
+++ b/coding/Cargo.toml
@@ -24,8 +24,6 @@ commonware-parallel = { workspace = true, features = ["std"] }
 commonware-storage = { workspace = true, features = ["std"] }
 commonware-utils = { workspace = true, features = ["std"] }
 num-rational.workspace = true
-rand.workspace = true
-rand_core.workspace = true
 rayon.workspace = true
 thiserror.workspace = true
 

--- a/coding/conformance.toml
+++ b/coding/conformance.toml
@@ -16,4 +16,4 @@ hash = "0571442797c611b3822c8a9c54138de9f54fc5b9daaf01796f611a5c74466710"
 
 ["commonware_coding::zoda::tests::conformance::EncodeCheck"]
 n_cases = 256
-hash = "a9438c5c79dc8395133cbb86e1712c181426a863df2c05ecfef64fa870ec0f66"
+hash = "53215b81fa0da82160cefcc3b090a7cabbf6305777fdd2e103a770cc7b904b2c"

--- a/coding/conformance.toml
+++ b/coding/conformance.toml
@@ -13,3 +13,7 @@ hash = "fbf783e8550fe15cd7000f8185e1ca3bc9641ba0baf156ba6365d3b224e2222d"
 ["commonware_coding::zoda::tests::conformance::CodecConformance<WeakShard<Sha256Digest>>"]
 n_cases = 65536
 hash = "0571442797c611b3822c8a9c54138de9f54fc5b9daaf01796f611a5c74466710"
+
+["commonware_coding::zoda::tests::conformance::EncodeCheck"]
+n_cases = 256
+hash = "a9438c5c79dc8395133cbb86e1712c181426a863df2c05ecfef64fa870ec0f66"

--- a/coding/src/benches/bench.rs
+++ b/coding/src/benches/bench.rs
@@ -2,7 +2,7 @@ use commonware_coding::{Config, Scheme};
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::{NZUsize, NZU16};
 use criterion::{criterion_main, BatchSize, Criterion};
-use rand::{RngCore, SeedableRng as _};
+use rand::{Rng, SeedableRng as _};
 use rand_chacha::ChaCha8Rng;
 use shard_selection::SELECTIONS;
 

--- a/coding/src/benches/bench_phased.rs
+++ b/coding/src/benches/bench_phased.rs
@@ -2,7 +2,7 @@ use commonware_coding::{Config, PhasedScheme};
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::{NZUsize, NZU16};
 use criterion::{criterion_main, BatchSize, Criterion};
-use rand::{RngCore, SeedableRng as _};
+use rand::{Rng, SeedableRng as _};
 use rand_chacha::ChaCha8Rng;
 use shard_selection::SELECTIONS;
 

--- a/coding/src/benches/bench_phased_size.rs
+++ b/coding/src/benches/bench_phased_size.rs
@@ -3,7 +3,7 @@ use commonware_coding::{Config, PhasedScheme, Zoda};
 use commonware_cryptography::Sha256;
 use commonware_parallel::Sequential;
 use commonware_utils::NZU16;
-use rand::{RngCore as _, SeedableRng as _};
+use rand::{Rng as _, SeedableRng as _};
 use rand_chacha::ChaCha8Rng;
 
 const STRATEGY: Sequential = Sequential;

--- a/coding/src/benches/bench_size.rs
+++ b/coding/src/benches/bench_size.rs
@@ -3,7 +3,7 @@ use commonware_coding::{Config, PhasedAsScheme, ReedSolomon, Scheme, Zoda};
 use commonware_cryptography::Sha256;
 use commonware_parallel::Sequential;
 use commonware_utils::NZU16;
-use rand::{RngCore as _, SeedableRng as _};
+use rand::{Rng as _, SeedableRng as _};
 use rand_chacha::ChaCha8Rng;
 
 const STRATEGY: Sequential = Sequential;

--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -127,7 +127,6 @@ use commonware_math::{
 };
 use commonware_parallel::Strategy;
 use commonware_storage::bmt::{Builder as BmtBuilder, Error as BmtError, Proof};
-use rand::seq::SliceRandom as _;
 use std::{marker::PhantomData, sync::Arc};
 use thiserror::Error;
 
@@ -345,7 +344,7 @@ fn shuffle_indices(transcript: &Transcript, total: usize) -> Vec<u32> {
         .try_into()
         .expect("encoded_rows exceeds u32::MAX; data too large for ZODA");
     let mut out = (0..total).collect::<Vec<_>>();
-    out.shuffle(&mut transcript.noise(b"shuffle"));
+    transcript.shuffle(b"shuffle", &mut out);
     out
 }
 

--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -354,7 +354,7 @@ fn shuffle_indices(transcript: &Transcript, total: usize) -> Vec<u32> {
 /// This matrix is random, using the transcript as a deterministic source of randomness.
 fn checking_matrix(transcript: &Transcript, topology: &Topology) -> Matrix<F> {
     Matrix::rand(
-        &mut transcript.noise(b"checking matrix"),
+        transcript.noise(b"checking matrix"),
         topology.data_cols,
         topology.column_samples,
     )

--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -811,9 +811,50 @@ mod tests {
     mod conformance {
         use super::*;
         use commonware_codec::conformance::CodecConformance;
+        use commonware_conformance::Conformance;
         use commonware_cryptography::sha256::Digest as Sha256Digest;
 
+        struct EncodeCheck;
+
+        impl Conformance for EncodeCheck {
+            async fn commit(seed: u64) -> Vec<u8> {
+                let config = Config {
+                    minimum_shards: NZU16!(2),
+                    extra_shards: NZU16!(1),
+                };
+                let data: Vec<_> = (0..seed as usize % 768)
+                    .map(|i| (seed as u8).wrapping_add(i as u8))
+                    .collect();
+
+                let (commitment, shards) =
+                    Zoda::<Sha256>::encode(b"conformance", &config, &data[..], &STRATEGY).unwrap();
+
+                let mut log = commitment.encode().to_vec();
+                for (i, shard) in shards.into_iter().enumerate() {
+                    let index: u16 = i.try_into().unwrap();
+                    let (checking_data, _, weak_shard) =
+                        Zoda::<Sha256>::weaken(b"conformance", &config, &commitment, index, shard)
+                            .unwrap();
+                    let checked_shard = Zoda::<Sha256>::check(
+                        &config,
+                        &commitment,
+                        &checking_data,
+                        index,
+                        weak_shard.clone(),
+                    )
+                    .unwrap();
+
+                    log.extend(index.encode());
+                    log.extend(weak_shard.encode());
+                    log.extend(checked_shard.shard.encode());
+                    log.extend(checked_shard.commitment.encode());
+                }
+                log
+            }
+        }
+
         commonware_conformance::conformance_tests! {
+            EncodeCheck => 256,
             CodecConformance<StrongShard<Sha256Digest>>,
             CodecConformance<WeakShard<Sha256Digest>>,
         }

--- a/collector/fuzz/fuzz_targets/collector.rs
+++ b/collector/fuzz/fuzz_targets/collector.rs
@@ -21,7 +21,7 @@ use commonware_runtime::{
 };
 use commonware_utils::channel::{mpsc, oneshot};
 use libfuzzer_sys::fuzz_target;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{
     collections::HashMap,
     num::NonZeroUsize,
@@ -132,9 +132,9 @@ struct FuzzHandler {
 impl FuzzHandler {
     fn new(respond: bool, mut rng: StdRng) -> Self {
         let mut response_map = HashMap::new();
-        for _ in 0..rng.gen_range(0..10) {
-            let id = rng.gen();
-            let result_len = rng.gen_range(0..100);
+        for _ in 0..rng.random_range(0..10) {
+            let id = rng.random();
+            let result_len = rng.random_range(0..100);
             let mut result = vec![0u8; result_len];
             rng.fill(&mut result[..]);
             response_map.insert(id, FuzzResponse { id, result });
@@ -315,9 +315,12 @@ fn fuzz(input: FuzzInput) {
         let mut restarts = 0usize;
 
         for i in 2..5 {
-            let seed = rng.gen();
+            let seed = rng.random();
             peers.push(PrivateKey::from_seed(seed));
-            handlers.insert(i, FuzzHandler::new(rng.gen(), StdRng::seed_from_u64(seed)));
+            handlers.insert(
+                i,
+                FuzzHandler::new(rng.random(), StdRng::seed_from_u64(seed)),
+            );
             monitors.insert(i, FuzzMonitor::new());
         }
         assert!(!peers.is_empty(), "no peers");
@@ -334,13 +337,13 @@ fn fuzz(input: FuzzInput) {
                         let recipients = match recipients_type {
                             RecipientsType::All => Recipients::All,
                             RecipientsType::One => {
-                                let target_idx = rng.gen_range(0..peers.len());
+                                let target_idx = rng.random_range(0..peers.len());
                                 Recipients::One(peers[target_idx].public_key())
                             }
                             RecipientsType::Some => {
                                 let mut selected = vec![];
                                 for (i, peer) in peers.iter().enumerate() {
-                                    if i != idx && rng.gen_bool(0.5) {
+                                    if i != idx && rng.random_bool(0.5) {
                                         selected.push(peer.public_key());
                                     }
                                 }
@@ -407,7 +410,7 @@ fn fuzz(input: FuzzInput) {
                     let mailbox_size = usize::from(mailbox_size.max(MIN_BUFFER_SIZE));
                     let mailbox_size = NonZeroUsize::new(mailbox_size).unwrap();
                     let handler = handlers.get(&idx).cloned().unwrap_or_else(|| {
-                        FuzzHandler::new(true, StdRng::seed_from_u64(rng.gen()))
+                        FuzzHandler::new(true, StdRng::seed_from_u64(rng.random()))
                     });
                     let monitor = monitors.get(&idx).cloned().unwrap_or_else(FuzzMonitor::new);
                     let config = Config {

--- a/consensus/conformance.toml
+++ b/consensus/conformance.toml
@@ -24,11 +24,11 @@ hash = "e53b4b684f0344590427aae976d298e3b6fd2b08ef46ff2cad5def04b4f7690b"
 
 ["commonware_consensus::marshal::conformance::CodingStorageConformance"]
 n_cases = 32
-hash = "87011da609173eff07008418afce29de77356663e1681e25b0e530e020da21ac"
+hash = "0e08b1fc95dc959c09296c615323111272900f4709dd04dd0a449604a4b4bed4"
 
 ["commonware_consensus::marshal::conformance::StandardStorageConformance"]
 n_cases = 32
-hash = "c1b012f81b93360a970d0a98dbc768af6c6d87617590878d137ae73ddfc8492f"
+hash = "c15b5e7ac2edb7a8fd93da3b356ffb46f40ecae12f2857072d28e1b41f0242c6"
 
 ["commonware_consensus::marshal::resolver::handler::tests::conformance::CodecConformance<Key<D>>"]
 n_cases = 65536
@@ -64,11 +64,11 @@ hash = "6fc6f17d8734a14fb841a8acc1a39cda7519bdd025700663e260d3b000c9c5c6"
 
 ["commonware_consensus::simplex::elector::tests::conformance::RandomSelectLeaderConformance"]
 n_cases = 512
-hash = "4df7290375d7ae3b005cfad96dc5fc091bdce4a246665f94b79acf34159a3945"
+hash = "b67e7a2a61c54156c0422160a6dbc096b01f518c26784505def8b5849c597b74"
 
 ["commonware_consensus::simplex::elector::tests::conformance::RoundRobinShuffleConformance"]
 n_cases = 512
-hash = "d6232310a3adc5cc8bf0767d095251f25211f165419372a5fe6b4ed7b06dd765"
+hash = "b892972a5b3cad361beebcc4f90a81dff4833c96411d02f0c5151e29689f1baf"
 
 ["commonware_consensus::simplex::scheme::bls12381_threshold::vrf::tests::conformance::CodecConformance<Certificate<MinSig>>"]
 n_cases = 65536

--- a/consensus/fuzz/src/disrupter.rs
+++ b/consensus/fuzz/src/disrupter.rs
@@ -12,8 +12,8 @@ use commonware_cryptography::sha256::Digest as Sha256Digest;
 use commonware_macros::select;
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, IoBuf, Spawner};
-use rand::Rng;
-use rand_core::CryptoRngCore;
+use rand::{Rng, RngExt as _};
+use rand_core::CryptoRng;
 use std::{collections::VecDeque, time::Duration};
 
 const TIMEOUT: Duration = Duration::from_millis(100);
@@ -22,7 +22,7 @@ const LATEST_PROPOSALS_MAX_LEN: usize = 100;
 
 /// Byzantine actor that disrupts consensus by sending malformed/mutated messages.
 pub struct Disrupter<
-    E: Clock + Spawner + CryptoRngCore,
+    E: Clock + Spawner + CryptoRng,
     S: Scheme<Sha256Digest>,
     St: Strategy + 'static,
 > {
@@ -37,7 +37,7 @@ pub struct Disrupter<
     latest_proposals: VecDeque<Proposal<Sha256Digest>>,
 }
 
-impl<E: Clock + Spawner + CryptoRngCore, S: Scheme<Sha256Digest>, St: Strategy + 'static>
+impl<E: Clock + Spawner + CryptoRng, S: Scheme<Sha256Digest>, St: Strategy + 'static>
     Disrupter<E, S, St>
 where
     <S::Certificate as Read>::Cfg: Default,
@@ -58,7 +58,7 @@ where
     }
 
     fn message(&mut self) -> Message {
-        match (self.context.gen::<u8>()) % 4 {
+        match (self.context.random::<u8>()) % 4 {
             0 => Message::Notarize,
             1 => Message::Finalize,
             2 => Message::Nullify,
@@ -146,7 +146,7 @@ where
     }
 
     fn bytes(&mut self) -> Vec<u8> {
-        let len = self.context.gen::<u8>();
+        let len = self.context.random::<u8>();
         let mut bytes = vec![0u8; len as usize];
         self.context.fill_bytes(&mut bytes);
         bytes
@@ -158,9 +158,9 @@ where
         }
 
         let mut result = input.to_vec();
-        let pos = self.context.gen_range(0..result.len());
+        let pos = self.context.random_range(0..result.len());
 
-        match (self.context.gen::<u8>()) % 5 {
+        match (self.context.random::<u8>()) % 5 {
             0 => result[pos] = result[pos].wrapping_add(1),
             1 => result[pos] = result[pos].wrapping_sub(1),
             2 => result[pos] ^= 0xFF,
@@ -213,7 +213,7 @@ where
 
         loop {
             // Send disruptive messages across all channels
-            match (self.context.gen::<u8>()) % 7 {
+            match (self.context.random::<u8>()) % 7 {
                 0 => self.send_random_vote(&mut vote_sender).await,
                 1 => self.send_proposal(&mut vote_sender).await,
                 2 => {
@@ -283,7 +283,7 @@ where
         }
 
         // Optionally send mutated vote
-        if self.context.gen_bool(0.5) {
+        if self.context.random_bool(0.5) {
             let mutated = self.mutate_bytes(&msg);
             let _ = sender.send(Recipients::All, mutated, true);
         }
@@ -362,7 +362,7 @@ where
         }
 
         // Optionally send mutated certificate
-        if self.context.gen_bool(0.5) {
+        if self.context.random_bool(0.5) {
             let cert = self
                 .strategy
                 .mutate_certificate_bytes(self.context.as_mut(), &msg);
@@ -375,7 +375,7 @@ where
             return;
         }
         // Optionally send malformed resolver data
-        if self.context.gen_bool(0.5) {
+        if self.context.random_bool(0.5) {
             let mutated = self
                 .strategy
                 .mutate_resolver_bytes(self.context.as_mut(), &msg);
@@ -404,7 +404,7 @@ where
             return;
         }
 
-        let idx = self.context.gen_range(0..participants.len());
+        let idx = self.context.random_range(0..participants.len());
         let victim = participants[idx].clone();
 
         // Send 10 messages to victim

--- a/consensus/fuzz/src/invariants.rs
+++ b/consensus/fuzz/src/invariants.rs
@@ -11,7 +11,7 @@ use commonware_cryptography::{
     certificate::{self, Signers},
     sha256::Digest as Sha256Digest,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::collections::{HashMap, HashSet};
 
 pub fn check<P: Simplex>(n: u32, replicas: Vec<ReplicaState>) {
@@ -205,7 +205,7 @@ pub fn extract<E, S, L>(
     max_participants: usize,
 ) -> Vec<ReplicaState>
 where
-    E: CryptoRngCore,
+    E: CryptoRng,
     S: Scheme<Sha256Digest>,
     L: Elector<S>,
 {

--- a/consensus/fuzz/src/strategy.rs
+++ b/consensus/fuzz/src/strategy.rs
@@ -5,7 +5,7 @@ use commonware_consensus::{
     Viewable,
 };
 use commonware_cryptography::sha256::Digest as Sha256Digest;
-use rand::Rng;
+use rand::{Rng, RngExt as _};
 
 pub trait Strategy: Send + Sync {
     fn random_proposal(
@@ -153,7 +153,7 @@ impl Strategy for SmallScope {
     ) -> Proposal<Sha256Digest> {
         let view = proposal.view().get();
         let parent = proposal.parent.get();
-        match rng.gen::<u8>() % 5 {
+        match rng.random::<u8>() % 5 {
             0 => proposal_with_view(proposal, view.saturating_add(1)),
             1 => proposal_with_view(proposal, view.saturating_sub(1)),
             2 => proposal_with_parent_view(proposal, parent.saturating_add(1)),
@@ -170,7 +170,7 @@ impl Strategy for SmallScope {
         last_notarized_view: u64,
         last_nullified_view: u64,
     ) -> u64 {
-        match rng.gen::<u8>() % 12 {
+        match rng.random::<u8>() % 12 {
             0 => last_vote_view,
             1 => last_vote_view.saturating_add(1),
             2 => last_vote_view.saturating_sub(1),
@@ -194,7 +194,7 @@ impl Strategy for SmallScope {
         last_notarized_view: u64,
         last_nullified_view: u64,
     ) -> u64 {
-        match rng.gen::<u8>() % 8 {
+        match rng.random::<u8>() % 8 {
             0 => {
                 let hi = last_notarized_view
                     .min(last_vote_view)
@@ -219,7 +219,7 @@ impl Strategy for SmallScope {
         last_notarized_view: u64,
         last_nullified_view: u64,
     ) -> u64 {
-        match rng.gen::<u8>() % 6 {
+        match rng.random::<u8>() % 6 {
             0 => last_vote_view.saturating_sub(1),
             1 => last_finalized_view,
             2 => last_notarized_view.saturating_sub(1),
@@ -248,7 +248,7 @@ impl Strategy for SmallScope {
         if proposals_len <= 1 {
             return Some(0);
         }
-        if rng.gen_bool(0.5) {
+        if rng.random_bool(0.5) {
             return None;
         }
         Some(proposals_len - 2)
@@ -318,7 +318,7 @@ impl Strategy for AnyScope {
         last_nullified_view: u64,
     ) -> Proposal<Sha256Digest> {
         let view = proposal.view().get();
-        match rng.gen::<u8>() % 4 {
+        match rng.random::<u8>() % 4 {
             0 => proposal_with_payload(proposal, random_payload(rng)),
             1 => proposal_with_view(
                 proposal,
@@ -444,10 +444,10 @@ impl Strategy for AnyScope {
         if proposals_len == 0 {
             return None;
         }
-        if rng.gen_bool(0.5) {
+        if rng.random_bool(0.5) {
             return None;
         }
-        let idx = rng.gen_range(0..proposals_len);
+        let idx = rng.random_range(0..proposals_len);
         Some(idx)
     }
 
@@ -519,8 +519,8 @@ impl Strategy for FutureScope {
     ) -> Proposal<Sha256Digest> {
         let view = proposal.view().get();
         let parent = proposal.parent.get();
-        let bump = if rng.gen_bool(0.5) { 1 } else { 2 };
-        match rng.gen::<u8>() % 3 {
+        let bump = if rng.random_bool(0.5) { 1 } else { 2 };
+        match rng.random::<u8>() % 3 {
             0 => proposal_with_view(proposal, view.saturating_add(bump)),
             1 => proposal_with_parent_view(proposal, parent.saturating_add(bump)),
             _ => {
@@ -543,7 +543,7 @@ impl Strategy for FutureScope {
         _last_notarized_view: u64,
         _last_nullified_view: u64,
     ) -> u64 {
-        let bump = if rng.gen_bool(0.5) { 1 } else { 2 };
+        let bump = if rng.random_bool(0.5) { 1 } else { 2 };
         last_vote_view.saturating_add(bump)
     }
 
@@ -555,7 +555,7 @@ impl Strategy for FutureScope {
         _last_notarized_view: u64,
         _last_nullified_view: u64,
     ) -> u64 {
-        let bump = if rng.gen_bool(0.5) { 1 } else { 2 };
+        let bump = if rng.random_bool(0.5) { 1 } else { 2 };
         last_vote_view.saturating_add(bump)
     }
 
@@ -567,7 +567,7 @@ impl Strategy for FutureScope {
         _last_notarized_view: u64,
         _last_nullified_view: u64,
     ) -> u64 {
-        let bump = if rng.gen_bool(0.5) { 1 } else { 2 };
+        let bump = if rng.random_bool(0.5) { 1 } else { 2 };
         base_view.saturating_sub(bump)
     }
 
@@ -590,7 +590,7 @@ impl Strategy for FutureScope {
         if proposals_len <= 1 {
             return Some(0);
         }
-        if rng.gen_bool(0.5) {
+        if rng.random_bool(0.5) {
             return None;
         }
         Some(proposals_len - 2)
@@ -633,8 +633,8 @@ fn proposal_with_payload(
 
 fn tweak_payload(rng: &mut impl Rng, payload: Sha256Digest) -> Sha256Digest {
     let mut bytes = payload.0;
-    let idx = rng.gen_range(0..bytes.len());
-    let bit = rng.gen::<u8>() % 8;
+    let idx = rng.random_range(0..bytes.len());
+    let bit = rng.random::<u8>() % 8;
     bytes[idx] ^= 1 << bit;
     Sha256Digest(bytes)
 }
@@ -644,8 +644,8 @@ fn tweak_bytes(rng: &mut impl Rng, bytes: &[u8]) -> Vec<u8> {
         return vec![0];
     }
     let mut out = bytes.to_vec();
-    let idx = rng.gen_range(0..out.len());
-    let bit = rng.gen::<u8>() % 8;
+    let idx = rng.random_range(0..out.len());
+    let bit = rng.random::<u8>() % 8;
     out[idx] ^= 1 << bit;
     out
 }
@@ -663,7 +663,7 @@ fn random_view(
     last_notarized_view: u64,
     last_nullified_view: u64,
 ) -> u64 {
-    match rng.gen::<u8>() % 7 {
+    match rng.random::<u8>() % 7 {
         0 => {
             if last_finalized_view == 0 {
                 last_finalized_view
@@ -685,19 +685,19 @@ fn random_view(
             sample_inclusive(rng, last_finalized_view, hi)
         }
         3 => {
-            let k = 1 + (rng.gen::<u8>() as u64 % 4);
+            let k = 1 + (rng.random::<u8>() as u64 % 4);
             add_or_sample_at_or_above(rng, last_vote_view, k)
         }
         4 => {
-            let k = 5 + (rng.gen::<u8>() as u64 % 6);
+            let k = 5 + (rng.random::<u8>() as u64 % 6);
             add_or_sample_at_or_above(rng, last_vote_view, k)
         }
         5 => {
             let view = last_vote_view.max(last_nullified_view);
-            let k = 1 + (rng.gen::<u8>() as u64 % 10);
+            let k = 1 + (rng.random::<u8>() as u64 % 10);
             add_or_sample_at_or_above(rng, view, k)
         }
-        _ => rng.gen::<u64>(),
+        _ => rng.random::<u64>(),
     }
 }
 
@@ -727,8 +727,8 @@ fn sample_inclusive(rng: &mut impl Rng, lo: u64, hi: u64) -> u64 {
         return lo;
     }
     if lo == 0 && hi == u64::MAX {
-        return rng.gen::<u64>();
+        return rng.random::<u64>();
     }
     let width = (hi - lo) + 1;
-    lo + (rng.gen::<u64>() % width)
+    lo + (rng.random::<u64>() % width)
 }

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -33,7 +33,7 @@ use futures::{
     future::{self, Either},
     pin_mut, StreamExt,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     cmp::max,
     collections::BTreeMap,
@@ -68,7 +68,7 @@ struct DigestRequest<D: Digest> {
 
 /// Instance of the engine.
 pub struct Engine<
-    E: BufferPooler + Clock + Spawner + Storage + Metrics + CryptoRngCore,
+    E: BufferPooler + Clock + Spawner + Storage + Metrics + CryptoRng,
     P: Provider<Scope = Epoch>,
     D: Digest,
     A: Automaton<Context = Height, Digest = D>,
@@ -151,7 +151,7 @@ pub struct Engine<
 }
 
 impl<
-        E: BufferPooler + Clock + Spawner + Storage + Metrics + CryptoRngCore,
+        E: BufferPooler + Clock + Spawner + Storage + Metrics + CryptoRng,
         P: Provider<Scope = Epoch, Scheme: scheme::Scheme<D>>,
         D: Digest,
         A: Automaton<Context = Height, Digest = D>,

--- a/consensus/src/aggregation/mocks/reporter.rs
+++ b/consensus/src/aggregation/mocks/reporter.rs
@@ -14,7 +14,7 @@ use commonware_cryptography::{certificate::Scheme, Digest};
 use commonware_parallel::Sequential;
 use commonware_runtime::{spawn_cell, ContextCell, Handle, Metrics, Spawner};
 use commonware_utils::{channel::oneshot, NZUsize};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::collections::{btree_map::Entry, BTreeMap, HashSet, VecDeque};
 
 #[allow(clippy::large_enum_variant)]
@@ -35,7 +35,7 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
     }
 }
 
-pub struct Reporter<R: CryptoRngCore, S: Scheme, D: Digest> {
+pub struct Reporter<R: CryptoRng, S: Scheme, D: Digest> {
     // RNG used for signature verification
     context: ContextCell<R>,
 
@@ -63,7 +63,7 @@ pub struct Reporter<R: CryptoRngCore, S: Scheme, D: Digest> {
 
 impl<R, S, D> Reporter<R, S, D>
 where
-    R: CryptoRngCore + Metrics,
+    R: CryptoRng + Metrics,
     S: scheme::Scheme<D>,
     D: Digest,
 {

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -124,7 +124,7 @@ mod tests {
         test_rng, NZUsize, NonZeroDuration, NZU16,
     };
     use futures::future::join_all;
-    use rand::{rngs::StdRng, Rng};
+    use rand::{rngs::StdRng, RngExt as _};
     use std::{
         collections::BTreeMap,
         num::{NonZeroU16, NonZeroU32, NonZeroUsize},
@@ -560,7 +560,8 @@ mod tests {
                             });
 
                     // Random shutdown timing to simulate unclean shutdown
-                    let shutdown_wait = context.gen_range(shutdown_range_min..shutdown_range_max);
+                    let shutdown_wait =
+                        context.random_range(shutdown_range_min..shutdown_range_max);
                     select! {
                         _ = context.sleep(shutdown_wait) => {
                             debug!(shutdown_wait = ?shutdown_wait, "Simulating unclean shutdown");

--- a/consensus/src/aggregation/types.rs
+++ b/consensus/src/aggregation/types.rs
@@ -13,7 +13,7 @@ use commonware_cryptography::{
 };
 use commonware_parallel::Strategy;
 use commonware_utils::{channel::oneshot, union, N3f1};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::hash::Hash;
 
 /// Error that may be encountered when interacting with `aggregation`.
@@ -183,7 +183,7 @@ impl<S: Scheme, D: Digest> Ack<S, D> {
     /// Domain separation is automatically applied to prevent signature reuse.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<D>,
     {
         scheme.verify_attestation::<_, D>(rng, &self.item, &self.attestation, strategy)
@@ -334,7 +334,7 @@ impl<S: Scheme, D: Digest> Certificate<S, D> {
     /// Verifies the recovered certificate for the item.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<D>,
     {
         scheme.verify_certificate::<_, D, N3f1>(rng, &self.item, &self.certificate, strategy)

--- a/consensus/src/marshal/conformance.rs
+++ b/consensus/src/marshal/conformance.rs
@@ -15,7 +15,7 @@ use commonware_conformance::{conformance_tests, Conformance};
 use commonware_cryptography::certificate::{mocks::Fixture, ConstantProvider};
 use commonware_runtime::{deterministic, Clock, Runner, Supervisor as _};
 use commonware_utils::NZUsize;
-use rand::Rng;
+use rand::RngExt as _;
 use std::time::Duration;
 
 const CASES: usize = 32;
@@ -76,7 +76,7 @@ fn marshal_commit<H: TestHarness>(seed: u64) -> Vec<u8> {
         };
         let mut peers = Vec::<ValidatorHandle<H>>::new();
         let mut parent = H::genesis_block(NUM_VALIDATORS as u16);
-        let count = context.gen_range(1..=BLOCKS_PER_EPOCH.get().min(4));
+        let count = context.random_range(1..=BLOCKS_PER_EPOCH.get().min(4));
         for height in 1..=count {
             let height = Height::new(height);
             let round = Round::new(Epoch::zero(), View::new(height.get()));
@@ -87,7 +87,7 @@ fn marshal_commit<H: TestHarness>(seed: u64) -> Vec<u8> {
                 H::digest(&parent),
                 H::commitment(&parent),
                 height,
-                context.gen(),
+                context.random(),
                 NUM_VALIDATORS as u16,
             );
             H::verify(&mut handle, round, &block, &mut peers).await;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -53,7 +53,7 @@ use futures::{
     future::{join, join_all},
     try_join,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{collections::BTreeMap, future::Future, num::NonZeroUsize};
 use tracing::{debug, info_span, warn, Instrument as _, Span};
 
@@ -83,7 +83,7 @@ struct ResolverDelivery<V: Variant> {
 /// behind.
 pub struct Actor<E, V, P, FC, FB, ES, T, A = Exact>
 where
-    E: BufferPooler + CryptoRngCore + Spawner + Metrics + Clock + Storage,
+    E: BufferPooler + CryptoRng + Spawner + Metrics + Clock + Storage,
     V: Variant,
     P: Provider<Scope = Epoch, Scheme: Scheme<V::Commitment>>,
     FC: Certificates<
@@ -148,7 +148,7 @@ where
 
 impl<E, V, P, FC, FB, ES, T, A> Actor<E, V, P, FC, FB, ES, T, A>
 where
-    E: BufferPooler + CryptoRngCore + Spawner + Metrics + Clock + Storage,
+    E: BufferPooler + CryptoRng + Spawner + Metrics + Clock + Storage,
     V: Variant,
     P: Provider<Scope = Epoch, Scheme: Scheme<V::Commitment>>,
     FC: Certificates<

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -54,7 +54,7 @@ use commonware_utils::{test_rng_seeded, vec::NonEmptyVec, NZUsize, NZU16, NZU64}
 use futures::StreamExt;
 use rand::{
     seq::{IteratorRandom, SliceRandom},
-    Rng,
+    RngExt as _,
 };
 use std::{
     collections::BTreeMap,
@@ -355,7 +355,7 @@ fn contract_runner(seed: u64) -> deterministic::Runner {
 
 fn restart_cycles_for_seed(seed: u64) -> usize {
     let mut rng = test_rng_seeded(seed);
-    rng.gen_range(2..=4)
+    rng.random_range(2..=4)
 }
 
 struct HailstormValidator<H: TestHarness> {
@@ -556,13 +556,13 @@ async fn drive_hailstorm_height_up_to_verify<H: TestHarness>(
 ) -> PendingHailstormHeight<H> {
     let height = Height::new(height_value);
     let active = active_validator_indices(state.validators);
-    let proposer_idx = active[context.gen_range(0..active.len())];
+    let proposer_idx = active[context.random_range(0..active.len())];
     let verifier_count = usize::min(QUORUM as usize, active.len());
     let verifier_indices = active
         .iter()
         .copied()
         .filter(|idx| *idx != proposer_idx)
-        .choose_multiple(context, verifier_count.saturating_sub(1));
+        .sample(context, verifier_count.saturating_sub(1));
     let block = H::make_test_block(
         *state.parent,
         *state.parent_commitment,
@@ -732,7 +732,7 @@ pub fn hailstorm<H: TestHarness>(
         let max_down = max_down.max(1);
 
         for shutdown_idx in 0..shutdowns {
-            let leadup = context.gen_range(1..=max_interval);
+            let leadup = context.random_range(1..=max_interval);
             target_height += leadup;
 
             // Pick validators to crash and compute how far the advance should
@@ -743,13 +743,10 @@ pub fn hailstorm<H: TestHarness>(
             // reported for it.
             let active_pre = active_validator_indices(&validators);
             let down_limit = usize::min(max_down, active_pre.len().saturating_sub(1));
-            let down_count = context.gen_range(1..=down_limit.max(1));
-            let mut selected = active_pre
-                .iter()
-                .copied()
-                .choose_multiple(&mut context, down_count);
+            let down_count = context.random_range(1..=down_limit.max(1));
+            let mut selected = active_pre.iter().copied().sample(&mut context, down_count);
             selected.sort_unstable();
-            let crash_after = context.gen_range(0..=leadup);
+            let crash_after = context.random_range(0..=leadup);
             let persisted_height = target_height - leadup + crash_after;
 
             {
@@ -821,7 +818,7 @@ pub fn hailstorm<H: TestHarness>(
                 "marshal hailstorm shutdown"
             );
 
-            let downtime = context.gen_range(1..=max_interval);
+            let downtime = context.random_range(1..=max_interval);
             target_height += downtime;
             let mut state = HailstormState {
                 validators: &mut validators,
@@ -3101,10 +3098,10 @@ pub fn finalize<H: TestHarness>(seed: u64, link: Link, quorum_sees_finalization:
 
             let fin = H::make_finalization(proposal, &schemes, QUORUM);
             if quorum_sees_finalization {
-                let do_finalize = context.gen_bool(0.2);
+                let do_finalize = context.random_bool(0.2);
                 for (i, h) in handles
                     .iter_mut()
-                    .choose_multiple(&mut context, NUM_VALIDATORS as usize)
+                    .sample(&mut context, NUM_VALIDATORS as usize)
                     .iter_mut()
                     .enumerate()
                 {
@@ -3117,7 +3114,7 @@ pub fn finalize<H: TestHarness>(seed: u64, link: Link, quorum_sees_finalization:
                 }
             } else {
                 for h in handles.iter_mut() {
-                    if context.gen_bool(0.2)
+                    if context.random_bool(0.2)
                         || height.get() == NUM_BLOCKS
                         || height == bounds.last()
                     {

--- a/consensus/src/ordered_broadcast/engine.rs
+++ b/consensus/src/ordered_broadcast/engine.rs
@@ -42,7 +42,7 @@ use futures::{
     future::{self, Either},
     pin_mut, StreamExt,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     collections::BTreeMap,
     num::{NonZeroU64, NonZeroUsize},
@@ -60,7 +60,7 @@ struct Verify<C: PublicKey, D: Digest> {
 
 /// Instance of the engine.
 pub struct Engine<
-    E: BufferPooler + Clock + Spawner + CryptoRngCore + Storage + Metrics,
+    E: BufferPooler + Clock + Spawner + CryptoRng + Storage + Metrics,
     C: Signer,
     S: SequencersProvider<PublicKey = C::PublicKey>,
     P: Provider<Scope = Epoch, Scheme: scheme::Scheme<C::PublicKey, D>>,
@@ -198,7 +198,7 @@ pub struct Engine<
 }
 
 impl<
-        E: BufferPooler + Clock + Spawner + CryptoRngCore + Storage + Metrics,
+        E: BufferPooler + Clock + Spawner + CryptoRng + Storage + Metrics,
         C: Signer,
         S: SequencersProvider<PublicKey = C::PublicKey>,
         P: Provider<Scope = Epoch, Scheme: scheme::Scheme<C::PublicKey, D, PublicKey = C::PublicKey>>,

--- a/consensus/src/ordered_broadcast/mocks/reporter.rs
+++ b/consensus/src/ordered_broadcast/mocks/reporter.rs
@@ -14,7 +14,7 @@ use commonware_cryptography::{certificate::Scheme, Digest, PublicKey};
 use commonware_parallel::Sequential;
 use commonware_runtime::{spawn_cell, ContextCell, Handle, Metrics, Spawner};
 use commonware_utils::{channel::oneshot, NZUsize};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::collections::{btree_map::Entry, BTreeMap, HashMap, HashSet, VecDeque};
 
 #[allow(clippy::large_enum_variant)]
@@ -34,7 +34,7 @@ impl<C: PublicKey, S: Scheme, D: Digest> Policy for Message<C, S, D> {
     }
 }
 
-pub struct Reporter<R: CryptoRngCore, C: PublicKey, S: Scheme, D: Digest> {
+pub struct Reporter<R: CryptoRng, C: PublicKey, S: Scheme, D: Digest> {
     context: ContextCell<R>,
     mailbox: Receiver<Message<C, S, D>>,
 
@@ -60,7 +60,7 @@ pub struct Reporter<R: CryptoRngCore, C: PublicKey, S: Scheme, D: Digest> {
 
 impl<R, C, S, D> Reporter<R, C, S, D>
 where
-    R: CryptoRngCore + Metrics,
+    R: CryptoRng + Metrics,
     C: PublicKey,
     S: Scheme,
     D: Digest,

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -13,7 +13,7 @@ use commonware_cryptography::{
 };
 use commonware_parallel::Strategy;
 use commonware_utils::{channel::oneshot, ordered::Set, union, N3f1};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     hash::{Hash, Hasher},
     sync::Arc,
@@ -632,7 +632,7 @@ impl<P: PublicKey, S: Scheme, D: Digest> Node<P, S, D> {
         strategy: &impl Strategy,
     ) -> Result<Option<Chunk<P, D>>, Error>
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         Pr: Provider<Scope = Epoch, Scheme = S>,
         S: scheme::Scheme<P, D>,
     {
@@ -789,7 +789,7 @@ impl<P: PublicKey, S: Scheme, D: Digest> Ack<P, S, D> {
     /// Returns true if the attestation is valid, false otherwise.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<P, D>,
     {
         let ctx = AckSubject {
@@ -1061,7 +1061,7 @@ impl<P: PublicKey, S: Scheme, D: Digest> Lock<P, S, D> {
     /// Returns true if the signature is valid, false otherwise.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<P, D>,
     {
         let ctx = AckSubject {

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -29,7 +29,7 @@ use commonware_runtime::{
     Clock, ContextCell, Handle, Metrics, Spawner,
 };
 use commonware_utils::ordered::{Quorum, Set};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::collections::BTreeMap;
 use tracing::{debug, info_span, trace, Span};
 
@@ -43,7 +43,7 @@ struct Current {
 
 pub struct Actor<E, S, B, D, Re, Rl, T>
 where
-    E: Spawner + Metrics + Clock + CryptoRngCore,
+    E: Spawner + Metrics + Clock + CryptoRng,
     S: Scheme<D>,
     B: Blocker<PublicKey = S::PublicKey>,
     D: Digest,
@@ -80,7 +80,7 @@ where
 
 impl<E, S, B, D, Re, Rl, T> Actor<E, S, B, D, Re, Rl, T>
 where
-    E: Spawner + Metrics + Clock + CryptoRngCore,
+    E: Spawner + Metrics + Clock + CryptoRng,
     S: Scheme<D>,
     B: Blocker<PublicKey = S::PublicKey>,
     D: Digest,

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -19,7 +19,7 @@ use commonware_utils::{
     ordered::{Quorum, Set},
     N3f1,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use tracing::{info_span, Span};
 
 /// Per-view state for vote accumulation and certificate tracking.
@@ -327,7 +327,7 @@ impl<
     }
 
     #[tracing::instrument(name = "simplex.batcher.verify_notarizes", level = "info", skip_all, fields(epoch = self.round.epoch().traced(), view = self.round.view().traced()))]
-    pub fn verify_notarizes<E: CryptoRngCore>(
+    pub fn verify_notarizes<E: CryptoRng>(
         &mut self,
         rng: &mut E,
         strategy: &impl Strategy,
@@ -344,7 +344,7 @@ impl<
     }
 
     #[tracing::instrument(name = "simplex.batcher.verify_nullifies", level = "info", skip_all, fields(epoch = self.round.epoch().traced(), view = self.round.view().traced()))]
-    pub fn verify_nullifies<E: CryptoRngCore>(
+    pub fn verify_nullifies<E: CryptoRng>(
         &mut self,
         rng: &mut E,
         strategy: &impl Strategy,
@@ -361,7 +361,7 @@ impl<
     }
 
     #[tracing::instrument(name = "simplex.batcher.verify_finalizes", level = "info", skip_all, fields(epoch = self.round.epoch().traced(), view = self.round.view().traced()))]
-    pub fn verify_finalizes<E: CryptoRngCore>(
+    pub fn verify_finalizes<E: CryptoRng>(
         &mut self,
         rng: &mut E,
         strategy: &impl Strategy,

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use commonware_cryptography::{certificate::Verification, Digest};
 use commonware_parallel::Strategy;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// `Verifier` is a utility for tracking and verifying consensus messages.
 ///
@@ -198,7 +198,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// A tuple containing:
     /// * A `Vec<Vote<S, D>>` of successfully verified [Vote::Notarize] messages.
     /// * A `Vec<Participant>` of signer indices for whom verification failed.
-    pub fn verify_notarizes<R: CryptoRngCore>(
+    pub fn verify_notarizes<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
@@ -292,7 +292,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// A tuple containing:
     /// * A `Vec<Vote<S, D>>` of successfully verified [Vote::Nullify] messages.
     /// * A `Vec<Participant>` of signer indices for whom verification failed.
-    pub fn verify_nullifies<R: CryptoRngCore>(
+    pub fn verify_nullifies<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
@@ -368,7 +368,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// A tuple containing:
     /// * A `Vec<Vote<S, D>>` of successfully verified [Vote::Finalize] messages.
     /// * A `Vec<Participant>` of signer indices for whom verification failed.
-    pub fn verify_finalizes<R: CryptoRngCore>(
+    pub fn verify_finalizes<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -25,13 +25,13 @@ use commonware_runtime::{
     Metrics, Spawner,
 };
 use commonware_utils::{channel::fallible::OneshotExt, ordered::Quorum, sequence::U64};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{num::NonZeroUsize, time::Duration};
 use tracing::{debug, info_span};
 
 /// Requests are made concurrently to multiple peers.
 pub struct Actor<
-    E: BufferPooler + Clock + CryptoRngCore + Metrics + Spawner,
+    E: BufferPooler + Clock + CryptoRng + Metrics + Spawner,
     S: Scheme<D>,
     B: Blocker<PublicKey = S::PublicKey>,
     D: Digest,
@@ -52,7 +52,7 @@ pub struct Actor<
 }
 
 impl<
-        E: BufferPooler + Clock + CryptoRngCore + Metrics + Spawner,
+        E: BufferPooler + Clock + CryptoRng + Metrics + Spawner,
         S: Scheme<D>,
         B: Blocker<PublicKey = S::PublicKey>,
         D: Digest,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -36,7 +36,7 @@ use commonware_storage::journal::segmented::variable::{Config as JConfig, Journa
 use commonware_utils::{channel::oneshot, futures::AbortablePool};
 use core::{future::Future, panic};
 use futures::{pin_mut, StreamExt};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     num::NonZeroUsize,
     pin::Pin,
@@ -95,7 +95,7 @@ impl<'a, V: Viewable, R> Future for Waiter<'a, V, R> {
 
 /// Actor responsible for driving participation in the consensus protocol.
 pub struct Actor<
-    E: BufferPooler + Clock + CryptoRngCore + Spawner + Storage + Metrics,
+    E: BufferPooler + Clock + CryptoRng + Spawner + Storage + Metrics,
     S: Scheme<D>,
     L: Elector<S>,
     B: Blocker<PublicKey = S::PublicKey>,
@@ -127,7 +127,7 @@ pub struct Actor<
 }
 
 impl<
-        E: BufferPooler + Clock + CryptoRngCore + Spawner + Storage + Metrics,
+        E: BufferPooler + Clock + CryptoRng + Spawner + Storage + Metrics,
         S: Scheme<D>,
         L: Elector<S>,
         B: Blocker<PublicKey = S::PublicKey>,

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -21,7 +21,7 @@ use commonware_runtime::{
     Clock, Metrics,
 };
 use commonware_utils::futures::Aborter;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     collections::{BTreeMap, BTreeSet},
     mem::{replace, take},
@@ -90,7 +90,7 @@ pub struct Config<S: certificate::Scheme, L: ElectorConfig<S>> {
 ///
 /// Tracks proposals and certificates for each view. Vote aggregation and verification
 /// is handled by the [crate::simplex::actors::batcher].
-pub struct State<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: Digest> {
+pub struct State<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: Digest> {
     context: E,
     scheme: S,
     elector: L::Elector,
@@ -113,7 +113,7 @@ pub struct State<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorCon
     nullifications: CounterFamily<Leader<S::PublicKey>>,
 }
 
-impl<E: Clock + CryptoRngCore + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: Digest>
+impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: ElectorConfig<S>, D: Digest>
     State<E, S, L, D>
 {
     pub fn new(context: E, cfg: Config<S, L>) -> Self {

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -10,7 +10,7 @@ use commonware_cryptography::{certificate::Scheme, Digest};
 use commonware_p2p::Blocker;
 use commonware_parallel::Strategy;
 use commonware_runtime::buffer::paged::CacheRef;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{num::NonZeroUsize, time::Duration};
 
 /// Controls whether and how the engine proactively forwards certified blocks
@@ -53,7 +53,7 @@ pub enum Floor<S: Scheme, D: Digest> {
 impl<S: Scheme, D: Digest> Floor<S, D> {
     fn assert<Rng>(&self, epoch: Epoch, rng: &mut Rng, scheme: &S, strategy: &impl Strategy)
     where
-        Rng: CryptoRngCore,
+        Rng: CryptoRng,
         S: super::scheme::Scheme<D>,
     {
         if let Self::Finalized(finalization) = self {
@@ -198,7 +198,7 @@ impl<
     /// The RNG is used to verify finalized floor certificates.
     pub fn assert<Rng>(&self, rng: &mut Rng)
     where
-        Rng: CryptoRngCore,
+        Rng: CryptoRng,
         S: super::scheme::Scheme<D>,
     {
         assert!(

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -496,7 +496,7 @@ mod tests {
         use commonware_codec::{Encode, Write};
         use commonware_conformance::Conformance;
         use commonware_cryptography::Sha256;
-        use rand::{Rng, SeedableRng};
+        use rand::{RngExt as _, SeedableRng};
         use rand_chacha::ChaCha8Rng;
 
         /// Conformance test for shuffled RoundRobin leader election.
@@ -511,12 +511,12 @@ mod tests {
                 let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
                 // Generate deterministic participants (using ed25519 fixture)
-                let n = rng.gen_range(1..=100);
+                let n = rng.random_range(1..=100);
                 let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, n);
                 let participants = Set::try_from_iter(participants).unwrap();
 
                 // Generate a random seed for shuffling
-                let shuffle_seed: [u8; 32] = rng.gen();
+                let shuffle_seed: [u8; 32] = rng.random();
 
                 // Build the shuffled elector
                 let elector: RoundRobinElector<ed25519::Scheme> =
@@ -539,7 +539,7 @@ mod tests {
                 let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
                 // Generate deterministic BLS threshold fixture (4-10 participants)
-                let n = rng.gen_range(4..=10);
+                let n = rng.random_range(4..=10);
                 let Fixture {
                     participants,
                     schemes,
@@ -550,8 +550,8 @@ mod tests {
                 let quorum = N3f1::quorum(schemes.len()) as usize;
 
                 // Generate deterministic round parameters
-                let epoch = rng.gen_range(0..1000);
-                let view = rng.gen_range(2..=101);
+                let epoch = rng.random_range(0..1000);
+                let view = rng.random_range(2..=101);
 
                 let round = Round::new(Epoch::new(epoch), View::new(view));
 

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -15,12 +15,12 @@ use commonware_parallel::Strategy;
 use commonware_runtime::{
     spawn_cell, BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner, Storage,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use tracing::debug;
 
 /// Instance of `simplex` consensus engine.
 pub struct Engine<
-    E: BufferPooler + Clock + CryptoRngCore + Spawner + Storage + Metrics,
+    E: BufferPooler + Clock + CryptoRng + Spawner + Storage + Metrics,
     S: Scheme<D>,
     L: Elector<S>,
     B: Blocker<PublicKey = S::PublicKey>,
@@ -43,7 +43,7 @@ pub struct Engine<
 }
 
 impl<
-        E: BufferPooler + Clock + CryptoRngCore + Spawner + Storage + Metrics,
+        E: BufferPooler + Clock + CryptoRng + Spawner + Storage + Metrics,
         S: Scheme<D>,
         L: Elector<S>,
         B: Blocker<PublicKey = S::PublicKey>,

--- a/consensus/src/simplex/mocks/application.rs
+++ b/consensus/src/simplex/mocks/application.rs
@@ -18,7 +18,7 @@ use commonware_utils::channel::{
     fallible::{FallibleExt, OneshotExt},
     mpsc, oneshot,
 };
-use rand::{Rng, RngCore};
+use rand::{Rng, RngExt as _};
 use rand_distr::{Distribution, Normal};
 use std::{
     collections::{HashMap, HashSet},
@@ -166,7 +166,7 @@ pub struct Config<H: Hasher, P: PublicKey> {
     pub should_certify: Certifier<H::Digest>,
 }
 
-pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
+pub struct Application<E: Clock + Rng + Spawner, H: Hasher, P: PublicKey> {
     context: ContextCell<E>,
     hasher: H,
     me: P,
@@ -209,7 +209,7 @@ pub struct Application<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> {
     pending_certifications: Vec<oneshot::Sender<bool>>,
 }
 
-impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P> {
+impl<E: Clock + Rng + Spawner, H: Hasher, P: PublicKey> Application<E, H, P> {
     pub fn new(context: E, cfg: Config<H, P>) -> (Self, Mailbox<H::Digest, P>) {
         // Register self on relay
         let broadcast = cfg.relay.register(cfg.me.clone());
@@ -297,7 +297,7 @@ impl<E: Clock + RngCore + Spawner, H: Hasher, P: PublicKey> Application<E, H, P>
             .await;
 
         // Generate the payload
-        let rand = self.context.gen::<u64>();
+        let rand = self.context.random::<u64>();
         let payload = (context.round, context.parent.1, rand).encode();
         self.hasher.update(&payload);
         let digest = self.hasher.finalize();

--- a/consensus/src/simplex/mocks/conflicter.rs
+++ b/consensus/src/simplex/mocks/conflicter.rs
@@ -9,7 +9,7 @@ use commonware_cryptography::{certificate::Scheme, Hasher};
 use commonware_math::algebra::Random;
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Spawner};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::marker::PhantomData;
 use tracing::debug;
 
@@ -17,7 +17,7 @@ pub struct Config<S: Scheme> {
     pub scheme: S,
 }
 
-pub struct Conflicter<E: Clock + CryptoRngCore + Spawner, S: Scheme, H: Hasher> {
+pub struct Conflicter<E: Clock + CryptoRng + Spawner, S: Scheme, H: Hasher> {
     context: ContextCell<E>,
     scheme: S,
     _hasher: PhantomData<H>,
@@ -25,7 +25,7 @@ pub struct Conflicter<E: Clock + CryptoRngCore + Spawner, S: Scheme, H: Hasher> 
 
 impl<E, S, H> Conflicter<E, S, H>
 where
-    E: Clock + CryptoRngCore + Spawner,
+    E: Clock + CryptoRng + Spawner,
     S: scheme::Scheme<H::Digest>,
     H: Hasher,
 {

--- a/consensus/src/simplex/mocks/equivocator.rs
+++ b/consensus/src/simplex/mocks/equivocator.rs
@@ -15,7 +15,7 @@ use commonware_cryptography::{certificate, Hasher};
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Spawner};
 use commonware_utils::ordered::Quorum;
-use rand::{seq::IteratorRandom, Rng};
+use rand::{seq::IteratorRandom, Rng, RngExt as _};
 use std::{collections::HashSet, sync::Arc};
 
 pub struct Config<S: certificate::Scheme, L: ElectorConfig<S>, H: Hasher> {
@@ -125,8 +125,8 @@ impl<E: Clock + Rng + Spawner, S: Scheme<H::Digest>, L: ElectorConfig<S>, H: Has
                 .unwrap();
 
             // Create two different proposals
-            let payload_a = (next_round, parent, self.context.gen::<u64>()).encode();
-            let payload_b = (next_round, parent, self.context.gen::<u64>()).encode();
+            let payload_a = (next_round, parent, self.context.random::<u64>()).encode();
+            let payload_b = (next_round, parent, self.context.random::<u64>()).encode();
 
             // Compute digests
             self.hasher.update(&payload_a);

--- a/consensus/src/simplex/mocks/impersonator.rs
+++ b/consensus/src/simplex/mocks/impersonator.rs
@@ -11,7 +11,7 @@ use commonware_codec::{DecodeExt, Encode};
 use commonware_cryptography::{certificate::Scheme, Hasher};
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Spawner};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::marker::PhantomData;
 use tracing::debug;
 
@@ -19,14 +19,14 @@ pub struct Config<S: Scheme> {
     pub scheme: S,
 }
 
-pub struct Impersonator<E: Clock + CryptoRngCore + Spawner, S: Scheme, H: Hasher> {
+pub struct Impersonator<E: Clock + CryptoRng + Spawner, S: Scheme, H: Hasher> {
     context: ContextCell<E>,
     scheme: S,
 
     _hasher: PhantomData<H>,
 }
 
-impl<E: Clock + CryptoRngCore + Spawner, S: scheme::Scheme<H::Digest>, H: Hasher>
+impl<E: Clock + CryptoRng + Spawner, S: scheme::Scheme<H::Digest>, H: Hasher>
     Impersonator<E, S, H>
 {
     pub fn new(context: E, cfg: Config<S>) -> Self {

--- a/consensus/src/simplex/mocks/outdated.rs
+++ b/consensus/src/simplex/mocks/outdated.rs
@@ -12,7 +12,7 @@ use commonware_codec::{DecodeExt, Encode};
 use commonware_cryptography::{certificate::Scheme, Hasher};
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Spawner};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::collections::HashMap;
 use tracing::debug;
 
@@ -21,7 +21,7 @@ pub struct Config<S: Scheme> {
     pub view_delta: ViewDelta,
 }
 
-pub struct Outdated<E: Clock + CryptoRngCore + Spawner, S: Scheme, H: Hasher> {
+pub struct Outdated<E: Clock + CryptoRng + Spawner, S: Scheme, H: Hasher> {
     context: ContextCell<E>,
     scheme: S,
 
@@ -31,7 +31,7 @@ pub struct Outdated<E: Clock + CryptoRngCore + Spawner, S: Scheme, H: Hasher> {
 
 impl<E, S, H> Outdated<E, S, H>
 where
-    E: Clock + CryptoRngCore + Spawner,
+    E: Clock + CryptoRng + Spawner,
     S: scheme::Scheme<H::Digest>,
     H: Hasher,
 {

--- a/consensus/src/simplex/mocks/reporter.rs
+++ b/consensus/src/simplex/mocks/reporter.rs
@@ -28,7 +28,7 @@ use commonware_utils::{
     sync::Mutex,
     N3f1,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
@@ -47,7 +47,7 @@ pub struct Config<S: Scheme, L: ElectorConfig<S>> {
     pub elector: L,
 }
 
-pub struct Reporter<E: CryptoRngCore, S: Scheme, L: ElectorConfig<S>, D: Digest> {
+pub struct Reporter<E: CryptoRng, S: Scheme, L: ElectorConfig<S>, D: Digest> {
     context: Arc<Mutex<E>>,
     pub participants: Set<S::PublicKey>,
     scheme: S,
@@ -71,7 +71,7 @@ pub struct Reporter<E: CryptoRngCore, S: Scheme, L: ElectorConfig<S>, D: Digest>
 
 impl<E, S, L, D> Clone for Reporter<E, S, L, D>
 where
-    E: CryptoRngCore,
+    E: CryptoRng,
     S: Scheme,
     L: ElectorConfig<S>,
     L::Elector: Clone,
@@ -102,7 +102,7 @@ where
 
 impl<E, S, L, D> Reporter<E, S, L, D>
 where
-    E: CryptoRngCore,
+    E: CryptoRng,
     S: Scheme,
     L: ElectorConfig<S>,
     D: Digest + Eq + Hash + Clone,
@@ -160,7 +160,7 @@ where
 
 impl<E, S, L, D> crate::Reporter for Reporter<E, S, L, D>
 where
-    E: CryptoRngCore + Send + Sync + 'static,
+    E: CryptoRng + Send + Sync + 'static,
     S: scheme::Scheme<D>,
     L: ElectorConfig<S>,
     D: Digest + Eq + Hash + Clone,
@@ -345,7 +345,7 @@ where
 
 impl<E, S, L, D> Monitor for Reporter<E, S, L, D>
 where
-    E: CryptoRngCore + Send + Sync + 'static,
+    E: CryptoRng + Send + Sync + 'static,
     S: Scheme,
     L: ElectorConfig<S>,
     D: Digest + Eq + Hash + Clone,

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -77,7 +77,7 @@ use crate::{
 use commonware_cryptography::certificate::Scheme;
 use commonware_p2p::simulated::SplitTarget;
 use commonware_utils::ordered::Set;
-use rand::{seq::SliceRandom, Rng};
+use rand::{seq::SliceRandom, Rng, RngExt as _};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -1207,7 +1207,7 @@ fn sample_unique_indices(rng: &mut impl Rng, total: u128, samples: usize) -> Vec
     let mut sampled = Vec::with_capacity(samples);
     let mut seen = HashSet::with_capacity(samples);
     for idx in (total - samples as u128)..total {
-        let candidate = rng.gen_range(0..=idx);
+        let candidate = rng.random_range(0..=idx);
         if seen.insert(candidate) {
             sampled.push(candidate);
         } else {

--- a/consensus/src/simplex/mocks/wrapped.rs
+++ b/consensus/src/simplex/mocks/wrapped.rs
@@ -156,7 +156,7 @@ where
         strategy: &impl commonware_parallel::Strategy,
     ) -> bool
     where
-        R: rand_core::CryptoRngCore,
+        R: rand_core::CryptoRng,
         D: Digest,
         M: Faults,
     {
@@ -218,7 +218,7 @@ where
         strategy: &impl commonware_parallel::Strategy,
     ) -> bool
     where
-        R: rand_core::CryptoRngCore,
+        R: rand_core::CryptoRng,
         D: Digest,
     {
         self.inner.verify_attestation(
@@ -237,7 +237,7 @@ where
         strategy: &impl commonware_parallel::Strategy,
     ) -> Verification<Self>
     where
-        R: rand_core::CryptoRngCore,
+        R: rand_core::CryptoRng,
         D: Digest,
         I: IntoIterator<Item = Attestation<Self>>,
         I::IntoIter: Send,

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -459,7 +459,7 @@ mod tests {
     use commonware_utils::{ordered::Set, sync::Mutex, test_rng, Faults, N3f1, NZUsize, NZU16};
     use engine::Engine;
     use futures::future::join_all;
-    use rand::{rngs::StdRng, Rng as _, SeedableRng};
+    use rand::{rngs::StdRng, RngExt as _, SeedableRng};
     use std::{
         collections::{BTreeMap, HashMap, HashSet},
         num::{NonZeroU16, NonZeroU32, NonZeroUsize},
@@ -1585,12 +1585,12 @@ mod tests {
             schemes,
             ..
         } = fixture(&mut rng, &namespace, n);
+        let reporter_seed: [u8; 32] = rng.random();
 
         // Create block relay, shared across restarts.
         let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, S::PublicKey>::new());
 
         loop {
-            let rng = rng.clone();
             let participants = participants.clone();
             let schemes = schemes.clone();
             let shutdowns = shutdowns.clone();
@@ -1633,7 +1633,8 @@ mod tests {
                         scheme: schemes[idx].clone(),
                         elector: elector.clone(),
                     };
-                    let reporter = mocks::reporter::Reporter::new(rng.clone(), reporter_config);
+                    let reporter_rng = StdRng::from_seed(reporter_seed);
+                    let reporter = mocks::reporter::Reporter::new(reporter_rng, reporter_config);
                     reporters.insert(validator.clone(), reporter.clone());
                     let application_cfg = mocks::application::Config {
                         hasher: Sha256::default(),
@@ -1698,7 +1699,7 @@ mod tests {
 
                 // Exit at random points for unclean shutdown of entire set
                 let wait =
-                    context.gen_range(Duration::from_millis(100)..Duration::from_millis(2_000));
+                    context.random_range(Duration::from_millis(100)..Duration::from_millis(2_000));
                 let result = select! {
                     _ = context.sleep(wait) => {
                         // Collect reporters to check faults
@@ -3882,7 +3883,7 @@ mod tests {
             join_all(finalizers).await;
 
             // Abort a validator
-            let idx = context.gen_range(1..engines.len()); // skip byzantine validator
+            let idx = context.random_range(1..engines.len()); // skip byzantine validator
             let validator = &participants[idx];
             let handle = engines.remove(idx);
             handle.abort();
@@ -5566,7 +5567,7 @@ mod tests {
                 target = target.saturating_add(interval);
 
                 // Select a random engine to shutdown
-                let idx = context.gen_range(0..engine_handlers.len());
+                let idx = context.random_range(0..engine_handlers.len());
                 let validator = &participants[idx];
                 let handle = engine_handlers.remove(&idx).unwrap();
                 handle.abort();
@@ -5854,8 +5855,7 @@ mod tests {
             let trailing_finalizations = campaign.trailing_finalizations;
             let mut case_fixture =
                 |ctx: &mut deterministic::Context, ns: &[u8], n: u32| fixture(ctx, ns, n);
-            let cfg = deterministic::Config::new()
-                .with_rng(Box::new(StdRng::from_rng(&mut *rng).unwrap()));
+            let cfg = deterministic::Config::new().with_rng(Box::new(StdRng::from_rng(&mut *rng)));
             let executor = deterministic::Runner::new(cfg);
             executor.start(|mut context| async move {
                 let Fixture {

--- a/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
@@ -60,7 +60,7 @@ use commonware_macros::stability;
 use commonware_parallel::Strategy;
 use commonware_utils::{ordered::Set, Faults};
 use rand::{rngs::StdRng, SeedableRng};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::Debug,
@@ -246,7 +246,7 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
     /// from a certificate of the target round (i.e. notarization, finalization,
     /// or nullification).
     #[stability(ALPHA)]
-    pub fn encrypt<R: CryptoRngCore>(
+    pub fn encrypt<R: CryptoRng>(
         &self,
         rng: &mut R,
         target: Round,
@@ -269,7 +269,7 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
 /// from a certificate of the target round (i.e. notarization, finalization,
 /// or nullification).
 #[stability(ALPHA)]
-pub fn encrypt<R: CryptoRngCore, V: Variant>(
+pub fn encrypt<R: CryptoRng, V: Variant>(
     rng: &mut R,
     identity: V::Public,
     namespace: &[u8],
@@ -296,7 +296,7 @@ pub fn fixture<V, R>(
 >
 where
     V: Variant,
-    R: rand::RngCore + rand::CryptoRng,
+    R: rand::Rng + rand::CryptoRng,
 {
     commonware_cryptography::bls12381::certificate::threshold::mocks::fixture::<_, V, _>(
         rng,
@@ -562,7 +562,7 @@ impl<P: PublicKey, V: Variant> certificate::Verifier for Scheme<P, V> {
         strategy: &impl Strategy,
     ) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         M: Faults,
     {
@@ -591,7 +591,7 @@ impl<P: PublicKey, V: Variant> certificate::Verifier for Scheme<P, V> {
         strategy: &impl Strategy,
     ) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (Subject<'a, D>, &'a Self::Certificate)>,
         M: Faults,
@@ -691,7 +691,7 @@ impl<P: PublicKey, V: Variant> certificate::Scheme for Scheme<P, V> {
         strategy: &impl Strategy,
     ) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
     {
         let Ok(evaluated) = self.polynomial().partial_public(attestation.signer) else {
@@ -730,7 +730,7 @@ impl<P: PublicKey, V: Variant> certificate::Scheme for Scheme<P, V> {
         strategy: &impl Strategy,
     ) -> Verification<Self>
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: IntoIterator<Item = Attestation<Self>>,
         I::IntoIter: Send,

--- a/consensus/src/simplex/scheme/reporter.rs
+++ b/consensus/src/simplex/scheme/reporter.rs
@@ -26,7 +26,7 @@ use commonware_actor::Feedback;
 use commonware_cryptography::{certificate, Digest};
 use commonware_parallel::Strategy;
 use commonware_utils::sync::Mutex;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::sync::Arc;
 
 /// Reporter wrapper that filters and verifies activities based on scheme attributability.
@@ -35,7 +35,7 @@ use std::sync::Arc;
 /// activities. It prevents signature forgery attacks on non-attributable schemes while ensuring
 /// all activities are cryptographically valid before reporting.
 pub struct AttributableReporter<
-    E: CryptoRngCore + Send + 'static,
+    E: CryptoRng + Send + 'static,
     S: certificate::Scheme,
     D: Digest,
     T: Strategy,
@@ -54,7 +54,7 @@ pub struct AttributableReporter<
 }
 
 impl<
-        E: CryptoRngCore + Send + 'static,
+        E: CryptoRng + Send + 'static,
         S: certificate::Scheme + Clone,
         D: Digest,
         T: Strategy,
@@ -73,7 +73,7 @@ impl<
 }
 
 impl<
-        E: CryptoRngCore + Send + 'static,
+        E: CryptoRng + Send + 'static,
         S: certificate::Scheme,
         D: Digest,
         T: Strategy,
@@ -93,7 +93,7 @@ impl<
 }
 
 impl<
-        E: CryptoRngCore + Send + 'static,
+        E: CryptoRng + Send + 'static,
         S: Scheme<D>,
         D: Digest,
         T: Strategy,

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -13,7 +13,7 @@ use commonware_cryptography::{
 };
 use commonware_parallel::Strategy;
 use commonware_utils::N3f1;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{collections::HashSet, fmt::Debug, hash::Hash};
 
 /// Context is a collection of metadata from consensus about a given payload.
@@ -847,7 +847,7 @@ impl<S: Scheme, D: Digest> Notarize<S, D> {
     /// This ensures that the notarize signature is valid for the claimed proposal.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<D>,
     {
         scheme.verify_attestation::<_, D>(
@@ -953,7 +953,7 @@ pub fn verify_certificates<'a, R, S, D>(
     strategy: &impl Strategy,
 ) -> Vec<bool>
 where
-    R: CryptoRngCore,
+    R: CryptoRng,
     S: CertificateVerifier<D>,
     D: Digest,
 {
@@ -995,7 +995,7 @@ impl<S: Scheme, D: Digest> Notarization<S, D> {
     /// Verifies the notarization certificate against the provided signing scheme.
     ///
     /// This ensures that the certificate is valid for the claimed proposal.
-    pub fn verify<R: CryptoRngCore>(
+    pub fn verify<R: CryptoRng>(
         &self,
         rng: &mut R,
         scheme: &impl CertificateVerifier<D, Certificate = S::Certificate>,
@@ -1128,7 +1128,7 @@ impl<S: Scheme> Nullify<S> {
     /// This ensures that the nullify signature is valid for the given round.
     pub fn verify<R, D: Digest>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<D>,
     {
         scheme.verify_attestation::<_, D>(
@@ -1227,7 +1227,7 @@ impl<S: Scheme> Nullification<S> {
     /// Verifies the nullification certificate against the provided signing scheme.
     ///
     /// This ensures that the certificate is valid for the claimed round.
-    pub fn verify<R: CryptoRngCore, D: Digest>(
+    pub fn verify<R: CryptoRng, D: Digest>(
         &self,
         rng: &mut R,
         scheme: &impl CertificateVerifier<D, Certificate = S::Certificate>,
@@ -1342,7 +1342,7 @@ impl<S: Scheme, D: Digest> Finalize<S, D> {
     /// This ensures that the finalize signature is valid for the claimed proposal.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<D>,
     {
         scheme.verify_attestation::<_, D>(
@@ -1472,7 +1472,7 @@ impl<S: Scheme, D: Digest> Finalization<S, D> {
     /// Verifies the finalization certificate against the provided signing scheme.
     ///
     /// This ensures that the certificate is valid for the claimed proposal.
-    pub fn verify<R: CryptoRngCore>(
+    pub fn verify<R: CryptoRng>(
         &self,
         rng: &mut R,
         scheme: &impl CertificateVerifier<D, Certificate = S::Certificate>,
@@ -1744,12 +1744,7 @@ impl<S: Scheme, D: Digest> Response<S, D> {
     }
 
     /// Verifies the certificates contained in this response against the signing scheme.
-    pub fn verify<R: CryptoRngCore>(
-        &self,
-        rng: &mut R,
-        scheme: &S,
-        strategy: &impl Strategy,
-    ) -> bool
+    pub fn verify<R: CryptoRng>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
         S: scheme::Scheme<D>,
     {
@@ -1987,12 +1982,7 @@ impl<S: Scheme, D: Digest> Activity<S, D> {
     /// This method **always** performs verification regardless of whether the activity has been
     /// previously verified. Callers can use [`Activity::verified`] to check if verification is
     /// necessary before calling this method.
-    pub fn verify<R: CryptoRngCore>(
-        &self,
-        rng: &mut R,
-        scheme: &S,
-        strategy: &impl Strategy,
-    ) -> bool
+    pub fn verify<R: CryptoRng>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
         S: scheme::Scheme<D>,
     {
@@ -2267,7 +2257,7 @@ impl<S: Scheme, D: Digest> ConflictingNotarize<S, D> {
     /// Verifies that both conflicting signatures are valid, proving Byzantine behavior.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<D>,
     {
         self.notarize_1.verify(rng, scheme, strategy)
@@ -2395,7 +2385,7 @@ impl<S: Scheme, D: Digest> ConflictingFinalize<S, D> {
     /// Verifies that both conflicting signatures are valid, proving Byzantine behavior.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<D>,
     {
         self.finalize_1.verify(rng, scheme, strategy)
@@ -2512,7 +2502,7 @@ impl<S: Scheme, D: Digest> NullifyFinalize<S, D> {
     /// Verifies that both the nullify and finalize signatures are valid, proving Byzantine behavior.
     pub fn verify<R>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         S: scheme::Scheme<D>,
     {
         self.nullify.verify(rng, scheme, strategy) && self.finalize.verify(rng, scheme, strategy)

--- a/consensus/src/types.rs
+++ b/consensus/src/types.rs
@@ -729,7 +729,7 @@ commonware_macros::stability_scope!(ALPHA {
             num::NonZeroU16,
             ops::{Deref, Range},
         };
-        use rand_core::CryptoRngCore;
+        use rand_core::CryptoRng;
 
         /// A [`Digest`] containing a coding commitment, encoded [`CodingConfig`], and context hash.
         ///
@@ -800,7 +800,7 @@ commonware_macros::stability_scope!(ALPHA {
         }
 
         impl Random for Commitment {
-            fn random(mut rng: impl CryptoRngCore) -> Self {
+            fn random(mut rng: impl CryptoRng) -> Self {
                 let mut buf = [0u8; Self::SIZE];
                 rng.fill_bytes(&mut buf[..Self::CONFIG_OFFSET]);
 
@@ -1710,7 +1710,7 @@ mod tests {
         struct Digest([u8; Self::SIZE]);
 
         impl Random for Digest {
-            fn random(mut rng: impl rand_core::CryptoRngCore) -> Self {
+            fn random(mut rng: impl rand_core::CryptoRng) -> Self {
                 let mut buf = [0u8; Self::SIZE];
                 rng.fill_bytes(&mut buf);
                 Self(buf)

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -1,4 +1,4 @@
 cooldown_minutes = 10080
 enforcement = "strict"
-lockfile_baseline = "ignore"
+lockfile_baseline = "floor"
 cache_dir = "target/cargo-cooldown"

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -58,8 +58,14 @@ default-features = false
 features = ["alloc"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
-# Enable "js" feature when WASM is target
-version = "0.2.15"
+# Enable the JS backend for transitive dependencies that use getrandom on WASM.
+version = "0.4.3"
+features = ["wasm_js"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom_v2]
+# Enable the JS backend for transitive dependencies that still use getrandom 0.2 on WASM.
+package = "getrandom"
+version = "0.2"
 features = ["js"]
 
 [dev-dependencies]
@@ -107,6 +113,7 @@ std = [
 	"ecdsa/std",
 	"fixedbitset/std",
 	"getrandom/std",
+	"getrandom_v2/std",
 	"num-rational",
 	"num-traits",
 	"num-traits?/std",
@@ -115,7 +122,6 @@ std = [
 	"rand/std",
 	"rand/std_rng",
 	"rand_chacha/std",
-	"rand_core/std",
 	"thiserror/std",
 	"zeroize/std",
 ]

--- a/cryptography/conformance.toml
+++ b/cryptography/conformance.toml
@@ -136,7 +136,7 @@ hash = "0cbb8c8644dffe0be78d1307fb5034dd804921d66799c1aaec3d335b44e9616c"
 
 ["commonware_cryptography::handshake::conformance::Handshake"]
 n_cases = 4096
-hash = "ed6ff974cf9460e825683ccaef3946e46c0db7281b41209dcee641ad1d46db77"
+hash = "057cc42a74390f0b43250b8fba2c42abad651bee6beacb510f2f2a950185a694"
 
 ["commonware_cryptography::handshake::key_exchange::conformance::CodecConformance<EphemeralPublicKey>"]
 n_cases = 65536

--- a/cryptography/conformance.toml
+++ b/cryptography/conformance.toml
@@ -188,7 +188,7 @@ hash = "c0501d4a691d1fccec7c5906e8608228569d24164150edd215838593e3b77512"
 
 ["commonware_cryptography::transcript::test::conformance::TranscriptOps"]
 n_cases = 4096
-hash = "e7d77c36167f3660015eee2c68d412443a0aa53cf3d8b94363f976519153d3e1"
+hash = "9115bb89c941947d7bfabb3c67b7812c842c3ab8be196a61e3378a873e2e5837"
 
 ["commonware_cryptography::zk::bulletproofs::ipa::conformance::CodecConformance<Claim<TestF,TestG>>"]
 n_cases = 65536

--- a/cryptography/conformance.toml
+++ b/cryptography/conformance.toml
@@ -186,6 +186,10 @@ hash = "d65ced18cacd65769e8f9732131a06216e6600d5a115c4ed7483a8530813ddcd"
 n_cases = 65536
 hash = "c0501d4a691d1fccec7c5906e8608228569d24164150edd215838593e3b77512"
 
+["commonware_cryptography::transcript::test::conformance::TranscriptOps"]
+n_cases = 4096
+hash = "e7d77c36167f3660015eee2c68d412443a0aa53cf3d8b94363f976519153d3e1"
+
 ["commonware_cryptography::zk::bulletproofs::ipa::conformance::CodecConformance<Claim<TestF,TestG>>"]
 n_cases = 65536
 hash = "e21188fc5031748fd25a5804f268ec5887612b7c78d5bc5fe97f0fb62be69f45"

--- a/cryptography/fuzz/Cargo.toml
+++ b/cryptography/fuzz/Cargo.toml
@@ -19,7 +19,6 @@ commonware-parallel = { workspace = true, features = ["std"] }
 commonware-utils = { workspace = true, features = ["std"] }
 crc.workspace = true
 ed25519-consensus.workspace = true
-ed25519-zebra.workspace = true
 libfuzzer-sys.workspace = true
 num-rational.workspace = true
 p256 = { workspace = true, features = ["ecdsa"] }

--- a/cryptography/fuzz/fuzz_targets/bls12381_threshold_operations.rs
+++ b/cryptography/fuzz/fuzz_targets/bls12381_threshold_operations.rs
@@ -11,7 +11,7 @@ use commonware_cryptography::bls12381::primitives::{
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::{N3f1, Participant};
 use libfuzzer_sys::fuzz_target;
-use rand::thread_rng;
+use rand::rng;
 use std::num::NonZeroUsize;
 
 mod common;
@@ -293,7 +293,7 @@ fn fuzz(op: FuzzOperation) {
                     })
                     .collect();
                 let _ = threshold::batch_verify_same_signer::<_, MinPk, _>(
-                    &mut thread_rng(),
+                    &mut rng(),
                     &public,
                     index,
                     &entries_refs,
@@ -323,7 +323,7 @@ fn fuzz(op: FuzzOperation) {
                     })
                     .collect();
                 let _ = threshold::batch_verify_same_signer::<_, MinSig, _>(
-                    &mut thread_rng(),
+                    &mut rng(),
                     &public,
                     index,
                     &entries_refs,
@@ -347,7 +347,7 @@ fn fuzz(op: FuzzOperation) {
                     })
                     .collect();
                 let _ = threshold::batch_verify_same_message::<_, MinPk, _>(
-                    &mut thread_rng(),
+                    &mut rng(),
                     &public,
                     &namespace,
                     &message,
@@ -372,7 +372,7 @@ fn fuzz(op: FuzzOperation) {
                     })
                     .collect();
                 let _ = threshold::batch_verify_same_message::<_, MinSig, _>(
-                    &mut thread_rng(),
+                    &mut rng(),
                     &public,
                     &namespace,
                     &message,

--- a/cryptography/fuzz/fuzz_targets/ed25519_decode.rs
+++ b/cryptography/fuzz/fuzz_targets/ed25519_decode.rs
@@ -11,10 +11,6 @@ use ed25519_consensus::{
     Signature as ConsensusSignature, SigningKey as ConsensusPrivateKey,
     VerificationKey as ConsensusPublicKey,
 };
-use ed25519_zebra::{
-    Signature as ZebraSignature, SigningKey as ZebraPrivateKey, VerificationKey as ZebraPublicKey,
-    VerificationKeyBytes as ZebraPublicKeyBytes,
-};
 use libfuzzer_sys::fuzz_target;
 
 #[derive(Debug)]
@@ -128,42 +124,29 @@ fn split_namespace_message(bytes: &[u8]) -> (&[u8], &[u8]) {
 
 fn test_pubkey(pubkey: &[u8]) {
     let consensus_result = ConsensusPublicKey::try_from(pubkey);
-    let zebra_result = ZebraPublicKey::try_from(pubkey);
     let our_result = PublicKey::decode(pubkey);
 
-    // All implementations should agree on public key validity
+    // Consensus implements the same ZIP-215 validation rules.
     assert_eq!(consensus_result.is_err(), our_result.is_err());
-    assert_eq!(zebra_result.is_err(), our_result.is_err());
 
     // If all succeeded, check round-trip encoding
-    if let (Ok(consensus_key), Ok(zebra_key), Ok(our_key)) =
-        (consensus_result, zebra_result, our_result)
-    {
+    if let (Ok(consensus_key), Ok(our_key)) = (consensus_result, our_result) {
         let our_bytes = our_key.encode();
         assert_eq!(&consensus_key.to_bytes()[..], our_bytes.as_ref());
-        assert_eq!(
-            ZebraPublicKeyBytes::from(zebra_key).as_ref(),
-            our_bytes.as_ref()
-        );
     }
 }
 
 fn test_signature(signature: &[u8]) {
     let consensus_result = ConsensusSignature::try_from(signature);
-    let zebra_result = ZebraSignature::from_slice(signature);
     let our_result = Signature::decode(signature);
 
-    // All implementations should agree on signature byte validity
+    // Consensus implements the same ZIP-215 validation rules.
     assert_eq!(consensus_result.is_err(), our_result.is_err());
-    assert_eq!(zebra_result.is_err(), our_result.is_err());
 
     // If all succeeded, check round-trip encoding
-    if let (Ok(consensus_signature), Ok(zebra_signature), Ok(our_signature)) =
-        (consensus_result, zebra_result, our_result)
-    {
+    if let (Ok(consensus_signature), Ok(our_signature)) = (consensus_result, our_result) {
         let our_bytes = our_signature.encode();
         assert_eq!(&consensus_signature.to_bytes()[..], our_bytes.as_ref());
-        assert_eq!(&zebra_signature.to_bytes()[..], our_bytes.as_ref());
     }
 }
 
@@ -177,13 +160,6 @@ fn test_verification(pubkey: &[u8], signature: &[u8], namespace: &[u8], message:
         (Ok(public_key), Ok(signature)) => Some(public_key.verify(&signature, &payload).is_ok()),
         _ => None,
     };
-    let zebra_result = match (
-        ZebraPublicKey::try_from(pubkey),
-        ZebraSignature::from_slice(signature),
-    ) {
-        (Ok(public_key), Ok(signature)) => Some(public_key.verify(&signature, &payload).is_ok()),
-        _ => None,
-    };
     let our_result = match (PublicKey::decode(pubkey), Signature::decode(signature)) {
         (Ok(public_key), Ok(signature)) => Some(public_key.verify(namespace, message, &signature)),
         _ => None,
@@ -191,7 +167,6 @@ fn test_verification(pubkey: &[u8], signature: &[u8], namespace: &[u8], message:
 
     // Decoding and verification should agree for arbitrary triples
     assert_eq!(consensus_result, our_result);
-    assert_eq!(zebra_result, our_result);
 }
 
 fn test_signing(seed: [u8; 32], namespace: &[u8], message: &[u8]) {
@@ -199,36 +174,27 @@ fn test_signing(seed: [u8; 32], namespace: &[u8], message: &[u8]) {
 
     // Construct equivalent signing keys from the same raw seed
     let consensus_private_key = ConsensusPrivateKey::from(seed);
-    let zebra_private_key = ZebraPrivateKey::from(seed);
     let our_private_key = PrivateKey::decode(seed.as_ref()).unwrap();
 
     // The derived public keys should have identical encodings
     let consensus_public_key = ConsensusPublicKey::from(&consensus_private_key);
-    let zebra_public_key = ZebraPublicKey::from(&zebra_private_key);
     let our_public_key = our_private_key.public_key();
 
     assert_eq!(
         &consensus_public_key.to_bytes()[..],
         our_public_key.as_ref()
     );
-    assert_eq!(
-        ZebraPublicKeyBytes::from(zebra_public_key).as_ref(),
-        our_public_key.as_ref()
-    );
 
     // Signing the same domain-separated payload should produce identical signatures
     let consensus_signature = consensus_private_key.sign(&payload);
-    let zebra_signature = zebra_private_key.sign(&payload);
     let our_signature = our_private_key.sign(namespace, message);
 
     assert_eq!(&consensus_signature.to_bytes()[..], our_signature.as_ref());
-    assert_eq!(&zebra_signature.to_bytes()[..], our_signature.as_ref());
 
     // Each implementation should accept the signature it produced
     assert!(consensus_public_key
         .verify(&consensus_signature, &payload)
         .is_ok());
-    assert!(zebra_public_key.verify(&zebra_signature, &payload).is_ok());
     assert!(our_public_key.verify(namespace, message, &our_signature));
 }
 

--- a/cryptography/fuzz/fuzz_targets/metamorph_lthash.rs
+++ b/cryptography/fuzz/fuzz_targets/metamorph_lthash.rs
@@ -3,7 +3,7 @@
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::lthash::LtHash;
 use libfuzzer_sys::fuzz_target;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 
 #[derive(Debug, Arbitrary)]
 enum MutationType {
@@ -38,7 +38,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 }
 
 fn generate_random_bytes(rng: &mut StdRng, min_len: usize, max_len: usize) -> Vec<u8> {
-    let len = rng.gen_range(min_len..=max_len);
+    let len = rng.random_range(min_len..=max_len);
     let mut bytes = vec![0u8; len];
     rng.fill(&mut bytes[..]);
     bytes
@@ -146,7 +146,7 @@ fn fuzz(input: FuzzInput) {
             // Shuffle elements
             let mut shuffled_elements = elements.clone();
             for i in (1..shuffled_elements.len()).rev() {
-                let j = rng.gen_range(0..=i);
+                let j = rng.random_range(0..=i);
                 shuffled_elements.swap(i, j);
             }
 

--- a/cryptography/src/banderwagon.rs
+++ b/cryptography/src/banderwagon.rs
@@ -58,7 +58,7 @@ impl F {
 }
 
 impl Random for F {
-    fn random(mut rng: impl rand_core::CryptoRngCore) -> Self {
+    fn random(mut rng: impl rand_core::CryptoRng) -> Self {
         // Rejection-sample a uniform element of `[0, r)`. Each candidate is
         // `F::BITS` random bits (the width of `r`), so it lands in `[0, 2^BITS)`
         // and is accepted with probability `r / 2^BITS > 0.9`: ~1.1 draws on

--- a/cryptography/src/blake3/benches/hash_message.rs
+++ b/cryptography/src/blake3/benches/hash_message.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::{blake3::Blake3, Hasher};
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 fn bench_hash_message(c: &mut Criterion) {
     let mut sampler = StdRng::seed_from_u64(0);

--- a/cryptography/src/blake3/mod.rs
+++ b/cryptography/src/blake3/mod.rs
@@ -31,7 +31,7 @@ use core::{
     fmt::{Debug, Display},
     ops::Deref,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use zeroize::Zeroize;
 
 /// Re-export [blake3::Hasher] as `CoreBlake3` for external use if needed.
@@ -167,7 +167,7 @@ impl crate::Digest for Digest {
 }
 
 impl Random for Digest {
-    fn random(mut rng: impl CryptoRngCore) -> Self {
+    fn random(mut rng: impl CryptoRng) -> Self {
         let mut array = [0u8; DIGEST_LENGTH];
         rng.fill_bytes(&mut array);
         Self(array)

--- a/cryptography/src/bloomfilter/benches/contains.rs
+++ b/cryptography/src/bloomfilter/benches/contains.rs
@@ -2,7 +2,7 @@ use commonware_cryptography::{blake3::Blake3, sha256::Sha256, BloomFilter, Hashe
 use commonware_utils::rational::BigRationalExt;
 use criterion::{criterion_group, Criterion};
 use num_rational::BigRational;
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{collections::HashSet, hint::black_box, num::NonZeroUsize};
 
 const ITEM_SIZES: [usize; 3] = [32, 2048, 4096];

--- a/cryptography/src/bloomfilter/benches/insert.rs
+++ b/cryptography/src/bloomfilter/benches/insert.rs
@@ -2,7 +2,7 @@ use commonware_cryptography::{blake3::Blake3, sha256::Sha256, BloomFilter, Hashe
 use commonware_utils::rational::BigRationalExt;
 use criterion::{criterion_group, BatchSize, Criterion};
 use num_rational::BigRational;
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::num::NonZeroUsize;
 
 const ITEM_SIZES: [usize; 3] = [32, 2048, 4096];

--- a/cryptography/src/bls12381/benches/aggregate_verify_same_message.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_same_message.rs
@@ -1,11 +1,11 @@
 use commonware_cryptography::bls12381::primitives::{ops, variant::MinSig};
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 
 fn bench_aggregate_verify_same_message(c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
-    thread_rng().fill(&mut msg);
+    rng().fill(&mut msg);
     for n in [10, 100, 1000, 10000].into_iter() {
         c.bench_function(&format!("{}/pks={}", module_path!(), n), |b| {
             b.iter_batched(
@@ -13,7 +13,7 @@ fn bench_aggregate_verify_same_message(c: &mut Criterion) {
                     let mut public_keys = Vec::with_capacity(n);
                     let mut signatures = Vec::with_capacity(n);
                     for _ in 0..n {
-                        let (private, public) = ops::keypair::<_, MinSig>(&mut thread_rng());
+                        let (private, public) = ops::keypair::<_, MinSig>(&mut rng());
                         let signature = ops::sign_message::<MinSig>(&private, namespace, &msg);
                         public_keys.push(public);
                         signatures.push(signature);

--- a/cryptography/src/bls12381/benches/aggregate_verify_same_signer.rs
+++ b/cryptography/src/bls12381/benches/aggregate_verify_same_signer.rs
@@ -2,7 +2,7 @@ use commonware_cryptography::bls12381::primitives::{ops, variant::MinSig};
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 
 fn bench_aggregate_verify_same_signer(c: &mut Criterion) {
     let namespace = b"namespace";
@@ -10,7 +10,7 @@ fn bench_aggregate_verify_same_signer(c: &mut Criterion) {
         let mut msgs = Vec::with_capacity(n);
         for _ in 0..n {
             let mut msg = [0u8; 32];
-            thread_rng().fill(&mut msg);
+            rng().fill(&mut msg);
             msgs.push(msg);
         }
         for concurrency in [1, 8].into_iter() {
@@ -20,7 +20,7 @@ fn bench_aggregate_verify_same_signer(c: &mut Criterion) {
                 |b| {
                     b.iter_batched(
                         || {
-                            let (private, public) = ops::keypair::<_, MinSig>(&mut thread_rng());
+                            let (private, public) = ops::keypair::<_, MinSig>(&mut rng());
                             let sigs: Vec<_> = msgs
                                 .iter()
                                 .map(|msg| ops::sign_message::<MinSig>(&private, namespace, msg))

--- a/cryptography/src/bls12381/benches/batch_verify_same_signer.rs
+++ b/cryptography/src/bls12381/benches/batch_verify_same_signer.rs
@@ -2,7 +2,7 @@ use commonware_cryptography::bls12381::primitives::{ops, variant::MinSig};
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 
 fn bench_batch_verify_same_signer(c: &mut Criterion) {
     let namespace = b"namespace";
@@ -10,7 +10,7 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
         let mut msgs: Vec<[u8; 32]> = Vec::with_capacity(n);
         for _ in 0..n {
             let mut msg = [0u8; 32];
-            thread_rng().fill(&mut msg);
+            rng().fill(&mut msg);
             msgs.push(msg);
         }
         for concurrency in [1, 8] {
@@ -20,7 +20,7 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
                 |b| {
                     b.iter_batched(
                         || {
-                            let (private, public) = ops::keypair::<_, MinSig>(&mut thread_rng());
+                            let (private, public) = ops::keypair::<_, MinSig>(&mut rng());
                             let entries: Vec<_> = msgs
                                 .iter()
                                 .map(|msg| {
@@ -33,7 +33,7 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
                         |(public, entries)| {
                             if concurrency > 1 {
                                 ops::batch::verify_same_signer::<_, MinSig, _>(
-                                    &mut thread_rng(),
+                                    &mut rng(),
                                     &public,
                                     &entries,
                                     &strategy,
@@ -41,7 +41,7 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
                                 .unwrap();
                             } else {
                                 ops::batch::verify_same_signer::<_, MinSig, _>(
-                                    &mut thread_rng(),
+                                    &mut rng(),
                                     &public,
                                     &entries,
                                     &Sequential,

--- a/cryptography/src/bls12381/benches/combine_public_keys.rs
+++ b/cryptography/src/bls12381/benches/combine_public_keys.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::bls12381::primitives::{ops, variant::MinSig};
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::thread_rng;
+use rand::rng;
 use std::hint::black_box;
 
 fn bench_combine_public_keys(c: &mut Criterion) {
@@ -10,7 +10,7 @@ fn bench_combine_public_keys(c: &mut Criterion) {
                 || {
                     let mut public_keys = Vec::with_capacity(n);
                     for _ in 0..n {
-                        let public_key = ops::keypair::<_, MinSig>(&mut thread_rng()).1;
+                        let public_key = ops::keypair::<_, MinSig>(&mut rng()).1;
                         public_keys.push(public_key);
                     }
                     public_keys

--- a/cryptography/src/bls12381/benches/combine_signatures.rs
+++ b/cryptography/src/bls12381/benches/combine_signatures.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::bls12381::primitives::{ops, variant::MinSig};
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_combine_signatures(c: &mut Criterion) {
@@ -9,13 +9,13 @@ fn bench_combine_signatures(c: &mut Criterion) {
         let mut msgs = Vec::with_capacity(n);
         for _ in 0..n {
             let mut msg = [0u8; 32];
-            thread_rng().fill(&mut msg);
+            rng().fill(&mut msg);
             msgs.push(msg);
         }
         c.bench_function(&format!("{}/sigs={}", module_path!(), n), |b| {
             b.iter_batched(
                 || {
-                    let private = ops::keypair::<_, MinSig>(&mut thread_rng()).0;
+                    let private = ops::keypair::<_, MinSig>(&mut rng()).0;
                     let mut signatures = Vec::with_capacity(n);
                     for msg in msgs.iter() {
                         let signature = ops::sign_message::<MinSig>(&private, namespace, msg);

--- a/cryptography/src/bls12381/benches/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/benches/dkg/feldman_desmedt.rs
@@ -11,7 +11,7 @@ use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::{ordered::Set, Faults, N3f1, NZUsize, TryCollect};
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{collections::BTreeMap, hint::black_box};
 
 type V = MinSig;
@@ -23,7 +23,7 @@ struct Bench {
 }
 
 impl Bench {
-    fn new(mut rng: impl CryptoRngCore, reshare: bool, n: u32) -> Self {
+    fn new(mut rng: impl CryptoRng, reshare: bool, n: u32) -> Self {
         let private_keys = (0..n)
             .map(|_| PrivateKey::random(&mut rng))
             .collect::<Vec<_>>();

--- a/cryptography/src/bls12381/benches/dkg/golden.rs
+++ b/cryptography/src/bls12381/benches/dkg/golden.rs
@@ -7,7 +7,7 @@ use commonware_parallel::Sequential;
 use commonware_utils::{ordered::Set, N3f1, TryCollect};
 use criterion::{criterion_group, BatchSize, Criterion};
 use rand::{rngs::StdRng, SeedableRng};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{collections::BTreeMap, hint::black_box, num::NonZeroU32, sync::LazyLock};
 
 const BENCH_NAMESPACE: &[u8] = b"bench";
@@ -36,7 +36,7 @@ struct Bench {
 }
 
 impl Bench {
-    fn new(rng: &mut impl CryptoRngCore, n: u32) -> Self {
+    fn new(rng: &mut impl CryptoRng, n: u32) -> Self {
         let me = PrivateKey::random(&mut *rng);
         let dealers: Set<PublicKey> = std::iter::once(me.public()).try_collect().unwrap();
         let players: Set<PublicKey> = (0..n)
@@ -47,7 +47,7 @@ impl Bench {
         Self { info, me }
     }
 
-    fn deal(&self, rng: &mut impl CryptoRngCore) -> SignedDealerLog {
+    fn deal(&self, rng: &mut impl CryptoRng) -> SignedDealerLog {
         golden::deal(rng, &SETUP, &self.info, &self.me, None, &Sequential)
             .expect("honest deal should succeed")
     }

--- a/cryptography/src/bls12381/benches/hash_to_curve.rs
+++ b/cryptography/src/bls12381/benches/hash_to_curve.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::bls12381::primitives::{
 use commonware_parallel::{Rayon, Sequential, Strategy};
 use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_hash_to_curve(c: &mut Criterion) {
@@ -15,7 +15,7 @@ fn bench_hash_to_curve(c: &mut Criterion) {
         let mut msgs: Vec<[u8; 32]> = Vec::with_capacity(n);
         for _ in 0..n {
             let mut msg = [0u8; 32];
-            thread_rng().fill(&mut msg);
+            rng().fill(&mut msg);
             msgs.push(msg);
         }
 

--- a/cryptography/src/bls12381/benches/scheme_batch_verify_same_message.rs
+++ b/cryptography/src/bls12381/benches/scheme_batch_verify_same_message.rs
@@ -3,13 +3,13 @@ use commonware_math::algebra::Random;
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_scheme_batch_verify_same_message(c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
-    thread_rng().fill(&mut msg);
+    rng().fill(&mut msg);
     for n_signers in [1, 10, 100, 1000, 10000].into_iter() {
         for concurrency in [1, 8] {
             let rayon = (concurrency > 1).then(|| Rayon::new(NZUsize!(concurrency)).unwrap());
@@ -20,7 +20,7 @@ fn bench_scheme_batch_verify_same_message(c: &mut Criterion) {
                         || {
                             let mut batch = bls12381::Batch::new(n_signers);
                             for _ in 0..n_signers {
-                                let signer = bls12381::PrivateKey::random(&mut thread_rng());
+                                let signer = bls12381::PrivateKey::random(rng());
                                 let sig = signer.sign(namespace, &msg);
                                 assert!(batch.add(namespace, &msg, &signer.public_key(), &sig));
                             }
@@ -29,9 +29,9 @@ fn bench_scheme_batch_verify_same_message(c: &mut Criterion) {
                         |batch| {
                             #[allow(clippy::option_if_let_else)]
                             if let Some(rayon) = rayon.as_ref() {
-                                black_box(batch.verify(&mut thread_rng(), rayon))
+                                black_box(batch.verify(&mut rng(), rayon))
                             } else {
-                                black_box(batch.verify(&mut thread_rng(), &Sequential))
+                                black_box(batch.verify(&mut rng(), &Sequential))
                             }
                         },
                         BatchSize::SmallInput,

--- a/cryptography/src/bls12381/benches/scheme_batch_verify_same_signer.rs
+++ b/cryptography/src/bls12381/benches/scheme_batch_verify_same_signer.rs
@@ -3,7 +3,7 @@ use commonware_math::algebra::Random;
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_scheme_batch_verify_same_signer(c: &mut Criterion) {
@@ -14,7 +14,7 @@ fn bench_scheme_batch_verify_same_signer(c: &mut Criterion) {
             let mut msgs = Vec::with_capacity(n_messages);
             for _ in 0..n_messages {
                 let mut msg = [0u8; 32];
-                thread_rng().fill(&mut msg);
+                rng().fill(&mut msg);
                 msgs.push(msg);
             }
             c.bench_function(
@@ -28,7 +28,7 @@ fn bench_scheme_batch_verify_same_signer(c: &mut Criterion) {
                     b.iter_batched(
                         || {
                             let mut batch = bls12381::Batch::new(n_messages);
-                            let signer = bls12381::PrivateKey::random(&mut thread_rng());
+                            let signer = bls12381::PrivateKey::random(rng());
                             for msg in msgs.iter() {
                                 let sig = signer.sign(namespace, msg);
                                 assert!(batch.add(namespace, msg, &signer.public_key(), &sig));
@@ -38,9 +38,9 @@ fn bench_scheme_batch_verify_same_signer(c: &mut Criterion) {
                         |batch| {
                             #[allow(clippy::option_if_let_else)]
                             if let Some(rayon) = rayon.as_ref() {
-                                black_box(batch.verify(&mut thread_rng(), rayon))
+                                black_box(batch.verify(&mut rng(), rayon))
                             } else {
-                                black_box(batch.verify(&mut thread_rng(), &Sequential))
+                                black_box(batch.verify(&mut rng(), &Sequential))
                             }
                         },
                         BatchSize::SmallInput,

--- a/cryptography/src/bls12381/benches/signature_generation.rs
+++ b/cryptography/src/bls12381/benches/signature_generation.rs
@@ -1,13 +1,13 @@
 use commonware_cryptography::{bls12381, Signer as _};
 use commonware_math::algebra::Random;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_signature_generation(c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
-    thread_rng().fill(&mut msg);
+    rng().fill(&mut msg);
     c.bench_function(
         &format!(
             "{}/ns_len={} msg_len={}",
@@ -17,7 +17,7 @@ fn bench_signature_generation(c: &mut Criterion) {
         ),
         |b| {
             b.iter_batched(
-                || bls12381::PrivateKey::random(&mut thread_rng()),
+                || bls12381::PrivateKey::random(rng()),
                 |private_key| {
                     black_box(private_key.sign(namespace, &msg));
                 },

--- a/cryptography/src/bls12381/benches/signature_verification.rs
+++ b/cryptography/src/bls12381/benches/signature_verification.rs
@@ -1,13 +1,13 @@
 use commonware_cryptography::{bls12381, Signer as _, Verifier as _};
 use commonware_math::algebra::Random;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_signature_verification(c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
-    thread_rng().fill(&mut msg);
+    rng().fill(&mut msg);
     c.bench_function(
         &format!(
             "{}/ns_len={} msg_len={}",
@@ -18,7 +18,7 @@ fn bench_signature_verification(c: &mut Criterion) {
         |b| {
             b.iter_batched(
                 || {
-                    let private_key = bls12381::PrivateKey::random(&mut thread_rng());
+                    let private_key = bls12381::PrivateKey::random(rng());
                     let public_key = private_key.public_key();
                     let signature = private_key.sign(namespace, &msg);
                     (public_key, signature)

--- a/cryptography/src/bls12381/benches/threshold_batch_verify_same_signer.rs
+++ b/cryptography/src/bls12381/benches/threshold_batch_verify_same_signer.rs
@@ -9,7 +9,7 @@ use commonware_cryptography::{
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::{Faults, N3f1, NZUsize, TryCollect};
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::hint::black_box;
 
 fn bench_threshold_batch_verify_same_signer(c: &mut Criterion) {

--- a/cryptography/src/bls12381/benches/tle_decrypt.rs
+++ b/cryptography/src/bls12381/benches/tle_decrypt.rs
@@ -3,11 +3,11 @@ use commonware_cryptography::bls12381::{
     tle::{decrypt, encrypt, Block},
 };
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::thread_rng;
+use rand::rng;
 use std::hint::black_box;
 
 fn bench_tle_decrypt(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let (master_secret, master_public) = ops::keypair::<_, MinSig>(&mut rng);
     let target = 10u64.to_be_bytes();
     let message = Block::new([0x42u8; 32]);

--- a/cryptography/src/bls12381/benches/tle_encrypt.rs
+++ b/cryptography/src/bls12381/benches/tle_encrypt.rs
@@ -3,11 +3,11 @@ use commonware_cryptography::bls12381::{
     tle::{encrypt, Block},
 };
 use criterion::{criterion_group, Criterion};
-use rand::thread_rng;
+use rand::rng;
 use std::hint::black_box;
 
 fn bench_tle_encrypt(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let (_, master_public) = keypair::<_, MinSig>(&mut rng);
     let target = 10u64.to_be_bytes();
     let message = Block::new([0x42u8; 32]);

--- a/cryptography/src/bls12381/certificate/multisig/mocks.rs
+++ b/cryptography/src/bls12381/certificate/multisig/mocks.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use commonware_math::algebra::Random;
 use commonware_utils::{ordered::BiMap, TryCollect as _};
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 
 /// Builds ed25519 identities and matching BLS12-381 multisig schemes.
 pub fn fixture<S, V, R>(
@@ -19,7 +19,7 @@ pub fn fixture<S, V, R>(
 ) -> Fixture<S>
 where
     V: Variant,
-    R: RngCore + CryptoRng,
+    R: Rng + CryptoRng,
     S: Scheme<PublicKey = ed25519::PublicKey>,
 {
     assert!(n > 0);

--- a/cryptography/src/bls12381/certificate/multisig/mod.rs
+++ b/cryptography/src/bls12381/certificate/multisig/mod.rs
@@ -24,7 +24,7 @@ use commonware_utils::{
     ordered::{BiMap, Quorum, Set},
     Faults, Participant,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 #[cfg(feature = "std")]
 use std::collections::BTreeSet;
 
@@ -153,7 +153,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     where
         S: Scheme<Signature = V::Signature>,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: IntoIterator<Item = Attestation<S>>,
         I::IntoIter: Send,
@@ -248,7 +248,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     where
         S: Scheme,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         M: Faults,
     {
@@ -291,7 +291,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     where
         S: Scheme,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (S::Subject<'a, D>, &'a Certificate<V>)>,
         M: Faults,
@@ -418,7 +418,7 @@ macro_rules! impl_certificate_bls12381_multisig {
         ) -> $crate::certificate::mocks::Fixture<Scheme<$crate::ed25519::PublicKey, V>>
         where
             V: $crate::bls12381::primitives::variant::Variant,
-            R: rand::RngCore + rand::CryptoRng,
+            R: rand::Rng + rand::CryptoRng,
         {
             $crate::bls12381::certificate::multisig::mocks::fixture::<_, V, _>(
                 rng,
@@ -487,7 +487,7 @@ macro_rules! impl_certificate_bls12381_multisig {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 M: commonware_utils::Faults,
             {
@@ -502,7 +502,7 @@ macro_rules! impl_certificate_bls12381_multisig {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
                 M: commonware_utils::Faults,
@@ -555,7 +555,7 @@ macro_rules! impl_certificate_bls12381_multisig {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
             {
                 self.generic
@@ -570,7 +570,7 @@ macro_rules! impl_certificate_bls12381_multisig {
                 strategy: &impl commonware_parallel::Strategy,
             ) -> $crate::certificate::Verification<Self>
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
                 I::IntoIter: Send
@@ -643,7 +643,7 @@ mod tests {
     impl_certificate_bls12381_multisig!(TestSubject, Vec<u8>);
 
     fn setup_signers<V: Variant>(
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         n: u32,
     ) -> (
         Vec<Scheme<ed25519::PublicKey, V>>,

--- a/cryptography/src/bls12381/certificate/threshold/mocks.rs
+++ b/cryptography/src/bls12381/certificate/threshold/mocks.rs
@@ -9,7 +9,7 @@ use crate::{
     ed25519,
 };
 use commonware_utils::{ordered::Set, N3f1};
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 
 /// Builds ed25519 identities and matching BLS12-381 threshold schemes.
 pub fn fixture<S, V, R>(
@@ -21,7 +21,7 @@ pub fn fixture<S, V, R>(
 ) -> Fixture<S>
 where
     V: Variant,
-    R: RngCore + CryptoRng,
+    R: Rng + CryptoRng,
     S: Scheme<PublicKey = ed25519::PublicKey>,
 {
     assert!(n > 0);

--- a/cryptography/src/bls12381/certificate/threshold/mod.rs
+++ b/cryptography/src/bls12381/certificate/threshold/mod.rs
@@ -28,7 +28,7 @@ use commonware_codec::{types::lazy::Lazy, Error, FixedSize, Read, ReadExt, Write
 use commonware_parallel::Strategy;
 use commonware_utils::{ordered::Set, Faults, Participant};
 use core::fmt::Debug;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 #[cfg(feature = "std")]
 use std::collections::BTreeSet;
 
@@ -261,7 +261,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     where
         S: Scheme<Signature = V::Signature>,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: IntoIterator<Item = Attestation<S>>,
         I::IntoIter: Send,
@@ -345,7 +345,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     where
         S: Scheme,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         M: Faults,
     {
@@ -371,7 +371,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     where
         S: Scheme,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (S::Subject<'a, D>, &'a Certificate<V>)>,
         T: Strategy,
@@ -508,7 +508,7 @@ macro_rules! impl_certificate_bls12381_threshold {
         ) -> $crate::certificate::mocks::Fixture<Scheme<$crate::ed25519::PublicKey, V>>
         where
             V: $crate::bls12381::primitives::variant::Variant,
-            R: rand::RngCore + rand::CryptoRng,
+            R: rand::Rng + rand::CryptoRng,
         {
             $crate::bls12381::certificate::threshold::mocks::fixture::<_, V, _>(
                 rng,
@@ -601,7 +601,7 @@ macro_rules! impl_certificate_bls12381_threshold {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 M: commonware_utils::Faults,
             {
@@ -616,7 +616,7 @@ macro_rules! impl_certificate_bls12381_threshold {
                 strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
                 M: commonware_utils::Faults,
@@ -670,7 +670,7 @@ macro_rules! impl_certificate_bls12381_threshold {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
             {
                 self.generic
@@ -685,7 +685,7 @@ macro_rules! impl_certificate_bls12381_threshold {
                 strategy: &impl commonware_parallel::Strategy,
             ) -> $crate::certificate::Verification<Self>
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
                 I::IntoIter: Send
@@ -762,7 +762,7 @@ mod tests {
 
     #[allow(clippy::type_complexity)]
     fn setup_signers<V: Variant>(
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         n: u32,
     ) -> (
         Vec<Scheme<ed25519::PublicKey, V>>,
@@ -1375,7 +1375,7 @@ mod tests {
         signer_shares_must_match_participant_indices::<MinSig>();
     }
 
-    fn make_participants<R: rand::RngCore + rand::CryptoRng + Clone>(
+    fn make_participants<R: rand::Rng + rand::CryptoRng>(
         rng: &mut R,
         n: u32,
     ) -> Set<ed25519::PublicKey> {

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -321,7 +321,7 @@ use commonware_utils::{
     Faults, Participant, TryCollect, NZU32,
 };
 use core::num::NonZeroU32;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{borrow::Cow, collections::BTreeMap, marker::PhantomData};
 use thiserror::Error;
 
@@ -524,7 +524,7 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
     /// However, if there is a previous round, we expect a share, hence `Result`.
     fn unwrap_or_random_share(
         &self,
-        mut rng: impl CryptoRngCore,
+        mut rng: impl CryptoRng,
         share: Option<Scalar>,
     ) -> Result<Scalar, Error> {
         let out = match (self.previous.as_ref(), share) {
@@ -610,7 +610,7 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
     #[must_use]
     fn check_dealer_log<M: Faults, B: BatchVerifier<PublicKey = P>>(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         strategy: &impl Strategy,
         round_transcript: &Transcript,
         dealer: &P,
@@ -1337,7 +1337,7 @@ impl<V: Variant, P: PublicKey, M: Faults> Logs<V, P, M> {
     }
 
     fn check_dealers<B: BatchVerifier<PublicKey = P>>(
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         info: &Info<V, P>,
         strategy: &impl Strategy,
         transcript: &Transcript,
@@ -1383,7 +1383,7 @@ impl<V: Variant, P: PublicKey, M: Faults> Logs<V, P, M> {
     /// each call.
     pub fn pre_verify<B: BatchVerifier<PublicKey = P>>(
         &mut self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         strategy: &impl Strategy,
     ) {
         let required_commitments = self.info.required_commitments::<M>() as usize;
@@ -1442,7 +1442,7 @@ impl<V: Variant, P: PublicKey, M: Faults> Logs<V, P, M> {
     /// This might return an error if there are not enough good logs that we can use.
     fn select<B: BatchVerifier<PublicKey = P>>(
         mut self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         strategy: &impl Strategy,
     ) -> Result<SelectedLogs<V, P>, Error> {
         self.pre_verify::<B>(rng, strategy);
@@ -1493,7 +1493,7 @@ impl<V: Variant, S: Signer> Dealer<V, S> {
     /// [crate::handshake], or [commonware-p2p](https://docs.rs/commonware-p2p/latest/commonware_p2p/).
     #[allow(clippy::type_complexity)]
     pub fn start<M: Faults>(
-        mut rng: impl CryptoRngCore,
+        mut rng: impl CryptoRng,
         info: Info<V, S::PublicKey>,
         me: S,
         share: Option<Share>,
@@ -1678,7 +1678,7 @@ impl<V: Variant, P: PublicKey> ObserveInner<V, P> {
 ///
 /// This will only ever return [`Error::DkgFailed`].
 pub fn observe<V: Variant, P: PublicKey, M: Faults, B: BatchVerifier<PublicKey = P>>(
-    rng: &mut impl CryptoRngCore,
+    rng: &mut impl CryptoRng,
     logs: Logs<V, P, M>,
     strategy: &impl Strategy,
 ) -> Result<Output<V, P>, Error> {
@@ -1829,7 +1829,7 @@ impl<V: Variant, S: Signer> Player<V, S> {
     /// [`Error::MismatchedLogs`] if `logs` are bound to a different DKG round.
     pub fn finalize<M: Faults, B: BatchVerifier<PublicKey = S::PublicKey>>(
         self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         logs: Logs<V, S::PublicKey, M>,
         strategy: &impl Strategy,
     ) -> Result<(Output<V, S::PublicKey>, Share), Error> {
@@ -1900,7 +1900,7 @@ pub type DealResult<V, P> = Result<(Output<V, P>, Map<P, Share>), Error>;
 
 /// Simply distribute shares at random, instead of performing a distributed protocol.
 pub fn deal<V: Variant, P: Clone + Ord, M: Faults>(
-    mut rng: impl CryptoRngCore,
+    mut rng: impl CryptoRng,
     mode: Mode,
     players: Set<P>,
 ) -> DealResult<V, P> {
@@ -1942,7 +1942,7 @@ pub fn deal<V: Variant, P: Clone + Ord, M: Faults>(
 /// the trouble of generating signing keys. The downside is that the result isn't
 /// compatible with subsequent DKGs, which need an [`Output`].
 pub fn deal_anonymous<V: Variant, M: Faults>(
-    rng: impl CryptoRngCore,
+    rng: impl CryptoRng,
     mode: Mode,
     n: NonZeroU32,
 ) -> (Sharing<V>, Vec<Share>) {

--- a/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
+++ b/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
@@ -27,7 +27,7 @@ use core::{
     hash::{Hash, Hasher},
     ops::Deref,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::num::NonZeroU32;
 use zeroize::Zeroizing;
 
@@ -159,7 +159,7 @@ pub struct PrivateKey {
 }
 
 impl Random for PrivateKey {
-    fn random(rng: impl CryptoRngCore) -> Self {
+    fn random(rng: impl CryptoRng) -> Self {
         Self {
             inner: Secret::new(F::random(rng)),
         }
@@ -185,13 +185,13 @@ impl crate::Signer for PrivateKey {
             let mut nonce_t = t.fork(b"nonce");
             let x_bytes = Zeroizing::new(x.encode_fixed::<{ F::SIZE }>());
             nonce_t.commit(x_bytes.as_slice());
-            F::random(&mut nonce_t.noise(b"k"))
+            F::random(nonce_t.noise(b"k"))
         });
 
         let k_big = G::generator() * &k;
         let k_big_bytes: [u8; G::SIZE] = k_big.encode_fixed();
         t.commit(k_big_bytes.as_slice());
-        let e = F::random(&mut t.noise(b"challenge"));
+        let e = F::random(t.noise(b"challenge"));
 
         // s = k + e * x
         let s = self.inner.expose(|x| e * x + &k);
@@ -230,7 +230,7 @@ impl PrivateKey {
     /// Panics if `receivers` contains duplicate public keys.
     pub(super) fn vrf_batch_checked(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         setup: &Setup,
         transcript: &mut Transcript,
         msg: &Summary,
@@ -415,7 +415,7 @@ impl crate::Verifier for PublicKey {
             .commit(msg)
             .commit(self.raw.as_slice())
             .commit(sig.raw[..G::SIZE].as_ref());
-        let e = F::random(&mut t.noise(b"challenge"));
+        let e = F::random(t.noise(b"challenge"));
 
         // Check: s * G == K + e * X
         let lhs = G::generator() * &s;
@@ -616,7 +616,7 @@ impl VrfCommitments {
     ///
     /// Panics if `outputs` contains duplicate sender public keys.
     pub fn check_batch(
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         setup: &Setup,
         transcript: &Transcript,
         players: &Set<PublicKey>,

--- a/cryptography/src/bls12381/dkg/golden/mod.rs
+++ b/cryptography/src/bls12381/dkg/golden/mod.rs
@@ -148,7 +148,7 @@ use commonware_utils::{
 };
 pub use evrf::{PrivateKey, PublicKey, Setup};
 use evrf::{Signature, VrfCommitments};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{borrow::Cow, collections::BTreeMap, num::NonZeroU32};
 
 const NAMESPACE: &[u8] = b"_COMMONWARE_CRYPTOGRAPHY_BLS12381_GOLDEN_DKG";
@@ -422,7 +422,7 @@ impl Info {
     /// However, if there is a previous round, we expect a share, hence `Result`.
     fn unwrap_or_random_share(
         &self,
-        mut rng: impl CryptoRngCore,
+        mut rng: impl CryptoRng,
         share: Option<Scalar>,
     ) -> Result<Scalar, Error> {
         let out = match (self.previous.as_ref(), share) {
@@ -477,7 +477,7 @@ const fn check_setup(setup: &Setup, info: &Info) -> Result<(), Error> {
 ///
 /// Returns a [`SignedDealerLog`] ready for broadcast.
 pub fn deal(
-    rng: &mut impl CryptoRngCore,
+    rng: &mut impl CryptoRng,
     setup: &Setup,
     info: &Info,
     me: &PrivateKey,
@@ -559,7 +559,7 @@ impl Selection {
 }
 
 fn select(
-    rng: &mut impl CryptoRngCore,
+    rng: &mut impl CryptoRng,
     setup: &Setup,
     info: &Info,
     logs: BTreeMap<PublicKey, DealerLog>,
@@ -620,7 +620,7 @@ fn select(
 /// [`Error::DkgFailed`] if too few valid dealings are available, or
 /// [`Error::UnsupportedNumPlayers`] if `setup` is too small for `info`.
 pub fn observe(
-    rng: &mut impl CryptoRngCore,
+    rng: &mut impl CryptoRng,
     setup: &Setup,
     info: &Info,
     logs: BTreeMap<PublicKey, DealerLog>,
@@ -654,7 +654,7 @@ pub fn observe(
 /// `setup` must support at least `info.players.len()` players (see
 /// [`Setup::supports`]); otherwise [`Error::UnsupportedNumPlayers`] is returned.
 pub fn play(
-    rng: &mut impl CryptoRngCore,
+    rng: &mut impl CryptoRng,
     setup: &Setup,
     info: &Info,
     logs: BTreeMap<PublicKey, DealerLog>,
@@ -835,7 +835,7 @@ impl Read for DealerLog {
 impl DealerLog {
     #[allow(dead_code)]
     fn batch_check(
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         setup: &Setup,
         info: &Info,
         batch: impl IntoIterator<Item = (PublicKey, Self)>,
@@ -943,7 +943,7 @@ impl Dealing {
     #[must_use]
     fn check(
         &self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         info: &Info,
         dealer: &PublicKey,
         mask_commitments: &Map<PublicKey, G1>,

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -49,7 +49,7 @@ use core::{
     ptr,
 };
 use ctutils::{Choice, CtEq};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 fn all_zero(bytes: &[u8]) -> Choice {
@@ -285,7 +285,7 @@ pub struct SmallScalar {
 
 impl SmallScalar {
     /// Generates a random 128-bit scalar.
-    pub fn random(mut rng: impl CryptoRngCore) -> Self {
+    pub fn random(mut rng: impl CryptoRng) -> Self {
         // blst_scalar is 32 bytes
         let mut bytes = [0u8; 32];
         // Fill the last 16 bytes (128 bits) with entropy.
@@ -541,7 +541,7 @@ impl FixedSize for Private {
 }
 
 impl Random for Private {
-    fn random(rng: impl CryptoRngCore) -> Self {
+    fn random(rng: impl CryptoRng) -> Self {
         Self::new(Scalar::random(rng))
     }
 }
@@ -930,7 +930,7 @@ impl Field for Scalar {
 
 impl Random for Scalar {
     /// Returns a random **non-zero** scalar.
-    fn random(mut rng: impl CryptoRngCore) -> Self {
+    fn random(mut rng: impl CryptoRng) -> Self {
         let mut ikm = Zeroizing::new([0u8; IKM_LENGTH]);
         rng.fill_bytes(ikm.as_mut());
         Self::from_ikm(&ikm)
@@ -1941,7 +1941,7 @@ mod tests {
     #[test]
     fn basic_group() {
         // Reference: https://github.com/celo-org/celo-threshold-bls-rs/blob/b0ef82ff79769d085a5a7d3f4fe690b1c8fe6dc9/crates/threshold-bls/src/curve/bls12381.rs#L200-L220
-        let s = Scalar::random(&mut test_rng());
+        let s = Scalar::random(test_rng());
         let mut s2 = s.clone();
         s2.double();
 
@@ -1956,7 +1956,7 @@ mod tests {
 
     #[test]
     fn test_scalar_codec() {
-        let original = Scalar::random(&mut test_rng());
+        let original = Scalar::random(test_rng());
         let mut encoded = original.encode();
         assert_eq!(encoded.len(), Scalar::SIZE);
         let decoded = Scalar::decode_cfg(&mut encoded, &ScalarReadCfg::RejectZero).unwrap();
@@ -2037,7 +2037,7 @@ mod tests {
     #[test]
     fn test_scalar_read_cfg_accepts_canonical_zero() {
         // Round-trips canonical encodings, including zero.
-        let s = Scalar::random(&mut test_rng());
+        let s = Scalar::random(test_rng());
         let bytes = s.encode_fixed::<{ Scalar::SIZE }>();
         assert_eq!(
             Scalar::decode_cfg(bytes.as_ref(), &ScalarReadCfg::AllowZero).unwrap(),
@@ -2055,7 +2055,7 @@ mod tests {
 
     #[test]
     fn test_g1_codec() {
-        let original = G1::generator() * &Scalar::random(&mut test_rng());
+        let original = G1::generator() * &Scalar::random(test_rng());
         let mut encoded = original.encode();
         assert_eq!(encoded.len(), G1::SIZE);
         let decoded = G1::decode(&mut encoded).unwrap();
@@ -2064,7 +2064,7 @@ mod tests {
 
     #[test]
     fn test_g2_codec() {
-        let original = G2::generator() * &Scalar::random(&mut test_rng());
+        let original = G2::generator() * &Scalar::random(test_rng());
         let mut encoded = original.encode();
         assert_eq!(encoded.len(), G2::SIZE);
         let decoded = G2::decode(&mut encoded).unwrap();

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -18,13 +18,15 @@
 //!     primitives::{ops::{self, threshold}, variant::MinSig, sharing::Mode},
 //! };
 //! use commonware_utils::{NZU32, N3f1};
-//! use rand::rngs::OsRng;
+//! use rand::{rngs::StdRng, SeedableRng};
+//!
+//! let mut rng = StdRng::seed_from_u64(0);
 //!
 //! // Configure number of players
 //! let n = NZU32!(5);
 //!
 //! // Generate commitment and shares
-//! let (sharing, shares) = dkg::deal_anonymous::<MinSig, N3f1>(&mut OsRng, Mode::default(), n);
+//! let (sharing, shares) = dkg::deal_anonymous::<MinSig, N3f1>(&mut rng, Mode::default(), n);
 //!
 //! // Generate partial signatures from shares
 //! let namespace = b"demo";

--- a/cryptography/src/bls12381/primitives/ops/batch.rs
+++ b/cryptography/src/bls12381/primitives/ops/batch.rs
@@ -21,7 +21,7 @@ use super::{
 use alloc::{vec, vec::Vec};
 use commonware_math::algebra::Space;
 use commonware_parallel::Strategy;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// Segment tree for batch verification bisection.
 ///
@@ -205,7 +205,7 @@ pub fn verify_same_message<R, V>(
     par: &impl Strategy,
 ) -> Vec<usize>
 where
-    R: CryptoRngCore,
+    R: CryptoRng,
     V: Variant,
 {
     if entries.is_empty() {
@@ -259,7 +259,7 @@ pub fn verify_same_signer<'a, R, V, I>(
     strategy: &impl Strategy,
 ) -> Result<(), Error>
 where
-    R: CryptoRngCore,
+    R: CryptoRng,
     V: Variant,
     I: IntoIterator<Item = &'a (&'a [u8], &'a [u8], V::Signature)>,
 {

--- a/cryptography/src/bls12381/primitives/ops/mod.rs
+++ b/cryptography/src/bls12381/primitives/ops/mod.rs
@@ -37,7 +37,7 @@ pub fn compute_public<V: Variant>(private: &Private) -> V::Public {
 }
 
 /// Returns a new keypair derived from the provided randomness.
-pub fn keypair<R: rand_core::CryptoRngCore, V: Variant>(rng: &mut R) -> (Private, V::Public) {
+pub fn keypair<R: rand_core::CryptoRng, V: Variant>(rng: &mut R) -> (Private, V::Public) {
     let private = Private::random(rng);
     let public = compute_public::<V>(&private);
     (private, public)
@@ -495,7 +495,7 @@ mod tests {
             // Verify using batch verification
             let hm = hash::<MinPk>(MinPk::MESSAGE, &message);
             let batch_result = MinPk::batch_verify(
-                &mut rand::thread_rng(),
+                &mut rand::rng(),
                 &[public_key],
                 &[hm],
                 &[signature],
@@ -568,7 +568,7 @@ mod tests {
         }
 
         MinPk::batch_verify(
-            &mut rand::thread_rng(),
+            &mut rand::rng(),
             &valid_publics,
             &valid_hms,
             &valid_signatures,
@@ -577,7 +577,7 @@ mod tests {
         .expect("batch verify of valid vectors should succeed");
 
         assert!(MinPk::batch_verify(
-            &mut rand::thread_rng(),
+            &mut rand::rng(),
             &all_publics,
             &all_hms,
             &all_signatures,

--- a/cryptography/src/bls12381/primitives/ops/threshold.rs
+++ b/cryptography/src/bls12381/primitives/ops/threshold.rs
@@ -22,7 +22,7 @@ use alloc::{vec, vec::Vec};
 use commonware_codec::Encode;
 use commonware_parallel::Strategy;
 use commonware_utils::{ordered::Map, union_unique, Faults, Participant};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// Prepares partial signature evaluations for threshold recovery.
 fn prepare_evaluations<'a, V: Variant>(
@@ -131,7 +131,7 @@ pub fn batch_verify_same_signer<'a, R, V, I>(
     strategy: &impl Strategy,
 ) -> Result<(), Error>
 where
-    R: CryptoRngCore,
+    R: CryptoRng,
     V: Variant,
     I: IntoIterator<Item = &'a (&'a [u8], &'a [u8], PartialSignature<V>)>,
 {
@@ -172,7 +172,7 @@ fn batch_verify_same_message_bisect<'a, R, V>(
     strategy: &impl Strategy,
 ) -> Vec<&'a PartialSignature<V>>
 where
-    R: CryptoRngCore,
+    R: CryptoRng,
     V: Variant,
 {
     // Convert to the format expected by verify_same_message
@@ -212,7 +212,7 @@ pub fn batch_verify_same_message<'a, R, V, I>(
     strategy: &impl Strategy,
 ) -> Result<(), Vec<&'a PartialSignature<V>>>
 where
-    R: CryptoRngCore,
+    R: CryptoRng,
     V: Variant,
     I: IntoIterator<Item = &'a PartialSignature<V>>,
 {

--- a/cryptography/src/bls12381/primitives/sharing.rs
+++ b/cryptography/src/bls12381/primitives/sharing.rs
@@ -509,7 +509,7 @@ mod tests {
             let max_degree = u32::try_from(subset.len() - 1).expect("subset len fits in u32");
             let degree = u.int_in_range(0u32..=max_degree)?;
             let seed: u64 = u.arbitrary()?;
-            let poly: Poly<Scalar> = Poly::new(&mut StdRng::seed_from_u64(seed), degree);
+            let poly: Poly<Scalar> = Poly::new(StdRng::seed_from_u64(seed), degree);
 
             let all_shares = Map::from_iter_dedup((0..total.get()).map(|i| {
                 let participant = Participant::new(i);
@@ -563,7 +563,7 @@ mod fuzz {
             let total: u32 = u.int_in_range(1..=100)?;
             let mode: Mode = u.arbitrary()?;
             let seed: u64 = u.arbitrary()?;
-            let poly = Poly::new(&mut StdRng::seed_from_u64(seed), N3f1::quorum(total) - 1);
+            let poly = Poly::new(StdRng::seed_from_u64(seed), N3f1::quorum(total) - 1);
             Ok(Self::new(
                 mode,
                 NZU32!(total),

--- a/cryptography/src/bls12381/primitives/variant.rs
+++ b/cryptography/src/bls12381/primitives/variant.rs
@@ -19,7 +19,7 @@ use core::{
     fmt::{Debug, Formatter},
     hash::Hash,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// A specific instance of a signature scheme.
 pub trait Variant: Clone + Send + Sync + Hash + Eq + Debug + 'static {
@@ -58,7 +58,7 @@ pub trait Variant: Clone + Send + Sync + Hash + Eq + Debug + 'static {
 
     /// Verify a batch of signatures from the provided public keys and pre-hashed messages.
     fn batch_verify(
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         publics: &[Self::Public],
         hms: &[Self::Signature],
         signatures: &[Self::Signature],
@@ -120,7 +120,7 @@ impl Variant for MinPk {
     ///
     /// Source: <https://ethresear.ch/t/security-of-bls-batch-verification/10748>
     fn batch_verify(
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         publics: &[Self::Public],
         hms: &[Self::Signature],
         signatures: &[Self::Signature],
@@ -222,7 +222,7 @@ impl Variant for MinSig {
     ///
     /// Source: <https://ethresear.ch/t/security-of-bls-batch-verification/10748>
     fn batch_verify(
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         publics: &[Self::Public],
         hms: &[Self::Signature],
         signatures: &[Self::Signature],

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -9,10 +9,12 @@
 //! ```rust
 //! use commonware_cryptography::{bls12381, PrivateKey, PublicKey, Signature, Verifier as _, Signer as _};
 //! use commonware_math::algebra::Random;
-//! use rand::rngs::OsRng;
+//! use rand::{rngs::StdRng, SeedableRng};
+//!
+//! let mut rng = StdRng::seed_from_u64(0);
 //!
 //! // Generate a new private key
-//! let mut signer = bls12381::PrivateKey::random(&mut OsRng);
+//! let mut signer = bls12381::PrivateKey::random(&mut rng);
 //!
 //! // Create a message to sign
 //! let namespace = b"demo";
@@ -46,7 +48,7 @@ use core::{
     hash::{Hash, Hasher},
     ops::Deref,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use zeroize::Zeroizing;
 
 const CURVE_NAME: &str = "bls12381";
@@ -122,7 +124,7 @@ impl crate::Signer for PrivateKey {
 }
 
 impl Random for PrivateKey {
-    fn random(mut rng: impl CryptoRngCore) -> Self {
+    fn random(mut rng: impl CryptoRng) -> Self {
         let (private, _) = ops::keypair::<_, MinPk>(&mut rng);
         private.into()
     }
@@ -394,7 +396,7 @@ impl BatchVerifier for Batch {
         true
     }
 
-    fn verify<R: CryptoRngCore>(self, rng: &mut R, strategy: &impl Strategy) -> bool {
+    fn verify<R: CryptoRng>(self, rng: &mut R, strategy: &impl Strategy) -> bool {
         MinPk::batch_verify(rng, &self.publics, &self.hms, &self.signatures, strategy).is_ok()
     }
 }

--- a/cryptography/src/bls12381/tle.rs
+++ b/cryptography/src/bls12381/tle.rs
@@ -40,10 +40,12 @@
 //!         variant::MinPk,
 //!     },
 //! };
-//! use rand::rngs::OsRng;
+//! use rand::{rngs::StdRng, SeedableRng};
+//!
+//! let mut rng = StdRng::seed_from_u64(0);
 //!
 //! // Generate keypair
-//! let (master_secret, master_public) = keypair::<_, MinPk>(&mut OsRng);
+//! let (master_secret, master_public) = keypair::<_, MinPk>(&mut rng);
 //!
 //! // Define a target (e.g., a timestamp or round number)
 //! let target = 12345u64.to_be_bytes();
@@ -54,7 +56,7 @@
 //!
 //! // Encrypt the message for the target
 //! let ciphertext = encrypt::<_, MinPk>(
-//!     &mut OsRng,
+//!     &mut rng,
 //!     master_public,
 //!     (b"_TLE_", &target),
 //!     &message,
@@ -93,7 +95,7 @@ use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, FixedSize, Read, ReadExt, Write};
 use commonware_math::algebra::CryptoGroup;
 use commonware_utils::sequence::FixedBytes;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use zeroize::Zeroizing;
 
 /// Domain separation tag for hashing the `h3` message to a scalar.
@@ -268,7 +270,7 @@ fn xor(a: &Block, b: &Block) -> Block {
 ///
 /// # Returns
 /// * `Ciphertext<V>` - The encrypted ciphertext
-pub fn encrypt<R: CryptoRngCore, V: Variant>(
+pub fn encrypt<R: CryptoRng, V: Variant>(
     rng: &mut R,
     public: V::Public,
     target: (&[u8], &[u8]),

--- a/cryptography/src/certificate.rs
+++ b/cryptography/src/certificate.rs
@@ -73,7 +73,7 @@ use commonware_codec::{
 use commonware_parallel::Strategy;
 use commonware_utils::{bitmap::BitMap, ordered::Set, Faults, Participant};
 use core::{fmt::Debug, hash::Hash};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 #[cfg(feature = "std")]
 use std::{collections::BTreeSet, sync::Arc, vec::Vec};
 
@@ -204,7 +204,7 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
         strategy: &impl Strategy,
     ) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         M: Faults;
 
@@ -216,7 +216,7 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
         strategy: &impl Strategy,
     ) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
         M: Faults,
@@ -242,7 +242,7 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
         strategy: &impl Strategy,
     ) -> Vec<bool>
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         Self::Subject<'a, D>: Copy,
         Self::Certificate: 'a,
@@ -342,7 +342,7 @@ pub trait Scheme: Verifier {
         strategy: &impl Strategy,
     ) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest;
 
     /// Batch-verifies attestations and separates valid attestations from signer indices that failed
@@ -358,7 +358,7 @@ pub trait Scheme: Verifier {
         strategy: &impl Strategy,
     ) -> Verification<Self>
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: IntoIterator<Item = Attestation<Self>>,
         I::IntoIter: Send,
@@ -445,7 +445,7 @@ impl<S: Scheme> Verifier for Scoped<S> {
         strategy: &impl Strategy,
     ) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         M: Faults,
     {
@@ -460,7 +460,7 @@ impl<S: Scheme> Verifier for Scoped<S> {
         strategy: &impl Strategy,
     ) -> bool
     where
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
         M: Faults,

--- a/cryptography/src/certificate/mocks.rs
+++ b/cryptography/src/certificate/mocks.rs
@@ -13,7 +13,7 @@ use commonware_utils::{
     Faults, Participant,
 };
 use core::fmt;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     sync::Arc,
@@ -270,7 +270,7 @@ where
     where
         S: Scheme<Signature = U64>,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: IntoIterator<Item = Attestation<S>>,
     {
@@ -367,7 +367,7 @@ where
     where
         S: Scheme<Certificate = U64>,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         M: Faults,
     {
@@ -387,7 +387,7 @@ where
     where
         S: Scheme<Certificate = U64>,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: rand_core::CryptoRngCore,
+        R: rand_core::CryptoRng,
         D: Digest,
         I: Iterator<Item = (S::Subject<'a, D>, &'a U64)>,
         M: Faults,
@@ -438,7 +438,7 @@ macro_rules! impl_certificate_mock {
             n: u32,
         ) -> $crate::certificate::mocks::Fixture<Scheme<$crate::ed25519::PublicKey>>
         where
-            R: rand::RngCore + rand::CryptoRng,
+            R: rand::Rng + rand::CryptoRng,
         {
             fixture_with::<true, true, true, R>(rng, namespace, n)
         }
@@ -459,7 +459,7 @@ macro_rules! impl_certificate_mock {
             Scheme<$crate::ed25519::PublicKey, ATTRIBUTABLE, BATCHABLE, ALLOW_INVALID>,
         >
         where
-            R: rand::RngCore + rand::CryptoRng,
+            R: rand::Rng + rand::CryptoRng,
         {
             assert!(n > 0);
 
@@ -574,7 +574,7 @@ macro_rules! impl_certificate_mock {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 M: commonware_utils::Faults,
             {
@@ -589,7 +589,7 @@ macro_rules! impl_certificate_mock {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
                 M: commonware_utils::Faults,
@@ -658,7 +658,7 @@ macro_rules! impl_certificate_mock {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
             {
                 self.generic
@@ -673,7 +673,7 @@ macro_rules! impl_certificate_mock {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> $crate::certificate::Verification<Self>
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
             {

--- a/cryptography/src/crc32/mod.rs
+++ b/cryptography/src/crc32/mod.rs
@@ -36,7 +36,7 @@ use core::{
     fmt::{Debug, Display},
     ops::Deref,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// Size of a CRC32 checksum in bytes.
 const SIZE: usize = 4;
@@ -178,7 +178,7 @@ impl crate::Digest for Digest {
 }
 
 impl Random for Digest {
-    fn random(mut rng: impl CryptoRngCore) -> Self {
+    fn random(mut rng: impl CryptoRng) -> Self {
         let mut array = [0u8; SIZE];
         rng.fill_bytes(&mut array);
         Self(array)

--- a/cryptography/src/ed25519/benches/batch_verify_same_message.rs
+++ b/cryptography/src/ed25519/benches/batch_verify_same_message.rs
@@ -3,13 +3,13 @@ use commonware_math::algebra::Random;
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_batch_verify_same_message(c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
-    thread_rng().fill(&mut msg);
+    rng().fill(&mut msg);
     for n_signers in [1, 10, 100, 1000, 10000].into_iter() {
         for concurrency in [1, 8] {
             let rayon = (concurrency > 1).then(|| Rayon::new(NZUsize!(concurrency)).unwrap());
@@ -20,7 +20,7 @@ fn bench_batch_verify_same_message(c: &mut Criterion) {
                         || {
                             let mut batch = ed25519::Batch::new(n_signers);
                             for _ in 0..n_signers {
-                                let signer = ed25519::PrivateKey::random(&mut thread_rng());
+                                let signer = ed25519::PrivateKey::random(rng());
                                 let sig = signer.sign(namespace, &msg);
                                 assert!(batch.add(namespace, &msg, &signer.public_key(), &sig));
                             }
@@ -29,9 +29,9 @@ fn bench_batch_verify_same_message(c: &mut Criterion) {
                         |batch| {
                             #[allow(clippy::option_if_let_else)]
                             if let Some(rayon) = rayon.as_ref() {
-                                black_box(batch.verify(&mut thread_rng(), rayon))
+                                black_box(batch.verify(&mut rng(), rayon))
                             } else {
-                                black_box(batch.verify(&mut thread_rng(), &Sequential))
+                                black_box(batch.verify(&mut rng(), &Sequential))
                             }
                         },
                         BatchSize::SmallInput,

--- a/cryptography/src/ed25519/benches/batch_verify_same_signer.rs
+++ b/cryptography/src/ed25519/benches/batch_verify_same_signer.rs
@@ -3,7 +3,7 @@ use commonware_math::algebra::Random;
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::NZUsize;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_batch_verify_same_signer(c: &mut Criterion) {
@@ -14,7 +14,7 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
             let mut msgs = Vec::with_capacity(n_messages);
             for _ in 0..n_messages {
                 let mut msg = [0u8; 32];
-                thread_rng().fill(&mut msg);
+                rng().fill(&mut msg);
                 msgs.push(msg);
             }
             c.bench_function(
@@ -28,7 +28,7 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
                     b.iter_batched(
                         || {
                             let mut batch = ed25519::Batch::new(n_messages);
-                            let signer = ed25519::PrivateKey::random(&mut thread_rng());
+                            let signer = ed25519::PrivateKey::random(rng());
                             for msg in msgs.iter() {
                                 let sig = signer.sign(namespace, msg);
                                 assert!(batch.add(namespace, msg, &signer.public_key(), &sig));
@@ -38,9 +38,9 @@ fn bench_batch_verify_same_signer(c: &mut Criterion) {
                         |batch| {
                             #[allow(clippy::option_if_let_else)]
                             if let Some(rayon) = rayon.as_ref() {
-                                black_box(batch.verify(&mut thread_rng(), rayon))
+                                black_box(batch.verify(&mut rng(), rayon))
                             } else {
-                                black_box(batch.verify(&mut thread_rng(), &Sequential))
+                                black_box(batch.verify(&mut rng(), &Sequential))
                             }
                         },
                         BatchSize::SmallInput,

--- a/cryptography/src/ed25519/benches/signature_generation.rs
+++ b/cryptography/src/ed25519/benches/signature_generation.rs
@@ -1,13 +1,13 @@
 use commonware_cryptography::{ed25519, Signer as _};
 use commonware_math::algebra::Random;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_signature_generation(c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
-    thread_rng().fill(&mut msg);
+    rng().fill(&mut msg);
     c.bench_function(
         &format!(
             "{}/ns_len={} msg_len={}",
@@ -17,7 +17,7 @@ fn bench_signature_generation(c: &mut Criterion) {
         ),
         |b| {
             b.iter_batched(
-                || ed25519::PrivateKey::random(&mut thread_rng()),
+                || ed25519::PrivateKey::random(rng()),
                 |private_key| {
                     black_box(private_key.sign(namespace, &msg));
                 },

--- a/cryptography/src/ed25519/benches/signature_verification.rs
+++ b/cryptography/src/ed25519/benches/signature_verification.rs
@@ -1,13 +1,13 @@
 use commonware_cryptography::{ed25519, Signer as _, Verifier as _};
 use commonware_math::algebra::Random;
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_signature_verify(c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
-    thread_rng().fill(&mut msg);
+    rng().fill(&mut msg);
     c.bench_function(
         &format!(
             "{}/ns_len={} msg_len={}",
@@ -18,7 +18,7 @@ fn bench_signature_verify(c: &mut Criterion) {
         |b| {
             b.iter_batched(
                 || {
-                    let private_key = ed25519::PrivateKey::random(&mut thread_rng());
+                    let private_key = ed25519::PrivateKey::random(rng());
                     let public_key = private_key.public_key();
                     let signature = private_key.sign(namespace, &msg);
                     (public_key, signature)

--- a/cryptography/src/ed25519/certificate/mocks.rs
+++ b/cryptography/src/ed25519/certificate/mocks.rs
@@ -10,12 +10,12 @@ use commonware_utils::{
     ordered::{Map, Set},
     TryCollect as _,
 };
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 
 /// Generates ed25519 identity participants.
 pub fn participants<R>(rng: &mut R, n: u32) -> Map<PublicKey, PrivateKey>
 where
-    R: RngCore + CryptoRng,
+    R: Rng + CryptoRng,
 {
     (0..n)
         .map(|_| {
@@ -36,7 +36,7 @@ pub fn fixture<S, R>(
     verifier: impl Fn(&[u8], Set<PublicKey>) -> S,
 ) -> Fixture<S>
 where
-    R: RngCore + CryptoRng,
+    R: Rng + CryptoRng,
     S: Scheme<PublicKey = PublicKey>,
 {
     assert!(n > 0);

--- a/cryptography/src/ed25519/certificate/mod.rs
+++ b/cryptography/src/ed25519/certificate/mod.rs
@@ -20,7 +20,7 @@ use commonware_utils::{
     ordered::{Quorum, Set},
     Faults, Participant,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 #[cfg(feature = "std")]
 use std::collections::BTreeSet;
 
@@ -124,7 +124,7 @@ impl<N: Namespace> Generic<N> {
     where
         S: Scheme<Signature = Ed25519Signature>,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: IntoIterator<Item = Attestation<S>>,
     {
@@ -267,7 +267,7 @@ impl<N: Namespace> Generic<N> {
     where
         S: Scheme,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         M: Faults,
     {
@@ -289,7 +289,7 @@ impl<N: Namespace> Generic<N> {
     where
         S: Scheme,
         S::Subject<'a, D>: Subject<Namespace = N>,
-        R: CryptoRngCore,
+        R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (S::Subject<'a, D>, &'a Certificate)>,
         M: Faults,
@@ -426,7 +426,7 @@ macro_rules! impl_certificate_ed25519 {
             n: u32,
         ) -> $crate::certificate::mocks::Fixture<Scheme>
         where
-            R: rand::RngCore + rand::CryptoRng,
+            R: rand::Rng + rand::CryptoRng,
         {
             $crate::ed25519::certificate::mocks::fixture(
                 rng,
@@ -496,7 +496,7 @@ macro_rules! impl_certificate_ed25519 {
                 strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 M: commonware_utils::Faults,
             {
@@ -511,7 +511,7 @@ macro_rules! impl_certificate_ed25519 {
                 strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
                 M: commonware_utils::Faults,
@@ -562,7 +562,7 @@ macro_rules! impl_certificate_ed25519 {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
             {
                 self.generic
@@ -577,7 +577,7 @@ macro_rules! impl_certificate_ed25519 {
                 strategy: &impl commonware_parallel::Strategy,
             ) -> $crate::certificate::Verification<Self>
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
             {
@@ -641,7 +641,7 @@ mod tests {
     // Use the macro to generate the test scheme
     impl_certificate_ed25519!(TestSubject, Vec<u8>);
 
-    fn setup_signers(rng: &mut impl CryptoRngCore, n: u32) -> (Vec<Scheme>, Scheme) {
+    fn setup_signers(rng: &mut impl CryptoRng, n: u32) -> (Vec<Scheme>, Scheme) {
         let private_keys: Vec<_> = (0..n).map(|_| PrivateKey::random(&mut *rng)).collect();
         let participants: Set<PublicKey> = private_keys
             .iter()

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -233,7 +233,7 @@ impl Verifier {
         let mut B_coeff = Scalar::ZERO;
 
         for (vk, payload, sig) in items {
-            let k = super::scalar_from_hash(
+            let k = Scalar::from_hash(
                 Sha512::default()
                     .chain(&sig.R_bytes[..])
                     .chain(vk.as_bytes())

--- a/cryptography/src/ed25519/core/batch.rs
+++ b/cryptography/src/ed25519/core/batch.rs
@@ -53,13 +53,13 @@ use curve25519_dalek::{
     traits::{IsIdentity, VartimeMultiscalarMul},
 };
 use hashbrown::HashMap;
-use rand_core::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, Rng};
 use sha2::{digest::Update, Sha512};
 
 const NOISE_BATCH_VERIFY: &[u8] = b"batch_verify";
 
 // Shim to generate a u128 without importing `rand`.
-fn gen_u128<R: RngCore + CryptoRng>(mut rng: R) -> u128 {
+fn gen_u128<R: Rng + CryptoRng>(mut rng: R) -> u128 {
     let mut bytes = [0u8; 16];
     rng.fill_bytes(&mut bytes[..]);
     u128::from_le_bytes(bytes)
@@ -110,7 +110,7 @@ impl Verifier {
     /// verifications. This function does not have the same verification criteria
     /// as individual verification, which may reject some signatures this method
     /// accepts.
-    pub fn verify<R: RngCore + CryptoRng>(
+    pub fn verify<R: Rng + CryptoRng>(
         self,
         mut rng: R,
         strategy: &impl Strategy,
@@ -275,7 +275,7 @@ mod tests {
     use super::{super::SigningKey, *};
     use commonware_parallel::{Rayon, Sequential};
     use commonware_utils::{test_rng, NZUsize};
-    use rand::Rng;
+    use rand::RngExt as _;
 
     /// Generate `signers` keys with `per_signer` signed messages each.
     fn signatures(

--- a/cryptography/src/ed25519/core/mod.rs
+++ b/cryptography/src/ed25519/core/mod.rs
@@ -11,15 +11,11 @@
 //! - Adapted code to `commonware`'s clippy rules.
 //! - The batch verifier accepts pre-decompressed [`VerificationKey`] values and reuses their
 //!   cached point decompression state.
-//! - Replaced `Scalar::from_hash` with [`Scalar::from_bytes_mod_order_wide`] to use `sha2` 0.11.
 //!
 //! [`ed25519_consensus`]: https://crates.io/crates/ed25519-consensus
 //! [`ed25519_zebra`]: https://crates.io/crates/ed25519-zebra
 //! [`curve25519_dalek_ng`]: https://crates.io/crates/curve25519-dalek-ng
 //! [`Scalar::from_bytes_mod_order`]: curve25519_dalek::scalar::Scalar::from_bytes_mod_order
-
-use curve25519_dalek::scalar::Scalar;
-use sha2::{Digest, Sha512};
 
 pub mod batch;
 mod error;
@@ -31,8 +27,3 @@ pub use error::Error;
 pub use signature::Signature;
 pub use signing_key::SigningKey;
 pub use verification_key::{VerificationKey, VerificationKeyBytes};
-
-/// Reduce a SHA-512 digest to a scalar modulo the group order.
-fn scalar_from_hash(h: Sha512) -> Scalar {
-    Scalar::from_bytes_mod_order_wide(&h.finalize().into())
-}

--- a/cryptography/src/ed25519/core/signing_key.rs
+++ b/cryptography/src/ed25519/core/signing_key.rs
@@ -1,4 +1,4 @@
-use super::{scalar_from_hash, Error, Signature, VerificationKey, VerificationKeyBytes};
+use super::{Error, Signature, VerificationKey, VerificationKeyBytes};
 use commonware_formatting::Hex;
 use core::convert::TryFrom;
 use curve25519_dalek::{constants, scalar::Scalar};
@@ -140,13 +140,13 @@ impl SigningKey {
     /// Create a signature on `msg` using this key.
     #[allow(non_snake_case)]
     pub fn sign(&self, msg: &[u8]) -> Signature {
-        let r = scalar_from_hash(Sha512::default().chain(&self.prefix[..]).chain(msg));
+        let r = Scalar::from_hash(Sha512::default().chain(&self.prefix[..]).chain(msg));
 
         let R_bytes = (&r * constants::ED25519_BASEPOINT_TABLE)
             .compress()
             .to_bytes();
 
-        let k = scalar_from_hash(
+        let k = Scalar::from_hash(
             Sha512::default()
                 .chain(&R_bytes[..])
                 .chain(&self.vk.A_bytes.0[..])

--- a/cryptography/src/ed25519/core/signing_key.rs
+++ b/cryptography/src/ed25519/core/signing_key.rs
@@ -2,7 +2,7 @@ use super::{scalar_from_hash, Error, Signature, VerificationKey, VerificationKey
 use commonware_formatting::Hex;
 use core::convert::TryFrom;
 use curve25519_dalek::{constants, scalar::Scalar};
-use rand_core::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, Rng};
 use sha2::{digest::Update, Digest, Sha512};
 
 /// An Ed25519 signing key.
@@ -131,7 +131,7 @@ impl zeroize::Zeroize for SigningKey {
 
 impl SigningKey {
     /// Generate a new signing key.
-    pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> Self {
+    pub fn new<R: Rng + CryptoRng>(mut rng: R) -> Self {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes[..]);
         bytes.into()

--- a/cryptography/src/ed25519/core/verification_key.rs
+++ b/cryptography/src/ed25519/core/verification_key.rs
@@ -1,4 +1,4 @@
-use super::{scalar_from_hash, Error, Signature};
+use super::{Error, Signature};
 use commonware_formatting::Hex;
 use core::convert::{TryFrom, TryInto};
 use curve25519_dalek::{
@@ -208,7 +208,7 @@ impl VerificationKey {
     /// [ps]: https://zips.z.cash/protocol/protocol.pdf#concreteed25519
     /// [ZIP215]: https://github.com/zcash/zips/blob/master/zip-0215.rst
     pub fn verify(&self, signature: &Signature, msg: &[u8]) -> Result<(), Error> {
-        let k = scalar_from_hash(
+        let k = Scalar::from_hash(
             Sha512::default()
                 .chain(&signature.R_bytes[..])
                 .chain(&self.A_bytes.0[..])

--- a/cryptography/src/ed25519/mod.rs
+++ b/cryptography/src/ed25519/mod.rs
@@ -10,10 +10,12 @@
 //! ```rust
 //! use commonware_cryptography::{ed25519, PrivateKey, PublicKey, Signature, Verifier as _, Signer as _};
 //! use commonware_math::algebra::Random;
-//! use rand::rngs::OsRng;
+//! use rand::{rngs::StdRng, SeedableRng};
+//!
+//! let mut rng = StdRng::seed_from_u64(0);
 //!
 //! // Generate a new private key
-//! let mut signer = ed25519::PrivateKey::random(&mut OsRng);
+//! let mut signer = ed25519::PrivateKey::random(&mut rng);
 //!
 //! // Create a message to sign
 //! let namespace = b"demo";

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -15,7 +15,7 @@ use core::{
     hash::Hash,
     ops::Deref,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 #[cfg(feature = "std")]
 use std::borrow::{Cow, ToOwned};
 use zeroize::Zeroizing;
@@ -59,7 +59,7 @@ impl PrivateKey {
 }
 
 impl Random for PrivateKey {
-    fn random(rng: impl CryptoRngCore) -> Self {
+    fn random(rng: impl CryptoRng) -> Self {
         let key = ed_core::SigningKey::new(rng);
         Self {
             key: Secret::new(key),
@@ -341,7 +341,7 @@ impl BatchVerifier for Batch {
         self.add_inner(Some(namespace), message, public_key, signature)
     }
 
-    fn verify<R: CryptoRngCore>(self, rng: &mut R, strategy: &impl Strategy) -> bool {
+    fn verify<R: CryptoRng>(self, rng: &mut R, strategy: &impl Strategy) -> bool {
         self.verifier.verify(rng, strategy).is_ok()
     }
 }
@@ -523,7 +523,7 @@ mod tests {
     #[should_panic]
     fn bad_signature() {
         let (private_key, public_key, message, _) = vector_1();
-        let private_key_2 = PrivateKey::random(&mut test_rng());
+        let private_key_2 = PrivateKey::random(test_rng());
         let bad_signature = private_key_2.sign_inner(None, &message);
         test_sign_and_verify(private_key, public_key, &message, bad_signature);
     }
@@ -787,7 +787,7 @@ mod tests {
 
     #[test]
     fn test_private_key_redacted() {
-        let private_key = PrivateKey::random(&mut test_rng());
+        let private_key = PrivateKey::random(test_rng());
         let debug = format!("{:?}", private_key);
         let display = format!("{}", private_key);
         assert!(debug.contains("REDACTED"));
@@ -796,7 +796,7 @@ mod tests {
 
     #[test]
     fn test_from_private_key_to_public_key() {
-        let private_key = PrivateKey::random(&mut test_rng());
+        let private_key = PrivateKey::random(test_rng());
         assert_eq!(private_key.public_key(), PublicKey::from(private_key));
     }
 

--- a/cryptography/src/handshake.rs
+++ b/cryptography/src/handshake.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 use commonware_codec::{Encode, FixedSize, Read, ReadExt, Write};
 use core::ops::Range;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 mod error;
 pub use error::Error;
@@ -244,7 +244,7 @@ impl<S, P> Context<S, P> {
 /// Initiates a handshake as the dialer.
 /// Returns the dialer state and the first message to send.
 pub fn dial_start<S: Signer, P: PublicKey>(
-    rng: impl CryptoRngCore,
+    rng: impl CryptoRng,
     ctx: Context<S, P>,
 ) -> (DialState<P>, Syn<<S as Signer>::Signature>) {
     let Context {
@@ -325,7 +325,7 @@ pub fn dial_end<P: PublicKey>(
 /// Processes the first handshake message as the listener.
 /// Verifies the dialer's message and returns state and response.
 pub fn listen_start<S: Signer, P: PublicKey>(
-    rng: impl CryptoRngCore,
+    rng: impl CryptoRng,
     ctx: Context<S, P>,
     msg: Syn<<P as Verifier>::Signature>,
 ) -> Result<(ListenState, SynAck<<S as Signer>::Signature>), Error> {

--- a/cryptography/src/handshake/cipher.rs
+++ b/cryptography/src/handshake/cipher.rs
@@ -1,6 +1,6 @@
 use super::error::Error;
 use crate::Secret;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::vec::Vec;
 use zeroize::Zeroizing;
 
@@ -135,7 +135,7 @@ pub struct SendCipher {
 
 impl SendCipher {
     /// Creates a new sending cipher with a random key.
-    pub fn new(mut rng: impl CryptoRngCore) -> Self {
+    pub fn new(mut rng: impl CryptoRng) -> Self {
         let mut key_bytes = Zeroizing::new([0u8; KEY_SIZE_BYTES]);
         rng.fill_bytes(key_bytes.as_mut());
         Self {
@@ -172,7 +172,7 @@ pub struct RecvCipher {
 
 impl RecvCipher {
     /// Creates a new receiving cipher with a random key.
-    pub fn new(mut rng: impl CryptoRngCore) -> Self {
+    pub fn new(mut rng: impl CryptoRng) -> Self {
         let mut key_bytes = Zeroizing::new([0u8; KEY_SIZE_BYTES]);
         rng.fill_bytes(key_bytes.as_mut());
         Self {
@@ -236,8 +236,8 @@ mod tests {
 
     #[test]
     fn test_send_recv_roundtrip() {
-        let mut send = SendCipher::new(&mut test_rng());
-        let mut recv = RecvCipher::new(&mut test_rng());
+        let mut send = SendCipher::new(test_rng());
+        let mut recv = RecvCipher::new(test_rng());
 
         let plaintext = b"hello world";
         let ciphertext = send.send(plaintext).unwrap();
@@ -249,8 +249,8 @@ mod tests {
 
     #[test]
     fn test_recv_wrong_key_fails() {
-        let mut send = SendCipher::new(&mut test_rng_seeded(0));
-        let mut recv = RecvCipher::new(&mut test_rng_seeded(1));
+        let mut send = SendCipher::new(test_rng_seeded(0));
+        let mut recv = RecvCipher::new(test_rng_seeded(1));
 
         let ciphertext = send.send(b"hello").unwrap();
         assert!(matches!(
@@ -280,8 +280,8 @@ mod tests {
 
     #[test]
     fn test_send_recv_in_place_roundtrip() {
-        let mut send = SendCipher::new(&mut test_rng());
-        let mut recv = RecvCipher::new(&mut test_rng());
+        let mut send = SendCipher::new(test_rng());
+        let mut recv = RecvCipher::new(test_rng());
 
         let plaintext = b"hello world";
         let mut buf = vec![0u8; plaintext.len() + TAG_SIZE];
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_recv_in_place_ciphertext_too_short() {
-        let mut recv = RecvCipher::new(&mut test_rng());
+        let mut recv = RecvCipher::new(test_rng());
 
         // Buffer smaller than tag size
         let mut buf = vec![0u8; TAG_SIZE - 1];
@@ -313,8 +313,8 @@ mod tests {
 
     #[test]
     fn test_send_in_place_recv_compatibility() {
-        let mut send = SendCipher::new(&mut test_rng());
-        let mut recv = RecvCipher::new(&mut test_rng());
+        let mut send = SendCipher::new(test_rng());
+        let mut recv = RecvCipher::new(test_rng());
 
         let plaintext = b"cross-api test";
         let mut buf = vec![0u8; plaintext.len() + TAG_SIZE];
@@ -330,8 +330,8 @@ mod tests {
 
     #[test]
     fn test_send_recv_in_place_compatibility() {
-        let mut send = SendCipher::new(&mut test_rng());
-        let mut recv = RecvCipher::new(&mut test_rng());
+        let mut send = SendCipher::new(test_rng());
+        let mut recv = RecvCipher::new(test_rng());
 
         let plaintext = b"cross-api test";
         let mut ciphertext = send.send(plaintext).unwrap();
@@ -343,8 +343,8 @@ mod tests {
 
     #[test]
     fn test_nonce_sync_after_truncated_recv() {
-        let mut send = SendCipher::new(&mut test_rng());
-        let mut recv = RecvCipher::new(&mut test_rng());
+        let mut send = SendCipher::new(test_rng());
+        let mut recv = RecvCipher::new(test_rng());
 
         // Send message (sender nonce: 0 -> 1)
         let ciphertext = send.send(b"message 1").unwrap();
@@ -359,8 +359,8 @@ mod tests {
 
     #[test]
     fn test_nonce_sync_after_corrupted_recv() {
-        let mut send = SendCipher::new(&mut test_rng());
-        let mut recv = RecvCipher::new(&mut test_rng());
+        let mut send = SendCipher::new(test_rng());
+        let mut recv = RecvCipher::new(test_rng());
 
         // Send message (sender nonce: 0 -> 1)
         let ciphertext = send.send(b"message 1").unwrap();

--- a/cryptography/src/handshake/conformance.rs
+++ b/cryptography/src/handshake/conformance.rs
@@ -9,7 +9,7 @@ use crate::{
 use commonware_codec::Encode;
 use commonware_conformance::{conformance_tests, Conformance};
 use commonware_math::algebra::Random;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt as _, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
 const NAMESPACE: &[u8] = b"_COMMONWARE_HANDSHAKE_CONFORMANCE_TESTS";
@@ -57,7 +57,7 @@ impl Conformance for Handshake {
         let (mut listener_tx, mut listener_rx) = listen_end(listener_state, dialer_ack).unwrap();
 
         // Generate a random message to send to the listener from the dialer.
-        let mut random_msg = vec![0u8; rng.gen_range(0..256)];
+        let mut random_msg = vec![0u8; rng.random_range(0..256)];
         rng.fill(&mut random_msg[..]);
         log.extend(random_msg.encode());
 
@@ -70,7 +70,7 @@ impl Conformance for Handshake {
         log.extend(received_msg.encode());
 
         // Generate a random message to send to the dialer from the listener.
-        let mut random_msg = vec![0u8; rng.gen_range(0..256)];
+        let mut random_msg = vec![0u8; rng.random_range(0..256)];
         rng.fill(&mut random_msg[..]);
         log.extend(random_msg.encode());
 

--- a/cryptography/src/handshake/key_exchange.rs
+++ b/cryptography/src/handshake/key_exchange.rs
@@ -1,6 +1,6 @@
 use crate::Secret;
 use commonware_codec::{FixedSize, Read, ReadExt, Write};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// A shared secret derived from X25519 key exchange.
 pub struct SharedSecret {
@@ -64,9 +64,9 @@ pub struct SecretKey {
 
 impl SecretKey {
     /// Generates a new random ephemeral secret key.
-    pub fn new(rng: impl CryptoRngCore) -> Self {
+    pub fn new(mut rng: impl CryptoRng) -> Self {
         Self {
-            inner: Secret::new(x25519_dalek::EphemeralSecret::random_from_rng(rng)),
+            inner: Secret::new(x25519_dalek::EphemeralSecret::random_from_rng(&mut rng)),
         }
     }
 

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -58,7 +58,7 @@ commonware_macros::stability_scope!(BETA {
     use commonware_utils::Array;
     use rand::SeedableRng as _;
     use rand_chacha::ChaCha20Rng;
-    use rand_core::CryptoRngCore;
+    use rand_core::CryptoRng;
 
     pub mod secret;
     pub use crate::secret::Secret;
@@ -108,7 +108,7 @@ commonware_macros::stability_scope!(BETA {
         /// This function is insecure and should only be used for examples
         /// and testing.
         fn from_seed(seed: u64) -> Self {
-            Self::random(&mut ChaCha20Rng::seed_from_u64(seed))
+            Self::random(ChaCha20Rng::seed_from_u64(seed))
         }
     }
 
@@ -191,7 +191,7 @@ commonware_macros::stability_scope!(BETA {
         /// (`c_1 + d` and `c_2 - d`).
         ///
         /// You can read more about this [here](https://ethresear.ch/t/security-of-bls-batch-verification/10748#the-importance-of-randomness-4).
-        fn verify<R: CryptoRngCore>(self, rng: &mut R, strategy: &impl Strategy) -> bool;
+        fn verify<R: CryptoRng>(self, rng: &mut R, strategy: &impl Strategy) -> bool;
     }
 
     /// Specializes the [commonware_utils::Array] trait with the Copy trait for cryptographic digests
@@ -287,7 +287,7 @@ mod tests {
     use commonware_utils::test_rng;
 
     fn test_validate<C: PrivateKey>() {
-        let private_key = C::random(&mut test_rng());
+        let private_key = C::random(test_rng());
         let public_key = private_key.public_key();
         assert!(C::PublicKey::decode(public_key.as_ref()).is_ok());
     }

--- a/cryptography/src/reed_solomon/benches/bench.rs
+++ b/cryptography/src/reed_solomon/benches/bench.rs
@@ -10,7 +10,7 @@ use commonware_cryptography::reed_solomon::{
     Decoder, Encoder, SHARD_CHUNK_BYTES,
 };
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{Rng, RngExt as _, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::hint::black_box;
 
@@ -389,7 +389,7 @@ fn benchmarks_engine_one<E: Engine>(c: &mut Criterion, engine_name: &str, engine
     let shard_chunk_count = SHARD_BYTES / SHARD_CHUNK_BYTES;
 
     let mut rng = ChaCha8Rng::from_seed([0; 32]);
-    let mut data = [(); GF_ORDER].map(|_| rng.gen());
+    let mut data = [(); GF_ORDER].map(|_| rng.random());
 
     c.bench_function(
         &format!("reed_solomon::engine_eval_poly/engine={engine_name} elems={GF_ORDER}"),

--- a/cryptography/src/reed_solomon/engine/engine_nosimd.rs
+++ b/cryptography/src/reed_solomon/engine/engine_nosimd.rs
@@ -336,7 +336,7 @@ mod tests {
     use crate::reed_solomon::engine::{Engine, Naive, NoSimd, SHARD_CHUNK_BYTES};
     #[cfg(not(feature = "std"))]
     use alloc::vec;
-    use rand::{Rng, RngCore, SeedableRng};
+    use rand::{Rng, RngExt as _, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 
     #[test]
@@ -351,7 +351,7 @@ mod tests {
             rng.fill_bytes(data_nosimd.as_flattened_mut());
             let mut data_naive = data_nosimd.clone();
 
-            let log_m = rng.gen();
+            let log_m = rng.random();
 
             nosimd.mul(&mut data_nosimd, log_m);
             naive.mul(&mut data_naive, log_m);

--- a/cryptography/src/reed_solomon/engine/fwht.rs
+++ b/cryptography/src/reed_solomon/engine/fwht.rs
@@ -62,7 +62,7 @@ mod tests {
     use super::*;
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt as _, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 
     // Reference implementation
@@ -103,7 +103,7 @@ mod tests {
     fn test_full() {
         let mut rng = ChaCha8Rng::from_seed([0; 32]);
 
-        let mut data1 = [(); GF_ORDER].map(|_| rng.gen());
+        let mut data1 = [(); GF_ORDER].map(|_| rng.random());
         let mut data2 = data1;
 
         fwht(&mut data1, GF_ORDER);
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn test_truncated() {
         let mut rng = ChaCha8Rng::from_seed([0; 32]);
-        let random: Vec<GfElement> = (0..GF_ORDER).map(|_| rng.gen()).collect();
+        let random: Vec<GfElement> = (0..GF_ORDER).map(|_| rng.random()).collect();
 
         for nonzero_count in [
             0,

--- a/cryptography/src/reed_solomon/test_util.rs
+++ b/cryptography/src/reed_solomon/test_util.rs
@@ -4,7 +4,7 @@ use crate::reed_solomon::{
 };
 use core::ops::Range;
 use fixedbitset::FixedBitSet;
-use rand::{RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;

--- a/cryptography/src/secp256r1/benches/signature_generation.rs
+++ b/cryptography/src/secp256r1/benches/signature_generation.rs
@@ -1,12 +1,12 @@
 use commonware_cryptography::{secp256r1, PrivateKey};
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_signature_generation<S: PrivateKey>(variant: impl AsRef<str>, c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
-    thread_rng().fill(&mut msg);
+    rng().fill(&mut msg);
     c.bench_function(
         &format!(
             "{}/variant={} ns_len={} msg_len={}",
@@ -17,7 +17,7 @@ fn bench_signature_generation<S: PrivateKey>(variant: impl AsRef<str>, c: &mut C
         ),
         |b| {
             b.iter_batched(
-                || S::random(&mut thread_rng()),
+                || S::random(rng()),
                 |signer| {
                     black_box(signer.sign(namespace, &msg));
                 },

--- a/cryptography/src/secp256r1/benches/signature_verification.rs
+++ b/cryptography/src/secp256r1/benches/signature_verification.rs
@@ -1,12 +1,12 @@
 use commonware_cryptography::{secp256r1, PrivateKey, Verifier};
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::{thread_rng, Rng};
+use rand::{rng, RngExt as _};
 use std::hint::black_box;
 
 fn bench_signature_verify<S: PrivateKey>(variant: impl AsRef<str>, c: &mut Criterion) {
     let namespace = b"namespace";
     let mut msg = [0u8; 32];
-    thread_rng().fill(&mut msg);
+    rng().fill(&mut msg);
     c.bench_function(
         &format!(
             "{}/variant={} ns_len={} msg_len={}",
@@ -18,7 +18,7 @@ fn bench_signature_verify<S: PrivateKey>(variant: impl AsRef<str>, c: &mut Crite
         |b| {
             b.iter_batched(
                 || {
-                    let private_key = S::random(&mut thread_rng());
+                    let private_key = S::random(rng());
                     let public_key = private_key.public_key();
                     let signature = private_key.sign(namespace, &msg);
                     (public_key, signature)

--- a/cryptography/src/secp256r1/certificate/mocks.rs
+++ b/cryptography/src/secp256r1/certificate/mocks.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use commonware_math::algebra::Random;
 use commonware_utils::{ordered::BiMap, TryCollect as _};
-use rand::{CryptoRng, RngCore};
+use rand::{CryptoRng, Rng};
 
 /// Builds ed25519 identities and matching Secp256r1 signing schemes.
 pub fn fixture<S, R>(
@@ -19,7 +19,7 @@ pub fn fixture<S, R>(
     verifier: impl Fn(&[u8], BiMap<ed25519::PublicKey, PublicKey>) -> S,
 ) -> Fixture<S>
 where
-    R: RngCore + CryptoRng,
+    R: Rng + CryptoRng,
     S: Scheme<PublicKey = ed25519::PublicKey>,
 {
     assert!(n > 0);

--- a/cryptography/src/secp256r1/certificate/mod.rs
+++ b/cryptography/src/secp256r1/certificate/mod.rs
@@ -354,7 +354,7 @@ macro_rules! impl_certificate_secp256r1 {
             n: u32,
         ) -> $crate::certificate::mocks::Fixture<Scheme<$crate::ed25519::PublicKey>>
         where
-            R: rand::RngCore + rand::CryptoRng,
+            R: rand::Rng + rand::CryptoRng,
         {
             $crate::secp256r1::certificate::mocks::fixture(
                 rng,
@@ -414,7 +414,7 @@ macro_rules! impl_certificate_secp256r1 {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 M: commonware_utils::Faults,
             {
@@ -432,7 +432,7 @@ macro_rules! impl_certificate_secp256r1 {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
                 M: commonware_utils::Faults,
@@ -486,7 +486,7 @@ macro_rules! impl_certificate_secp256r1 {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> bool
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
             {
                 self.generic
@@ -501,7 +501,7 @@ macro_rules! impl_certificate_secp256r1 {
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> $crate::certificate::Verification<Self>
             where
-                R: rand_core::CryptoRngCore,
+                R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
             {
@@ -543,7 +543,7 @@ mod tests {
     use commonware_math::algebra::Random;
     use commonware_parallel::Sequential;
     use commonware_utils::{ordered::BiMap, test_rng, Faults, N3f1, TryCollect};
-    use rand_core::CryptoRngCore;
+    use rand_core::CryptoRng;
 
     const NAMESPACE: &[u8] = b"test-secp256r1";
     const MESSAGE: &[u8] = b"test message";
@@ -570,7 +570,7 @@ mod tests {
     impl_certificate_secp256r1!(TestSubject, Vec<u8>);
 
     fn setup_signers(
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         n: u32,
     ) -> (Vec<Scheme<PublicKey>>, Scheme<PublicKey>) {
         let private_keys: Vec<_> = (0..n).map(|_| PrivateKey::random(&mut *rng)).collect();

--- a/cryptography/src/secp256r1/common.rs
+++ b/cryptography/src/secp256r1/common.rs
@@ -9,8 +9,11 @@ use core::{
     hash::{Hash, Hasher},
     ops::Deref,
 };
-use p256::ecdsa::{SigningKey, VerifyingKey};
-use rand_core::CryptoRngCore;
+use p256::{
+    ecdsa::{SigningKey, VerifyingKey},
+    elliptic_curve::Generate,
+};
+use rand_core::CryptoRng;
 use zeroize::Zeroizing;
 
 pub const CURVE_NAME: &str = "secp256r1";
@@ -48,8 +51,8 @@ impl PrivateKeyInner {
 }
 
 impl Random for PrivateKeyInner {
-    fn random(mut rng: impl CryptoRngCore) -> Self {
-        Self::new(SigningKey::random(&mut rng))
+    fn random(mut rng: impl CryptoRng) -> Self {
+        Self::new(SigningKey::generate_from_rng(&mut rng))
     }
 }
 
@@ -110,7 +113,7 @@ pub struct PublicKeyInner {
 
 impl PublicKeyInner {
     pub fn new(key: VerifyingKey) -> Self {
-        let encoded = key.to_encoded_point(true);
+        let encoded = key.to_sec1_point(true);
         let raw: [u8; PUBLIC_KEY_LENGTH] = encoded.as_bytes().try_into().unwrap();
         Self { raw, key }
     }
@@ -123,7 +126,7 @@ impl PublicKeyInner {
     /// in memory, extracting the uncompressed form directly is faster.
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub fn to_uncompressed(&self) -> [u8; 65] {
-        let encoded = self.key.to_encoded_point(false);
+        let encoded = self.key.to_sec1_point(false);
         encoded.as_bytes().try_into().unwrap()
     }
 }
@@ -208,7 +211,7 @@ macro_rules! impl_private_key_wrapper {
         impl crate::PrivateKey for $name {}
 
         impl commonware_math::algebra::Random for $name {
-            fn random(rng: impl rand_core::CryptoRngCore) -> Self {
+            fn random(rng: impl rand_core::CryptoRng) -> Self {
                 Self(PrivateKeyInner::random(rng))
             }
         }
@@ -585,9 +588,9 @@ pub(crate) mod tests {
     pub fn parse_signature(r: &str, s: &str) -> p256::ecdsa::Signature {
         let vec_r = commonware_formatting::from_hex(r).unwrap();
         let vec_s = commonware_formatting::from_hex(s).unwrap();
-        let f1 = p256::FieldBytes::from_slice(&vec_r);
-        let f2 = p256::FieldBytes::from_slice(&vec_s);
-        p256::ecdsa::Signature::from_scalars(*f1, *f2).unwrap()
+        let f1 = p256::FieldBytes::try_from(vec_r.as_slice()).unwrap();
+        let f2 = p256::FieldBytes::try_from(vec_s.as_slice()).unwrap();
+        p256::ecdsa::Signature::from_scalars(f1, f2).unwrap()
     }
 
     pub fn vector_sig_verification_1_raw() -> (PublicKeyInner, p256::ecdsa::Signature, Vec<u8>, bool)

--- a/cryptography/src/secp256r1/mod.rs
+++ b/cryptography/src/secp256r1/mod.rs
@@ -8,10 +8,12 @@
 //! ```rust
 //! use commonware_cryptography::{secp256r1, PrivateKey, PublicKey, Signature, Recoverable, Verifier as _, Signer as _};
 //! use commonware_math::algebra::Random;
-//! use rand::rngs::OsRng;
+//! use rand::{rngs::StdRng, SeedableRng};
+//!
+//! let mut rng = StdRng::seed_from_u64(0);
 //!
 //! // Generate a new private key
-//! let mut signer = secp256r1::standard::PrivateKey::random(&mut OsRng);
+//! let mut signer = secp256r1::standard::PrivateKey::random(&mut rng);
 //!
 //! // Create a message to sign
 //! let namespace = b"demo";
@@ -24,7 +26,7 @@
 //! assert!(signer.public_key().verify(namespace, msg, &signature));
 //!
 //! // Generate a new private key that supports recoverable signatures
-//! let mut signer = secp256r1::recoverable::PrivateKey::random(&mut OsRng);
+//! let mut signer = secp256r1::recoverable::PrivateKey::random(&mut rng);
 //!
 //! // Sign the message
 //! let signature = signer.sign(namespace, msg);

--- a/cryptography/src/secp256r1/recoverable.rs
+++ b/cryptography/src/secp256r1/recoverable.rs
@@ -49,17 +49,14 @@ impl PrivateKey {
         let payload = namespace.map_or(Cow::Borrowed(msg), |namespace| {
             Cow::Owned(union_unique(namespace, msg))
         });
-        let (mut signature, mut recovery_id) = self
-            .0
-            .key
-            .expose(|key| key.sign_recoverable(&payload))
-            .expect("signing must succeed");
+        let (mut signature, mut recovery_id) =
+            self.0.key.expose(|key| key.sign_recoverable(&payload));
 
         // The signing algorithm generates k, then calculates r <- x(k * G). Normalizing s by negating it is equivalent
         // to negating k. This has no effect on x(k * G) but y(-k * G) = -y(k * G), hence the need to flip the bit if
         // we move s into the lower half of the curve order.
-        if let Some(normalized) = signature.normalize_s() {
-            signature = normalized;
+        if signature.s().is_high().into() {
+            signature = signature.normalize_s();
             recovery_id = RecoveryId::new(!recovery_id.is_y_odd(), recovery_id.is_x_reduced());
         }
 
@@ -437,7 +434,7 @@ mod tests {
         let signature = private_key.sign_inner(None, message);
         assert_eq!(
             signature.signature.to_bytes().to_vec(),
-            exp_sig.normalize_s().unwrap().to_bytes().to_vec()
+            exp_sig.normalize_s().to_bytes().to_vec()
         );
 
         let (message, exp_sig) = (
@@ -667,9 +664,7 @@ mod tests {
                 assert!(Signature::decode(sig.as_ref()).is_err());
                 assert!(Signature::decode(Bytes::from(sig)).is_err());
 
-                if let Some(normalized_sig) = ecdsa_signature.normalize_s() {
-                    ecdsa_signature = normalized_sig;
-                }
+                ecdsa_signature = ecdsa_signature.normalize_s();
             }
             let recovery_id =
                 RecoveryId::trial_recovery_from_msg(&public_key.0.key, &message, &ecdsa_signature)

--- a/cryptography/src/secp256r1/standard.rs
+++ b/cryptography/src/secp256r1/standard.rs
@@ -52,7 +52,7 @@ impl PrivateKey {
             Cow::Owned(union_unique(namespace, msg))
         });
         let signature: p256::ecdsa::Signature = self.0.key.expose(|key| key.sign(&payload));
-        let signature = signature.normalize_s().unwrap_or(signature);
+        let signature = signature.normalize_s();
         Signature::try_from(signature).expect("freshly signed signature is valid")
     }
 }
@@ -341,7 +341,7 @@ mod tests {
             .unwrap(),
         );
         let signature = private_key.sign_inner(None, message);
-        assert_eq!(signature.to_vec(), exp_sig.normalize_s().unwrap().to_vec());
+        assert_eq!(signature.to_vec(), exp_sig.normalize_s().to_vec());
 
         let (message, exp_sig) = (
             b"test",
@@ -555,9 +555,7 @@ mod tests {
                 assert!(Signature::decode(sig.as_ref()).is_err());
                 assert!(Signature::decode(Bytes::from(sig)).is_err());
 
-                if let Some(normalized_sig) = ecdsa_signature.normalize_s() {
-                    ecdsa_signature = normalized_sig;
-                }
+                ecdsa_signature = ecdsa_signature.normalize_s();
             }
             let signature = Signature::try_from(ecdsa_signature).unwrap();
             public_key.verify_inner(None, &message, &signature)

--- a/cryptography/src/sha256/benches/hash_message.rs
+++ b/cryptography/src/sha256/benches/hash_message.rs
@@ -1,6 +1,6 @@
 use commonware_cryptography::{Hasher, Sha256};
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 fn bench_hash_message(c: &mut Criterion) {
     let mut sampler = StdRng::seed_from_u64(0);

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -34,7 +34,7 @@ use core::{
     fmt::{Debug, Display},
     ops::Deref,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use sha2::{Digest as _, Sha256 as ISha256};
 use zeroize::Zeroize;
 
@@ -153,7 +153,7 @@ impl crate::Digest for Digest {
 }
 
 impl Random for Digest {
-    fn random(mut rng: impl CryptoRngCore) -> Self {
+    fn random(mut rng: impl CryptoRng) -> Self {
         let mut array = [0u8; DIGEST_LENGTH];
         rng.fill_bytes(&mut array);
         Self(array)

--- a/cryptography/src/transcript.rs
+++ b/cryptography/src/transcript.rs
@@ -568,8 +568,107 @@ mod test {
     mod conformance {
         use super::*;
         use commonware_codec::conformance::CodecConformance;
+        use commonware_conformance::Conformance;
+
+        struct TranscriptOps;
+
+        impl Conformance for TranscriptOps {
+            async fn commit(seed: u64) -> Vec<u8> {
+                let seed_bytes = seed.to_le_bytes();
+                let namespace = seed_bytes[..(seed as usize % seed_bytes.len()) + 1].to_vec();
+                let data: Vec<_> = (0..seed as usize % 256)
+                    .map(|i| (seed as u8).wrapping_add((3 * i) as u8))
+                    .collect();
+                let split = data.len() / 2;
+
+                let mut transcript = Transcript::new(&namespace);
+                transcript.append(&data[..split]);
+                transcript.commit(&data[split..]);
+
+                let mut log = transcript.summarize().encode().to_vec();
+                log.extend(
+                    Transcript::new(&namespace)
+                        .commit(&data[..split])
+                        .commit(&data[split..])
+                        .summarize()
+                        .encode(),
+                );
+                log.extend(
+                    Transcript::new(&namespace)
+                        .append(data.as_slice())
+                        .commit([].as_slice())
+                        .summarize()
+                        .encode(),
+                );
+                let resumed = Transcript::resume(transcript.summarize());
+                log.extend(resumed.summarize().encode());
+                log.extend(transcript.fork(b"left").summarize().encode());
+                log.extend(transcript.fork(b"right").summarize().encode());
+
+                let mut noise = [0u8; 80];
+                let mut rng = transcript.noise(b"noise");
+                log.extend(rng.next_u32().encode());
+                log.extend(rng.next_u64().encode());
+                rng.fill_bytes(&mut noise[..31]);
+                rng.fill_bytes(&mut noise[31..]);
+                log.extend(noise);
+
+                let private_key = ed25519::PrivateKey::from_seed(seed);
+                let public_key = private_key.public_key();
+                let summary = transcript.summarize();
+                let summary_sig = summary.sign(&private_key);
+                let transcript_sig = transcript.sign(&private_key);
+                log.extend(summary_sig.encode());
+                log.extend(transcript_sig.encode());
+                log.extend(summary.verify(&public_key, &summary_sig).encode());
+                log.extend(transcript.verify(&public_key, &transcript_sig).encode());
+
+                let mut summary_batch = ed25519::Batch::new(1);
+                log.extend(
+                    summary
+                        .add_to_batch(&mut summary_batch, &public_key, &summary_sig)
+                        .encode(),
+                );
+                log.extend(
+                    summary_batch
+                        .verify(&mut transcript.noise(b"summary batch"), &Sequential)
+                        .encode(),
+                );
+
+                let mut transcript_batch = ed25519::Batch::new(1);
+                log.extend(
+                    transcript
+                        .add_to_batch(&mut transcript_batch, &public_key, &transcript_sig)
+                        .encode(),
+                );
+                log.extend(
+                    transcript_batch
+                        .verify(&mut transcript.noise(b"transcript batch"), &Sequential)
+                        .encode(),
+                );
+
+                let mut pending = Transcript::new(&namespace);
+                pending.append(data.as_slice());
+                let pending_summary = pending.summarize();
+                log.extend(pending_summary.encode());
+                log.extend(pending.fork(b"pending fork").summarize().encode());
+
+                let mut pending_noise = [0u8; 37];
+                pending
+                    .noise(b"pending noise")
+                    .fill_bytes(&mut pending_noise);
+                log.extend(pending_noise);
+
+                let pending_sig = pending.sign(&private_key);
+                log.extend(pending_sig.encode());
+                log.extend(pending.verify(&public_key, &pending_sig).encode());
+
+                log
+            }
+        }
 
         commonware_conformance::conformance_tests! {
+            TranscriptOps => 4096,
             CodecConformance<Summary>,
         }
     }

--- a/cryptography/src/transcript.rs
+++ b/cryptography/src/transcript.rs
@@ -9,14 +9,11 @@ use bytes::Buf;
 use commonware_codec::{varint::UInt, EncodeSize, FixedArray, FixedSize, Read, ReadExt, Write};
 use commonware_math::algebra::Random;
 use commonware_utils::{Array, Span};
-use core::{fmt::Display, ops::Deref};
-use rand_core::{
-    impls::{next_u32_via_fill, next_u64_via_fill},
-    CryptoRng, CryptoRngCore, RngCore,
-};
+use core::{convert::Infallible, fmt::Display, ops::Deref};
+use rand_core::{CryptoRng, TryCryptoRng, TryRng};
 use zeroize::ZeroizeOnDrop;
 
-/// Provides an implementation of [CryptoRngCore].
+/// Provides an implementation of [CryptoRng].
 ///
 /// We intentionally don't expose this struct, to make the impl returned by
 /// [Transcript::noise] completely opaque.
@@ -37,22 +34,28 @@ impl Rng {
     }
 }
 
-impl RngCore for Rng {
-    fn next_u32(&mut self) -> u32 {
-        next_u32_via_fill(self)
+impl TryRng for Rng {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        let mut bytes = [0u8; 4];
+        self.try_fill_bytes(&mut bytes)?;
+        Ok(u32::from_le_bytes(bytes))
     }
 
-    fn next_u64(&mut self) -> u64 {
-        next_u64_via_fill(self)
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let mut bytes = [0u8; 8];
+        self.try_fill_bytes(&mut bytes)?;
+        Ok(u64::from_le_bytes(bytes))
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         let dest_len = dest.len();
         let remaining = &self.buf[self.start..];
         if remaining.len() >= dest_len {
             dest.copy_from_slice(&remaining[..dest_len]);
             self.start += dest_len;
-            return;
+            return Ok(());
         }
 
         let (start, mut dest) = dest.split_at_mut(remaining.len());
@@ -71,15 +74,12 @@ impl RngCore for Rng {
             dest.copy_from_slice(&self.buf[..dest_len]);
             self.start = dest_len;
         }
-    }
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.fill_bytes(dest);
         Ok(())
     }
 }
 
-impl CryptoRng for Rng {}
+impl TryCryptoRng for Rng {}
 
 fn flush(hasher: &mut blake3::Hasher, pending: u64) {
     let mut pending_bytes = [0u8; 9];
@@ -238,7 +238,7 @@ impl Transcript {
     ///
     /// The label will also affect the noise. Changing the label will change
     /// the stream of bytes generated.
-    pub fn noise(&self, label: &'static [u8]) -> impl CryptoRngCore {
+    pub fn noise(&self, label: &'static [u8]) -> impl CryptoRng {
         let mut out = Self::start(StartTag::Noise, Some(self.summarize()));
         out.commit(label);
         Rng::new(out.hasher.finalize_xof())
@@ -393,7 +393,7 @@ impl crate::Digest for Summary {
 }
 
 impl Random for Summary {
-    fn random(mut rng: impl CryptoRngCore) -> Self {
+    fn random(mut rng: impl CryptoRng) -> Self {
         let mut bytes = [0u8; blake3::OUT_LEN];
         rng.fill_bytes(&mut bytes[..]);
         Self {
@@ -419,6 +419,7 @@ mod test {
     use commonware_codec::{DecodeExt as _, Encode};
     use commonware_parallel::Sequential;
     use commonware_utils::test_rng;
+    use rand_core::Rng;
 
     #[test]
     fn test_namespace_affects_summary() {

--- a/cryptography/src/transcript.rs
+++ b/cryptography/src/transcript.rs
@@ -8,8 +8,12 @@ use blake3::BLOCK_LEN;
 use bytes::Buf;
 use commonware_codec::{varint::UInt, EncodeSize, FixedArray, FixedSize, Read, ReadExt, Write};
 use commonware_math::algebra::Random;
-use commonware_utils::{Array, Span, NZU64};
-use core::{convert::Infallible, fmt::Display, num::NonZeroU64, ops::Deref};
+#[commonware_macros::stability(ALPHA)]
+use commonware_utils::NZU64;
+use commonware_utils::{Array, Span};
+#[commonware_macros::stability(ALPHA)]
+use core::num::NonZeroU64;
+use core::{convert::Infallible, fmt::Display, ops::Deref};
 use rand_core::{CryptoRng, TryCryptoRng, TryRng};
 use zeroize::ZeroizeOnDrop;
 
@@ -307,6 +311,7 @@ impl Transcript {
 }
 
 /// Sample a uniform value in `0..bound` from an infallible RNG.
+#[commonware_macros::stability(ALPHA)]
 fn sample(mut rng: impl CryptoRng, bound: NonZeroU64) -> u64 {
     let bound = bound.get();
 

--- a/cryptography/src/transcript.rs
+++ b/cryptography/src/transcript.rs
@@ -8,8 +8,8 @@ use blake3::BLOCK_LEN;
 use bytes::Buf;
 use commonware_codec::{varint::UInt, EncodeSize, FixedArray, FixedSize, Read, ReadExt, Write};
 use commonware_math::algebra::Random;
-use commonware_utils::{Array, Span};
-use core::{convert::Infallible, fmt::Display, ops::Deref};
+use commonware_utils::{Array, Span, NZU64};
+use core::{convert::Infallible, fmt::Display, num::NonZeroU64, ops::Deref};
 use rand_core::{CryptoRng, TryCryptoRng, TryRng};
 use zeroize::ZeroizeOnDrop;
 
@@ -244,6 +244,47 @@ impl Transcript {
         Rng::new(out.hasher.finalize_xof())
     }
 
+    /// Shuffle a slice deterministically, based on this transcript.
+    ///
+    /// The permutation will depend on all of the messages committed to the
+    /// transcript so far. This is a Fisher-Yates shuffle over [Transcript::noise].
+    ///
+    /// The label will also affect the permutation. Changing the label will
+    /// change the resulting order:
+    /// ```
+    /// # use commonware_cryptography::transcript::Transcript;
+    /// let t = Transcript::new(b"test");
+    /// let mut a = [0u32, 1, 2, 3, 4, 5, 6, 7];
+    /// let mut b = a;
+    /// t.shuffle(b"A", &mut a);
+    /// t.shuffle(b"B", &mut b);
+    /// assert_ne!(a, b);
+    /// ```
+    #[commonware_macros::stability(ALPHA)]
+    pub fn shuffle<T>(&self, label: &'static [u8], items: &mut [T]) {
+        let mut rng = self.noise(label);
+        for i in (1..items.len()).rev() {
+            let j = sample(&mut rng, NZU64!(i as u64 + 1));
+            items.swap(i, j as usize);
+        }
+    }
+
+    /// Sample a uniform value in `0..bound`, based on this transcript.
+    ///
+    /// The value is unbiased, and will depend on all of the messages committed
+    /// to the transcript so far. The label will also affect the value:
+    /// ```
+    /// # use commonware_cryptography::transcript::Transcript;
+    /// # use commonware_utils::NZU64;
+    /// let t = Transcript::new(b"test");
+    /// assert_eq!(t.sample(b"A", NZU64!(100)), t.sample(b"A", NZU64!(100)));
+    /// assert!(t.sample(b"A", NZU64!(100)) < 100);
+    /// ```
+    #[commonware_macros::stability(ALPHA)]
+    pub fn sample(&self, label: &'static [u8], bound: NonZeroU64) -> u64 {
+        sample(self.noise(label), bound)
+    }
+
     /// Extract a compact summary from this transcript.
     ///
     /// This can be used to compare transcripts for equality:
@@ -262,6 +303,21 @@ impl Transcript {
             self.hasher.finalize()
         };
         Summary { hash }
+    }
+}
+
+/// Sample a uniform value in `0..bound` from an infallible RNG.
+fn sample(mut rng: impl CryptoRng, bound: NonZeroU64) -> u64 {
+    let bound = bound.get();
+
+    // Accept only draws below the largest multiple of `bound`, so that the
+    // modulo is unbiased. Fewer than two draws are needed on average.
+    let zone = bound * (u64::MAX / bound);
+    loop {
+        let v = rng.next_u64();
+        if v < zone {
+            return v % bound;
+        }
     }
 }
 
@@ -555,6 +611,56 @@ mod test {
     }
 
     #[test]
+    fn test_shuffle_is_permutation() {
+        let t = Transcript::new(b"test");
+        let mut items: Vec<u32> = (0..1000).collect();
+        t.shuffle(b"shuffle", &mut items);
+        assert_ne!(items, (0..1000).collect::<Vec<_>>());
+        items.sort_unstable();
+        assert_eq!(items, (0..1000).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_shuffle_is_deterministic() {
+        let mut t = Transcript::new(b"test");
+        t.commit(b"DATA".as_slice());
+        let mut s1: Vec<u32> = (0..100).collect();
+        let mut s2 = s1.clone();
+        t.shuffle(b"shuffle", &mut s1);
+        t.shuffle(b"shuffle", &mut s2);
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn test_shuffle_label_and_history_matter() {
+        let t1 = Transcript::new(b"test");
+        let mut t2 = Transcript::new(b"test");
+        t2.commit(b"DATA".as_slice());
+        let mut base: Vec<u32> = (0..100).collect();
+        let (mut a, mut b, mut c) = (base.clone(), base.clone(), base.clone());
+        t1.shuffle(b"A", &mut a);
+        t1.shuffle(b"B", &mut b);
+        t2.shuffle(b"A", &mut c);
+        base.clear();
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_sample_within_bound() {
+        let t = Transcript::new(b"test");
+        let mut rng = t.noise(b"sample");
+        for bound in [1, 2, 3, 7, 100, 1 << 40, u64::MAX] {
+            assert!(sample(&mut rng, NZU64!(bound)) < bound);
+        }
+        assert_eq!(t.sample(b"sample", NZU64!(1)), 0);
+        assert_eq!(
+            t.sample(b"one shot", NZU64!(1000)),
+            sample(t.noise(b"one shot"), NZU64!(1000))
+        );
+    }
+
+    #[test]
     fn test_missing_append() {
         let s1 = Transcript::new(b"foo").append(b"AB".as_slice()).summarize();
         let s2 = Transcript::new(b"foo")
@@ -612,6 +718,13 @@ mod test {
                 rng.fill_bytes(&mut noise[..31]);
                 rng.fill_bytes(&mut noise[31..]);
                 log.extend(noise);
+
+                let mut indices: Vec<u32> = (0..(seed % 100) as u32).collect();
+                transcript.shuffle(b"shuffle", &mut indices);
+                for index in &indices {
+                    log.extend(index.encode());
+                }
+                log.extend(transcript.sample(b"sample", NZU64!(seed | 1)).encode());
 
                 let private_key = ed25519::PrivateKey::from_seed(seed);
                 let public_key = private_key.public_key();

--- a/cryptography/src/zk/bulletproofs/circuit.rs
+++ b/cryptography/src/zk/bulletproofs/circuit.rs
@@ -140,7 +140,7 @@ use commonware_math::{
     synthetic::Synthetic,
 };
 use commonware_parallel::{Sequential, Strategy};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     collections::BTreeMap,
     ops::{Index, IndexMut, Mul},
@@ -358,7 +358,7 @@ mod zkc {
     use crate::zk::circuit as zk;
     use commonware_math::algebra::{Field, Random, Ring};
     use commonware_utils::ordered::Map;
-    use rand_core::CryptoRngCore;
+    use rand_core::CryptoRng;
     use std::{borrow::Cow, collections::BTreeMap};
 
     /// A column of the bulletproofs weight matrix.
@@ -530,7 +530,7 @@ mod zkc {
         /// Without a `blinding_rng`, the blinding factors are zero.
         pub fn circuit_and_witness(
             mut self,
-            blinding_rng: Option<&mut impl CryptoRngCore>,
+            blinding_rng: Option<&mut impl CryptoRng>,
             zkc: zk::ValuedCircuit<F>,
         ) -> (super::Circuit<F>, super::Witness<F>) {
             self.populate(&zkc.circuit);
@@ -833,7 +833,7 @@ pub fn zkc_to_circuit<F: Field + Random>(
 /// allocated by the circuit; other indices are unsupported, and may panic
 /// or leave a commitment unconstrained.
 pub fn zkc_to_circuit_and_witness<F: Field + Random>(
-    blinding_rng: Option<&mut impl CryptoRngCore>,
+    blinding_rng: Option<&mut impl CryptoRng>,
     zkc: crate::zk::circuit::ValuedCircuit<F>,
     committed_indices: &[crate::zk::circuit::CircuitIdx],
 ) -> (Circuit<F>, Witness<F>) {
@@ -983,7 +983,7 @@ impl<G> Setup<G> {
     /// returned `Vec` indicate that the corresponding item is structurally
     /// invalid; they are reported as `false` in the result without ever
     /// being included in any subset sum.
-    pub fn eval_check_batched<F: Field + Random, R: CryptoRngCore>(
+    pub fn eval_check_batched<F: Field + Random, R: CryptoRng>(
         &self,
         rng: &mut R,
         f: impl FnOnce(&Setup<Synthetic<F, G>>, &mut R) -> Option<Vec<Option<Synthetic<F, G>>>>,
@@ -1265,7 +1265,7 @@ where
 /// witness lengths are inconsistent with the circuit, or if the claim does not
 /// match the witness.
 pub fn prove<F: Field + Encode + Random, G: CryptoGroup<Scalar = F> + Encode>(
-    rng: &mut impl CryptoRngCore,
+    rng: &mut impl CryptoRng,
     transcript: &mut Transcript,
     setup: &Setup<G>,
     circuit: &Circuit<F>,
@@ -1710,7 +1710,7 @@ pub fn prove<F: Field + Encode + Random, G: CryptoGroup<Scalar = F> + Encode>(
 /// The extra randomness is used to compress the circuit-specific checks into a
 /// single equation before combining them with the inner product argument.
 pub fn verify<F: Field + Encode + Random, G: CryptoGroup<Scalar = F> + Encode>(
-    rng: &mut impl CryptoRngCore,
+    rng: &mut impl CryptoRng,
     transcript: &mut Transcript,
     setup: &Setup<Synthetic<F, G>>,
     circuit: &Circuit<F>,

--- a/cryptography/src/zk/bulletproofs/ipa.rs
+++ b/cryptography/src/zk/bulletproofs/ipa.rs
@@ -590,7 +590,7 @@ where
     // At this point, we've committed to the claim we're trying to prove, so
     // we can't pull any shenanigans by modifying the claim based on the challenges.
     transcript.commit(claim.encode());
-    let w = F::random(&mut transcript.noise(b"w challenge"));
+    let w = F::random(transcript.noise(b"w challenge"));
     let w_q = setup.product_generator.clone() * &w;
 
     let mut l_r_coms = Vec::<(G, G)>::new();
@@ -616,7 +616,7 @@ where
         l_r_coms.push((l.clone(), r.clone()));
         transcript.commit(l.encode());
         transcript.commit(r.encode());
-        let u = F::random(&mut transcript.noise(b"u challenge"));
+        let u = F::random(transcript.noise(b"u challenge"));
         let u_inv = u.inv();
 
         for (a_lo_i, a_hi_i) in a_lo.iter_mut().zip(a_hi.iter_mut()) {
@@ -763,7 +763,7 @@ where
     }
     transcript.commit(claim.encode());
 
-    let w = F::random(&mut transcript.noise(b"w challenge"));
+    let w = F::random(transcript.noise(b"w challenge"));
 
     // We reduce verification down to one MSM which needs to equal 0:
     // commitment + product * U + sum(u_i^2 * L_i + u_i^-2 * R_i)

--- a/cryptography/src/zk/pedersen_to_plain.rs
+++ b/cryptography/src/zk/pedersen_to_plain.rs
@@ -101,7 +101,7 @@ use commonware_math::{
     algebra::{CryptoGroup, Field, Random, Space},
     synthetic::Synthetic,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// Generators used by the proof system.
 ///
@@ -288,7 +288,7 @@ where
 /// This is a low-level constructor and assumes that `claim` and `witness`
 /// correspond. It does not check that relationship for you.
 pub fn prove<F: Field + Random, G: CryptoGroup<Scalar = F> + Encode>(
-    rng: &mut impl CryptoRngCore,
+    rng: &mut impl CryptoRng,
     transcript: &mut Transcript,
     setup: &Setup<G>,
     claim: &Claim<G>,
@@ -343,7 +343,7 @@ where
 ///
 /// Returns `true` if the proof is valid for the current transcript state.
 pub fn verify<F: Field + Random, G: CryptoGroup<Scalar = F> + Encode + PartialEq>(
-    rng: &mut impl CryptoRngCore,
+    rng: &mut impl CryptoRng,
     transcript: &mut Transcript,
     setup: &Setup<Synthetic<F, G>>,
     claim: &Claim<G>,
@@ -491,7 +491,7 @@ pub mod fuzz {
             self.honest
         }
 
-        fn verify(self, rng: &mut impl CryptoRngCore) -> bool {
+        fn verify(self, rng: &mut impl CryptoRng) -> bool {
             let ns = if self.bad_namespace {
                 BAD_NAMESPACE
             } else {

--- a/examples/bridge/src/application/actor.rs
+++ b/examples/bridge/src/application/actor.rs
@@ -20,12 +20,12 @@ use commonware_cryptography::{
 use commonware_parallel::Sequential;
 use commonware_runtime::{Metrics, Sink, Spawner, Stream};
 use commonware_stream::encrypted::{Receiver, Sender};
-use rand::Rng;
-use rand_core::CryptoRngCore;
+use rand::RngExt as _;
+use rand_core::CryptoRng;
 use tracing::{debug, info};
 
 /// Application actor.
-pub struct Application<R: CryptoRngCore + Spawner + Metrics, H: Hasher, Si: Sink, St: Stream> {
+pub struct Application<R: CryptoRng + Spawner + Metrics, H: Hasher, Si: Sink, St: Stream> {
     context: R,
     indexer: (Sender<Si>, Receiver<St>),
     this_network: <MinSig as Variant>::Public,
@@ -34,9 +34,7 @@ pub struct Application<R: CryptoRngCore + Spawner + Metrics, H: Hasher, Si: Sink
     mailbox: ActorReceiver<Message<H::Digest>>,
 }
 
-impl<R: CryptoRngCore + Spawner + Metrics, H: Hasher, Si: Sink, St: Stream>
-    Application<R, H, Si, St>
-{
+impl<R: CryptoRng + Spawner + Metrics, H: Hasher, Si: Sink, St: Stream> Application<R, H, Si, St> {
     /// Create a new application actor.
     pub fn new(context: R, config: Config<H, Si, St>) -> (Self, Scheme, Mailbox<H::Digest>) {
         let (sender, mailbox) = mailbox::new(context.child("mailbox"), config.mailbox_size);
@@ -62,10 +60,10 @@ impl<R: CryptoRngCore + Spawner + Metrics, H: Hasher, Si: Sink, St: Stream>
             match message {
                 Message::Propose { round, response } => {
                     // Either propose a random message (prefix=0) or include a consensus certificate (prefix=1)
-                    let block = match self.context.gen_bool(0.5) {
+                    let block = match self.context.random_bool(0.5) {
                         true => {
                             // Generate a random message
-                            BlockFormat::<H::Digest>::Random(self.context.gen())
+                            BlockFormat::<H::Digest>::Random(self.context.random())
                         }
                         false => {
                             // Fetch a certificate from the indexer for the other network

--- a/examples/bridge/src/types/block.rs
+++ b/examples/bridge/src/types/block.rs
@@ -84,7 +84,7 @@ mod tests {
     }
 
     fn new_finalization() -> Finalization<Scheme, Sha256Digest> {
-        let scalar = group::Scalar::random(&mut test_rng());
+        let scalar = group::Scalar::random(test_rng());
         let mut signature = <MinSig as Variant>::Signature::generator();
         signature *= &scalar;
         Finalization {

--- a/examples/bridge/src/types/inbound.rs
+++ b/examples/bridge/src/types/inbound.rs
@@ -235,13 +235,13 @@ mod tests {
 
     fn new_group_public() -> <MinSig as Variant>::Public {
         let mut result = <MinSig as Variant>::Public::generator();
-        let scalar = group::Scalar::random(&mut test_rng());
+        let scalar = group::Scalar::random(test_rng());
         result *= &scalar;
         result
     }
 
     fn new_finalization() -> Finalization<Scheme, Sha256Digest> {
-        let scalar = group::Scalar::random(&mut test_rng());
+        let scalar = group::Scalar::random(test_rng());
         let mut signature = <MinSig as Variant>::Signature::generator();
         signature *= &scalar;
         Finalization {

--- a/examples/bridge/src/types/outbound.rs
+++ b/examples/bridge/src/types/outbound.rs
@@ -99,7 +99,7 @@ mod tests {
     }
 
     fn new_finalization() -> Finalization<Scheme, Sha256Digest> {
-        let scalar = group::Scalar::random(&mut test_rng());
+        let scalar = group::Scalar::random(test_rng());
         let mut signature = <MinSig as commonware_cryptography::bls12381::primitives::variant::Variant>::Signature::generator();
         signature *= &scalar;
         Finalization {

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -21,7 +21,7 @@ use estimator::{
     mean, median, parse_task, std_dev, Command, Distribution, Latencies, RegionConfig,
 };
 use futures::future::try_join_all;
-use rand::RngCore;
+use rand::Rng;
 use std::{
     collections::{BTreeMap, BTreeSet},
     num::NonZeroU32,
@@ -290,7 +290,7 @@ fn run_single_simulation(
 }
 
 /// Core simulation logic that runs the network simulation
-async fn run_simulation_logic<C: Spawner + BufferPooler + Clock + Metrics + RNetwork + RngCore>(
+async fn run_simulation_logic<C: Spawner + BufferPooler + Clock + Metrics + RNetwork + Rng>(
     context: C,
     proposer_idx: usize,
     peers: usize,

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -24,7 +24,7 @@ commonware-p2p.workspace = true
 commonware-runtime.workspace = true
 commonware-utils.workspace = true
 futures.workspace = true
-rand = { workspace = true, features = ["small_rng"] }
+rand = { workspace = true, features = ["std_rng", "sys_rng"] }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true
 tracing.workspace = true

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -14,7 +14,7 @@ use commonware_runtime::{
 };
 use commonware_utils::{ordered::Set, union, TryCollect, NZU32};
 use futures::future::try_join_all;
-use rand::{rngs::SmallRng, RngCore, SeedableRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},

--- a/examples/flood/src/bin/setup.rs
+++ b/examples/flood/src/bin/setup.rs
@@ -5,7 +5,7 @@ use commonware_deployer::aws;
 use commonware_flood::Config;
 use commonware_formatting::hex;
 use commonware_math::algebra::Random;
-use rand::{rngs::OsRng, seq::IteratorRandom};
+use rand::{rngs::StdRng, seq::IteratorRandom};
 use std::num::NonZeroUsize;
 use tracing::info;
 use uuid::Uuid;
@@ -122,8 +122,9 @@ fn main() {
         bootstrappers <= peers,
         "bootstrappers must be less than peers"
     );
+    let mut rng = rand::make_rng::<StdRng>();
     let peer_schemes = (0..peers)
-        .map(|_| ed25519::PrivateKey::random(&mut OsRng))
+        .map(|_| ed25519::PrivateKey::random(&mut rng))
         .collect::<Vec<_>>();
     let allowed_peers: Vec<String> = peer_schemes
         .iter()
@@ -131,7 +132,7 @@ fn main() {
         .collect();
     let bootstrappers = allowed_peers
         .iter()
-        .choose_multiple(&mut OsRng, bootstrappers)
+        .sample(&mut rng, bootstrappers)
         .into_iter()
         .cloned()
         .collect::<Vec<_>>();

--- a/examples/log/src/application/actor.rs
+++ b/examples/log/src/application/actor.rs
@@ -7,7 +7,7 @@ use commonware_actor::mailbox::{self, Receiver};
 use commonware_cryptography::Hasher;
 use commonware_formatting::hex;
 use commonware_runtime::{spawn_cell, ContextCell, Handle, Metrics, Spawner};
-use rand::Rng;
+use rand::{Rng, RngExt as _};
 use tracing::info;
 
 /// Application actor.

--- a/examples/reshare/Cargo.toml
+++ b/examples/reshare/Cargo.toml
@@ -31,7 +31,7 @@ commonware-runtime.workspace = true
 commonware-storage.workspace = true
 commonware-utils.workspace = true
 futures.workspace = true
-rand.workspace = true
+rand = { workspace = true, features = ["std_rng", "sys_rng"] }
 rand_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/examples/reshare/src/dkg/actor.rs
+++ b/examples/reshare/src/dkg/actor.rs
@@ -39,7 +39,7 @@ use commonware_runtime::{
     Storage as RuntimeStorage,
 };
 use commonware_utils::{ordered::Set, Acknowledgement as _, N3f1, NZU32};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::num::{NonZeroU32, NonZeroUsize};
 use tracing::{debug, info, warn};
 
@@ -114,7 +114,7 @@ pub struct Config<C: Signer, P, B> {
 
 pub struct Actor<E, P, B, H, C, V>
 where
-    E: BufferPooler + Spawner + Metrics + CryptoRngCore + Clock + RuntimeStorage,
+    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + RuntimeStorage,
     P: Manager<PublicKey = C::PublicKey>,
     B: Blocker<PublicKey = C::PublicKey>,
     H: Hasher,
@@ -140,7 +140,7 @@ where
 
 impl<E, P, B, H, C, V> Actor<E, P, B, H, C, V>
 where
-    E: BufferPooler + Spawner + Metrics + CryptoRngCore + Clock + RuntimeStorage,
+    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + RuntimeStorage,
     P: Manager<PublicKey = C::PublicKey>,
     B: Blocker<PublicKey = C::PublicKey>,
     H: Hasher,

--- a/examples/reshare/src/dkg/state.rs
+++ b/examples/reshare/src/dkg/state.rs
@@ -35,7 +35,7 @@ use commonware_storage::{
 };
 use commonware_utils::{Faults, NZUsize, NZU16};
 use futures::StreamExt;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     collections::BTreeMap,
     num::{NonZeroU16, NonZeroU32, NonZeroUsize},
@@ -663,7 +663,7 @@ impl<V: Variant, C: Signer> Player<V, C> {
     /// Finalize the player's participation in the DKG round.
     pub fn finalize<M: Faults, B: BatchVerifier<PublicKey = C::PublicKey>>(
         self,
-        rng: &mut impl CryptoRngCore,
+        rng: &mut impl CryptoRng,
         logs: Logs<V, C::PublicKey, M>,
         strategy: &impl Strategy,
     ) -> Result<

--- a/examples/reshare/src/engine.rs
+++ b/examples/reshare/src/engine.rs
@@ -35,7 +35,7 @@ use commonware_runtime::{
 use commonware_storage::archive::immutable;
 use commonware_utils::{union, NZUsize, NZU16, NZU32, NZU64};
 use futures::future::try_join_all;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     marker::PhantomData,
     num::{NonZero, NonZeroU16, NonZeroUsize},
@@ -82,7 +82,7 @@ where
 
 pub struct Engine<E, C, P, B, H, V, S, L, T>
 where
-    E: BufferPooler + Spawner + Metrics + CryptoRngCore + Clock + Storage + Network,
+    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + Storage + Network,
     C: Signer,
     P: Manager<PublicKey = C::PublicKey>,
     B: Blocker<PublicKey = C::PublicKey>,
@@ -126,7 +126,7 @@ where
 
 impl<E, C, P, B, H, V, S, L, T> Engine<E, C, P, B, H, V, S, L, T>
 where
-    E: BufferPooler + Spawner + Metrics + CryptoRngCore + Clock + Storage + Network,
+    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + Storage + Network,
     C: Signer,
     P: Manager<PublicKey = C::PublicKey>,
     B: Blocker<PublicKey = C::PublicKey>,

--- a/examples/reshare/src/orchestrator/actor.rs
+++ b/examples/reshare/src/orchestrator/actor.rs
@@ -28,7 +28,7 @@ use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Network, Spawner, Storage,
 };
 use commonware_utils::{vec::NonEmptyVec, NZUsize, NZU16};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{collections::BTreeMap, marker::PhantomData, num::NonZeroUsize, time::Duration};
 use tracing::{debug, info, warn};
 
@@ -62,7 +62,7 @@ where
 
 pub struct Actor<E, B, V, C, H, A, S, L, T>
 where
-    E: BufferPooler + Spawner + Metrics + CryptoRngCore + Clock + Storage + Network,
+    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + Storage + Network,
     B: Blocker<PublicKey = C::PublicKey>,
     V: Variant,
     C: Signer,
@@ -94,7 +94,7 @@ where
 
 impl<E, B, V, C, H, A, S, L, T> Actor<E, B, V, C, H, A, S, L, T>
 where
-    E: BufferPooler + Spawner + Metrics + CryptoRngCore + Clock + Storage + Network,
+    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + Storage + Network,
     B: Blocker<PublicKey = C::PublicKey>,
     V: Variant,
     C: Signer,

--- a/examples/reshare/src/setup.rs
+++ b/examples/reshare/src/setup.rs
@@ -15,11 +15,7 @@ use commonware_utils::{
     ordered::{Map, Set},
     Faults, N3f1, TryCollect, NZU32,
 };
-use rand::{
-    rngs::{OsRng, StdRng},
-    seq::IteratorRandom,
-    SeedableRng,
-};
+use rand::{rngs::StdRng, seq::IteratorRandom, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -122,7 +118,7 @@ impl<P: commonware_cryptography::PublicKey> PeerConfig<P> {
         }
         let mut rng = StdRng::seed_from_u64(round);
         p_iter
-            .choose_multiple(&mut rng, to_choose)
+            .sample(&mut rng, to_choose)
             .into_iter()
             .try_collect()
             .unwrap()
@@ -182,8 +178,9 @@ fn generate_identities(
     Vec<(PrivateKey, Option<Share>)>,
 ) {
     // Generate p2p private keys
+    let mut rng = rand::make_rng::<StdRng>();
     let peer_signers = (0..num_peers)
-        .map(|_| PrivateKey::random(&mut OsRng))
+        .map(|_| PrivateKey::random(&mut rng))
         .collect::<Vec<_>>();
 
     // Generate consensus key
@@ -197,7 +194,7 @@ fn generate_identities(
         (None, Map::default())
     } else {
         let (output, shares) = deal::<MinSig, _, N3f1>(
-            OsRng,
+            &mut rng,
             Default::default(),
             all_participants
                 .iter()
@@ -226,10 +223,11 @@ fn generate_configs(
     output: Option<&Output<MinSig, PublicKey>>,
     identities: &[(PrivateKey, Option<Share>)],
 ) -> Vec<PathBuf> {
+    let mut rng = rand::make_rng::<StdRng>();
     let bootstrappers = identities
         .iter()
         .enumerate()
-        .choose_multiple(&mut OsRng, args.num_bootstrappers)
+        .sample(&mut rng, args.num_bootstrappers)
         .into_iter()
         .map(|(i, (signer, _))| {
             (

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -187,8 +187,8 @@ mod test {
         channel::{mpsc, oneshot},
         test_rng_seeded, union, N3f1, TryCollect,
     };
-    use rand::seq::SliceRandom;
-    use rand_core::CryptoRngCore;
+    use rand::seq::IndexedRandom;
+    use rand_core::CryptoRng;
     use std::{
         collections::{btree_map::Entry, BTreeMap, HashSet},
         future::Future,
@@ -276,7 +276,7 @@ mod test {
     }
 
     impl Team {
-        fn reshare(mut rng: impl CryptoRngCore, total: u32, per_round: &[u32]) -> Self {
+        fn reshare(mut rng: impl CryptoRng, total: u32, per_round: &[u32]) -> Self {
             let mut participants = (0..total)
                 .map(|i| {
                     let sk = PrivateKey::from_seed(i as u64);
@@ -813,7 +813,7 @@ mod test {
                             team.participants.keys().cloned().collect();
                         let crash_count = (*count).min(all_participants.len());
                         let to_crash: Vec<PublicKey> = all_participants
-                            .choose_multiple(&mut ctx, crash_count)
+                            .sample(&mut ctx, crash_count)
                             .cloned()
                             .collect();
                         for pk in to_crash {

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -32,7 +32,7 @@ commonware-storage = { workspace = true, features = ["std"] }
 commonware-stream.workspace = true
 commonware-utils.workspace = true
 futures.workspace = true
-rand.workspace = true
+rand = { workspace = true, features = ["thread_rng"] }
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -25,7 +25,7 @@ use commonware_utils::{
     channel::mpsc::{self, error::TrySendError},
     DurationExt,
 };
-use rand::Rng;
+use rand::RngExt as _;
 use std::{
     future::Future,
     net::{Ipv4Addr, SocketAddr},
@@ -536,7 +536,7 @@ fn parse_config() -> Result<Config, Box<dyn std::error::Error>> {
             .to_string();
         // Only add suffix if using the default value
         if storage_dir == DEFAULT_CLIENT_DIR_PREFIX {
-            let suffix: u64 = rand::thread_rng().gen();
+            let suffix: u64 = rand::rng().random();
             format!("{storage_dir}-{suffix}")
         } else {
             storage_dir

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -30,7 +30,7 @@ use commonware_utils::{
     sync::{AsyncRwLock, Mutex},
     DurationExt,
 };
-use rand::{Rng, RngCore};
+use rand::{Rng, RngExt as _};
 use std::{
     future::Future,
     net::{Ipv4Addr, SocketAddr},
@@ -173,7 +173,7 @@ async fn maybe_add_operations<DB, E>(
 ) -> Result<(), BoxError>
 where
     DB: ExampleDatabase<Family = mmr::Family>,
-    E: Storage + Clock + Metrics + RngCore,
+    E: Storage + Clock + Metrics + Rng,
 {
     let now = context.current();
     let should_add = {
@@ -542,7 +542,7 @@ async fn initialize_database<DB, E>(
 ) -> Result<DB, BoxError>
 where
     DB: Syncable<Family = mmr::Family>,
-    E: RngCore,
+    E: Rng,
 {
     info!("starting {} database", DB::name());
 
@@ -573,7 +573,7 @@ async fn initialize_compact_database<DB, E>(
 ) -> Result<DB, BoxError>
 where
     DB: CompactSyncable<Family = mmr::Family>,
-    E: RngCore,
+    E: Rng,
 {
     info!("starting {} database", DB::name());
 
@@ -608,7 +608,7 @@ where
     DB: ExampleDatabase<Family = mmr::Family> + Send + Sync + 'static,
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
-    E: Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: Storage + Clock + Metrics + Network + Spawner + Rng + Send,
     Mode: ServeMode<DB> + 'static,
 {
     // Create listener to accept connections
@@ -663,7 +663,7 @@ where
     DB: Syncable<Family = mmr::Family> + Send + Sync + 'static,
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
-    E: Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: Storage + Clock + Metrics + Network + Spawner + Rng + Send,
 {
     let database = initialize_database(database, &config, &mut context).await?;
     run_server::<DB, E, FullMode>(context, config, database).await
@@ -679,7 +679,7 @@ where
     DB: CompactSyncable<Family = mmr::Family> + Send + Sync + 'static,
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
-    E: Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: Storage + Clock + Metrics + Network + Spawner + Rng + Send,
     Arc<AsyncRwLock<DB>>: compact::Resolver<
         Family = mmr::Family,
         Op = DB::Operation,
@@ -695,7 +695,7 @@ where
 #[boxed]
 async fn run_any<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
 {
     let db_config = any::create_config(&context);
     let database = any::Database::init(context.child("database"), db_config).await?;
@@ -707,7 +707,7 @@ where
 #[boxed]
 async fn run_current<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
 {
     let db_config = current::create_config(&context);
     let database = current::Database::init(context.child("database"), db_config).await?;
@@ -719,7 +719,7 @@ where
 #[boxed]
 async fn run_immutable<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
 {
     let db_config = immutable::create_config(&context);
     let database = immutable::Database::init(context.child("database"), db_config).await?;
@@ -734,7 +734,7 @@ async fn run_immutable_full_source<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
 {
     let db_config = immutable::create_config(&context);
     let database = immutable::Database::init(context.child("database"), db_config).await?;
@@ -746,7 +746,7 @@ where
 #[boxed]
 async fn run_keyless<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
 {
     let db_config = keyless::create_config(&context);
     let database = keyless::Database::init(context.child("database"), db_config).await?;
@@ -761,7 +761,7 @@ async fn run_keyless_full_source<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
 {
     let db_config = keyless::create_config(&context);
     let database = keyless::Database::init(context.child("database"), db_config).await?;
@@ -775,7 +775,7 @@ async fn run_immutable_compact<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
 {
     let db_config = immutable_compact::create_config(&context);
     let database = immutable_compact::Database::init(context.child("database"), db_config).await?;
@@ -789,7 +789,7 @@ async fn run_keyless_compact<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + RngCore + Send,
+    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
 {
     let db_config = keyless_compact::create_config(&context);
     let database = keyless_compact::Database::init(context.child("database"), db_config).await?;
@@ -926,7 +926,7 @@ fn parse_config() -> Result<Config, Box<dyn std::error::Error>> {
                 .to_string();
             // Only add suffix if using the default value
             if storage_dir == "/tmp/commonware-sync/server" {
-                let suffix: u64 = rand::thread_rng().gen();
+                let suffix: u64 = rand::rng().random();
                 format!("{storage_dir}-{suffix}")
             } else {
                 storage_dir

--- a/formatting/src/benches/decode.rs
+++ b/formatting/src/benches/decode.rs
@@ -6,7 +6,7 @@
 //! 50/50).
 
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::hint::black_box;
 
 /// Inject whitespace at every 8th character, plus a `prefix` at the start.

--- a/formatting/src/benches/display.rs
+++ b/formatting/src/benches/display.rs
@@ -2,7 +2,7 @@
 
 use commonware_formatting::Hex;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{fmt::Write as _, hint::black_box};
 
 fn bench_display(c: &mut Criterion) {

--- a/formatting/src/benches/encode.rs
+++ b/formatting/src/benches/encode.rs
@@ -1,7 +1,7 @@
 //! Benchmark: `hex()` encoding.
 
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::hint::black_box;
 
 fn bench_encode(c: &mut Criterion) {

--- a/glue/src/simulate/plan.rs
+++ b/glue/src/simulate/plan.rs
@@ -16,7 +16,7 @@ use commonware_p2p::{
 };
 use commonware_runtime::{deterministic, Clock, Runner as _, Spawner, Supervisor as _};
 use commonware_utils::{channel::mpsc, ordered::Set, NZUsize, TryCollect};
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 use std::{
     collections::HashSet,
     sync::{
@@ -622,7 +622,7 @@ impl<D: EngineDefinition> Plan<D> {
                 let active = team.active_keys();
                 let crash_count = count.min(active.len());
                 let to_crash: Vec<D::PublicKey> = active
-                    .choose_multiple(&mut ctx, crash_count)
+                    .sample(&mut ctx, crash_count)
                     .cloned()
                     .collect();
                 for pk in to_crash {

--- a/glue/src/stateful/probe/actor/discovery.rs
+++ b/glue/src/stateful/probe/actor/discovery.rs
@@ -25,7 +25,7 @@ use commonware_utils::{
     Faults, N3f1, NonZeroDuration,
 };
 use futures::future::{self, Either};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::collections::BTreeMap;
 use tracing::debug;
 
@@ -36,7 +36,7 @@ use tracing::debug;
 /// (after the floor has been consumed), it hands off to [`Service`].
 pub(super) struct Discovery<E, S, D, V, T, P, B>
 where
-    E: Spawner + CryptoRngCore + Clock + Metrics,
+    E: Spawner + CryptoRng + Clock + Metrics,
     S: Scheme<V::Commitment>,
     D: Provider<Scope = Epoch, Scheme = S>,
     V: Variant,
@@ -57,7 +57,7 @@ where
 
 impl<E, S, D, V, T, P, B> Discovery<E, S, D, V, T, P, B>
 where
-    E: Spawner + CryptoRngCore + Clock + Metrics,
+    E: Spawner + CryptoRng + Clock + Metrics,
     S: Scheme<V::Commitment>,
     D: Provider<Scope = Epoch, Scheme = S>,
     V: Variant,

--- a/glue/src/stateful/probe/actor/mod.rs
+++ b/glue/src/stateful/probe/actor/mod.rs
@@ -7,7 +7,7 @@ use commonware_parallel::Strategy;
 use commonware_runtime::{spawn_cell, Clock, ContextCell, Handle, Metrics, Spawner};
 use commonware_utils::NonZeroDuration;
 use discovery::Discovery;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::num::NonZeroUsize;
 
 mod discovery;
@@ -16,7 +16,7 @@ mod service;
 /// Configuration for the [`Probe`] actor.
 pub struct Config<E, D, T, P, B>
 where
-    E: Spawner + CryptoRngCore + Clock + Metrics,
+    E: Spawner + CryptoRng + Clock + Metrics,
     D: Provider<Scope = Epoch>,
     T: Strategy,
     P: PublicKey,
@@ -48,7 +48,7 @@ where
 /// without consuming one and enters service without soliciting peers.
 pub struct Probe<E, S, D, V, T, P, B>
 where
-    E: Spawner + CryptoRngCore + Clock + Metrics,
+    E: Spawner + CryptoRng + Clock + Metrics,
     S: Scheme<V::Commitment>,
     D: Provider<Scope = Epoch, Scheme = S>,
     V: Variant,
@@ -67,7 +67,7 @@ where
 
 impl<E, S, D, V, T, P, B> Probe<E, S, D, V, T, P, B>
 where
-    E: Spawner + CryptoRngCore + Clock + Metrics,
+    E: Spawner + CryptoRng + Clock + Metrics,
     S: Scheme<V::Commitment>,
     D: Provider<Scope = Epoch, Scheme = S>,
     V: Variant,

--- a/glue/src/stateful/probe/actor/service.rs
+++ b/glue/src/stateful/probe/actor/service.rs
@@ -14,7 +14,7 @@ use commonware_p2p::{Blocker, Receiver, Recipients, Sender};
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
 use commonware_utils::channel::fallible::OneshotExt;
 use futures::future::{self, Either};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use tracing::debug;
 
 /// The service phase of [`Probe`](super::Probe).
@@ -24,7 +24,7 @@ use tracing::debug;
 /// consumed its floor and a marshal has been attached.
 pub(super) struct Service<E, S, V, P, B>
 where
-    E: Spawner + CryptoRngCore + Clock + Metrics,
+    E: Spawner + CryptoRng + Clock + Metrics,
     S: Scheme<V::Commitment>,
     V: Variant,
     P: PublicKey,
@@ -39,7 +39,7 @@ where
 
 impl<E, S, V, P, B> Service<E, S, V, P, B>
 where
-    E: Spawner + CryptoRngCore + Clock + Metrics,
+    E: Spawner + CryptoRng + Clock + Metrics,
     S: Scheme<V::Commitment>,
     V: Variant,
     P: PublicKey,

--- a/glue/src/stateful/probe/mod.rs
+++ b/glue/src/stateful/probe/mod.rs
@@ -347,7 +347,7 @@ mod test {
             strategy: &impl ParallelStrategy,
         ) -> bool
         where
-            R: rand_core::CryptoRngCore,
+            R: rand_core::CryptoRng,
             D: commonware_cryptography::Digest,
             M: commonware_utils::Faults,
         {
@@ -362,7 +362,7 @@ mod test {
             strategy: &impl ParallelStrategy,
         ) -> bool
         where
-            R: rand_core::CryptoRngCore,
+            R: rand_core::CryptoRng,
             D: commonware_cryptography::Digest,
             I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
             M: commonware_utils::Faults,
@@ -415,7 +415,7 @@ mod test {
             strategy: &impl ParallelStrategy,
         ) -> bool
         where
-            R: rand_core::CryptoRngCore,
+            R: rand_core::CryptoRng,
             D: commonware_cryptography::Digest,
         {
             let attestation = Attestation::<Scheme> {
@@ -434,7 +434,7 @@ mod test {
             strategy: &impl ParallelStrategy,
         ) -> Verification<Self>
         where
-            R: rand_core::CryptoRngCore,
+            R: rand_core::CryptoRng,
             D: commonware_cryptography::Digest,
             I: IntoIterator<Item = Attestation<Self>>,
             I::IntoIter: Send,

--- a/invariants/Cargo.toml
+++ b/invariants/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 arbitrary.workspace = true
 commonware-formatting = { workspace = true, features = ["std"] }
 commonware-macros.workspace = true
-rand = { workspace = true, features = ["std", "std_rng"] }
+rand = { workspace = true, features = ["std", "std_rng", "thread_rng"] }
 rand_chacha.workspace = true
 rand_core.workspace = true
 

--- a/invariants/src/minifuzz.rs
+++ b/invariants/src/minifuzz.rs
@@ -53,7 +53,7 @@
 use arbitrary::Unstructured;
 use commonware_formatting::from_hex;
 use rand_chacha::ChaCha8Rng;
-use rand_core::{RngCore as _, SeedableRng};
+use rand_core::{Rng as _, SeedableRng};
 use std::{
     panic::{catch_unwind, AssertUnwindSafe, UnwindSafe},
     time::{Duration, Instant},

--- a/justfile
+++ b/justfile
@@ -90,8 +90,7 @@ check-publish-order:
 
 # Check that locked dependencies are at least 7 days old
 cooldown:
-    cargo cooldown --workspace --all-features check
-    git diff --exit-code Cargo.lock
+    ./.github/scripts/check_dependency_cooldown.sh
 
 # Run custom Dylint lints
 dylint:

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -28,7 +28,6 @@ std = [
 	"commonware-macros/std",
 	"commonware-parallel/std",
 	"commonware-utils/std",
-	"rand_core/std",
 ]
 fuzz = [ "arbitrary", "arbitrary/derive", "dep:arbitrary", "std" ]
 

--- a/math/src/algebra.rs
+++ b/math/src/algebra.rs
@@ -10,7 +10,7 @@ use core::{
     iter,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// Yield all the bits in a u64, from lowest to highest.
 fn yield_bits_le(x: u64) -> impl Iterator<Item = bool> {
@@ -405,7 +405,7 @@ pub trait HashToGroup: CryptoGroup {
     ///
     /// If you have a more efficient implementation, or want more collision security,
     /// override this method.
-    fn rand_to_group(mut rng: impl CryptoRngCore) -> Self {
+    fn rand_to_group(mut rng: impl CryptoRng) -> Self {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes);
         Self::hash_to_group(&[], &bytes)
@@ -421,7 +421,7 @@ pub trait HashToGroup: CryptoGroup {
 /// object as the sampler.
 pub trait Random {
     /// Sample an object uniformly at random.
-    fn random(rng: impl CryptoRngCore) -> Self;
+    fn random(rng: impl CryptoRng) -> Self;
 }
 
 #[cfg(any(test, feature = "arbitrary"))]

--- a/math/src/fields/goldilocks.rs
+++ b/math/src/fields/goldilocks.rs
@@ -1,7 +1,7 @@
 use crate::algebra::{Additive, Field, FieldNTT, Multiplicative, Object, Random, Ring};
 use commonware_codec::{FixedSize, Read, Write};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// The modulus P := 2^64 - 2^32 + 1.
 ///
@@ -283,7 +283,7 @@ impl F {
 impl Object for F {}
 
 impl Random for F {
-    fn random(mut rng: impl CryptoRngCore) -> Self {
+    fn random(mut rng: impl CryptoRng) -> Self {
         // this fails only about once every 2^32 attempts
         loop {
             let x = rng.next_u64();

--- a/math/src/ntt.rs
+++ b/math/src/ntt.rs
@@ -7,7 +7,7 @@ use core::{
     num::NonZeroU32,
     ops::{Index, IndexMut},
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 #[cfg(feature = "std")]
 use std::vec::Vec;
 
@@ -850,7 +850,7 @@ impl<F> Matrix<F> {
 
 impl<F: crate::algebra::Random> Matrix<F> {
     /// Create a random matrix with certain dimensions.
-    pub fn rand(mut rng: impl CryptoRngCore, rows: usize, cols: usize) -> Self
+    pub fn rand(mut rng: impl CryptoRng, rows: usize, cols: usize) -> Self
     where
         F: Additive,
     {

--- a/math/src/poly.rs
+++ b/math/src/poly.rs
@@ -12,7 +12,7 @@ use core::{
     num::NonZeroU32,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 #[cfg(feature = "std")]
 use std::borrow::Cow;
 
@@ -219,14 +219,14 @@ impl<K: Read> Read for Poly<K> {
 impl<K: Random> Poly<K> {
     // Returns a new polynomial of the given degree where each coefficient is
     // sampled at random from the provided RNG.
-    pub fn new(mut rng: impl CryptoRngCore, degree: u32) -> Self {
+    pub fn new(mut rng: impl CryptoRng, degree: u32) -> Self {
         Self::from_iter_unchecked((0..=degree).map(|_| K::random(&mut rng)))
     }
 
     /// Returns a new scalar polynomial with a particular value for the constant coefficient.
     ///
     /// This does the same thing as [`Poly::new`] otherwise.
-    pub fn new_with_constant(mut rng: impl CryptoRngCore, degree: u32, constant: K) -> Self {
+    pub fn new_with_constant(mut rng: impl CryptoRng, degree: u32, constant: K) -> Self {
         Self::from_iter_unchecked(
             iter::once(constant).chain((0..=degree).skip(1).map(|_| K::random(&mut rng))),
         )

--- a/math/src/test.rs
+++ b/math/src/test.rs
@@ -4,7 +4,7 @@ use core::{
     fmt::Debug,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 const P: u64 = 4_611_686_018_427_389_243;
 const Q: u64 = 9_223_372_036_854_778_487;
@@ -61,7 +61,7 @@ impl From<u64> for F {
 impl Object for F {}
 
 impl Random for F {
-    fn random(mut rng: impl CryptoRngCore) -> Self {
+    fn random(mut rng: impl CryptoRng) -> Self {
         let mut bytes = [0u8; 8];
         rng.fill_bytes(&mut bytes);
         Self(u64::from_le_bytes(bytes) % P)

--- a/p2p/fuzz/fuzz_targets/simulated.rs
+++ b/p2p/fuzz/fuzz_targets/simulated.rs
@@ -9,7 +9,7 @@ use commonware_p2p::{
 use commonware_runtime::{deterministic, Clock, IoBuf, Quota, Runner, Supervisor as _};
 use commonware_utils::NZUsize;
 use libfuzzer_sys::fuzz_target;
-use rand::Rng;
+use rand::RngExt as _;
 use std::{
     collections::{hash_map, HashMap, HashSet, VecDeque},
     num::NonZeroU32,
@@ -120,7 +120,7 @@ fn fuzz(input: FuzzInput) {
         // Generate peer identities
         let mut peer_pks = Vec::new();
         for _ in 0..num_peers {
-            let private_key = ed25519::PrivateKey::from_seed(context.gen());
+            let private_key = ed25519::PrivateKey::from_seed(context.random());
             peer_pks.push(private_key.public_key());
         }
 

--- a/p2p/fuzz/src/lib.rs
+++ b/p2p/fuzz/src/lib.rs
@@ -16,7 +16,7 @@ use commonware_utils::{
     ordered::{Map, Set},
     NZUsize, TryCollect, NZU32,
 };
-use rand::{seq::SliceRandom, Rng};
+use rand::{seq::SliceRandom, RngExt as _};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     future::Future,
@@ -414,7 +414,7 @@ pub fn fuzz<N: NetworkScheme>(input: FuzzInput) {
         let mut peer_infos = Vec::new();
 
         for i in 0..input.peers {
-            let private_key = ed25519::PrivateKey::from_seed(context.gen());
+            let private_key = ed25519::PrivateKey::from_seed(context.random());
             let public_key = private_key.public_key();
             let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), base_port + i as u16);
 
@@ -609,7 +609,7 @@ pub fn fuzz<N: NetworkScheme>(input: FuzzInput) {
                     // Build a random subset of peer IDs (using a set to avoid duplicates)
                     let mut peer_ids = HashSet::new();
                     for _ in 0..peer_set_size {
-                        let id = context.gen::<usize>() % topology.peers.len();
+                        let id = context.random::<u64>() as usize % topology.peers.len();
                         peer_ids.insert(id as PeerId);
                     }
                     let peer_ids: Vec<_> = peer_ids.into_iter().collect();

--- a/p2p/src/authenticated/discovery/actors/dialer.rs
+++ b/p2p/src/authenticated/discovery/actors/dialer.rs
@@ -19,8 +19,8 @@ use commonware_runtime::{
     StreamOf,
 };
 use commonware_stream::encrypted::{dial, Config as StreamConfig};
-use rand::seq::SliceRandom;
-use rand_core::CryptoRngCore;
+use rand::seq::{IndexedRandom, SliceRandom};
+use rand_core::CryptoRng;
 use std::time::Duration;
 use tracing::debug;
 
@@ -65,10 +65,8 @@ pub struct Actor<E: Spawner + Clock + Network + Resolver + Metrics, C: Signer> {
     attempts: CounterFamily<metrics::Peer<C::PublicKey>>,
 }
 
-impl<
-        E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRngCore + Metrics,
-        C: Signer,
-    > Actor<E, C>
+impl<E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRng + Metrics, C: Signer>
+    Actor<E, C>
 {
     pub fn new(context: E, cfg: Config<C>) -> Self {
         let attempts = context.family("attempts", "The number of dial attempts made to each peer");

--- a/p2p/src/authenticated/discovery/actors/listener.rs
+++ b/p2p/src/authenticated/discovery/actors/listener.rs
@@ -14,7 +14,7 @@ use commonware_runtime::{
 };
 use commonware_stream::encrypted::{listen, Config as StreamConfig};
 use commonware_utils::{concurrency::Limiter, net::SubnetMask, IpAddrExt};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{net::SocketAddr, num::NonZeroU32};
 use tracing::debug;
 
@@ -34,7 +34,7 @@ pub struct Config<C: Signer> {
     pub allowed_handshake_rate_per_subnet: Quota,
 }
 
-pub struct Actor<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + Metrics, C: Signer> {
+pub struct Actor<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signer> {
     context: ContextCell<E>,
 
     address: SocketAddr,
@@ -49,7 +49,7 @@ pub struct Actor<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + M
     handshakes_subnet_rate_limited: Counter,
 }
 
-impl<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + Metrics, C: Signer> Actor<E, C> {
+impl<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signer> Actor<E, C> {
     pub fn new(context: E, cfg: Config<C>) -> Self {
         // Create metrics
         let handshakes_blocked = context.counter(

--- a/p2p/src/authenticated/discovery/actors/peer/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/actor.rs
@@ -19,7 +19,7 @@ use commonware_runtime::{
 };
 use commonware_stream::encrypted::{Receiver, Sender};
 use commonware_utils::time::SYSTEM_TIME_PRECISION;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tracing::debug;
 
@@ -42,7 +42,7 @@ pub struct Actor<E: Spawner + BufferPooler + Clock + Metrics, C: PublicKey> {
     rate_limited: CounterFamily<metrics::Message<C>>,
 }
 
-impl<E: Spawner + BufferPooler + Clock + CryptoRngCore + Metrics, C: PublicKey> Actor<E, C> {
+impl<E: Spawner + BufferPooler + Clock + CryptoRng + Metrics, C: PublicKey> Actor<E, C> {
     pub fn new(context: E, cfg: Config<C>) -> (Self, Mailbox<C>, Relay<EncodedData>) {
         let (control_sender, control_receiver) =
             Mailbox::new(context.child("mailbox"), cfg.mailbox_size);

--- a/p2p/src/authenticated/discovery/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/spawner/actor.rs
@@ -18,12 +18,12 @@ use commonware_runtime::{
     telemetry::metrics::{CounterFamily, MetricsExt as _},
     BufferPooler, Clock, ContextCell, Handle, Metrics, Sink, Spawner, Stream,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{num::NonZeroUsize, time::Duration};
 use tracing::debug;
 
 pub struct Actor<
-    E: Spawner + BufferPooler + Clock + CryptoRngCore + Metrics,
+    E: Spawner + BufferPooler + Clock + CryptoRng + Metrics,
     O: Sink,
     I: Stream,
     C: PublicKey,
@@ -44,12 +44,8 @@ pub struct Actor<
     rate_limited: CounterFamily<metrics::Message<C>>,
 }
 
-impl<
-        E: Spawner + BufferPooler + Clock + CryptoRngCore + Metrics,
-        O: Sink,
-        I: Stream,
-        C: PublicKey,
-    > Actor<E, O, I, C>
+impl<E: Spawner + BufferPooler + Clock + CryptoRng + Metrics, O: Sink, I: Stream, C: PublicKey>
+    Actor<E, O, I, C>
 {
     #[allow(clippy::type_complexity)]
     pub fn new(context: E, cfg: Config<C>) -> (Self, Mailbox<Message<O, I, C>>) {

--- a/p2p/src/authenticated/discovery/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/actor.rs
@@ -252,7 +252,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
                 // Truncate to a random selection of peers if we have too many infos
                 let max = self.peer_gossip_max_count;
                 if infos.len() > max {
-                    infos.partial_shuffle(self.context.as_mut(), max);
+                    let _ = infos.partial_shuffle(self.context.as_mut(), max);
                     infos.truncate(max);
                 }
 

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -275,7 +275,7 @@ mod tests {
         IoBuf, Metrics, Network as RNetwork, Quota, Resolver, Runner, Spawner, Supervisor as _,
     };
     use commonware_utils::{channel::mpsc, hostname, ordered::Set, NZUsize, TryCollect, NZU32};
-    use rand_core::{CryptoRngCore, RngCore};
+    use rand_core::{CryptoRng, Rng};
     use std::{
         collections::HashSet,
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -312,7 +312,7 @@ mod tests {
     /// We set a unique `base_port` for each test to avoid "address already in use"
     /// errors when tests are run immediately after each other.
     async fn run_network(
-        context: impl Spawner + BufferPooler + Clock + CryptoRngCore + RNetwork + Resolver + Metrics,
+        context: impl Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics,
         max_message_size: u32,
         base_port: u16,
         n: usize,

--- a/p2p/src/authenticated/discovery/network.rs
+++ b/p2p/src/authenticated/discovery/network.rs
@@ -15,7 +15,7 @@ use commonware_runtime::{
 };
 use commonware_stream::encrypted::Config as StreamConfig;
 use commonware_utils::union;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use tracing::{debug, info};
 
 /// Unique suffix for all messages signed by the tracker.
@@ -26,7 +26,7 @@ const STREAM_SUFFIX: &[u8] = b"_STREAM";
 
 /// Implementation of an `authenticated` network.
 pub struct Network<
-    E: Spawner + BufferPooler + Clock + CryptoRngCore + RNetwork + Resolver + Metrics,
+    E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics,
     C: Signer,
 > {
     context: ContextCell<E>,
@@ -40,10 +40,8 @@ pub struct Network<
     info_verifier: InfoVerifier<C::PublicKey>,
 }
 
-impl<
-        E: Spawner + BufferPooler + Clock + CryptoRngCore + RNetwork + Resolver + Metrics,
-        C: Signer,
-    > Network<E, C>
+impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics, C: Signer>
+    Network<E, C>
 {
     /// Create a new instance of an `authenticated` network.
     ///

--- a/p2p/src/authenticated/discovery/types.rs
+++ b/p2p/src/authenticated/discovery/types.rs
@@ -402,7 +402,7 @@ mod tests {
 
     const NAMESPACE: &[u8] = b"test";
 
-    fn signed_peer_info(rng: &mut impl rand_core::CryptoRngCore) -> Info<PublicKey> {
+    fn signed_peer_info(rng: &mut impl rand_core::CryptoRng) -> Info<PublicKey> {
         let c = PrivateKey::random(rng);
         Info {
             ingress: Ingress::Socket(SocketAddr::from(([127, 0, 0, 1], 8080))),

--- a/p2p/src/authenticated/lookup/actors/dialer.rs
+++ b/p2p/src/authenticated/lookup/actors/dialer.rs
@@ -22,8 +22,8 @@ use commonware_runtime::{
     StreamOf,
 };
 use commonware_stream::encrypted::{dial, Config as StreamConfig};
-use rand::seq::SliceRandom;
-use rand_core::CryptoRngCore;
+use rand::seq::{IndexedRandom, SliceRandom};
+use rand_core::CryptoRng;
 use std::time::Duration;
 use tracing::debug;
 
@@ -68,10 +68,8 @@ pub struct Actor<E: Spawner + BufferPooler + Clock + Network + Resolver + Metric
     attempts: CounterFamily<metrics::Peer<C::PublicKey>>,
 }
 
-impl<
-        E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRngCore + Metrics,
-        C: Signer,
-    > Actor<E, C>
+impl<E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRng + Metrics, C: Signer>
+    Actor<E, C>
 {
     pub fn new(context: E, cfg: Config<C>) -> Self {
         let attempts = context.family("attempts", "The number of dial attempts made to each peer");

--- a/p2p/src/authenticated/lookup/actors/listener.rs
+++ b/p2p/src/authenticated/lookup/actors/listener.rs
@@ -16,7 +16,7 @@ use commonware_runtime::{
 use commonware_stream::encrypted::{listen, Config as StreamConfig};
 use commonware_utils::{channel::ring, concurrency::Limiter, net::SubnetMask, IpAddrExt, NZUsize};
 use futures::{Sink, StreamExt};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{
     collections::HashSet,
     fmt,
@@ -69,7 +69,7 @@ pub struct Config<C: Signer> {
     pub allowed_handshake_rate_per_subnet: Quota,
 }
 
-pub struct Actor<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + Metrics, C: Signer> {
+pub struct Actor<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signer> {
     context: ContextCell<E>,
 
     address: SocketAddr,
@@ -87,7 +87,7 @@ pub struct Actor<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + M
     handshakes_subnet_rate_limited: Counter,
 }
 
-impl<E: Spawner + BufferPooler + Clock + Network + CryptoRngCore + Metrics, C: Signer> Actor<E, C> {
+impl<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signer> Actor<E, C> {
     pub fn new(context: E, cfg: Config<C>, updates: Updates) -> Self {
         // Create metrics
         let handshakes_blocked = context.counter(

--- a/p2p/src/authenticated/lookup/actors/peer/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/peer/actor.rs
@@ -18,7 +18,7 @@ use commonware_runtime::{
 use commonware_stream::encrypted::{Receiver, Sender};
 use commonware_utils::{channel::ring, time::SYSTEM_TIME_PRECISION};
 use futures::{FutureExt as _, StreamExt as _};
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tracing::debug;
 
@@ -38,7 +38,7 @@ pub struct Actor<E: Spawner + BufferPooler + Clock + Metrics, C: PublicKey> {
     _phantom: std::marker::PhantomData<C>,
 }
 
-impl<E: Spawner + BufferPooler + Clock + CryptoRngCore + Metrics, C: PublicKey> Actor<E, C> {
+impl<E: Spawner + BufferPooler + Clock + CryptoRng + Metrics, C: PublicKey> Actor<E, C> {
     pub fn new(context: E, cfg: Config<C>) -> (Self, Mailbox, Relay<EncodedData>) {
         let (control_sender, control_receiver) = Mailbox::new(cfg.mailbox_size);
         let (relay, receivers) = Relay::new(context.child("relay"), cfg.mailbox_size);

--- a/p2p/src/authenticated/lookup/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/actor.rs
@@ -14,12 +14,12 @@ use commonware_runtime::{
     telemetry::metrics::{CounterFamily, MetricsExt as _},
     BufferPooler, Clock, ContextCell, Handle, Metrics, Sink, Spawner, Stream,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::num::NonZeroUsize;
 use tracing::debug;
 
 pub struct Actor<
-    E: Spawner + BufferPooler + Clock + CryptoRngCore + Metrics,
+    E: Spawner + BufferPooler + Clock + CryptoRng + Metrics,
     Si: Sink,
     St: Stream,
     C: PublicKey,
@@ -38,7 +38,7 @@ pub struct Actor<
 }
 
 impl<
-        E: Spawner + BufferPooler + Clock + CryptoRngCore + Metrics,
+        E: Spawner + BufferPooler + Clock + CryptoRng + Metrics,
         Si: Sink,
         St: Stream,
         C: PublicKey,

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -232,7 +232,7 @@ mod tests {
         ordered::{Map, Set},
         Hostname, NZUsize, TryCollect, NZU32,
     };
-    use rand_core::{CryptoRngCore, RngCore};
+    use rand_core::{CryptoRng, Rng};
     use std::{
         collections::HashSet,
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -269,7 +269,7 @@ mod tests {
     /// We set a unique `base_port` for each test to avoid "address already in use"
     /// errors when tests are run immediately after each other.
     async fn run_network(
-        context: impl Spawner + BufferPooler + Clock + CryptoRngCore + RNetwork + Resolver + Metrics,
+        context: impl Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics,
         max_message_size: u32,
         base_port: u16,
         n: usize,

--- a/p2p/src/authenticated/lookup/network.rs
+++ b/p2p/src/authenticated/lookup/network.rs
@@ -15,17 +15,14 @@ use commonware_runtime::{
 };
 use commonware_stream::encrypted::Config as StreamConfig;
 use commonware_utils::union;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use tracing::{debug, info};
 
 /// Unique suffix for all messages signed in a stream.
 const STREAM_SUFFIX: &[u8] = b"_STREAM";
 
 /// Implementation of an `authenticated` network.
-pub struct Network<
-    E: Spawner + BufferPooler + Clock + CryptoRngCore + RNetwork + Metrics,
-    C: Signer,
-> {
+pub struct Network<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Metrics, C: Signer> {
     context: ContextCell<E>,
     cfg: Config<C>,
 
@@ -37,10 +34,8 @@ pub struct Network<
     listener: listener::Updates,
 }
 
-impl<
-        E: Spawner + BufferPooler + Clock + CryptoRngCore + RNetwork + Resolver + Metrics,
-        C: Signer,
-    > Network<E, C>
+impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics, C: Signer>
+    Network<E, C>
 {
     /// Create a new instance of an `authenticated` network.
     ///

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -201,7 +201,7 @@ mod tests {
         ordered::{Map, Set},
         NZUsize, NZU32,
     };
-    use rand::Rng;
+    use rand::RngExt as _;
     use std::{
         collections::{BTreeMap, HashMap, HashSet},
         net::SocketAddr,
@@ -308,7 +308,7 @@ mod tests {
                     let keys = agents.keys().cloned().collect::<Vec<_>>();
 
                     loop {
-                        let index = context.gen_range(0..keys.len());
+                        let index = context.random_range(0..keys.len());
                         let sender = &keys[index];
                         let msg = format!("hello from {sender:?}");
                         let msg = IoBuf::copy_from_slice(msg.as_bytes());
@@ -380,7 +380,7 @@ mod tests {
 
             // Send invalid message
             let keys = agents.keys().collect::<Vec<_>>();
-            let index = context.gen_range(0..keys.len());
+            let index = context.random_range(0..keys.len());
             let sender = keys[index];
             let mut message_sender = agents.get(sender).unwrap().clone();
             let mut msg = vec![0u8; 1024 * 1024 + 1];
@@ -985,8 +985,8 @@ mod tests {
         expected_duration_ms: u64,
     ) {
         // Create two agents
-        let pk1 = PrivateKey::from_seed(context.gen::<u64>()).public_key();
-        let pk2 = PrivateKey::from_seed(context.gen::<u64>()).public_key();
+        let pk1 = PrivateKey::from_seed(context.random::<u64>()).public_key();
+        let pk2 = PrivateKey::from_seed(context.random::<u64>()).public_key();
         let (mut sender, _) = oracle
             .control(pk1.clone())
             .register(0, TEST_QUOTA)

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -32,7 +32,7 @@ use commonware_utils::{
 };
 use either::Either;
 use futures::{future, Sink};
-use rand::Rng;
+use rand::{Rng, RngExt as _};
 use rand_distr::{Distribution, Normal};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
@@ -771,7 +771,7 @@ impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> Network<E, P> 
             let latency = Duration::from_millis(link.sampler.sample(self.context.as_mut()) as u64);
 
             // Determine if the message should be delivered
-            let should_deliver = self.context.gen_bool(link.success_rate);
+            let should_deliver = self.context.random_bool(link.success_rate);
 
             // Enqueue message for delivery
             let completions = self.transmitter.enqueue(

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -35,7 +35,7 @@ loom = { workspace = true, optional = true }
 opentelemetry.workspace = true
 pin-project = { workspace = true, optional = true }
 prometheus-client.workspace = true
-rand.workspace = true
+rand = { workspace = true, features = ["std_rng", "sys_rng"] }
 rand_core.workspace = true
 rayon.workspace = true
 sha2.workspace = true
@@ -46,8 +46,14 @@ tracing-opentelemetry.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
-# Enable "js" feature when WASM is target
-version = "0.2.15"
+# Enable the JS backend for transitive dependencies that use getrandom on WASM.
+version = "0.4.3"
+features = ["wasm_js"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom_v2]
+# Enable the JS backend for transitive dependencies that still use getrandom 0.2 on WASM.
+package = "getrandom"
+version = "0.2"
 features = ["js"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -61,7 +67,7 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 clap = { workspace = true, features = ["derive"] }
-rand = { workspace = true, features = ["small_rng"] }
+rand = { workspace = true, features = ["sys_rng"] }
 rstest.workspace = true
 serde_json.workspace = true
 

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -86,12 +86,12 @@ use futures::{
 use governor::clock::{Clock as GClock, ReasonablyRealtime};
 #[cfg(feature = "external")]
 use pin_project::pin_project;
-use rand::{prelude::SliceRandom, rngs::StdRng, CryptoRng, RngCore, SeedableRng};
-use rand_core::CryptoRngCore;
+use rand::{prelude::SliceRandom, rngs::StdRng, CryptoRng, Rng, SeedableRng, TryCryptoRng, TryRng};
 use rayon::{ThreadPoolBuildError, ThreadPoolBuilder};
 use sha2::{Digest as _, Sha256};
 use std::{
     collections::{BTreeMap, BinaryHeap, HashMap},
+    convert::Infallible,
     mem::{replace, take},
     net::{IpAddr, SocketAddr},
     num::NonZeroUsize,
@@ -183,7 +183,7 @@ impl Auditor {
 }
 
 /// A dynamic RNG that can safely be sent between threads.
-pub type BoxDynRng = Box<dyn CryptoRngCore + Send + 'static>;
+pub type BoxDynRng = Box<dyn CryptoRng + Send + 'static>;
 
 /// Configuration for the `deterministic` runtime.
 pub struct Config {
@@ -1480,44 +1480,38 @@ impl crate::Resolver for Context {
     }
 }
 
-impl RngCore for Context {
-    fn next_u32(&mut self) -> u32 {
+impl TryRng for Context {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         let executor = self.executor();
         executor.auditor.event(b"rand", |hasher| {
             hasher.update(b"next_u32");
         });
         let result = executor.rng.lock().next_u32();
-        result
+        Ok(result)
     }
 
-    fn next_u64(&mut self) -> u64 {
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
         let executor = self.executor();
         executor.auditor.event(b"rand", |hasher| {
             hasher.update(b"next_u64");
         });
         let result = executor.rng.lock().next_u64();
-        result
+        Ok(result)
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         let executor = self.executor();
         executor.auditor.event(b"rand", |hasher| {
             hasher.update(b"fill_bytes");
         });
         executor.rng.lock().fill_bytes(dest);
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        let executor = self.executor();
-        executor.auditor.event(b"rand", |hasher| {
-            hasher.update(b"try_fill_bytes");
-        });
-        let result = executor.rng.lock().try_fill_bytes(dest);
-        result
+        Ok(())
     }
 }
 
-impl CryptoRng for Context {}
+impl TryCryptoRng for Context {}
 
 impl crate::Storage for Context {
     type Blob = <Storage as crate::Storage>::Blob;

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -1146,7 +1146,7 @@ mod loom_tests {
         },
         thread,
     };
-    use rand::Rng;
+    use rand::{Rng, RngExt as _};
     use rstest::rstest;
 
     // This module uses loom to model the waker's producer/loop protocol over
@@ -1302,7 +1302,7 @@ mod loom_tests {
         fn generate_program(rng: &mut impl Rng, len: usize) -> Vec<Self> {
             (0..len)
                 .map(|_| {
-                    if rng.gen_bool(0.5) {
+                    if rng.random_bool(0.5) {
                         Self::Publish
                     } else {
                         Self::Wake

--- a/runtime/src/storage/benches/runner.rs
+++ b/runtime/src/storage/benches/runner.rs
@@ -6,7 +6,7 @@ use crate::{
     report::Stats,
 };
 use commonware_runtime::{Blob, IoBufMut, IoBufs};
-use rand::{rngs::SmallRng, Rng, SeedableRng};
+use rand::{rngs::SmallRng, RngExt as _, SeedableRng};
 use std::time::Instant;
 
 /// Operations between deadline checks.
@@ -42,7 +42,7 @@ pub fn sequential_blocks(start: u64, stride: u64, total_blocks: u64) -> impl FnM
 #[inline]
 pub fn random_blocks(seed: u64, total_blocks: u64) -> impl FnMut() -> u64 {
     let mut rng = SmallRng::seed_from_u64(seed);
-    move || rng.gen_range(0..total_blocks)
+    move || rng.random_range(0..total_blocks)
 }
 
 /// Read loop without statistics collection (for cache warm-up).

--- a/runtime/src/storage/benches/workload.rs
+++ b/runtime/src/storage/benches/workload.rs
@@ -14,7 +14,7 @@ use commonware_runtime::{tokio::Context, Blob as _, Storage as _};
 use futures::{stream::FuturesUnordered, TryStreamExt};
 use rand::{
     rngs::{SmallRng, StdRng},
-    Rng, SeedableRng,
+    RngExt as _, SeedableRng,
 };
 use std::{
     sync::{
@@ -291,7 +291,7 @@ async fn run_read_write_append(cfg: &Config, context: &Context) -> Result<Report
             async move {
                 let random_block = || {
                     let total_blocks = current_len.load(Ordering::Relaxed) / io_size;
-                    rng.gen_range(0..total_blocks)
+                    rng.random_range(0..total_blocks)
                 };
                 run_read_loop(blob, deadline, cfg.io_size, random_block).await
             }

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -3,7 +3,7 @@
 use crate::{deterministic::BoxDynRng, Error, Handle, IoBufs, IoBufsMut};
 use bytes::Buf;
 use commonware_utils::sync::{Mutex, RwLock};
-use rand::Rng;
+use rand::RngExt as _;
 use std::{
     io::Error as IoError,
     sync::{
@@ -171,7 +171,7 @@ impl Oracle {
         if rate >= 1.0 {
             return true;
         }
-        self.rng.lock().gen::<f64>() < rate
+        self.rng.lock().random::<f64>() < rate
     }
 
     /// Generate a random value strictly between `from` and `to`, or None if not possible.
@@ -183,7 +183,7 @@ impl Oracle {
         if max - min <= 1 {
             return None;
         }
-        Some(self.rng.lock().gen_range(min + 1..max))
+        Some(self.rng.lock().random_range(min + 1..max))
     }
 
     /// Try to generate a partial operation target. Returns Some if both the rate

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -260,7 +260,7 @@ mod tests {
         storage::tests::run_storage_tests, telemetry::metrics::Registry, Blob, BufferPoolConfig,
         Storage as _,
     };
-    use rand::{Rng as _, SeedableRng};
+    use rand::RngExt as _;
     use std::env;
 
     fn test_pool() -> BufferPool {
@@ -268,10 +268,16 @@ mod tests {
         BufferPool::new(BufferPoolConfig::for_storage(), &mut registry)
     }
 
+    fn random_suffix() -> u64 {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        rng.random()
+    }
+
     #[tokio::test]
     async fn test_storage() {
-        let mut rng = rand::rngs::StdRng::from_entropy();
-        let storage_directory = env::temp_dir().join(format!("storage_tokio_{}", rng.gen::<u64>()));
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let storage_directory =
+            env::temp_dir().join(format!("storage_tokio_{}", rng.random::<u64>()));
         let config = Config::new(storage_directory, 2 * 1024 * 1024);
         let storage = Storage::new(config, test_pool());
         run_storage_tests(storage).await;
@@ -281,9 +287,9 @@ mod tests {
     /// usable and a later sync still persists data.
     #[tokio::test]
     async fn test_start_sync_dropped_receiver() {
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let storage_directory =
-            env::temp_dir().join(format!("storage_tokio_start_sync_{}", rng.gen::<u64>()));
+            env::temp_dir().join(format!("storage_tokio_start_sync_{}", rng.random::<u64>()));
         let config = Config::new(storage_directory, 2 * 1024 * 1024);
         let storage = Storage::new(config, test_pool());
 
@@ -305,9 +311,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_blob_header_handling() {
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let storage_directory =
-            env::temp_dir().join(format!("storage_tokio_header_{}", rng.gen::<u64>()));
+            env::temp_dir().join(format!("storage_tokio_header_{}", rng.random::<u64>()));
         let config = Config::new(storage_directory.clone(), 2 * 1024 * 1024);
         let storage = Storage::new(config, test_pool());
 
@@ -404,7 +410,7 @@ mod tests {
     #[tokio::test]
     async fn test_blob_magic_mismatch() {
         let storage_directory =
-            env::temp_dir().join(format!("test_magic_mismatch_{}", rand::random::<u64>()));
+            env::temp_dir().join(format!("test_magic_mismatch_{}", random_suffix()));
         let storage = Storage::new(
             Config {
                 storage_directory: storage_directory.clone(),
@@ -439,7 +445,7 @@ mod tests {
             let storage_directory = env::temp_dir().join(format!(
                 "test_scan_non_canonical_{}_{}",
                 bad_name.replace([' ', '0', 'x', 'X'], "_"),
-                rand::random::<u64>()
+                random_suffix()
             ));
             let storage = Storage::new(
                 Config {

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -31,10 +31,11 @@ use commonware_macros::{select, stability};
 use commonware_parallel::ThreadPool;
 use commonware_utils::{sync::Mutex, NZUsize};
 use governor::clock::{Clock as GClock, ReasonablyRealtime};
-use rand::{rngs::OsRng, CryptoRng, RngCore};
+use rand::{rngs::SysRng, TryCryptoRng, TryRng};
 #[stability(BETA)]
 use rayon::{ThreadPoolBuildError, ThreadPoolBuilder};
 use std::{
+    convert::Infallible,
     env,
     future::Future,
     net::{IpAddr, SocketAddr},
@@ -174,7 +175,9 @@ pub struct Config {
 impl Config {
     /// Returns a new [Config] with default values.
     pub fn new() -> Self {
-        let rng = OsRng.next_u64();
+        let rng = SysRng
+            .try_next_u64()
+            .expect("failed to generate randomness");
         let storage_directory = env::temp_dir().join(format!("commonware_tokio_runtime_{rng}"));
         Self {
             worker_threads: 2,
@@ -778,25 +781,30 @@ impl crate::Resolver for Context {
     }
 }
 
-impl RngCore for Context {
-    fn next_u32(&mut self) -> u32 {
-        OsRng.next_u32()
+impl TryRng for Context {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(SysRng
+            .try_next_u32()
+            .expect("failed to generate randomness"))
     }
 
-    fn next_u64(&mut self) -> u64 {
-        OsRng.next_u64()
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(SysRng
+            .try_next_u64()
+            .expect("failed to generate randomness"))
     }
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        OsRng.fill_bytes(dest);
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        OsRng.try_fill_bytes(dest)
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        SysRng
+            .try_fill_bytes(dest)
+            .expect("failed to generate randomness");
+        Ok(())
     }
 }
 
-impl CryptoRng for Context {}
+impl TryCryptoRng for Context {}
 
 impl crate::Storage for Context {
     type Blob = <Storage as crate::Storage>::Blob;

--- a/runtime/src/utils/buffer/benches/read.rs
+++ b/runtime/src/utils/buffer/benches/read.rs
@@ -6,7 +6,7 @@ use commonware_runtime::{
 };
 use commonware_utils::NZUsize;
 use criterion::Criterion;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::time::Instant;
 
 // Use cache size pages so all data fits in cache (testing buffer performance, not disk).
@@ -45,7 +45,7 @@ where
                     for _ in 0..iters {
                         // Ensure ~1/100 reads are going to be cache misses.
                         for _ in 0..TOTAL_PAGES * 100 {
-                            let offset = rng.gen_range(0..=max_offset) as u64;
+                            let offset = rng.random_range(0..=max_offset) as u64;
                             append.read_into(&mut buf, offset).await.unwrap();
                         }
                     }

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -1,10 +1,10 @@
 ["commonware_storage::archive::conformance::ArchiveImmutable"]
 n_cases = 128
-hash = "76d177808be5f0485ea3de5ccdb52f876c664b29991e3ae0186fe51aa9e0fb71"
+hash = "8a1672e106ef417d61be6f6b6152e65760d93b316e9d0c6c9a3adaeb06b6edf5"
 
 ["commonware_storage::archive::conformance::ArchivePrunable"]
 n_cases = 128
-hash = "590d5e27608bed5c2945a3347b04f13bbeb706ba28ca38f6c307c4428a621ca7"
+hash = "83963814c3e62534fe235281537eb5c258a6516aa1f190742f1b612e9ce37f34"
 
 ["commonware_storage::archive::immutable::storage::conformance::CodecConformance<Record>"]
 n_cases = 65536
@@ -48,27 +48,27 @@ hash = "13b3e99a8c74b50dc18150194a92306de670b94e6642758feb6d9b6e9881f827"
 
 ["commonware_storage::journal::conformance::ContiguousFixed"]
 n_cases = 512
-hash = "1c3307a66101b00acbc1fbce17daff5481a4f830f89f4a61690f760bedd66e40"
+hash = "282be0238aa697705ce2fd961a5c3495079aedda46264aa84fac7a9895830ef2"
 
 ["commonware_storage::journal::conformance::ContiguousVariable"]
 n_cases = 512
-hash = "983594bdfda5dae51a347e669f05d863e11c92ff2aa50c842866320832598f52"
+hash = "263dd1483065719a0f812eb7bee83c081db8f626dc0fa3ebfcdc64293c4c01f4"
 
 ["commonware_storage::journal::conformance::SegmentedFixed"]
 n_cases = 512
-hash = "fb5d8f684b1a03c0bbaf8c4fd7b67043fa73496446fff115e75d7521154b6ad1"
+hash = "f9052603feb48019bda29e34bb53818af7ca9a65090da20ad2225dfc89deeca0"
 
 ["commonware_storage::journal::conformance::SegmentedGlob"]
 n_cases = 512
-hash = "bcc3e67945fe5a97a644e839aeff277bb29711503da65a20e84077e69ae9dcef"
+hash = "837ab291e8002b60af3d6333ab630af2e2d52c41d1eb986da8fffae5bc484e48"
 
 ["commonware_storage::journal::conformance::SegmentedOversized"]
 n_cases = 512
-hash = "ada5da872b95b6369905c2fca454f3276935a380d3da91190bc04f1602e7c501"
+hash = "0ed326c34e7094465994353e7d50b8a2aeb57ab4210041a6ef67699d6037891e"
 
 ["commonware_storage::journal::conformance::SegmentedVariable"]
 n_cases = 512
-hash = "506b5a02d1a7c3e249f514b889e6099c27bb0723ebc711514263f0c71f0676ef"
+hash = "ed3d31fad3d7d716e55f30fc3b54d9c47832162598033aa70a8ffb71622e14f8"
 
 ["commonware_storage::merkle::conformance::MmbRootStability"]
 n_cases = 200
@@ -352,4 +352,4 @@ hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
 
 ["commonware_storage::queue::conformance::QueueConformance"]
 n_cases = 512
-hash = "c6f6eaf561267f964b0c95cfa2a022172515931e2f3880e82141279276d2d6cf"
+hash = "deb5ca1f980ee6a524526d638f59f1ceee10f772e5cb9804151cf83acfddfd1c"

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -17,7 +17,7 @@ use commonware_storage::{
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use libfuzzer_sys::fuzz_target;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::num::{NonZeroU16, NonZeroU64};
 
 const MAX_OPERATIONS: usize = 50;
@@ -82,16 +82,16 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 }
 
 fn generate_key(rng: &mut StdRng, seed: u64) -> Digest {
-    let mut data = vec![0u8; rng.gen_range(1..=MAX_KEY_SIZE)];
+    let mut data = vec![0u8; rng.random_range(1..=MAX_KEY_SIZE)];
     for (i, byte) in data.iter_mut().enumerate() {
-        *byte = ((seed >> (i % 8)) & 0xFF) as u8 ^ rng.gen::<u8>();
+        *byte = ((seed >> (i % 8)) & 0xFF) as u8 ^ rng.random::<u8>();
     }
     Sha256::hash(&data)
 }
 
 fn generate_value(rng: &mut StdRng, size: usize) -> Vec<u8> {
     let actual_size = size.clamp(1, MAX_VALUE_SIZE);
-    (0..actual_size).map(|_| rng.gen()).collect()
+    (0..actual_size).map(|_| rng.random()).collect()
 }
 
 #[allow(clippy::type_complexity)]

--- a/storage/src/archive/benches/get.rs
+++ b/storage/src/archive/benches/get.rs
@@ -9,7 +9,7 @@ use commonware_runtime::{
 use commonware_storage::archive::{Archive as ArchiveTrait, Identifier};
 use criterion::{criterion_group, Criterion};
 use futures::future::try_join_all;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{hint::black_box, time::Instant};
 
 /// Items pre-loaded into the archive.
@@ -27,7 +27,7 @@ fn select_keys(keys: &[Key], reads: usize) -> Vec<Key> {
     let mut rng = StdRng::seed_from_u64(42);
     let mut selected_keys = Vec::with_capacity(reads);
     for _ in 0..reads {
-        selected_keys.push(keys[rng.gen_range(0..ITEMS as usize)].clone());
+        selected_keys.push(keys[rng.random_range(0..ITEMS as usize)].clone());
     }
     selected_keys
 }
@@ -36,7 +36,7 @@ fn select_indices(reads: usize) -> Vec<u64> {
     let mut rng = StdRng::seed_from_u64(42);
     let mut selected_indices = Vec::with_capacity(reads);
     for _ in 0..reads {
-        selected_indices.push(rng.gen_range(0..ITEMS));
+        selected_indices.push(rng.random_range(0..ITEMS));
     }
     selected_indices
 }

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -8,7 +8,7 @@ use commonware_storage::{
     translator::TwoCap,
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::num::{NonZeroU16, NonZeroUsize};
 
 /// Number of bytes that can be buffered in a section before being written to a

--- a/storage/src/archive/conformance.rs
+++ b/storage/src/archive/conformance.rs
@@ -9,7 +9,7 @@ use commonware_conformance::{conformance_tests, Conformance};
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervisor as _};
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
 use core::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
-use rand::Rng;
+use rand::RngExt as _;
 
 const WRITE_BUFFER: NonZeroUsize = NZUsize!(1024);
 const ITEMS_PER_SECTION: NonZeroU64 = NZU64!(1024);
@@ -42,12 +42,12 @@ impl Conformance for ArchivePrunable {
             .unwrap();
 
             // Write random items
-            let items_count = context.gen_range(100..500);
+            let items_count = context.random_range(100..500);
             for i in 0..items_count {
                 let mut key_bytes = [0u8; 64];
                 context.fill(&mut key_bytes);
                 let key = FixedBytes::<64>::decode(key_bytes.as_ref()).unwrap();
-                let value: i32 = context.gen();
+                let value: i32 = context.random();
                 archive.put(i as u64, key, value).await.unwrap();
             }
             archive.sync().await.unwrap();
@@ -90,12 +90,12 @@ impl Conformance for ArchiveImmutable {
             .unwrap();
 
             // Write random items
-            let items_count = context.gen_range(100..500);
+            let items_count = context.random_range(100..500);
             for i in 0..items_count {
                 let mut key_bytes = [0u8; 64];
                 context.fill(&mut key_bytes);
                 let key = FixedBytes::<64>::decode(key_bytes.as_ref()).unwrap();
-                let value: i32 = context.gen();
+                let value: i32 = context.random();
                 archive.put(i as u64, key, value).await.unwrap();
             }
             archive.sync().await.unwrap();

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -232,7 +232,7 @@ mod tests {
         Metrics as _, Runner, Supervisor as _,
     };
     use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
-    use rand::Rng;
+    use rand::RngExt as _;
     use std::{
         collections::BTreeMap,
         num::{NonZeroU16, NonZeroUsize},
@@ -677,14 +677,14 @@ mod tests {
             // Insert 100 keys with gaps
             let mut last_index = 0u64;
             while keys.len() < 100 {
-                let gap: u64 = context.gen_range(1..=10);
+                let gap: u64 = context.random_range(1..=10);
                 let index = last_index + gap;
                 last_index = index;
 
                 let mut key_bytes = [0u8; 64];
                 context.fill(&mut key_bytes);
                 let key = FixedBytes::<64>::decode(key_bytes.as_ref()).unwrap();
-                let data: i32 = context.gen();
+                let data: i32 = context.random();
 
                 if keys.contains_key(&index) {
                     continue;
@@ -802,7 +802,7 @@ mod tests {
                 let mut key = [0u8; 64];
                 context.fill(&mut key);
                 let key = FixedBytes::<64>::decode(key.as_ref()).unwrap();
-                let data: i32 = context.gen();
+                let data: i32 = context.random();
 
                 archive
                     .put(index, key.clone(), data)
@@ -811,7 +811,7 @@ mod tests {
                 keys.insert(key, (index, data));
 
                 // Randomly sync the archive
-                if context.gen_bool(0.1) {
+                if context.random_bool(0.1) {
                     archive.sync().await.expect("Failed to sync archive");
                 }
             }

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -232,7 +232,7 @@ mod tests {
         BufferPooler, Error as RError, Metrics as _, Runner, Spawner as _, Supervisor as _,
     };
     use commonware_utils::{sequence::FixedBytes, sync::Mutex, NZUsize, NZU16, NZU64};
-    use rand::Rng;
+    use rand::RngExt as _;
     use std::{
         collections::BTreeMap,
         num::{NonZeroU16, NonZeroU64},

--- a/storage/src/bmt/benches/prove_multi.rs
+++ b/storage/src/bmt/benches/prove_multi.rs
@@ -2,7 +2,7 @@ use commonware_cryptography::{sha256, Hasher, Sha256};
 use commonware_math::algebra::Random as _;
 use commonware_storage::bmt::Builder;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use rand::{rngs::StdRng, seq::IndexedRandom, SeedableRng};
 
 const SAMPLE_SIZE: usize = 100;
 
@@ -26,10 +26,8 @@ fn bench_prove_multi(c: &mut Criterion) {
             |b| {
                 b.iter_batched(
                     || {
-                        let samples: Vec<_> = queries
-                            .choose_multiple(&mut sampler, SAMPLE_SIZE)
-                            .cloned()
-                            .collect();
+                        let samples: Vec<_> =
+                            queries.sample(&mut sampler, SAMPLE_SIZE).cloned().collect();
                         let positions: Vec<u32> = samples.iter().map(|(pos, _)| *pos).collect();
                         let proof = tree.multi_proof(&positions).unwrap();
                         (samples, proof)

--- a/storage/src/bmt/benches/prove_range.rs
+++ b/storage/src/bmt/benches/prove_range.rs
@@ -2,7 +2,7 @@ use commonware_cryptography::{sha256, Hasher, Sha256};
 use commonware_math::algebra::Random as _;
 use commonware_storage::bmt::Builder;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 
 const SAMPLE_SIZE: usize = 100;
 
@@ -26,7 +26,7 @@ fn bench_prove_range(c: &mut Criterion) {
             |b| {
                 b.iter_batched(
                     || {
-                        let start = sampler.gen_range(0..(n - SAMPLE_SIZE));
+                        let start = sampler.random_range(0..(n - SAMPLE_SIZE));
                         let end = start + SAMPLE_SIZE;
                         (
                             start,

--- a/storage/src/bmt/benches/prove_single.rs
+++ b/storage/src/bmt/benches/prove_single.rs
@@ -2,7 +2,7 @@ use commonware_cryptography::{sha256, Hasher, Sha256};
 use commonware_math::algebra::Random as _;
 use commonware_storage::bmt::Builder;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use rand::{rngs::StdRng, seq::IndexedRandom, SeedableRng};
 
 const SAMPLE_SIZE: usize = 100;
 
@@ -27,7 +27,7 @@ fn bench_prove_single(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let samples = queries
-                            .choose_multiple(&mut sampler, SAMPLE_SIZE)
+                            .sample(&mut sampler, SAMPLE_SIZE)
                             .cloned()
                             .collect::<Vec<_>>();
                         samples

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -131,7 +131,7 @@ mod tests {
         deterministic, telemetry::metrics::has_metric_value, Metrics as _, Runner, Supervisor as _,
     };
     use commonware_utils::{NZUsize, NZU16, NZU64};
-    use rand::Rng;
+    use rand::RngExt as _;
     use std::{collections::BTreeMap, num::NonZeroU16};
 
     const DEFAULT_ITEMS_PER_BLOB: u64 = 65536;

--- a/storage/src/freezer/benches/get.rs
+++ b/storage/src/freezer/benches/get.rs
@@ -7,7 +7,7 @@ use commonware_runtime::{
 use commonware_storage::freezer::Identifier;
 use criterion::{criterion_group, Criterion};
 use futures::future::try_join_all;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{hint::black_box, time::Instant};
 
 /// Items pre-loaded into the store.
@@ -26,7 +26,7 @@ pub fn select_keys(count: usize, keys: &[Key]) -> Vec<Key> {
     let mut rng = StdRng::seed_from_u64(42);
     let mut selected_keys = Vec::with_capacity(count);
     for _ in 0..count {
-        let idx = rng.gen_range(0..keys.len());
+        let idx = rng.random_range(0..keys.len());
         selected_keys.push(keys[idx].clone());
     }
     selected_keys

--- a/storage/src/freezer/benches/utils.rs
+++ b/storage/src/freezer/benches/utils.rs
@@ -3,7 +3,7 @@
 use commonware_runtime::{buffer::paged::CacheRef, tokio::Context};
 use commonware_storage::freezer::{Checkpoint, Config, Freezer};
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::num::{NonZeroU16, NonZeroUsize};
 
 /// Number of bytes that can be buffered before being written to disk.

--- a/storage/src/freezer/conformance.rs
+++ b/storage/src/freezer/conformance.rs
@@ -5,7 +5,7 @@ use commonware_conformance::{conformance_tests, Conformance};
 use commonware_runtime::{buffer::paged::CacheRef, deterministic, Runner, Supervisor as _};
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16};
 use core::num::{NonZeroU16, NonZeroUsize};
-use rand::Rng;
+use rand::RngExt as _;
 
 const WRITE_BUFFER: NonZeroUsize = NZUsize!(1024);
 const PAGE_SIZE: NonZeroU16 = NZU16!(1024);

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -289,7 +289,7 @@ mod tests {
     use commonware_macros::{test_group, test_traced};
     use commonware_runtime::{deterministic, Blob, Metrics as _, Runner, Storage, Supervisor as _};
     use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16};
-    use rand::{Rng, RngCore};
+    use rand::{Rng, RngExt as _};
     use std::num::NonZeroU16;
 
     fn test_key(key: &str) -> FixedBytes<64> {
@@ -1234,7 +1234,7 @@ mod tests {
                 pairs.push((key, value));
 
                 // Randomly sync to test resizing
-                if context.gen_bool(0.1) {
+                if context.random_bool(0.1) {
                     freezer.sync().await.expect("Failed to sync");
                 }
             }

--- a/storage/src/index/benches/hashmap_insert.rs
+++ b/storage/src/index/benches/hashmap_insert.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::Rng;
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::collections::HashMap;
 
 #[cfg(not(full_bench))]
@@ -21,15 +21,15 @@ fn bench_hashmap_insert(c: &mut Criterion) {
                     || {
                         // Perform all random ops
                         let mut vec: Vec<(Vec<u8>, u64, u32, u32)> = Vec::with_capacity(n);
-                        let mut rng = rand::thread_rng();
+                        let mut rng = StdRng::seed_from_u64((n as u64) ^ (k as u64));
                         let mut key = vec![0; k];
 
                         // Populate vec with dummy data
                         for _ in 0..n {
                             rng.fill(&mut key[..]);
-                            let section = rng.gen();
-                            let offset = rng.gen();
-                            let len = rng.gen();
+                            let section = rng.random();
+                            let offset = rng.random();
+                            let len = rng.random();
                             vec.push((key.clone(), section, offset, len));
                         }
                         vec

--- a/storage/src/index/benches/hashmap_insert_fixed.rs
+++ b/storage/src/index/benches/hashmap_insert_fixed.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::Rng;
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::collections::HashMap;
 
 #[cfg(not(full_bench))]
@@ -20,14 +20,14 @@ fn bench_hashmap_insert_fixed(c: &mut Criterion) {
                 || {
                     // Perform all random ops
                     let mut vec: Vec<([u8; 4], u64, u32, u32)> = Vec::with_capacity(n);
-                    let mut rng = rand::thread_rng();
+                    let mut rng = StdRng::seed_from_u64(n as u64);
 
                     // Populate vec with dummy data
                     for _ in 0..n {
-                        let key: [u8; 4] = rng.gen();
-                        let section = rng.gen();
-                        let offset = rng.gen();
-                        let len = rng.gen();
+                        let key: [u8; 4] = rng.random();
+                        let section = rng.random();
+                        let offset = rng.random();
+                        let len = rng.random();
                         vec.push((key, section, offset, len));
                     }
                     vec

--- a/storage/src/index/benches/hashmap_iteration.rs
+++ b/storage/src/index/benches/hashmap_iteration.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, BatchSize, Criterion};
-use rand::Rng;
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{collections::HashMap, hint::black_box};
 
 #[cfg(not(full_bench))]
@@ -20,16 +20,16 @@ fn bench_hashmap_iteration(c: &mut Criterion) {
                 b.iter_batched(
                     || {
                         let mut map = HashMap::with_capacity(n);
-                        let mut rng = rand::thread_rng();
+                        let mut rng = StdRng::seed_from_u64((n as u64) ^ (k as u64));
                         let mut key = vec![0; k];
 
                         // Populate the HashMap with dummy data
                         for _ in 0..n {
                             rng.fill(&mut key[..]);
                             let value = MockIndex {
-                                section: rng.gen(),
-                                _offset: rng.gen(),
-                                _len: rng.gen(),
+                                section: rng.random(),
+                                _offset: rng.random(),
+                                _len: rng.random(),
                             };
                             map.insert(key.clone(), value);
                         }

--- a/storage/src/index/benches/scale.rs
+++ b/storage/src/index/benches/scale.rs
@@ -21,7 +21,7 @@ use commonware_storage::{
     index::{ordered, partitioned, unordered, Unordered},
     translator::{Cap, EightCap},
 };
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{
     hint::black_box,
     time::{Duration, Instant},

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -265,7 +265,7 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Runner, Supervisor as _};
     use commonware_utils::sync::Mutex;
-    use rand::Rng;
+    use rand::RngExt as _;
     use std::{
         collections::{HashMap, HashSet},
         sync::Arc,

--- a/storage/src/journal/benches/bench.rs
+++ b/storage/src/journal/benches/bench.rs
@@ -6,7 +6,7 @@ use commonware_storage::journal::contiguous::{
 };
 use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
 use criterion::criterion_main;
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
 
 mod fixed_append;

--- a/storage/src/journal/benches/fixed_read_random.rs
+++ b/storage/src/journal/benches/fixed_read_random.rs
@@ -8,7 +8,7 @@ use commonware_storage::journal::contiguous::{fixed::Journal, Contiguous as _};
 use commonware_utils::{sequence::FixedBytes, NZU64};
 use criterion::{criterion_group, Criterion};
 use futures::future::try_join_all;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{
     hint::black_box,
     num::NonZeroU64,
@@ -36,7 +36,7 @@ async fn bench_run_serial(
     let reader = journal.snapshot().await.unwrap();
     let mut rng = StdRng::seed_from_u64(0);
     for _ in 0..items_to_read {
-        let pos = rng.gen_range(0..ITEMS_TO_WRITE);
+        let pos = rng.random_range(0..ITEMS_TO_WRITE);
         black_box(reader.read(pos).await.expect("failed to read data"));
     }
 }
@@ -50,7 +50,7 @@ async fn bench_run_concurrent(
     let mut rng = StdRng::seed_from_u64(0);
     let mut futures = Vec::with_capacity(items_to_read);
     for _ in 0..items_to_read {
-        let pos = rng.gen_range(0..ITEMS_TO_WRITE);
+        let pos = rng.random_range(0..ITEMS_TO_WRITE);
         futures.push(reader.read(pos));
     }
     try_join_all(futures).await.expect("failed to read data");
@@ -64,7 +64,7 @@ async fn bench_run_read_many(
     let reader = journal.snapshot().await.unwrap();
     let mut rng = StdRng::seed_from_u64(0);
     let mut positions: Vec<u64> = (0..items_to_read)
-        .map(|_| rng.gen_range(0..ITEMS_TO_WRITE))
+        .map(|_| rng.random_range(0..ITEMS_TO_WRITE))
         .collect();
     positions.sort_unstable();
     positions.dedup();

--- a/storage/src/journal/benches/variable_read_random.rs
+++ b/storage/src/journal/benches/variable_read_random.rs
@@ -8,7 +8,7 @@ use commonware_storage::journal::contiguous::{variable::Journal, Contiguous as _
 use commonware_utils::{sequence::FixedBytes, NZU64};
 use criterion::{criterion_group, Criterion};
 use futures::future::try_join_all;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{
     hint::black_box,
     num::NonZeroU64,
@@ -36,7 +36,7 @@ async fn bench_run_serial(
     let reader = journal.snapshot().await.unwrap();
     let mut rng = StdRng::seed_from_u64(0);
     for _ in 0..items_to_read {
-        let pos = rng.gen_range(0..ITEMS_TO_WRITE);
+        let pos = rng.random_range(0..ITEMS_TO_WRITE);
         black_box(reader.read(pos).await.expect("failed to read data"));
     }
 }
@@ -50,7 +50,7 @@ async fn bench_run_concurrent(
     let mut rng = StdRng::seed_from_u64(0);
     let mut futures = Vec::with_capacity(items_to_read);
     for _ in 0..items_to_read {
-        let pos = rng.gen_range(0..ITEMS_TO_WRITE);
+        let pos = rng.random_range(0..ITEMS_TO_WRITE);
         futures.push(reader.read(pos));
     }
     try_join_all(futures).await.expect("failed to read data");
@@ -64,7 +64,7 @@ async fn bench_run_read_many(
     let reader = journal.snapshot().await.unwrap();
     let mut rng = StdRng::seed_from_u64(0);
     let mut positions: Vec<u64> = (0..items_to_read)
-        .map(|_| rng.gen_range(0..ITEMS_TO_WRITE))
+        .map(|_| rng.random_range(0..ITEMS_TO_WRITE))
         .collect();
     positions.sort_unstable();
     positions.dedup();

--- a/storage/src/journal/conformance.rs
+++ b/storage/src/journal/conformance.rs
@@ -12,7 +12,7 @@ use commonware_runtime::{
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use core::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
 use oversized::Record;
-use rand::Rng;
+use rand::RngExt as _;
 
 const WRITE_BUFFER: NonZeroUsize = NZUsize!(1024);
 const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(4096);
@@ -36,7 +36,7 @@ impl Conformance for ContiguousFixed {
                 .unwrap();
 
             let mut data_to_write =
-                vec![0u64; context.gen_range(0..(ITEMS_PER_BLOB.get() as usize) * 4)];
+                vec![0u64; context.random_range(0..(ITEMS_PER_BLOB.get() as usize) * 4)];
             context.fill(&mut data_to_write[..]);
 
             for item in data_to_write.iter() {
@@ -70,9 +70,9 @@ impl Conformance for ContiguousVariable {
                     .unwrap();
 
             let mut data_to_write =
-                vec![Vec::new(); context.gen_range(0..(ITEMS_PER_BLOB.get() as usize) * 4)];
+                vec![Vec::new(); context.random_range(0..(ITEMS_PER_BLOB.get() as usize) * 4)];
             for item in data_to_write.iter_mut() {
-                let size = context.gen_range(0..256);
+                let size = context.random_range(0..256);
                 item.resize(size, 0);
                 context.fill(item.as_mut_slice());
             }
@@ -105,7 +105,7 @@ impl Conformance for SegmentedFixed {
                     .unwrap();
 
             // Write items across multiple sections
-            let items_count = context.gen_range(0..(ITEMS_PER_BLOB.get() as usize) * 4);
+            let items_count = context.random_range(0..(ITEMS_PER_BLOB.get() as usize) * 4);
             let mut data_to_write = vec![0u64; items_count];
             context.fill(&mut data_to_write[..]);
 
@@ -141,10 +141,10 @@ impl Conformance for SegmentedGlob {
                 .unwrap();
 
             // Write variable-size items across multiple sections
-            let items_count = context.gen_range(0..(ITEMS_PER_BLOB.get() as usize) * 4);
+            let items_count = context.random_range(0..(ITEMS_PER_BLOB.get() as usize) * 4);
             let mut data_to_write = vec![Vec::new(); items_count];
             for item in data_to_write.iter_mut() {
-                let size = context.gen_range(0..256);
+                let size = context.random_range(0..256);
                 item.resize(size, 0);
                 context.fill(item.as_mut_slice());
             }
@@ -183,10 +183,10 @@ impl Conformance for SegmentedVariable {
                     .unwrap();
 
             // Write variable-size items across multiple sections
-            let items_count = context.gen_range(0..(ITEMS_PER_BLOB.get() as usize) * 4);
+            let items_count = context.random_range(0..(ITEMS_PER_BLOB.get() as usize) * 4);
             let mut data_to_write = vec![Vec::new(); items_count];
             for item in data_to_write.iter_mut() {
-                let size = context.gen_range(0..256);
+                let size = context.random_range(0..256);
                 item.resize(size, 0);
                 context.fill(item.as_mut_slice());
             }
@@ -276,10 +276,10 @@ impl Conformance for SegmentedOversized {
             .unwrap();
 
             // Write variable-size items across multiple sections
-            let items_count = context.gen_range(0..(ITEMS_PER_BLOB.get() as usize) * 4);
+            let items_count = context.random_range(0..(ITEMS_PER_BLOB.get() as usize) * 4);
             let mut data_to_write = vec![Vec::new(); items_count];
             for item in data_to_write.iter_mut() {
-                let size = context.gen_range(0..256);
+                let size = context.random_range(0..256);
                 item.resize(size, 0);
                 context.fill(item.as_mut_slice());
             }

--- a/storage/src/merkle/benches/position_to_location.rs
+++ b/storage/src/merkle/benches/position_to_location.rs
@@ -1,6 +1,6 @@
 use commonware_storage::merkle::{Family, Location, Position};
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::hint::black_box;
 
 #[cfg(not(full_bench))]
@@ -18,7 +18,7 @@ const SAMPLES: usize = 4096;
 fn sample_positions<F: Family>(max_leaves: u64) -> Vec<Position<F>> {
     let mut rng = StdRng::seed_from_u64(0);
     (0..SAMPLES)
-        .map(|_| F::location_to_position(Location::new(rng.gen_range(0..max_leaves))))
+        .map(|_| F::location_to_position(Location::new(rng.random_range(0..max_leaves))))
         .collect()
 }
 

--- a/storage/src/merkle/benches/prove_many_elements.rs
+++ b/storage/src/merkle/benches/prove_many_elements.rs
@@ -5,7 +5,7 @@ use commonware_storage::merkle::{
 };
 use criterion::{criterion_group, BatchSize, Criterion};
 use futures::executor::block_on;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::ops::Range;
 
 type StandardHasher<H> = merkle::hasher::Standard<H>;
@@ -44,7 +44,7 @@ fn make_test_data<F: Family>(
     let max_start = n as u64 - range;
     let mut samples: Vec<Sample<F>> = Vec::with_capacity(SAMPLE_SIZE);
     while samples.len() < SAMPLE_SIZE {
-        let start_index = sampler.gen_range(0..max_start);
+        let start_index = sampler.random_range(0..max_start);
         let leaf_range = Location::<F>::new(start_index)..Location::<F>::new(start_index + range);
         if samples
             .iter()

--- a/storage/src/merkle/benches/prove_single_element.rs
+++ b/storage/src/merkle/benches/prove_single_element.rs
@@ -3,7 +3,7 @@ use commonware_math::algebra::Random as _;
 use commonware_storage::merkle::{self, mem::Mem, Bagging::ForwardFold, Family, Location};
 use criterion::{criterion_group, BatchSize, Criterion};
 use futures::executor::block_on;
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use rand::{rngs::StdRng, seq::IndexedRandom, SeedableRng};
 
 type StandardHasher<H> = merkle::hasher::Standard<H>;
 
@@ -35,7 +35,7 @@ fn make_test_data<F: Family>(n: usize) -> (Mem<F, sha256::Digest>, sha256::Diges
     });
     let root = mem.root(&hasher, 0).unwrap();
     let samples = elements
-        .choose_multiple(&mut sampler, SAMPLE_SIZE)
+        .sample(&mut sampler, SAMPLE_SIZE)
         .cloned()
         .map(|(loc, element)| (Location::<F>::new(loc as u64), element))
         .collect::<Vec<_>>();

--- a/storage/src/merkle/benches/update.rs
+++ b/storage/src/merkle/benches/update.rs
@@ -8,7 +8,7 @@ use commonware_runtime::{
 use commonware_storage::merkle::{self, mem::Mem, Bagging::ForwardFold, Family, Location};
 use commonware_utils::NZUsize;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{collections::HashMap, num::NonZeroUsize, time::Instant};
 
 type StandardHasher<H> = merkle::hasher::Standard<H>;
@@ -72,9 +72,9 @@ fn bench_update_family<F: Family>(c: &mut Criterion, runner: &tokio::Runner, fam
                                 // Simulate leaf-batching being the responsibility of the caller.
                                 let mut leaf_map = HashMap::new();
                                 for _ in 0..updates {
-                                    let rand_leaf_num = sampler.gen_range(0..leaves);
+                                    let rand_leaf_num = sampler.random_range(0..leaves);
                                     let rand_leaf_loc = leaf_locations[rand_leaf_num];
-                                    let rand_leaf_swap = sampler.gen_range(0..elements.len());
+                                    let rand_leaf_swap = sampler.random_range(0..elements.len());
                                     let new_element = &elements[rand_leaf_swap];
                                     leaf_map.insert(rand_leaf_loc, *new_element);
                                 }

--- a/storage/src/metadata/benches/utils.rs
+++ b/storage/src/metadata/benches/utils.rs
@@ -1,7 +1,7 @@
 use commonware_runtime::tokio::Context;
 use commonware_storage::metadata::{Config, Metadata};
 use commonware_utils::sequence::U64;
-use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
+use rand::{rngs::StdRng, seq::SliceRandom, RngExt as _, SeedableRng};
 
 /// Partition used across all metadata benchmarks.
 pub const PARTITION: &str = "metadata-bench-partition";

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -91,7 +91,7 @@ mod tests {
     use commonware_macros::{test_group, test_traced};
     use commonware_runtime::{deterministic, Blob, Metrics as _, Runner, Storage, Supervisor as _};
     use commonware_utils::sequence::U64;
-    use rand::{Rng, RngCore};
+    use rand::{Rng, RngExt as _};
 
     #[test_traced]
     fn test_put_get_clear() {
@@ -1071,13 +1071,13 @@ mod tests {
                 metadata.put(key, value);
 
                 // Sync occasionally
-                if context.gen_bool(0.1) {
+                if context.random_bool(0.1) {
                     metadata.sync().await.unwrap();
                 }
 
                 // Update some existing keys
-                if context.gen_bool(0.1) {
-                    let selected_index = context.gen_range(0..=i);
+                if context.random_bool(0.1) {
+                    let selected_index = context.random_range(0..=i);
                     let update_key = U64::new(selected_index as u64);
                     let mut new_value = vec![0u8; 64];
                     context.fill_bytes(&mut new_value);
@@ -1085,15 +1085,15 @@ mod tests {
                 }
 
                 // Remove some keys
-                if context.gen_bool(0.1) {
-                    let selected_index = context.gen_range(0..=i);
+                if context.random_bool(0.1) {
+                    let selected_index = context.random_range(0..=i);
                     let remove_key = U64::new(selected_index as u64);
                     metadata.remove(&remove_key);
                 }
 
                 // Use get_mut occasionally
-                if context.gen_bool(0.1) {
-                    let selected_index = context.gen_range(0..=i);
+                if context.random_bool(0.1) {
+                    let selected_index = context.random_range(0..=i);
                     let mut_key = U64::new(selected_index as u64);
                     if let Some(value) = metadata.get_mut(&mut_key) {
                         if !value.is_empty() {

--- a/storage/src/ordinal/benches/get.rs
+++ b/storage/src/ordinal/benches/get.rs
@@ -8,7 +8,7 @@ use commonware_storage::utils::bits_for_indices;
 use commonware_utils::NZU64;
 use criterion::{criterion_group, Criterion};
 use futures::future::try_join_all;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{hint::black_box, time::Instant};
 
 /// Items pre-loaded into the store.
@@ -19,7 +19,7 @@ pub fn select_indices(count: usize, items: u64) -> Vec<u64> {
     let mut rng = StdRng::seed_from_u64(42);
     let mut selected_indices = Vec::with_capacity(count);
     for _ in 0..count {
-        selected_indices.push(rng.gen_range(0..items));
+        selected_indices.push(rng.random_range(0..items));
     }
     selected_indices
 }

--- a/storage/src/ordinal/benches/utils.rs
+++ b/storage/src/ordinal/benches/utils.rs
@@ -1,7 +1,7 @@
 use commonware_runtime::tokio::Context;
 use commonware_storage::ordinal;
 use commonware_utils::{bitmap::BitMap, sequence::FixedBytes, NZUsize, NZU64};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::BTreeMap;
 
 /// Number of bytes that can be buffered before being written to disk.

--- a/storage/src/ordinal/mod.rs
+++ b/storage/src/ordinal/mod.rs
@@ -146,7 +146,7 @@ mod tests {
         deterministic, Blob, Buf, BufMut, Metrics as _, Runner, Storage, Supervisor as _,
     };
     use commonware_utils::{bitmap::BitMap, sequence::FixedBytes, NZUsize, NZU64};
-    use rand::RngCore;
+    use rand::Rng;
     use std::collections::BTreeMap;
 
     const DEFAULT_ITEMS_PER_BLOB: u64 = 1000;

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2589,7 +2589,7 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_runtime::{deterministic, Runner as _, Supervisor as _};
     use commonware_utils::test_rng;
-    use rand::Rng;
+    use rand::RngExt as _;
 
     const BITMAP_CHUNK_BITS: u64 = bitmap::Prunable::<BITMAP_CHUNK_BYTES>::CHUNK_SIZE_BITS;
 
@@ -2614,11 +2614,11 @@ mod tests {
         let mut rng = test_rng();
         for _ in 0..50 {
             // Build 1-4 sorted diffs over a small key universe so overlaps are common.
-            let num_diffs = rng.gen_range(1..=4);
+            let num_diffs = rng.random_range(1..=4);
             let diffs: Vec<DiffVec<u64, mmr::Family, u64>> = (0..num_diffs)
                 .map(|d| {
-                    let mut keys: Vec<u64> = (0..rng.gen_range(0..30))
-                        .map(|_| rng.gen_range(0..50u64))
+                    let mut keys: Vec<u64> = (0..rng.random_range(0..30))
+                        .map(|_| rng.random_range(0..50u64))
                         .collect();
                     keys.sort_unstable();
                     keys.dedup();
@@ -2638,8 +2638,8 @@ mod tests {
                 .collect();
 
             // Ascending queries spanning the universe (with gaps and duplicates).
-            let mut queries: Vec<u64> = (0..rng.gen_range(1..60))
-                .map(|_| rng.gen_range(0..55u64))
+            let mut queries: Vec<u64> = (0..rng.random_range(1..60))
+                .map(|_| rng.random_range(0..55u64))
                 .collect();
             queries.sort_unstable();
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -156,7 +156,7 @@ pub(crate) mod test {
     };
     use commonware_utils::{sequence::FixedBytes, test_rng_seeded, NZU64};
     use futures::StreamExt as _;
-    use rand::{rngs::StdRng, seq::IteratorRandom, RngCore, SeedableRng};
+    use rand::{rngs::StdRng, seq::IteratorRandom, Rng, SeedableRng};
     use std::collections::{BTreeMap, HashMap};
 
     /// A generic type alias for an Any database parameterized by merkle family.

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -325,7 +325,7 @@ mod test {
     use commonware_runtime::{deterministic::Context, Supervisor as _};
     use commonware_utils::{sequence::FixedBytes, test_rng};
     use core::{future::Future, pin::Pin};
-    use rand::Rng;
+    use rand::RngExt as _;
 
     /// [`find_next_key_ascending`] must return exactly what [`find_next_key`] returns for any
     /// ascending query sequence, including queries past the last candidate (cyclic wrap).
@@ -333,14 +333,14 @@ mod test {
     fn find_next_key_ascending_matches_binary_search() {
         let mut rng = test_rng();
         for _ in 0..50 {
-            let mut candidates: Vec<u64> = (0..rng.gen_range(1..40))
-                .map(|_| rng.gen_range(0..60u64))
+            let mut candidates: Vec<u64> = (0..rng.random_range(1..40))
+                .map(|_| rng.random_range(0..60u64))
                 .collect();
             candidates.sort_unstable();
             candidates.dedup();
 
-            let mut queries: Vec<u64> = (0..rng.gen_range(1..80))
-                .map(|_| rng.gen_range(0..70u64))
+            let mut queries: Vec<u64> = (0..rng.random_range(1..80))
+                .map(|_| rng.random_range(0..70u64))
                 .collect();
             queries.sort_unstable();
 

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -159,7 +159,7 @@ pub(crate) mod test {
         BufferPooler, Runner as _, Supervisor as _,
     };
     use commonware_utils::{sequence::FixedBytes, test_rng_seeded, NZUsize, NZU16, NZU64};
-    use rand::RngCore;
+    use rand::Rng;
     // Janky page & cache sizes to exercise boundary conditions.
     const PAGE_SIZE: u16 = 103;
     const PAGE_CACHE_SIZE: usize = 13;
@@ -456,7 +456,7 @@ pub(crate) mod test {
             let base = db.to_batch();
 
             // Parent batch: insert key_a.
-            let key_a = Digest::random(&mut test_rng_seeded(800));
+            let key_a = Digest::random(test_rng_seeded(800));
             let val_a = vec![1u8; 10];
             let parent_batch = base
                 .new_batch::<Sha256>()
@@ -466,7 +466,7 @@ pub(crate) mod test {
                 .unwrap();
 
             // Child batch: insert key_b.
-            let key_b = Digest::random(&mut test_rng_seeded(801));
+            let key_b = Digest::random(test_rng_seeded(801));
             let val_b = vec![2u8; 10];
             let child_batch = parent_batch
                 .new_batch::<Sha256>()
@@ -504,7 +504,7 @@ pub(crate) mod test {
 
             let base = db.to_batch();
 
-            let key_x = Digest::random(&mut test_rng_seeded(810));
+            let key_x = Digest::random(test_rng_seeded(810));
             let val_x = vec![10u8; 8];
             let parent_batch = base
                 .new_batch::<Sha256>()
@@ -548,7 +548,7 @@ pub(crate) mod test {
 
             let base = db.to_batch();
 
-            let key_x = Digest::random(&mut test_rng_seeded(820));
+            let key_x = Digest::random(test_rng_seeded(820));
             let val_a = vec![10u8; 8];
             let parent_batch = base
                 .new_batch::<Sha256>()

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -32,7 +32,7 @@ use commonware_utils::{
     NZU64,
 };
 use futures::{pin_mut, FutureExt};
-use rand::RngCore as _;
+use rand::Rng as _;
 use std::{
     num::NonZeroU64,
     sync::{
@@ -2100,7 +2100,7 @@ mod harnesses {
     use commonware_math::algebra::Random;
     use commonware_runtime::{deterministic::Context, BufferPooler};
     use commonware_utils::test_rng_seeded;
-    use rand::RngCore;
+    use rand::Rng;
 
     // ===== Family-generic op creation helpers =====
     //

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -143,7 +143,7 @@ pub(crate) mod test {
     };
     use commonware_utils::{test_rng_seeded, NZUsize, NZU64};
     use core::num::NonZeroUsize;
-    use rand::RngCore;
+    use rand::Rng;
     use std::collections::HashMap;
 
     /// A generic type alias for an Any database parameterized by merkle family.

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -144,7 +144,7 @@ pub(crate) mod test {
         BufferPooler, Runner as _, Supervisor as _,
     };
     use commonware_utils::{test_rng_seeded, NZUsize, NZU16, NZU64};
-    use rand::RngCore;
+    use rand::Rng;
     use std::{
         num::{NonZeroU16, NonZeroUsize},
         sync::Arc,
@@ -872,7 +872,7 @@ pub(crate) mod test {
             let base = db.to_batch();
 
             // Build a child batch via owned API, merkleize, and apply.
-            let key = Digest::random(&mut commonware_utils::test_rng_seeded(200));
+            let key = Digest::random(commonware_utils::test_rng_seeded(200));
             let value = vec![42u8; 16];
             let child_batch = base
                 .new_batch::<Sha256>()
@@ -907,7 +907,7 @@ pub(crate) mod test {
             let base = db.to_batch();
 
             // Parent batch (via owned API).
-            let key_a = Digest::random(&mut commonware_utils::test_rng_seeded(300));
+            let key_a = Digest::random(commonware_utils::test_rng_seeded(300));
             let val_a = vec![1u8; 10];
             let parent_batch = base
                 .new_batch::<Sha256>()
@@ -917,7 +917,7 @@ pub(crate) mod test {
                 .unwrap();
 
             // Child batch (built on parent batch).
-            let key_b = Digest::random(&mut commonware_utils::test_rng_seeded(301));
+            let key_b = Digest::random(commonware_utils::test_rng_seeded(301));
             let val_b = vec![2u8; 10];
             let child_batch = parent_batch
                 .new_batch::<Sha256>()
@@ -954,7 +954,7 @@ pub(crate) mod test {
             let base = db.to_batch();
 
             // Fork A.
-            let key_a = Digest::random(&mut commonware_utils::test_rng_seeded(400));
+            let key_a = Digest::random(commonware_utils::test_rng_seeded(400));
             let fork_a = base
                 .new_batch::<Sha256>()
                 .write(key_a, Some(vec![10u8; 8]))
@@ -963,7 +963,7 @@ pub(crate) mod test {
                 .unwrap();
 
             // Fork B (different key, same parent).
-            let key_b = Digest::random(&mut commonware_utils::test_rng_seeded(401));
+            let key_b = Digest::random(commonware_utils::test_rng_seeded(401));
             let fork_b = base
                 .new_batch::<Sha256>()
                 .write(key_b, Some(vec![20u8; 8]))
@@ -1012,7 +1012,7 @@ pub(crate) mod test {
             let mut collection: HashMap<sha256::Digest, Arc<Snap>> = HashMap::new();
 
             // Depth 1.
-            let key = Digest::random(&mut commonware_utils::test_rng_seeded(500));
+            let key = Digest::random(commonware_utils::test_rng_seeded(500));
             let batch1 = base
                 .new_batch::<Sha256>()
                 .write(key, Some(vec![1u8; 8]))
@@ -1024,7 +1024,7 @@ pub(crate) mod test {
             // Depth 2 (retrieve batch1 from collection, build child).
             let batch1_root = *collection.keys().next().unwrap();
             let batch1_ref = collection.get(&batch1_root).unwrap();
-            let key = Digest::random(&mut commonware_utils::test_rng_seeded(501));
+            let key = Digest::random(commonware_utils::test_rng_seeded(501));
             let batch2 = batch1_ref
                 .new_batch::<Sha256>()
                 .write(key, Some(vec![2u8; 8]))
@@ -1053,7 +1053,7 @@ pub(crate) mod test {
             let base = db.to_batch();
 
             // Parent batch: insert key_x.
-            let key_x = Digest::random(&mut commonware_utils::test_rng_seeded(700));
+            let key_x = Digest::random(commonware_utils::test_rng_seeded(700));
             let val_a = vec![10u8; 8];
             let parent_batch = base
                 .new_batch::<Sha256>()
@@ -1099,7 +1099,7 @@ pub(crate) mod test {
             let base = db.to_batch();
 
             // Parent batch: insert key_x with value_a.
-            let key_x = Digest::random(&mut commonware_utils::test_rng_seeded(600));
+            let key_x = Digest::random(commonware_utils::test_rng_seeded(600));
             let val_a = vec![10u8; 8];
             let parent_batch = base
                 .new_batch::<Sha256>()
@@ -1148,7 +1148,7 @@ pub(crate) mod test {
             let base = db.to_batch();
 
             // Grandparent: insert key_a.
-            let key_a = Digest::random(&mut commonware_utils::test_rng_seeded(900));
+            let key_a = Digest::random(commonware_utils::test_rng_seeded(900));
             let val_a = vec![1u8; 10];
             let grandparent_batch = base
                 .new_batch::<Sha256>()
@@ -1158,7 +1158,7 @@ pub(crate) mod test {
                 .unwrap();
 
             // Parent: insert key_b.
-            let key_b = Digest::random(&mut commonware_utils::test_rng_seeded(901));
+            let key_b = Digest::random(commonware_utils::test_rng_seeded(901));
             let val_b = vec![2u8; 10];
             let parent_batch = grandparent_batch
                 .new_batch::<Sha256>()
@@ -1168,7 +1168,7 @@ pub(crate) mod test {
                 .unwrap();
 
             // Child: insert key_c.
-            let key_c = Digest::random(&mut commonware_utils::test_rng_seeded(902));
+            let key_c = Digest::random(commonware_utils::test_rng_seeded(902));
             let val_c = vec![3u8; 10];
             let child_batch = parent_batch
                 .new_batch::<Sha256>()
@@ -1211,7 +1211,7 @@ pub(crate) mod test {
             db.commit().await.unwrap();
 
             let base = db.to_batch();
-            let key_x = Digest::random(&mut commonware_utils::test_rng_seeded(910));
+            let key_x = Digest::random(commonware_utils::test_rng_seeded(910));
 
             // Grandparent: insert key_x = val_a.
             let val_a = vec![10u8; 8];
@@ -1272,7 +1272,7 @@ pub(crate) mod test {
             db.commit().await.unwrap();
 
             // Chain: DB <-- a <-- b
-            let key_a = Digest::random(&mut commonware_utils::test_rng_seeded(800));
+            let key_a = Digest::random(commonware_utils::test_rng_seeded(800));
             let val_a = vec![10u8; 8];
             let a = db
                 .new_batch()
@@ -1281,7 +1281,7 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            let key_b = Digest::random(&mut commonware_utils::test_rng_seeded(801));
+            let key_b = Digest::random(commonware_utils::test_rng_seeded(801));
             let val_b = vec![20u8; 8];
             let b = a
                 .new_batch::<Sha256>()
@@ -1295,7 +1295,7 @@ pub(crate) mod test {
             db.commit().await.unwrap();
 
             // Build c from b. This must not panic despite a being freed.
-            let key_c = Digest::random(&mut commonware_utils::test_rng_seeded(802));
+            let key_c = Digest::random(commonware_utils::test_rng_seeded(802));
             let val_c = vec![30u8; 8];
             let c = b
                 .new_batch::<Sha256>()
@@ -1337,7 +1337,7 @@ pub(crate) mod test {
             let base = db.to_batch();
 
             // Chain: base <-- a <-- b <-- c
-            let key_a = Digest::random(&mut commonware_utils::test_rng_seeded(700));
+            let key_a = Digest::random(commonware_utils::test_rng_seeded(700));
             let val_a = vec![1u8; 10];
             let a = base
                 .new_batch::<Sha256>()
@@ -1346,7 +1346,7 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            let key_b = Digest::random(&mut commonware_utils::test_rng_seeded(701));
+            let key_b = Digest::random(commonware_utils::test_rng_seeded(701));
             let val_b = vec![2u8; 10];
             let b = a
                 .new_batch::<Sha256>()
@@ -1355,7 +1355,7 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            let key_c = Digest::random(&mut commonware_utils::test_rng_seeded(702));
+            let key_c = Digest::random(commonware_utils::test_rng_seeded(702));
             let val_c = vec![3u8; 10];
             let c = b
                 .new_batch::<Sha256>()

--- a/storage/src/qmdb/benches/apply_batch.rs
+++ b/storage/src/qmdb/benches/apply_batch.rs
@@ -17,7 +17,7 @@ use commonware_storage::{
 };
 use commonware_utils::NZU64;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{
     num::NonZeroU64,
     time::{Duration, Instant},

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -28,7 +28,7 @@ use commonware_storage::{
     translator::EightCap,
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
-use rand::{distributions::Distribution, rngs::StdRng, RngCore, SeedableRng};
+use rand::{distr::Distribution, rngs::StdRng, Rng, SeedableRng};
 use rand_distr::Zipf;
 use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
 
@@ -639,7 +639,8 @@ pub async fn gen_random_kv<F, M>(
         // Sample over the full keyspace (which may exceed the seeded set, so some samples hit unseeded
         // keys and insert them). `Zipf::new` samples a rank in `[1, space]`; map it to a 0-based index.
         let space = keyspace.unwrap_or(num_elements);
-        let zipf = key_zipf_exponent.map(|s| Zipf::new(space, s).expect("valid zipf parameters"));
+        let zipf =
+            key_zipf_exponent.map(|s| Zipf::new(space as f64, s).expect("valid zipf parameters"));
         let mut batch = db.new_batch();
         for _ in 0u64..num_operations {
             let idx = match &zipf {

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -38,7 +38,7 @@ use commonware_storage::{
     translator::EightCap,
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{
     hint::black_box,
     num::{NonZeroU16, NonZeroU64, NonZeroUsize},

--- a/storage/src/qmdb/benches/generate.rs
+++ b/storage/src/qmdb/benches/generate.rs
@@ -18,7 +18,7 @@ use commonware_storage::{
     qmdb::any::traits::DbAny,
 };
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::time::{Duration, Instant};
 
 const NUM_ELEMENTS: u64 = 1_000;

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -529,7 +529,7 @@ pub mod tests {
     use commonware_utils::{bitmap::Readable, NZUsize, NZU16, NZU64};
     use core::future::Future;
     use ordered::tests::test_build_small_close_reopen as test_ordered_build_small_close_reopen;
-    use rand::{rngs::StdRng, RngCore, SeedableRng};
+    use rand::{rngs::StdRng, Rng, SeedableRng};
     use std::{
         num::{NonZeroU16, NonZeroUsize},
         sync::Arc,

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -182,7 +182,7 @@ pub mod tests {
         NZU64,
     };
     use core::future::Future;
-    use rand::RngCore;
+    use rand::Rng;
 
     /// Concrete db type used in the shared proof tests, generic over journal (`C`) and value
     /// encoding (`V`).

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -25,7 +25,7 @@ use commonware_runtime::{
     deterministic, deterministic::Context, BufferPooler, Runner as _, Supervisor as _,
 };
 use commonware_utils::non_empty_range;
-use rand::RngCore as _;
+use rand::Rng as _;
 
 // ===== Harness Implementations =====
 

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -114,7 +114,7 @@ pub mod test {
     use commonware_macros::test_traced;
     use commonware_runtime::{deterministic, Metrics, Runner as _, Supervisor as _};
     use commonware_utils::test_rng_seeded;
-    use rand::RngCore as _;
+    use rand::Rng as _;
     use std::collections::HashMap;
 
     /// A type alias for the concrete [Db] type used in these unit tests.

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -46,7 +46,7 @@ pub mod tests {
         NZU64,
     };
     use core::future::Future;
-    use rand::RngCore;
+    use rand::Rng;
 
     /// Concrete db type used in the shared proof tests, generic over journal (`C`) and value
     /// encoding (`V`).

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -29,7 +29,7 @@ use commonware_runtime::{
 };
 use commonware_utils::{channel::mpsc, non_empty_range, test_rng_seeded, NZUsize, NZU16, NZU64};
 use harnesses::VariableMmrHarness as H;
-use rand::RngCore as _;
+use rand::Rng as _;
 use std::{
     collections::{HashMap, VecDeque},
     future::Future,

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -26,7 +26,7 @@ use commonware_runtime::{
 };
 use commonware_utils::{channel::mpsc, non_empty_range, test_rng_seeded, NZUsize, NZU16, NZU64};
 use harnesses::VariableMmrHarness as H;
-use rand::RngCore as _;
+use rand::Rng as _;
 use std::{
     collections::VecDeque,
     future::Future,

--- a/storage/src/queue/conformance.rs
+++ b/storage/src/queue/conformance.rs
@@ -8,7 +8,7 @@ use commonware_runtime::{
 };
 use commonware_utils::{NZUsize, NZU16, NZU64};
 use core::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
-use rand::Rng;
+use rand::RngExt as _;
 
 const WRITE_BUFFER: NonZeroUsize = NZUsize!(1024);
 const ITEMS_PER_SECTION: NonZeroU64 = NZU64!(64);
@@ -40,10 +40,10 @@ impl Conformance for QueueConformance {
             .unwrap();
 
             // Enqueue random variable-length items across multiple sections
-            let items_count = context.gen_range(1..(ITEMS_PER_SECTION.get() as usize) * 4);
+            let items_count = context.random_range(1..(ITEMS_PER_SECTION.get() as usize) * 4);
             let mut data = vec![Vec::new(); items_count];
             for item in data.iter_mut() {
-                let size = context.gen_range(0..256);
+                let size = context.random_range(0..256);
                 item.resize(size, 0);
                 context.fill(item.as_mut_slice());
             }

--- a/stream/src/encrypted.rs
+++ b/stream/src/encrypted.rs
@@ -72,7 +72,7 @@ use commonware_runtime::{
     Stream,
 };
 use commonware_utils::SystemTimeExt;
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 use std::{future::Future, ops::Range, time::Duration};
 use thiserror::Error;
 
@@ -184,7 +184,7 @@ where
 
 /// Establishes an authenticated connection to a peer as the dialer.
 /// Returns sender and receiver for encrypted communication.
-pub async fn dial<R: BufferPooler + CryptoRngCore + Clock, S: Signer, I: Stream, O: Sink>(
+pub async fn dial<R: BufferPooler + CryptoRng + Clock, S: Signer, I: Stream, O: Sink>(
     ctx: R,
     config: Config<S>,
     peer: S::PublicKey,
@@ -244,7 +244,7 @@ pub async fn dial<R: BufferPooler + CryptoRngCore + Clock, S: Signer, I: Stream,
 /// Accepts an authenticated connection from a peer as the listener.
 /// Returns the peer's identity, sender, and receiver for encrypted communication.
 pub async fn listen<
-    R: BufferPooler + CryptoRngCore + Clock,
+    R: BufferPooler + CryptoRng + Clock,
     S: Signer,
     I: Stream,
     O: Sink,

--- a/stream/src/utils/codec.rs
+++ b/stream/src/utils/codec.rs
@@ -131,7 +131,7 @@ mod tests {
     use commonware_runtime::{
         deterministic, mocks, BufMut, IoBufMut, Runner, Spawner, Supervisor as _,
     };
-    use rand::Rng;
+    use rand::RngExt as _;
 
     const MAX_MESSAGE_SIZE: u32 = 1024;
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -36,8 +36,14 @@ tracing = { workspace = true, optional = true }
 zeroize.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
-# Enable "js" feature when WASM is target
-version = "0.2.15"
+# Enable the JS backend for transitive dependencies that use getrandom on WASM.
+version = "0.4.3"
+features = ["wasm_js"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom_v2]
+# Enable the JS backend for transitive dependencies that still use getrandom 0.2 on WASM.
+package = "getrandom"
+version = "0.2"
 features = ["js"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom_v3]
@@ -68,6 +74,7 @@ std = [
 	"commonware-macros/std",
 	"futures",
 	"getrandom/std",
+	"getrandom_v2/std",
 	"getrandom_v3/std",
 	"num-bigint",
 	"num-bigint?/std",

--- a/utils/conformance.toml
+++ b/utils/conformance.toml
@@ -60,7 +60,7 @@ hash = "325e95b11c01813a05e248096ac421c3224dd0ca5b9af362291bd568b473a4fc"
 
 ["commonware_utils::rng::tests::conformance::FuzzRngConformance"]
 n_cases = 1024
-hash = "d0183ff92294532c435ef0bdb5735f25d16ec633adc7324f885d8b8117389134"
+hash = "98c11adc87998940c19bf9c9ce8554ce91409e81375078b99f511fbb64cf3e79"
 
 ["commonware_utils::sequence::fixed_bytes::tests::conformance::CodecConformance<FixedBytes<16>>"]
 n_cases = 65536

--- a/utils/src/bitmap/benches/count_ones.rs
+++ b/utils/src/bitmap/benches/count_ones.rs
@@ -1,13 +1,13 @@
 use commonware_utils::bitmap::BitMap;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::hint::black_box;
 
 fn bench_count_ones<const CHUNK_SIZE: usize>(c: &mut Criterion, size: u64) {
     let mut rng = StdRng::seed_from_u64(size);
     let mut bitmap = BitMap::<CHUNK_SIZE>::with_capacity(size);
     for _ in 0..size {
-        bitmap.push(rng.gen::<bool>());
+        bitmap.push(rng.random::<bool>());
     }
     c.bench_function(
         &format!("{}/size={size} chunk_size={CHUNK_SIZE}", module_path!()),

--- a/utils/src/bitmap/historical/tests.rs
+++ b/utils/src/bitmap/historical/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::bitmap::Prunable;
 use commonware_formatting::hex;
+use rand::RngExt as _;
 
 /// Test basic dirty lifecycle: creation, operations, commit, and abort.
 #[test]
@@ -879,11 +880,11 @@ fn test_randomized_helper<R: rand::Rng>(rng: &mut R) {
 
         for _ in 0..OPERATIONS_PER_COMMIT {
             // Pick a random operation based on probability distribution
-            let op_choice = rng.gen_range(0..100);
+            let op_choice = rng.random_range(0..100);
 
             // Special case: if bitmap is empty, we can only push
             if current_len == 0 {
-                let bit_value = rng.gen_bool(0.5);
+                let bit_value = rng.random_bool(0.5);
                 dirty.push(bit_value);
                 ground_truth.push(bit_value);
                 current_len += 1;
@@ -892,15 +893,15 @@ fn test_randomized_helper<R: rand::Rng>(rng: &mut R) {
 
             // Operation: PUSH (55% probability)
             if op_choice < PROB_PUSH {
-                let bit_value = rng.gen_bool(0.5);
+                let bit_value = rng.random_bool(0.5);
                 dirty.push(bit_value);
                 ground_truth.push(bit_value);
                 current_len += 1;
             }
             // Operation: MODIFY existing bit (20% probability)
             else if op_choice < PROB_MODIFY {
-                let bit = rng.gen_range(0..current_len);
-                let new_value = rng.gen_bool(0.5);
+                let bit = rng.random_range(0..current_len);
+                let new_value = rng.random_bool(0.5);
 
                 // Safety: Only modify bits that aren't pruned
                 let chunk_idx = Prunable::<4>::to_chunk_index(bit);
@@ -924,7 +925,7 @@ fn test_randomized_helper<R: rand::Rng>(rng: &mut R) {
                 // Only prune if there's at least one unpruned complete chunk we can prune
                 if max_prune_chunk > current_pruned {
                     // Randomly pick a chunk boundary to prune to (between current_pruned+1 and max)
-                    let prune_chunk = rng.gen_range((current_pruned + 1)..=max_prune_chunk);
+                    let prune_chunk = rng.random_range((current_pruned + 1)..=max_prune_chunk);
                     let prune_to = (prune_chunk as u64) * CHUNK_SIZE_BITS;
 
                     dirty.prune_to_bit(prune_to);

--- a/utils/src/bitmap/roaring/container/bitmap.rs
+++ b/utils/src/bitmap/roaring/container/bitmap.rs
@@ -948,12 +948,12 @@ mod tests {
         // Property: incremental run_count tracking from `insert` must agree with the
         // bulk `count_runs` scan over the same word array.
         use crate::test_rng;
-        use rand::Rng;
+        use rand::RngExt as _;
 
         let mut rng = test_rng();
         let mut b = Bitmap::new();
         for _ in 0..2000 {
-            let v: u16 = rng.gen();
+            let v: u16 = rng.random();
             b.insert(v);
         }
         // The cached field is what callers see; the scan is the ground truth.

--- a/utils/src/cache/benches/get.rs
+++ b/utils/src/cache/benches/get.rs
@@ -1,6 +1,6 @@
 use commonware_utils::cache::Clock;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{hint::black_box, num::NonZeroUsize};
 
 /// Benchmarks the cache-hit read path: a full cache, all lookups present.
@@ -12,7 +12,7 @@ fn bench_get(c: &mut Criterion) {
         }
         let mut rng = StdRng::seed_from_u64(capacity as u64);
         let keys: Vec<u64> = (0..1024)
-            .map(|_| rng.gen_range(0..capacity as u64))
+            .map(|_| rng.random_range(0..capacity as u64))
             .collect();
         c.bench_function(&format!("{}/capacity={capacity}", module_path!()), |b| {
             b.iter(|| {

--- a/utils/src/cache/benches/insert.rs
+++ b/utils/src/cache/benches/insert.rs
@@ -1,6 +1,6 @@
 use commonware_utils::cache::Clock;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{hint::black_box, num::NonZeroUsize};
 
 /// Benchmarks the steady-state insert path under churn: a full cache with a
@@ -14,7 +14,7 @@ fn bench_insert(c: &mut Criterion) {
             cache.put(i, i);
         }
         let mut rng = StdRng::seed_from_u64(capacity as u64);
-        let keys: Vec<u64> = (0..1024).map(|_| rng.gen_range(0..working)).collect();
+        let keys: Vec<u64> = (0..1024).map(|_| rng.random_range(0..working)).collect();
         c.bench_function(&format!("{}/capacity={capacity}", module_path!()), |b| {
             b.iter(|| {
                 for k in &keys {

--- a/utils/src/cache/benches/mixed.rs
+++ b/utils/src/cache/benches/mixed.rs
@@ -1,6 +1,6 @@
 use commonware_utils::cache::Clock;
 use criterion::{criterion_group, Criterion};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 use std::{hint::black_box, num::NonZeroUsize};
 
 /// Benchmarks a read-heavy mix under churn: 8 hits per miss insert, so resident
@@ -19,7 +19,7 @@ fn bench_mixed(c: &mut Criterion) {
             .map(|round| {
                 let mut reads = [0u64; 8];
                 for slot in &mut reads {
-                    *slot = rng.gen_range(0..capacity as u64);
+                    *slot = rng.random_range(0..capacity as u64);
                 }
                 (reads, u64::MAX - round)
             })

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -336,7 +336,7 @@ mod tests {
     use super::*;
     use commonware_formatting::hex;
     use num_bigint::BigUint;
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use rand::{rngs::StdRng, RngExt as _, SeedableRng};
 
     #[test]
     fn test_union() {
@@ -415,7 +415,7 @@ mod tests {
         // Test case 3: check equivalence with BigUint
         for i in 0..100 {
             let mut rng = StdRng::seed_from_u64(i);
-            let bytes: [u8; 32] = rng.gen();
+            let bytes: [u8; 32] = rng.random();
 
             // 1-byte modulus
             let n = 11u64;

--- a/utils/src/rng.rs
+++ b/utils/src/rng.rs
@@ -1,7 +1,7 @@
 //! Utilities for random number generation.
 
-use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng};
-use std::mem::size_of;
+use core::{convert::Infallible, mem::size_of};
+use rand::{rngs::StdRng, SeedableRng, TryCryptoRng, TryRng};
 
 /// Returns a seeded RNG for deterministic testing.
 ///
@@ -131,22 +131,8 @@ impl FuzzRng {
         self.ctr = self.ctr.wrapping_add(1);
         mix64(word ^ ctr ^ crate::GOLDEN_RATIO)
     }
-}
 
-impl RngCore for FuzzRng {
-    fn next_u32(&mut self) -> u32 {
-        let mut buf = [0u8; 4];
-        self.fill_bytes(&mut buf);
-        u32::from_be_bytes(buf)
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        let mut buf = [0u8; BLOCK_BYTES];
-        self.fill_bytes(&mut buf);
-        u64::from_be_bytes(buf)
-    }
-
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
+    fn fill_bytes_stream(&mut self, dest: &mut [u8]) {
         let mut written = 0;
         while written < dest.len() {
             if self.cache_pos == self.cache.len() {
@@ -167,9 +153,25 @@ impl RngCore for FuzzRng {
             written += take;
         }
     }
+}
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.fill_bytes(dest);
+impl TryRng for FuzzRng {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        let mut buf = [0u8; 4];
+        self.fill_bytes_stream(&mut buf);
+        Ok(u32::from_be_bytes(buf))
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let mut buf = [0u8; BLOCK_BYTES];
+        self.fill_bytes_stream(&mut buf);
+        Ok(u64::from_be_bytes(buf))
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        self.fill_bytes_stream(dest);
         Ok(())
     }
 }
@@ -177,11 +179,12 @@ impl RngCore for FuzzRng {
 // SAFETY: FuzzRng is not cryptographically secure. It implements CryptoRng
 // only because the consensus fuzzer requires CryptoRng-bounded RNG. This type
 // must never be used outside of fuzz/test contexts.
-impl CryptoRng for FuzzRng {}
+impl TryCryptoRng for FuzzRng {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::Rng;
 
     #[test]
     fn test_empty_bytes_not_constant() {
@@ -373,7 +376,7 @@ mod tests {
     mod conformance {
         use super::*;
         use commonware_conformance::Conformance;
-        use rand::Rng;
+        use rand::RngExt as _;
 
         /// Conformance wrapper for FuzzRng that tests output stability.
         ///
@@ -385,7 +388,7 @@ mod tests {
         impl Conformance for FuzzRngConformance {
             async fn commit(seed: u64) -> Vec<u8> {
                 let mut seed_rng = test_rng_seeded(seed);
-                let len = seed_rng.gen_range(1..=64);
+                let len = seed_rng.random_range(1..=64);
                 let mut input = vec![0u8; len];
                 seed_rng.fill_bytes(&mut input);
 

--- a/utils/src/time.rs
+++ b/utils/src/time.rs
@@ -1,6 +1,6 @@
 //! Utility functions for `std::time`.
 
-use rand::Rng;
+use rand::{Rng, RngExt as _};
 use std::time::{Duration, SystemTime};
 
 /// Number of nanoseconds in a second.
@@ -194,7 +194,7 @@ impl SystemTimeExt for SystemTime {
     }
 
     fn add_jittered(&self, rng: &mut impl Rng, jitter: Duration) -> SystemTime {
-        *self + rng.gen_range(Duration::default()..=jitter * 2)
+        *self + rng.random_range(Duration::default()..=jitter * 2)
     }
 
     fn limit() -> SystemTime {


### PR DESCRIPTION
## Overview

> [!NOTE]
> Need to wait the cooldown? `curve25519-dalek` `5.0.0` just got released.

The `rand` ecosystem has been undergoing a large upgrade over the last few months, and all of our dependencies have now landed on the new version. This PR upgrades `rand` and its ecosystem to `^0.10.0`.

Related: #1841 