### PR TITLE
[storage] [runtime] Make contiguous journal blob rollover cancellation-safe

### DIFF
--- a/glue/src/simulate/plan.rs
+++ b/glue/src/simulate/plan.rs
@@ -226,7 +226,7 @@ impl<D: EngineDefinition> PlanBuilder<D> {
     }
 
     /// Enable deterministic storage fault injection for the simulation.
-    pub const fn with_storage_fault(mut self, faults: deterministic::FaultConfig) -> Self {
+    pub fn with_storage_fault(mut self, faults: deterministic::FaultConfig) -> Self {
         self.storage_fault = Some(faults);
         self
     }

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -298,7 +298,7 @@ impl Config {
     /// When set, the runtime will inject deterministic storage errors based on
     /// the provided configuration. Faults are drawn from the shared RNG, ensuring
     /// reproducible failure patterns for a given seed.
-    pub const fn with_storage_fault_config(mut self, faults: FaultConfig) -> Self {
+    pub fn with_storage_fault_config(mut self, faults: FaultConfig) -> Self {
         self.storage_fault_cfg = faults;
         self
     }

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -61,6 +61,14 @@ pub struct Config {
 
     /// Failure rate for `scan` operations.
     pub scan_rate: Option<f64>,
+
+    /// Blob (partition, name) whose next write parks forever, letting tests drop a future
+    /// mid-write. Cleared when it fires.
+    pub stall_write: Option<(String, Vec<u8>)>,
+
+    /// Blob (partition, name) whose next open parks forever (before any filesystem work),
+    /// letting tests drop a future mid-open. Cleared when it fires.
+    pub stall_open: Option<(String, Vec<u8>)>,
 }
 
 impl Config {
@@ -144,6 +152,32 @@ impl Oracle {
     /// Check if a fault should be injected for the given operation.
     fn should_fail(&self, op: Op) -> bool {
         self.roll(Some(self.config.read().rate_for(op)))
+    }
+
+    /// Park forever if a write stall targets this blob, clearing the stall first.
+    async fn stall_write(&self, partition: &str, name: &[u8]) {
+        let fired = self
+            .config
+            .write()
+            .stall_write
+            .take_if(|(p, n)| p == partition && n == name)
+            .is_some();
+        if fired {
+            futures::future::pending::<()>().await;
+        }
+    }
+
+    /// Park forever if an open stall targets this blob, clearing the stall first.
+    async fn stall_open(&self, partition: &str, name: &[u8]) {
+        let fired = self
+            .config
+            .write()
+            .stall_open
+            .take_if(|(p, n)| p == partition && n == name)
+            .is_some();
+        if fired {
+            futures::future::pending::<()>().await;
+        }
     }
 
     /// Check if a write fault should be injected. Returns (should_fail, partial_rate).
@@ -240,6 +274,7 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
         name: &[u8],
         versions: std::ops::RangeInclusive<u16>,
     ) -> Result<(Self::Blob, u64, u16), Error> {
+        self.ctx.stall_open(partition, name).await;
         if self.ctx.should_fail(Op::Open) {
             return Err(injected_io_error().into());
         }
@@ -247,7 +282,11 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
             .open_versioned(partition, name, versions)
             .await
             .map(|(blob, len, blob_version)| {
-                (Blob::new(self.ctx.clone(), blob, len), len, blob_version)
+                (
+                    Blob::new(self.ctx.clone(), blob, len, partition, name),
+                    len,
+                    blob_version,
+                )
             })
     }
 
@@ -273,14 +312,19 @@ pub struct Blob<B: crate::Blob> {
     ctx: Oracle,
     /// Tracked size for partial resize support.
     size: Arc<AtomicU64>,
+    /// Identity for stall targeting.
+    partition: String,
+    name: Vec<u8>,
 }
 
 impl<B: crate::Blob> Blob<B> {
-    fn new(ctx: Oracle, inner: B, size: u64) -> Self {
+    fn new(ctx: Oracle, inner: B, size: u64, partition: &str, name: &[u8]) -> Self {
         Self {
             inner,
             ctx,
             size: Arc::new(AtomicU64::new(size)),
+            partition: partition.into(),
+            name: name.into(),
         }
     }
 }
@@ -306,6 +350,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
     }
 
     async fn write_at(&self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
+        self.ctx.stall_write(&self.partition, &self.name).await;
         let bufs = bufs.into();
         let total_bytes = bufs.remaining() as u64;
 
@@ -335,6 +380,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
+        self.ctx.stall_write(&self.partition, &self.name).await;
         let bufs = bufs.into();
         let total_bytes = bufs.remaining() as u64;
         if total_bytes == 0 {

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -244,10 +244,7 @@ mod tests {
             ];
             for (offset, len) in cases {
                 let read = sealed.read_at(offset, len).await.unwrap().coalesce();
-                assert_eq!(
-                    read.as_ref(),
-                    &data[offset as usize..offset as usize + len]
-                );
+                assert_eq!(read.as_ref(), &data[offset as usize..offset as usize + len]);
             }
         });
     }
@@ -788,5 +785,4 @@ mod tests {
             assert_eq!(buf, data);
         });
     }
-
 }

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -3,11 +3,10 @@
 //!
 //! # Sealing and durability
 //!
-//! [`super::Writer::seal`] consumes the write handle and returns a [`Sealed`] handle without
-//! fsyncing the underlying blob. Buffered logical bytes are flushed to the blob (so subsequent
-//! reads observe them), but a crash before [`Sealed::sync`] may lose the most recently sealed
-//! bytes. Callers that need durability must invoke [`Sealed::sync`] (typically driven from a
-//! higher-level commit path).
+//! A [`Sealed`] is created by [`super::Writer::snapshot`] or [`super::Writer::roll`], both of
+//! which flush first, so every byte of the view has been written to the blob. Sealing does
+//! not make bytes durable: call [`Sealed::sync`] (or sync the writer beforehand) if they must
+//! survive a crash.
 //!
 //! # Cheap sharing
 //!
