### PR TITLE
[storage/qmdb] Improved Merkleize

### DIFF
--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -2295,12 +2295,9 @@ mod tests {
         assert_eq!(g2_set.len(), NUM_ITEMS);
 
         // Verify that `BTreeSet` iteration is sorted, which relies on `Ord`.
-        let scalars: Vec<_> = scalar_set.iter().collect();
-        assert!(scalars.windows(2).all(|w| w[0] <= w[1]));
-        let g1s: Vec<_> = g1_set.iter().collect();
-        assert!(g1s.windows(2).all(|w| w[0] <= w[1]));
-        let g2s: Vec<_> = g2_set.iter().collect();
-        assert!(g2s.windows(2).all(|w| w[0] <= w[1]));
+        assert!(scalar_set.iter().is_sorted());
+        assert!(g1_set.iter().is_sorted());
+        assert!(g2_set.iter().is_sorted());
 
         // Test that we can use these types as keys in hash maps, which relies on `Hash` and `Eq`.
         let scalar_map: HashMap<_, _> = scalar_set.iter().cloned().zip(0..).collect();

--- a/storage/src/index/partitioned/mod.rs
+++ b/storage/src/index/partitioned/mod.rs
@@ -172,12 +172,10 @@ mod tests {
             &[0xFF],
             &[0xFF, 0xFF],
         ];
-        for window in ordered_keys.windows(2) {
-            assert!(
-                window[0] < window[1],
-                "test keys must be in lexicographic order"
-            );
-        }
+        assert!(
+            ordered_keys.is_sorted_by(|a, b| a < b),
+            "test keys must be in lexicographic order"
+        );
 
         let mut prev = 0;
         for key in ordered_keys {

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -741,7 +741,10 @@ where
         // acquisition per blob a shard touches). The sortedness assert keeps contract
         // violations deterministic: past it, a non-increasing batch would only trip per-shard
         // validation when an inversion lands inside a single shard.
-        crate::journal::assert_positions_increasing(positions);
+        assert!(
+            positions.is_sorted_by(|a, b| a < b),
+            "positions must be strictly increasing"
+        );
         let strategy = self.strategy();
         let journal = &self.journal;
         let mut items = strategy.run(

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1176,7 +1176,10 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
         if positions.is_empty() {
             return Ok(Vec::new());
         }
-        crate::journal::assert_positions_increasing(positions);
+        assert!(
+            positions.is_sorted_by(|a, b| a < b),
+            "positions must be strictly increasing"
+        );
         for &pos in positions {
             self.validate_readable(pos)?;
         }
@@ -1246,7 +1249,10 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
     /// position: `Some(item)` for sync hits and `None` for positions that require I/O, fail to
     /// decode, or fall outside `bounds()`.
     pub(super) fn probe_items(&self, positions: &[u64]) -> Vec<Option<A>> {
-        crate::journal::assert_positions_increasing(positions);
+        assert!(
+            positions.is_sorted_by(|a, b| a < b),
+            "positions must be strictly increasing"
+        );
         let mut out: Vec<Option<A>> = (0..positions.len()).map(|_| None).collect();
 
         // Sorted positions put pruned ones in a prefix and out-of-range ones in a suffix, so

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -685,7 +685,10 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
         if last_position >= self.bounds.end {
             return Err(Error::ItemOutOfRange(last_position));
         }
-        crate::journal::assert_positions_increasing(positions);
+        assert!(
+            positions.is_sorted_by(|a, b| a < b),
+            "positions must be strictly increasing"
+        );
         Ok(())
     }
 
@@ -1036,7 +1039,10 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
     }
 
     fn try_read_many_sync(&self, positions: &[u64]) -> Vec<Option<V>> {
-        crate::journal::assert_positions_increasing(positions);
+        assert!(
+            positions.is_sorted_by(|a, b| a < b),
+            "positions must be strictly increasing"
+        );
         let mut items: Vec<Option<V>> = (0..positions.len()).map(|_| None).collect();
         self.read_many_sync_pass(positions, &mut items);
         items

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -15,7 +15,7 @@ pub mod segmented;
 /// Assert the batched-read caller contract that positions are strictly increasing.
 pub(crate) fn assert_positions_increasing(positions: &[u64]) {
     assert!(
-        positions.windows(2).all(|w| w[0] < w[1]),
+        positions.is_sorted_by(|a, b| a < b),
         "positions must be strictly increasing"
     );
 }

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -12,14 +12,6 @@ pub mod contiguous;
 mod frame;
 pub mod segmented;
 
-/// Assert the batched-read caller contract that positions are strictly increasing.
-pub(crate) fn assert_positions_increasing(positions: &[u64]) {
-    assert!(
-        positions.is_sorted_by(|a, b| a < b),
-        "positions must be strictly increasing"
-    );
-}
-
 #[cfg(all(test, feature = "arbitrary"))]
 mod conformance;
 

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -178,7 +178,10 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         positions: &[u64],
         buf: &mut [u8],
     ) -> Result<(Vec<A>, usize), Error> {
-        crate::journal::assert_positions_increasing(positions);
+        assert!(
+            positions.is_sorted_by(|a, b| a < b),
+            "positions must be strictly increasing"
+        );
         if positions.is_empty() {
             return Ok((Vec::new(), 0));
         }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -38,6 +38,11 @@ use tracing::debug;
 type DiffVec<K, F, V> = Vec<(K, DiffEntry<F, V>)>;
 type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 
+/// User mutation recorded before `ops` and `diff` materialization.
+///
+/// `(key, superseded committed location, new value)` where `None` means delete.
+type EmitEvent<K, F, V> = (K, Option<Location<F>>, Option<V>);
+
 /// One contiguous chunk of floor-raise candidates paired with their resolved operations.
 type CandidateChunk<'a, F, U> = (&'a [Location<F>], &'a [Operation<F, U>]);
 
@@ -114,6 +119,39 @@ pub(crate) fn lookup_sorted<'a, K: Ord, V>(entries: &'a [(K, V)], key: &K) -> Op
         .binary_search_by(|(candidate, _)| candidate.cmp(key))
         .ok()
         .map(|idx| &entries[idx].1)
+}
+
+/// Returns whether sorted, deduplicated `locs` contains `target`, advancing `cursor` past
+/// entries below it. Successive calls must use non-decreasing `target`s.
+fn sorted_contains<F: Family>(
+    locs: &[Location<F>],
+    cursor: &mut usize,
+    target: Location<F>,
+) -> bool {
+    while locs.get(*cursor).is_some_and(|&loc| loc < target) {
+        *cursor += 1;
+    }
+    locs.get(*cursor) == Some(&target)
+}
+
+/// Merge two key-sorted diffs with disjoint keys into one sorted diff.
+fn merge_sorted_diffs<K: Ord, F: Family, V>(
+    a: DiffVec<K, F, V>,
+    b: DiffVec<K, F, V>,
+) -> DiffVec<K, F, V> {
+    let mut merged = Vec::with_capacity(a.len() + b.len());
+    let mut a = a.into_iter().peekable();
+    let mut b = b.into_iter().peekable();
+    while let (Some(x), Some(y)) = (a.peek(), b.peek()) {
+        if x.0 < y.0 {
+            merged.push(a.next().expect("peeked"));
+        } else {
+            merged.push(b.next().expect("peeked"));
+        }
+    }
+    merged.extend(a);
+    merged.extend(b);
+    merged
 }
 
 /// Where this batch's inherited state comes from.
@@ -851,6 +889,16 @@ where
             strategy.sort_by(&mut superseded_locs, |a, b| a.cmp(b));
             superseded_locs.dedup();
 
+            // The raise appends at most `total_steps` moved ops plus the CommitFloor; reserve
+            // once instead of growing mid-loop.
+            ops.reserve(total_steps as usize + 1);
+
+            // `fill_candidates` yields ascending locations, so superseded checks advance a
+            // monotonic cursor.
+            let mut filter_cursor = 0;
+            let mut apply_cursor = 0;
+
+            // Scan active operations in `[floor, fixed_tip)` and move them to the tip.
             while moved < total_steps {
                 // Collect candidates, capped by the number of active ops still needed.
                 // `scan_from` tracks prefetch progress separately from `floor`, so
@@ -868,7 +916,9 @@ where
                 let read_candidates: Vec<_> = candidates
                     .iter()
                     .copied()
-                    .filter(|candidate| superseded_locs.binary_search(candidate).is_err())
+                    .filter(|&candidate| {
+                        !sorted_contains(&superseded_locs, &mut filter_cursor, candidate)
+                    })
                     .collect();
                 let (resolved, outcomes): (_, Vec<Vec<FloorOutcome<F>>>) =
                     if read_candidates.is_empty() {
@@ -945,7 +995,7 @@ where
                 let mut reads = read_candidates.into_iter().zip(resolved);
                 for candidate in candidates {
                     floor = Location::new(*candidate + 1);
-                    if superseded_locs.binary_search(&candidate).is_ok() {
+                    if sorted_contains(&superseded_locs, &mut apply_cursor, candidate) {
                         continue;
                     }
                     let (read_candidate, op) = reads.next().expect("one read per candidate");
@@ -988,8 +1038,8 @@ where
                 // `floor_diff` only accumulates keys that were not already present in `diff`.
                 // A key can only be moved once during this floor raise because, after it is
                 // moved, its new location lies above `fixed_tip` and the scan never revisits it.
-                diff.extend(floor_diff);
-                strategy.sort_by(&mut diff, |a, b| a.0.cmp(&b.0));
+                strategy.sort_by(&mut floor_diff, |a, b| a.0.cmp(&b.0));
+                diff = merge_sorted_diffs(diff, floor_diff);
                 assert!(diff.is_sorted_by(|a, b| a.0 < b.0));
             }
         } else {
@@ -1564,40 +1614,19 @@ where
         let locations = m.gather_existing_locations(&mutations, db, false);
         let results = m.read_ops(&locations, &[], &db.log).await?;
 
-        // Generate user mutation operations.
-        let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
-            Vec::with_capacity(mutations.len() + staged_updates.len() + 1);
-        let mut diff: DiffVec<K, F, V::Value> =
+        // Record user mutations as events in op order; `ops` and `diff` are materialized from
+        // them across the strategy below.
+        let mut events: Vec<EmitEvent<K, F, V::Value>> =
             Vec::with_capacity(mutations.len() + staged_updates.len());
         let mut active_keys_delta: isize = 0;
-        let mut user_steps: u64 = 0;
 
         // Write a user mutation at the next batch location, preserving the previous committed
         // location of the key it supersedes.
         let mut emit = |key: K, base_old_loc: Option<Location<F>>, mutation: Option<V::Value>| {
-            let new_loc = Location::new(m.base_size + ops.len() as u64);
-            match mutation {
-                Some(value) => {
-                    ops.push(Operation::Update(update::Unordered(
-                        key.clone(),
-                        value.clone(),
-                    )));
-                    diff.push((
-                        key,
-                        DiffEntry::Active {
-                            value,
-                            loc: new_loc,
-                            base_old_loc,
-                        },
-                    ));
-                }
-                None => {
-                    ops.push(Operation::Delete(key.clone()));
-                    diff.push((key, DiffEntry::Deleted { base_old_loc }));
-                    active_keys_delta -= 1;
-                }
+            if mutation.is_none() {
+                active_keys_delta -= 1;
             }
-            user_steps += 1;
+            events.push((key, base_old_loc, mutation));
         };
 
         // Process updates/deletes of existing keys in location order, merging staged entries
@@ -1640,6 +1669,10 @@ where
             emit(key, Some(loc), mutation);
         }
 
+        // Floor-raise steps cover the user mutations recorded so far; creates below add
+        // active keys without stepping the floor.
+        let user_steps = events.len() as u64;
+
         // Handle parent-deleted keys that the child wants to re-create.
         let parent_deleted_creates = m.extract_parent_deleted_creates(&mut mutations);
 
@@ -1658,23 +1691,37 @@ where
         db.strategy()
             .sort_by(&mut creates, |(a, _, _), (b, _, _)| a.cmp(b));
         for (key, value, base_old_loc) in creates {
-            let new_loc = Location::new(m.base_size + ops.len() as u64);
-            ops.push(Operation::Update(update::Unordered(
-                key.clone(),
-                value.clone(),
-            )));
-            diff.push((
-                key,
-                DiffEntry::Active {
-                    value,
-                    loc: new_loc,
-                    base_old_loc,
-                },
-            ));
             active_keys_delta += 1;
+            events.push((key, base_old_loc, Some(value)));
         }
 
-        db.strategy().sort_by(&mut diff, |a, b| a.0.cmp(&b.0));
+        // Materialize `ops` and `diff` from the recorded events.
+        let strategy = db.strategy();
+        let ops: Vec<Operation<F, update::Unordered<K, V>>> =
+            strategy.map_collect_vec(&events, |(key, _, mutation)| {
+                mutation.as_ref().map_or_else(
+                    || Operation::Delete(key.clone()),
+                    |value| Operation::Update(update::Unordered(key.clone(), value.clone())),
+                )
+            });
+        let mut diff: DiffVec<K, F, V::Value> = strategy.map_collect_vec(
+            events.into_iter().enumerate(),
+            |(i, (key, base_old_loc, mutation))| {
+                let loc = Location::new(m.base_size + i as u64);
+                match mutation {
+                    Some(value) => (
+                        key,
+                        DiffEntry::Active {
+                            value,
+                            loc,
+                            base_old_loc,
+                        },
+                    ),
+                    None => (key, DiffEntry::Deleted { base_old_loc }),
+                }
+            },
+        );
+        strategy.sort_by(&mut diff, |a, b| a.0.cmp(&b.0));
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
         m.finish(
@@ -2676,6 +2723,65 @@ mod tests {
         let mut cursors = DiffCursors::new([diff.as_slice()]);
         assert!(cursors.resolve(&5).is_some());
         cursors.resolve(&1);
+    }
+
+    /// `sorted_contains` matches `binary_search` for ascending queries over sorted, deduped
+    /// locations.
+    #[test]
+    fn sorted_contains_matches_binary_search() {
+        let mut rng = test_rng();
+        for _ in 0..50 {
+            let mut locs: Vec<Location<mmr::Family>> = (0..rng.random_range(0..40))
+                .map(|_| loc(rng.random_range(0..100u64)))
+                .collect();
+            locs.sort_unstable();
+            locs.dedup();
+
+            let mut queries: Vec<u64> = (0..rng.random_range(1..80))
+                .map(|_| rng.random_range(0..110u64))
+                .collect();
+            queries.sort_unstable();
+
+            let mut cursor = 0;
+            for q in queries.into_iter().map(loc) {
+                assert_eq!(
+                    sorted_contains(&locs, &mut cursor, q),
+                    locs.binary_search(&q).is_ok(),
+                    "query {q} diverged"
+                );
+            }
+        }
+    }
+
+    /// `merge_sorted_diffs` matches `extend` + `sort_by_key` for disjoint, sorted diffs.
+    #[test]
+    fn merge_sorted_diffs_matches_sort() {
+        let mut rng = test_rng();
+        for _ in 0..50 {
+            // Disjoint key sets: evens on one side, odds on the other.
+            let mut build = |offset: u64| -> DiffVec<u64, mmr::Family, u64> {
+                let mut keys: Vec<u64> = (0..rng.random_range(0..30))
+                    .map(|_| rng.random_range(0..50u64) * 2 + offset)
+                    .collect();
+                keys.sort_unstable();
+                keys.dedup();
+                keys.into_iter().map(|k| (k, active(k, k))).collect()
+            };
+            let a = build(0);
+            let b = build(1);
+
+            let mut reference = a.clone();
+            reference.extend(b.clone());
+            reference.sort_by_key(|x| x.0);
+
+            let merged = merge_sorted_diffs(a, b);
+            assert_eq!(merged.len(), reference.len());
+            for ((mk, me), (rk, re)) in merged.iter().zip(&reference) {
+                assert_eq!(mk, rk);
+                assert_eq!(me.loc(), re.loc());
+                assert_eq!(me.value(), re.value());
+            }
+        }
     }
 
     /// Single-step oracle for [`fill_candidates`]: return the next floor-raise candidate in

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -900,6 +900,11 @@ where
                     break;
                 }
 
+                // The `sorted_contains` cursor relies on the candidate sequence ascending
+                // across the whole raise. `floor` is one past the last processed candidate.
+                assert!(candidates[0] >= floor);
+                assert!(candidates.is_sorted_by(|a, b| a < b));
+
                 // `read_candidates` omits locations already superseded by this diff. Keep
                 // `resolved` and `outcomes` in that filtered order, then walk `candidates`
                 // below so superseded locations still advance the floor in scan order.
@@ -1585,11 +1590,11 @@ where
     /// otherwise require) and accepts the floor-raise candidate source.
     ///
     /// The callback must yield candidates in ascending location order, both within one call
-    /// and across successive calls. It may skip locations only when it knows they are
-    /// inactive. The floor-raise loop revalidates each returned candidate against the batch
-    /// diff, ancestor diffs, and snapshot because the bitmap reflects committed state only --
-    /// uncommitted ancestor ops aren't tracked, and bits can be set for locations superseded
-    /// by an overlay in this chain.
+    /// and across successive calls (the floor raise asserts this). It may skip locations only
+    /// when it knows they are inactive. The floor-raise loop revalidates each returned
+    /// candidate against the batch diff, ancestor diffs, and snapshot because the bitmap
+    /// reflects committed state only -- uncommitted ancestor ops aren't tracked, and bits can
+    /// be set for locations superseded by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
@@ -1775,11 +1780,11 @@ where
     /// op generation directly) and accepts the floor-raise candidate source.
     ///
     /// The callback must yield candidates in ascending location order, both within one call
-    /// and across successive calls. It may skip locations only when it knows they are
-    /// inactive. The floor-raise loop revalidates each returned candidate against the batch
-    /// diff, ancestor diffs, and snapshot because the bitmap reflects committed state only --
-    /// uncommitted ancestor ops aren't tracked, and bits can be set for locations superseded
-    /// by an overlay in this chain.
+    /// and across successive calls (the floor raise asserts this). It may skip locations only
+    /// when it knows they are inactive. The floor-raise loop revalidates each returned
+    /// candidate against the batch diff, ancestor diffs, and snapshot because the bitmap
+    /// reflects committed state only -- uncommitted ancestor ops aren't tracked, and bits can
+    /// be set for locations superseded by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Ordered<K, V>, N, S>,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -116,17 +116,13 @@ pub(crate) fn lookup_sorted<'a, K: Ord, V>(entries: &'a [(K, V)], key: &K) -> Op
         .map(|idx| &entries[idx].1)
 }
 
-/// Returns whether sorted, deduplicated `locs` contains `target`, advancing `cursor` past
+/// Returns whether sorted, deduplicated `items` contains `target`, advancing `cursor` past
 /// entries below it. Successive calls must use non-decreasing `target`s.
-fn sorted_contains<F: Family>(
-    locs: &[Location<F>],
-    cursor: &mut usize,
-    target: Location<F>,
-) -> bool {
-    while locs.get(*cursor).is_some_and(|&loc| loc < target) {
+fn sorted_contains<T: Ord>(items: &[T], cursor: &mut usize, target: &T) -> bool {
+    while items.get(*cursor).is_some_and(|item| item < target) {
         *cursor += 1;
     }
-    locs.get(*cursor) == Some(&target)
+    items.get(*cursor) == Some(target)
 }
 
 /// Merge two key-sorted diffs with disjoint keys into one sorted diff.
@@ -890,8 +886,7 @@ where
 
             // `fill_candidates` yields ascending locations, so superseded checks advance a
             // monotonic cursor.
-            let mut filter_cursor = 0;
-            let mut apply_cursor = 0;
+            let mut superseded_cursor = 0;
 
             // Scan active operations in `[floor, fixed_tip)` and move them to the tip.
             while moved < total_steps {
@@ -905,7 +900,7 @@ where
                     break;
                 }
 
-                // Both `sorted_contains` cursors rely on the candidate sequence ascending
+                // The `sorted_contains` cursor relies on the candidate sequence ascending
                 // across the whole raise. `floor` is one past the last processed candidate.
                 assert!(candidates[0] >= floor);
                 assert!(candidates.is_sorted_by(|a, b| a < b));
@@ -916,8 +911,8 @@ where
                 let read_candidates: Vec<_> = candidates
                     .iter()
                     .copied()
-                    .filter(|&candidate| {
-                        !sorted_contains(&superseded_locs, &mut filter_cursor, candidate)
+                    .filter(|candidate| {
+                        !sorted_contains(&superseded_locs, &mut superseded_cursor, candidate)
                     })
                     .collect();
                 let (resolved, outcomes): (_, Vec<Vec<FloorOutcome<F>>>) =
@@ -990,16 +985,18 @@ where
                         (resolved, outcomes)
                     };
 
-                // Apply in candidate order, moving active ops to the tip.
+                // Apply in candidate order, moving active ops to the tip. `read_candidates`
+                // preserves candidate order, so a candidate that does not match the next
+                // pending read was superseded and only advances the floor.
                 let mut outcomes = outcomes.into_iter().flatten();
-                let mut reads = read_candidates.into_iter().zip(resolved);
+                let mut reads = resolved.into_iter();
+                let mut pending = read_candidates.iter().peekable();
                 for candidate in candidates {
                     floor = Location::new(*candidate + 1);
-                    if sorted_contains(&superseded_locs, &mut apply_cursor, candidate) {
+                    if pending.next_if(|&&pending| pending == candidate).is_none() {
                         continue;
                     }
-                    let (read_candidate, op) = reads.next().expect("one read per candidate");
-                    assert_eq!(candidate, read_candidate);
+                    let op = reads.next().expect("one read per candidate");
                     let outcome = outcomes.next().expect("one outcome per read candidate");
                     match outcome {
                         FloorOutcome::Inactive => continue,
@@ -2733,16 +2730,16 @@ mod tests {
     }
 
     /// `sorted_contains` matches `binary_search` for ascending queries over sorted, deduped
-    /// locations.
+    /// items.
     #[test]
     fn sorted_contains_matches_binary_search() {
         let mut rng = test_rng();
         for _ in 0..50 {
-            let mut locs: Vec<Location<mmr::Family>> = (0..rng.random_range(0..40))
-                .map(|_| loc(rng.random_range(0..100u64)))
+            let mut items: Vec<u64> = (0..rng.random_range(0..40))
+                .map(|_| rng.random_range(0..100u64))
                 .collect();
-            locs.sort_unstable();
-            locs.dedup();
+            items.sort_unstable();
+            items.dedup();
 
             let mut queries: Vec<u64> = (0..rng.random_range(1..80))
                 .map(|_| rng.random_range(0..110u64))
@@ -2750,10 +2747,10 @@ mod tests {
             queries.sort_unstable();
 
             let mut cursor = 0;
-            for q in queries.into_iter().map(loc) {
+            for q in queries {
                 assert_eq!(
-                    sorted_contains(&locs, &mut cursor, q),
-                    locs.binary_search(&q).is_ok(),
+                    sorted_contains(&items, &mut cursor, &q),
+                    items.binary_search(&q).is_ok(),
                     "query {q} diverged"
                 );
             }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -38,11 +38,6 @@ use tracing::debug;
 type DiffVec<K, F, V> = Vec<(K, DiffEntry<F, V>)>;
 type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 
-/// User mutation recorded before `ops` and `diff` materialization.
-///
-/// `(key, superseded committed location, new value)` where `None` means delete.
-type EmitEvent<K, F, V> = (K, Option<Location<F>>, Option<V>);
-
 /// One contiguous chunk of floor-raise candidates paired with their resolved operations.
 type CandidateChunk<'a, F, U> = (&'a [Location<F>], &'a [Operation<F, U>]);
 
@@ -889,7 +884,7 @@ where
             strategy.sort_by(&mut superseded_locs, |a, b| a.cmp(b));
             superseded_locs.dedup();
 
-            // The raise appends at most `total_steps` moved ops plus the CommitFloor; reserve
+            // The raise appends at most `total_steps` moved ops plus the CommitFloor. Reserve
             // once instead of growing mid-loop.
             ops.reserve(total_steps as usize + 1);
 
@@ -909,6 +904,11 @@ where
                 if candidates.is_empty() {
                     break;
                 }
+
+                // Both `sorted_contains` cursors rely on the candidate sequence ascending
+                // across the whole raise. `floor` is one past the last processed candidate.
+                assert!(candidates[0] >= floor);
+                assert!(candidates.is_sorted_by(|a, b| a < b));
 
                 // `read_candidates` omits locations already superseded by this diff. Keep
                 // `resolved` and `outcomes` in that filtered order, then walk `candidates`
@@ -1592,10 +1592,12 @@ where
     /// [`Staged::merkleize`] (loaded keys skip the journal re-read their resolution would
     /// otherwise require) and accepts the floor-raise candidate source.
     ///
-    /// The callback may skip locations only when it knows they are inactive. The floor-raise
-    /// loop revalidates each returned candidate against the batch diff, ancestor diffs, and
-    /// snapshot because the bitmap reflects committed state only -- uncommitted ancestor ops
-    /// aren't tracked, and bits can be set for locations superseded by an overlay in this chain.
+    /// The callback must yield candidates in ascending location order, both within one call
+    /// and across successive calls (the floor raise asserts this). It may skip locations only
+    /// when it knows they are inactive. The floor-raise loop revalidates each returned
+    /// candidate against the batch diff, ancestor diffs, and snapshot because the bitmap
+    /// reflects committed state only -- uncommitted ancestor ops aren't tracked, and bits can
+    /// be set for locations superseded by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
@@ -1614,19 +1616,40 @@ where
         let locations = m.gather_existing_locations(&mutations, db, false);
         let results = m.read_ops(&locations, &[], &db.log).await?;
 
-        // Record user mutations as events in op order; `ops` and `diff` are materialized from
-        // them across the strategy below.
-        let mut events: Vec<EmitEvent<K, F, V::Value>> =
+        // Generate user mutation operations.
+        let mut ops: Vec<Operation<F, update::Unordered<K, V>>> =
+            Vec::with_capacity(mutations.len() + staged_updates.len() + 1);
+        let mut diff: DiffVec<K, F, V::Value> =
             Vec::with_capacity(mutations.len() + staged_updates.len());
         let mut active_keys_delta: isize = 0;
+        let mut user_steps: u64 = 0;
 
         // Write a user mutation at the next batch location, preserving the previous committed
         // location of the key it supersedes.
         let mut emit = |key: K, base_old_loc: Option<Location<F>>, mutation: Option<V::Value>| {
-            if mutation.is_none() {
-                active_keys_delta -= 1;
+            let new_loc = Location::new(m.base_size + ops.len() as u64);
+            match mutation {
+                Some(value) => {
+                    ops.push(Operation::Update(update::Unordered(
+                        key.clone(),
+                        value.clone(),
+                    )));
+                    diff.push((
+                        key,
+                        DiffEntry::Active {
+                            value,
+                            loc: new_loc,
+                            base_old_loc,
+                        },
+                    ));
+                }
+                None => {
+                    ops.push(Operation::Delete(key.clone()));
+                    diff.push((key, DiffEntry::Deleted { base_old_loc }));
+                    active_keys_delta -= 1;
+                }
             }
-            events.push((key, base_old_loc, mutation));
+            user_steps += 1;
         };
 
         // Process updates/deletes of existing keys in location order, merging staged entries
@@ -1669,10 +1692,6 @@ where
             emit(key, Some(loc), mutation);
         }
 
-        // Floor-raise steps cover the user mutations recorded so far; creates below add
-        // active keys without stepping the floor.
-        let user_steps = events.len() as u64;
-
         // Handle parent-deleted keys that the child wants to re-create.
         let parent_deleted_creates = m.extract_parent_deleted_creates(&mut mutations);
 
@@ -1691,37 +1710,23 @@ where
         db.strategy()
             .sort_by(&mut creates, |(a, _, _), (b, _, _)| a.cmp(b));
         for (key, value, base_old_loc) in creates {
+            let new_loc = Location::new(m.base_size + ops.len() as u64);
+            ops.push(Operation::Update(update::Unordered(
+                key.clone(),
+                value.clone(),
+            )));
+            diff.push((
+                key,
+                DiffEntry::Active {
+                    value,
+                    loc: new_loc,
+                    base_old_loc,
+                },
+            ));
             active_keys_delta += 1;
-            events.push((key, base_old_loc, Some(value)));
         }
 
-        // Materialize `ops` and `diff` from the recorded events.
-        let strategy = db.strategy();
-        let ops: Vec<Operation<F, update::Unordered<K, V>>> =
-            strategy.map_collect_vec(&events, |(key, _, mutation)| {
-                mutation.as_ref().map_or_else(
-                    || Operation::Delete(key.clone()),
-                    |value| Operation::Update(update::Unordered(key.clone(), value.clone())),
-                )
-            });
-        let mut diff: DiffVec<K, F, V::Value> = strategy.map_collect_vec(
-            events.into_iter().enumerate(),
-            |(i, (key, base_old_loc, mutation))| {
-                let loc = Location::new(m.base_size + i as u64);
-                match mutation {
-                    Some(value) => (
-                        key,
-                        DiffEntry::Active {
-                            value,
-                            loc,
-                            base_old_loc,
-                        },
-                    ),
-                    None => (key, DiffEntry::Deleted { base_old_loc }),
-                }
-            },
-        );
-        strategy.sort_by(&mut diff, |a, b| a.0.cmp(&b.0));
+        db.strategy().sort_by(&mut diff, |a, b| a.0.cmp(&b.0));
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
         m.finish(
@@ -1777,10 +1782,12 @@ where
     /// resolution would otherwise require: the caller's new value and the cached next key feed
     /// op generation directly) and accepts the floor-raise candidate source.
     ///
-    /// The callback may skip locations only when it knows they are inactive. The floor-raise
-    /// loop revalidates each returned candidate against the batch diff, ancestor diffs, and
-    /// snapshot because the bitmap reflects committed state only -- uncommitted ancestor ops
-    /// aren't tracked, and bits can be set for locations superseded by an overlay in this chain.
+    /// The callback must yield candidates in ascending location order, both within one call
+    /// and across successive calls (the floor raise asserts this). It may skip locations only
+    /// when it knows they are inactive. The floor-raise loop revalidates each returned
+    /// candidate against the batch diff, ancestor diffs, and snapshot because the bitmap
+    /// reflects committed state only -- uncommitted ancestor ops aren't tracked, and bits can
+    /// be set for locations superseded by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Ordered<K, V>, N, S>,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -900,11 +900,6 @@ where
                     break;
                 }
 
-                // The `sorted_contains` cursor relies on the candidate sequence ascending
-                // across the whole raise. `floor` is one past the last processed candidate.
-                assert!(candidates[0] >= floor);
-                assert!(candidates.is_sorted_by(|a, b| a < b));
-
                 // `read_candidates` omits locations already superseded by this diff. Keep
                 // `resolved` and `outcomes` in that filtered order, then walk `candidates`
                 // below so superseded locations still advance the floor in scan order.
@@ -1590,11 +1585,11 @@ where
     /// otherwise require) and accepts the floor-raise candidate source.
     ///
     /// The callback must yield candidates in ascending location order, both within one call
-    /// and across successive calls (the floor raise asserts this). It may skip locations only
-    /// when it knows they are inactive. The floor-raise loop revalidates each returned
-    /// candidate against the batch diff, ancestor diffs, and snapshot because the bitmap
-    /// reflects committed state only -- uncommitted ancestor ops aren't tracked, and bits can
-    /// be set for locations superseded by an overlay in this chain.
+    /// and across successive calls. It may skip locations only when it knows they are
+    /// inactive. The floor-raise loop revalidates each returned candidate against the batch
+    /// diff, ancestor diffs, and snapshot because the bitmap reflects committed state only --
+    /// uncommitted ancestor ops aren't tracked, and bits can be set for locations superseded
+    /// by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
@@ -1780,11 +1775,11 @@ where
     /// op generation directly) and accepts the floor-raise candidate source.
     ///
     /// The callback must yield candidates in ascending location order, both within one call
-    /// and across successive calls (the floor raise asserts this). It may skip locations only
-    /// when it knows they are inactive. The floor-raise loop revalidates each returned
-    /// candidate against the batch diff, ancestor diffs, and snapshot because the bitmap
-    /// reflects committed state only -- uncommitted ancestor ops aren't tracked, and bits can
-    /// be set for locations superseded by an overlay in this chain.
+    /// and across successive calls. It may skip locations only when it knows they are
+    /// inactive. The floor-raise loop revalidates each returned candidate against the batch
+    /// diff, ancestor diffs, and snapshot because the bitmap reflects committed state only --
+    /// uncommitted ancestor ops aren't tracked, and bits can be set for locations superseded
+    /// by an overlay in this chain.
     pub(crate) async fn merkleize_with_floor_scan<E, C, I, const N: usize>(
         self,
         db: &Db<F, E, C, I, H, update::Ordered<K, V>, N, S>,

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -195,7 +195,7 @@ where
             return Ok(Vec::new());
         }
         assert!(
-            locs.windows(2).all(|w| w[0] < w[1]),
+            locs.is_sorted_by(|a, b| a < b),
             "locations must be strictly increasing"
         );
         let mut results = Vec::with_capacity(locs.len());
@@ -363,7 +363,7 @@ where
             return Ok(Vec::new());
         }
         assert!(
-            locs.windows(2).all(|w| w[0] < w[1]),
+            locs.is_sorted_by(|a, b| a < b),
             "locations must be strictly increasing"
         );
         let mut results = Vec::with_capacity(locs.len());

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -201,7 +201,7 @@ where
         self.metrics.get_many_calls.inc();
         self.metrics.lookups_requested.inc_by(locs.len() as u64);
         assert!(
-            locs.windows(2).all(|w| w[0] < w[1]),
+            locs.is_sorted_by(|a, b| a < b),
             "locations must be strictly increasing"
         );
         let op_count = self.journal.bounds().end;

--- a/utils/src/bitmap/roaring/container/array.rs
+++ b/utils/src/bitmap/roaring/container/array.rs
@@ -519,7 +519,7 @@ fn validate_values(values: &[u16]) -> Result<(), CodecError> {
     if values.len() > MAX_CARDINALITY {
         return Err(CodecError::InvalidLength(values.len()));
     }
-    if values.windows(2).any(|w| w[0] >= w[1]) {
+    if !values.is_sorted_by(|a, b| a < b) {
         return Err(CodecError::Invalid(
             "Array",
             "values must be sorted and unique",

--- a/utils/src/bitmap/roaring/fuzz.rs
+++ b/utils/src/bitmap/roaring/fuzz.rs
@@ -315,11 +315,7 @@ impl Plan {
                     }
                 }
                 assert!(result.len() <= limit);
-
-                let values: Vec<_> = result.iter().collect();
-                for window in values.windows(2) {
-                    assert!(window[0] < window[1], "union not sorted");
-                }
+                assert!(result.iter().is_sorted_by(|a, b| a < b), "union not sorted");
             }
 
             Self::Intersection {
@@ -345,11 +341,10 @@ impl Plan {
                     assert!(b.contains(v), "intersection contains value not in b: {}", v);
                 }
                 assert!(result.len() <= limit);
-
-                let values: Vec<_> = result.iter().collect();
-                for window in values.windows(2) {
-                    assert!(window[0] < window[1], "intersection not sorted");
-                }
+                assert!(
+                    result.iter().is_sorted_by(|a, b| a < b),
+                    "intersection not sorted"
+                );
             }
 
             Self::Difference {
@@ -374,20 +369,17 @@ impl Plan {
                     assert!(!b.contains(v), "difference contains value in b: {}", v);
                 }
                 assert!(result.len() <= limit);
-
-                let values: Vec<_> = result.iter().collect();
-                for window in values.windows(2) {
-                    assert!(window[0] < window[1], "difference not sorted");
-                }
+                assert!(
+                    result.iter().is_sorted_by(|a, b| a < b),
+                    "difference not sorted"
+                );
             }
 
             Self::Iterator { values } => {
                 let bitmap = build_bitmap(&values);
                 let collected: Vec<_> = bitmap.iter().collect();
                 assert_eq!(collected.len() as u64, bitmap.len());
-                for window in collected.windows(2) {
-                    assert!(window[0] < window[1], "iterator not sorted");
-                }
+                assert!(collected.is_sorted_by(|a, b| a < b), "iterator not sorted");
                 for &v in &collected {
                     assert!(bitmap.contains(v));
                 }
@@ -411,9 +403,10 @@ impl Plan {
                     );
                     assert!(bitmap.contains(v));
                 }
-                for window in collected.windows(2) {
-                    assert!(window[0] < window[1], "iter_range not sorted");
-                }
+                assert!(
+                    collected.is_sorted_by(|a, b| a < b),
+                    "iter_range not sorted"
+                );
             }
 
             Self::MinMax { values } => {
@@ -515,9 +508,7 @@ impl Plan {
 
                 let collected: Vec<_> = bitmap.iter().collect();
                 assert_eq!(collected.len() as u64, bitmap.len());
-                for window in collected.windows(2) {
-                    assert!(window[0] < window[1], "iterator not sorted");
-                }
+                assert!(collected.is_sorted_by(|a, b| a < b), "iterator not sorted");
                 for &v in &collected {
                     assert!(bitmap.contains(v));
                 }


### PR DESCRIPTION
## Summary

Speed up the unordered QMDB `merkleize` path by reducing redundant work during the floor raise. Every change was ablated independently against the base with interleaved A/B runs. The op/diff strategy materialization from the original spike measured as a wash and was removed, so the final PR keeps only the changes that paid for themselves.

## Changes

- **`sorted_contains`**: Replace `binary_search` on `superseded_locs` with a monotonic cursor. `fill_candidates` yields ascending locations, so a single cursor scan is O(len) total. The ascending requirement is now part of the documented `fill_candidates` contract and asserted by the floor raise.
- **`merge_sorted_diffs`**: Merge the sorted `floor_diff` into the sorted main `diff` in O(n) instead of extending and re-sorting.
- **`ops` capacity reservation**: Reserve `total_steps + 1` capacity before the floor raise to avoid mid-loop reallocations.
- **Cleanup**: Convert manual `windows(2)` sortedness walks to `is_sorted_by`/`is_sorted` across storage, utils, and cryptography.

## Benchmarks

Using the `constantinople` shape from #4144, with each variant built in its own target dir, runs interleaved base/PR across process lifetimes, and the first two iterations of each process dropped as warmup:

```bash
cargo bench -p commonware-storage --bench constantinople -- any::unordered::fixed::mmb 0 10 1000000 32768 1 32768 <threads>
```

Total ms, threads=8 (48 samples per variant):

| metric | main | this PR | delta |
|--------|------|---------|-------|
| p10    | 7.16 ms | 6.75 ms | -5.7% |
| p50    | 8.43 ms | 7.27 ms | -13.8% |
| mean   | 8.29 ms | 7.28 ms | -12.3% |
| max    | 9.52 ms | 8.53 ms | -10.4% |

Total ms, threads=1 (24 samples per variant):

| metric | main | this PR | delta |
|--------|------|---------|-------|
| p10    | 16.57 ms | 14.62 ms | -11.8% |
| p50    | 17.11 ms | 15.24 ms | -10.9% |
| mean   | 17.28 ms | 15.21 ms | -12.0% |
| max    | 18.88 ms | 15.68 ms | -16.9% |

The merkleize phase alone improves -16.5% p50 at threads=8 (7.58 ms to 6.33 ms) and -11.6% at threads=1 (14.55 ms to 12.86 ms). Roots matched on every iteration of every run.

### Per-change attribution

Four variants (base, full spike, spike minus merge, spike minus materialization) were benchmarked to attribute the win, 10 interleaved rounds at threads=8 and 5 at threads=1:

- `merge_sorted_diffs`: ~0.9-1.0 ms of the merkleize win at both thread counts. The threads=1 result rules out a policy or scheduling explanation.
- `sorted_contains`: ~0.3 ms at threads=8, ~0.1 ms at threads=1.
- Strategy materialization of `ops`/`diff` (in the original spike): a wash (6.06 ms vs 6.03 ms merkleize p50 at threads=8 against the direct emit loop) while adding hot-path allocations, so it was removed. The Rayon `map_collect_vec` collects its input into a temp `Vec` before the serial/parallel decision, which cancels the parallel upside for cheap per-element work.

## Test Plan

- `just test -p commonware-storage qmdb` - 1560 passed
- `just test -p commonware-storage journal` - 406 passed
- `just test -p commonware-utils roaring` - 203 passed
- `just test -p commonware-cryptography bls12381::primitives::group` - 29 passed
- `just lint` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
