### PR TITLE
[runtime] Defer blob creation's directory fsyncs to the first durable operation

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -674,6 +674,11 @@ stability_scope!(BETA {
     /// recovery: data read at initialization can be assumed to survive a
     /// subsequent crash without an explicit [`Blob::sync`].
     ///
+    /// A blob whose creation was never followed by a durability request is the
+    /// exception: it may vanish entirely across a crash (see
+    /// [`Storage::open_versioned`]), so recovery must not depend on the
+    /// existence of a blob it never synced.
+    ///
     /// # Partition Names
     ///
     /// Partition names must be non-empty and contain only ASCII alphanumeric
@@ -824,7 +829,8 @@ stability_scope!(BETA {
         /// This is not a durability barrier for previous operations. When it completes,
         /// only the bytes submitted to this call are guaranteed durable. Earlier unsynced
         /// [`Blob::write_at`] or [`Blob::resize`] calls require [`Blob::sync`] to become
-        /// durable.
+        /// durable. A handle's first durability request additionally covers the blob's
+        /// directory entries, exactly as [`Blob::sync`] does.
         fn write_at_sync(
             &self,
             offset: u64,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -705,7 +705,12 @@ stability_scope!(BETA {
         /// Multiple instances of the same blob can be opened concurrently, however,
         /// writing to the same blob concurrently may lead to undefined behavior.
         ///
-        /// An Ok result indicates the blob is durably created (or already exists).
+        /// # Durability
+        ///
+        /// Creation is NOT durable until the blob's first durability request ([Blob::sync],
+        /// [Blob::start_sync], or [Blob::write_at_sync]) returns: a blob that is never synced
+        /// may not survive a crash, consistent with nothing having been promised. This keeps
+        /// fsyncs off the open path.
         ///
         /// # Versions
         ///
@@ -832,7 +837,9 @@ stability_scope!(BETA {
         /// If the length is less than the current length, the blob is resized.
         fn resize(&self, len: u64) -> impl Future<Output = Result<(), Error>> + Send;
 
-        /// Ensure all pending data is durably persisted.
+        /// Ensure all pending data is durably persisted, including (on a handle's first
+        /// durability request) the blob's directory entries: creation defers those, so a
+        /// blob's existence becomes durable together with its first synced contents.
         fn sync(&self) -> impl Future<Output = Result<(), Error>> + Send;
 
         /// Request that all pending data is durably persisted.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -829,8 +829,9 @@ stability_scope!(BETA {
         /// This is not a durability barrier for previous operations. When it completes,
         /// only the bytes submitted to this call are guaranteed durable. Earlier unsynced
         /// [`Blob::write_at`] or [`Blob::resize`] calls require [`Blob::sync`] to become
-        /// durable. A handle's first durability request additionally covers the blob's
-        /// directory entries, exactly as [`Blob::sync`] does.
+        /// durable. A handle's first non-empty call additionally covers the blob's
+        /// directory entries, as [`Blob::sync`] does (a call with no bytes returns early
+        /// and defers that coverage).
         fn write_at_sync(
             &self,
             offset: u64,
@@ -844,8 +845,8 @@ stability_scope!(BETA {
         fn resize(&self, len: u64) -> impl Future<Output = Result<(), Error>> + Send;
 
         /// Ensure all pending data is durably persisted, including (on a handle's first
-        /// durability request) the blob's directory entries: creation defers those, so a
-        /// blob's existence becomes durable together with its first synced contents.
+        /// durability request) the blob's directory entries (see
+        /// [`Storage::open_versioned`]).
         fn sync(&self) -> impl Future<Output = Result<(), Error>> + Send;
 
         /// Request that all pending data is durably persisted.

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -1057,7 +1057,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
-            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
+            crate::storage::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
 
         // Read and write should fail through their wrapper-specific error enums
@@ -1117,7 +1117,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
-            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
+            crate::storage::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         // Sync should fail through the blob-specific wrapper before any kernel work is attempted.
         let err = blob
@@ -1157,7 +1157,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
-            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
+            crate::storage::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         let err = blob
             .start_sync()
@@ -1201,7 +1201,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
-            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
+            crate::storage::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         let err = blob
             .resize(0)
@@ -1240,7 +1240,7 @@ mod tests {
             submitter.clone(),
             pool,
             Header::PRELUDE_SIZE_U64,
-            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
+            crate::storage::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         // The request should reach the kernel and come back as a wrapped sync failure.
         let err = blob

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -439,8 +439,8 @@ impl crate::Blob for Blob {
                 Error::Io(e) => Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e),
                 err => err,
             })?;
-        // Once per handle; a blocking call, consistent with the blocking directory fs
-        // operations open_versioned performs inline.
+        // A blocking call, consistent with the blocking directory fs operations
+        // open_versioned performs inline.
         self.dirs.sync()
     }
 
@@ -1268,40 +1268,11 @@ mod tests {
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
 
-    /// Creation performs no directory fsyncs; a handle's first durable operation does
-    /// (parent + root), exactly once. Relies on nextest's process-per-test isolation for
-    /// the global counter.
     #[tokio::test]
     async fn test_creation_defers_dir_syncs() {
-        use std::sync::atomic::Ordering;
-
-        let count = || super::DIR_SYNC_CALLS.load(Ordering::Relaxed);
         let (storage, storage_directory) = create_test_storage();
 
-        // Creation and plain writes leave the directory entries unsynced.
-        let before = count();
-        let (blob, _) = storage.open("partition", b"deferred").await.unwrap();
-        blob.write_at(0, b"data".to_vec()).await.unwrap();
-        assert_eq!(count() - before, 0);
-
-        // The first sync covers parent and root; later syncs skip them.
-        blob.sync().await.unwrap();
-        assert_eq!(count() - before, 2);
-        blob.sync().await.unwrap();
-        assert_eq!(count() - before, 2);
-
-        // write_at_sync as a fresh handle's first durable operation takes the full-sync
-        // path in front of the ring's sync write; a second one uses the fast path.
-        let (blob2, _) = storage.open("partition", b"deferred2").await.unwrap();
-        blob2.write_at_sync(0, b"x".to_vec()).await.unwrap();
-        assert_eq!(count() - before, 4);
-        blob2.write_at_sync(1, b"y".to_vec()).await.unwrap();
-        assert_eq!(count() - before, 4);
-
-        // start_sync as the first durable operation covers them once resolved.
-        let (blob3, _) = storage.open("partition", b"deferred3").await.unwrap();
-        blob3.start_sync().await.await.unwrap();
-        assert_eq!(count() - before, 6);
+        crate::storage::tests::assert_creation_defers_dir_syncs(&storage).await;
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -162,9 +162,6 @@ impl crate::Storage for Storage {
             .parent()
             .ok_or_else(|| Error::PartitionMissing(partition.into()))?;
 
-        // Check if partition exists before creating
-        let parent_existed = parent.exists();
-
         // Create the partition directory if it does not exist
         fs::create_dir_all(parent).map_err(|_| Error::PartitionCreationFailed(partition.into()))?;
 
@@ -197,18 +194,13 @@ impl crate::Storage for Storage {
                 file.sync_all()
                     .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
 
-                // Sync the directories to ensure the directory entry is durable. This must also
-                // run when recreating a torn blob: the creation it is recovering from may have
-                // crashed before its own directory syncs completed.
-                sync_dir(parent)?;
-                if !parent_existed {
-                    sync_dir(&self.storage_directory)?;
-                }
-
                 (info, data_offset)
             }
         };
 
+        // Creation deferred its directory fsyncs; the blob's first durable operation
+        // performs them (see [super::DirSync]).
+        let dirs = super::DirSync::new(parent.to_path_buf(), self.storage_directory.clone());
         let blob = Blob::new(
             partition.into(),
             name,
@@ -216,6 +208,7 @@ impl crate::Storage for Storage {
             self.io_handle.clone(),
             self.pool.clone(),
             data_offset,
+            dirs,
         );
         Ok((blob, info))
     }
@@ -293,6 +286,8 @@ pub struct Blob {
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// Directory entries made durable by the first durable operation (shared across clones).
+    dirs: Arc<super::DirSync>,
 }
 
 impl Clone for Blob {
@@ -304,6 +299,7 @@ impl Clone for Blob {
             io_handle: self.io_handle.clone(),
             pool: self.pool.clone(),
             data_offset: self.data_offset,
+            dirs: self.dirs.clone(),
         }
     }
 }
@@ -317,6 +313,7 @@ impl Blob {
         io_handle: iouring::Handle,
         pool: BufferPool,
         data_offset: u64,
+        dirs: super::DirSync,
     ) -> Self {
         Self {
             partition,
@@ -325,6 +322,7 @@ impl Blob {
             io_handle,
             pool,
             data_offset,
+            dirs: Arc::new(dirs),
         }
     }
 }
@@ -407,6 +405,14 @@ impl crate::Blob for Blob {
             return Ok(());
         }
 
+        // The ring's sync write makes only the written range durable, never directory
+        // entries: until those are synced, write plainly and take the full-sync path.
+        if !self.dirs.synced() {
+            self.io_handle
+                .write_at(self.file.clone(), offset, bufs)
+                .await?;
+            return self.sync().await;
+        }
         self.io_handle
             .write_at_sync(self.file.clone(), offset, bufs)
             .await
@@ -433,16 +439,20 @@ impl crate::Blob for Blob {
             .map_err(|err| match err {
                 Error::Io(e) => Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e),
                 err => err,
-            })
+            })?;
+        // Once per handle; a blocking call, consistent with the blocking directory fs
+        // operations open_versioned performs inline.
+        self.dirs.sync()
     }
 
     async fn start_sync(&self) -> Handle<()> {
         let partition = self.partition.clone();
         let name = self.name.clone();
         let receiver = self.io_handle.start_sync(self.file.clone()).await;
+        let dirs = self.dirs.clone();
         Handle::from_future(async move {
             match receiver.await {
-                Ok(Ok(())) => Ok(()),
+                Ok(Ok(())) => dirs.sync(),
                 Ok(Err(Error::Io(e))) => Err(Error::BlobSyncFailed(partition, hex(&name), e)),
                 Ok(Err(err)) => Err(err),
                 Err(_) => Err(Error::Closed),
@@ -1048,6 +1058,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
+            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
 
         // Read and write should fail through their wrapper-specific error enums
@@ -1107,6 +1118,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
+            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         // Sync should fail through the blob-specific wrapper before any kernel work is attempted.
         let err = blob
@@ -1146,6 +1158,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
+            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         let err = blob
             .start_sync()
@@ -1189,6 +1202,7 @@ mod tests {
             submitter,
             pool,
             Header::PRELUDE_SIZE_U64,
+            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         let err = blob
             .resize(0)
@@ -1227,6 +1241,7 @@ mod tests {
             submitter.clone(),
             pool,
             Header::PRELUDE_SIZE_U64,
+            super::DirSync::new(storage_directory.clone(), storage_directory.clone()),
         );
         // The request should reach the kernel and come back as a wrapped sync failure.
         let err = blob
@@ -1250,6 +1265,44 @@ mod tests {
         drop(submitter);
         // Joining the loop proves the live backend path shut down cleanly after the error.
         handle.join().unwrap();
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    /// Creation performs no directory fsyncs; a handle's first durable operation does
+    /// (parent + root), exactly once. Relies on nextest's process-per-test isolation for
+    /// the global counter.
+    #[tokio::test]
+    async fn test_creation_defers_dir_syncs() {
+        use std::sync::atomic::Ordering;
+
+        let count = || super::DIR_SYNC_CALLS.load(Ordering::Relaxed);
+        let (storage, storage_directory) = create_test_storage();
+
+        // Creation and plain writes leave the directory entries unsynced.
+        let before = count();
+        let (blob, _) = storage.open("partition", b"deferred").await.unwrap();
+        blob.write_at(0, b"data".to_vec()).await.unwrap();
+        assert_eq!(count() - before, 0);
+
+        // The first sync covers parent and root; later syncs skip them.
+        blob.sync().await.unwrap();
+        assert_eq!(count() - before, 2);
+        blob.sync().await.unwrap();
+        assert_eq!(count() - before, 2);
+
+        // write_at_sync as a fresh handle's first durable operation takes the full-sync
+        // path in front of the ring's sync write; a second one uses the fast path.
+        let (blob2, _) = storage.open("partition", b"deferred2").await.unwrap();
+        blob2.write_at_sync(0, b"x".to_vec()).await.unwrap();
+        assert_eq!(count() - before, 4);
+        blob2.write_at_sync(1, b"y".to_vec()).await.unwrap();
+        assert_eq!(count() - before, 4);
+
+        // start_sync as the first durable operation covers them once resolved.
+        let (blob3, _) = storage.open("partition", b"deferred3").await.unwrap();
+        blob3.start_sync().await.await.unwrap();
+        assert_eq!(count() - before, 6);
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -174,7 +174,6 @@ impl crate::Storage for Storage {
             .open(&path)
             .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e.into()))?;
 
-        // Assume empty files are newly created. Existing empty files will be synced too; that's OK.
         let raw_len = file.metadata().map_err(|_| Error::ReadFailed)?.len();
 
         // Handle header: existing blobs have their header read; new blobs and blobs left torn

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -484,6 +484,67 @@ stability_scope!(BETA {
         }
     }
 
+    /// Directory entries a blob's first durable operation must fsync.
+    ///
+    /// Creation no longer syncs directories, so a new blob's existence becomes durable
+    /// together with its first synced contents. A blob that is never synced may not survive
+    /// a crash, which is within its contract: nothing was promised. Reopened blobs also
+    /// carry unsynced state, since the handle cannot know whether the entries were ever
+    /// fsynced (e.g. a creation or recovery that crashed first).
+    #[cfg(unix)]
+    pub(crate) struct DirSync {
+        parent: std::path::PathBuf,
+        root: std::path::PathBuf,
+        synced: std::sync::atomic::AtomicBool,
+    }
+
+    /// Counts directory fsyncs so tests can assert when durability is established (sound
+    /// under nextest's process-per-test isolation).
+    #[cfg(all(test, unix))]
+    pub(crate) static DIR_SYNC_CALLS: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    #[cfg(unix)]
+    impl DirSync {
+        pub(crate) const fn new(parent: std::path::PathBuf, root: std::path::PathBuf) -> Self {
+            Self {
+                parent,
+                root,
+                synced: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        /// Returns true once the directory entries are known durable, permitting
+        /// range-scoped durability fast paths that cannot cover them.
+        pub(crate) fn synced(&self) -> bool {
+            self.synced.load(std::sync::atomic::Ordering::Acquire)
+        }
+
+        /// Fsyncs the blob's parent directory and the storage root once per handle;
+        /// subsequent calls are no-ops. Racing first calls may both fsync, which is
+        /// harmless. Blocking: call from a blocking context.
+        pub(crate) fn sync(&self) -> Result<(), crate::Error> {
+            if self.synced() {
+                return Ok(());
+            }
+            for dir in [&self.parent, &self.root] {
+                #[cfg(test)]
+                DIR_SYNC_CALLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                std::fs::File::open(dir)
+                    .and_then(|d| d.sync_all())
+                    .map_err(|e| {
+                        crate::Error::BlobSyncFailed(
+                            dir.to_string_lossy().to_string(),
+                            "directory".to_string(),
+                            e.into(),
+                        )
+                    })?;
+            }
+            self.synced.store(true, std::sync::atomic::Ordering::Release);
+            Ok(())
+        }
+    }
+
     /// Resolves a header that failed to parse: `Ok(None)` if the blob's raw contents are those
     /// of a creation that was interrupted before its header became durable (the caller
     /// recreates the blob), and the loud corruption error otherwise.

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -770,6 +770,30 @@ pub(crate) mod tests {
         ));
     }
 
+    /// A failed directory fsync leaves the once-flag unset, so a retry covers the
+    /// entries; success sets it and later calls are no-ops.
+    #[cfg(unix)]
+    #[test]
+    fn test_dir_sync_failure_retries() {
+        let root = std::env::temp_dir().join(format!("test_dir_sync_retry_{}", std::process::id()));
+        let missing = root.join("missing");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        // The parent does not exist: sync fails and the flag stays unset.
+        let dirs = super::DirSync::new(missing.clone(), root.clone());
+        assert!(dirs.sync().is_err());
+        assert!(!dirs.synced());
+
+        // Once the parent exists, a retry succeeds and later calls are no-ops.
+        std::fs::create_dir_all(&missing).unwrap();
+        dirs.sync().unwrap();
+        assert!(dirs.synced());
+        dirs.sync().unwrap();
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     /// Every parse failure converts to a contextual error naming its cause.
     #[test]
     fn test_header_error_messages() {

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -486,11 +486,11 @@ stability_scope!(BETA {
 
     /// Directory entries a blob's first durable operation must fsync.
     ///
-    /// Creation no longer syncs directories, so a new blob's existence becomes durable
-    /// together with its first synced contents. A blob that is never synced may not survive
-    /// a crash, which is within its contract: nothing was promised. Reopened blobs also
-    /// carry unsynced state, since the handle cannot know whether the entries were ever
-    /// fsynced (e.g. a creation or recovery that crashed first).
+    /// Creation defers these fsyncs, so a new blob's existence becomes durable together
+    /// with its first synced contents (see the durability contract on
+    /// [crate::Storage::open_versioned]). Reopened blobs also start unsynced: the handle
+    /// cannot know whether the entries were ever fsynced (e.g. a creation or recovery
+    /// that crashed first).
     #[cfg(unix)]
     pub(crate) struct DirSync {
         parent: std::path::PathBuf,
@@ -1066,6 +1066,51 @@ pub(crate) mod tests {
     }
 
     /// Runs the full suite of tests on the provided storage implementation.
+    /// Asserts the deferred-directory-fsync contract against a live backend: creation and
+    /// plain writes perform no directory fsyncs; a handle's first durable operation covers
+    /// parent and root exactly once. Relies on nextest's process-per-test isolation for the
+    /// global counter.
+    #[cfg(unix)]
+    pub(crate) async fn assert_creation_defers_dir_syncs<S: crate::Storage>(storage: &S) {
+        use std::sync::atomic::Ordering;
+
+        let count = || super::DIR_SYNC_CALLS.load(Ordering::Relaxed);
+
+        // Creation and plain writes leave the directory entries unsynced.
+        let before = count();
+        let (blob, _) = storage.open("partition", b"deferred").await.unwrap();
+        blob.write_at(0, b"data".to_vec()).await.unwrap();
+        assert_eq!(count() - before, 0);
+
+        // The first sync covers parent and root; later syncs skip them.
+        blob.sync().await.unwrap();
+        assert_eq!(count() - before, 2);
+        blob.sync().await.unwrap();
+        assert_eq!(count() - before, 2);
+
+        // A fresh handle's first durable write_at_sync must route through the backend's
+        // full-sync path ahead of any range-scoped fast path (RWF_SYNC on tokio/Linux, the
+        // ring's sync write on iouring); afterward the once-flag (or the fast path) skips
+        // the directory work.
+        let (blob2, _) = storage.open("partition", b"deferred2").await.unwrap();
+        blob2.write_at_sync(0, b"x".to_vec()).await.unwrap();
+        assert_eq!(count() - before, 4);
+        blob2.write_at_sync(1, b"y".to_vec()).await.unwrap();
+        assert_eq!(count() - before, 4);
+
+        // start_sync as the first durable operation covers them once resolved.
+        let (blob3, _) = storage.open("partition", b"deferred3").await.unwrap();
+        blob3.start_sync().await.await.unwrap();
+        assert_eq!(count() - before, 6);
+
+        // A reopened handle cannot know its entries are durable and re-syncs once.
+        drop(blob);
+        let (blob, _) = storage.open("partition", b"deferred").await.unwrap();
+        blob.sync().await.unwrap();
+        assert_eq!(count() - before, 8);
+        drop(blob);
+    }
+
     pub(crate) async fn run_storage_tests<S>(storage: S)
     where
         S: Storage + Send + Sync + 'static,

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -131,10 +131,6 @@ impl crate::Storage for Storage {
             None => return Err(Error::PartitionCreationFailed(partition.into())),
         };
 
-        // Check if partition exists before creating
-        #[cfg(unix)]
-        let parent_existed = parent.exists();
-
         // Create the partition directory, if it does not exist
         fs::create_dir_all(parent)
             .await
@@ -150,30 +146,7 @@ impl crate::Storage for Storage {
             .await
             .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e.into()))?;
 
-        // Assume empty files are newly created. Existing empty files will be synced too; that's OK.
         let len = file.metadata().await.map_err(|_| Error::ReadFailed)?.len();
-        let newly_created = len == 0;
-
-        // Only sync if we created a new file
-        if newly_created {
-            // Sync the file to ensure it is durable
-            file.sync_all()
-                .await
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-
-            // Windows doesn't have a notion of syncing a directory entry to ensure that it's
-            // durably persisted. See https://github.com/commonwarexyz/monorepo/issues/2026.
-            #[cfg(unix)]
-            {
-                // Sync the parent directory to ensure the directory entry is durable.
-                sync_dir(parent).await?;
-
-                // Sync storage directory if parent directory did not exist
-                if !parent_existed {
-                    sync_dir(&self.cfg.storage_directory).await?;
-                }
-            }
-        }
 
         // Set the maximum buffer size
         file.set_max_buf_size(self.cfg.maximum_buffer_size);
@@ -206,9 +179,21 @@ impl crate::Storage for Storage {
             // Convert to a blocking std::fs::File
             let file = file.into_std().await;
 
+            // Creation deferred its directory fsyncs; the blob's first durable operation
+            // performs them (see [super::DirSync]).
+            let dirs =
+                super::DirSync::new(parent.to_path_buf(), self.cfg.storage_directory.clone());
+
             // Construct the blob
             Ok((
-                Self::Blob::new(partition.into(), name, file, self.pool.clone(), data_offset),
+                Self::Blob::new(
+                    partition.into(),
+                    name,
+                    file,
+                    self.pool.clone(),
+                    data_offset,
+                    dirs,
+                ),
                 info,
             ))
         }
@@ -499,6 +484,60 @@ mod tests {
                 "page {page} failed CRC validation at aligned boundary"
             );
         }
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    /// Creation performs no directory fsyncs; a handle's first durable operation does
+    /// (parent + root), exactly once. Relies on nextest's process-per-test isolation for
+    /// the global counter.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_creation_defers_dir_syncs() {
+        use std::sync::atomic::Ordering;
+
+        let count = || crate::storage::DIR_SYNC_CALLS.load(Ordering::Relaxed);
+        let storage_directory =
+            env::temp_dir().join(format!("test_dir_sync_defer_{}", random_suffix()));
+        let storage = Storage::new(
+            Config {
+                storage_directory: storage_directory.clone(),
+                maximum_buffer_size: 1024 * 1024,
+            },
+            test_pool(),
+        );
+
+        // Creation and plain writes leave the directory entries unsynced.
+        let before = count();
+        let (blob, _) = storage.open("partition", b"deferred").await.unwrap();
+        blob.write_at(0, b"data".to_vec()).await.unwrap();
+        assert_eq!(count() - before, 0);
+
+        // The first sync covers parent and root; later syncs skip them.
+        blob.sync().await.unwrap();
+        assert_eq!(count() - before, 2);
+        blob.sync().await.unwrap();
+        assert_eq!(count() - before, 2);
+
+        // write_at_sync as a fresh handle's first durable operation also covers them
+        // (on Linux this exercises the gate in front of the RWF_SYNC fast path), and a
+        // second write_at_sync skips them.
+        let (blob2, _) = storage.open("partition", b"deferred2").await.unwrap();
+        blob2.write_at_sync(0, b"x".to_vec()).await.unwrap();
+        assert_eq!(count() - before, 4);
+        blob2.write_at_sync(1, b"y".to_vec()).await.unwrap();
+        assert_eq!(count() - before, 4);
+
+        // start_sync as the first durable operation covers them once resolved.
+        let (blob3, _) = storage.open("partition", b"deferred3").await.unwrap();
+        blob3.start_sync().await.await.unwrap();
+        assert_eq!(count() - before, 6);
+
+        // A reopened handle cannot know its entries are durable and re-syncs once.
+        drop(blob);
+        let (blob, _) = storage.open("partition", b"deferred").await.unwrap();
+        blob.sync().await.unwrap();
+        assert_eq!(count() - before, 8);
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -488,15 +488,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
 
-    /// Creation performs no directory fsyncs; a handle's first durable operation does
-    /// (parent + root), exactly once. Relies on nextest's process-per-test isolation for
-    /// the global counter.
     #[cfg(unix)]
     #[tokio::test]
     async fn test_creation_defers_dir_syncs() {
-        use std::sync::atomic::Ordering;
-
-        let count = || crate::storage::DIR_SYNC_CALLS.load(Ordering::Relaxed);
         let storage_directory =
             env::temp_dir().join(format!("test_dir_sync_defer_{}", random_suffix()));
         let storage = Storage::new(
@@ -507,37 +501,7 @@ mod tests {
             test_pool(),
         );
 
-        // Creation and plain writes leave the directory entries unsynced.
-        let before = count();
-        let (blob, _) = storage.open("partition", b"deferred").await.unwrap();
-        blob.write_at(0, b"data".to_vec()).await.unwrap();
-        assert_eq!(count() - before, 0);
-
-        // The first sync covers parent and root; later syncs skip them.
-        blob.sync().await.unwrap();
-        assert_eq!(count() - before, 2);
-        blob.sync().await.unwrap();
-        assert_eq!(count() - before, 2);
-
-        // write_at_sync as a fresh handle's first durable operation also covers them
-        // (on Linux this exercises the gate in front of the RWF_SYNC fast path), and a
-        // second write_at_sync skips them.
-        let (blob2, _) = storage.open("partition", b"deferred2").await.unwrap();
-        blob2.write_at_sync(0, b"x".to_vec()).await.unwrap();
-        assert_eq!(count() - before, 4);
-        blob2.write_at_sync(1, b"y".to_vec()).await.unwrap();
-        assert_eq!(count() - before, 4);
-
-        // start_sync as the first durable operation covers them once resolved.
-        let (blob3, _) = storage.open("partition", b"deferred3").await.unwrap();
-        blob3.start_sync().await.await.unwrap();
-        assert_eq!(count() - before, 6);
-
-        // A reopened handle cannot know its entries are durable and re-syncs once.
-        drop(blob);
-        let (blob, _) = storage.open("partition", b"deferred").await.unwrap();
-        blob.sync().await.unwrap();
-        assert_eq!(count() - before, 8);
+        crate::storage::tests::assert_creation_defers_dir_syncs(&storage).await;
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -187,39 +187,26 @@ impl crate::Blob for Blob {
             return Ok(());
         }
 
-        cfg_if! {
-            if #[cfg(target_os = "linux")] {
-                // RWF_SYNC makes only the written range durable, never directory entries:
-                // until those are synced, take the full-sync path instead.
-                if self.dirs.synced() {
-                    task::spawn_blocking(move || {
-                        Self::write_vectored_at(&file, offset, bufs, Some(libc::RWF_SYNC))
-                    })
-                    .await
-                    .map_err(|_| Error::WriteFailed)?
-                } else {
-                    let partition = self.partition.clone();
-                    let name = self.name.clone();
-                    let dirs = self.dirs.clone();
-                    task::spawn_blocking(move || {
-                        Self::write_vectored_at(&file, offset, bufs, None)?;
-                        Self::sync_inner(&file, &partition, &name, &dirs)
-                    })
-                    .await
-                    .map_err(|_| Error::WriteFailed)?
-                }
-            } else {
-                let partition = self.partition.clone();
-                let name = self.name.clone();
-                let dirs = self.dirs.clone();
-                task::spawn_blocking(move || {
-                    Self::write_vectored_at(&file, offset, bufs, None)?;
-                    Self::sync_inner(&file, &partition, &name, &dirs)
-                })
-                .await
-                .map_err(|_| Error::WriteFailed)?
-            }
+        // RWF_SYNC makes only the written range durable, never directory entries:
+        // the fast path applies only once those are synced.
+        #[cfg(target_os = "linux")]
+        if self.dirs.synced() {
+            return task::spawn_blocking(move || {
+                Self::write_vectored_at(&file, offset, bufs, Some(libc::RWF_SYNC))
+            })
+            .await
+            .map_err(|_| Error::WriteFailed)?;
         }
+
+        let partition = self.partition.clone();
+        let name = self.name.clone();
+        let dirs = self.dirs.clone();
+        task::spawn_blocking(move || {
+            Self::write_vectored_at(&file, offset, bufs, None)?;
+            Self::sync_inner(&file, &partition, &name, &dirs)
+        })
+        .await
+        .map_err(|_| Error::WriteFailed)?
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -1,3 +1,4 @@
+use super::super::DirSync;
 use crate::{Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut};
 use cfg_if::cfg_if;
 use commonware_formatting::hex;
@@ -22,15 +23,18 @@ pub struct Blob {
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// Directory entries made durable by the first durable operation (shared across clones).
+    dirs: Arc<DirSync>,
 }
 
 impl Blob {
-    pub fn new(
+    pub(crate) fn new(
         partition: String,
         name: &[u8],
         file: File,
         pool: BufferPool,
         data_offset: u64,
+        dirs: DirSync,
     ) -> Self {
         Self {
             partition,
@@ -38,12 +42,14 @@ impl Blob {
             file: Arc::new(file),
             pool,
             data_offset,
+            dirs: Arc::new(dirs),
         }
     }
 
-    fn sync_inner(file: &File, partition: &str, name: &[u8]) -> Result<(), Error> {
+    fn sync_inner(file: &File, partition: &str, name: &[u8], dirs: &DirSync) -> Result<(), Error> {
         file.sync_all()
-            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e.into()))
+            .map_err(|e| Error::BlobSyncFailed(partition.to_string(), hex(name), e.into()))?;
+        dirs.sync()
     }
 
     fn write_single_at(file: &File, offset: u64, buf: &[u8]) -> Result<(), Error> {
@@ -183,17 +189,32 @@ impl crate::Blob for Blob {
 
         cfg_if! {
             if #[cfg(target_os = "linux")] {
-                task::spawn_blocking(move || {
-                    Self::write_vectored_at(&file, offset, bufs, Some(libc::RWF_SYNC))
-                })
-                .await
-                .map_err(|_| Error::WriteFailed)?
+                // RWF_SYNC makes only the written range durable, never directory entries:
+                // until those are synced, take the full-sync path instead.
+                if self.dirs.synced() {
+                    task::spawn_blocking(move || {
+                        Self::write_vectored_at(&file, offset, bufs, Some(libc::RWF_SYNC))
+                    })
+                    .await
+                    .map_err(|_| Error::WriteFailed)?
+                } else {
+                    let partition = self.partition.clone();
+                    let name = self.name.clone();
+                    let dirs = self.dirs.clone();
+                    task::spawn_blocking(move || {
+                        Self::write_vectored_at(&file, offset, bufs, None)?;
+                        Self::sync_inner(&file, &partition, &name, &dirs)
+                    })
+                    .await
+                    .map_err(|_| Error::WriteFailed)?
+                }
             } else {
                 let partition = self.partition.clone();
                 let name = self.name.clone();
+                let dirs = self.dirs.clone();
                 task::spawn_blocking(move || {
                     Self::write_vectored_at(&file, offset, bufs, None)?;
-                    Self::sync_inner(&file, &partition, &name)
+                    Self::sync_inner(&file, &partition, &name, &dirs)
                 })
                 .await
                 .map_err(|_| Error::WriteFailed)?
@@ -220,7 +241,8 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         let partition = self.partition.clone();
         let name = self.name.clone();
-        task::spawn_blocking(move || Self::sync_inner(&file, &partition, &name))
+        let dirs = self.dirs.clone();
+        task::spawn_blocking(move || Self::sync_inner(&file, &partition, &name, &dirs))
             .await
             .map_err(|e| {
                 let err: std::io::Error = e.into();
@@ -233,8 +255,9 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         let partition = self.partition.clone();
         let name = self.name.clone();
+        let dirs = self.dirs.clone();
         task::spawn_blocking(move || {
-            let result = Self::sync_inner(&file, &partition, &name);
+            let result = Self::sync_inner(&file, &partition, &name, &dirs);
             let _ = tx.send(result);
         });
         Handle::from_receiver(rx)

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -375,6 +375,10 @@ impl<E: Context> Writable<E> {
         }
         let _ = self.metrics.tracked.try_set(0);
         self.tail = self.partition.open(tail_blob).await?;
+        // Make the fresh tail durable (creation defers that to the first sync, including its
+        // directory entries) before callers durably record state that references it.
+        self.tail.sync().await.map_err(Error::Runtime)?;
+        self.metrics.synced.inc();
         self.metrics.tracked.inc();
         self.oldest_blob_index = tail_blob;
         self.sealed.clear();

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -375,15 +375,13 @@ impl<E: Context> Writable<E> {
         }
         let _ = self.metrics.tracked.try_set(0);
         self.tail = self.partition.open(tail_blob).await?;
-        // Make the fresh tail durable (creation defers that to the first sync, including its
-        // directory entries) before callers durably record state that references it.
-        self.tail.sync().await.map_err(Error::Runtime)?;
-        self.metrics.synced.inc();
         self.metrics.tracked.inc();
         self.oldest_blob_index = tail_blob;
         self.sealed.clear();
         self.sealed_snapshot = None;
-        Ok(())
+        // Make the fresh tail durable (creation defers that to the first sync, including its
+        // directory entries) before callers durably record state that references it.
+        self.sync_from(tail_blob).await
     }
 
     /// Make every blob from `start_blob` onward durable.

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -522,7 +522,10 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             cfg.write_buffer,
         );
         let tail_blob = super::position_to_blob(clear_target, cfg.items_per_blob.get());
-        let blobs = Writable::recover(partition, BTreeMap::new(), tail_blob).await?;
+        let mut blobs = Writable::recover(partition, BTreeMap::new(), tail_blob).await?;
+        // Make the fresh tail durable (creation defers that to the first sync, including its
+        // directory entries) before the checkpoint durably records the clear against it.
+        blobs.sync_from(tail_blob).await?;
         checkpoint
             .finish_clear(cfg.items_per_blob.get(), clear_target)
             .await?;


### PR DESCRIPTION
Towards: #4190
Stacked on: #4184 (the recovery machinery there is what makes this deferral's crash states benign)

## Summary

Creating a blob paid two file fsyncs plus one or two directory fsyncs before `open` returned, putting up to four fsyncs on the contiguous journal's rollover path. With this change creation performs exactly **one file fsync** (the header write): the empty-file fsync existed only to order file durability ahead of the directory syncs, and the directory syncs now happen with the blob's **first durability request** instead of at creation.

## Design

Each blob handle carries a `DirSync` (parent + storage-root paths and a once-flag). `sync`, `start_sync`, and `write_at_sync` run it after the file fsync: fsync parent, fsync root, set the flag (`Release`; the fast-path gates read with `Acquire`). Both dirs are covered unconditionally, so no handle needs to know whether another open created the partition. Reopened handles also start unsynced, since they cannot know whether the entries were ever fsynced (e.g. a creation or recovery that crashed first).

The range-scoped `write_at_sync` fast paths (`pwritev2(RWF_SYNC)` on tokio-unix, the ring's sync write on iouring) cannot cover directory entries, so a handle's first `write_at_sync` routes through the full-sync path — this is what keeps `Metadata`'s checkpoint writes (whose only durability op is `write_at_sync`) fully durable.

## Safety argument

- The only new crash state is "never-synced blob vanished", which is already reachable today via a crash inside `open`, and is within contract: nothing was promised, and reopen recreates the blob. Contract docs updated accordingly (`Storage::open_versioned` owns the statement; `Blob::sync`/`write_at_sync` link to it).
- A torn header left at the blob's name heals via #4184's interrupted-creation recovery.
- Once any durable op returns, both content and dirents are durable (file fsync strictly before dir fsyncs, all before returning/resolving).
- Directory fsyncs are per-directory, so `remove()`'s existing dir fsync also persists any pending creations in the same partition.

## Adversarial review

A four-lens review of the deferral confirmed the crash-contract, backend-wiring, and doc claims, and found **one real regression, fixed here**: the contiguous journal's clear paths created a fresh tail blob and then durably finalized the clear checkpoint against it — a crash could persist the checkpoint while the never-synced tail vanished, leaving init permanently failing bounds recovery. `Writable::clear` and `complete_staged_clear` now sync the fresh tail before any checkpoint write. A follow-up verification pass confirmed the fix is complete: a systematic sweep found no other create-then-durably-reference orderings (rollover's new tail is always synced before any watermark advance by the dirty-blob tracking), and the fresh-tail sync provably reaches `Blob::sync` even on an empty paged writer.

## Notes

- Reopened handles pay the two directory fsyncs once per handle on their first durable op; they are cheap for already-durable entries.
- On iouring the (once per handle) directory fsyncs are blocking calls on the caller's task, consistent with the blocking directory operations its open path already performs inline.
- Windows semantics are unchanged: no directory-fsync primitive exists there (#2026).
- The vanished-never-synced-blob crash state cannot be modeled by the deterministic runtime's storage, so the clear-path ordering is enforced by review and the checkpoint module's documented invariant rather than a test. A faulty-storage mode that drops never-synced blobs would make this class testable and is left as a follow-up.
- Remaining #4190 step: move the last creation fsync (the header write) off the open path via a `start_sync` handle once #4180's submission ordering lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSarn1C4iMrjHQHrVcanFo