@@ -51,14 +50,16 @@ struct SealedInner<B: Blob> {
     /// Reference to the page cache used for reads of full pages.
     cache_ref: CacheRef,
 
-    /// Page-cache id. [`super::Writer::seal`] preserves the writer id so hot full pages remain
+    /// Page-cache id. [`super::Writer::roll`] preserves the writer id so hot full pages remain
     /// valid across the transition. [`super::Writer::snapshot`] uses a fresh id because the writer
     /// can keep mutating its own cache namespace.
     id: u64,
 }
 
 impl<B: Blob> Sealed<B> {
-    /// Construct a [`Sealed`] from already-validated parts. Invoked by [`super::Writer::seal`].
+    /// Construct a [`Sealed`] from already-validated parts. Invoked by
+    /// [`super::Writer::snapshot`] and [`super::Writer::roll`], which flush before constructing
+    /// the view.
     pub(super) fn new(
         blob: B,
         size: u64,
@@ -196,7 +197,7 @@ impl<B: Blob> Sealed<B> {
     }
 
     /// Page-cache id used for reads. Exposed for tests that verify the id is preserved across
-    /// [`super::Writer::seal`].
+    /// [`super::Writer::roll`].
     #[cfg(test)]
     pub(super) fn cache_id(&self) -> u64 {
         self.inner.id
@@ -216,48 +217,45 @@ mod tests {
     const PAGE_SIZE: NonZeroU16 = NZU16!(103); // janky page size to test alignment
     const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;
 
-    /// Seal a [Writer] and assert no fsync (full or range) occurred during the seal itself.
+    /// Roll a synced [Writer] and assert it performs no I/O on the old blob.
     #[test_traced("DEBUG")]
-    fn test_seal_no_fsync() {
+    fn test_roll_after_sync_performs_no_io() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let blob = SyncTrackingBlob::new();
             let cache_ref =
                 super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut append = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref)
+            let mut append = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
 
-            // Append some data crossing several pages but don't sync.
+            // Append some data crossing several pages, then sync it.
             let data: Vec<u8> = (0u8..=255).cycle().take(300).collect();
             append.append(&data).await.unwrap();
+            append.sync().await.unwrap();
 
-            let (_durable_before, _writes_before, full_before, range_before) = blob.snapshot();
-
-            // Seal -- this must flush logical bytes to the blob but NOT fsync.
-            let sealed = append.seal().await.unwrap();
-
-            let (_durable_after, _writes_after, full_after, range_after) = blob.snapshot();
-            assert_eq!(full_after, full_before, "seal must not invoke Blob::sync");
-            assert_eq!(
-                range_after, range_before,
-                "seal must not invoke Blob::write_at_sync"
-            );
+            // Rolling a synced writer has nothing left to flush: no writes, no syncs.
+            let successor = Writer::new(SyncTrackingBlob::new(), 0, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let before = blob.snapshot();
+            let sealed = append.roll(successor).await.unwrap();
+            assert_eq!(blob.snapshot(), before, "roll must not touch a synced blob");
 
             assert_eq!(sealed.size(), 300);
         });
     }
 
-    /// Sealing consumes the unique write handle; outstanding readers remain valid and agree
+    /// Rolling replaces the unique write handle; outstanding readers remain valid and agree
     /// with the sealed view.
     #[test_traced("DEBUG")]
-    fn test_seal_succeeds_with_readers() {
+    fn test_roll_succeeds_with_readers() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context.open("test_partition", b"readers").await.unwrap();
             let cache_ref =
                 super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
             writer.append(b"hello world").await.unwrap();
@@ -267,8 +265,12 @@ mod tests {
             let reader_clone = reader.clone();
             assert_eq!(reader.size(), 11);
 
-            // Seal succeeds while snapshots exist.
-            let sealed = writer.seal().await.unwrap();
+            // Rolling succeeds while snapshots exist.
+            let (succ, succ_size) = context.open("test_partition", b"readers2").await.unwrap();
+            let successor = Writer::new(succ, succ_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let sealed = writer.roll(successor).await.unwrap();
             assert_eq!(sealed.size(), 11);
 
             // Both snapshot handles keep reading the frozen state and agree with the sealed view.
@@ -301,7 +303,7 @@ mod tests {
             writer.append(&data).await.unwrap();
 
             let reader = writer.snapshot().await.unwrap();
-            let sealed = writer.seal().await.unwrap();
+            let sealed = writer.snapshot().await.unwrap();
             assert_eq!(reader.size(), total as u64);
 
             // Full range, a page-straddling range, and the partial page, each compared
@@ -335,10 +337,10 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Write data with no fsync.
+            // Snapshot flushes without fsyncing.
             let data: Vec<u8> = (0u8..=255).cycle().take(300).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             let (durable_before, _, full_before, _) = blob.snapshot();
             assert!(
@@ -361,35 +363,40 @@ mod tests {
         });
     }
 
-    /// Sealing preserves the originating [Writer]'s page-cache id.
+    /// Rolling preserves the originating [Writer]'s page-cache id.
     #[test_traced("DEBUG")]
-    fn test_seal_preserves_cache_id() {
+    fn test_roll_preserves_cache_id() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context.open("test_partition", b"cache_id").await.unwrap();
             let cache_ref =
                 super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
             let append_id = append.cache_id();
-            let sealed = append.seal().await.unwrap();
+            let (succ, succ_size) = context.open("test_partition", b"cache_id2").await.unwrap();
+            let successor = Writer::new(succ, succ_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let sealed = append.roll(successor).await.unwrap();
+
             assert_eq!(sealed.cache_id(), append_id);
         });
     }
 
     /// Sealing an empty blob yields an empty sealed view.
     #[test_traced("DEBUG")]
-    fn test_seal_empty_blob() {
+    fn test_sealed_empty_blob() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context.open("test_partition", b"empty").await.unwrap();
             let cache_ref =
                 super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
                 .await
                 .unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             assert_eq!(sealed.size(), 0);
 
@@ -400,9 +407,9 @@ mod tests {
         });
     }
 
-    /// Sealing a blob whose size is exactly a page-multiple has no partial page.
+    /// A sealed view of a blob whose size is exactly a page-multiple has no partial page.
     #[test_traced("DEBUG")]
-    fn test_seal_full_pages_only() {
+    fn test_sealed_full_pages_only() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context.open("test_partition", b"full").await.unwrap();
@@ -416,7 +423,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0u8..=255).cycle().take(page_size * 2).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             assert_eq!(sealed.size(), data.len() as u64);
 
@@ -427,9 +434,9 @@ mod tests {
         });
     }
 
-    /// Sealing a blob whose size is smaller than one page yields only a partial page.
+    /// A sealed view of a blob whose size is smaller than one page has only a partial page.
     #[test_traced("DEBUG")]
-    fn test_seal_partial_only() {
+    fn test_sealed_partial_only() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context.open("test_partition", b"partial").await.unwrap();
@@ -442,7 +449,7 @@ mod tests {
             // Append fewer than one page of data.
             let data: Vec<u8> = (0u8..=50).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             assert_eq!(sealed.size(), data.len() as u64);
 
@@ -454,7 +461,7 @@ mod tests {
 
     /// Reads that straddle the partial-page boundary stitch together cache and partial bytes.
     #[test_traced("DEBUG")]
-    fn test_seal_full_plus_partial_straddle() {
+    fn test_sealed_full_plus_partial_straddle() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context.open("test_partition", b"straddle").await.unwrap();
@@ -469,7 +476,7 @@ mod tests {
             let total = page_size + 17;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             assert_eq!(sealed.size(), total as u64);
 
@@ -507,7 +514,7 @@ mod tests {
 
             let data: Vec<u8> = (0u8..=255).cycle().take(250).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             let bufs = sealed.read_at(0, data.len()).await.unwrap();
             let coalesced = bufs.coalesce();
@@ -532,7 +539,7 @@ mod tests {
             let total = page_size + 50;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             // 4-byte items at three positions: pure cache, straddling boundary, pure partial.
             let offsets = [0u64, (page_size - 2) as u64, (page_size + 10) as u64];
@@ -566,7 +573,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0u8..=255).cycle().take(page_size * 2).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             let offsets = [0u64, page_size as u64];
             let item_size = 4usize;
@@ -596,7 +603,7 @@ mod tests {
                 .await
                 .unwrap();
             append.append(&[7; 32]).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             let mut out = vec![0u8; 8];
             let err = sealed
@@ -619,7 +626,7 @@ mod tests {
                 .await
                 .unwrap();
             append.append(&[7; 32]).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             let mut out = vec![0u8; 8];
             let err = sealed
@@ -655,7 +662,7 @@ mod tests {
             let total = page_size + 30;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             // Read fully within partial.
             let mut buf = vec![0u8; 10];
@@ -679,7 +686,7 @@ mod tests {
                 .unwrap();
             let cache_ref =
                 super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
 
@@ -687,7 +694,14 @@ mod tests {
             let total = page_size + 30;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let (succ, succ_size) = context
+                .open("test_partition", b"trs_straddle2")
+                .await
+                .unwrap();
+            let successor = Writer::new(succ, succ_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let sealed = append.roll(successor).await.unwrap();
 
             let mut buf = vec![0u8; 12];
             assert!(sealed.try_read_sync((page_size - 4) as u64, &mut buf));
@@ -710,7 +724,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0u8..=255).cycle().take(page_size + 5).collect();
             append.append(&data).await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             let mut buf = vec![9u8; 10];
             assert!(!sealed.try_read_sync(data.len() as u64, &mut buf));
@@ -735,7 +749,7 @@ mod tests {
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
             append.append(&data).await.unwrap();
             append.sync().await.unwrap();
-            let sealed = append.seal().await.unwrap();
+            let sealed = append.snapshot().await.unwrap();
 
             let mut replay = sealed.replay(NZUsize!(BUFFER_SIZE)).unwrap();
             assert_eq!(replay.blob_size(), total as u64);
@@ -799,10 +813,10 @@ mod tests {
         });
     }
 
-    /// `Sealed::replay` works without a prior `Append::sync` because `Append::seal` writes bytes
+    /// `Sealed::replay` works without a prior sync because the snapshot flush writes bytes
     /// to the blob without fsyncing.
     #[test_traced("DEBUG")]
-    fn test_seal_replay_without_sync() {
+    fn test_snapshot_replay_without_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let blob = SyncTrackingBlob::new();
@@ -816,13 +830,13 @@ mod tests {
             let total = page_size * 2 + 25;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
             append.append(&data).await.unwrap();
-            // Seal without a prior append sync.
-            let sealed = append.seal().await.unwrap();
+            // Snapshot flushes without fsyncing.
+            let sealed = append.snapshot().await.unwrap();
 
-            // Seal must not have fsynced.
+            // Nothing became durable.
             let (_durable, _writes, full_syncs, range_syncs) = blob.snapshot();
-            assert_eq!(full_syncs, 0, "seal must not invoke Blob::sync");
-            assert_eq!(range_syncs, 0, "seal must not invoke Blob::write_at_sync");
+            assert_eq!(full_syncs, 0, "flush must not fsync");
+            assert_eq!(range_syncs, 0, "flush must not invoke Blob::write_at_sync");
 
             // Replay must observe all bytes even though they were never fsynced.
             let mut replay = sealed.replay(NZUsize!(BUFFER_SIZE)).unwrap();
@@ -856,7 +870,7 @@ mod tests {
                     .await
                     .unwrap();
                 append.append(&data).await.unwrap();
-                let sealed = append.seal().await.unwrap();
+                let sealed = append.snapshot().await.unwrap();
                 sealed.sync().await.unwrap();
             }
 
@@ -872,7 +886,7 @@ mod tests {
 
     /// Sealing a recovered, already-synced partial page must not rewrite it.
     #[test_traced("DEBUG")]
-    fn test_seal_recovered_synced_partial_page_no_write() {
+    fn test_sealed_recovered_synced_partial_page_no_write() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let blob = SyncTrackingBlob::new();
@@ -906,7 +920,7 @@ mod tests {
             assert_eq!(full_after_sync, full_syncs + 1);
             assert_eq!(range_after_sync, range_syncs);
 
-            let sealed = recovered.seal().await.unwrap();
+            let sealed = recovered.snapshot().await.unwrap();
             let (_, writes_after_seal, full_after_seal, range_after_seal) = blob.snapshot();
             assert_eq!(
                 writes_after_seal, writes_after_sync,

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -57,9 +57,7 @@ struct SealedInner<B: Blob> {
 }
 
 impl<B: Blob> Sealed<B> {
-    /// Construct a [`Sealed`] from already-validated parts. Invoked by
-    /// [`super::Writer::snapshot`] and [`super::Writer::roll`], which flush before constructing
-    /// the view.
+    /// Construct a [`Sealed`] from already-validated parts.
     pub(super) fn new(
         blob: B,
         size: u64,
@@ -217,77 +215,10 @@ mod tests {
     const PAGE_SIZE: NonZeroU16 = NZU16!(103); // janky page size to test alignment
     const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;
 
-    /// Roll a synced [Writer] and assert it performs no I/O on the old blob.
+    /// A sealed view reads full pages and the partial page, from both the page cache and the
+    /// blob.
     #[test_traced("DEBUG")]
-    fn test_roll_after_sync_performs_no_io() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let blob = SyncTrackingBlob::new();
-            let cache_ref =
-                super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut append = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            // Append some data crossing several pages, then sync it.
-            let data: Vec<u8> = (0u8..=255).cycle().take(300).collect();
-            append.append(&data).await.unwrap();
-            append.sync().await.unwrap();
-
-            // Rolling a synced writer has nothing left to flush: no writes, no syncs.
-            let successor = Writer::new(SyncTrackingBlob::new(), 0, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            let before = blob.snapshot();
-            let sealed = append.roll(successor).await.unwrap();
-            assert_eq!(blob.snapshot(), before, "roll must not touch a synced blob");
-
-            assert_eq!(sealed.size(), 300);
-        });
-    }
-
-    /// Rolling replaces the unique write handle; outstanding readers remain valid and agree
-    /// with the sealed view.
-    #[test_traced("DEBUG")]
-    fn test_roll_succeeds_with_readers() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (blob, blob_size) = context.open("test_partition", b"readers").await.unwrap();
-            let cache_ref =
-                super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-            writer.append(b"hello world").await.unwrap();
-
-            // A snapshot captures the buffered bytes as an owned, frozen read handle.
-            let reader = writer.snapshot().await.unwrap();
-            let reader_clone = reader.clone();
-            assert_eq!(reader.size(), 11);
-
-            // Rolling succeeds while snapshots exist.
-            let (succ, succ_size) = context.open("test_partition", b"readers2").await.unwrap();
-            let successor = Writer::new(succ, succ_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            let sealed = writer.roll(successor).await.unwrap();
-            assert_eq!(sealed.size(), 11);
-
-            // Both snapshot handles keep reading the frozen state and agree with the sealed view.
-            for r in [&reader, &reader_clone] {
-                assert_eq!(r.size(), 11);
-                let via_reader = r.read_at(0, 11).await.unwrap().coalesce();
-                let via_sealed = sealed.read_at(0, 11).await.unwrap().coalesce();
-                assert_eq!(via_reader.as_ref(), b"hello world");
-                assert_eq!(via_sealed.as_ref(), via_reader.as_ref());
-            }
-        });
-    }
-
-    /// A reader created before sealing reads full pages and the partial page after the seal,
-    /// from both the page cache and the blob.
-    #[test_traced("DEBUG")]
-    fn test_reader_full_pages_after_seal() {
+    fn test_sealed_full_pages_and_partial() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context.open("test_partition", b"rdr_pages").await.unwrap();
@@ -302,25 +233,21 @@ mod tests {
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
             writer.append(&data).await.unwrap();
 
-            let reader = writer.snapshot().await.unwrap();
             let sealed = writer.snapshot().await.unwrap();
-            assert_eq!(reader.size(), total as u64);
+            assert_eq!(sealed.size(), total as u64);
 
-            // Full range, a page-straddling range, and the partial page, each compared
-            // against the sealed view.
+            // Full range, a page-straddling range, and the partial page.
             let cases = [
                 (0u64, total),
                 (page_size as u64 - 3, 6),
                 ((page_size * 3) as u64, 7),
             ];
             for (offset, len) in cases {
-                let via_reader = reader.read_at(offset, len).await.unwrap().coalesce();
-                let via_sealed = sealed.read_at(offset, len).await.unwrap().coalesce();
+                let read = sealed.read_at(offset, len).await.unwrap().coalesce();
                 assert_eq!(
-                    via_reader.as_ref(),
+                    read.as_ref(),
                     &data[offset as usize..offset as usize + len]
                 );
-                assert_eq!(via_sealed.as_ref(), via_reader.as_ref());
             }
         });
     }
@@ -360,28 +287,6 @@ mod tests {
                 !durable_after.is_empty(),
                 "blob bytes must be durable after Sealed::sync"
             );
-        });
-    }
-
-    /// Rolling preserves the originating [Writer]'s page-cache id.
-    #[test_traced("DEBUG")]
-    fn test_roll_preserves_cache_id() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (blob, blob_size) = context.open("test_partition", b"cache_id").await.unwrap();
-            let cache_ref =
-                super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-            let append_id = append.cache_id();
-            let (succ, succ_size) = context.open("test_partition", b"cache_id2").await.unwrap();
-            let successor = Writer::new(succ, succ_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            let sealed = append.roll(successor).await.unwrap();
-
-            assert_eq!(sealed.cache_id(), append_id);
         });
     }
 
@@ -884,53 +789,4 @@ mod tests {
         });
     }
 
-    /// Sealing a recovered, already-synced partial page must not rewrite it.
-    #[test_traced("DEBUG")]
-    fn test_sealed_recovered_synced_partial_page_no_write() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let blob = SyncTrackingBlob::new();
-            let cache_ref =
-                super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let data: Vec<u8> = (0u8..=255)
-                .cycle()
-                .take(PAGE_SIZE.get() as usize - 17)
-                .collect();
-
-            {
-                let mut writer = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref.clone())
-                    .await
-                    .unwrap();
-                writer.append(&data).await.unwrap();
-                writer.sync().await.unwrap();
-            }
-
-            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
-            let mut recovered = Writer::new(blob.clone(), blob.size(), BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(recovered.size(), data.len() as u64);
-
-            recovered.sync().await.unwrap();
-            let (_, writes_after_sync, full_after_sync, range_after_sync) = blob.snapshot();
-            assert_eq!(
-                writes_after_sync, writes,
-                "syncing an unchanged recovered partial page must not rewrite it"
-            );
-            assert_eq!(full_after_sync, full_syncs + 1);
-            assert_eq!(range_after_sync, range_syncs);
-
-            let sealed = recovered.snapshot().await.unwrap();
-            let (_, writes_after_seal, full_after_seal, range_after_seal) = blob.snapshot();
-            assert_eq!(
-                writes_after_seal, writes_after_sync,
-                "sealing an unchanged recovered partial page must not rewrite it"
-            );
-            assert_eq!(full_after_seal, full_after_sync);
-            assert_eq!(range_after_seal, range_after_sync);
-
-            let read = sealed.read_at(0, data.len()).await.unwrap().coalesce();
-            assert_eq!(read.as_ref(), data.as_slice());
-        });
-    }
 }

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -7,9 +7,11 @@
 //!
 //! [Writer::snapshot] captures a logical read view without consuming the writer.
 //!
-//! # Seal
+//! # Roll
 //!
-//! [Writer::seal] consumes the writer and turns it into an immutable [super::Sealed] view.
+//! [Writer::roll] flushes the writer, replaces it with a successor, and returns an immutable
+//! [super::Sealed] view of the just-flushed contents. [Writer::snapshot] and [Writer::roll]
+//! both flush first, so a [super::Sealed] view is always backed entirely by written bytes.
 //!
 //! # Paging
 //!
@@ -1091,7 +1093,8 @@ impl<B: Blob> Writer<B> {
         self.id
     }
 
-    /// Construct an immutable read handle for the current blob state.
+    /// Construct an immutable read handle for the current blob state. Callers must flush first
+    /// so every byte of the view is on the blob.
     fn sealed_handle(&self, id: u64) -> super::Sealed<B> {
         let logical_page_size = self.cache_ref.page_size();
         let full_pages = self.current_page;
@@ -1114,16 +1117,19 @@ impl<B: Blob> Writer<B> {
         )
     }
 
-    /// Consume the write handle and return an immutable [`super::Sealed`] handle for the same
-    /// blob.
+    /// Flush this writer, replace it with `successor`, and return an immutable
+    /// [`super::Sealed`] view of the just-flushed contents.
     ///
-    /// Buffered bytes (full and partial pages) are written to the underlying blob, but the blob is
-    /// not fsynced. The returned [`super::Sealed`] handle can be made durable later via
-    /// [`super::Sealed::sync`].
-    pub async fn seal(mut self) -> Result<super::Sealed<B>, Error> {
+    /// The sealed bytes are written to the blob but not durable; call [`super::Sealed::sync`]
+    /// (or [`Self::sync`] beforehand) if they must survive a crash.
+    pub async fn roll(&mut self, successor: Self) -> Result<super::Sealed<B>, Error> {
+        // Resolve any outstanding start_sync barrier before consuming this writer: its
+        // completion is the only witness of an in-flight fsync failure, and a flush with
+        // nothing to write would not wait on it.
         self.sync_state.wait_for_pending().await?;
         self.flush_internal(true, false).await?;
-        Ok(self.sealed_handle(self.id))
+        let old = std::mem::replace(self, successor);
+        Ok(old.sealed_handle(old.id))
     }
 }
 
@@ -1133,7 +1139,7 @@ mod tests {
     use crate::{
         buffer::{paged::CHECKSUM_SLOT_LEN_SIZE, tests::SyncTrackingBlob},
         deterministic,
-        mocks::{next_pending_sync, DelayedSyncBlob},
+        mocks::{fail_pending_syncs, next_pending_sync, DelayedSyncBlob},
         telemetry::metrics::Registry,
         Buf, BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Spawner as _,
         Storage as _, Supervisor as _,
@@ -2327,35 +2333,41 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
-    // Verifies seal cannot flush buffered bytes before pending start_sync finishes.
-    fn test_seal_waits_for_outstanding_start_sync_before_flushing() {
+    // Verifies roll cannot flush buffered bytes before pending start_sync finishes.
+    fn test_roll_waits_for_outstanding_start_sync_before_flushing() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let inner = SyncTrackingBlob::new();
             let (blob, pending) = DelayedSyncBlob::new(inner.clone());
             let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
 
             let prior = writer.start_sync().await;
             let deferred = next_pending_sync(&pending);
             writer.append(b"hello world").await.unwrap();
 
-            let seal = context
-                .child("seal")
-                .spawn(move |_| async move { writer.seal().await });
-            // The seal has reached the pending sync wait.
+            let (succ_blob, _succ_pending) = DelayedSyncBlob::new(SyncTrackingBlob::new());
+            let successor = Writer::new(succ_blob, 0, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let roll = context
+                .child("roll")
+                .spawn(move |_| async move { writer.roll(successor).await });
+            // The roll has reached the pending sync wait.
             deferred
                 .blocked
                 .await
-                .expect("seal never waited on start_sync");
+                .expect("roll never waited on start_sync");
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(writes, 0);
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
-            // Release the started sync so seal can flush.
+            // Release the started sync so roll can flush.
             deferred.release.send(Ok(())).unwrap();
-            let sealed = seal.await.unwrap().unwrap();
+            let sealed = roll.await.unwrap().unwrap();
             prior.await.unwrap();
             let read = sealed
                 .read_at(0, b"hello world".len())
@@ -4960,6 +4972,118 @@ mod tests {
                 .unwrap()
                 .coalesce();
             assert_eq!(read.as_ref(), &data[..new_size as usize]);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    // Verifies roll flushes the writer, seals its contents, and installs the successor.
+    fn test_roll_flushes_and_seals() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let blob = SyncTrackingBlob::new();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            writer.append(b"hello world").await.unwrap();
+
+            let succ_blob = SyncTrackingBlob::new();
+            let successor = Writer::new(succ_blob.clone(), 0, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let sealed = writer.roll(successor).await.unwrap();
+
+            let read = sealed
+                .read_at(0, b"hello world".len())
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), b"hello world");
+
+            sealed.sync().await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
+
+            // The writer continues on the successor's blob.
+            writer.append(b"next").await.unwrap();
+            writer.sync().await.unwrap();
+            let (_, succ_writes, _, _) = succ_blob.snapshot();
+            assert_eq!(succ_writes, 1);
+            assert_eq!(writer.size(), 4);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    // Verifies roll surfaces a pending start_sync failure instead of dropping its completion
+    // with the consumed writer.
+    fn test_roll_surfaces_pending_sync_failure() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, pending) = DelayedSyncBlob::new(SyncTrackingBlob::new());
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Begin an fsync, then fail it while it is still pending.
+            let prior = writer.start_sync().await;
+            fail_pending_syncs(&pending);
+
+            // Nothing is buffered, so only the barrier wait can surface the failure.
+            let (succ_blob, _) = DelayedSyncBlob::new(SyncTrackingBlob::new());
+            let successor = Writer::new(succ_blob, 0, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert!(writer.roll(successor).await.is_err());
+            assert!(prior.await.is_err());
+        });
+    }
+
+    #[test_traced]
+    // Dropping a roll future mid-flush leaves the writer installed and retryable.
+    fn test_roll_cancelled_mid_flush() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, size) = context
+                .open("test_partition", b"roll_cancel")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            writer.append(b"hello world").await.unwrap();
+
+            // Park the flush write inside roll, then drop the future. The successor writer
+            // dies with it; the rolled writer must survive untouched.
+            let faults = context.storage_fault_config();
+            faults.write().stall_write = Some(("test_partition".into(), b"roll_cancel".to_vec()));
+            {
+                let (succ, succ_size) = context.open("test_partition", b"succ1").await.unwrap();
+                let successor = Writer::new(succ, succ_size, BUFFER_SIZE, cache_ref.clone())
+                    .await
+                    .unwrap();
+                let fut = writer.roll(successor);
+                futures::pin_mut!(fut);
+                assert!(futures::poll!(&mut fut).is_pending());
+            }
+            assert!(
+                faults.read().stall_write.is_none(),
+                "roll did not park at the flush"
+            );
+
+            // The writer is intact and a retried roll seals every appended byte.
+            assert_eq!(writer.size(), 11);
+            let (succ, succ_size) = context.open("test_partition", b"succ2").await.unwrap();
+            let successor = Writer::new(succ, succ_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let sealed = writer.roll(successor).await.unwrap();
+            assert_eq!(sealed.size(), 11);
+            let read = sealed.read_at(0, 11).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"hello world");
         });
     }
 }

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1123,9 +1123,6 @@ impl<B: Blob> Writer<B> {
     /// The sealed bytes are written to the blob but not durable; call [`super::Sealed::sync`]
     /// (or [`Self::sync`] beforehand) if they must survive a crash.
     pub async fn roll(&mut self, successor: Self) -> Result<super::Sealed<B>, Error> {
-        // Resolve any outstanding start_sync barrier before consuming this writer: its
-        // completion is the only witness of an in-flight fsync failure, and a flush with
-        // nothing to write would not wait on it.
         self.sync_state.wait_for_pending().await?;
         self.flush_internal(true, false).await?;
         let old = std::mem::replace(self, successor);
@@ -5084,6 +5081,141 @@ mod tests {
             assert_eq!(sealed.size(), 11);
             let read = sealed.read_at(0, 11).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), b"hello world");
+        });
+    }
+
+    /// Roll a synced [Writer] and assert it performs no I/O on the old blob.
+    #[test_traced("DEBUG")]
+    fn test_roll_after_sync_performs_no_io() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let blob = SyncTrackingBlob::new();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut append = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Append some data crossing several pages, then sync it.
+            let data: Vec<u8> = (0u8..=255).cycle().take(300).collect();
+            append.append(&data).await.unwrap();
+            append.sync().await.unwrap();
+
+            // Rolling a synced writer has nothing left to flush: no writes, no syncs.
+            let successor = Writer::new(SyncTrackingBlob::new(), 0, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let before = blob.snapshot();
+            let sealed = append.roll(successor).await.unwrap();
+            assert_eq!(blob.snapshot(), before, "roll must not touch a synced blob");
+
+            assert_eq!(sealed.size(), 300);
+        });
+    }
+
+    /// Rolling replaces the unique write handle; outstanding readers remain valid and agree
+    /// with the sealed view.
+    #[test_traced("DEBUG")]
+    fn test_roll_succeeds_with_readers() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context.open("test_partition", b"readers").await.unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            writer.append(b"hello world").await.unwrap();
+
+            // A snapshot captures the buffered bytes as an owned, frozen read handle.
+            let reader = writer.snapshot().await.unwrap();
+            let reader_clone = reader.clone();
+            assert_eq!(reader.size(), 11);
+
+            // Rolling succeeds while snapshots exist.
+            let (succ, succ_size) = context.open("test_partition", b"readers2").await.unwrap();
+            let successor = Writer::new(succ, succ_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let sealed = writer.roll(successor).await.unwrap();
+            assert_eq!(sealed.size(), 11);
+
+            // Both snapshot handles keep reading the frozen state and agree with the sealed view.
+            for r in [&reader, &reader_clone] {
+                assert_eq!(r.size(), 11);
+                let via_reader = r.read_at(0, 11).await.unwrap().coalesce();
+                let via_sealed = sealed.read_at(0, 11).await.unwrap().coalesce();
+                assert_eq!(via_reader.as_ref(), b"hello world");
+                assert_eq!(via_sealed.as_ref(), via_reader.as_ref());
+            }
+        });
+    }
+
+    /// Rolling preserves the originating [Writer]'s page-cache id.
+    #[test_traced("DEBUG")]
+    fn test_roll_preserves_cache_id() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context.open("test_partition", b"cache_id").await.unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            let append_id = append.cache_id();
+            let (succ, succ_size) = context.open("test_partition", b"cache_id2").await.unwrap();
+            let successor = Writer::new(succ, succ_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let sealed = append.roll(successor).await.unwrap();
+
+            assert_eq!(sealed.cache_id(), append_id);
+        });
+    }
+
+    /// Sealing a recovered, already-synced partial page must not rewrite it.
+    #[test_traced("DEBUG")]
+    fn test_snapshot_recovered_synced_partial_page_no_write() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let blob = SyncTrackingBlob::new();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let data: Vec<u8> = (0u8..=255)
+                .cycle()
+                .take(PAGE_SIZE.get() as usize - 17)
+                .collect();
+
+            {
+                let mut writer = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref.clone())
+                    .await
+                    .unwrap();
+                writer.append(&data).await.unwrap();
+                writer.sync().await.unwrap();
+            }
+
+            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
+            let mut recovered = Writer::new(blob.clone(), blob.size(), BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(recovered.size(), data.len() as u64);
+
+            recovered.sync().await.unwrap();
+            let (_, writes_after_sync, full_after_sync, range_after_sync) = blob.snapshot();
+            assert_eq!(
+                writes_after_sync, writes,
+                "syncing an unchanged recovered partial page must not rewrite it"
+            );
+            assert_eq!(full_after_sync, full_syncs + 1);
+            assert_eq!(range_after_sync, range_syncs);
+
+            let sealed = recovered.snapshot().await.unwrap();
+            let (_, writes_after_seal, full_after_seal, range_after_seal) = blob.snapshot();
+            assert_eq!(
+                writes_after_seal, writes_after_sync,
+                "sealing an unchanged recovered partial page must not rewrite it"
+            );
+            assert_eq!(full_after_seal, full_after_sync);
+            assert_eq!(range_after_seal, range_after_sync);
+
+            let read = sealed.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
         });
     }
 }

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -372,6 +372,15 @@ impl<E: Context> Writable<E> {
         for blob in self.oldest_blob_index..=self.tail_blob_index() {
             self.partition.remove(blob).await?;
         }
+
+        // An interrupted rollover can leave an untracked successor blob on disk; it must not
+        // survive the clear.
+        if let Some(stray) = self.tail_blob_index().checked_add(1) {
+            match self.partition.remove(stray).await {
+                Ok(()) | Err(Error::Runtime(RError::BlobMissing(..))) => {}
+                Err(err) => return Err(err),
+            }
+        }
         let _ = self.metrics.tracked.try_set(0);
         self.tail = self.partition.open(tail_blob).await?;
         self.metrics.tracked.inc();

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -186,8 +186,6 @@ impl<E: Context> Writable<E> {
             if blob == tail_blob {
                 tail = Some(writer);
             } else {
-                // Seal the recovered writer; the flush is a no-op because recovery already
-                // wrote back any repairs.
                 sealed.push(writer.snapshot().await.map_err(Error::Runtime)?);
             }
         }
@@ -259,10 +257,6 @@ impl<E: Context> Writable<E> {
     }
 
     /// Seal the tail (no fsync) and open the next blob as the new tail.
-    ///
-    /// Cancellation-safe: a dropped future leaves the current tail installed and unsealed,
-    /// and a later append retries the rollover; the swap and the sealed-list update are
-    /// synchronous.
     pub(super) async fn seal_tail(&mut self) -> Result<(), Error> {
         // Open the next tail first so a failure leaves the current tail untouched.
         let next_blob = self
@@ -270,8 +264,6 @@ impl<E: Context> Writable<E> {
             .checked_add(1)
             .ok_or(Error::OffsetOverflow)?;
         let new_writer = self.partition.open(next_blob).await?;
-
-        // Dirty tracking covers the sealed blob until commit/sync.
         let sealed = self.tail.roll(new_writer).await.map_err(Error::Runtime)?;
         self.metrics.tracked.inc();
         self.sealed.push(sealed);

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -176,7 +176,7 @@ impl<E: Context> Writable<E> {
         let mut sealed = Vec::with_capacity(pending.len());
         let mut tail: Option<Writer<E::Blob>> = None;
         let mut expected = oldest;
-        for (blob, writer) in pending {
+        for (blob, mut writer) in pending {
             if expected != Some(blob) {
                 return Err(Error::Corruption(format!(
                     "retained blobs must be contiguous (expected {expected:?}, got {blob})"
@@ -186,7 +186,9 @@ impl<E: Context> Writable<E> {
             if blob == tail_blob {
                 tail = Some(writer);
             } else {
-                sealed.push(writer.seal().await.map_err(Error::Runtime)?);
+                // Seal the recovered writer; the flush is a no-op because recovery already
+                // wrote back any repairs.
+                sealed.push(writer.snapshot().await.map_err(Error::Runtime)?);
             }
         }
         let tail = match tail {
@@ -257,6 +259,10 @@ impl<E: Context> Writable<E> {
     }
 
     /// Seal the tail (no fsync) and open the next blob as the new tail.
+    ///
+    /// Cancellation-safe: a dropped future leaves the current tail installed and unsealed,
+    /// and a later append retries the rollover; the swap and the sealed-list update are
+    /// synchronous.
     pub(super) async fn seal_tail(&mut self) -> Result<(), Error> {
         // Open the next tail first so a failure leaves the current tail untouched.
         let next_blob = self
@@ -264,8 +270,9 @@ impl<E: Context> Writable<E> {
             .checked_add(1)
             .ok_or(Error::OffsetOverflow)?;
         let new_writer = self.partition.open(next_blob).await?;
-        let old_writer = std::mem::replace(&mut self.tail, new_writer);
-        let sealed = old_writer.seal().await.map_err(Error::Runtime)?;
+
+        // Dirty tracking covers the sealed blob until commit/sync.
+        let sealed = self.tail.roll(new_writer).await.map_err(Error::Runtime)?;
         self.metrics.tracked.inc();
         self.sealed.push(sealed);
         self.sealed_snapshot = None;
@@ -829,7 +836,7 @@ mod tests {
                 0
             );
 
-            let sealed = writer.seal().await.unwrap();
+            let sealed = writer.snapshot().await.unwrap();
             let sealed_blob = Blob::Sealed(sealed);
             assert_insufficient_length(
                 sealed_blob

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -935,6 +935,14 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .checked_add(items_count as u64)
             .ok_or(Error::SizeOverflow)?;
 
+        // A dropped append can leave a full tail unsealed with bounds already advanced; seal it
+        // before appending more.
+        if super::position_to_blob(self.bounds.end, self.items_per_blob.get())
+            > self.blobs.tail_blob_index()
+        {
+            self.blobs.seal_tail().await?;
+        }
+
         let first_dirty_blob = super::position_to_blob(self.bounds.end, self.items_per_blob.get());
         self.mark_dirty_from(first_dirty_blob);
         let mut written = 0;
@@ -1037,10 +1045,11 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// event of failure as items are always pruned in order from oldest to newest.
     pub async fn prune(&mut self, min_item_pos: u64) -> Result<bool, Error> {
         // Calculate the blob that would contain min_item_pos, capped to the tail (which is
-        // guaranteed to exist by our invariant).
+        // guaranteed to exist by our invariant). The cap comes from the blob map, not
+        // `bounds.end`: after an interrupted rollover the tail is a full blob that `bounds.end`
+        // already lies past, and it must not be pruned.
         let target_blob = super::position_to_blob(min_item_pos, self.items_per_blob.get());
-        let tail_blob = super::position_to_blob(self.bounds.end, self.items_per_blob.get());
-        let min_blob = std::cmp::min(target_blob, tail_blob);
+        let min_blob = std::cmp::min(target_blob, self.blobs.tail_blob_index());
 
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok(false);
@@ -4989,5 +4998,211 @@ mod tests {
 
             journal.destroy().await.unwrap();
         });
+    }
+
+    /// Cancel a boundary-crossing append at the successor open inside `seal_tail`, then verify
+    /// the journal stays consistent, appendable, and recoverable.
+    #[test_traced]
+    fn test_append_cancelled_at_seal_tail_open() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(1));
+            cfg.partition = "cancel-seal-open".into();
+            let faults = context.storage_fault_config();
+            faults.write().stall_open = Some((blob_partition(&cfg), 1u64.to_be_bytes().to_vec()));
+
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            let items = [test_digest(0), test_digest(1)];
+
+            // With one item per blob, the append fills blob 0 and enters seal_tail, which
+            // flushes the tail and then parks opening blob 1. Dropping the parked future
+            // cancels the rollover mid-flight.
+            {
+                let fut = journal.append(&items[0]);
+                pin_mut!(fut);
+                assert!(futures::poll!(&mut fut).is_pending());
+            }
+            assert!(
+                faults.read().stall_open.is_none(),
+                "append did not park at the successor open"
+            );
+
+            // The tail is still blob 0 and the claimed item remains readable.
+            assert_eq!(journal.bounds(), 0..1);
+            assert_eq!(journal.test_newest_blob(), Some(0));
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+
+            // The next append retries the interrupted rollover first.
+            journal.append(&items[1]).await.unwrap();
+            assert_eq!(journal.bounds(), 0..2);
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+            assert_eq!(journal.read(1).await.unwrap(), items[1]);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..2);
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+            assert_eq!(journal.read(1).await.unwrap(), items[1]);
+        });
+    }
+
+    /// Cancel a boundary-crossing append at the tail flush write inside `seal_tail`, then verify
+    /// the live handle stays consistent and appendable. Reopen is NOT asserted here: the paged
+    /// writer publishes flush state before awaiting its write, so the retried rollover's flush
+    /// is a no-op and the tip page is not durable after this cancellation until the writer-level
+    /// cancel-safety work lands (#4160/#4161).
+    #[test_traced]
+    fn test_append_cancelled_at_seal_tail_flush() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(1));
+            cfg.partition = "cancel-seal-flush".into();
+            let faults = context.storage_fault_config();
+            faults.write().stall_write = Some((blob_partition(&cfg), 0u64.to_be_bytes().to_vec()));
+
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            let items = [test_digest(0), test_digest(1)];
+
+            // The append is buffered, so the first write to blob 0 is the tail flush inside
+            // seal_tail. Dropping the parked future cancels the rollover mid-flush.
+            {
+                let fut = journal.append(&items[0]);
+                pin_mut!(fut);
+                assert!(futures::poll!(&mut fut).is_pending());
+            }
+            assert!(
+                faults.read().stall_write.is_none(),
+                "append did not park at the tail flush"
+            );
+
+            // The tail is still blob 0 and the claimed item remains readable.
+            assert_eq!(journal.bounds(), 0..1);
+            assert_eq!(journal.test_newest_blob(), Some(0));
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+
+            // The next append retries the interrupted rollover first.
+            journal.append(&items[1]).await.unwrap();
+            assert_eq!(journal.bounds(), 0..2);
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+            assert_eq!(journal.read(1).await.unwrap(), items[1]);
+            journal.sync().await.unwrap();
+        });
+    }
+
+    /// Prune during a pending rollover must not panic and must not remove the still-installed
+    /// full tail; after the rollover completes, a retried prune removes it.
+    #[test_traced]
+    fn test_prune_during_pending_rollover() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(1));
+            cfg.partition = "cancel-seal-prune".into();
+            let faults = context.storage_fault_config();
+            faults.write().stall_write = Some((blob_partition(&cfg), 0u64.to_be_bytes().to_vec()));
+
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            let items = [test_digest(0), test_digest(1)];
+            {
+                let fut = journal.append(&items[0]);
+                pin_mut!(fut);
+                assert!(futures::poll!(&mut fut).is_pending());
+            }
+            assert!(
+                faults.read().stall_write.is_none(),
+                "append did not park at the tail flush"
+            );
+
+            // Blob 0 is a full unsealed tail; pruning must decline to remove it.
+            assert!(!journal.prune(1).await.unwrap());
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+
+            // After the rollover completes, blob 0 is sealed history and can be pruned.
+            journal.append(&items[1]).await.unwrap();
+            assert!(journal.prune(1).await.unwrap());
+            assert!(matches!(journal.read(0).await, Err(Error::ItemPruned(0))));
+            assert_eq!(journal.read(1).await.unwrap(), items[1]);
+        });
+    }
+
+    /// Rewind during a pending rollover must shrink the still-installed tail like any other
+    /// unsealed writer.
+    #[test_traced]
+    fn test_rewind_during_pending_rollover() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(1));
+            cfg.partition = "cancel-seal-rewind".into();
+            let faults = context.storage_fault_config();
+            faults.write().stall_write = Some((blob_partition(&cfg), 0u64.to_be_bytes().to_vec()));
+
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            let items = [test_digest(0), test_digest(1)];
+            {
+                let fut = journal.append(&items[0]);
+                pin_mut!(fut);
+                assert!(futures::poll!(&mut fut).is_pending());
+            }
+            assert!(
+                faults.read().stall_write.is_none(),
+                "append did not park at the tail flush"
+            );
+
+            // The full unsealed tail shrinks in place.
+            journal.rewind(0).await.unwrap();
+            assert_eq!(journal.bounds(), 0..0);
+
+            // The journal accepts new appends after the rewind.
+            journal.append(&items[1]).await.unwrap();
+            assert_eq!(journal.bounds(), 0..1);
+            assert_eq!(journal.read(0).await.unwrap(), items[1]);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..1);
+            assert_eq!(journal.read(0).await.unwrap(), items[1]);
+        });
+    }
+
+    /// A cancelled rollover followed by recovery appends must be deterministic.
+    #[test_traced]
+    fn test_append_cancelled_at_seal_tail_flush_is_deterministic() {
+        fn run(seed: u64) -> String {
+            let executor = deterministic::Runner::seeded(seed);
+            executor.start(|context| async move {
+                let mut cfg = test_cfg(&context, NZU64!(1));
+                cfg.partition = "cancel-seal-determinism".into();
+                context.storage_fault_config().write().stall_write =
+                    Some((blob_partition(&cfg), 0u64.to_be_bytes().to_vec()));
+
+                let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+                let items = [test_digest(0), test_digest(1)];
+                {
+                    let fut = journal.append(&items[0]);
+                    pin_mut!(fut);
+                    assert!(futures::poll!(&mut fut).is_pending());
+                }
+                journal.append(&items[1]).await.unwrap();
+                journal.sync().await.unwrap();
+                context.auditor().state()
+            })
+        }
+
+        assert_eq!(run(7), run(7));
     }
 }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -5124,9 +5124,15 @@ mod tests {
                 "append did not park at the tail flush"
             );
 
