### PR TITLE
[runtime,storage] Parallelize blob opens; narrow the storage namespace lock

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1566,6 +1566,10 @@ impl TryCryptoRng for Context {}
 impl crate::Storage for Context {
     type Blob = <Storage as crate::Storage>::Blob;
 
+    fn open_concurrency(&self) -> std::num::NonZeroUsize {
+        self.storage.open_concurrency()
+    }
+
     async fn open_versioned(
         &self,
         partition: &str,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -78,6 +78,9 @@ stability_scope!(BETA {
     /// Default [`Blob`] version used when no version is specified via [`Storage::open`].
     pub const DEFAULT_BLOB_VERSION: u16 = 0;
 
+    /// Default number of blob opens a storage backend productively absorbs at once.
+    pub(crate) const DEFAULT_OPEN_CONCURRENCY: NonZeroUsize = commonware_utils::NZUsize!(16);
+
     /// Errors that can occur when interacting with the runtime.
     #[derive(Error, Debug, Clone)]
     pub enum Error {
@@ -607,6 +610,12 @@ stability_scope!(BETA {
     pub trait Storage: Send + Sync + 'static {
         /// The readable/writeable storage buffer that can be opened by this Storage.
         type Blob: Blob;
+
+        /// The number of concurrent blob opens this storage productively absorbs, as a hint
+        /// for callers that open many blobs at once (e.g. initialization scans).
+        fn open_concurrency(&self) -> std::num::NonZeroUsize {
+            DEFAULT_OPEN_CONCURRENCY
+        }
 
         /// [`Storage::open_versioned`] with [`DEFAULT_BLOB_VERSION`] as the only value
         /// in the versions range. The blob version is omitted from the return value.

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -489,6 +489,10 @@ impl<E: Spawner> Spawner for DelayedSyncContext<E> {
 impl<E: Storage> Storage for DelayedSyncContext<E> {
     type Blob = DelayedSyncBlob<E::Blob>;
 
+    fn open_concurrency(&self) -> std::num::NonZeroUsize {
+        self.inner.open_concurrency()
+    }
+
     async fn open_versioned(
         &self,
         partition: &str,
@@ -716,6 +720,10 @@ forward_context!(SyncFaultContext, fail_partition);
 
 impl<E: Storage> Storage for SyncFaultContext<E> {
     type Blob = SyncFaultBlob<E::Blob>;
+
+    fn open_concurrency(&self) -> std::num::NonZeroUsize {
+        self.inner.open_concurrency()
+    }
 
     async fn open_versioned(
         &self,

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -21,6 +21,10 @@ impl<S: crate::Storage> Storage<S> {
 impl<S: crate::Storage> crate::Storage for Storage<S> {
     type Blob = Blob<S::Blob>;
 
+    fn open_concurrency(&self) -> std::num::NonZeroUsize {
+        self.inner.open_concurrency()
+    }
+
     async fn open_versioned(
         &self,
         partition: &str,

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -234,6 +234,10 @@ fn injected_io_error() -> IoError {
 impl<S: crate::Storage> crate::Storage for Storage<S> {
     type Blob = Blob<S::Blob>;
 
+    fn open_concurrency(&self) -> std::num::NonZeroUsize {
+        self.inner.open_concurrency()
+    }
+
     async fn open_versioned(
         &self,
         partition: &str,

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -33,6 +33,7 @@ use commonware_utils::sync::Mutex;
 use std::{
     fs::{self, File},
     io::{Error as IoError, Read, Seek, SeekFrom, Write},
+    num::NonZeroUsize,
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::Arc,
@@ -66,6 +67,8 @@ pub struct Config {
     pub iouring_config: iouring::Config,
     /// Stack size for the dedicated io_uring worker thread.
     pub thread_stack_size: usize,
+    /// See [crate::Storage::open_concurrency].
+    pub open_concurrency: NonZeroUsize,
 }
 
 #[derive(Clone)]
@@ -74,6 +77,7 @@ pub struct Storage {
     storage_directory: PathBuf,
     io_handle: iouring::Handle,
     pool: BufferPool,
+    open_concurrency: NonZeroUsize,
 }
 
 impl Storage {
@@ -83,6 +87,7 @@ impl Storage {
             storage_directory,
             mut iouring_config,
             thread_stack_size,
+            open_concurrency,
         } = cfg;
 
         // Optimize performance by hinting the kernel that a single task will
@@ -98,6 +103,7 @@ impl Storage {
             storage_directory,
             io_handle,
             pool,
+            open_concurrency,
         };
 
         utils::thread::spawn(thread_stack_size, move || iouring_loop.run());
@@ -107,6 +113,10 @@ impl Storage {
 
 impl crate::Storage for Storage {
     type Blob = Blob;
+
+    fn open_concurrency(&self) -> NonZeroUsize {
+        self.open_concurrency
+    }
 
     async fn open_versioned(
         &self,
@@ -423,8 +433,9 @@ impl crate::Blob for Blob {
 mod tests {
     use super::{Header, *};
     use crate::{
-        Blob as _, BufferPool, BufferPoolConfig, IoBuf, IoBufMut, Storage as _,
-        storage::tests::run_storage_tests, telemetry::metrics::Registry, utils::thread,
+        Blob as _, BufferPool, BufferPoolConfig, DEFAULT_OPEN_CONCURRENCY, IoBuf, IoBufMut,
+        Storage as _, storage::tests::run_storage_tests, telemetry::metrics::Registry,
+        utils::thread,
     };
     use std::{
         env,
@@ -458,6 +469,7 @@ mod tests {
                 storage_directory: storage_directory.clone(),
                 iouring_config: Default::default(),
                 thread_stack_size: thread::system_thread_stack_size(),
+                open_concurrency: DEFAULT_OPEN_CONCURRENCY,
             },
             &mut registry.sub_registry("storage"),
             pool,
@@ -851,6 +863,7 @@ mod tests {
                 storage_directory: storage_root.clone(),
                 iouring_config: Default::default(),
                 thread_stack_size: utils::thread::system_thread_stack_size(),
+                open_concurrency: DEFAULT_OPEN_CONCURRENCY,
             },
             &mut registry.sub_registry("storage"),
             pool,
@@ -886,6 +899,7 @@ mod tests {
                 storage_directory: storage_directory.clone(),
                 iouring_config: Default::default(),
                 thread_stack_size: utils::thread::system_thread_stack_size(),
+                open_concurrency: DEFAULT_OPEN_CONCURRENCY,
             },
             &mut registry.sub_registry("storage"),
             pool,

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -85,6 +85,10 @@ impl<S> Storage<S> {
 impl<S: crate::Storage> crate::Storage for Storage<S> {
     type Blob = Blob<S::Blob>;
 
+    fn open_concurrency(&self) -> std::num::NonZeroUsize {
+        self.inner.open_concurrency()
+    }
+
     async fn open_versioned(
         &self,
         partition: &str,

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -1,20 +1,33 @@
 use super::Header;
-use crate::{BufferPool, Error};
+use crate::{BufferPool, DEFAULT_OPEN_CONCURRENCY, Error};
 use commonware_codec::Encode;
 use commonware_formatting::{from_hex, hex};
 #[cfg(unix)]
 use std::path::Path;
-use std::{ops::RangeInclusive, path::PathBuf, sync::Arc};
+use std::{
+    future::Future,
+    hash::{Hash, Hasher},
+    io::ErrorKind,
+    num::NonZeroUsize,
+    ops::RangeInclusive,
+    path::PathBuf,
+    sync::Arc,
+};
 use tokio::{
     fs,
     io::{AsyncReadExt, AsyncWriteExt},
-    sync::Mutex,
+    sync::RwLock,
 };
 
 #[cfg(not(unix))]
 mod fallback;
 #[cfg(unix)]
 mod unix;
+
+#[cfg(not(unix))]
+type BackendBlob = fallback::Blob;
+#[cfg(unix)]
+type BackendBlob = unix::Blob;
 
 /// Syncs a directory to ensure directory entry changes are durable.
 /// On Unix, directory metadata (file creation/deletion) must be explicitly
@@ -41,6 +54,8 @@ async fn sync_dir(path: &Path) -> Result<(), Error> {
 pub struct Config {
     pub storage_directory: PathBuf,
     pub maximum_buffer_size: usize,
+    /// See [crate::Storage::open_concurrency].
+    pub open_concurrency: NonZeroUsize,
 }
 
 impl Config {
@@ -48,13 +63,50 @@ impl Config {
         Self {
             storage_directory,
             maximum_buffer_size,
+            open_concurrency: DEFAULT_OPEN_CONCURRENCY,
         }
     }
 }
 
+/// Maps only an absent partition to [`Error::PartitionMissing`], preserving all other I/O
+/// failures so callers never mistake a failed removal for a successful reset.
+fn partition_remove_error(partition: &str, error: std::io::Error) -> Error {
+    if error.kind() == ErrorKind::NotFound {
+        Error::PartitionMissing(partition.into())
+    } else {
+        error.into()
+    }
+}
+
+#[derive(Clone, Default)]
+struct Cancellation(Arc<std::sync::atomic::AtomicBool>);
+
+impl Cancellation {
+    fn cancelled(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
+struct CancelOnDrop(Cancellation);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.0.store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
+/// Number of partition-lock stripes. Collisions only cost spurious serialization of unrelated
+/// partitions, so a small fixed table suffices.
+const PARTITION_LOCK_STRIPES: usize = 64;
+
 #[derive(Clone)]
 pub struct Storage {
-    lock: Arc<Mutex<()>>,
+    /// Striped per-partition locks. Each lock upholds two invariants (see #3869): after
+    /// [crate::Storage::remove] returns, a [crate::Storage::scan] must not observe the removed
+    /// name, and an open must not recreate a blob between removal's unlink and its directory
+    /// fsync. Existing blobs reopen under a shared lock; creation, healing, scans, and removals
+    /// hold it exclusively.
+    partition_locks: Arc<[RwLock<()>; PARTITION_LOCK_STRIPES]>,
     cfg: Config,
     pool: BufferPool,
 }
@@ -62,10 +114,88 @@ pub struct Storage {
 impl Storage {
     pub fn new(cfg: Config, pool: BufferPool) -> Self {
         Self {
-            lock: Arc::new(Mutex::new(())),
+            partition_locks: Arc::new(std::array::from_fn(|_| RwLock::new(()))),
             cfg,
             pool,
         }
+    }
+
+    /// Hashes a partition for lock selection, folding ASCII case so aliases on a
+    /// case-insensitive filesystem select the same lock. Names are ASCII-only (see
+    /// [super::validate_partition_name]), so case is the only aliasing a filesystem can
+    /// introduce; on case-sensitive filesystems folding only risks serializing
+    /// otherwise-independent operations.
+    fn hash_partition(partition: &str, hasher: &mut impl Hasher) {
+        partition.len().hash(hasher);
+        for byte in partition.bytes() {
+            byte.to_ascii_lowercase().hash(hasher);
+        }
+    }
+
+    /// Returns the lock stripe for `partition`.
+    fn partition_lock(&self, partition: &str) -> &RwLock<()> {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        Self::hash_partition(partition, &mut hasher);
+        &self.partition_locks[hasher.finish() as usize % PARTITION_LOCK_STRIPES]
+    }
+
+    /// Validate an existing blob's header and construct its backend handle.
+    async fn finish_existing(
+        &self,
+        partition: &str,
+        name: &[u8],
+        mut file: fs::File,
+        len: u64,
+        versions: &RangeInclusive<u16>,
+    ) -> Result<(BackendBlob, u64, u16), Error> {
+        file.set_max_buf_size(self.cfg.maximum_buffer_size);
+        let mut header_bytes = [0u8; Header::SIZE];
+        file.read_exact(&mut header_bytes)
+            .await
+            .map_err(|_| Error::ReadFailed)?;
+        let (blob_version, logical_size) =
+            Header::from(header_bytes, len, versions).map_err(|e| e.into_error(partition, name))?;
+        Ok(self
+            .finish_blob(partition, name, file, logical_size, blob_version)
+            .await)
+    }
+
+    /// Construct the platform-specific blob handle from an opened Tokio file.
+    #[cfg_attr(not(unix), allow(clippy::unused_async))]
+    async fn finish_blob(
+        &self,
+        partition: &str,
+        name: &[u8],
+        file: fs::File,
+        logical_size: u64,
+        blob_version: u16,
+    ) -> (BackendBlob, u64, u16) {
+        #[cfg(unix)]
+        let file = file.into_std().await;
+        (
+            BackendBlob::new(partition.into(), name, file, self.pool.clone()),
+            logical_size,
+            blob_version,
+        )
+    }
+}
+
+/// Runs a filesystem operation to completion after it has crossed its cancellation boundary,
+/// even if its caller is cancelled. Tokio filesystem futures delegate to blocking tasks that keep
+/// running when dropped, so the task must also retain the operation's lock guards until those
+/// tasks finish.
+async fn complete_on_cancel<F, Fut, T>(operation: F) -> T
+where
+    F: FnOnce(Cancellation) -> Fut,
+    Fut: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let cancellation = Cancellation::default();
+    let _cancel_on_drop = CancelOnDrop(cancellation.clone());
+    match tokio::spawn(operation(cancellation)).await {
+        Ok(output) => output,
+        Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
+        Err(error) => panic!("storage operation task was cancelled: {error}"),
     }
 }
 
@@ -75,6 +205,10 @@ impl crate::Storage for Storage {
     #[cfg(not(unix))]
     type Blob = fallback::Blob;
 
+    fn open_concurrency(&self) -> NonZeroUsize {
+        self.cfg.open_concurrency
+    }
+
     async fn open_versioned(
         &self,
         partition: &str,
@@ -83,151 +217,169 @@ impl crate::Storage for Storage {
     ) -> Result<(Self::Blob, u64, u16), Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock
-        let _guard = self.lock.lock().await;
-
-        // Construct the full path
+        // The normal reopen path is read-only and runs concurrently with other opens. Creation
+        // and healing fall back to the exclusive path below.
+        let partition_guard = self.partition_lock(partition).read().await;
         let path = self.cfg.storage_directory.join(partition).join(hex(name));
-        let parent = match path.parent() {
-            Some(parent) => parent,
-            None => return Err(Error::PartitionCreationFailed(partition.into())),
-        };
-
-        // Check if partition exists before creating
-        #[cfg(unix)]
-        let parent_existed = parent.exists();
-
-        // Create the partition directory, if it does not exist
-        fs::create_dir_all(parent)
-            .await
-            .map_err(|_| Error::PartitionCreationFailed(partition.into()))?;
-
-        // Open the file, creating it if it doesn't exist
-        let mut file = fs::OpenOptions::new()
+        let existing = fs::OpenOptions::new()
             .read(true)
             .write(true)
-            .create(true)
-            .truncate(false)
             .open(&path)
-            .await
-            .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e.into()))?;
-
-        // Assume empty files are newly created. Existing empty files will be synced too; that's OK.
-        let len = file.metadata().await.map_err(|_| Error::ReadFailed)?.len();
-        let newly_created = len == 0;
-
-        // Only sync if we created a new file
-        if newly_created {
-            // Sync the file to ensure it is durable
-            file.sync_all()
-                .await
-                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-
-            // Windows doesn't have a notion of syncing a directory entry to ensure that it's
-            // durably persisted. See https://github.com/commonwarexyz/monorepo/issues/2026.
-            #[cfg(unix)]
-            {
-                // Sync the parent directory to ensure the directory entry is durable.
-                sync_dir(parent).await?;
-
-                // Sync storage directory if parent directory did not exist
-                if !parent_existed {
-                    sync_dir(&self.cfg.storage_directory).await?;
+            .await;
+        match existing {
+            Ok(file) => {
+                let len = file.metadata().await.map_err(|_| Error::ReadFailed)?.len();
+                if !Header::missing(len) {
+                    return self
+                        .finish_existing(partition, name, file, len, &versions)
+                        .await;
                 }
             }
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(Error::BlobOpenFailed(
+                    partition.into(),
+                    hex(name),
+                    error.into(),
+                ));
+            }
         }
+        drop(partition_guard);
 
-        // Set the maximum buffer size
-        file.set_max_buf_size(self.cfg.maximum_buffer_size);
+        // Missing and sub-header blobs require mutation. Serialize that exceptional path at the
+        // partition level, rechecking after taking the write lock in case another opener repaired
+        // the blob first.
+        let storage = self.clone();
+        let partition = partition.to_owned();
+        let name = name.to_vec();
+        let operation = move |cancellation: Cancellation| async move {
+            let partition = partition.as_str();
+            let name = name.as_slice();
 
-        // Handle header: new/corrupted blobs get a fresh header written,
-        // existing blobs have their header read.
-        let (blob_version, logical_size) = if Header::missing(len) {
-            // New or partially-created blob: reset it and write a fresh header. The
-            // file grows only as header bytes are written, so a create interrupted by
-            // a process crash leaves some prefix of the header, which the next open
-            // resets here instead of rejecting as corrupt below.
-            let (header, blob_version) = Header::new(&versions);
+            let _partition_guard = storage.partition_lock(partition).write().await;
+            if cancellation.cancelled() {
+                return Err(Error::Aborted);
+            }
+
+            let path = storage
+                .cfg
+                .storage_directory
+                .join(partition)
+                .join(hex(name));
+            let parent = match path.parent() {
+                Some(parent) => parent,
+                None => return Err(Error::PartitionCreationFailed(partition.into())),
+            };
+            fs::create_dir_all(parent)
+                .await
+                .map_err(|_| Error::PartitionCreationFailed(partition.into()))?;
+
+            let mut file = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&path)
+                .await
+                .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e.into()))?;
+
+            let len = file.metadata().await.map_err(|_| Error::ReadFailed)?.len();
+            if !Header::missing(len) {
+                return storage
+                    .finish_existing(partition, name, file, len, &versions)
+                    .await;
+            }
+
+            file.set_max_buf_size(storage.cfg.maximum_buffer_size);
+            // Truncate to zero (not the header size) so a crash cannot splice residual bytes into
+            // a valid-looking header, and make the empty file and both directory levels durable
+            // BEFORE writing the header: the reopen path admits any header-valid blob without
+            // syncing directories, so header validity must certify that its creating open
+            // completed the namespace syncs. A failure or crash anywhere before the header write
+            // leaves a sub-header file, which the next open routes back through this path.
+            // Windows doesn't have a notion of syncing a directory entry; see #2026.
             file.set_len(0)
                 .await
                 .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
+            file.sync_all()
+                .await
+                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
+            #[cfg(unix)]
+            {
+                sync_dir(parent).await?;
+                sync_dir(&storage.cfg.storage_directory).await?;
+            }
+
+            let (header, blob_version) = Header::new(&versions);
             file.write_all(&header.encode())
                 .await
                 .map_err(|_| Error::WriteFailed)?;
             file.sync_all()
                 .await
                 .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-            (blob_version, 0)
-        } else {
-            // Existing blob - read and validate header
-            let mut header_bytes = [0u8; Header::SIZE];
-            file.read_exact(&mut header_bytes)
-                .await
-                .map_err(|_| Error::ReadFailed)?;
-            Header::from(header_bytes, len, &versions).map_err(|e| e.into_error(partition, name))?
+
+            Ok(storage
+                .finish_blob(partition, name, file, 0, blob_version)
+                .await)
         };
-
-        #[cfg(unix)]
-        {
-            // Convert to a blocking std::fs::File
-            let file = file.into_std().await;
-
-            // Construct the blob
-            Ok((
-                Self::Blob::new(partition.into(), name, file, self.pool.clone()),
-                logical_size,
-                blob_version,
-            ))
-        }
-        #[cfg(not(unix))]
-        {
-            // Construct the blob
-            Ok((
-                Self::Blob::new(partition.into(), name, file, self.pool.clone()),
-                logical_size,
-                blob_version,
-            ))
-        }
+        complete_on_cancel(operation).await
     }
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock
-        let _guard = self.lock.lock().await;
+        let storage = self.clone();
+        let partition = partition.to_owned();
+        let name = name.map(<[u8]>::to_vec);
+        let operation = move |cancellation: Cancellation| async move {
+            let partition = partition.as_str();
+            let name = name.as_deref();
 
-        // Remove all related files
-        let path = self.cfg.storage_directory.join(partition);
-        if let Some(name) = name {
-            let blob_path = path.join(hex(name));
-            fs::remove_file(blob_path)
-                .await
-                .map_err(|_| Error::BlobMissing(partition.into(), hex(name)))?;
+            // Take the partition lock's write half: no open may recreate a blob between the
+            // unlink and the directory fsync, and no scan may observe a partial removal.
+            let _guard = storage.partition_lock(partition).write().await;
+            // Honor cancellation until removal linearizes under the write lock. Past this point,
+            // run to completion so an unlink is always followed by its directory fsync.
+            if cancellation.cancelled() {
+                return Err(Error::Aborted);
+            }
 
-            // Sync the partition directory to ensure the removal is durable.
-            // Windows doesn't have a notion of syncing a directory entry to ensure that it's
-            // durably persisted. See https://github.com/commonwarexyz/monorepo/issues/2026.
-            #[cfg(unix)]
-            sync_dir(&path).await?;
-        } else {
-            fs::remove_dir_all(&path)
-                .await
-                .map_err(|_| Error::PartitionMissing(partition.into()))?;
+            // Remove all related files
+            let path = storage.cfg.storage_directory.join(partition);
+            if let Some(name) = name {
+                let blob_path = path.join(hex(name));
+                fs::remove_file(blob_path)
+                    .await
+                    .map_err(|_| Error::BlobMissing(partition.into(), hex(name)))?;
 
-            // Sync the storage directory to ensure the removal is durable.
-            // Windows doesn't have a notion of syncing a directory entry to ensure that it's
-            // durably persisted. See https://github.com/commonwarexyz/monorepo/issues/2026.
-            #[cfg(unix)]
-            sync_dir(&self.cfg.storage_directory).await?;
-        }
-        Ok(())
+                // Sync the partition directory to ensure the removal is durable.
+                // Windows doesn't have a notion of syncing a directory entry to ensure that it's
+                // durably persisted. See https://github.com/commonwarexyz/monorepo/issues/2026.
+                #[cfg(unix)]
+                sync_dir(&path).await?;
+            } else {
+                fs::remove_dir_all(&path)
+                    .await
+                    .map_err(|error| partition_remove_error(partition, error))?;
+
+                // Sync the storage directory to ensure the removal is durable.
+                // Windows doesn't have a notion of syncing a directory entry to ensure that it's
+                // durably persisted. See https://github.com/commonwarexyz/monorepo/issues/2026.
+                #[cfg(unix)]
+                sync_dir(&storage.cfg.storage_directory).await?;
+            }
+            Ok(())
+        };
+        complete_on_cancel(operation).await
     }
 
     async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock
-        let _guard = self.lock.lock().await;
+        // Take the partition lock exclusively so scan cannot observe a blob midway through open.
+        // This preserves the prior namespace snapshot while still allowing the opens performed
+        // after the scan to run concurrently.
+        let _guard = self.partition_lock(partition).write().await;
 
         // Scan the partition directory
         let path = self.cfg.storage_directory.join(partition);
@@ -265,7 +417,10 @@ mod tests {
     };
     use commonware_utils::sys_rng;
     use rand::RngExt as _;
-    use std::env;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::{env, time::Duration};
+    use tokio::sync::{Mutex, oneshot};
 
     fn test_pool() -> BufferPool {
         let mut registry = Registry::default();
@@ -275,6 +430,255 @@ mod tests {
     fn random_suffix() -> u64 {
         let mut rng = sys_rng();
         rng.random()
+    }
+
+    /// Cancelling a caller must not release a mutating operation's lock while its detached
+    /// filesystem work is still running.
+    #[tokio::test]
+    async fn test_complete_on_cancel_retains_guards() {
+        let lock = Arc::new(Mutex::new(()));
+        let operation_lock = lock.clone();
+        let (started_sender, started_receiver) = oneshot::channel();
+        let (finish_sender, finish_receiver) = oneshot::channel();
+
+        let caller = tokio::spawn(async move {
+            complete_on_cancel(move |_| async move {
+                let _guard = operation_lock.lock().await;
+                started_sender.send(()).unwrap();
+                finish_receiver.await.unwrap();
+            })
+            .await;
+        });
+
+        started_receiver.await.unwrap();
+        caller.abort();
+        assert!(caller.await.unwrap_err().is_cancelled());
+        assert!(lock.try_lock().is_err());
+
+        finish_sender.send(()).unwrap();
+        let _guard = tokio::time::timeout(Duration::from_secs(1), lock.lock())
+            .await
+            .expect("detached operation did not release its guard");
+    }
+
+    #[test]
+    fn test_partition_remove_error_preserves_non_missing_failures() {
+        let missing =
+            partition_remove_error("partition", std::io::Error::from(ErrorKind::NotFound));
+        assert!(matches!(missing, Error::PartitionMissing(partition) if partition == "partition"));
+
+        let denied = partition_remove_error(
+            "partition",
+            std::io::Error::from(ErrorKind::PermissionDenied),
+        );
+        assert!(matches!(denied, Error::Io(error) if error.kind() == ErrorKind::PermissionDenied));
+    }
+
+    /// A cancelled open that has not acquired the partition lock must not run after removal and
+    /// recreate the partition.
+    #[tokio::test]
+    async fn test_cancelled_open_does_not_resurrect_partition() {
+        let storage_directory =
+            env::temp_dir().join(format!("test_cancelled_open_{}", random_suffix()));
+        let partition_path = storage_directory.join("partition");
+        fs::create_dir_all(&partition_path).await.unwrap();
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 1024 * 1024),
+            test_pool(),
+        );
+
+        // Let the read-only probe observe the missing blob, then hold the fallback before its
+        // exclusive cancellation boundary.
+        let removal_guard = storage.partition_lock("partition").read().await;
+        let open_storage = storage.clone();
+        let caller = tokio::spawn(async move { open_storage.open("partition", b"stale").await });
+        // The probe's filesystem open completes on the blocking pool, so wait on wall time (not
+        // yields) for the repair to queue its exclusive acquisition.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut repair_queued = false;
+        while tokio::time::Instant::now() < deadline {
+            if storage.partition_lock("partition").try_read().is_err() {
+                repair_queued = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert!(
+            repair_queued,
+            "detached repair did not reach the write lock"
+        );
+        caller.abort();
+        let error = match caller.await {
+            Err(error) => error,
+            Ok(_) => panic!("cancelled open caller completed"),
+        };
+        assert!(error.is_cancelled());
+
+        // Model a completed partition removal, then let the queued detached operation run.
+        fs::remove_dir_all(&partition_path).await.unwrap();
+        drop(removal_guard);
+        let barrier = storage.partition_lock("partition").write().await;
+        drop(barrier);
+
+        assert!(!partition_path.exists());
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    /// A cancelled remove that has not acquired the partition lock must not later delete a
+    /// partition the caller has resumed using.
+    #[tokio::test]
+    async fn test_cancelled_remove_does_not_delete_partition() {
+        let storage_directory =
+            env::temp_dir().join(format!("test_cancelled_remove_{}", random_suffix()));
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 1024 * 1024),
+            test_pool(),
+        );
+        let (blob, _) = storage.open("partition", b"retained").await.unwrap();
+        drop(blob);
+        let blob_path = storage_directory.join("partition").join(hex(b"retained"));
+
+        // Keep the detached remove before its cancellation boundary until its caller is gone.
+        let operation_guard = storage.partition_lock("partition").read().await;
+        let remove_storage = storage.clone();
+        let caller = tokio::spawn(async move { remove_storage.remove("partition", None).await });
+        let mut remove_queued = false;
+        for _ in 0..100 {
+            // Tokio's writer-preferring lock stops admitting readers once the remove is queued.
+            if storage.partition_lock("partition").try_read().is_err() {
+                remove_queued = true;
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            remove_queued,
+            "detached remove did not reach the write lock"
+        );
+        caller.abort();
+        let error = match caller.await {
+            Err(error) => error,
+            Ok(_) => panic!("cancelled remove caller completed"),
+        };
+        assert!(error.is_cancelled());
+
+        drop(operation_guard);
+        let barrier = storage.partition_lock("partition").write().await;
+        drop(barrier);
+
+        assert!(blob_path.exists());
+        storage.remove("partition", None).await.unwrap();
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    /// A create attempt that fails before completing its directory syncs must leave a
+    /// sub-header file so a retry replays the full durability sequence instead of admitting a
+    /// blob whose namespace entry was never made durable through the reopen path.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_failed_create_leaves_sub_header_blob() {
+        let storage_directory =
+            env::temp_dir().join(format!("test_failed_create_{}", random_suffix()));
+        let partition_path = storage_directory.join("partition");
+        fs::create_dir_all(&partition_path).await.unwrap();
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 1024 * 1024),
+            test_pool(),
+        );
+
+        // Deny read on the storage root so its directory fsync fails (syncing requires opening
+        // the directory read-only) while traversal and creation inside it still work.
+        let normal = std::fs::metadata(&storage_directory).unwrap().permissions();
+        std::fs::set_permissions(&storage_directory, std::fs::Permissions::from_mode(0o311))
+            .unwrap();
+        // Permissions cannot deny access to privileged users (e.g. root in a CI container).
+        if std::fs::File::open(&storage_directory).is_ok() {
+            let _ = std::fs::remove_dir_all(&storage_directory);
+            return;
+        }
+
+        assert!(
+            storage.open("partition", b"blob").await.is_err(),
+            "create must fail when the storage root cannot be synced"
+        );
+        let len = std::fs::metadata(partition_path.join(hex(b"blob")))
+            .unwrap()
+            .len();
+        assert!(
+            Header::missing(len),
+            "failed create left a header-valid blob (len {len})"
+        );
+
+        // With the failure cleared, a retry replays the full creation sequence.
+        std::fs::set_permissions(&storage_directory, normal).unwrap();
+        let (_, size) = storage.open("partition", b"blob").await.unwrap();
+        assert_eq!(size, 0);
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    /// Existing blobs reopen concurrently, while creation, scans, and removals serialize at the
+    /// partition boundary.
+    #[tokio::test]
+    async fn test_narrowed_locking_invariants() {
+        let storage_directory =
+            env::temp_dir().join(format!("test_narrowed_locking_{}", random_suffix()));
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 1024 * 1024),
+            test_pool(),
+        );
+
+        // Case aliases must select the same lock stripes. On a case-sensitive filesystem this
+        // only introduces harmless false contention; on a case-insensitive filesystem it keeps
+        // operations on the same physical path coordinated.
+        assert!(std::ptr::eq(
+            storage.partition_lock("Alias"),
+            storage.partition_lock("alias")
+        ));
+        let alias_guard = storage.partition_lock("Alias").write().await;
+        assert!(storage.partition_lock("alias").try_read().is_err());
+        drop(alias_guard);
+
+        let partition_guard = storage.partition_lock("shared").read().await;
+        let concurrent_partition_guard = storage.partition_lock("shared").try_read().unwrap();
+        drop((partition_guard, concurrent_partition_guard));
+
+        // Create many distinct blobs, then reopen them concurrently across two partitions.
+        for i in 0..32u64 {
+            let partition = if i % 2 == 0 { "even" } else { "odd" };
+            storage.open(partition, &i.to_be_bytes()).await.unwrap();
+        }
+        let mut handles = Vec::new();
+        for i in 0..32u64 {
+            let storage = storage.clone();
+            handles.push(tokio::spawn(async move {
+                let partition = if i % 2 == 0 { "even" } else { "odd" };
+                storage.open(partition, &i.to_be_bytes()).await.unwrap();
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // Concurrent opens of the same fresh blob serialize through the partition write lock, so
+        // both succeed and agree on the resulting empty blob.
+        for round in 0..8u64 {
+            let name = round.to_be_bytes();
+            let (a, b) = tokio::join!(storage.open("races", &name), storage.open("races", &name));
+            let (_, size_a) = a.unwrap();
+            let (_, size_b) = b.unwrap();
+            assert_eq!(size_a, 0);
+            assert_eq!(size_b, 0);
+        }
+
+        // After remove returns, a scan must not observe the removed name.
+        storage
+            .remove("even", Some(&0u64.to_be_bytes()))
+            .await
+            .unwrap();
+        let names = storage.scan("even").await.unwrap();
+        assert!(!names.contains(&0u64.to_be_bytes().to_vec()));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
     }
 
     #[tokio::test]
@@ -416,10 +820,7 @@ mod tests {
         let storage_directory =
             env::temp_dir().join(format!("test_magic_mismatch_{}", random_suffix()));
         let storage = Storage::new(
-            Config {
-                storage_directory: storage_directory.clone(),
-                maximum_buffer_size: 1024 * 1024,
-            },
+            Config::new(storage_directory.clone(), 1024 * 1024),
             test_pool(),
         );
 
@@ -445,10 +846,7 @@ mod tests {
         let storage_directory =
             env::temp_dir().join(format!("test_partial_header_reset_{}", random_suffix()));
         let storage = Storage::new(
-            Config {
-                storage_directory: storage_directory.clone(),
-                maximum_buffer_size: 1024 * 1024,
-            },
+            Config::new(storage_directory.clone(), 1024 * 1024),
             test_pool(),
         );
         let partition_path = storage_directory.join("partition");
@@ -498,10 +896,7 @@ mod tests {
                 random_suffix()
             ));
             let storage = Storage::new(
-                Config {
-                    storage_directory: storage_directory.clone(),
-                    maximum_buffer_size: 1024 * 1024,
-                },
+                Config::new(storage_directory.clone(), 1024 * 1024),
                 test_pool(),
             );
 

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -169,6 +169,9 @@ pub struct Config {
     /// Tokio sets the default value to 2MB.
     maximum_buffer_size: usize,
 
+    /// See [crate::Storage::open_concurrency].
+    open_concurrency: NonZeroUsize,
+
     /// Network configuration.
     network_cfg: NetworkConfig,
 
@@ -192,6 +195,7 @@ impl Config {
             catch_panics: false,
             storage_directory,
             maximum_buffer_size: 2 * 1024 * 1024, // 2 MB
+            open_concurrency: crate::DEFAULT_OPEN_CONCURRENCY,
             network_cfg: NetworkConfig::default(),
             network_buffer_pool_cfg: None,
             storage_buffer_pool_cfg: None,
@@ -255,6 +259,11 @@ impl Config {
         self
     }
     /// See [Config]
+    pub const fn with_open_concurrency(mut self, n: NonZeroUsize) -> Self {
+        self.open_concurrency = n;
+        self
+    }
+    /// See [Config]
     pub fn with_network_buffer_pool_config(mut self, cfg: BufferPoolConfig) -> Self {
         self.network_buffer_pool_cfg = Some(cfg);
         self
@@ -309,6 +318,10 @@ impl Config {
     /// See [Config]
     pub const fn maximum_buffer_size(&self) -> usize {
         self.maximum_buffer_size
+    }
+    /// See [Config]
+    pub const fn open_concurrency(&self) -> NonZeroUsize {
+        self.open_concurrency
     }
 
     /// Returns the network buffer pool config, deriving pool parallelism from
@@ -426,6 +439,7 @@ impl crate::Runner for Runner {
                             storage_directory: self.cfg.storage_directory.clone(),
                             iouring_config: Default::default(),
                             thread_stack_size: self.cfg.thread_stack_size,
+                            open_concurrency: self.cfg.open_concurrency,
                         },
                         &mut iouring_registry,
                         storage_buffer_pool.clone(),
@@ -435,10 +449,14 @@ impl crate::Runner for Runner {
             } else {
                 let storage = MeteredStorage::new(
                     TokioStorage::new(
-                        TokioStorageConfig::new(
-                            self.cfg.storage_directory.clone(),
-                            self.cfg.maximum_buffer_size,
-                        ),
+                        {
+                            let mut cfg = TokioStorageConfig::new(
+                                self.cfg.storage_directory.clone(),
+                                self.cfg.maximum_buffer_size,
+                            );
+                            cfg.open_concurrency = self.cfg.open_concurrency;
+                            cfg
+                        },
                         storage_buffer_pool.clone(),
                     ),
                     &mut runtime_registry,
@@ -816,6 +834,10 @@ impl TryCryptoRng for Context {}
 
 impl crate::Storage for Context {
     type Blob = <Storage as crate::Storage>::Blob;
+
+    fn open_concurrency(&self) -> std::num::NonZeroUsize {
+        self.storage.open_concurrency()
+    }
 
     async fn open_versioned(
         &self,

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -3,6 +3,7 @@
 use crate::{
     Context,
     journal::{Error, frame::FrameReader},
+    try_collect_concurrent,
 };
 use commonware_formatting::hex;
 use commonware_runtime::{
@@ -80,18 +81,29 @@ impl<E: Context> Partition<E> {
     pub(super) async fn open_all(&self) -> Result<BTreeMap<u64, Writer<E::Blob>>, Error> {
         let stored = Self::scan_names(&self.context, &self.name).await?;
 
-        let mut blobs = BTreeMap::new();
+        // Parse every name first, so malformed names surface deterministically.
+        let mut indices = Vec::with_capacity(stored.len());
         for name in stored {
             let hex_name = hex(&name);
             let bytes: [u8; 8] = name
                 .try_into()
                 .map_err(|_| Error::InvalidBlobName(hex_name.clone()))?;
-            let index = u64::from_be_bytes(bytes);
-            let writer = self.open(index).await?;
-            debug!(index, blob = hex_name, "loaded blob");
-            blobs.insert(index, writer);
+            indices.push((u64::from_be_bytes(bytes), hex_name));
         }
-        Ok(blobs)
+
+        // Open blobs concurrently, keyed by index. After an error, drain in-flight opens before
+        // returning so filesystem work is never abandoned while it may still mutate a blob.
+        let results = try_collect_concurrent(
+            indices,
+            self.context.open_concurrency(),
+            |(index, hex_name)| async move {
+                let writer = self.open(index).await?;
+                debug!(index, blob = hex_name, "loaded blob");
+                Ok::<_, Error>((index, writer))
+            },
+        )
+        .await?;
+        Ok(results.into_iter().collect())
     }
 
     /// Remove the given blob.

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -3,7 +3,7 @@
 //! This module provides `Manager`, a reusable component that handles
 //! section-based blob storage, pruning, syncing, and metrics.
 
-use crate::journal::Error;
+use crate::{journal::Error, try_collect_concurrent};
 use commonware_formatting::hex;
 use commonware_runtime::{
     Blob, BufferPool, Error as RError, Handle, Metrics, Storage,
@@ -199,25 +199,41 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
     ///
     /// Scans the partition for existing blobs and opens them.
     pub async fn init(context: E, cfg: Config<F>) -> Result<Self, Error> {
-        // Iterate over blobs in partition
-        let mut blobs = BTreeMap::new();
         let stored_blobs = match context.scan(&cfg.partition).await {
             Ok(blobs) => blobs,
             Err(RError::PartitionMissing(_)) => Vec::new(),
             Err(err) => return Err(Error::Runtime(err)),
         };
 
+        // Parse every name first, so malformed names surface deterministically.
+        let mut sections = Vec::with_capacity(stored_blobs.len());
         for name in stored_blobs {
-            let (blob, size) = context.open(&cfg.partition, &name).await?;
             let hex_name = hex(&name);
             let section = match name.try_into() {
                 Ok(section) => u64::from_be_bytes(section),
                 Err(_) => return Err(Error::InvalidBlobName(hex_name)),
             };
-            debug!(section, blob = hex_name, size, "loaded section");
-            let buffer = cfg.factory.create(blob, size).await?;
-            blobs.insert(section, buffer);
+            sections.push((section, hex_name));
         }
+
+        // Open blobs concurrently, keyed by section. After an error, drain in-flight opens before
+        // returning so filesystem work is never abandoned while it may still mutate a blob.
+        let context_ref = &context;
+        let cfg_ref = &cfg;
+        let results = try_collect_concurrent(
+            sections,
+            context.open_concurrency(),
+            |(section, hex_name)| async move {
+                let (blob, size) = context_ref
+                    .open(&cfg_ref.partition, &section.to_be_bytes())
+                    .await?;
+                debug!(section, blob = hex_name, size, "loaded section");
+                let buffer = cfg_ref.factory.create(blob, size).await?;
+                Ok::<_, Error>((section, buffer))
+            },
+        )
+        .await?;
+        let blobs: BTreeMap<_, _> = results.into_iter().collect();
 
         // Initialize metrics
         let tracked = context.gauge("tracked", "Number of blobs");

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -10,6 +10,172 @@
 )]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
+commonware_macros::stability_scope!(BETA, cfg(feature = "std") {
+use futures::{stream::FuturesUnordered, StreamExt as _};
+
+async fn indexed_result<Fut, T, E>(index: usize, future: Fut) -> (usize, Result<T, E>)
+where
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    (index, future.await)
+}
+
+/// Runs up to `concurrency` operations at once. After the first observed error, stops scheduling
+/// new work but drains every operation already in flight before returning the earliest error in
+/// input order among the operations that were started.
+async fn try_collect_concurrent<I, F, Fut, T, E>(
+    items: I,
+    concurrency: std::num::NonZeroUsize,
+    mut operation: F,
+) -> Result<Vec<T>, E>
+where
+    I: IntoIterator,
+    F: FnMut(I::Item) -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    let mut items = items.into_iter();
+    let mut pending = FuturesUnordered::new();
+    let mut next_index = 0usize;
+    while pending.len() < concurrency.get() {
+        let Some(item) = items.next() else {
+            break;
+        };
+        pending.push(indexed_result(next_index, operation(item)));
+        next_index += 1;
+    }
+
+    let mut outputs = Vec::new();
+    let mut first_error: Option<(usize, E)> = None;
+    while let Some((index, result)) = pending.next().await {
+        match result {
+            Ok(output) if first_error.is_none() => {
+                outputs.push(output);
+                if let Some(item) = items.next() {
+                    pending.push(indexed_result(next_index, operation(item)));
+                    next_index += 1;
+                }
+            }
+            Ok(_) => {}
+            Err(error) => {
+                if first_error
+                    .as_ref()
+                    .is_none_or(|(first_index, _)| index < *first_index)
+                {
+                    first_error = Some((index, error));
+                }
+            }
+        }
+    }
+
+    first_error.map_or_else(|| Ok(outputs), |(_, error)| Err(error))
+}
+
+#[cfg(test)]
+mod concurrent_tests {
+    use super::try_collect_concurrent;
+    use commonware_utils::sync::Mutex;
+    use futures::{channel::oneshot, executor::block_on};
+    use std::{
+        num::NonZeroUsize,
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Arc,
+        },
+        thread,
+        time::{Duration, Instant},
+    };
+
+    #[test]
+    fn test_try_collect_concurrent_drains_without_scheduling_more() {
+        let started = Arc::new(AtomicUsize::new(0));
+        let completed = Arc::new(AtomicBool::new(false));
+        let scheduled_after_error = Arc::new(AtomicBool::new(false));
+        let (release_sender, release_receiver) = oneshot::channel();
+        let release_receiver = Arc::new(Mutex::new(Some(release_receiver)));
+
+        let thread_started = started.clone();
+        let thread_completed = completed.clone();
+        let thread_scheduled_after_error = scheduled_after_error.clone();
+        let handle = thread::spawn(move || {
+            block_on(try_collect_concurrent(
+                0..4,
+                NonZeroUsize::new(2).unwrap(),
+                move |item| {
+                    let started = thread_started.clone();
+                    let completed = thread_completed.clone();
+                    let scheduled_after_error = thread_scheduled_after_error.clone();
+                    let release = (item == 1).then(|| release_receiver.lock().take().unwrap());
+                    async move {
+                        started.fetch_add(1, Ordering::SeqCst);
+                        match item {
+                            0 => Err("first error"),
+                            1 => {
+                                release.unwrap().await.unwrap();
+                                completed.store(true, Ordering::SeqCst);
+                                Ok(item)
+                            }
+                            _ => {
+                                scheduled_after_error.store(true, Ordering::SeqCst);
+                                Ok(item)
+                            }
+                        }
+                    }
+                },
+            ))
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while started.load(Ordering::SeqCst) < 2 && Instant::now() < deadline {
+            thread::yield_now();
+        }
+        assert_eq!(started.load(Ordering::SeqCst), 2);
+        assert!(!handle.is_finished(), "in-flight operation was not drained");
+        assert!(!scheduled_after_error.load(Ordering::SeqCst));
+
+        release_sender.send(()).unwrap();
+        assert_eq!(handle.join().unwrap(), Err("first error"));
+        assert!(completed.load(Ordering::SeqCst));
+        assert_eq!(started.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn test_try_collect_concurrent_returns_earliest_started_error() {
+        let later_failed = Arc::new(AtomicBool::new(false));
+        let (release_sender, release_receiver) = oneshot::channel();
+
+        let thread_later_failed = later_failed.clone();
+        let handle = thread::spawn(move || {
+            let mut release_receiver = Some(release_receiver);
+            block_on(try_collect_concurrent(
+                0..2,
+                NonZeroUsize::new(2).unwrap(),
+                move |item| {
+                    let later_failed = thread_later_failed.clone();
+                    let release = (item == 0).then(|| release_receiver.take().unwrap());
+                    async move {
+                        if let Some(release) = release {
+                            release.await.unwrap();
+                            Err::<(), _>("earlier input error")
+                        } else {
+                            later_failed.store(true, Ordering::SeqCst);
+                            Err::<(), _>("later input error")
+                        }
+                    }
+                },
+            ))
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !later_failed.load(Ordering::SeqCst) && Instant::now() < deadline {
+            thread::yield_now();
+        }
+        assert!(later_failed.load(Ordering::SeqCst));
+        release_sender.send(()).unwrap();
+        assert_eq!(handle.join().unwrap(), Err("earlier input error"));
+    }
+}
+});
+
 commonware_macros::stability_scope!(ALPHA {
     extern crate alloc;
 

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -1,5 +1,5 @@
 use super::{Config, Error};
-use crate::{Context, rmap::RMap};
+use crate::{Context, rmap::RMap, try_collect_concurrent};
 use commonware_codec::{CodecFixed, FixedSize, Read, ReadExt, Write as CodecWrite};
 use commonware_cryptography::{Crc32, crc32};
 use commonware_formatting::hex;
@@ -122,7 +122,6 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         // Reset the store unless committed bits are provided to recover from the stored blobs
         let record_size = Record::<V>::SIZE as u64;
         let items_per_blob = config.items_per_blob.get();
-        let mut blobs = BTreeMap::new();
         let stored_blobs = if bits.is_none() {
             match context.remove(&config.partition, None).await {
                 Ok(()) | Err(RError::PartitionMissing(_)) => Vec::new(),
@@ -136,30 +135,45 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
             }
         };
 
-        // Open all blobs and check for partial records
+        // Parse every name first, so malformed names surface deterministically.
+        let mut indices = Vec::with_capacity(stored_blobs.len());
         for name in stored_blobs {
-            let (blob, mut len) = context.open(&config.partition, &name).await?;
             let index = match name.try_into() {
                 Ok(index) => u64::from_be_bytes(index),
                 Err(nm) => Err(Error::InvalidBlobName(hex(&nm)))?,
             };
-
-            // Check if blob size is aligned to record size
-            if bits.is_some() && len % record_size != 0 {
-                warn!(
-                    blob = index,
-                    invalid_size = len,
-                    record_size,
-                    "blob size is not a multiple of record size, truncating"
-                );
-                len -= len % record_size;
-                blob.resize(len).await?;
-                blob.sync().await?;
-            }
-
-            debug!(blob = index, len, "found index blob");
-            blobs.insert(index, (blob, len));
+            indices.push(index);
         }
+
+        // Open all blobs concurrently and check for partial records. After an error, drain
+        // in-flight operations before returning so a resize or sync is never abandoned.
+        let context_ref = &context;
+        let config_ref = &config;
+        let bits_ref = &bits;
+        let results =
+            try_collect_concurrent(indices, context.open_concurrency(), |index| async move {
+                let (blob, mut len) = context_ref
+                    .open(&config_ref.partition, &index.to_be_bytes())
+                    .await?;
+
+                // Check if blob size is aligned to record size
+                if bits_ref.is_some() && len % record_size != 0 {
+                    warn!(
+                        blob = index,
+                        invalid_size = len,
+                        record_size,
+                        "blob size is not a multiple of record size, truncating"
+                    );
+                    len -= len % record_size;
+                    blob.resize(len).await?;
+                    blob.sync().await?;
+                }
+
+                debug!(blob = index, len, "found index blob");
+                Ok::<_, Error>((index, (blob, len)))
+            })
+            .await?;
+        let mut blobs: BTreeMap<_, _> = results.into_iter().collect();
 
         // Initialize intervals by scanning committed records
         debug!(


### PR DESCRIPTION
Towards: #4190 (adjacent: removes the serialization that made blob-open latency invisible to fix)

## Summary

The tokio backend held one process-global mutex across every `open_versioned` (including creation fsyncs), `remove` (unlink plus directory fsync), and `scan`. A journal prune could therefore block an unrelated journal's rollover open for the duration of each directory fsync, and initialization could not overlap blob opens at all.

This PR replaces that global serialization with per-partition coordination and opens the large sequential initialization sets (contiguous journal, segmented journal, and ordinal) with bounded concurrency.

## Locking design

The tokio backend uses a striped set of per-partition `RwLock`s:

- A valid existing blob reopens under the shared side, so the normal initialization path runs concurrently.
- A missing or sub-header blob drops the shared guard, takes the exclusive side, and rechecks before creating or healing it. This serializes the exceptional mutation path within a partition without a second per-name lock.
- Scans and removals take the exclusive side. A scan cannot observe a blob midway through creation, and an open cannot recreate a blob between removal's unlink and directory fsync.

Partition names are folded to lowercase for lock selection so aliases on case-insensitive filesystems cannot bypass coordination. Stripe collisions only introduce harmless serialization. Tokio's writer-preferring `RwLock` prevents a stream of reopens from starving a pending scan, creation, or removal.

## Cancellation and durability

Tokio filesystem operations may continue in the blocking pool after their futures are dropped. Creation/healing and removal therefore use an explicit cancellation boundary under the exclusive partition lock:

- If the caller was cancelled while waiting for the lock, the operation exits before mutating the namespace.
- After crossing the boundary, the operation and its lock guard run to completion even if the caller disappears.

This prevents a cancelled open from recreating a partition after removal and ensures an unlink is followed by its directory fsync.

Creation and healing truncate to zero before writing the header, so interrupted writes that leave a sub-header file are healed by the next open. Arbitrary full-length V0 header tears remain outside this PR and may still be reported as corruption; those will be handled by the V1 format. On Unix, every successful slow path syncs the file, partition directory, and storage root; doing this unconditionally also covers a retry after an earlier attempt created the partition but failed before syncing its root entry.

Whole-partition removal maps only `NotFound` to `PartitionMissing`; other I/O failures remain visible to callers.

## Bounded initialization

The concurrency limit is a runtime storage property: `Storage::open_concurrency` is a defaulted trait hint (16), configurable by the tokio and io_uring backends and forwarded by storage wrappers. Initialization code asks its context for the limit.

The bounded collector stops scheduling new work after observing an error, drains operations already in flight, and returns the earliest error by input index among those operations. Blob names are parsed before the concurrent stage, so malformed names and open failures retain deterministic selection.

Under the deterministic runtime these loops use the memory backend, whose opens complete in one poll, so seeded scheduling remains reproducible.
