### PR TITLE
[runtime] Recreate blobs left torn by an interrupted creation

### DIFF
--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -162,9 +162,25 @@ impl crate::Storage for Storage {
             // Existing blob - honor the header it records
             HeaderResolution::Valid { blob_version, size } => (blob_version, size),
             HeaderResolution::Recreate => {
-                // New, torn, or corrupted blob - truncate and write header with latest version
+                // Make the blob name durable BEFORE writing the header: a valid header on
+                // disk then implies its directory entries are durable, which is what lets
+                // the Valid arm skip directory syncs. A healed torn creation (raw_len > 0)
+                // may be retrying an attempt that failed before its directory syncs, so its
+                // directory entries cannot be assumed durable even though they exist.
+                // `parent_existed` reflects the live filesystem, so a partition directory
+                // left by a failed prior attempt in this process skips the storage-root
+                // sync; that narrow window is accepted (process restarts are covered by the
+                // startup filesystem sync).
+                sync_dir(parent)?;
+                if !parent_existed || raw_len > 0 {
+                    sync_dir(&self.storage_directory)?;
+                }
+
+                // Truncate to zero before writing so a torn header write cannot splice old
+                // bytes into a fully valid header with a wrong version: every partial state
+                // stays shorter than the header and heals on the next open.
                 let (header, blob_version) = Header::new(&versions);
-                file.set_len(Header::SIZE_U64)
+                file.set_len(0)
                     .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
                 file.seek(SeekFrom::Start(0))
                     .map_err(|_| Error::WriteFailed)?;
@@ -172,14 +188,6 @@ impl crate::Storage for Storage {
                     .map_err(|_| Error::WriteFailed)?;
                 file.sync_all()
                     .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-
-                // Make the blob name durable. A healed torn creation (raw_len > 0) may be
-                // retrying an attempt that failed before its directory syncs, so its directory
-                // entries cannot be assumed durable even though they exist.
-                sync_dir(parent)?;
-                if !parent_existed || raw_len > 0 {
-                    sync_dir(&self.storage_directory)?;
-                }
 
                 (blob_version, 0)
             }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -37,9 +37,15 @@ use std::{
     sync::Arc,
 };
 
+/// Counts [sync_dir] calls so tests can assert directory-entry durability.
+#[cfg(test)]
+static SYNC_DIR_CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 /// Syncs a directory to ensure directory entry changes are durable.
 /// On Unix, directory metadata (file creation/deletion) must be explicitly fsynced.
 fn sync_dir(path: &Path) -> Result<(), Error> {
+    #[cfg(test)]
+    SYNC_DIR_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let dir = File::open(path).map_err(|e| {
         Error::BlobOpenFailed(
             path.to_string_lossy().to_string(),
@@ -167,13 +173,12 @@ impl crate::Storage for Storage {
                 file.sync_all()
                     .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
 
-                // For new files, sync the parent directory to ensure the directory entry is
-                // durable.
-                if raw_len == 0 {
-                    sync_dir(parent)?;
-                    if !parent_existed {
-                        sync_dir(&self.storage_directory)?;
-                    }
+                // Make the blob name durable. A healed torn creation (raw_len > 0) may be
+                // retrying an attempt that failed before its directory syncs, so its directory
+                // entries cannot be assumed durable even though they exist.
+                sync_dir(parent)?;
+                if !parent_existed || raw_len > 0 {
+                    sync_dir(&self.storage_directory)?;
                 }
 
                 (blob_version, 0)
@@ -601,6 +606,26 @@ mod tests {
         assert!(err
             .to_string()
             .starts_with("blob corrupt: partition/6261645f6d61676963 reason: invalid magic"));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_blob_torn_header_recreate_syncs_directories() {
+        let (storage, storage_directory) = create_test_storage();
+        let partition_path = storage_directory.join("partition");
+        std::fs::create_dir_all(&partition_path).unwrap();
+        std::fs::write(partition_path.join(hex(b"torn")), vec![0u8; Header::SIZE]).unwrap();
+
+        // Healing must also make the blob's directory entries durable: the attempt that left
+        // the torn file may have failed before its own directory syncs.
+        let sync_dirs = SYNC_DIR_CALLS.load(std::sync::atomic::Ordering::Relaxed);
+        let (_, size) = storage.open("partition", b"torn").await.unwrap();
+        assert_eq!(size, 0, "torn blob should be recreated empty");
+        assert!(
+            SYNC_DIR_CALLS.load(std::sync::atomic::Ordering::Relaxed) >= sync_dirs + 2,
+            "healing a torn creation should sync its directory entries"
+        );
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -144,27 +144,8 @@ impl crate::Storage for Storage {
 
         // Handle header: new/corrupted blobs get a fresh header written,
         // existing blobs have their header read.
-        let (blob_version, logical_len) = if Header::missing(raw_len) {
-            // New (or corrupted) blob - truncate and write header with latest version
-            let (header, blob_version) = Header::new(&versions);
-            file.set_len(Header::SIZE_U64)
-                .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
-            file.seek(SeekFrom::Start(0))
-                .map_err(|_| Error::WriteFailed)?;
-            file.write_all(&header.encode())
-                .map_err(|_| Error::WriteFailed)?;
-            file.sync_all()
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-
-            // For new files, sync the parent directory to ensure the directory entry is durable.
-            if raw_len == 0 {
-                sync_dir(parent)?;
-                if !parent_existed {
-                    sync_dir(&self.storage_directory)?;
-                }
-            }
-
-            (blob_version, 0)
+        let parsed = if Header::missing(raw_len) {
+            None
         } else {
             // Existing blob - read and validate header
             file.seek(SeekFrom::Start(0))
@@ -172,8 +153,37 @@ impl crate::Storage for Storage {
             let mut header_bytes = [0u8; Header::SIZE];
             file.read_exact(&mut header_bytes)
                 .map_err(|_| Error::ReadFailed)?;
-            Header::from(header_bytes, raw_len, &versions)
-                .map_err(|e| e.into_error(partition, name))?
+            match Header::from(header_bytes, raw_len, &versions) {
+                Ok(parsed) => Some(parsed),
+                Err(e) if e.interrupted_creation(raw_len) => None,
+                Err(e) => return Err(e.into_error(partition, name)),
+            }
+        };
+        let (blob_version, logical_len) = match parsed {
+            Some(parsed) => parsed,
+            None => {
+                // New, torn, or corrupted blob - truncate and write header with latest version
+                let (header, blob_version) = Header::new(&versions);
+                file.set_len(Header::SIZE_U64)
+                    .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
+                file.seek(SeekFrom::Start(0))
+                    .map_err(|_| Error::WriteFailed)?;
+                file.write_all(&header.encode())
+                    .map_err(|_| Error::WriteFailed)?;
+                file.sync_all()
+                    .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
+
+                // For new files, sync the parent directory to ensure the directory entry is
+                // durable.
+                if raw_len == 0 {
+                    sync_dir(parent)?;
+                    if !parent_existed {
+                        sync_dir(&self.storage_directory)?;
+                    }
+                }
+
+                (blob_version, 0)
+            }
         };
 
         let blob = Blob::new(
@@ -582,9 +592,11 @@ mod tests {
         let partition_path = storage_directory.join("partition");
         std::fs::create_dir_all(&partition_path).unwrap();
 
-        // Manually create a file with invalid magic bytes
+        // Manually create a file with invalid magic bytes. It must be larger than the header
+        // region: it may carry data, so it is corrupt (a header-sized file would instead be
+        // healed as an interrupted creation).
         let bad_magic_path = partition_path.join(hex(b"bad_magic"));
-        std::fs::write(&bad_magic_path, vec![0u8; Header::SIZE]).unwrap();
+        std::fs::write(&bad_magic_path, vec![0u8; Header::SIZE + 1]).unwrap();
 
         // Opening should fail with corrupt error
         let err = storage

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -20,7 +20,7 @@
 //! This implementation is only available on Linux systems that support io_uring.
 //! It requires Linux kernel 6.1 or newer. See [crate::iouring] for details.
 
-use super::Header;
+use super::{Header, HeaderResolution};
 use crate::{
     iouring::{self},
     telemetry::metrics::Register,
@@ -144,24 +144,18 @@ impl crate::Storage for Storage {
 
         // Handle header: new/corrupted blobs get a fresh header written,
         // existing blobs have their header read.
-        let parsed = if Header::missing(raw_len) {
-            None
-        } else {
-            // Existing blob - read and validate header
-            file.seek(SeekFrom::Start(0))
-                .map_err(|_| Error::ReadFailed)?;
-            let mut header_bytes = [0u8; Header::SIZE];
-            file.read_exact(&mut header_bytes)
-                .map_err(|_| Error::ReadFailed)?;
-            match Header::from(header_bytes, raw_len, &versions) {
-                Ok(parsed) => Some(parsed),
-                Err(e) if e.interrupted_creation(raw_len) => None,
-                Err(e) => return Err(e.into_error(partition, name)),
-            }
-        };
-        let (blob_version, logical_len) = match parsed {
-            Some(parsed) => parsed,
-            None => {
+        let mut head = [0u8; Header::SIZE];
+        let head_len = raw_len.min(Header::SIZE_U64) as usize;
+        file.seek(SeekFrom::Start(0))
+            .map_err(|_| Error::ReadFailed)?;
+        file.read_exact(&mut head[..head_len])
+            .map_err(|_| Error::ReadFailed)?;
+        let resolution = Header::resolve(&head[..head_len], raw_len, &versions)
+            .map_err(|e| e.into_error(partition, name))?;
+        let (blob_version, logical_len) = match resolution {
+            // Existing blob - honor the header it records
+            HeaderResolution::Valid { blob_version, size } => (blob_version, size),
+            HeaderResolution::Recreate => {
                 // New, torn, or corrupted blob - truncate and write header with latest version
                 let (header, blob_version) = Header::new(&versions);
                 file.set_len(Header::SIZE_U64)

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -56,19 +56,26 @@ impl crate::Storage for Storage {
         let content = partition_entry.entry(name.into()).or_default();
 
         let raw_len = content.len() as u64;
-        let (blob_version, logical_len) = if Header::missing(raw_len) {
-            // New or corrupted blob - truncate and write default header with latest version
-            let (header, blob_version) = Header::new(&versions);
-            content.clear();
-            content.extend_from_slice(&header.encode());
-            (blob_version, 0)
+        let parsed = if Header::missing(raw_len) {
+            None
         } else {
             // Existing blob - read and validate header
             let mut header_bytes = [0u8; Header::SIZE];
             header_bytes.copy_from_slice(&content[..Header::SIZE]);
-            Header::from(header_bytes, raw_len, &versions)
-                .map_err(|e| e.into_error(partition, name))?
+            match Header::from(header_bytes, raw_len, &versions) {
+                Ok(parsed) => Some(parsed),
+                Err(e) if e.interrupted_creation(raw_len) => None,
+                Err(e) => return Err(e.into_error(partition, name)),
+            }
         };
+        let (blob_version, logical_len) = parsed.unwrap_or_else(|| {
+            // New, torn, or corrupted blob - truncate and write default header with latest
+            // version
+            let (header, blob_version) = Header::new(&versions);
+            content.clear();
+            content.extend_from_slice(&header.encode());
+            (blob_version, 0)
+        });
 
         Ok((
             Blob::new(
@@ -337,11 +344,13 @@ mod tests {
     async fn test_blob_magic_mismatch() {
         let storage = Storage::new(test_pool());
 
-        // Manually insert a blob with invalid magic bytes
+        // Manually insert a blob with invalid magic bytes. It must be larger than the header
+        // region: it may carry data, so it is corrupt (a header-sized file would instead be
+        // healed as an interrupted creation).
         {
             let mut partitions = storage.partitions.lock();
             let partition = partitions.entry("partition".into()).or_default();
-            partition.insert(b"bad_magic".to_vec(), vec![0u8; Header::SIZE]);
+            partition.insert(b"bad_magic".to_vec(), vec![0u8; Header::SIZE + 1]);
         }
 
         // Opening should fail with corrupt error
@@ -349,5 +358,53 @@ mod tests {
         assert!(
             matches!(result, Err(crate::Error::BlobCorrupt(_, _, reason)) if reason.contains("invalid magic"))
         );
+    }
+
+    #[tokio::test]
+    async fn test_blob_torn_header_recreated() {
+        let storage = Storage::new(test_pool());
+
+        // A creation interrupted mid-write can leave any garbage in the header region.
+        // Anything that does not parse as a header on a file no larger than the header
+        // region is recreated in place, and the recreated blob is fully usable.
+        let mut torn_version = Vec::from(Header::MAGIC);
+        torn_version.extend_from_slice(&[0xFF; Header::SIZE - Header::MAGIC_LENGTH]);
+        let states = [
+            (b"zeros".as_slice(), vec![0u8; Header::SIZE]),
+            (b"version".as_slice(), torn_version),
+        ];
+        for (name, torn) in states {
+            {
+                let mut partitions = storage.partitions.lock();
+                let partition = partitions.entry("partition".into()).or_default();
+                partition.insert(name.to_vec(), torn);
+            }
+            let (blob, size) = storage.open("partition", name).await.unwrap();
+            assert_eq!(size, 0, "torn blob should be recreated empty");
+            blob.write_at(0, b"hello").await.unwrap();
+            blob.sync().await.unwrap();
+            drop(blob);
+
+            let (blob, size) = storage.open("partition", name).await.unwrap();
+            assert_eq!(size, 5);
+            let read_buf = blob.read_at(0, 5).await.unwrap();
+            assert_eq!(read_buf.coalesce(), b"hello");
+        }
+
+        // A valid header whose blob version is outside the caller's range is a real
+        // conflict, not a torn creation.
+        {
+            let (header, _) = Header::new(&(7..=7));
+            let mut partitions = storage.partitions.lock();
+            let partition = partitions.entry("partition".into()).or_default();
+            partition.insert(b"conflict".to_vec(), header.encode().into());
+        }
+        let result = storage
+            .open_versioned("partition", b"conflict", 0..=0)
+            .await;
+        assert!(matches!(
+            result,
+            Err(crate::Error::BlobVersionMismatch { .. })
+        ));
     }
 }

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,4 +1,4 @@
-use super::Header;
+use super::{Header, HeaderResolution};
 use crate::{Buf, BufferPool, Handle, IoBufs, IoBufsMut};
 use commonware_codec::Encode;
 use commonware_formatting::hex;
@@ -56,26 +56,21 @@ impl crate::Storage for Storage {
         let content = partition_entry.entry(name.into()).or_default();
 
         let raw_len = content.len() as u64;
-        let parsed = if Header::missing(raw_len) {
-            None
-        } else {
-            // Existing blob - read and validate header
-            let mut header_bytes = [0u8; Header::SIZE];
-            header_bytes.copy_from_slice(&content[..Header::SIZE]);
-            match Header::from(header_bytes, raw_len, &versions) {
-                Ok(parsed) => Some(parsed),
-                Err(e) if e.interrupted_creation(raw_len) => None,
-                Err(e) => return Err(e.into_error(partition, name)),
-            }
-        };
-        let (blob_version, logical_len) = parsed.unwrap_or_else(|| {
+        let head_len = (raw_len as usize).min(Header::SIZE);
+        let resolution = Header::resolve(&content[..head_len], raw_len, &versions)
+            .map_err(|e| e.into_error(partition, name))?;
+        let (blob_version, logical_len) = match resolution {
+            // Existing blob - honor the header it records
+            HeaderResolution::Valid { blob_version, size } => (blob_version, size),
             // New, torn, or corrupted blob - truncate and write default header with latest
             // version
-            let (header, blob_version) = Header::new(&versions);
-            content.clear();
-            content.extend_from_slice(&header.encode());
-            (blob_version, 0)
-        });
+            HeaderResolution::Recreate => {
+                let (header, blob_version) = Header::new(&versions);
+                content.clear();
+                content.extend_from_slice(&header.encode());
+                (blob_version, 0)
+            }
+        };
 
         Ok((
             Blob::new(

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -146,6 +146,23 @@ stability_scope!(BETA {
                 }
             }
         }
+
+        /// Returns true when this error on a blob of `raw_len` raw bytes indicates a creation
+        /// that never completed, so the blob can be recreated without losing data.
+        ///
+        /// Creation makes the header durable before [crate::Storage::open] returns, and data
+        /// can only be written through the returned blob. A file no larger than the header
+        /// region whose bytes do not form a header (writes may tear at any point) can
+        /// therefore only be a creation that never completed. [HeaderError::VersionMismatch]
+        /// never qualifies: it requires a fully valid header, so it reports a real version
+        /// conflict.
+        pub(crate) const fn interrupted_creation(&self, raw_len: u64) -> bool {
+            raw_len <= Header::SIZE_U64
+                && matches!(
+                    self,
+                    Self::InvalidMagic { .. } | Self::UnsupportedRuntimeVersion { .. }
+                )
+        }
     }
 
     /// Fixed-size header at the start of each [crate::Blob].
@@ -311,6 +328,34 @@ pub(crate) mod tests {
         let (header, _) = Header::new(&(5..=5));
         assert!(header.validate(&(3..=7)).is_ok());
         assert!(header.validate(&(5..=5)).is_ok());
+    }
+
+    #[test]
+    fn test_header_error_interrupted_creation() {
+        let magic = HeaderError::InvalidMagic {
+            expected: Header::MAGIC,
+            found: [0; 4],
+        };
+        let runtime = HeaderError::UnsupportedRuntimeVersion {
+            expected: Header::RUNTIME_VERSION,
+            found: 7,
+        };
+        let version = HeaderError::VersionMismatch {
+            expected: 0..=0,
+            found: 3,
+        };
+
+        // Bytes that do not form a header on a file no larger than the header region can
+        // only be an interrupted creation.
+        assert!(magic.interrupted_creation(Header::SIZE_U64));
+        assert!(runtime.interrupted_creation(Header::SIZE_U64));
+
+        // A version mismatch requires a fully valid header: a real conflict, never torn.
+        assert!(!version.interrupted_creation(Header::SIZE_U64));
+
+        // Anything larger than the header region may carry data.
+        assert!(!magic.interrupted_creation(Header::SIZE_U64 + 1));
+        assert!(!runtime.interrupted_creation(Header::SIZE_U64 + 1));
     }
 
     #[test]

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -165,6 +165,16 @@ stability_scope!(BETA {
         }
     }
 
+    /// Outcome of resolving a blob's header at open (see [Header::resolve]).
+    #[derive(Clone, Copy, Debug)]
+    pub(crate) enum HeaderResolution {
+        /// The blob needs a fresh header written: it is new, or an interrupted creation left
+        /// it with a torn header and no committed data.
+        Recreate,
+        /// The header parsed and validated.
+        Valid { blob_version: u16, size: u64 },
+    }
+
     /// Fixed-size header at the start of each [crate::Blob].
     ///
     /// On-disk layout (8 bytes, big-endian):
@@ -225,6 +235,29 @@ stability_scope!(BETA {
                 .expect("header decode should never fail for correct size input");
             header.validate(versions)?;
             Ok((header.blob_version, raw_len - Self::SIZE_U64))
+        }
+
+        /// Resolves a blob's header at open, deciding between recreating the blob and
+        /// honoring the header it records.
+        ///
+        /// `head` holds the blob's first `min(raw_len, Header::SIZE)` raw bytes. Errors are
+        /// classified with [HeaderError::interrupted_creation]: a torn header on a blob that
+        /// cannot hold committed data resolves to [HeaderResolution::Recreate], anything else
+        /// stays a hard error.
+        pub(crate) fn resolve(
+            head: &[u8],
+            raw_len: u64,
+            versions: &RangeInclusive<u16>,
+        ) -> Result<HeaderResolution, HeaderError> {
+            if Self::missing(raw_len) {
+                return Ok(HeaderResolution::Recreate);
+            }
+            let prelude: [u8; Self::SIZE] = head[..Self::SIZE].try_into().unwrap();
+            match Self::from(prelude, raw_len, versions) {
+                Ok((blob_version, size)) => Ok(HeaderResolution::Valid { blob_version, size }),
+                Err(e) if e.interrupted_creation(raw_len) => Ok(HeaderResolution::Recreate),
+                Err(e) => Err(e),
+            }
         }
 
         /// Validates the magic bytes, runtime version, and blob version.

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -1,4 +1,4 @@
-use super::Header;
+use super::{Header, HeaderResolution};
 use crate::{BufferPool, Error};
 use commonware_codec::Encode;
 use commonware_formatting::{from_hex, hex};
@@ -142,23 +142,17 @@ impl crate::Storage for Storage {
 
         // Handle header: new/corrupted blobs get a fresh header written,
         // existing blobs have their header read.
-        let parsed = if Header::missing(len) {
-            None
-        } else {
-            // Existing blob - read and validate header
-            let mut header_bytes = [0u8; Header::SIZE];
-            file.read_exact(&mut header_bytes)
-                .await
-                .map_err(|_| Error::ReadFailed)?;
-            match Header::from(header_bytes, len, &versions) {
-                Ok(parsed) => Some(parsed),
-                Err(e) if e.interrupted_creation(len) => None,
-                Err(e) => return Err(e.into_error(partition, name)),
-            }
-        };
-        let (blob_version, logical_size) = match parsed {
-            Some(parsed) => parsed,
-            None => {
+        let mut head = [0u8; Header::SIZE];
+        let head_len = len.min(Header::SIZE_U64) as usize;
+        file.read_exact(&mut head[..head_len])
+            .await
+            .map_err(|_| Error::ReadFailed)?;
+        let resolution = Header::resolve(&head[..head_len], len, &versions)
+            .map_err(|e| e.into_error(partition, name))?;
+        let (blob_version, logical_size) = match resolution {
+            // Existing blob - honor the header it records
+            HeaderResolution::Valid { blob_version, size } => (blob_version, size),
+            HeaderResolution::Recreate => {
                 // New, torn, or corrupted blob - truncate and write header with latest version
                 let (header, blob_version) = Header::new(&versions);
                 file.set_len(Header::SIZE_U64)

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -16,11 +16,17 @@ mod fallback;
 #[cfg(unix)]
 mod unix;
 
+/// Counts [sync_dir] calls so tests can assert directory-entry durability.
+#[cfg(all(test, unix))]
+static SYNC_DIR_CALLS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 /// Syncs a directory to ensure directory entry changes are durable.
 /// On Unix, directory metadata (file creation/deletion) must be explicitly
 /// fsynced.
 #[cfg(unix)]
 async fn sync_dir(path: &Path) -> Result<(), Error> {
+    #[cfg(test)]
+    SYNC_DIR_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let dir = fs::File::open(path).await.map_err(|e| {
         Error::BlobOpenFailed(
             path.to_string_lossy().to_string(),
@@ -165,6 +171,17 @@ impl crate::Storage for Storage {
                 file.sync_all()
                     .await
                     .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
+
+                // A healed torn creation (len > 0) may be retrying an attempt that failed
+                // before its directory syncs, so its directory entries cannot be assumed
+                // durable even though they exist. (A brand-new file's entries were synced
+                // above; Windows lacks directory-entry syncing, see issue #2026.)
+                #[cfg(unix)]
+                if len > 0 {
+                    sync_dir(parent).await?;
+                    sync_dir(&self.cfg.storage_directory).await?;
+                }
+
                 (blob_version, 0)
             }
         };
@@ -461,8 +478,17 @@ mod tests {
         for (name, torn) in states {
             std::fs::write(partition_path.join(hex(name)), torn).unwrap();
 
+            // Healing must also make the blob's directory entries durable: the attempt that
+            // left the torn file may have failed before its own directory syncs.
+            #[cfg(unix)]
+            let sync_dirs = SYNC_DIR_CALLS.load(std::sync::atomic::Ordering::Relaxed);
             let (blob, size) = storage.open("partition", name).await.unwrap();
             assert_eq!(size, 0, "torn blob should be recreated empty");
+            #[cfg(unix)]
+            assert!(
+                SYNC_DIR_CALLS.load(std::sync::atomic::Ordering::Relaxed) >= sync_dirs + 2,
+                "healing a torn creation should sync its directory entries"
+            );
             blob.write_at(0, b"hello".to_vec()).await.unwrap();
             blob.sync().await.unwrap();
             drop(blob);

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -136,7 +136,11 @@ impl crate::Storage for Storage {
                 // Sync the parent directory to ensure the directory entry is durable.
                 sync_dir(parent).await?;
 
-                // Sync storage directory if parent directory did not exist
+                // Sync storage directory if parent directory did not exist.
+                // `parent_existed` reflects the live filesystem, so a partition directory
+                // left by a failed prior attempt in this process skips this sync; that
+                // narrow window is accepted (process restarts are covered by the startup
+                // filesystem sync).
                 if !parent_existed {
                     sync_dir(&self.cfg.storage_directory).await?;
                 }
@@ -159,9 +163,24 @@ impl crate::Storage for Storage {
             // Existing blob - honor the header it records
             HeaderResolution::Valid { blob_version, size } => (blob_version, size),
             HeaderResolution::Recreate => {
-                // New, torn, or corrupted blob - truncate and write header with latest version
+                // Make the blob name durable BEFORE writing the header: a valid header on
+                // disk then implies its directory entries are durable, which is what lets
+                // the Valid arm skip directory syncs. A healed torn creation (len > 0) may
+                // be retrying an attempt that failed before its directory syncs, so its
+                // directory entries cannot be assumed durable even though they exist. (A
+                // brand-new file's entries were synced above; Windows lacks directory-entry
+                // syncing, see issue #2026.)
+                #[cfg(unix)]
+                if len > 0 {
+                    sync_dir(parent).await?;
+                    sync_dir(&self.cfg.storage_directory).await?;
+                }
+
+                // Truncate to zero before writing so a torn header write cannot splice old
+                // bytes into a fully valid header with a wrong version: every partial state
+                // stays shorter than the header and heals on the next open.
                 let (header, blob_version) = Header::new(&versions);
-                file.set_len(Header::SIZE_U64)
+                file.set_len(0)
                     .await
                     .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
                 file.rewind().await.map_err(|_| Error::WriteFailed)?;
@@ -171,16 +190,6 @@ impl crate::Storage for Storage {
                 file.sync_all()
                     .await
                     .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-
-                // A healed torn creation (len > 0) may be retrying an attempt that failed
-                // before its directory syncs, so its directory entries cannot be assumed
-                // durable even though they exist. (A brand-new file's entries were synced
-                // above; Windows lacks directory-entry syncing, see issue #2026.)
-                #[cfg(unix)]
-                if len > 0 {
-                    sync_dir(parent).await?;
-                    sync_dir(&self.cfg.storage_directory).await?;
-                }
 
                 (blob_version, 0)
             }

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::{ops::RangeInclusive, path::PathBuf, sync::Arc};
 use tokio::{
     fs,
-    io::{AsyncReadExt, AsyncWriteExt},
+    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
     sync::Mutex,
 };
 
@@ -142,26 +142,37 @@ impl crate::Storage for Storage {
 
         // Handle header: new/corrupted blobs get a fresh header written,
         // existing blobs have their header read.
-        let (blob_version, logical_size) = if Header::missing(len) {
-            // New or corrupted blob - truncate and write header with latest version
-            let (header, blob_version) = Header::new(&versions);
-            file.set_len(Header::SIZE_U64)
-                .await
-                .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
-            file.write_all(&header.encode())
-                .await
-                .map_err(|_| Error::WriteFailed)?;
-            file.sync_all()
-                .await
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-            (blob_version, 0)
+        let parsed = if Header::missing(len) {
+            None
         } else {
             // Existing blob - read and validate header
             let mut header_bytes = [0u8; Header::SIZE];
             file.read_exact(&mut header_bytes)
                 .await
                 .map_err(|_| Error::ReadFailed)?;
-            Header::from(header_bytes, len, &versions).map_err(|e| e.into_error(partition, name))?
+            match Header::from(header_bytes, len, &versions) {
+                Ok(parsed) => Some(parsed),
+                Err(e) if e.interrupted_creation(len) => None,
+                Err(e) => return Err(e.into_error(partition, name)),
+            }
+        };
+        let (blob_version, logical_size) = match parsed {
+            Some(parsed) => parsed,
+            None => {
+                // New, torn, or corrupted blob - truncate and write header with latest version
+                let (header, blob_version) = Header::new(&versions);
+                file.set_len(Header::SIZE_U64)
+                    .await
+                    .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
+                file.rewind().await.map_err(|_| Error::WriteFailed)?;
+                file.write_all(&header.encode())
+                    .await
+                    .map_err(|_| Error::WriteFailed)?;
+                file.sync_all()
+                    .await
+                    .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
+                (blob_version, 0)
+            }
         };
 
         #[cfg(unix)]
@@ -413,17 +424,73 @@ mod tests {
             test_pool(),
         );
 
-        // Create the partition directory and a file with invalid magic bytes
+        // Create the partition directory and a file with invalid magic bytes. It must be
+        // larger than the header region: it may carry data, so it is corrupt (a header-sized
+        // file would instead be healed as an interrupted creation).
         let partition_path = storage_directory.join("partition");
         std::fs::create_dir_all(&partition_path).unwrap();
         let bad_magic_path = partition_path.join(hex(b"bad_magic"));
-        std::fs::write(&bad_magic_path, vec![0u8; Header::SIZE]).unwrap();
+        std::fs::write(&bad_magic_path, vec![0u8; Header::SIZE + 1]).unwrap();
 
         // Opening should fail with corrupt error
         let result = storage.open("partition", b"bad_magic").await;
         assert!(
             matches!(result, Err(crate::Error::BlobCorrupt(_, _, reason)) if reason.contains("invalid magic"))
         );
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_blob_torn_header_recreated() {
+        let storage_directory =
+            env::temp_dir().join(format!("test_torn_header_{}", rand::random::<u64>()));
+        let storage = Storage::new(
+            Config {
+                storage_directory: storage_directory.clone(),
+                maximum_buffer_size: 1024 * 1024,
+            },
+            test_pool(),
+        );
+        let partition_path = storage_directory.join("partition");
+        std::fs::create_dir_all(&partition_path).unwrap();
+
+        // A creation interrupted mid-write can leave any garbage in the header region.
+        // Anything that does not parse as a header on a file no larger than the header
+        // region is recreated in place, and the recreated blob is fully usable.
+        let mut torn_version = Vec::from(Header::MAGIC);
+        torn_version.extend_from_slice(&[0xFF; Header::SIZE - Header::MAGIC_LENGTH]);
+        let states = [
+            (b"zeros".as_slice(), vec![0u8; Header::SIZE]),
+            (b"version".as_slice(), torn_version),
+        ];
+        for (name, torn) in states {
+            std::fs::write(partition_path.join(hex(name)), torn).unwrap();
+
+            let (blob, size) = storage.open("partition", name).await.unwrap();
+            assert_eq!(size, 0, "torn blob should be recreated empty");
+            blob.write_at(0, b"hello".to_vec()).await.unwrap();
+            blob.sync().await.unwrap();
+            drop(blob);
+
+            let (blob, size) = storage.open("partition", name).await.unwrap();
+            assert_eq!(size, 5);
+            let read_buf = blob.read_at(0, 5).await.unwrap();
+            assert_eq!(read_buf.coalesce(), b"hello");
+            drop(blob);
+        }
+
+        // A valid header whose blob version is outside the caller's range is a real
+        // conflict, not a torn creation.
+        let (header, _) = Header::new(&(7..=7));
+        std::fs::write(partition_path.join(hex(b"conflict")), header.encode()).unwrap();
+        let result = storage
+            .open_versioned("partition", b"conflict", 0..=0)
+            .await;
+        assert!(matches!(
+            result,
+            Err(crate::Error::BlobVersionMismatch { .. })
+        ));
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }


### PR DESCRIPTION
> **Status: parked.** Likely superseded by #4194, which defers blob durability to the first sync: under that contract the creation-time durability choreography this PR hardens is deleted entirely, and the torn-header recovery core it introduces is carried forward there with a simpler justification (geometry instead of sync ordering). This PR remains the fsync-on-create alternative if #4194 does not ship.

## Summary

Blob creation writes the header into the new file in place (`set_len` -> `write` -> `sync`), so a crash mid-creation can leave a committed-length file whose header bytes are garbage — writes may tear at any point. Opening such a file returned `BlobCorrupt`, and since contiguous-journal init opens every scanned blob, one torn tail file (created eagerly by `seal_tail`) blocked journal reopen until an operator deleted it by hand. Every other layer of the stack already recovers from torn writes unattended (dual page CRC slots, journal rewind); the blob header was the only torn write that escalated to a human.

## Design

Creation makes the header durable before `open` ever returns the blob, and data can only be written through the returned blob. An invalid header on a file **no larger than the header region** is therefore provably a creation that never completed — no data was ever committed through the API — and `open` now recreates it in place. This holds under arbitrary tearing and adds no I/O to the happy path.

What still fails loudly:
- Files **larger** than the header region with an invalid header: data may be at stake, so recreating (which truncates) would be destructive. Still `BlobCorrupt`.
- A valid header whose blob version is outside the caller's range: a fully valid header cannot be a torn creation, so `BlobVersionMismatch` is preserved at any size.

The parse-and-classify decision lives in one shared helper (`Header::resolve`): backends read the blob's leading header bytes and receive either the validated header or the decision to recreate, so classification cannot drift between backends; only the I/O primitives (read, set_len, write, sync) remain per backend.

The rule extends today's `raw_len < 8` recreate behavior to the torn states a crash can actually produce (e.g. a zero-filled file at committed length, or valid magic with garbled version bytes). Existing magic-mismatch tests used an 8-byte zero file — exactly the state that now heals — and were re-specified against a header-region-plus-one file.

## Tests

- `interrupted_creation` classifier unit test (torn states heal at header size, version conflicts and larger files never do).
- Torn-header recreate tests on the memory backend (the deterministic runtime's substrate) and the tokio backend, whose recreate path needed a cursor rewind that the reopen assertion pins. The classification is shared code (`Header::resolve`), so these cover it once; iouring's (updated) magic-mismatch test still covers the loud path, and the full iouring suite plus clippy verified on Linux.

## Notes

- The heal is crash-idempotent: creation and heal truncate the file to zero before writing the header, so a torn header write cannot splice leftover bytes into a valid header with a wrong version - every partial state stays shorter than the header and heals on the next open.
- Directory syncs precede the header write, so a valid header on disk implies its directory entries are durable; this is what entitles the Valid path to skip directory syncs on reopen (including a retry of an attempt that failed mid-creation).

- Reported by qed-audit against #4184; the window predates the V1 header layout (V0 creation has the identical sequence), which is why this lands off `main`. When #4184 rebases onto it, the same rule extends to the 4096-byte V1 header region and its extension-CRC/truncation failures.
- The blob layer cannot distinguish a torn creation from byzantine rot of a previously synced header on a file that never grew past the header region; recreating is chosen because such a file contains no committed data either way. Data-bearing blobs are unaffected by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSarn1C4iMrjHQHrVcanFo