+            // The stray successor blob exists on disk, untracked by the journal.
+            let stray = 1u64.to_be_bytes().to_vec();
+            assert!(scan_partition(&context, &blob_partition(&cfg))
+                .await
+                .contains(&stray));
+
             // Reset far past the stray, then use the journal normally.
             journal.clear_to_size(20).await.unwrap();
-            journal.append(&items[1]).await.unwrap();
+            assert_eq!(journal.append(&items[1]).await.unwrap(), 20);
             journal.sync().await.unwrap();
             drop(journal);
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -5096,6 +5096,49 @@ mod tests {
         });
     }
 
+    /// A cancelled rollover leaves an untracked successor blob on disk; `clear_to_size` must
+    /// remove it so it cannot corrupt a later recovery.
+    #[test_traced]
+    fn test_clear_after_cancelled_rollover_removes_stray_blob() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(1));
+            cfg.partition = "cancel-seal-clear".into();
+            let faults = context.storage_fault_config();
+            faults.write().stall_write = Some((blob_partition(&cfg), 0u64.to_be_bytes().to_vec()));
+
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            let items = [test_digest(0), test_digest(1)];
+
+            // Cancel a boundary-crossing append at the tail flush. seal_tail already created
+            // blob 1 on disk before the roll parked, so an untracked blob is left behind.
+            {
+                let fut = journal.append(&items[0]);
+                pin_mut!(fut);
+                assert!(futures::poll!(&mut fut).is_pending());
+            }
+            assert!(
+                faults.read().stall_write.is_none(),
+                "append did not park at the tail flush"
+            );
+
+            // Reset far past the stray, then use the journal normally.
+            journal.clear_to_size(20).await.unwrap();
+            journal.append(&items[1]).await.unwrap();
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            // The stray blob must not survive the clear to confuse recovery.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 20..21);
+            assert_eq!(journal.read(20).await.unwrap(), items[1]);
+        });
+    }
+
     /// Prune during a pending rollover must not panic and must not remove the still-installed
     /// full tail; after the rollover completes, a retried prune removes it.
     #[test_traced]

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1197,6 +1197,15 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
         let items_per_blob = self.items_per_blob.get();
 
