### PR TITLE
[storage] Make Ordinal init cancel-safe

### DIFF
--- a/storage/src/ordinal/mod.rs
+++ b/storage/src/ordinal/mod.rs
@@ -55,10 +55,11 @@
 //!
 //! To recover existing data, pass `Some(bits)` to [Ordinal::init]. The bits identify which records
 //! were durably committed by the caller. [Ordinal] validates required records using their CRC32 and
-//! rebuilds the in-memory [crate::rmap::RMap]. Stored sections omitted from `bits` are removed, and
-//! stored records whose bits are unset are cleared before replay. Missing or invalid required records
-//! fail initialization. Passing `Some(BTreeMap::new())` or `None` removes all stored sections and
-//! starts empty.
+//! rebuilds the in-memory [crate::rmap::RMap]. Stored sections omitted from `bits` are removed.
+//! Stored records whose bits are unset are ignored and left on disk untouched; only `bits` governs
+//! what [Ordinal::has] and [Ordinal::get] observe. Missing or invalid required records fail
+//! initialization. Passing `Some(BTreeMap::new())` or `None` removes all stored sections and starts
+//! empty.
 //!
 //! # Example
 //!
@@ -1822,20 +1823,26 @@ mod tests {
                 );
             }
 
-            // Unselected records in a retained section are physically cleared.
+            // Unselected records in a retained section are left on disk untouched, so a later
+            // commit of one of them recovers the value it was originally written with.
             {
                 let mut bitmap = BitMap::zeroes(10);
                 bitmap.set(0, true); // Index 10
                 let bitmap_option = Some(bitmap);
                 let mut bits_map: BTreeMap<u64, &Option<BitMap>> = BTreeMap::new();
                 bits_map.insert(1, &bitmap_option);
-                let result = Ordinal::<_, FixedBytes<32>>::init(
+                let store = Ordinal::<_, FixedBytes<32>>::init(
                     context.child("third"),
                     cfg.clone(),
                     Some(bits_map),
                 )
-                .await;
-                assert!(matches!(result, Err(Error::MissingRecord(10))));
+                .await
+                .expect("Failed to initialize store with bits");
+                assert!(store.has(10));
+                assert_eq!(
+                    store.get(10).await.unwrap().unwrap(),
+                    FixedBytes::new([10u8; 32])
+                );
             }
         });
     }

--- a/storage/src/ordinal/mod.rs
+++ b/storage/src/ordinal/mod.rs
@@ -1848,6 +1848,66 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_init_zero_bit_bitmap_retains_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-ordinal".into(),
+                items_per_blob: NZU64!(10),
+                write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
+            };
+
+            // Write a record into section 1 and sync it.
+            {
+                let mut store =
+                    Ordinal::<_, FixedBytes<32>>::init(context.child("first"), cfg.clone(), None)
+                        .await
+                        .expect("Failed to initialize store");
+                store
+                    .put(10, FixedBytes::new([10u8; 32]))
+                    .await
+                    .expect("Failed to put data");
+                store.sync().await.expect("Failed to sync data");
+            }
+
+            // Restart with section 1 explicitly listed but no bits set: nothing is committed
+            // yet, but the section's records must survive on disk.
+            let empty = Some(BitMap::zeroes(10));
+            {
+                let mut bits_map: BTreeMap<u64, &Option<BitMap>> = BTreeMap::new();
+                bits_map.insert(1, &empty);
+                let store = Ordinal::<_, FixedBytes<32>>::init(
+                    context.child("second"),
+                    cfg.clone(),
+                    Some(bits_map),
+                )
+                .await
+                .expect("Failed to initialize store with zero-bit bitmap");
+                assert!(!store.has(10));
+            }
+
+            // Restart again with the record's bit set: it must recover the synced value.
+            let mut bitmap = BitMap::zeroes(10);
+            bitmap.set(0, true); // Index 10
+            let committed = Some(bitmap);
+            {
+                let mut bits_map: BTreeMap<u64, &Option<BitMap>> = BTreeMap::new();
+                bits_map.insert(1, &committed);
+                let store =
+                    Ordinal::<_, FixedBytes<32>>::init(context.child("third"), cfg, Some(bits_map))
+                        .await
+                        .expect("Failed to initialize store with committed bit");
+                assert!(store.has(10));
+                assert_eq!(
+                    store.get(10).await.unwrap().unwrap(),
+                    FixedBytes::new([10u8; 32])
+                );
+            }
+        });
+    }
+
+    #[test_traced]
     fn test_init_none_option_all_records_exist() {
         // Initialize the deterministic context
         let executor = deterministic::Runner::default();

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -174,27 +174,6 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
                 }
             }
 
