### PR TITLE
[runtime,storage] Defer blob durability to the first sync

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -697,7 +697,9 @@ stability_scope!(BETA {
         /// Multiple instances of the same blob can be opened concurrently, however,
         /// writing to the same blob concurrently may lead to undefined behavior.
         ///
-        /// An Ok result indicates the blob is durably created (or already exists).
+        /// Creation is NOT durable until the blob's first [Blob::sync] returns: a crash
+        /// before then may lose the blob (or leave a torn header), and reopening recreates
+        /// it empty. Data written to the blob is likewise only durable after a sync.
         ///
         /// # Versions
         ///
@@ -818,7 +820,9 @@ stability_scope!(BETA {
         /// If the length is less than the current length, the blob is resized.
         fn resize(&self, len: u64) -> impl Future<Output = Result<(), Error>> + Send;
 
-        /// Ensure all pending data is durably persisted.
+        /// Ensure all pending data is durably persisted, including (on the first call) the
+        /// blob's directory entries: until a sync returns, neither the blob's contents nor
+        /// its existence are crash-durable.
         fn sync(&self) -> impl Future<Output = Result<(), Error>> + Send;
 
         /// Request that all pending data is durably persisted.

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -20,7 +20,7 @@
 //! This implementation is only available on Linux systems that support io_uring.
 //! It requires Linux kernel 6.1 or newer. See [crate::iouring] for details.
 
-use super::{Header, HeaderError, ParsedHeader};
+use super::{Header, HeaderResolution};
 use crate::{
     iouring::{self},
     telemetry::metrics::Register,
@@ -37,6 +37,40 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+
+/// Directories whose entries must be durable before a blob's contents are durable: the
+/// partition directory (holds the blob's entry) and the storage root (holds the partition
+/// directory's entry). Creation performs no fsyncs, so the blob's first sync makes these
+/// durable. Directory fsyncs are rare one-shots, so they run as blocking calls rather than
+/// through the ring.
+struct DirSync {
+    parent: PathBuf,
+    root: PathBuf,
+    synced: std::sync::atomic::AtomicBool,
+}
+
+impl DirSync {
+    const fn new(parent: PathBuf, root: PathBuf) -> Self {
+        Self {
+            parent,
+            root,
+            synced: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Fsync the directory entries once per blob handle (subsequent calls are no-ops).
+    /// Racing first syncs may both fsync; that is harmless.
+    fn sync(&self) -> Result<(), Error> {
+        if self.synced.load(std::sync::atomic::Ordering::Acquire) {
+            return Ok(());
+        }
+        sync_dir(&self.parent)?;
+        sync_dir(&self.root)?;
+        self.synced
+            .store(true, std::sync::atomic::Ordering::Release);
+        Ok(())
+    }
+}
 
 /// Syncs a directory to ensure directory entry changes are durable.
 /// On Unix, directory metadata (file creation/deletion) must be explicitly fsynced.
@@ -126,9 +160,6 @@ impl crate::Storage for Storage {
             .parent()
             .ok_or_else(|| Error::PartitionMissing(partition.into()))?;
 
-        // Check if partition exists before creating
-        let parent_existed = parent.exists();
-
         // Create the partition directory if it does not exist
         fs::create_dir_all(parent).map_err(|_| Error::PartitionCreationFailed(partition.into()))?;
 
@@ -144,78 +175,41 @@ impl crate::Storage for Storage {
         // Assume empty files are newly created. Existing empty files will be synced too; that's OK.
         let raw_len = file.metadata().map_err(|_| Error::ReadFailed)?.len();
 
-        // Handle header: new/corrupted blobs get a fresh header written,
-        // existing blobs have their header read.
-        let (info, data_offset) = if Header::missing(raw_len) {
-            // New (or corrupted) blob - truncate and write the header region with latest version
-            // Truncate to zero before writing so a torn header write cannot splice old
-            // bytes into a fully valid header with a wrong version: every partial state
-            // stays shorter than the prelude and is recreated on the next open.
-            let (region, blob_version, data_offset) = Header::create(&versions, layout);
-            file.set_len(0)
-                .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
-            file.seek(SeekFrom::Start(0))
-                .map_err(|_| Error::WriteFailed)?;
-            file.write_all(&region).map_err(|_| Error::WriteFailed)?;
-            file.sync_all()
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-
-            // For new files, sync the parent directory to ensure the directory entry is durable.
-            if raw_len == 0 {
-                sync_dir(parent)?;
-                if !parent_existed {
-                    sync_dir(&self.storage_directory)?;
-                }
-            }
-
-            let info = BlobInfo {
-                size: 0,
-                blob_version,
-                layout,
-            };
-            (info, data_offset)
-        } else {
-            // Existing blob - read and validate the header, honoring the layout it records
-            file.seek(SeekFrom::Start(0))
-                .map_err(|_| Error::ReadFailed)?;
-            let mut prelude = [0u8; Header::PRELUDE_SIZE];
-            file.read_exact(&mut prelude)
-                .map_err(|_| Error::ReadFailed)?;
-            let parsed = Header::parse_prelude(prelude, &versions)
-                .map_err(|e| e.into_error(partition, name))?;
-            match parsed {
-                ParsedHeader::V0 { blob_version } => {
-                    let info = BlobInfo {
-                        size: raw_len - Header::PRELUDE_SIZE_U64,
-                        blob_version,
-                        layout: BlobHeaderLayout::V0,
-                    };
-                    (info, Header::PRELUDE_SIZE_U64)
-                }
-                ParsedHeader::NeedsExtension { blob_version } => {
-                    let ext_end = Header::PRELUDE_SIZE_U64 + Header::EXTENSION_SIZE as u64;
-                    if raw_len < ext_end {
-                        return Err(HeaderError::TruncatedHeader {
-                            data_offset: ext_end,
-                            raw_len,
-                        }
-                        .into_error(partition, name));
-                    }
-                    let mut extension = [0u8; Header::EXTENSION_SIZE];
-                    file.read_exact(&mut extension)
-                        .map_err(|_| Error::ReadFailed)?;
-                    let data_offset = Header::parse_extension(prelude, extension, raw_len)
-                        .map_err(|e| e.into_error(partition, name))?;
-                    let info = BlobInfo {
-                        size: raw_len - data_offset,
-                        blob_version,
-                        layout: BlobHeaderLayout::V1,
-                    };
-                    (info, data_offset)
-                }
+        // Resolve the header: torn or missing headers are recreated, valid headers are
+        // honored. Creation performs NO fsyncs: durability (of the file and its directory
+        // entries) is established by the blob's first sync.
+        let mut head = [0u8; Header::RESOLVE_SIZE];
+        let head_len = raw_len.min(Header::RESOLVE_SIZE as u64) as usize;
+        file.seek(SeekFrom::Start(0))
+            .map_err(|_| Error::ReadFailed)?;
+        file.read_exact(&mut head[..head_len])
+            .map_err(|_| Error::ReadFailed)?;
+        let resolution = Header::resolve(&head[..head_len], raw_len, &versions)
+            .map_err(|e| e.into_error(partition, name))?;
+        let (info, data_offset) = match resolution {
+            // Existing blob - honor the header it records
+            HeaderResolution::Valid { info, data_offset } => (info, data_offset),
+            // New, torn, or corrupted blob - truncate and write the header region. Truncate
+            // to zero first so a torn header write cannot splice old bytes into a fully
+            // valid header with a wrong version: every partial state stays shorter than the
+            // header region and is recreated on the next open.
+            HeaderResolution::Recreate => {
+                let (region, blob_version, data_offset) = Header::create(&versions, layout);
+                file.set_len(0)
+                    .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
+                file.seek(SeekFrom::Start(0))
+                    .map_err(|_| Error::WriteFailed)?;
+                file.write_all(&region).map_err(|_| Error::WriteFailed)?;
+                let info = BlobInfo {
+                    size: 0,
+                    blob_version,
+                    layout,
+                };
+                (info, data_offset)
             }
         };
 
+        let dirs = DirSync::new(parent.to_path_buf(), self.storage_directory.clone());
         let blob = Blob::new(
             partition.into(),
             name,
@@ -223,6 +217,7 @@ impl crate::Storage for Storage {
             self.io_handle.clone(),
             self.pool.clone(),
             data_offset,
+            dirs,
         );
         Ok((blob, info))
     }
@@ -300,6 +295,8 @@ pub struct Blob {
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// Directory entries made durable by the first sync (shared across clones).
+    dirs: Arc<DirSync>,
 }
 
 impl Clone for Blob {
@@ -311,6 +308,7 @@ impl Clone for Blob {
             io_handle: self.io_handle.clone(),
             pool: self.pool.clone(),
             data_offset: self.data_offset,
+            dirs: self.dirs.clone(),
         }
     }
 }
@@ -324,6 +322,7 @@ impl Blob {
         io_handle: iouring::Handle,
         pool: BufferPool,
         data_offset: u64,
+        dirs: DirSync,
     ) -> Self {
         Self {
             partition,
@@ -332,6 +331,7 @@ impl Blob {
             io_handle,
             pool,
             data_offset,
+            dirs: Arc::new(dirs),
         }
     }
 }
@@ -440,16 +440,18 @@ impl crate::Blob for Blob {
             .map_err(|err| match err {
                 Error::Io(e) => Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e),
                 err => err,
-            })
+            })?;
+        self.dirs.sync()
     }
 
     async fn start_sync(&self) -> Handle<()> {
         let partition = self.partition.clone();
         let name = self.name.clone();
         let receiver = self.io_handle.start_sync(self.file.clone()).await;
+        let dirs = self.dirs.clone();
         Handle::from_future(async move {
             match receiver.await {
-                Ok(Ok(())) => Ok(()),
+                Ok(Ok(())) => dirs.sync(),
                 Ok(Err(Error::Io(e))) => Err(Error::BlobSyncFailed(partition, hex(&name), e)),
                 Ok(Err(err)) => Err(err),
                 Err(_) => Err(Error::Closed),
@@ -723,9 +725,16 @@ mod tests {
         let partition_path = storage_directory.join("partition");
         std::fs::create_dir_all(&partition_path).unwrap();
 
-        // Manually create a file with invalid magic bytes
+        // Manually create a file with invalid magic bytes. It must exceed the largest
+        // header region a creation writes (V1_DATA_OFFSET): a file within that bound holds
+        // no synced data and is recreated as an interrupted creation, while anything larger
+        // may carry data, so its invalid header is corruption.
         let bad_magic_path = partition_path.join(hex(b"bad_magic"));
-        std::fs::write(&bad_magic_path, vec![0u8; Header::PRELUDE_SIZE]).unwrap();
+        std::fs::write(
+            &bad_magic_path,
+            vec![0u8; Header::V1_DATA_OFFSET as usize + 1],
+        )
+        .unwrap();
 
         // Opening should fail with corrupt error
         let err = storage
@@ -1051,6 +1060,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
+            DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
 
         // Read and write should fail through their wrapper-specific error enums
@@ -1110,6 +1120,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
+            DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         // Sync should fail through the blob-specific wrapper before any kernel work is attempted.
         let err = blob
@@ -1149,6 +1160,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
+            DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         let err = blob
             .start_sync()
@@ -1192,6 +1204,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
+            DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         let err = blob
             .resize(0)
@@ -1230,6 +1243,7 @@ mod tests {
             submitter.clone(),
             pool,
             Header::PRELUDE_SIZE_U64,
+            DirSync::new(std::env::temp_dir(), std::env::temp_dir()),
         );
         // The request should reach the kernel and come back as a wrapped sync failure.
         let err = blob

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,4 +1,4 @@
-use super::{Header, HeaderError, ParsedHeader};
+use super::{Header, HeaderResolution};
 #[commonware_macros::stability(BETA)]
 use crate::{BlobHeaderLayout, BlobInfo};
 use crate::{Buf, BufferPool, Handle, IoBufs, IoBufsMut};
@@ -58,52 +58,24 @@ impl crate::Storage for Storage {
         let content = partition_entry.entry(name.into()).or_default();
 
         let raw_len = content.len() as u64;
-        let (info, data_offset) = if Header::missing(raw_len) {
-            // New or corrupted blob - truncate and write the header region with latest version
-            let (region, blob_version, data_offset) = Header::create(&versions, layout);
-            content.clear();
-            content.extend_from_slice(&region);
-            let info = BlobInfo {
-                size: 0,
-                blob_version,
-                layout,
-            };
-            (info, data_offset)
-        } else {
-            // Existing blob - read and validate the header, honoring the layout it records
-            let mut prelude = [0u8; Header::PRELUDE_SIZE];
-            prelude.copy_from_slice(&content[..Header::PRELUDE_SIZE]);
-            let parsed = Header::parse_prelude(prelude, &versions)
-                .map_err(|e| e.into_error(partition, name))?;
-            match parsed {
-                ParsedHeader::V0 { blob_version } => {
-                    let info = BlobInfo {
-                        size: raw_len - Header::PRELUDE_SIZE_U64,
-                        blob_version,
-                        layout: BlobHeaderLayout::V0,
-                    };
-                    (info, Header::PRELUDE_SIZE_U64)
-                }
-                ParsedHeader::NeedsExtension { blob_version } => {
-                    let ext_end = Header::PRELUDE_SIZE + Header::EXTENSION_SIZE;
-                    if content.len() < ext_end {
-                        return Err(HeaderError::TruncatedHeader {
-                            data_offset: ext_end as u64,
-                            raw_len,
-                        }
-                        .into_error(partition, name));
-                    }
-                    let mut extension = [0u8; Header::EXTENSION_SIZE];
-                    extension.copy_from_slice(&content[Header::PRELUDE_SIZE..ext_end]);
-                    let data_offset = Header::parse_extension(prelude, extension, raw_len)
-                        .map_err(|e| e.into_error(partition, name))?;
-                    let info = BlobInfo {
-                        size: raw_len - data_offset,
-                        blob_version,
-                        layout: BlobHeaderLayout::V1,
-                    };
-                    (info, data_offset)
-                }
+        let head_len = (raw_len as usize).min(Header::RESOLVE_SIZE);
+        let resolution = Header::resolve(&content[..head_len], raw_len, &versions)
+            .map_err(|e| e.into_error(partition, name))?;
+        let (info, data_offset) = match resolution {
+            // Existing blob - honor the header it records
+            HeaderResolution::Valid { info, data_offset } => (info, data_offset),
+            // New, torn, or corrupted blob - truncate and write the header region with
+            // latest version
+            HeaderResolution::Recreate => {
+                let (region, blob_version, data_offset) = Header::create(&versions, layout);
+                content.clear();
+                content.extend_from_slice(&region);
+                let info = BlobInfo {
+                    size: 0,
+                    blob_version,
+                    layout,
+                };
+                (info, data_offset)
             }
         };
 
@@ -433,11 +405,17 @@ mod tests {
     async fn test_blob_magic_mismatch() {
         let storage = Storage::new(test_pool());
 
-        // Manually insert a blob with invalid magic bytes
+        // Manually insert a blob with invalid magic bytes. It must exceed the largest
+        // header region a creation writes (V1_DATA_OFFSET): a file within that bound holds
+        // no synced data and is recreated as an interrupted creation, while anything larger
+        // may carry data, so its invalid header is corruption.
         {
             let mut partitions = storage.partitions.lock();
             let partition = partitions.entry("partition".into()).or_default();
-            partition.insert(b"bad_magic".to_vec(), vec![0u8; Header::PRELUDE_SIZE]);
+            partition.insert(
+                b"bad_magic".to_vec(),
+                vec![0u8; Header::V1_DATA_OFFSET as usize + 1],
+            );
         }
 
         // Opening should fail with corrupt error

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -179,6 +179,30 @@ stability_scope!(BETA {
                 ),
             }
         }
+
+        /// Returns true when this error on a blob of `raw_len` raw bytes indicates a creation
+        /// whose durability was never established, so the blob can be recreated without
+        /// losing anything a caller was promised.
+        ///
+        /// Data lives past the header region and durability is only promised once a
+        /// [crate::Blob::sync] returns (which makes the whole file, header included,
+        /// durable). A file no larger than the largest header region a writer produces
+        /// ([Header::V1_DATA_OFFSET]) whose bytes do not form a header (writes may tear at
+        /// any point) therefore holds no synced data. Two errors never qualify:
+        /// [HeaderError::VersionMismatch] requires a fully valid header and reports a real
+        /// version conflict, and [HeaderError::InvalidDataOffset] requires a CRC-valid
+        /// extension recording an offset no writer produces, so it reports a writer bug
+        /// rather than tearing.
+        pub(crate) const fn interrupted_creation(&self, raw_len: u64) -> bool {
+            raw_len <= Header::V1_DATA_OFFSET
+                && matches!(
+                    self,
+                    Self::InvalidMagic { .. }
+                        | Self::UnsupportedRuntimeVersion { .. }
+                        | Self::InvalidHeaderChecksum
+                        | Self::TruncatedHeader { .. }
+                )
+        }
     }
 
     /// Fixed-size header prelude at the start of each [crate::Blob].
@@ -219,6 +243,19 @@ stability_scope!(BETA {
         NeedsExtension { blob_version: u16 },
     }
 
+    /// Outcome of resolving a blob's header region at open (see [Header::resolve]).
+    #[derive(Clone, Copy, Debug)]
+    pub(crate) enum HeaderResolution {
+        /// The blob needs a fresh header region written: it is new, or an interrupted
+        /// creation left it with a torn header and no synced data.
+        Recreate,
+        /// The header parsed and validated; data begins at `data_offset`.
+        Valid {
+            info: crate::BlobInfo,
+            data_offset: u64,
+        },
+    }
+
     impl Header {
         /// Size of the header prelude in bytes.
         pub(crate) const PRELUDE_SIZE: usize = 8;
@@ -228,6 +265,10 @@ stability_scope!(BETA {
 
         /// Size of the V1 header extension in bytes (data offset + CRC32).
         pub(crate) const EXTENSION_SIZE: usize = 8;
+
+        /// Number of leading blob bytes needed to resolve any header (prelude plus
+        /// extension).
+        pub(crate) const RESOLVE_SIZE: usize = Self::PRELUDE_SIZE + Self::EXTENSION_SIZE;
 
         /// Data offset written when creating a blob with [BlobHeaderLayout::V1]: the header
         /// region occupies exactly one 4096-byte page.
@@ -342,6 +383,68 @@ stability_scope!(BETA {
                 });
             }
             Ok(data_offset)
+        }
+
+        /// Resolves a blob's header region at open, deciding between recreating the blob
+        /// and honoring the header it records.
+        ///
+        /// `head` holds the blob's first `min(raw_len, RESOLVE_SIZE)` raw bytes. Errors are
+        /// classified with [HeaderError::interrupted_creation]: a torn header on a blob that
+        /// cannot hold synced data resolves to [HeaderResolution::Recreate], anything else
+        /// stays a hard error.
+        pub(crate) fn resolve(
+            head: &[u8],
+            raw_len: u64,
+            versions: &RangeInclusive<u16>,
+        ) -> Result<HeaderResolution, HeaderError> {
+            if Self::missing(raw_len) {
+                return Ok(HeaderResolution::Recreate);
+            }
+            match Self::try_parse(head, raw_len, versions) {
+                Ok(resolution) => Ok(resolution),
+                Err(e) if e.interrupted_creation(raw_len) => Ok(HeaderResolution::Recreate),
+                Err(e) => Err(e),
+            }
+        }
+
+        /// Parses and validates a full header (prelude, and extension if the layout has one)
+        /// from a blob's first bytes.
+        fn try_parse(
+            head: &[u8],
+            raw_len: u64,
+            versions: &RangeInclusive<u16>,
+        ) -> Result<HeaderResolution, HeaderError> {
+            let prelude: [u8; Self::PRELUDE_SIZE] =
+                head[..Self::PRELUDE_SIZE].try_into().unwrap();
+            let (blob_version, layout, data_offset) = match Self::parse_prelude(
+                prelude, versions,
+            )? {
+                ParsedHeader::V0 { blob_version } => {
+                    (blob_version, BlobHeaderLayout::V0, Self::PRELUDE_SIZE_U64)
+                }
+                ParsedHeader::NeedsExtension { blob_version } => {
+                    if raw_len < Self::RESOLVE_SIZE as u64 {
+                        return Err(HeaderError::TruncatedHeader {
+                            data_offset: Self::RESOLVE_SIZE as u64,
+                            raw_len,
+                        });
+                    }
+                    let extension: [u8; Self::EXTENSION_SIZE] = head
+                        [Self::PRELUDE_SIZE..Self::RESOLVE_SIZE]
+                        .try_into()
+                        .unwrap();
+                    let data_offset = Self::parse_extension(prelude, extension, raw_len)?;
+                    (blob_version, BlobHeaderLayout::V1, data_offset)
+                }
+            };
+            Ok(HeaderResolution::Valid {
+                info: crate::BlobInfo {
+                    size: raw_len - data_offset,
+                    blob_version,
+                    layout,
+                },
+                data_offset,
+            })
         }
 
         /// Validates the magic bytes, runtime version, and blob version.

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -1,4 +1,4 @@
-use super::{Header, HeaderError, ParsedHeader};
+use super::{Header, HeaderResolution};
 #[commonware_macros::stability(BETA)]
 use crate::{BlobHeaderLayout, BlobInfo};
 use crate::{BufferPool, Error};
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::{ops::RangeInclusive, path::PathBuf, sync::Arc};
 use tokio::{
     fs,
-    io::{AsyncReadExt, AsyncWriteExt},
+    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
     sync::Mutex,
 };
 
@@ -95,10 +95,6 @@ impl crate::Storage for Storage {
             None => return Err(Error::PartitionCreationFailed(partition.into())),
         };
 
-        // Check if partition exists before creating
-        #[cfg(unix)]
-        let parent_existed = parent.exists();
-
         // Create the partition directory, if it does not exist
         fs::create_dir_all(parent)
             .await
@@ -114,96 +110,43 @@ impl crate::Storage for Storage {
             .await
             .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e.into()))?;
 
-        // Assume empty files are newly created. Existing empty files will be synced too; that's OK.
         let len = file.metadata().await.map_err(|_| Error::ReadFailed)?.len();
-        let newly_created = len == 0;
-
-        // Only sync if we created a new file
-        if newly_created {
-            // Sync the file to ensure it is durable
-            file.sync_all()
-                .await
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-
-            // Windows doesn't have a notion of syncing a directory entry to ensure that it's
-            // durably persisted. See https://github.com/commonwarexyz/monorepo/issues/2026.
-            #[cfg(unix)]
-            {
-                // Sync the parent directory to ensure the directory entry is durable.
-                sync_dir(parent).await?;
-
-                // Sync storage directory if parent directory did not exist
-                if !parent_existed {
-                    sync_dir(&self.cfg.storage_directory).await?;
-                }
-            }
-        }
 
         // Set the maximum buffer size
         file.set_max_buf_size(self.cfg.maximum_buffer_size);
 
-        // Handle header: new/corrupted blobs get a fresh header written,
-        // existing blobs have their header read.
-        let (info, data_offset) = if Header::missing(len) {
-            // New or corrupted blob - truncate and write the header region with latest version
-            // Truncate to zero before writing so a torn header write cannot splice old
-            // bytes into a fully valid header with a wrong version: every partial state
-            // stays shorter than the prelude and is recreated on the next open.
-            let (region, blob_version, data_offset) = Header::create(&versions, layout);
-            file.set_len(0)
-                .await
-                .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
-            file.write_all(&region)
-                .await
-                .map_err(|_| Error::WriteFailed)?;
-            file.sync_all()
-                .await
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-            let info = BlobInfo {
-                size: 0,
-                blob_version,
-                layout,
-            };
-            (info, data_offset)
-        } else {
-            // Existing blob - read and validate the header, honoring the layout it records
-            let mut prelude = [0u8; Header::PRELUDE_SIZE];
-            file.read_exact(&mut prelude)
-                .await
-                .map_err(|_| Error::ReadFailed)?;
-            let parsed = Header::parse_prelude(prelude, &versions)
-                .map_err(|e| e.into_error(partition, name))?;
-            match parsed {
-                ParsedHeader::V0 { blob_version } => {
-                    let info = BlobInfo {
-                        size: len - Header::PRELUDE_SIZE_U64,
-                        blob_version,
-                        layout: BlobHeaderLayout::V0,
-                    };
-                    (info, Header::PRELUDE_SIZE_U64)
-                }
-                ParsedHeader::NeedsExtension { blob_version } => {
-                    let ext_end = Header::PRELUDE_SIZE_U64 + Header::EXTENSION_SIZE as u64;
-                    if len < ext_end {
-                        return Err(HeaderError::TruncatedHeader {
-                            data_offset: ext_end,
-                            raw_len: len,
-                        }
-                        .into_error(partition, name));
-                    }
-                    let mut extension = [0u8; Header::EXTENSION_SIZE];
-                    file.read_exact(&mut extension)
-                        .await
-                        .map_err(|_| Error::ReadFailed)?;
-                    let data_offset = Header::parse_extension(prelude, extension, len)
-                        .map_err(|e| e.into_error(partition, name))?;
-                    let info = BlobInfo {
-                        size: len - data_offset,
-                        blob_version,
-                        layout: BlobHeaderLayout::V1,
-                    };
-                    (info, data_offset)
-                }
+        // Resolve the header: torn or missing headers are recreated, valid headers are
+        // honored. Creation performs NO fsyncs: durability (of the file and its directory
+        // entries) is established by the blob's first sync.
+        let mut head = [0u8; Header::RESOLVE_SIZE];
+        let head_len = len.min(Header::RESOLVE_SIZE as u64) as usize;
+        file.read_exact(&mut head[..head_len])
+            .await
+            .map_err(|_| Error::ReadFailed)?;
+        let resolution = Header::resolve(&head[..head_len], len, &versions)
+            .map_err(|e| e.into_error(partition, name))?;
+        let (info, data_offset) = match resolution {
+            // Existing blob - honor the header it records
+            HeaderResolution::Valid { info, data_offset } => (info, data_offset),
+            // New, torn, or corrupted blob - truncate and write the header region. Truncate
+            // to zero first so a torn header write cannot splice old bytes into a fully
+            // valid header with a wrong version: every partial state stays shorter than the
+            // header region and is recreated on the next open.
+            HeaderResolution::Recreate => {
+                let (region, blob_version, data_offset) = Header::create(&versions, layout);
+                file.set_len(0)
+                    .await
+                    .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
+                file.rewind().await.map_err(|_| Error::WriteFailed)?;
+                file.write_all(&region)
+                    .await
+                    .map_err(|_| Error::WriteFailed)?;
+                let info = BlobInfo {
+                    size: 0,
+                    blob_version,
+                    layout,
+                };
+                (info, data_offset)
             }
         };
 
@@ -213,8 +156,16 @@ impl crate::Storage for Storage {
             let file = file.into_std().await;
 
             // Construct the blob
+            let dirs = unix::DirSync::new(parent.to_path_buf(), self.cfg.storage_directory.clone());
             Ok((
-                Self::Blob::new(partition.into(), name, file, self.pool.clone(), data_offset),
+                Self::Blob::new(
+                    partition.into(),
+                    name,
+                    file,
+                    self.pool.clone(),
+                    data_offset,
+                    dirs,
+                ),
                 info,
             ))
         }
@@ -501,7 +452,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_blob_truncated_extension_is_corrupt() {
+    async fn test_blob_truncated_extension_is_recreated() {
         let storage_directory = env::temp_dir().join(format!(
             "test_truncated_extension_{}",
             rand::random::<u64>()
@@ -524,11 +475,9 @@ mod tests {
         file.set_len(Header::PRELUDE_SIZE_U64 + 4).unwrap();
         drop(file);
 
-        // Opening must report corruption, not a transient read failure.
-        let result = storage.open("partition", b"truncated").await;
-        assert!(
-            matches!(result, Err(crate::Error::BlobCorrupt(_, _, reason)) if reason.contains("truncated"))
-        );
+        // An interrupted creation holds no synced data: opening recreates the blob.
+        let (_, size) = storage.open("partition", b"truncated").await.unwrap();
+        assert_eq!(size, 0, "truncated creation should be recreated empty");
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
@@ -582,6 +531,110 @@ mod tests {
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_creation_defers_durability_to_first_sync() {
+        let storage_directory =
+            env::temp_dir().join(format!("test_deferred_create_{}", rand::random::<u64>()));
+        let storage = Storage::new(
+            Config {
+                storage_directory: storage_directory.clone(),
+                maximum_buffer_size: 1024 * 1024,
+            },
+            test_pool(),
+        );
+
+        // Creation performs no directory fsyncs.
+        let before = unix::DIR_SYNC_CALLS.load(std::sync::atomic::Ordering::Relaxed);
+        let (blob, _) = storage.open("partition", b"deferred").await.unwrap();
+        assert_eq!(
+            unix::DIR_SYNC_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+            before,
+            "creation should not fsync directories"
+        );
+
+        // The first sync makes the blob's directory entries durable...
+        blob.write_at(0, b"hello".to_vec()).await.unwrap();
+        blob.sync().await.unwrap();
+        assert_eq!(
+            unix::DIR_SYNC_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+            before + 2,
+            "first sync should fsync the partition directory and storage root"
+        );
+
+        // ...and later syncs do not repeat the directory fsyncs.
+        blob.sync().await.unwrap();
+        assert_eq!(
+            unix::DIR_SYNC_CALLS.load(std::sync::atomic::Ordering::Relaxed),
+            before + 2,
+            "later syncs should not fsync directories again"
+        );
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_blob_torn_header_recreated() {
+        let storage_directory =
+            env::temp_dir().join(format!("test_torn_header_{}", rand::random::<u64>()));
+        let storage = Storage::new(
+            Config {
+                storage_directory: storage_directory.clone(),
+                maximum_buffer_size: 1024 * 1024,
+            },
+            test_pool(),
+        );
+        let partition_path = storage_directory.join("partition");
+        std::fs::create_dir_all(&partition_path).unwrap();
+
+        // A creation interrupted before its first sync can leave any garbage in the header
+        // region. Anything that does not parse as a header on a file no larger than the
+        // header region is recreated in place, and the recreated blob is fully usable.
+        let mut torn_version = Vec::from(Header::MAGIC);
+        torn_version.extend_from_slice(&[0xFF; Header::PRELUDE_SIZE - Header::MAGIC_LENGTH]);
+        let mut torn_extension =
+            Vec::from(&Header::create(&(0..=0), BlobHeaderLayout::V1).0[..Header::PRELUDE_SIZE]);
+        torn_extension.extend_from_slice(&[0xFF; Header::EXTENSION_SIZE]);
+        let states = [
+            (b"zeros".as_slice(), vec![0u8; Header::PRELUDE_SIZE]),
+            (
+                b"region".as_slice(),
+                vec![0u8; Header::V1_DATA_OFFSET as usize],
+            ),
+            (b"version".as_slice(), torn_version),
+            (b"extension".as_slice(), torn_extension),
+        ];
+        for (name, torn) in states {
+            std::fs::write(partition_path.join(hex(name)), torn).unwrap();
+
+            let (blob, size) = storage.open("partition", name).await.unwrap();
+            assert_eq!(size, 0, "torn blob should be recreated empty");
+            blob.write_at(0, b"hello".to_vec()).await.unwrap();
+            blob.sync().await.unwrap();
+            drop(blob);
+
+            let (blob, size) = storage.open("partition", name).await.unwrap();
+            assert_eq!(size, 5);
+            let read_buf = blob.read_at(0, 5).await.unwrap();
+            assert_eq!(read_buf.coalesce(), b"hello");
+            drop(blob);
+        }
+
+        // A valid header whose blob version is outside the caller's range is a real
+        // conflict, not a torn creation.
+        let (region, _, _) = Header::create(&(7..=7), BlobHeaderLayout::V0);
+        std::fs::write(partition_path.join(hex(b"conflict")), region).unwrap();
+        let result = storage
+            .open_versioned("partition", b"conflict", 0..=0, BlobHeaderLayout::V1)
+            .await;
+        assert!(matches!(
+            result,
+            Err(crate::Error::BlobVersionMismatch { .. })
+        ));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
     #[tokio::test]
     async fn test_blob_magic_mismatch() {
         let storage_directory =
@@ -594,11 +647,18 @@ mod tests {
             test_pool(),
         );
 
-        // Create the partition directory and a file with invalid magic bytes
+        // Create the partition directory and a file with invalid magic bytes. It must
+        // exceed the largest header region a creation writes (V1_DATA_OFFSET): a file within
+        // that bound holds no synced data and is recreated as an interrupted creation, while
+        // anything larger may carry data, so its invalid header is corruption.
         let partition_path = storage_directory.join("partition");
         std::fs::create_dir_all(&partition_path).unwrap();
         let bad_magic_path = partition_path.join(hex(b"bad_magic"));
-        std::fs::write(&bad_magic_path, vec![0u8; Header::PRELUDE_SIZE]).unwrap();
+        std::fs::write(
+            &bad_magic_path,
+            vec![0u8; Header::V1_DATA_OFFSET as usize + 1],
+        )
+        .unwrap();
 
         // Opening should fail with corrupt error
         let result = storage.open("partition", b"bad_magic").await;

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -6,13 +6,63 @@ use std::{
     fs::File,
     io::IoSlice,
     os::{fd::AsRawFd, unix::fs::FileExt},
-    sync::Arc,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 use tokio::task;
 
 // Cap iovec batch size: larger iovecs reduce syscall count but increase
 // per-write kernel setup overhead.
 const IOVEC_BATCH_SIZE: usize = 32;
+
+/// Directories whose entries must be durable before this blob's contents are durable:
+/// the partition directory (holds the blob's entry) and the storage root (holds the
+/// partition directory's entry). Creation performs no fsyncs, so the blob's first sync
+/// makes these durable.
+pub struct DirSync {
+    parent: PathBuf,
+    root: PathBuf,
+    synced: AtomicBool,
+}
+
+/// Counts directory fsyncs so tests can assert when durability is established.
+#[cfg(test)]
+pub(super) static DIR_SYNC_CALLS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+impl DirSync {
+    pub const fn new(parent: PathBuf, root: PathBuf) -> Self {
+        Self {
+            parent,
+            root,
+            synced: AtomicBool::new(false),
+        }
+    }
+
+    /// Fsync the directory entries once per blob handle (subsequent calls are no-ops).
+    /// Racing first syncs may both fsync; that is harmless.
+    fn sync(&self) -> Result<(), Error> {
+        if self.synced.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        for dir in [&self.parent, &self.root] {
+            #[cfg(test)]
+            DIR_SYNC_CALLS.fetch_add(1, Ordering::Relaxed);
+            File::open(dir).and_then(|d| d.sync_all()).map_err(|e| {
+                Error::BlobSyncFailed(
+                    dir.to_string_lossy().to_string(),
+                    "directory".to_string(),
+                    e.into(),
+                )
+            })?;
+        }
+        self.synced.store(true, Ordering::Release);
+        Ok(())
+    }
+}
 
 #[derive(Clone)]
 pub struct Blob {
@@ -22,6 +72,8 @@ pub struct Blob {
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// Directory entries made durable by the first sync (shared across clones).
+    dirs: Arc<DirSync>,
 }
 
 impl Blob {
@@ -31,6 +83,7 @@ impl Blob {
         file: File,
         pool: BufferPool,
         data_offset: u64,
+        dirs: DirSync,
     ) -> Self {
         Self {
             partition,
@@ -38,12 +91,14 @@ impl Blob {
             file: Arc::new(file),
             pool,
             data_offset,
+            dirs: Arc::new(dirs),
         }
     }
 
-    fn sync_inner(file: &File, partition: &str, name: &[u8]) -> Result<(), Error> {
+    fn sync_inner(file: &File, partition: &str, name: &[u8], dirs: &DirSync) -> Result<(), Error> {
         file.sync_all()
-            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e.into()))
+            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e.into()))?;
+        dirs.sync()
     }
 
     fn write_single_at(file: &File, offset: u64, buf: &[u8]) -> Result<(), Error> {
@@ -191,9 +246,10 @@ impl crate::Blob for Blob {
             } else {
                 let partition = self.partition.clone();
                 let name = self.name.clone();
+                let dirs = self.dirs.clone();
                 task::spawn_blocking(move || {
                     Self::write_vectored_at(&file, offset, bufs, None)?;
-                    Self::sync_inner(&file, &partition, &name)
+                    Self::sync_inner(&file, &partition, &name, &dirs)
                 })
                 .await
                 .map_err(|_| Error::WriteFailed)?
@@ -220,7 +276,8 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         let partition = self.partition.clone();
         let name = self.name.clone();
-        task::spawn_blocking(move || Self::sync_inner(&file, &partition, &name))
+        let dirs = self.dirs.clone();
+        task::spawn_blocking(move || Self::sync_inner(&file, &partition, &name, &dirs))
             .await
             .map_err(|e| {
                 let err: std::io::Error = e.into();
@@ -233,8 +290,9 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         let partition = self.partition.clone();
         let name = self.name.clone();
+        let dirs = self.dirs.clone();
         task::spawn_blocking(move || {
-            let result = Self::sync_inner(&file, &partition, &name);
+            let result = Self::sync_inner(&file, &partition, &name, &dirs);
             let _ = tx.send(result);
         });
         Handle::from_receiver(rx)

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -12,7 +12,7 @@ use commonware_runtime::{
 };
 use futures::future::try_join_all;
 use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Metrics for a journal's blobs.
 struct Metrics {
@@ -77,21 +77,47 @@ impl<E: Context> Partition<E> {
     }
 
     /// Scan the partition and open every existing blob as a [`Writer`], keyed by blob index.
-    pub(super) async fn open_all(&self) -> Result<BTreeMap<u64, Writer<E::Blob>>, Error> {
+    ///
+    /// A corrupt header on the HIGHEST-indexed blob is not an error here: blob creation is
+    /// not durable until the blob's first sync, so a crash can leave the newest blob with a
+    /// torn header that the runtime cannot heal (its raw length may exceed the header
+    /// region). That blob is skipped and its index returned so the caller can adjudicate
+    /// with its own recovery metadata. Corruption anywhere else stays a hard error.
+    pub(super) async fn open_all(
+        &self,
+    ) -> Result<(BTreeMap<u64, Writer<E::Blob>>, Option<u64>), Error> {
         let stored = Self::scan_names(&self.context, &self.name).await?;
 
-        let mut blobs = BTreeMap::new();
+        // Decode and sort indices so the highest blob is identifiable before opening.
+        let mut indices = Vec::with_capacity(stored.len());
         for name in stored {
             let hex_name = hex(&name);
             let bytes: [u8; 8] = name
                 .try_into()
                 .map_err(|_| Error::InvalidBlobName(hex_name.clone()))?;
-            let index = u64::from_be_bytes(bytes);
-            let writer = self.open(index).await?;
-            debug!(index, blob = hex_name, "loaded blob");
-            blobs.insert(index, writer);
+            indices.push(u64::from_be_bytes(bytes));
         }
-        Ok(blobs)
+        indices.sort_unstable();
+
+        let mut blobs = BTreeMap::new();
+        let mut corrupt_tail = None;
+        for (i, &index) in indices.iter().enumerate() {
+            match self.open(index).await {
+                Ok(writer) => {
+                    debug!(index, "loaded blob");
+                    blobs.insert(index, writer);
+                }
+                Err(Error::Runtime(RError::BlobCorrupt(p, n, reason)))
+                    if i == indices.len() - 1 =>
+                {
+                    warn!(index, %reason, "newest blob header is corrupt; deferring to caller");
+                    corrupt_tail = Some(index);
+                    let _ = (p, n);
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Ok((blobs, corrupt_tail))
     }
 
     /// Remove the given blob.

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -419,7 +419,33 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             cfg.page_cache,
             cfg.write_buffer,
         );
-        let mut pending = partition.open_all().await?;
+        let (mut pending, corrupt_tail) = partition.open_all().await?;
+
+        // A corrupt header on the newest blob is a torn, never-synced creation if the
+        // checkpoint watermark proves no item inside it was ever durably adopted (creation
+        // is not durable until a blob's first sync). In that case the blob provably holds
+        // nothing committed: remove it and let recovery proceed as if the crash had lost
+        // the file entirely. If the watermark points inside the blob, committed data is at
+        // stake, so fail loudly.
+        if let Some(corrupt) = corrupt_tail {
+            let blob_start = corrupt
+                .checked_mul(cfg.items_per_blob.get())
+                .ok_or(Error::OffsetOverflow)?;
+            if checkpoint.watermark().is_none_or(|w| w <= blob_start) {
+                warn!(
+                    blob = corrupt,
+                    "removing corrupt newest blob: no adopted items inside it"
+                );
+                partition.remove(corrupt).await?;
+            } else {
+                return Err(Error::Runtime(commonware_runtime::Error::BlobCorrupt(
+                    cfg.partition.clone(),
+                    format!("{corrupt}"),
+                    "newest blob header is corrupt and the checkpoint watermark lies inside it"
+                        .into(),
+                )));
+            }
+        }
 
         // Truncate any trailing non-chunk-aligned bytes on every blob before recovery. Items
         // are fixed size, so a blob ending in fewer than `CHUNK_SIZE` trailing bytes is junk
@@ -1491,6 +1517,76 @@ mod tests {
     /// Generate a SHA-256 digest for the given value.
     fn test_digest(value: u64) -> Digest {
         Sha256::hash(&value.to_be_bytes())
+    }
+
+    /// A crash before a new tail blob's first sync can leave it with a torn header the
+    /// runtime cannot heal (raw length beyond the header region). The journal adjudicates
+    /// with its checkpoint watermark: no adopted items inside the blob means it is removed
+    /// and the durable prefix recovers; a watermark inside it means committed data is at
+    /// stake, so init fails loudly. Raw torn bytes below the blob API can only be injected
+    /// through a real filesystem, hence the tokio runtime.
+    #[test_traced]
+    fn test_corrupt_unsynced_tail_blob_recovery() {
+        let storage_directory =
+            std::env::temp_dir().join(format!("journal_torn_tail_{}", rand::random::<u64>()));
+        let runtime_cfg = commonware_runtime::tokio::Config::new()
+            .with_storage_directory(storage_directory.clone());
+
+        // Build a journal with two full blobs (0, 1) and an empty tail (blob 2).
+        commonware_runtime::tokio::Runner::new(runtime_cfg.clone()).start({
+            move |context| async move {
+                let cfg = test_cfg(&context, NZU64!(2));
+                let mut journal = Journal::<_, Digest>::init(context.child("j"), cfg)
+                    .await
+                    .unwrap();
+                for i in 0u64..4 {
+                    journal.append(&test_digest(i)).await.unwrap();
+                }
+                journal.sync().await.unwrap();
+            }
+        });
+
+        // Simulate the post-crash state: the newest blob holds garbage larger than the
+        // header region, which the runtime classifies as corrupt (it may carry data).
+        let blob_path = storage_directory
+            .join("test-partition-blobs")
+            .join(commonware_formatting::hex(&2u64.to_be_bytes()));
+        std::fs::write(&blob_path, vec![0xAAu8; 5000]).unwrap();
+
+        // Reopen: the watermark (4) sits at the corrupt blob's start (2 * 2), so nothing
+        // adopted lives inside it; the journal removes it and recovers the durable prefix.
+        commonware_runtime::tokio::Runner::new(runtime_cfg.clone()).start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(2));
+            let mut journal = Journal::<_, Digest>::init(context.child("j"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.size(), 4);
+            for i in 0u64..4 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            // The journal remains fully usable past the recovered prefix.
+            journal.append(&test_digest(4)).await.unwrap();
+            journal.sync().await.unwrap();
+        });
+
+        // Now corrupt the newest blob while the watermark points INSIDE it (5 items were
+        // synced, so position 4 in blob 2 is adopted): init must fail loudly.
+        std::fs::write(&blob_path, vec![0xAAu8; 5000]).unwrap();
+        commonware_runtime::tokio::Runner::new(runtime_cfg).start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(2));
+            let result = Journal::<_, Digest>::init(context.child("j"), cfg).await;
+            let err = result.err().expect("init should fail loudly");
+            assert!(
+                matches!(
+                    &err,
+                    Error::Runtime(RuntimeError::BlobCorrupt(_, _, reason))
+                        if reason.contains("watermark")
+                ),
+                "expected loud corruption, got {err:?}"
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
     }
 
     fn test_cfg(pooler: &impl BufferPooler, items_per_blob: NonZeroU64) -> Config {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1095,7 +1095,14 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             cfg.page_cache,
             cfg.write_buffer,
         );
-        let mut pending = partition.open_all().await?;
+        let (mut pending, corrupt_tail) = partition.open_all().await?;
+        // TODO(prototype): adjudicate a corrupt newest blob with the checkpoint watermark
+        // as the fixed journal does; until then keep the strict behavior.
+        if let Some(corrupt) = corrupt_tail {
+            return Err(Error::Corruption(format!(
+                "newest blob {corrupt} header is corrupt"
+            )));
+        }
 
         // Validate and align the offsets journal to match the data blobs.
         let bounds = Self::align(


### PR DESCRIPTION
## Summary

Prototype for step 2 of #4190: blob **creation performs no fsyncs**. Durability - of the file, its directory entry, and the partition directory's own entry in the storage root - is established by the blob's **first `sync()`**. This deletes the entire creation-time durability choreography (the empty-file sync, the directory fsyncs at open, and their ordering concerns) and moves the cost off the journal rollover path: blobs that never sync never pay.

## Design

- **`DirSync`**: each file-backed `Blob` carries its partition-directory and storage-root paths plus a once flag; the first sync fsyncs file -> partition dir -> storage root (later syncs skip the directories). Contracts updated: `open_versioned` states creation is not durable until the first sync; `Blob::sync` owns dirent durability.
- **Torn-header recovery** (required foundation): with no creation fsync, torn headers at final names are normal crash states. `Header::resolve` recreates any file no larger than the header region whose bytes do not form a header - under this contract that file *provably* holds no synced data, by geometry alone: data lives past the region and a sync makes the whole file durable, header included. Creation truncates to zero before writing, so no torn write can splice leftover bytes into a valid wrong-version header. `VersionMismatch` (valid header, real conflict) and CRC-valid-but-bogus offsets stay loud at any size, as does any invalid header on a file large enough to carry data.
- **Watermark adjudication**: the one state the blob layer cannot classify - an invalid header on a file *larger* than the region, produced by writeback flushing unsynced data pages but not the header - is decided by the caller. The fixed contiguous journal's `open_all` defers a corrupt *newest* blob to `init`, which removes it when the checkpoint watermark proves no adopted item lives inside it and fails loudly when one does. A regression test drives both directions through a real filesystem.

## Status: prototype

Known gaps before this could leave draft:
- The variable contiguous journal keeps strict (loud) behavior; the same watermark pattern applies.
- Other blob consumers (metadata, archive, freezer) not yet audited under the weakened creation contract (metadata syncs immediately after writing, so it should be unaffected; the freezer interaction is the same class as the separately-assigned rewind-blindness issue).
- iouring compiles but has not been exercised on Linux yet; the non-unix fallback performs no directory fsyncs (pre-existing, #2026).
- The measurement that motivates this (creation-fsync cost on the rollover path) has not been run; per #4190 it should gate whether this ships.

## Notes

- Stacked on #4184 (page-aligned layout); the parked #4189/#4193 recovery/fsync work is subsumed by this design if it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSarn1C4iMrjHQHrVcanFo