+        // A dropped append can record offsets without advancing `bounds.end`. An item's data
+        // always lands before its offset, so recorded offsets index complete items: adopt
+        // them, as recovery would.
+        let offsets_size = self.offsets.size();
+        if offsets_size > self.bounds.end {
+            self.mark_dirty_from(position_to_blob(self.bounds.end, items_per_blob));
+            self.bounds.end = offsets_size;
+        }
+
         // A dropped append can leave a full tail unsealed with bounds already advanced; seal it
         // before appending more.
         if position_to_blob(self.bounds.end, items_per_blob) > self.blobs.tail_blob_index() {
@@ -6714,6 +6723,65 @@ mod tests {
 
             // The next append retries the interrupted rollover first.
             journal.append(&items[1]).await.unwrap();
+            assert_eq!(journal.bounds(), 0..2);
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+            assert_eq!(journal.read(1).await.unwrap(), items[1]);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, FixedBytes<32>>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..2);
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+            assert_eq!(journal.read(1).await.unwrap(), items[1]);
+        });
+    }
+
+    /// Cancel an append inside the offsets journal's rollover: the batch's data and offsets
+    /// are already written but `bounds.end` never advanced. The next append must adopt the
+    /// completed batch, as recovery would, and continue normally.
+    #[test_traced]
+    fn test_variable_append_cancelled_at_offsets_rollover() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "cancel-offsets-roll-variable".into(),
+                items_per_section: NZU64!(1),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
+                write_buffer: NZUsize!(1024),
+            };
+            let faults = context.storage_fault_config();
+            // With one item per section, the offsets journal rolls over on the same append that
+            // fills a data section. Park its successor open inside `offsets.append_many`.
+            faults.write().stall_open = Some((
+                format!("{}-blobs", cfg.offsets_partition()),
+                1u64.to_be_bytes().to_vec(),
+            ));
+
+            let mut journal =
+                Journal::<_, FixedBytes<32>>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+            let items = [FixedBytes::new([1; 32]), FixedBytes::new([2; 32])];
+
+            // The offsets entry is appended (offsets size advances) before `bounds.end` does, so
+            // dropping the parked future leaves the counter behind the written batch.
+            {
+                let fut = journal.append(&items[0]);
+                pin_mut!(fut);
+                assert!(futures::poll!(&mut fut).is_pending());
+            }
+            assert!(
+                faults.read().stall_open.is_none(),
+                "append did not park at the offsets successor open"
+            );
+            assert_eq!(journal.bounds(), 0..0);
+
+            // The retried append adopts the interrupted batch, then appends its own item.
+            assert_eq!(journal.append(&items[1]).await.unwrap(), 1);
             assert_eq!(journal.bounds(), 0..2);
             assert_eq!(journal.read(0).await.unwrap(), items[0]);
             assert_eq!(journal.read(1).await.unwrap(), items[1]);

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1188,13 +1188,6 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         }
         let encoded = IoBuf::from(encoded);
 
