### PR TITLE
[storage/qmdb] Parallelize staged-update sort in resolve_updates

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1171,6 +1171,7 @@ where
         self,
         updates: Vec<(usize, Option<U::Value>)>,
         upserts: Vec<(U::Key, Option<U::Value>)>,
+        strategy: &S,
     ) -> (UnmerkleizedBatch<F, H, U, S>, StagedUpdates<F, U>) {
         let Self {
             mut batch,
@@ -1206,7 +1207,10 @@ where
                 }
             }
         }
-        staged_updates.sort_unstable_by_key(|entry| entry.1);
+
+        // Locations are unique after last-write-wins dedup, so the parallel sort
+        // is deterministic.
+        strategy.sort_by(&mut staged_updates, |a, b| a.1.cmp(&b.1));
         (Self::apply_upserts(batch, upserts), staged_updates)
     }
 }
@@ -1249,7 +1253,7 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
-        let (batch, staged_updates) = self.resolve_updates(updates, upserts);
+        let (batch, staged_updates) = self.resolve_updates(updates, upserts, db.strategy());
         batch
             .merkleize_with_floor_scan(db, metadata, staged_updates, |floor, tip, limit, out| {
                 fill_candidates(&db.bitmap, floor, tip, limit, out)
@@ -1296,7 +1300,7 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
-        let (batch, staged_updates) = self.resolve_updates(updates, upserts);
+        let (batch, staged_updates) = self.resolve_updates(updates, upserts, db.strategy());
         batch
             .merkleize_with_floor_scan(db, metadata, staged_updates, |floor, tip, limit, out| {
                 fill_candidates(&db.bitmap, floor, tip, limit, out)
@@ -3353,6 +3357,7 @@ mod tests {
                     (5, Some(fallback)),
                 ],
                 vec![(k2, Some(upsert))],
+                &Sequential,
             );
 
             assert_eq!(
@@ -3445,7 +3450,7 @@ mod tests {
             updates.extend([(2 * n + 1, Some(mut_new)), (2 * n + 3, Some(staged_new))]);
 
             let (batch, staged_updates) =
-                staged.resolve_updates(updates, vec![(overlapped, Some(upsert))]);
+                staged.resolve_updates(updates, vec![(overlapped, Some(upsert))], &Sequential);
 
             let mut expected = vec![(staged_newer, loc(501), (), Some(staged_new))];
             expected
@@ -3558,6 +3563,7 @@ mod tests {
             let (batch, staged_updates) = staged.resolve_updates(
                 vec![(0, None), (1, Some(value_a)), (2, Some(value_b))],
                 Vec::new(),
+                &Sequential,
             );
 
             assert_eq!(

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -517,7 +517,7 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let (inner, staged_updates) = inner.resolve_updates(updates, upserts);
+        let (inner, staged_updates) = inner.resolve_updates(updates, upserts, db.any.strategy());
         let inner = inner
             .merkleize_with_floor_scan(
                 &db.any,
@@ -574,7 +574,7 @@ where
             grafted_parent,
             bitmap_parent,
         } = self;
-        let (inner, staged_updates) = inner.resolve_updates(updates, upserts);
+        let (inner, staged_updates) = inner.resolve_updates(updates, upserts, db.any.strategy());
         let inner = inner
             .merkleize_with_floor_scan(
                 &db.any,


### PR DESCRIPTION
## Motivation

`Staged::resolve_updates` ends with a serial `sort_unstable_by_key` over the staged updates. Each `StagedUpdate` carries the key, location, cached payload, and value (~90 bytes for a 32-byte-key fixed db), so at tens of thousands of staged updates the sort moves tens of MB of memory serially on the merkleize critical path while the strategy's workers sit idle. In CPU profiles of a constantinople-shape block it is the largest single serial phase inside `merkleize`.

## Change

Thread the db's `Strategy` into `resolve_updates` and sort with `strategy.sort_by`. Locations are unique after the last-write-wins dedup performed by the `handled` walk, so the comparator is a total order and the parallel sort result is deterministic.

## Measurements

Constantinople-shape pipeline (unique fixture, 32,768 txs → 65,536 staged updates over a 1M-account db, `Rayon(8)`, mimalloc, M-series macOS). Control and fix were built identically via a `[patch]` onto local worktrees:

| | merkleize | block pipeline |
|---|---|---|
| `main` (e1ab57dd8) | 11.85 ms | 13.99 ms |
| this PR | 9.3–10.2 ms | 11.2–12.4 ms |

State roots are byte-identical across all runs and all fixtures (unique/shared/mixed); the win holds at −14% to −23% of the end-to-end block pipeline depending on fixture.

Also measured and deliberately **not** included: skipping the `handled` set on an upsert-free fast path gains nothing beyond the sort (within noise — empty-map `BTreeMap::remove` is free and the ahash inserts are cheap), while dragging in duplicate-key ordering caveats. The set stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZo1ShQ8SAcnoM11QNvHwL
