### PR TITLE
[ci] Gate cooldown on PR dependency changes

### DIFF
--- a/.github/scripts/check_dependency_cooldown.sh
+++ b/.github/scripts/check_dependency_cooldown.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+check_cooldown() {
+  cargo cooldown --workspace --all-features check
+}
+
+check_lockfile() {
+  git diff --exit-code Cargo.lock
+}
+
+if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
+  check_cooldown
+  check_lockfile
+  exit 0
+fi
+
+base_ref="${COOLDOWN_BASE_REF:-}"
+head_sha="${COOLDOWN_HEAD_SHA:-}"
+if [[ -z "${base_ref}" || -z "${head_sha}" ]]; then
+  echo "COOLDOWN_BASE_REF and COOLDOWN_HEAD_SHA are required for pull_request cooldown checks" >&2
+  exit 1
+fi
+
+git fetch --no-tags --depth=1 origin "refs/heads/${base_ref}:refs/remotes/origin/${base_ref}"
+base_rev="refs/remotes/origin/${base_ref}"
+
+if git diff --quiet "${base_rev}" "${head_sha}" -- Cargo.lock; then
+  echo "Cargo.lock did not change; skipping cargo-cooldown."
+  exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+cp Cargo.lock "${tmpdir}/pr.Cargo.lock"
+trap 'cp "${tmpdir}/pr.Cargo.lock" Cargo.lock; rm -rf "${tmpdir}"' EXIT
+
+git show "${base_rev}:Cargo.lock" > Cargo.lock
+
+check_cooldown
+
+if ! cmp --silent Cargo.lock "${tmpdir}/pr.Cargo.lock"; then
+  echo "Cargo.lock differs after applying the cooldown baseline." >&2
+  echo "Regenerate Cargo.lock after the upgraded dependencies satisfy cooldown." >&2
+  exit 1
+fi

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -270,6 +270,9 @@ jobs:
       with:
         tool: just@1.43.0,cargo-cooldown@${{ env.CARGO_COOLDOWN_VERSION }}
     - name: Check dependency cooldown
+      env:
+        COOLDOWN_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        COOLDOWN_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: just cooldown
 
   Lock:

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -1,4 +1,4 @@
 cooldown_minutes = 10080
 enforcement = "strict"
-lockfile_baseline = "ignore"
+lockfile_baseline = "floor"
 cache_dir = "target/cargo-cooldown"

--- a/justfile
+++ b/justfile
@@ -87,8 +87,7 @@ check-publish-order:
 
 # Check that locked dependencies are at least 7 days old
 cooldown:
-    cargo cooldown --workspace --all-features check
-    git diff --exit-code Cargo.lock
+    ./.github/scripts/check_dependency_cooldown.sh
 
 # Run custom Dylint lints
 dylint:


### PR DESCRIPTION
## Overview

Adjusts the dependency cooldown CI job to compare against the PR base rather than always firing on the current lockfile. This allows us to merge PRs that fail the cooldown check when we want without borking `main` CI and still get cooldown notifications for PRs that bump to newly published dependencies.