-        // Reject the append before writing anything (to either the data blobs or offsets
-        // journal) if it would push the size past `u64::MAX`.
-        self.bounds
-            .end
-            .checked_add(items_count as u64)
-            .ok_or(Error::SizeOverflow)?;
-
         let items_per_blob = self.items_per_blob.get();
 
         // A dropped append can record offsets without advancing `bounds.end`. An item's data
@@ -1205,6 +1198,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             self.mark_dirty_from(position_to_blob(self.bounds.end, items_per_blob));
             self.bounds.end = offsets_size;
         }
+
+        // Reject the append before writing anything (to either the data blobs or offsets
+        // journal) if it would push the size past `u64::MAX`.
+        self.bounds
+            .end
+            .checked_add(items_count as u64)
+            .ok_or(Error::SizeOverflow)?;
 
         // A dropped append can leave a full tail unsealed with bounds already advanced; seal it
         // before appending more.

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1196,6 +1196,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             .ok_or(Error::SizeOverflow)?;
 
         let items_per_blob = self.items_per_blob.get();
+
+        // A dropped append can leave a full tail unsealed with bounds already advanced; seal it
+        // before appending more.
+        if position_to_blob(self.bounds.end, items_per_blob) > self.blobs.tail_blob_index() {
+            self.blobs.seal_tail().await?;
+        }
+
         self.mark_dirty_from(position_to_blob(self.bounds.end, items_per_blob));
         let mut written = 0;
         while written < items_count {
@@ -1301,10 +1308,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let items_per_blob = self.items_per_blob.get();
 
         // Calculate the blob that would contain min_position, capped to the tail (which is
-        // guaranteed to exist by our invariant).
+        // guaranteed to exist by our invariant). The cap comes from the blob map, not
+        // `bounds.end`: after an interrupted rollover the tail is a full blob that `bounds.end`
+        // already lies past, and it must not be pruned.
         let target_blob = position_to_blob(min_position, items_per_blob);
-        let tail_blob = position_to_blob(self.bounds.end, items_per_blob);
-        let min_blob = target_blob.min(tail_blob);
+        let min_blob = target_blob.min(self.blobs.tail_blob_index());
 
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok(false);
@@ -2036,7 +2044,7 @@ mod tests {
         deterministic, Metrics as _, Runner, Spawner as _, Storage, Supervisor as _,
     };
     use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
-    use futures::{FutureExt as _, StreamExt as _};
+    use futures::{pin_mut, FutureExt as _, StreamExt as _};
     use std::num::NonZeroU16;
 
     // Use some jank sizes to exercise boundary conditions.
@@ -6661,6 +6669,63 @@ mod tests {
 
             let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
             assert!(matches!(result, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// Cancel a boundary-crossing append at the successor open inside `seal_tail`, then verify
+    /// the journal stays consistent, appendable, and recoverable.
+    #[test_traced]
+    fn test_variable_append_cancelled_at_seal_tail_open() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "cancel-seal-open-variable".into(),
+                items_per_section: NZU64!(1),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
+                write_buffer: NZUsize!(1024),
+            };
+            let faults = context.storage_fault_config();
+            faults.write().stall_open = Some((cfg.data_partition(), 1u64.to_be_bytes().to_vec()));
+
+            let mut journal =
+                Journal::<_, FixedBytes<32>>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+            let items = [FixedBytes::new([1; 32]), FixedBytes::new([2; 32])];
+
+            // With one item per section, the append fills data blob 0 and enters seal_tail,
+            // which flushes the tail and then parks opening blob 1. Dropping the parked future
+            // cancels the rollover mid-flight.
+            {
+                let fut = journal.append(&items[0]);
+                pin_mut!(fut);
+                assert!(futures::poll!(&mut fut).is_pending());
+            }
+            assert!(
+                faults.read().stall_open.is_none(),
+                "append did not park at the successor open"
+            );
+
+            // The tail is still blob 0 and the claimed item remains readable.
+            assert_eq!(journal.bounds(), 0..1);
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+
+            // The next append retries the interrupted rollover first.
+            journal.append(&items[1]).await.unwrap();
+            assert_eq!(journal.bounds(), 0..2);
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+            assert_eq!(journal.read(1).await.unwrap(), items[1]);
+            journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, FixedBytes<32>>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..2);
+            assert_eq!(journal.read(0).await.unwrap(), items[0]);
+            assert_eq!(journal.read(1).await.unwrap(), items[1]);
         });
     }
 }

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -988,6 +988,7 @@ pub(crate) mod harnesses {
             Self::Db::init(ctx, config).await.unwrap()
         }
 