-            // Replay ignores records outside the committed bits, but recovery clears them so
-            // stored blobs match the checkpointed view
-            let empty = vec![0u8; Record::<V>::SIZE];
-            for (section, (blob, size)) in &blobs {
-                // A section with no bitmap requires every record, so nothing is cleared
-                let Some(Some(bits)) = bits.get(section) else {
-                    continue;
-                };
-                let mut modified = false;
-                for bit_index in 0..(*size / record_size) {
-                    if bit_index >= bits.len() || !bits.get(bit_index) {
-                        blob.write_at(bit_index * record_size, empty.clone())
-                            .await?;
-                        modified = true;
-                    }
-                }
-                if modified {
-                    blob.sync().await?;
-                }
-            }
-
             // Rebuild intervals from the committed records
             for (section, bits) in bits {
                 if let Some(bits) = bits {

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -158,14 +158,12 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         let mut items = 0;
         let mut intervals = RMap::new();
         if let Some(bits) = &bits {
-            // Drop sections the committed bits do not cover
+            // Drop sections omitted from `bits`. An explicitly listed section is retained
+            // even when its bitmap has no set bits: unset records are left on disk
+            // untouched, so a later restart can commit them.
             let sections = blobs.keys().copied().collect::<Vec<_>>();
             for section in sections {
-                let keep = match bits.get(&section) {
-                    Some(Some(bits)) => bits.count_ones() != 0,
-                    Some(None) => true,
-                    None => false,
-                };
+                let keep = bits.contains_key(&section);
                 if !keep {
                     context
                         .remove(&config.partition, Some(&section.to_be_bytes()))


### PR DESCRIPTION
## Context

`Ordinal` recovers its state from disk by replaying records into an in-memory `RMap` (`intervals`), driven by a caller-supplied `bits` map that identifies which record indices were durably committed. Everything the public API reports (`has`, `get`, `next_gap`, `missing_items`) is answered from `intervals` alone; none of it reads raw disk bytes at query time.

Despite that, `Ordinal::init` also physically zeroed any on-disk record whose bit was *not* set, for every section it kept. This wasn't required for correctness of the read path above — it was defense-in-depth, intended to keep the stored blob's contents matching the checkpointed view.

## The problem

The zeroing was a `blob.write_at()` + `blob.sync()` against a blob that `init` had just opened fresh via `context.open()`. Per the runtime's blob contract, two independently-opened handles to the same blob name are never ordered against each other. If the `init()` future is dropped mid-repair and `init()` is called again, the retry opens a brand-new handle to the same section. The abandoned zero-write from the first attempt is now an orphan: it can still land on disk at an arbitrary later time, through the old handle, unordered against anything the retry does.

Concretely: the retry can `put()` a new record at the same offset the orphan targets and `sync()` it successfully, and the orphan can then land afterward and zero out the bytes the retry just wrote. The in-memory `intervals` map (built during the retry) still reports the index as present, but a subsequent `get()` fails with `InvalidRecord` because the CRC no longer matches. If that corrupted state is later persisted through another durability barrier, a following restart can fail recovery entirely with `MissingRecord`.

## The fix

Remove the zeroing loop from `Ordinal::init`. Records outside the committed bits are simply left on disk as-is:

- They remain unreachable through the public API, since `has`/`get`/etc. are driven solely by `intervals`, which `bits` alone determines.
- If one of them is legitimately committed in a later `init` call, its original bytes are still valid and get replayed correctly.
- If it's instead overwritten via `put()`, that write fully replaces the record regardless of what was there before.

With no destructive write left in the repair path, there is nothing for a canceled `init` to orphan, and the corruption scenario above can no longer occur. The only thing `init` removes is whole sections omitted from `bits`: retention keys purely on presence in the map, so an explicitly listed section is retained even when none of its bits are set, leaving its uncommitted records on disk for a later restart to commit. Record replay/validation is unchanged.

Updated the module docs to describe the new (simpler) recovery contract, and updated the tests that exercised the old destructive behavior to assert the new one: an uncommitted record survives untouched — whether or not its section has any committed records — and is recoverable if a later `init` commits it.
