### PR TITLE
[storage] Skip redundant work in journal init and destroy, make destroy crash safe

### DIFF
--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -76,10 +76,11 @@ impl<E: Context> Partition<E> {
         }
     }
 
-    /// Scan the partition and open every existing blob as a [`Writer`], keyed by blob index.
-    pub(super) async fn open_all(&self) -> Result<BTreeMap<u64, Writer<E::Blob>>, Error> {
-        let stored = Self::scan_names(&self.context, &self.name).await?;
-
+    /// Open every named blob as a [`Writer`], keyed by blob index.
+    pub(super) async fn open_many(
+        &self,
+        stored: Vec<Vec<u8>>,
+    ) -> Result<BTreeMap<u64, Writer<E::Blob>>, Error> {
         let mut blobs = BTreeMap::new();
         for name in stored {
             let hex_name = hex(&name);
@@ -92,6 +93,12 @@ impl<E: Context> Partition<E> {
             blobs.insert(index, writer);
         }
         Ok(blobs)
+    }
+
+    /// Scan the partition and open every existing blob as a [`Writer`], keyed by blob index.
+    pub(super) async fn open_all(&self) -> Result<BTreeMap<u64, Writer<E::Blob>>, Error> {
+        let stored = Self::scan_names(&self.context, &self.name).await?;
+        self.open_many(stored).await
     }
 
     /// Remove the given blob.
@@ -114,7 +121,7 @@ impl<E: Context> Partition<E> {
     /// legacy partition (`prefix` itself) if it contains data, otherwise `{prefix}-blobs`.
     /// Both containing data is corruption.
     // TODO(#2941): Remove legacy partition support
-    pub(super) async fn select(context: &E, prefix: &str) -> Result<String, Error> {
+    pub(super) async fn select(context: &E, prefix: &str) -> Result<(String, Vec<Vec<u8>>), Error> {
         let new_partition = format!("{prefix}-blobs");
         let legacy_blobs = Self::scan_names(context, prefix).await?;
         let new_blobs = Self::scan_names(context, &new_partition).await?;
@@ -126,9 +133,9 @@ impl<E: Context> Partition<E> {
         }
 
         if !legacy_blobs.is_empty() {
-            Ok(prefix.into())
+            Ok((prefix.into(), legacy_blobs))
         } else {
-            Ok(new_partition)
+            Ok((new_partition, new_blobs))
         }
     }
 }
@@ -149,6 +156,11 @@ pub(super) struct Writable<E: Context> {
 
     /// Cached owned snapshot of [Self::sealed].
     sealed_snapshot: Option<Arc<[Sealed<E::Blob>]>>,
+
+    /// Test-only: park [Self::destroy] before its removal so tests can drop the pending
+    /// future with the clear intent staged but nothing removed.
+    #[cfg(test)]
+    pub(super) halt_destroy: bool,
 }
 
 impl<E: Context> Writable<E> {
@@ -212,6 +224,8 @@ impl<E: Context> Writable<E> {
             tail,
             sealed,
             sealed_snapshot: None,
+            #[cfg(test)]
+            halt_destroy: false,
         })
     }
 
@@ -398,12 +412,27 @@ impl<E: Context> Writable<E> {
 
     /// Remove every blob and the partition itself.
     pub(super) async fn destroy(self) -> Result<(), Error> {
-        let tail_blob = self.tail_blob_index();
-        drop(self.tail);
-        for blob in self.oldest_blob_index..=tail_blob {
-            self.partition.remove(blob).await?;
+        // Close every handle first (open files cannot be removed on every platform), then
+        // remove the partition wholesale.
+        let Self {
+            partition,
+            tail,
+            sealed,
+            sealed_snapshot,
+            #[cfg(test)]
+            halt_destroy,
+            ..
+        } = self;
+        drop(tail);
+        drop(sealed);
+        drop(sealed_snapshot);
+
+        #[cfg(test)]
+        if halt_destroy {
+            std::future::pending::<()>().await;
         }
-        Partition::remove_all(&self.partition.context, &self.partition.name).await
+
+        Partition::remove_all(&partition.context, &partition.name).await
     }
 }
 

--- a/storage/src/journal/contiguous/checkpoint.rs
+++ b/storage/src/journal/contiguous/checkpoint.rs
@@ -143,6 +143,12 @@ impl<E: Context> Checkpoint<E> {
         Ok(())
     }
 
+    /// Test-only: park the underlying metadata destroy between its two blob removals.
+    #[cfg(test)]
+    pub(super) const fn test_halt_metadata_destroy(&mut self, halt: bool) {
+        self.metadata.halt_destroy_between_blobs = halt;
+    }
+
     /// Remove the checkpoint's partition.
     pub(super) async fn destroy(self) -> Result<(), Error> {
         self.metadata.destroy().await?;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -401,14 +401,14 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             return Self::complete_staged_clear(context, cfg, checkpoint, clear_target).await;
         }
 
-        let blob_partition = Partition::select(&context, &cfg.partition).await?;
+        let (blob_partition, stored) = Partition::select(&context, &cfg.partition).await?;
         let partition = Partition::new(
             context.child("blobs"),
             blob_partition,
             cfg.page_cache,
             cfg.write_buffer,
         );
-        let mut pending = partition.open_all().await?;
+        let mut pending = partition.open_many(stored).await?;
 
         // Truncate any trailing non-chunk-aligned bytes on every blob before recovery. Items
         // are fixed size, so a blob ending in fewer than `CHUNK_SIZE` trailing bytes is junk
@@ -1020,7 +1020,15 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
     }
 
     /// See [Journal::destroy].
-    pub(crate) async fn destroy(self) -> Result<(), Error> {
+    pub(crate) async fn destroy(mut self) -> Result<(), Error> {
+        // Stage a clear intent before removing anything: the blob removals are unordered,
+        // and a crashed partial removal would otherwise read as retained loss on reopen.
+        // With the intent staged, a reopen after any later interruption completes the clear
+        // and yields a fresh, empty journal (an interruption before the intent is durable
+        // recovers the original journal): the checkpoint teardown removes its stale copy
+        // first, so the copy carrying the intent survives every crash prefix.
+        self.checkpoint.stage_clear(0).await?;
+
         self.blobs.destroy().await?;
         self.checkpoint.destroy().await?;
         Ok(())
@@ -1070,7 +1078,6 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
     /// calling `clear_to_size` to finish. If a crash interrupts the sequence, the next `init`
     /// completes the staged clear. The follow-up `clear_to_size` re-stages the same target
     /// idempotently.
-    #[commonware_macros::stability(ALPHA)]
     pub(super) async fn stage_clear_intent(&mut self, new_size: u64) -> Result<(), Error> {
         // A journal sized at `u64::MAX` can never accept an append, matching `init_at_size`.
         if new_size == u64::MAX {
@@ -1244,9 +1251,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     ///
     /// # Crash Safety
     ///
-    /// This operation is intended for final teardown and is not crash-safe. If interrupted,
-    /// reopening the same partition may observe partially removed state. Use [Self::init_at_size]
-    /// for a recoverable reset.
+    /// If interrupted, reopening the same partition recovers either the original journal
+    /// (when the interruption preceded the durable clear intent) or a fresh, empty journal,
+    /// never a partially destroyed state.
     pub async fn destroy(self) -> Result<(), Error> {
         (*self.0).destroy().await
     }
@@ -1768,6 +1775,86 @@ mod tests {
             Err(RuntimeError::PartitionMissing(_)) => Vec::new(),
             Err(err) => panic!("Failed to scan partition {partition}: {err}"),
         }
+    }
+
+    /// Destroy's blob removals are unordered, so a crash partway can leave gaps that would
+    /// read as retained loss. The staged clear intent makes a destroy interrupted during
+    /// blob removal reopen as an empty journal instead.
+    #[test_traced]
+    fn test_fixed_destroy_interrupted_during_blob_removal_reopens_empty() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..12u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal = journal.sync().await.unwrap();
+
+            // Drop the destroy with its intent staged but nothing removed, then simulate the
+            // unordered removal having gotten partway: an interior blob is gone.
+            journal.0.blobs.halt_destroy = true;
+            {
+                let fut = journal.destroy();
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "destroy must park before its removal"
+                );
+            }
+            context
+                .remove(&blob_partition(&cfg), Some(&1u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("interrupted destroy must reopen as an empty journal");
+            assert_eq!(journal.bounds(), 0..0);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Destroy is crash-safe through its checkpoint teardown: the metadata store removes
+    /// its stale copy first, so the staged clear intent survives a crash between the two
+    /// removals and reopening yields a fresh, empty journal.
+    #[test_traced]
+    fn test_fixed_destroy_interrupted_during_checkpoint_teardown_reopens_empty() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..12u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal = journal.sync().await.unwrap();
+
+            // A second sync generation populates both checkpoint copies.
+            (journal, _) = journal.append(&test_digest(12)).await.unwrap();
+            journal = journal.sync().await.unwrap();
+
+            // Drop the destroy parked between the two checkpoint-copy removals: the blob
+            // partition and the stale copy are gone; the surviving copy carries the intent.
+            journal.0.checkpoint.test_halt_metadata_destroy(true);
+            {
+                let fut = journal.destroy();
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "destroy must park between the checkpoint copies"
+                );
+            }
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("interrupted destroy must reopen as an empty journal");
+            assert_eq!(journal.bounds(), 0..0);
+            journal.destroy().await.unwrap();
+        });
     }
 
     #[test_traced]

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -318,10 +318,11 @@ pub trait Mutable: Contiguous + Sized {
     ///
     /// # Crash Safety
     ///
-    /// This operation is intended for final teardown and is not crash-safe. If interrupted,
-    /// reopening the same storage may observe partially removed state. Use a reset operation
-    /// provided by the concrete type when the journal must remain recoverable.
-    fn destroy(self) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+    /// If interrupted, reopening the same storage recovers either the original journal or a
+    /// fresh, empty journal, never a partially destroyed state.
+    fn destroy(self) -> impl std::future::Future<Output = Result<(), Error>> + Send
+    where
+        Self: Sized;
 
     /// Rewinds the journal to the last item matching `predicate`, returning the resulting
     /// size. If no item matches, the journal is rewound to the pruning boundary, discarding

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1532,7 +1532,16 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
     }
 
     /// See [Journal::destroy].
-    pub(crate) async fn destroy(self) -> Result<(), Error> {
+    pub(crate) async fn destroy(mut self) -> Result<(), Error> {
+        // Stage a reset intent in the offsets journal before removing anything: the blob
+        // removals are unordered, and a crashed partial removal would otherwise read as
+        // retained loss on reopen. With the intent staged, a reopen after any later
+        // interruption completes the reset (clearing the data partition with it) and
+        // yields a fresh, empty journal, while an interruption before the intent is
+        // durable recovers the original journal; the offsets journal's checkpoint teardown
+        // keeps the copy carrying the intent alive until last.
+        self.offsets.stage_clear_intent(0).await?;
+
         self.blobs.destroy().await?;
         self.offsets.destroy().await
     }
@@ -2241,9 +2250,9 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// # Crash Safety
     ///
-    /// This operation is intended for final teardown and is not crash-safe. If interrupted,
-    /// reopening the same partitions may observe partially removed state. Use [Self::init_at_size]
-    /// for a recoverable reset.
+    /// If interrupted, reopening the same partitions recovers either the original journal
+    /// (when the interruption preceded the durable reset intent) or a fresh, empty journal,
+    /// never a partially destroyed state.
     pub async fn destroy(self) -> Result<(), Error> {
         (*self.0).destroy().await
     }
@@ -5145,6 +5154,54 @@ mod tests {
                 assert_eq!(journal.read(7 + i).await.unwrap(), 700 + i);
             }
 
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Destroy's blob removals are unordered, so a crash partway can leave gaps that would
+    /// read as retained loss. The staged offsets reset intent makes a destroy interrupted
+    /// during blob removal reopen as an empty journal instead.
+    #[test_traced]
+    fn test_variable_destroy_interrupted_during_blob_removal_reopens_empty() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "destroy-interrupted".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..12u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            journal = journal.sync().await.unwrap();
+
+            // Drop the destroy with the offsets reset intent staged but nothing removed,
+            // then simulate partial unordered removal: an interior data blob is gone.
+            journal.0.blobs.halt_destroy = true;
+            {
+                let fut = journal.destroy();
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "destroy must park before its removal"
+                );
+            }
+            context
+                .remove(&cfg.data_partition(), Some(&1u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("interrupted destroy must reopen as an empty journal");
+            assert_eq!(journal.bounds(), 0..0);
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -72,6 +72,11 @@ struct State<B: Blob, K: Span> {
 pub struct Metadata<E: Context, K: Span, V: Codec> {
     context: E,
 
+    /// Test-only: park [Self::destroy] between its two blob removals so tests can drop the
+    /// pending future with only the stale copy removed.
+    #[cfg(test)]
+    pub(crate) halt_destroy_between_blobs: bool,
+
     map: BTreeMap<K, V>,
     partition: String,
     state: State<E::Blob, K>,
@@ -118,6 +123,9 @@ impl<E: Context, K: Span, V: Codec> Metadata<E, K, V> {
         let _ = keys.try_set(map.len());
         Ok(Self {
             context,
+
+            #[cfg(test)]
+            halt_destroy_between_blobs: false,
 
             map,
             partition: cfg.partition,
@@ -500,12 +508,27 @@ impl<E: Context, K: Span, V: Codec> Metadata<E, K, V> {
     /// Remove the underlying blobs for this [Metadata].
     pub async fn destroy(self) -> Result<(), Error> {
         let state = self.state;
-        for (i, wrapper) in state.blobs.into_iter().enumerate() {
+        // Remove the stale copy before the current one: the current copy carries the
+        // newest durable state (e.g. a journal's staged clear intent), so it must survive
+        // a crash between the removals for recovery to observe that state.
+        let [left, right] = state.blobs;
+        let ordered = if state.cursor == 0 {
+            [(1, right), (0, left)]
+        } else {
+            [(0, left), (1, right)]
+        };
+        for (i, wrapper) in ordered {
             drop(wrapper.blob);
             self.context
                 .remove(&self.partition, Some(BLOB_NAMES[i]))
                 .await?;
             debug!(blob = i, "destroyed blob");
+
+            // Parks after each removal; tests drop the future at the first park.
+            #[cfg(test)]
+            if self.halt_destroy_between_blobs {
+                std::future::pending::<()>().await;
+            }
         }
         match self.context.remove(&self.partition, None).await {
             Ok(()) => {}


### PR DESCRIPTION
## Summary

Two independent wastes on the contiguous journal's lifecycle paths, both found by the blob open-path audit:

- **Init rescanned a directory it had just scanned.** `Partition::select` already lists both candidate partitions to pick one; the fixed journal's init then listed the winner a third time before opening its blobs. `select` now returns the winning scan and init opens from it.
- **Destroy's documented contract is upgraded from "not crash-safe" to crash-safe.** Both journals' `destroy` docs previously disclaimed interruption entirely ("reopening the same partition may observe partially removed state"); they now promise that reopening after an interrupted destroy recovers either the original journal (interruption before the clear intent is durable) or a fresh, empty journal — never a partially destroyed state (see Crash safety of destroy).
- **Destroy paid a directory fsync per blob for nothing.** `Writable::destroy` removed every blob individually (each removal durably fsyncs the partition directory) immediately before removing the whole partition, which makes those fsyncs redundant. It now closes all handles first (open files cannot be removed on every platform) and removes the partition wholesale: one directory fsync instead of one per blob.

## Crash safety of destroy

Wholesale removal is unordered, so a destroy crashed during the blob-partition removal can leave gaps that recovery reads as retained loss (`recovery watermark exceeds recoverable size`) — and once boundaries are recorded rather than inferred from survivors, the old oldest-first prefix shape stops looking cleanly pruned too. Two changes make destroy crash-safe end to end, replacing the old "not crash-safe" disclaimer in its contract with the guarantee above:

- **A clear intent is staged before anything is removed.** Init honors a staged clear before scanning any blobs, so a reopen after any interruption past the durable intent wipes whatever remains unread and yields a fresh, empty journal; an interruption before the intent is durable has removed nothing and recovers the original journal. The savings hold — one metadata sync (two for the variable journal, whose offsets teardown re-stages internally) replaces the per-blob directory fsyncs.
- **The metadata store removes its stale copy first.** `Metadata::destroy` previously removed its two copies in index order, so a crash between them could delete the copy carrying the staged intent and leave a stale copy whose watermark outlives the removed data. Removing the stale copy first keeps the newest state alive through every crash prefix of the teardown (and hardens every other metadata consumer's destroy for free).

Park-point regressions drop the production destroy future before the blob removal (both journals) and between the two checkpoint-copy removals (fixed), then reopen; without the staged intent or with index-order removal they fail with the retained-loss corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSarn1C4iMrjHQHrVcanFo