+        #[boxed]
         async fn destroy(db: Self::Db) {
             db.destroy().await.unwrap();
         }
@@ -1195,7 +1196,7 @@ fn test_immutable_local_boundary_nodes_rejects_target_before_local_lower_bound()
         .unwrap()
         .is_some());
 
-        Box::pin(H::destroy(db)).await;
+        H::destroy(db).await;
     });
 }
 

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use commonware_codec::Encode;
 use commonware_cryptography::{sha256, Sha256};
+use commonware_macros::boxed;
 use commonware_runtime::{
     buffer::paged::CacheRef, deterministic, BufferPooler, Metrics, Runner as _, Supervisor as _,
 };
@@ -890,6 +891,7 @@ pub(crate) mod harnesses {
             VariableDb::<F>::init(ctx, config).await.unwrap()
         }
 
+        #[boxed]
         async fn destroy(db: Self::Db) {
             db.destroy().await.unwrap();
         }
@@ -1075,7 +1077,7 @@ fn test_keyless_local_boundary_nodes_rejects_target_before_local_lower_bound() {
         .unwrap()
         .is_some());
 
-        Box::pin(H::destroy(db)).await;
+        H::destroy(db).await;
     });
 }
 


### PR DESCRIPTION
Partially resolves #4148.

## Problem

