### PR TITLE
[ci] batch-build and count-balance fuzz jobs

### DIFF
--- a/.github/scripts/hash_partition.py
+++ b/.github/scripts/hash_partition.py
@@ -5,23 +5,35 @@
 # dependencies = []
 # ///
 """
-Hash-partition stdin lines deterministically.
+Partition stdin lines deterministically, balanced to within one entry.
 
-Reads lines from stdin and prints only those whose SHA-256 hash falls into the
-requested partition.
+Reads lines from stdin and prints only those assigned to the requested
+partition. Assignment uses rendezvous hashing with bounded loads: every entry
+ranks the partitions by `sha256(entry || partition)` and takes the
+highest-ranked partition that still has capacity `ceil(n / M)`. This keeps
+partition sizes balanced to within one entry while preserving most of the
+stability of plain hashing: adding or removing an entry moves that entry plus
+at most a short chain of capacity overflows, rather than reshuffling the
+whole set.
 
 Usage:
   - <command> | hash_partition.py N/M
 
 where N is the 1-indexed partition (1..M) and M is the total partition count.
-M=1 is a pass-through. Blank input lines are skipped.
+M=1 is a pass-through. Blank input lines are skipped and duplicates are
+assigned once.
 
-The hash bucket is `sha256(line) mod M`, which gives a stable assignment that
-doesn't shift when unrelated entries are added or removed.
+Entries are processed in an order derived from their own hashes, so the
+outcome is independent of input order.
 """
 
 import hashlib
+import math
 import sys
+
+
+def digest(data: str) -> int:
+    return int(hashlib.sha256(data.encode()).hexdigest(), 16)
 
 
 def main() -> None:
@@ -37,15 +49,35 @@ def main() -> None:
     if total < 1 or not (1 <= part <= total):
         sys.exit(f"partition out of range: {part}/{total}")
 
+    lines = []
+    seen = set()
     for raw in sys.stdin:
         line = raw.rstrip("\n")
-        if not line:
+        if not line or line in seen:
             continue
-        if total == 1:
+        seen.add(line)
+        lines.append(line)
+
+    if total == 1:
+        for line in lines:
             print(line)
-            continue
-        bucket = int(hashlib.sha256(line.encode()).hexdigest(), 16) % total
-        if bucket == part - 1:
+        return
+
+    capacity = math.ceil(len(lines) / total)
+    loads = [0] * total
+    assignment = {}
+    for line in sorted(lines, key=digest):
+        prefs = sorted(
+            range(total), key=lambda p: digest(f"{line}\x00{p}"), reverse=True
+        )
+        for p in prefs:
+            if loads[p] < capacity:
+                loads[p] += 1
+                assignment[line] = p
+                break
+
+    for line in lines:
+        if assignment[line] == part - 1:
             print(line)
 
 

--- a/.github/scripts/hash_partition.py
+++ b/.github/scripts/hash_partition.py
@@ -5,16 +5,18 @@
 # dependencies = []
 # ///
 """
-Partition stdin lines deterministically, balanced to within one entry.
+Partition stdin lines deterministically, with no partition exceeding its
+fair share.
 
 Reads lines from stdin and prints only those assigned to the requested
 partition. Assignment uses rendezvous hashing with bounded loads: every entry
 ranks the partitions by `sha256(entry || partition)` and takes the
-highest-ranked partition that still has capacity `ceil(n / M)`. This keeps
-partition sizes balanced to within one entry while preserving most of the
-stability of plain hashing: adding or removing an entry moves that entry plus
-at most a short chain of capacity overflows, rather than reshuffling the
-whole set.
+highest-ranked partition that still has capacity `ceil(n / M)`. The capacity
+bound caps the largest partition (and thus the job tail) at `ceil(n / M)`
+entries while preserving most of the stability of plain hashing: adding or
+removing an entry moves that entry plus at most a short chain of capacity
+overflows, rather than reshuffling the whole set. Only the maximum is
+bounded, so a partition can fall more than one entry below the others.
 
 Usage:
   - <command> | hash_partition.py N/M
@@ -24,7 +26,10 @@ M=1 is a pass-through. Blank input lines are skipped and duplicates are
 assigned once.
 
 Entries are processed in an order derived from their own hashes, so the
-outcome is independent of input order.
+outcome is independent of input order. Assignment does depend on the full
+input set, however. Parallel invocations selecting different partitions of
+the same set must be fed identical input, or an entry can be assigned to
+multiple partitions or to none.
 """
 
 import hashlib

--- a/justfile
+++ b/justfile
@@ -103,6 +103,13 @@ fuzz fuzz_dir max_time='60' max_mem='4000':
     #!/usr/bin/env bash
     set -euo pipefail
     targets=$(cargo {{nightly_version}} fuzz list --fuzz-dir {{fuzz_dir}} | python3 .github/scripts/hash_partition.py {{partition}})
+    if [ -z "$targets" ]; then
+        exit 0
+    fi
+    # Build every target in one cargo invocation before fuzzing. Each target is
+    # its own sanitizer-instrumented binary, so building inside the run loop
+    # serializes the links against the fuzz sessions while most cores sit idle.
+    cargo {{nightly_version}} fuzz build --fuzz-dir {{fuzz_dir}}
     for target in $targets; do
         cargo {{nightly_version}} fuzz run $target --fuzz-dir {{fuzz_dir}} -- -max_total_time={{max_time}} -rss_limit_mb={{max_mem}}
         rm -f {{fuzz_dir}}/target/*/release/$target


### PR DESCRIPTION
Two changes to how fuzz jobs are built and partitioned:

1. **Batch build**: build every target in one cargo invocation before the run loop. Each target is its own sanitizer-instrumented binary, so building inside the loop serialized the compiles and links between the 60s fuzz sessions while most cores sat idle.
   
2. **Balanced partitions via bounded rendezvous hashing**: hash partitioning balances well when there are enough entries to smooth the buckets out, which is why the test suites (thousands of tests across 20 partitions) keep plain nextest hash partitioning. Fuzz dirs have far too few entries for that: 36 storage targets across 4 partitions hashed to a 13/11/7/5 split, and since every target costs a fixed 60s of fuzzing, the largest partition set the job tail. `hash_partition.py` now ranks partitions per entry by `sha256(entry, partition)` and assigns each entry to its highest-ranked partition with capacity `ceil(n/M)`. This balances partitions to within one entry while keeping near-hash stability: simulated on the storage targets, an addition moves 1-2 existing entries (a naive round-robin would move all 36) and a removal moves 0-1, so per-partition corpus caches survive routine target additions. `test-benches` inherits the same behavior, since bench binaries are similarly few.

Measured on storage (the slowest fuzz job):

| | max partition | spread |
|---|---|---|
| before | 24.4m | 15.0-24.4m |
| batch build | 22.5m | 15.0-22.5m |
| + balanced partitions | **19.6m** | **18.2-19.6m** |