When an append crosses a blob boundary, the contiguous journal rolls over: `seal_tail()` seals the full tail and opens a successor. Dropping the append future while `seal_tail` was suspended corrupted the journal. `seal_tail` installed the successor as the tail *before* awaiting `old_writer.seal()`, and `seal(self)` consumed the writer while awaiting its flush, so a drop mid-seal destroyed the old tail: it never reached the sealed list, `tail_blob_index()` went off by one, and `bounds.end` already counted the appended item. From that state, reads of the item failed, `sync()` persisted a recovery watermark past the recoverable prefix (reopen then failed with `Corruption`), the next append opened the successor blob a second time, and `prune()` could hit an assertion. The corruption is in-memory struct state, so it affects every storage backend.

## Fix

The root cause is a consuming call (`seal(self)`) with an await inside it: a drop after the consume but before completion loses the writer. The fix replaces it with an in-place swap:

- `Writer::seal(self)` is deleted. `Writer::roll(&mut self, successor)` flushes the writer, then synchronously swaps in the successor and returns a `Sealed` view of the old contents (keeping the writer's page-cache id, so hot pages stay valid). Dropping the future mid-flush leaves the writer installed and retryable; only the successor is lost. Roll also waits for any outstanding `start_sync` first, since its completion is the only witness of an in-flight fsync failure.
- Every path to a `Sealed` (`snapshot` or `roll`) flushes first, so a `Sealed` with unwritten bytes is unrepresentable.
- `seal_tail` opens the successor first (a failure leaves the tail untouched), then rolls it in. Journal recovery seals below-tail writers via `snapshot` (the flush is a no-op there).

Durability is unchanged from main: rollover writes bytes without fsyncing, and sealed blobs become crash-durable at the next `commit()`/`sync()` via existing dirty tracking.