### PR TITLE
[consensus/simplex] Coalesce `fsync`

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -128,7 +128,9 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         ///
         /// This request is single-shot for the given `(context, payload)`. Once the returned
         /// channel resolves or closes, consensus treats verification as concluded and will not
-        /// retry the same request.
+        /// retry the same request. After a restart, however, consensus may request verification
+        /// for the same `(context, payload)` again if the result was not durably recorded before
+        /// shutdown.
         ///
         /// Implementations should therefore keep the request pending while the verdict may still
         /// change. Return `false` only when the payload is permanently invalid for this context.

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -161,7 +161,9 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         /// Like [`Automaton::verify`], payloads produced by [`Automaton::propose`] are certifiable-by-construction.
         /// Also like [`Automaton::verify`], certification is single-shot for the given
         /// `(round, payload)`. Once the returned channel resolves or closes, consensus treats
-        /// certification as concluded and will not retry the same request.
+        /// certification as concluded and will not retry the same request. After a restart,
+        /// however, consensus may request certification for the same `(round, payload)` again
+        /// if the result was not durably recorded before shutdown.
         ///
         /// Implementations should therefore keep the request pending while the verdict may still
         /// change. Return `false` only when the payload is permanently uncertifiable for that

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -253,10 +253,11 @@ impl<
 
     /// Syncs all journal sections with pending appends.
     ///
-    /// Invoked before any broadcast so everything we tell the network is
-    /// recoverable after a restart. Deferring syncs to this point (rather than
-    /// syncing after each append) coalesces back-to-back appends in the same
-    /// loop iteration into a single sync.
+    /// Invoked after each construction phase and before the corresponding
+    /// broadcast phase (regardless of whether anything will be broadcast) so
+    /// everything we tell the network is recoverable after a restart. Deferring
+    /// syncs to this boundary (rather than syncing after each append) coalesces
+    /// all appends in the same loop iteration into a single sync.
     async fn sync_journal(&mut self) {
         if self.dirty.is_empty() {
             return;
@@ -265,7 +266,7 @@ impl<
             .journal
             .as_mut()
             .expect("pending journal sections without a journal");
-        let sections: Vec<u64> = mem::take(&mut self.dirty).into_iter().collect();
+        let sections = mem::take(&mut self.dirty);
         let span = info_span!(
             "simplex.voter.journal.sync",
             epoch = self.state.epoch().traced(),
@@ -280,16 +281,14 @@ impl<
 
     /// Send a vote to every peer.
     ///
-    /// Syncs pending journal appends first. A vote must be durable before it
-    /// reaches the network so a restart cannot cause us to equivocate.
-    async fn broadcast_vote<T: Sender>(
+    /// Callers must sync pending journal appends first (via [Self::sync_journal]).
+    /// A vote must be durable before it reaches the network so a restart cannot
+    /// cause us to equivocate.
+    fn broadcast_vote<T: Sender>(
         &mut self,
         sender: &mut WrappedSender<T, Vote<S, D>>,
         vote: Vote<S, D>,
     ) {
-        // Persist anything we've journaled before the vote reaches the network
-        self.sync_journal().await;
-
         // Update outbound metrics
         let metric = match &vote {
             Vote::Notarize(_) => metrics::Outbound::notarize(),
@@ -304,16 +303,13 @@ impl<
 
     /// Send a certificate to every peer.
     ///
-    /// Syncs pending journal appends first so any state we advertise to the
-    /// network survives a restart.
-    async fn broadcast_certificate<T: Sender>(
+    /// Callers must sync pending journal appends first (via [Self::sync_journal])
+    /// so any state we advertise to the network survives a restart.
+    fn broadcast_certificate<T: Sender>(
         &mut self,
         sender: &mut WrappedSender<T, Certificate<S, D>>,
         certificate: Certificate<S, D>,
     ) {
-        // Persist anything we've journaled before the certificate reaches the network
-        self.sync_journal().await;
-
         // Update outbound metrics
         let metric = match &certificate {
             Certificate::Notarization(_) => metrics::Outbound::notarization(),
@@ -400,10 +396,12 @@ impl<
             self.handle_nullify(nullify.clone()).await;
         }
 
+        // Make the vote durable before it reaches the network
+        self.sync_journal().await;
+
         // Broadcast nullify vote (regardless)
         debug!(round=?nullify.round(), "broadcasting nullify");
-        self.broadcast_vote(vote_sender, Vote::Nullify(nullify))
-            .await;
+        self.broadcast_vote(vote_sender, Vote::Nullify(nullify));
     }
 
     /// Handle a timeout.
@@ -431,8 +429,7 @@ impl<
             .previous()
             .expect("we should never be in the genesis view");
         if let Some(certificate) = self.state.get_best_certificate(past_view) {
-            self.broadcast_certificate(certificate_sender, certificate)
-                .await;
+            self.broadcast_certificate(certificate_sender, certificate);
         }
     }
 
@@ -490,9 +487,9 @@ impl<
         // Get the notarization before advancing state
         let notarization = self.state.certified(view, success)?;
 
-        // Record the certification result for recovery. It is synced with the
-        // next broadcast. If lost to a crash before then, certification is
-        // re-requested on restart.
+        // Record the certification result for recovery. It is synced before this
+        // iteration's broadcast phase. If lost to a crash before then, certification
+        // is re-requested on restart.
         let artifact = Artifact::Certification(Rnd::new(self.state.epoch(), view), success);
         self.append_journal(view, artifact).await;
 
@@ -796,8 +793,10 @@ impl<
                     Certificate::Nullification(nullification) => {
                         trace!(%view, from_resolver, "received nullification");
                         if let Some(floor) = self.handle_nullification(nullification).await {
+                            // Make the nullification durable before advertising the floor
+                            self.sync_journal().await;
                             warn!(?floor, "broadcasting nullification floor");
-                            self.broadcast_certificate(certificate_sender, floor).await;
+                            self.broadcast_certificate(certificate_sender, floor);
                         }
                         if from_resolver {
                             resolved = Resolved::Nullification;
@@ -836,8 +835,7 @@ impl<
         resolved: Resolved,
     ) {
         // Build and record everything that became available before broadcasting
-        // anything. The first broadcast syncs the journal, so all appends made
-        // here (and earlier in the loop iteration) share a single sync.
+        // anything below.
         let notarize = self.prepare_notarize(batcher, view).await;
         let notarization = self.prepare_notarization(resolver, view, resolved).await;
         // We handle broadcast of `Nullify` votes in `timeout`, so this only emits certificates.
@@ -845,46 +843,47 @@ impl<
         let finalize = self.prepare_finalize(batcher, view).await;
         let finalization = self.prepare_finalization(resolver, view, resolved).await;
 
+        // Sync everything appended this iteration (during message processing and
+        // the construction phase above) in a single coalesced sync. This runs even
+        // if there is nothing to broadcast below so every artifact is durable by
+        // the end of the iteration that appended it.
+        self.sync_journal().await;
+
         // Broadcast everything we built (and report it to the application).
         if let Some(notarize) = notarize {
             debug!(proposal=?notarize.proposal, "broadcasting notarize");
-            self.broadcast_vote(vote_sender, Vote::Notarize(notarize))
-                .await;
+            self.broadcast_vote(vote_sender, Vote::Notarize(notarize));
         }
         if let Some(notarization) = notarization {
             debug!(proposal=?notarization.proposal, "broadcasting notarization");
             self.broadcast_certificate(
                 certificate_sender,
                 Certificate::Notarization(notarization.clone()),
-            )
-            .await;
+            );
             self.reporter.report(Activity::Notarization(notarization));
         }
         if let Some((nullification, floor)) = nullification {
             if let Some(floor) = floor {
                 warn!(?floor, "broadcasting nullification floor");
-                self.broadcast_certificate(certificate_sender, floor).await;
+                self.broadcast_certificate(certificate_sender, floor);
             }
             debug!(round=?nullification.round(), "broadcasting nullification");
             self.broadcast_certificate(
                 certificate_sender,
                 Certificate::Nullification(nullification.clone()),
-            )
-            .await;
+            );
             self.reporter.report(Activity::Nullification(nullification));
         }
         if let Some(finalize) = finalize {
             debug!(proposal=?finalize.proposal, "broadcasting finalize");
-            self.broadcast_vote(vote_sender, Vote::Finalize(finalize))
-                .await;
+            self.broadcast_vote(vote_sender, Vote::Finalize(finalize));
         }
         if let Some(finalization) = finalization {
             debug!(proposal=?finalization.proposal, "broadcasting finalization");
             self.broadcast_certificate(
                 certificate_sender,
                 Certificate::Finalization(finalization.clone()),
-            )
-            .await;
+            );
             self.reporter.report(Activity::Finalization(finalization));
         }
     }

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -64,10 +64,6 @@ enum Resolved {
 struct Staged<S: Scheme<D>, D: Digest> {
     notarize: Option<Notarize<S, D>>,
     notarization: Option<Notarization<S, D>>,
-    certification: Option<(Rnd, bool, Notarization<S, D>)>,
-    /// A nullify vote constructed on timeout, with the best certificate from
-    /// the previous view (on retry) to help others enter the view.
-    nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
     /// A nullification certificate, with the parent certificate of our proposal
     /// (the "floor") if we were the leader of the nullified view.
     nullification: Option<(Nullification<S>, Option<Certificate<S, D>>)>,
@@ -684,36 +680,35 @@ impl<
 
     /// Processes the automaton's response to a certification request.
     ///
-    /// Returns false if the view was already pruned (nothing to notify).
+    /// Returns whether the round was still active (false if it was already
+    /// pruned) and, if the result was recorded, the certification outcome to
+    /// stage for [Self::notify].
     async fn process_certified(
         &mut self,
         round: Rnd,
         certified: Result<bool, oneshot::error::RecvError>,
     ) -> (bool, Option<(bool, Notarization<S, D>)>) {
-        match certified {
-            Ok(certified) => {
-                if !certified {
-                    warn!(?round, "proposal failed certification");
-                }
-                let view = round.view();
-                let Some(notarization) = self.handle_certification(view, certified).await else {
-                    return (false, None);
-                };
-
-                return (true, Some((certified, notarization)));
-            }
+        // Unlike propose/verify (where failing to act will lead to a timeout
+        // and subsequent nullification), failing to certify can lead to a halt
+        // because we'll never exit the view without a notarization + certification.
+        //
+        // We do not assume failure here because we recover on restart: a synced
+        // certification result is replayed from the journal and a missing one
+        // causes certification to be re-requested.
+        let certified = match certified {
+            Ok(certified) => certified,
             Err(err) => {
-                // Unlike propose/verify (where failing to act will lead to a timeout
-                // and subsequent nullification), failing to certify can lead to a halt
-                // because we'll never exit the view without a notarization + certification.
-                //
-                // We do not assume failure here because we recover on restart: a synced
-                // certification result is replayed from the journal and a missing one
-                // causes certification to be re-requested.
                 debug!(?err, ?round, "failed to certify proposal");
+                return (true, None);
             }
         };
-        (true, None)
+        if !certified {
+            warn!(?round, "proposal failed certification");
+        }
+        let Some(notarization) = self.handle_certification(round.view(), certified).await else {
+            return (false, None);
+        };
+        (true, Some((certified, notarization)))
     }
 
     /// Processes a message from the resolver or batcher.
@@ -789,15 +784,12 @@ impl<
     ///
     /// We don't need to iterate over all views to check for new actions because messages we receive
     /// only affect a single view.
-    #[allow(clippy::type_complexity)]
     async fn construct(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,
         resolver: &mut resolver::Mailbox<S, D>,
         view: View,
         resolved: Resolved,
-        nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
-        certification: Option<(Rnd, bool, Notarization<S, D>)>,
     ) -> Staged<S, D> {
         let notarize = self.prepare_notarize(batcher, view).await;
         let notarization = self.prepare_notarization(resolver, view, resolved).await;
@@ -807,8 +799,6 @@ impl<
         Staged {
             notarize,
             notarization,
-            certification,
-            nullify,
             nullification,
             finalize,
             finalization,
@@ -819,27 +809,30 @@ impl<
     ///
     /// Callers must sync pending journal appends first (via [Self::sync_journal])
     /// so nothing reaches the network before it is durable.
+    #[allow(clippy::type_complexity)]
     fn notify<Sp: Sender, Sr: Sender>(
         &mut self,
         resolver: &mut resolver::Mailbox<S, D>,
         vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
         certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
         staged: Staged<S, D>,
+        nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
+        certification: Option<(bool, Notarization<S, D>)>,
     ) {
         assert!(!self.dirty, "journal must be synced before broadcast");
 
-        if let Some((round, certified, notarization)) = staged.certification {
+        if let Some((certified, notarization)) = certification {
             // Always forward certification outcomes to resolver. This can happen
             // after a nullification for the same view because certification is
             // asynchronous; finalization is the boundary that cancels in-flight
             // certification and suppresses late reporting.
-            resolver.certified(round, certified);
+            resolver.certified(notarization.round(), certified);
             if certified {
                 self.reporter.report(Activity::Certification(notarization));
             }
         }
 
-        if let Some((nullify, entry)) = staged.nullify {
+        if let Some((nullify, entry)) = nullify {
             debug!(round=?nullify.round(), "broadcasting nullify");
             self.broadcast_vote(vote_sender, Vote::Nullify(nullify));
 
@@ -1153,8 +1146,7 @@ impl<
                 if !processed {
                     continue;
                 }
-                certification = certification_result
-                    .map(|(success, notarization)| (round, success, notarization));
+                certification = certification_result;
             },
             Some(msg) = self.mailbox_receiver.recv() else break => {
                 // Handle messages from resolver and batcher
@@ -1192,14 +1184,7 @@ impl<
                 async {
                     // Build and record everything that became available for `view`.
                     let staged = self
-                        .construct(
-                            &mut batcher,
-                            &mut resolver,
-                            view,
-                            resolved,
-                            nullify,
-                            certification,
-                        )
+                        .construct(&mut batcher, &mut resolver, view, resolved)
                         .await;
 
                     // Sync everything appended this iteration (during message
@@ -1215,6 +1200,8 @@ impl<
                         &mut vote_sender,
                         &mut certificate_sender,
                         staged,
+                        nullify,
+                        certification,
                     );
                 }
                 .instrument(span)

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -58,6 +58,23 @@ enum Resolved {
     Finalization,
 }
 
+/// Messages built and recorded during an event loop iteration, staged for
+/// broadcast after the journal sync barrier (see [Actor::construct] and
+/// [Actor::notify]).
+#[allow(clippy::type_complexity)]
+struct Staged<S: Scheme<D>, D: Digest> {
+    /// A nullify vote constructed on timeout, with the best certificate from
+    /// the previous view (on retry) to help others enter the view.
+    nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
+    notarize: Option<Notarize<S, D>>,
+    notarization: Option<Notarization<S, D>>,
+    /// A nullification certificate, with the parent certificate of our proposal
+    /// (the "floor") if we were the leader of the nullified view.
+    nullification: Option<(Nullification<S>, Option<Certificate<S, D>>)>,
+    finalize: Option<Finalize<S, D>>,
+    finalization: Option<Finalization<S, D>>,
+}
+
 /// An outstanding request to the automaton.
 struct Request<V: Viewable, R>(
     /// Attached context for the pending item. Must yield a view.
@@ -253,12 +270,11 @@ impl<
 
     /// Syncs all journal sections with pending appends.
     ///
-    /// Invoked once per event loop iteration (by [Self::notify]) after the
-    /// construction phase and before the broadcast phase (regardless of whether
-    /// anything will be broadcast) so everything we tell the network is
-    /// recoverable after a restart. Deferring syncs to this boundary (rather
-    /// than syncing after each append) coalesces all appends in the same loop
-    /// iteration into a single sync.
+    /// Invoked once per event loop iteration, after [Self::construct] and before
+    /// [Self::notify] (regardless of whether anything will be broadcast), so
+    /// everything we tell the network is recoverable after a restart. Deferring
+    /// syncs to this boundary (rather than syncing after each append) coalesces
+    /// all appends in the same loop iteration into a single sync.
     async fn sync_journal(&mut self) {
         if self.dirty.is_empty() {
             return;
@@ -775,41 +791,53 @@ impl<
         }
     }
 
-    /// Emits any votes or certificates that became available for `view`.
+    /// Builds and records any votes or certificates that became available for `view`.
     ///
-    /// All outbound messages flow through here: everything is built and recorded
-    /// first (including the timeout's `nullify`, constructed by the caller), then
-    /// synced to the journal in a single batch, then broadcast.
+    /// Everything returned must be synced to the journal (via [Self::sync_journal])
+    /// before it is broadcast (via [Self::notify]).
     ///
     /// We don't need to iterate over all views to check for new actions because messages we receive
     /// only affect a single view.
-    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
-    async fn notify<Sp: Sender, Sr: Sender>(
+    #[allow(clippy::type_complexity)]
+    async fn construct(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,
         resolver: &mut resolver::Mailbox<S, D>,
-        vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
-        certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
         view: View,
         resolved: Resolved,
         nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
-    ) {
-        // Build and record everything that became available before broadcasting
-        // anything below.
+    ) -> Staged<S, D> {
         let notarize = self.prepare_notarize(batcher, view).await;
         let notarization = self.prepare_notarization(resolver, view, resolved).await;
         let nullification = self.prepare_nullification(resolver, view, resolved).await;
         let finalize = self.prepare_finalize(batcher, view).await;
         let finalization = self.prepare_finalization(resolver, view, resolved).await;
+        Staged {
+            nullify,
+            notarize,
+            notarization,
+            nullification,
+            finalize,
+            finalization,
+        }
+    }
 
-        // Sync everything appended this iteration (during message processing and
-        // the construction phase above) in a single coalesced sync. This runs even
-        // if there is nothing to broadcast below so every artifact is durable by
-        // the end of the iteration that appended it.
-        self.sync_journal().await;
+    /// Broadcasts everything constructed this iteration and reports it to the application.
+    ///
+    /// Callers must sync pending journal appends first (via [Self::sync_journal])
+    /// so nothing reaches the network before it is durable.
+    fn notify<Sp: Sender, Sr: Sender>(
+        &mut self,
+        vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
+        certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
+        staged: Staged<S, D>,
+    ) {
+        assert!(
+            self.dirty.is_empty(),
+            "journal must be synced before broadcast"
+        );
 
-        // Broadcast everything we built (and report it to the application).
-        if let Some((nullify, entry)) = nullify {
+        if let Some((nullify, entry)) = staged.nullify {
             debug!(round=?nullify.round(), "broadcasting nullify");
             self.broadcast_vote(vote_sender, Vote::Nullify(nullify));
 
@@ -818,11 +846,11 @@ impl<
                 self.broadcast_certificate(certificate_sender, entry);
             }
         }
-        if let Some(notarize) = notarize {
+        if let Some(notarize) = staged.notarize {
             debug!(proposal=?notarize.proposal, "broadcasting notarize");
             self.broadcast_vote(vote_sender, Vote::Notarize(notarize));
         }
-        if let Some(notarization) = notarization {
+        if let Some(notarization) = staged.notarization {
             debug!(proposal=?notarization.proposal, "broadcasting notarization");
             self.broadcast_certificate(
                 certificate_sender,
@@ -830,7 +858,7 @@ impl<
             );
             self.reporter.report(Activity::Notarization(notarization));
         }
-        if let Some((nullification, floor)) = nullification {
+        if let Some((nullification, floor)) = staged.nullification {
             if let Some(floor) = floor {
                 warn!(?floor, "broadcasting nullification floor");
                 self.broadcast_certificate(certificate_sender, floor);
@@ -842,11 +870,11 @@ impl<
             );
             self.reporter.report(Activity::Nullification(nullification));
         }
-        if let Some(finalize) = finalize {
+        if let Some(finalize) = staged.finalize {
             debug!(proposal=?finalize.proposal, "broadcasting finalize");
             self.broadcast_vote(vote_sender, Vote::Finalize(finalize));
         }
-        if let Some(finalization) = finalization {
+        if let Some(finalization) = staged.finalization {
             debug!(proposal=?finalization.proposal, "broadcasting finalization");
             self.broadcast_certificate(
                 certificate_sender,
@@ -1081,7 +1109,7 @@ impl<
                 debug!("context shutdown, stopping voter");
             },
             _ = self.context.sleep_until(timeout) => {
-                // Process the timeout (the constructed nullify is broadcast by notify)
+                // Process the timeout (the constructed nullify is staged for the broadcast phase)
                 let current_view = self.state.current_view();
                 let span = info_span!(
                     parent: self.state.view_span(current_view),
@@ -1156,15 +1184,22 @@ impl<
                     epoch = self.state.epoch().traced(),
                     view = view.traced()
                 );
-                self.notify(
-                    &mut batcher,
-                    &mut resolver,
-                    &mut vote_sender,
-                    &mut certificate_sender,
-                    view,
-                    resolved,
-                    nullify,
-                )
+                async {
+                    // Build and record everything that became available for `view`.
+                    let staged = self
+                        .construct(&mut batcher, &mut resolver, view, resolved, nullify)
+                        .await;
+
+                    // Sync everything appended this iteration (during message
+                    // processing and construction) in a single coalesced sync.
+                    // This runs even if there is nothing to broadcast (e.g. a
+                    // certification result was recorded) so every artifact is
+                    // durable by the end of the iteration that appended it.
+                    self.sync_journal().await;
+
+                    // Broadcast everything we built (and report it to the application).
+                    self.notify(&mut vote_sender, &mut certificate_sender, staged);
+                }
                 .instrument(span)
                 .await;
 

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -490,8 +490,9 @@ impl<
         // Get the notarization before advancing state
         let notarization = self.state.certified(view, success)?;
 
-        // Record the certification result for recovery. It is synced with our
-        // next broadcast (at the latest, the vote this result unlocks).
+        // Record the certification result for recovery. It is synced with the
+        // next broadcast. If lost to a crash before then, certification is
+        // re-requested on restart.
         let artifact = Artifact::Certification(Rnd::new(self.state.epoch(), view), success);
         self.append_journal(view, artifact).await;
 
@@ -515,44 +516,31 @@ impl<
         self.block_equivocator(equivocator);
     }
 
-    /// Build, persist, and broadcast a notarize vote when this view is ready.
-    async fn try_broadcast_notarize<Sp: Sender>(
+    /// Builds and records a notarize vote when this view is ready.
+    async fn prepare_notarize(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,
-        vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
         view: View,
-    ) {
+    ) -> Option<Notarize<S, D>> {
         // Construct a notarize vote
-        let Some(notarize) = self.state.construct_notarize(view) else {
-            return;
-        };
+        let notarize = self.state.construct_notarize(view)?;
 
         // Inform the batcher so it can aggregate our vote with others.
         batcher.constructed(Vote::Notarize(notarize.clone()));
         // Record the vote locally before sharing it.
         self.handle_notarize(notarize.clone()).await;
-
-        // Broadcast the notarize vote
-        debug!(
-            proposal=?notarize.proposal,
-            "broadcasting notarize"
-        );
-        self.broadcast_vote(vote_sender, Vote::Notarize(notarize))
-            .await;
+        Some(notarize)
     }
 
-    /// Share a notarization certificate once we can assemble it locally.
-    async fn try_broadcast_notarization<Sr: Sender>(
+    /// Builds and records a notarization certificate once we can assemble it locally.
+    async fn prepare_notarization(
         &mut self,
         resolver: &mut resolver::Mailbox<S, D>,
-        certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
         view: View,
         resolved: Resolved,
-    ) {
+    ) -> Option<Notarization<S, D>> {
         // Construct a notarization certificate
-        let Some(notarization) = self.state.broadcast_notarization(view) else {
-            return;
-        };
+        let notarization = self.state.broadcast_notarization(view)?;
 
         // Only the leader sees an unbiased latency sample, so record it now.
         if let Some(elapsed) = self.leader_elapsed(view) {
@@ -566,15 +554,7 @@ impl<
         }
         // Update our local round with the certificate.
         self.handle_notarization(notarization.clone()).await;
-        // Broadcast the notarization certificate
-        debug!(proposal=?notarization.proposal, "broadcasting notarization");
-        self.broadcast_certificate(
-            certificate_sender,
-            Certificate::Notarization(notarization.clone()),
-        )
-        .await;
-        // Surface the event to the application for observability.
-        self.reporter.report(Activity::Notarization(notarization));
+        Some(notarization)
     }
 
     /// Broadcast a nullify vote for `view` if the state machine allows it.
@@ -590,18 +570,18 @@ impl<
         Some(was_retry)
     }
 
-    /// Broadcast a nullification certificate if the round provides a candidate.
-    async fn try_broadcast_nullification<Sr: Sender>(
+    /// Builds and records a nullification certificate if the round provides a candidate.
+    ///
+    /// Also returns the best notarization or finalization we know of (i.e. the "floor")
+    /// if we were the leader in the provided view.
+    async fn prepare_nullification(
         &mut self,
         resolver: &mut resolver::Mailbox<S, D>,
-        certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
         view: View,
         resolved: Resolved,
-    ) {
+    ) -> Option<(Nullification<S>, Option<Certificate<S, D>>)> {
         // Construct the nullification certificate.
-        let Some(nullification) = self.state.broadcast_nullification(view) else {
-            return;
-        };
+        let nullification = self.state.broadcast_nullification(view)?;
 
         // Notify resolver so dependent parents can progress.
         // Skip if the resolver just sent us this certificate (avoid boomerang).
@@ -609,59 +589,35 @@ impl<
             resolver.updated(Certificate::Nullification(nullification.clone()));
         }
         // Track the certificate locally to avoid rebuilding it.
-        if let Some(floor) = self.handle_nullification(nullification.clone()).await {
-            warn!(?floor, "broadcasting nullification floor");
-            self.broadcast_certificate(certificate_sender, floor).await;
-        }
-        // Broadcast the nullification certificate.
-        debug!(round=?nullification.round(), "broadcasting nullification");
-        self.broadcast_certificate(
-            certificate_sender,
-            Certificate::Nullification(nullification.clone()),
-        )
-        .await;
-        // Surface the event to the application for observability.
-        self.reporter.report(Activity::Nullification(nullification));
+        let floor = self.handle_nullification(nullification.clone()).await;
+        Some((nullification, floor))
     }
 
-    /// Broadcast a finalize vote if the round provides a candidate.
-    async fn try_broadcast_finalize<Sp: Sender>(
+    /// Builds and records a finalize vote if the round provides a candidate.
+    async fn prepare_finalize(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,
-        vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
         view: View,
-    ) {
+    ) -> Option<Finalize<S, D>> {
         // Construct the finalize vote.
-        let Some(finalize) = self.state.construct_finalize(view) else {
-            return;
-        };
+        let finalize = self.state.construct_finalize(view)?;
 
         // Provide the vote to the batcher pipeline.
         batcher.constructed(Vote::Finalize(finalize.clone()));
-        // Update the round before persisting.
+        // Record the vote locally before sharing it.
         self.handle_finalize(finalize.clone()).await;
-
-        // Broadcast the finalize vote.
-        debug!(
-            proposal=?finalize.proposal,
-            "broadcasting finalize"
-        );
-        self.broadcast_vote(vote_sender, Vote::Finalize(finalize))
-            .await;
+        Some(finalize)
     }
 
-    /// Share a finalization certificate and notify observers of the new height.
-    async fn try_broadcast_finalization<Sr: Sender>(
+    /// Builds and records a finalization certificate if the round provides a candidate.
+    async fn prepare_finalization(
         &mut self,
         resolver: &mut resolver::Mailbox<S, D>,
-        certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
         view: View,
         resolved: Resolved,
-    ) {
+    ) -> Option<Finalization<S, D>> {
         // Construct the finalization certificate.
-        let Some(finalization) = self.state.broadcast_finalization(view) else {
-            return;
-        };
+        let finalization = self.state.broadcast_finalization(view)?;
 
         // Only record latency if we are the current leader.
         if let Some(elapsed) = self.leader_elapsed(view) {
@@ -675,15 +631,7 @@ impl<
         }
         // Advance the consensus core with the finalization proof.
         self.handle_finalization(finalization.clone()).await;
-        // Broadcast the finalization certificate.
-        debug!(proposal=?finalization.proposal, "broadcasting finalization");
-        self.broadcast_certificate(
-            certificate_sender,
-            Certificate::Finalization(finalization.clone()),
-        )
-        .await;
-        // Surface the event to the application for observability.
-        self.reporter.report(Activity::Finalization(finalization));
+        Some(finalization)
     }
 
     /// Processes the automaton's response to a proposal request.
@@ -792,8 +740,9 @@ impl<
                 // and subsequent nullification), failing to certify can lead to a halt
                 // because we'll never exit the view without a notarization + certification.
                 //
-                // We do not assume failure here because certification results are persisted
-                // to the journal and will be recovered on restart.
+                // We do not assume failure here because we recover on restart: a synced
+                // certification result is replayed from the journal and a missing one
+                // causes certification to be re-requested.
                 debug!(?err, ?round, "failed to certify proposal");
             }
         };
@@ -886,17 +835,58 @@ impl<
         view: View,
         resolved: Resolved,
     ) {
-        self.try_broadcast_notarize(batcher, vote_sender, view)
-            .await;
-        self.try_broadcast_notarization(resolver, certificate_sender, view, resolved)
-            .await;
+        // Build and record everything that became available before broadcasting
+        // anything. The first broadcast syncs the journal, so all appends made
+        // here (and earlier in the loop iteration) share a single sync.
+        let notarize = self.prepare_notarize(batcher, view).await;
+        let notarization = self.prepare_notarization(resolver, view, resolved).await;
         // We handle broadcast of `Nullify` votes in `timeout`, so this only emits certificates.
-        self.try_broadcast_nullification(resolver, certificate_sender, view, resolved)
+        let nullification = self.prepare_nullification(resolver, view, resolved).await;
+        let finalize = self.prepare_finalize(batcher, view).await;
+        let finalization = self.prepare_finalization(resolver, view, resolved).await;
+
+        // Broadcast everything we built (and report it to the application).
+        if let Some(notarize) = notarize {
+            debug!(proposal=?notarize.proposal, "broadcasting notarize");
+            self.broadcast_vote(vote_sender, Vote::Notarize(notarize))
+                .await;
+        }
+        if let Some(notarization) = notarization {
+            debug!(proposal=?notarization.proposal, "broadcasting notarization");
+            self.broadcast_certificate(
+                certificate_sender,
+                Certificate::Notarization(notarization.clone()),
+            )
             .await;
-        self.try_broadcast_finalize(batcher, vote_sender, view)
+            self.reporter.report(Activity::Notarization(notarization));
+        }
+        if let Some((nullification, floor)) = nullification {
+            if let Some(floor) = floor {
+                warn!(?floor, "broadcasting nullification floor");
+                self.broadcast_certificate(certificate_sender, floor).await;
+            }
+            debug!(round=?nullification.round(), "broadcasting nullification");
+            self.broadcast_certificate(
+                certificate_sender,
+                Certificate::Nullification(nullification.clone()),
+            )
             .await;
-        self.try_broadcast_finalization(resolver, certificate_sender, view, resolved)
+            self.reporter.report(Activity::Nullification(nullification));
+        }
+        if let Some(finalize) = finalize {
+            debug!(proposal=?finalize.proposal, "broadcasting finalize");
+            self.broadcast_vote(vote_sender, Vote::Finalize(finalize))
+                .await;
+        }
+        if let Some(finalization) = finalization {
+            debug!(proposal=?finalization.proposal, "broadcasting finalization");
+            self.broadcast_certificate(
+                certificate_sender,
+                Certificate::Finalization(finalization.clone()),
+            )
             .await;
+            self.reporter.report(Activity::Finalization(finalization));
+        }
     }
 
     /// Spawns the actor event loop with the provided channels.

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -34,10 +34,11 @@ use commonware_runtime::{
 };
 use commonware_storage::journal::segmented::variable::{Config as JConfig, Journal};
 use commonware_utils::{channel::oneshot, futures::AbortablePool};
-use core::{future::Future, panic};
+use core::{future::Future, mem, panic};
 use futures::{pin_mut, StreamExt};
 use rand_core::CryptoRng;
 use std::{
+    collections::BTreeSet,
     num::NonZeroUsize,
     pin::Pin,
     task::{self, Poll},
@@ -118,6 +119,7 @@ pub struct Actor<
     write_buffer: NonZeroUsize,
     page_cache: CacheRef,
     journal: Option<Journal<E, Artifact<S, D>>>,
+    dirty: BTreeSet<u64>,
 
     mailbox_receiver: mailbox::Receiver<Message<S, D>>,
 
@@ -183,6 +185,7 @@ impl<
                 write_buffer: cfg.write_buffer,
                 page_cache: cfg.page_cache,
                 journal: None,
+                dirty: BTreeSet::new(),
 
                 mailbox_receiver,
 
@@ -228,36 +231,65 @@ impl<
                 ))
                 .await
                 .expect("unable to prune journal");
+
+            // Pruned sections can no longer be synced, so drop any pending syncs for them.
+            self.dirty = self.dirty.split_off(&min_active.get());
         }
     }
 
     /// Appends a verified message to the journal.
+    ///
+    /// The append is not immediately durable. Sections with pending appends are
+    /// tracked and synced together by [Self::sync_journal].
     async fn append_journal(&mut self, view: View, artifact: Artifact<S, D>) {
         if let Some(journal) = self.journal.as_mut() {
             journal
                 .append(view.get(), &artifact)
                 .await
                 .expect("unable to append to journal");
+            self.dirty.insert(view.get());
         }
     }
 
-    /// Syncs the journal so other replicas can recover messages in `view`.
-    #[tracing::instrument(name = "simplex.voter.journal.sync", level = "info", skip_all, fields(epoch = self.state.epoch().traced(), view = view.traced()))]
-    async fn sync_journal(&mut self, view: View) {
-        if let Some(journal) = self.journal.as_mut() {
-            journal
-                .sync(view.get())
-                .await
-                .expect("unable to sync journal");
+    /// Syncs all journal sections with pending appends.
+    ///
+    /// Invoked before any broadcast so everything we tell the network is
+    /// recoverable after a restart. Deferring syncs to this point (rather than
+    /// syncing after each append) coalesces back-to-back appends in the same
+    /// loop iteration into a single sync.
+    async fn sync_journal(&mut self) {
+        if self.dirty.is_empty() {
+            return;
         }
+        let journal = self
+            .journal
+            .as_mut()
+            .expect("pending journal sections without a journal");
+        let sections: Vec<u64> = mem::take(&mut self.dirty).into_iter().collect();
+        let span = info_span!(
+            "simplex.voter.journal.sync",
+            epoch = self.state.epoch().traced(),
+            views = ?sections
+        );
+        journal
+            .sync(sections)
+            .instrument(span)
+            .await
+            .expect("unable to sync journal");
     }
 
     /// Send a vote to every peer.
-    fn broadcast_vote<T: Sender>(
+    ///
+    /// Syncs pending journal appends first. A vote must be durable before it
+    /// reaches the network so a restart cannot cause us to equivocate.
+    async fn broadcast_vote<T: Sender>(
         &mut self,
         sender: &mut WrappedSender<T, Vote<S, D>>,
         vote: Vote<S, D>,
     ) {
+        // Persist anything we've journaled before the vote reaches the network
+        self.sync_journal().await;
+
         // Update outbound metrics
         let metric = match &vote {
             Vote::Notarize(_) => metrics::Outbound::notarize(),
@@ -271,11 +303,17 @@ impl<
     }
 
     /// Send a certificate to every peer.
-    fn broadcast_certificate<T: Sender>(
+    ///
+    /// Syncs pending journal appends first so any state we advertise to the
+    /// network survives a restart.
+    async fn broadcast_certificate<T: Sender>(
         &mut self,
         sender: &mut WrappedSender<T, Certificate<S, D>>,
         certificate: Certificate<S, D>,
     ) {
+        // Persist anything we've journaled before the certificate reaches the network
+        self.sync_journal().await;
+
         // Update outbound metrics
         let metric = match &certificate {
             Certificate::Notarization(_) => metrics::Outbound::notarization(),
@@ -360,14 +398,12 @@ impl<
         if !retry {
             batcher.constructed(Vote::Nullify(nullify.clone()));
             self.handle_nullify(nullify.clone()).await;
-
-            // Sync the journal so first-attempt nullify votes survive restarts.
-            self.sync_journal(nullify.view()).await;
         }
 
         // Broadcast nullify vote (regardless)
         debug!(round=?nullify.round(), "broadcasting nullify");
-        self.broadcast_vote(vote_sender, Vote::Nullify(nullify));
+        self.broadcast_vote(vote_sender, Vote::Nullify(nullify))
+            .await;
     }
 
     /// Handle a timeout.
@@ -395,7 +431,8 @@ impl<
             .previous()
             .expect("we should never be in the genesis view");
         if let Some(certificate) = self.state.get_best_certificate(past_view) {
-            self.broadcast_certificate(certificate_sender, certificate);
+            self.broadcast_certificate(certificate_sender, certificate)
+                .await;
         }
     }
 
@@ -453,10 +490,10 @@ impl<
         // Get the notarization before advancing state
         let notarization = self.state.certified(view, success)?;
 
-        // Persist certification result for recovery
+        // Record the certification result for recovery. It is synced with our
+        // next broadcast (at the latest, the vote this result unlocks).
         let artifact = Artifact::Certification(Rnd::new(self.state.epoch(), view), success);
-        self.append_journal(view, artifact.clone()).await;
-        self.sync_journal(view).await;
+        self.append_journal(view, artifact).await;
 
         Some(notarization)
     }
@@ -494,15 +531,14 @@ impl<
         batcher.constructed(Vote::Notarize(notarize.clone()));
         // Record the vote locally before sharing it.
         self.handle_notarize(notarize.clone()).await;
-        // Keep the vote durable for crash recovery.
-        self.sync_journal(view).await;
 
         // Broadcast the notarize vote
         debug!(
             proposal=?notarize.proposal,
             "broadcasting notarize"
         );
-        self.broadcast_vote(vote_sender, Vote::Notarize(notarize));
+        self.broadcast_vote(vote_sender, Vote::Notarize(notarize))
+            .await;
     }
 
     /// Share a notarization certificate once we can assemble it locally.
@@ -530,14 +566,13 @@ impl<
         }
         // Update our local round with the certificate.
         self.handle_notarization(notarization.clone()).await;
-        // Persist the certificate before informing others.
-        self.sync_journal(view).await;
         // Broadcast the notarization certificate
         debug!(proposal=?notarization.proposal, "broadcasting notarization");
         self.broadcast_certificate(
             certificate_sender,
             Certificate::Notarization(notarization.clone()),
-        );
+        )
+        .await;
         // Surface the event to the application for observability.
         self.reporter.report(Activity::Notarization(notarization));
     }
@@ -576,16 +611,15 @@ impl<
         // Track the certificate locally to avoid rebuilding it.
         if let Some(floor) = self.handle_nullification(nullification.clone()).await {
             warn!(?floor, "broadcasting nullification floor");
-            self.broadcast_certificate(certificate_sender, floor);
+            self.broadcast_certificate(certificate_sender, floor).await;
         }
-        // Ensure deterministic restarts.
-        self.sync_journal(view).await;
         // Broadcast the nullification certificate.
         debug!(round=?nullification.round(), "broadcasting nullification");
         self.broadcast_certificate(
             certificate_sender,
             Certificate::Nullification(nullification.clone()),
-        );
+        )
+        .await;
         // Surface the event to the application for observability.
         self.reporter.report(Activity::Nullification(nullification));
     }
@@ -606,15 +640,14 @@ impl<
         batcher.constructed(Vote::Finalize(finalize.clone()));
         // Update the round before persisting.
         self.handle_finalize(finalize.clone()).await;
-        // Keep the vote durable for recovery.
-        self.sync_journal(view).await;
 
         // Broadcast the finalize vote.
         debug!(
             proposal=?finalize.proposal,
             "broadcasting finalize"
         );
-        self.broadcast_vote(vote_sender, Vote::Finalize(finalize));
+        self.broadcast_vote(vote_sender, Vote::Finalize(finalize))
+            .await;
     }
 
     /// Share a finalization certificate and notify observers of the new height.
@@ -642,14 +675,13 @@ impl<
         }
         // Advance the consensus core with the finalization proof.
         self.handle_finalization(finalization.clone()).await;
-        // Persist the proof before broadcasting it.
-        self.sync_journal(view).await;
         // Broadcast the finalization certificate.
         debug!(proposal=?finalization.proposal, "broadcasting finalization");
         self.broadcast_certificate(
             certificate_sender,
             Certificate::Finalization(finalization.clone()),
-        );
+        )
+        .await;
         // Surface the event to the application for observability.
         self.reporter.report(Activity::Finalization(finalization));
     }
@@ -816,7 +848,7 @@ impl<
                         trace!(%view, from_resolver, "received nullification");
                         if let Some(floor) = self.handle_nullification(nullification).await {
                             warn!(?floor, "broadcasting nullification floor");
-                            self.broadcast_certificate(certificate_sender, floor);
+                            self.broadcast_certificate(certificate_sender, floor).await;
                         }
                         if from_resolver {
                             resolved = Resolved::Nullification;

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -253,11 +253,12 @@ impl<
 
     /// Syncs all journal sections with pending appends.
     ///
-    /// Invoked after each construction phase and before the corresponding
-    /// broadcast phase (regardless of whether anything will be broadcast) so
-    /// everything we tell the network is recoverable after a restart. Deferring
-    /// syncs to this boundary (rather than syncing after each append) coalesces
-    /// all appends in the same loop iteration into a single sync.
+    /// Invoked once per event loop iteration (by [Self::notify]) after the
+    /// construction phase and before the broadcast phase (regardless of whether
+    /// anything will be broadcast) so everything we tell the network is
+    /// recoverable after a restart. Deferring syncs to this boundary (rather
+    /// than syncing after each append) coalesces all appends in the same loop
+    /// iteration into a single sync.
     async fn sync_journal(&mut self) {
         if self.dirty.is_empty() {
             return;
@@ -382,80 +383,48 @@ impl<
             .await;
     }
 
-    /// Emits a nullify vote (and persists it if it is a first attempt).
-    async fn broadcast_nullify<Sp: Sender>(
+    /// Handle a timeout.
+    ///
+    /// Builds and records a nullify vote for the current view (as many times as
+    /// required until we exit the view). Returns the vote for broadcast by
+    /// [Self::notify], along with the best certificate from the previous view
+    /// (on retry) to help others enter the view.
+    #[allow(clippy::type_complexity)]
+    async fn timeout(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,
-        vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
-        retry: bool,
-        nullify: Nullify<S>,
-    ) {
+    ) -> Option<(Nullify<S>, Option<Certificate<S, D>>)> {
+        // Construct a nullify vote for the current view
+        let view = self.state.current_view();
+        let (retry, nullify) = self.state.construct_nullify(view)?;
+
         // Process nullify (and persist it if it is a first attempt)
         if !retry {
             batcher.constructed(Vote::Nullify(nullify.clone()));
             self.handle_nullify(nullify.clone()).await;
+            return Some((nullify, None));
         }
 
-        // Make the vote durable before it reaches the network
-        self.sync_journal().await;
-
-        // Broadcast nullify vote (regardless)
-        debug!(round=?nullify.round(), "broadcasting nullify");
-        self.broadcast_vote(vote_sender, Vote::Nullify(nullify));
-    }
-
-    /// Handle a timeout.
-    async fn timeout<Sp: Sender, Sr: Sender>(
-        &mut self,
-        batcher: &mut batcher::Mailbox<S, D>,
-        vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
-        certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
-    ) {
-        // Attempt to broadcast a nullify vote for the current view (as many times as required
-        // until we exit the view)
-        let view = self.state.current_view();
-        let Some(retry) = self.try_broadcast_nullify(batcher, vote_sender, view).await else {
-            return;
-        };
-
-        // Broadcast entry to help others enter the view (if on retry).
+        // Include entry to help others enter the view (if on retry).
         //
         // We don't worry about recording this certificate because it must've already existed (and thus
         // we must've already broadcast and persisted it).
-        if !retry {
-            return;
-        }
         let past_view = view
             .previous()
             .expect("we should never be in the genesis view");
-        if let Some(certificate) = self.state.get_best_certificate(past_view) {
-            self.broadcast_certificate(certificate_sender, certificate);
-        }
+        Some((nullify, self.state.get_best_certificate(past_view)))
     }
 
     /// Tracks a verified nullification certificate if it is new.
-    ///
-    /// Returns the best notarization or finalization we know of (i.e. the "floor") if we were the leader
-    /// in the provided view (regardless of whether we built a proposal).
-    async fn handle_nullification(
-        &mut self,
-        nullification: Nullification<S>,
-    ) -> Option<Certificate<S, D>> {
+    async fn handle_nullification(&mut self, nullification: Nullification<S>) {
         let view = nullification.view();
         let artifact = Artifact::Nullification(nullification.clone());
 
         // Add verified nullification to journal
         if !self.state.add_nullification(nullification) {
-            return None;
+            return;
         }
         self.append_journal(view, artifact).await;
-
-        // If we were the leader and proposed, we should emit the parent certificate (a notarization or finalization)
-        // of our proposal
-        self.state
-            .leader_index(view)
-            .filter(|&leader| self.state.is_me(leader))
-            .and_then(|_| self.state.parent_certificate(view))
     }
 
     /// Persists our notarize vote to the journal for crash recovery.
@@ -554,23 +523,10 @@ impl<
         Some(notarization)
     }
 
-    /// Broadcast a nullify vote for `view` if the state machine allows it.
-    async fn try_broadcast_nullify<Sp: Sender>(
-        &mut self,
-        batcher: &mut batcher::Mailbox<S, D>,
-        vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
-        view: View,
-    ) -> Option<bool> {
-        let (was_retry, nullify) = self.state.construct_nullify(view)?;
-        self.broadcast_nullify(batcher, vote_sender, was_retry, nullify)
-            .await;
-        Some(was_retry)
-    }
-
     /// Builds and records a nullification certificate if the round provides a candidate.
     ///
     /// Also returns the best notarization or finalization we know of (i.e. the "floor")
-    /// if we were the leader in the provided view.
+    /// if we were the leader in the provided view (regardless of whether we built a proposal).
     async fn prepare_nullification(
         &mut self,
         resolver: &mut resolver::Mailbox<S, D>,
@@ -586,7 +542,14 @@ impl<
             resolver.updated(Certificate::Nullification(nullification.clone()));
         }
         // Track the certificate locally to avoid rebuilding it.
-        let floor = self.handle_nullification(nullification.clone()).await;
+        self.handle_nullification(nullification.clone()).await;
+        // If we were the leader, emit the parent certificate (a notarization or
+        // finalization) of our proposal so peers can catch up.
+        let floor = self
+            .state
+            .leader_index(view)
+            .filter(|&leader| self.state.is_me(leader))
+            .and_then(|_| self.state.parent_certificate(view));
         Some((nullification, floor))
     }
 
@@ -750,11 +713,7 @@ impl<
     ///
     /// Returns the view to notify and whether the message was a certificate
     /// from the resolver.
-    async fn process_message<Sr: Sender>(
-        &mut self,
-        certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
-        msg: Message<S, D>,
-    ) -> Option<(View, Resolved)> {
+    async fn process_message(&mut self, msg: Message<S, D>) -> Option<(View, Resolved)> {
         match msg {
             Message::Proposal { proposal, .. } => {
                 let view = proposal.view();
@@ -792,12 +751,7 @@ impl<
                     }
                     Certificate::Nullification(nullification) => {
                         trace!(%view, from_resolver, "received nullification");
-                        if let Some(floor) = self.handle_nullification(nullification).await {
-                            // Make the nullification durable before advertising the floor
-                            self.sync_journal().await;
-                            warn!(?floor, "broadcasting nullification floor");
-                            self.broadcast_certificate(certificate_sender, floor);
-                        }
+                        self.handle_nullification(nullification).await;
                         if from_resolver {
                             resolved = Resolved::Nullification;
                         }
@@ -823,8 +777,13 @@ impl<
 
     /// Emits any votes or certificates that became available for `view`.
     ///
+    /// All outbound messages flow through here: everything is built and recorded
+    /// first (including the timeout's `nullify`, constructed by the caller), then
+    /// synced to the journal in a single batch, then broadcast.
+    ///
     /// We don't need to iterate over all views to check for new actions because messages we receive
     /// only affect a single view.
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     async fn notify<Sp: Sender, Sr: Sender>(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,
@@ -833,12 +792,12 @@ impl<
         certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
         view: View,
         resolved: Resolved,
+        nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
     ) {
         // Build and record everything that became available before broadcasting
         // anything below.
         let notarize = self.prepare_notarize(batcher, view).await;
         let notarization = self.prepare_notarization(resolver, view, resolved).await;
-        // We handle broadcast of `Nullify` votes in `timeout`, so this only emits certificates.
         let nullification = self.prepare_nullification(resolver, view, resolved).await;
         let finalize = self.prepare_finalize(batcher, view).await;
         let finalization = self.prepare_finalization(resolver, view, resolved).await;
@@ -850,6 +809,15 @@ impl<
         self.sync_journal().await;
 
         // Broadcast everything we built (and report it to the application).
+        if let Some((nullify, entry)) = nullify {
+            debug!(round=?nullify.round(), "broadcasting nullify");
+            self.broadcast_vote(vote_sender, Vote::Nullify(nullify));
+
+            // Broadcast entry to help others enter the view (if on retry).
+            if let Some(entry) = entry {
+                self.broadcast_certificate(certificate_sender, entry);
+            }
+        }
         if let Some(notarize) = notarize {
             debug!(proposal=?notarize.proposal, "broadcasting notarize");
             self.broadcast_vote(vote_sender, Vote::Notarize(notarize));
@@ -1106,13 +1074,14 @@ impl<
                 let timeout = self.state.next_timeout_deadline();
                 let start = self.state.current_view();
                 let mut resolved = Resolved::None;
+                let mut nullify = None;
                 let view;
             },
             on_stopped => {
                 debug!("context shutdown, stopping voter");
             },
             _ = self.context.sleep_until(timeout) => {
-                // Process the timeout
+                // Process the timeout (the constructed nullify is broadcast by notify)
                 let current_view = self.state.current_view();
                 let span = info_span!(
                     parent: self.state.view_span(current_view),
@@ -1120,9 +1089,7 @@ impl<
                     epoch = self.state.epoch().traced(),
                     view = current_view.traced()
                 );
-                self.timeout(&mut batcher, &mut vote_sender, &mut certificate_sender)
-                    .instrument(span)
-                    .await;
+                nullify = self.timeout(&mut batcher).instrument(span).await;
                 view = self.state.current_view();
             },
             (context, span, proposed) = propose_wait => {
@@ -1166,7 +1133,7 @@ impl<
                     view = msg.view().traced()
                 );
                 let Some((processed_view, processed_resolved)) = self
-                    .process_message(&mut certificate_sender, msg)
+                    .process_message(msg)
                     .instrument(span)
                     .await
                 else {
@@ -1196,6 +1163,7 @@ impl<
                     &mut certificate_sender,
                     view,
                     resolved,
+                    nullify,
                 )
                 .instrument(span)
                 .await;

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -62,12 +62,12 @@ enum Resolved {
 /// [Actor::notify]).
 #[allow(clippy::type_complexity)]
 struct Staged<S: Scheme<D>, D: Digest> {
+    notarize: Option<Notarize<S, D>>,
+    notarization: Option<Notarization<S, D>>,
+    certification: Option<(Rnd, bool, Notarization<S, D>)>,
     /// A nullify vote constructed on timeout, with the best certificate from
     /// the previous view (on retry) to help others enter the view.
     nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
-    certification: Option<(Rnd, bool, Notarization<S, D>)>,
-    notarize: Option<Notarize<S, D>>,
-    notarization: Option<Notarization<S, D>>,
     /// A nullification certificate, with the parent certificate of our proposal
     /// (the "floor") if we were the leader of the nullified view.
     nullification: Option<(Nullification<S>, Option<Certificate<S, D>>)>,
@@ -805,10 +805,10 @@ impl<
         let finalize = self.prepare_finalize(batcher, view).await;
         let finalization = self.prepare_finalization(resolver, view, resolved).await;
         Staged {
-            nullify,
-            certification,
             notarize,
             notarization,
+            certification,
+            nullify,
             nullification,
             finalize,
             finalization,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -65,6 +65,7 @@ struct Staged<S: Scheme<D>, D: Digest> {
     /// A nullify vote constructed on timeout, with the best certificate from
     /// the previous view (on retry) to help others enter the view.
     nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
+    certification: Option<(Rnd, bool, Notarization<S, D>)>,
     notarize: Option<Notarize<S, D>>,
     notarization: Option<Notarization<S, D>>,
     /// A nullification certificate, with the parent certificate of our proposal
@@ -686,10 +687,9 @@ impl<
     /// Returns false if the view was already pruned (nothing to notify).
     async fn process_certified(
         &mut self,
-        resolver: &mut resolver::Mailbox<S, D>,
         round: Rnd,
         certified: Result<bool, oneshot::error::RecvError>,
-    ) -> bool {
+    ) -> (bool, Option<(bool, Notarization<S, D>)>) {
         match certified {
             Ok(certified) => {
                 if !certified {
@@ -697,17 +697,10 @@ impl<
                 }
                 let view = round.view();
                 let Some(notarization) = self.handle_certification(view, certified).await else {
-                    return false;
+                    return (false, None);
                 };
 
-                // Always forward certification outcomes to resolver.
-                // This can happen after a nullification for the same view because
-                // certification is asynchronous; finalization is the boundary that
-                // cancels in-flight certification and suppresses late reporting.
-                resolver.certified(round, certified);
-                if certified {
-                    self.reporter.report(Activity::Certification(notarization));
-                }
+                return (true, Some((certified, notarization)));
             }
             Err(err) => {
                 // Unlike propose/verify (where failing to act will lead to a timeout
@@ -720,7 +713,7 @@ impl<
                 debug!(?err, ?round, "failed to certify proposal");
             }
         };
-        true
+        (true, None)
     }
 
     /// Processes a message from the resolver or batcher.
@@ -804,6 +797,7 @@ impl<
         view: View,
         resolved: Resolved,
         nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
+        certification: Option<(Rnd, bool, Notarization<S, D>)>,
     ) -> Staged<S, D> {
         let notarize = self.prepare_notarize(batcher, view).await;
         let notarization = self.prepare_notarization(resolver, view, resolved).await;
@@ -812,6 +806,7 @@ impl<
         let finalization = self.prepare_finalization(resolver, view, resolved).await;
         Staged {
             nullify,
+            certification,
             notarize,
             notarization,
             nullification,
@@ -826,6 +821,7 @@ impl<
     /// so nothing reaches the network before it is durable.
     fn notify<Sp: Sender, Sr: Sender>(
         &mut self,
+        resolver: &mut resolver::Mailbox<S, D>,
         vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
         certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
         staged: Staged<S, D>,
@@ -834,6 +830,17 @@ impl<
             self.dirty.is_none(),
             "journal must be synced before broadcast"
         );
+
+        if let Some((round, certified, notarization)) = staged.certification {
+            // Always forward certification outcomes to resolver. This can happen
+            // after a nullification for the same view because certification is
+            // asynchronous; finalization is the boundary that cancels in-flight
+            // certification and suppresses late reporting.
+            resolver.certified(round, certified);
+            if certified {
+                self.reporter.report(Activity::Certification(notarization));
+            }
+        }
 
         if let Some((nullify, entry)) = staged.nullify {
             debug!(round=?nullify.round(), "broadcasting nullify");
@@ -1101,6 +1108,7 @@ impl<
                 let start = self.state.current_view();
                 let mut resolved = Resolved::None;
                 let mut nullify = None;
+                let mut certification = None;
                 let view;
             },
             on_stopped => {
@@ -1141,13 +1149,15 @@ impl<
             Ok((round, span, certified)) = certify_wait else continue => {
                 // Handle response to our certification request.
                 view = round.view();
-                if !self
-                    .process_certified(&mut resolver, round, certified)
+                let (processed, certification_result) = self
+                    .process_certified(round, certified)
                     .instrument(span)
-                    .await
-                {
+                    .await;
+                if !processed {
                     continue;
                 }
+                certification = certification_result
+                    .map(|(success, notarization)| (round, success, notarization));
             },
             Some(msg) = self.mailbox_receiver.recv() else break => {
                 // Handle messages from resolver and batcher
@@ -1185,7 +1195,14 @@ impl<
                 async {
                     // Build and record everything that became available for `view`.
                     let staged = self
-                        .construct(&mut batcher, &mut resolver, view, resolved, nullify)
+                        .construct(
+                            &mut batcher,
+                            &mut resolver,
+                            view,
+                            resolved,
+                            nullify,
+                            certification,
+                        )
                         .await;
 
                     // Sync everything appended this iteration (during message
@@ -1196,7 +1213,12 @@ impl<
                     self.sync_journal().await;
 
                     // Broadcast everything we built (and report it to the application).
-                    self.notify(&mut vote_sender, &mut certificate_sender, staged);
+                    self.notify(
+                        &mut resolver,
+                        &mut vote_sender,
+                        &mut certificate_sender,
+                        staged,
+                    );
                 }
                 .instrument(span)
                 .await;

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -34,11 +34,10 @@ use commonware_runtime::{
 };
 use commonware_storage::journal::segmented::variable::{Config as JConfig, Journal};
 use commonware_utils::{channel::oneshot, futures::AbortablePool};
-use core::{future::Future, mem, panic};
+use core::{future::Future, panic};
 use futures::{pin_mut, StreamExt};
 use rand_core::CryptoRng;
 use std::{
-    collections::BTreeSet,
     num::NonZeroUsize,
     pin::Pin,
     task::{self, Poll},
@@ -136,7 +135,7 @@ pub struct Actor<
     write_buffer: NonZeroUsize,
     page_cache: CacheRef,
     journal: Option<Journal<E, Artifact<S, D>>>,
-    dirty: BTreeSet<u64>,
+    dirty: Option<View>,
 
     mailbox_receiver: mailbox::Receiver<Message<S, D>>,
 
@@ -202,7 +201,7 @@ impl<
                 write_buffer: cfg.write_buffer,
                 page_cache: cfg.page_cache,
                 journal: None,
-                dirty: BTreeSet::new(),
+                dirty: None,
 
                 mailbox_receiver,
 
@@ -248,9 +247,6 @@ impl<
                 ))
                 .await
                 .expect("unable to prune journal");
-
-            // Pruned sections can no longer be synced, so drop any pending syncs for them.
-            self.dirty = self.dirty.split_off(&min_active.get());
         }
     }
 
@@ -264,11 +260,15 @@ impl<
                 .append(view.get(), &artifact)
                 .await
                 .expect("unable to append to journal");
-            self.dirty.insert(view.get());
+            assert!(
+                self.dirty.is_none_or(|dirty| dirty == view),
+                "event loop iteration appended to multiple journal sections"
+            );
+            self.dirty = Some(view);
         }
     }
 
-    /// Syncs all journal sections with pending appends.
+    /// Syncs the journal section with pending appends.
     ///
     /// Invoked once per event loop iteration, after [Self::construct] and before
     /// [Self::notify] (regardless of whether anything will be broadcast), so
@@ -276,24 +276,22 @@ impl<
     /// syncs to this boundary (rather than syncing after each append) coalesces
     /// all appends in the same loop iteration into a single sync.
     async fn sync_journal(&mut self) {
-        if self.dirty.is_empty() {
-            return;
-        }
+        let Some(view) = self.dirty else { return };
         let journal = self
             .journal
             .as_mut()
             .expect("pending journal sections without a journal");
-        let sections = mem::take(&mut self.dirty);
         let span = info_span!(
             "simplex.voter.journal.sync",
             epoch = self.state.epoch().traced(),
-            views = ?sections
+            view = view.traced()
         );
         journal
-            .sync(sections)
+            .sync(view.get())
             .instrument(span)
             .await
             .expect("unable to sync journal");
+        self.dirty = None;
     }
 
     /// Send a vote to every peer.
@@ -833,7 +831,7 @@ impl<
         staged: Staged<S, D>,
     ) {
         assert!(
-            self.dirty.is_empty(),
+            self.dirty.is_none(),
             "journal must be synced before broadcast"
         );
 

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -136,7 +136,7 @@ pub struct Actor<
     write_buffer: NonZeroUsize,
     page_cache: CacheRef,
     journal: Option<Journal<E, Artifact<S, D>>>,
-    dirty: Option<View>,
+    dirty: bool,
 
     mailbox_receiver: mailbox::Receiver<Message<S, D>>,
 
@@ -202,7 +202,7 @@ impl<
                 write_buffer: cfg.write_buffer,
                 page_cache: cfg.page_cache,
                 journal: None,
-                dirty: None,
+                dirty: false,
 
                 mailbox_receiver,
 
@@ -253,35 +253,35 @@ impl<
 
     /// Appends a verified message to the journal.
     ///
-    /// The append is not immediately durable. Sections with pending appends are
-    /// tracked and synced together by [Self::sync_journal].
+    /// The append is not immediately durable. All appends in an event loop
+    /// iteration target the view being processed and are synced together by
+    /// [Self::sync_journal].
     async fn append_journal(&mut self, view: View, artifact: Artifact<S, D>) {
         if let Some(journal) = self.journal.as_mut() {
             journal
                 .append(view.get(), &artifact)
                 .await
                 .expect("unable to append to journal");
-            assert!(
-                self.dirty.is_none_or(|dirty| dirty == view),
-                "event loop iteration appended to multiple journal sections"
-            );
-            self.dirty = Some(view);
+            self.dirty = true;
         }
     }
 
-    /// Syncs the journal section with pending appends.
+    /// Syncs the journal section for `view` (the view being processed) if the
+    /// iteration appended anything.
     ///
     /// Invoked once per event loop iteration, after [Self::construct] and before
     /// [Self::notify] (regardless of whether anything will be broadcast), so
     /// everything we tell the network is recoverable after a restart. Deferring
     /// syncs to this boundary (rather than syncing after each append) coalesces
     /// all appends in the same loop iteration into a single sync.
-    async fn sync_journal(&mut self) {
-        let Some(view) = self.dirty else { return };
+    async fn sync_journal(&mut self, view: View) {
+        if !self.dirty {
+            return;
+        }
         let journal = self
             .journal
             .as_mut()
-            .expect("pending journal sections without a journal");
+            .expect("pending journal appends without a journal");
         let span = info_span!(
             "simplex.voter.journal.sync",
             epoch = self.state.epoch().traced(),
@@ -292,7 +292,7 @@ impl<
             .instrument(span)
             .await
             .expect("unable to sync journal");
-        self.dirty = None;
+        self.dirty = false;
     }
 
     /// Send a vote to every peer.
@@ -826,10 +826,7 @@ impl<
         certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
         staged: Staged<S, D>,
     ) {
-        assert!(
-            self.dirty.is_none(),
-            "journal must be synced before broadcast"
-        );
+        assert!(!self.dirty, "journal must be synced before broadcast");
 
         if let Some((round, certified, notarization)) = staged.certification {
             // Always forward certification outcomes to resolver. This can happen
@@ -1210,7 +1207,7 @@ impl<
                     // This runs even if there is nothing to broadcast (e.g. a
                     // certification result was recorded) so every artifact is
                     // durable by the end of the iteration that appended it.
-                    self.sync_journal().await;
+                    self.sync_journal(view).await;
 
                     // Broadcast everything we built (and report it to the application).
                     self.notify(

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -401,10 +401,10 @@ impl<
 
     /// Handle a timeout.
     ///
-    /// Builds and records a nullify vote for the current view (as many times as
-    /// required until we exit the view). Returns the vote for broadcast by
-    /// [Self::notify], along with the best certificate from the previous view
-    /// (on retry) to help others enter the view.
+    /// Builds a nullify vote for the current view (as many times as required
+    /// until we exit the view) and records it on the first attempt. Returns the
+    /// vote for broadcast by [Self::notify], along with the best certificate
+    /// from the previous view (on retry) to help others enter the view.
     #[allow(clippy::type_complexity)]
     async fn timeout(
         &mut self,

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -8402,8 +8402,10 @@ mod tests {
             relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
-            // Wait until proposal verification and its journal sync have completed. This keeps the
-            // gate focused on the certification and finalize appends in the next iteration.
+            // Wait until the notarize for the target view is constructed. The gate is armed
+            // in the strictly later iteration that requests certification, by which point the
+            // notarize iteration's journal sync has completed, keeping the gate focused on
+            // the certification and finalize appends.
             loop {
                 select! {
                     msg = batcher_receiver.recv() => match msg.unwrap() {

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -87,8 +87,10 @@ mod tests {
     };
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        deterministic, telemetry::traces::collector::TraceStorage, Clock, Metrics as _, Quota,
-        Runner, Supervisor as _,
+        deterministic,
+        mocks::{next_pending_sync, DelayedSyncContext, PendingSyncs},
+        reschedule, telemetry::traces::collector::TraceStorage, Clock, Metrics as _, Quota, Runner,
+        Supervisor as _,
     };
     use commonware_storage::journal::segmented::variable::{Config as JConfig, Journal};
     use commonware_utils::{sync::Mutex, NZUsize, NZU16};
@@ -8245,13 +8247,12 @@ mod tests {
         first_view_progress_without_timeout::<_, _, RoundRobin>(secp256r1::fixture);
     }
 
-    /// Tests that a successful certification is correctly replayed from the journal
-    /// after a restart.
+    /// Tests that certification and finalize are coalesced into one durable section sync.
     ///
-    /// 1. First run: follower certifies a view successfully, which is persisted to journal.
-    /// 2. Abort the voter.
-    /// 3. Second run: voter replays journal and processes the Artifact::Certification entry,
-    ///    advancing past the certified view without re-certifying.
+    /// 1. First run: gate the section sync after certification and verify finalize is staged but
+    ///    not broadcast.
+    /// 2. Release the only section sync, observe the finalize broadcast, and abort the voter.
+    /// 3. Second run: replay both artifacts and advance without re-certifying.
     fn successful_certification_replayed_after_restart<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
@@ -8282,8 +8283,16 @@ mod tests {
                 mocks::reporter::Reporter::new(context.child("reporter"), reporter_cfg);
             let relay = Arc::new(mocks::relay::Relay::new());
             let epoch = Epoch::new(333);
+            let target_view = View::new(3);
 
-            // First run: certify a follower view successfully.
+            let pending_syncs = PendingSyncs::default();
+            let voter_context = DelayedSyncContext {
+                inner: context.child("voter"),
+                pending: pending_syncs.clone(),
+            };
+            let pending_syncs_for_certifier = pending_syncs.clone();
+
+            // Arm the sync gate immediately before the target certification succeeds.
             let app_cfg = mocks::application::Config {
                 hasher: Sha256::default(),
                 relay: relay.clone(),
@@ -8291,7 +8300,13 @@ mod tests {
                 propose_latency: (1.0, 0.0),
                 verify_latency: (1.0, 0.0),
                 certify_latency: (1.0, 0.0),
-                should_certify: mocks::application::Certifier::Always,
+                should_certify: mocks::application::Certifier::Custom(Box::new(
+                    move |round, _| {
+                        assert_eq!(round.view(), target_view);
+                        pending_syncs_for_certifier.arm();
+                        true
+                    },
+                )),
             };
             let (app_actor, application) =
                 mocks::application::Application::new(context.child("app"), app_cfg);
@@ -8314,11 +8329,17 @@ mod tests {
                 activity_timeout: ViewDelta::new(10),
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
-                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                page_cache: CacheRef::from_pooler(
+                    &voter_context,
+                    PAGE_SIZE,
+                    PAGE_CACHE_SIZE,
+                ),
             };
-            let (voter, mut mailbox) = Actor::new(context.child("voter"), voter_cfg);
-            let (resolver_sender, mut resolver_receiver) = mailbox::new(context.child("resolver_mailbox"), NZUsize!(8));
-            let (batcher_sender, mut batcher_receiver) = mailbox::new(context.child("batcher_mailbox"), NZUsize!(8));
+            let (voter, mut mailbox) = Actor::new(voter_context, voter_cfg);
+            let (resolver_sender, mut resolver_receiver) =
+                mailbox::new(context.child("resolver_mailbox"), NZUsize!(8));
+            let (batcher_sender, mut batcher_receiver) =
+                mailbox::new(context.child("batcher_mailbox"), NZUsize!(8));
             let (vote_sender, _) = oracle
                 .control(me.clone())
                 .register(0, TEST_QUOTA)
@@ -8329,6 +8350,24 @@ mod tests {
                 .register(1, TEST_QUOTA)
                 .await
                 .unwrap();
+            let observer = participants[1].clone();
+            let (_, mut observer_vote_receiver) = oracle
+                .control(observer.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            oracle
+                .add_link(
+                    me.clone(),
+                    observer,
+                    Link {
+                        latency: Duration::ZERO,
+                        jitter: Duration::ZERO,
+                        success_rate: 1.0,
+                    },
+                )
+                .await
+                .unwrap();
             let handle = voter.start(
                 batcher::Mailbox::new(batcher_sender),
                 resolver::Mailbox::new(resolver_sender),
@@ -8336,14 +8375,12 @@ mod tests {
                 cert_sender,
             );
 
-            if let batcher::Message::Update { .. } =
-                batcher_receiver.recv().await.unwrap()
-            {
-
-            }
+            assert!(matches!(
+                batcher_receiver.recv().await.unwrap(),
+                batcher::Message::Update { .. }
+            ));
 
             // Advance to follower view 3 (leader = participant 1).
-            let target_view = View::new(3);
             let parent_payload = advance_to_view(
                 &mut mailbox,
                 &mut batcher_receiver,
@@ -8364,39 +8401,110 @@ mod tests {
             relay.broadcast(&leader, Recipients::All, (proposal.payload, contents));
             mailbox.proposal(proposal.clone());
 
-            // Send notarization to trigger certification.
-            let (_, notarization) = build_notarization(&schemes, &proposal, quorum);
-            mailbox
-                .resolved(Certificate::Notarization(notarization));
-
-            // Wait for certification to complete (view advances past target_view).
+            // Wait until proposal verification and its journal sync have completed. This keeps the
+            // gate focused on the certification and finalize appends in the next iteration.
             loop {
                 select! {
-                    msg = resolver_receiver.recv() => match msg.unwrap() {
-                        MailboxMessage::Certified { round, success, .. } if round.view() == target_view => {
-                            assert!(success, "expected successful certification");
-                            break;
-                        }
+                    msg = batcher_receiver.recv() => match msg.unwrap() {
+                        batcher::Message::Constructed(Vote::Notarize(notarize))
+                            if notarize.view() == target_view => break,
                         _ => {}
                     },
-                    msg = batcher_receiver.recv() => {
-                        if let batcher::Message::Update { .. } = msg.unwrap() {
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("timed out waiting for notarize in view {target_view}");
+                    },
+                }
+            }
 
+            // Send notarization to trigger certification.
+            let (_, notarization) = build_notarization(&schemes, &proposal, quorum);
+            mailbox.resolved(Certificate::Notarization(notarization));
+
+            // Wait until the first durability operation reaches the gate. Both artifacts must have
+            // been appended by this point, but notify must still be waiting behind the sync.
+            while pending_syncs.lock().is_empty() {
+                reschedule().await;
+            }
+            let deferred = next_pending_sync(&pending_syncs);
+            let blocked = deferred.blocked;
+            blocked.await.expect("gated section sync was dropped");
+
+            let mut certified = false;
+            while let Some(msg) = resolver_receiver.recv().now_or_never().flatten() {
+                if let MailboxMessage::Certified { round, success, .. } = msg {
+                    if round.view() == target_view {
+                        assert!(success, "expected successful certification");
+                        certified = true;
+                    }
+                }
+            }
+            assert!(certified, "resolver did not observe successful certification");
+
+            let mut finalize_constructed = false;
+            while let Some(msg) = batcher_receiver.recv().now_or_never().flatten() {
+                if matches!(
+                    msg,
+                    batcher::Message::Constructed(Vote::Finalize(ref finalize))
+                        if finalize.view() == target_view
+                ) {
+                    finalize_constructed = true;
+                }
+            }
+            assert!(
+                finalize_constructed,
+                "finalize was not constructed before the section sync"
+            );
+            assert_eq!(
+                pending_syncs.calls(),
+                1,
+                "certification and finalize must share one section sync"
+            );
+
+            // While the section sync is blocked, no target finalize may reach the network.
+            let deadline = context.current() + Duration::from_millis(10);
+            loop {
+                select! {
+                    _ = context.sleep_until(deadline) => break,
+                    message = commonware_p2p::Receiver::recv(&mut observer_vote_receiver) => {
+                        let (_, message) = message.unwrap();
+                        let vote: Vote<S, Sha256Digest> = Vote::decode(message).unwrap();
+                        assert!(
+                            !matches!(
+                                vote,
+                                Vote::Finalize(ref finalize) if finalize.view() == target_view
+                            ),
+                            "finalize reached the network before its section sync completed"
+                        );
+                    },
+                }
+            }
+
+            deferred.release.send(Ok(())).unwrap();
+
+            // The durable finalize should be broadcast, without another section sync.
+            let deadline = context.current() + Duration::from_secs(5);
+            loop {
+                select! {
+                    _ = context.sleep_until(deadline) => {
+                        panic!("timed out waiting for finalize in view {target_view}");
+                    },
+                    message = commonware_p2p::Receiver::recv(&mut observer_vote_receiver) => {
+                        let (_, message) = message.unwrap();
+                        let vote: Vote<S, Sha256Digest> = Vote::decode(message).unwrap();
+                        if matches!(
+                            vote,
+                            Vote::Finalize(ref finalize) if finalize.view() == target_view
+                        ) {
+                            break;
                         }
                     },
-                    _ = context.sleep(Duration::from_secs(5)) => {
-                        panic!("timed out waiting for certification in first run");
-                    },
                 }
             }
-
-            // Drain any pending batcher messages so the view has advanced.
-            context.sleep(Duration::from_millis(50)).await;
-            while let Some(msg) = batcher_receiver.recv().now_or_never().flatten() {
-                if let batcher::Message::Update { .. } = msg {
-
-                }
-            }
+            assert_eq!(
+                pending_syncs.calls(),
+                1,
+                "certification and finalize used multiple section syncs"
+            );
 
             // Abort first voter.
             handle.abort();
@@ -8422,13 +8530,23 @@ mod tests {
                 mocks::application::Application::new(context.child("app_restarted"), app_cfg);
             app_actor.start();
 
+            let replay_reporter_cfg = mocks::reporter::Config {
+                participants: participants.clone().try_into().unwrap(),
+                scheme: schemes[0].clone(),
+                elector: elector.clone(),
+            };
+            let replay_reporter = mocks::reporter::Reporter::new(
+                context.child("reporter_restarted"),
+                replay_reporter_cfg,
+            );
+
             let voter_cfg = Config {
                 scheme: schemes[0].clone(),
                 elector,
                 blocker: oracle.control(me.clone()),
                 automaton: application.clone(),
                 relay: application.clone(),
-                reporter,
+                reporter: replay_reporter.clone(),
                 partition,
                 epoch,
                 floor: Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
@@ -8441,10 +8559,11 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
-            let (voter, _mailbox) =
-                Actor::new(context.child("voter_restarted"), voter_cfg);
-            let (resolver_sender, mut resolver_receiver) = mailbox::new(context.child("resolver_mailbox"), NZUsize!(8));
-            let (batcher_sender, mut batcher_receiver) = mailbox::new(context.child("batcher_mailbox"), NZUsize!(8));
+            let (voter, _mailbox) = Actor::new(context.child("voter_restarted"), voter_cfg);
+            let (resolver_sender, mut resolver_receiver) =
+                mailbox::new(context.child("resolver_mailbox"), NZUsize!(8));
+            let (batcher_sender, mut batcher_receiver) =
+                mailbox::new(context.child("batcher_mailbox"), NZUsize!(8));
             let (vote_sender, _) = oracle
                 .control(me.clone())
                 .register(2, TEST_QUOTA)
@@ -8462,10 +8581,10 @@ mod tests {
                 cert_sender,
             );
 
-            // Wait for replay to complete and verify the voter advanced past
-            // target_view (certification was replayed from journal).
+            // Wait for both replay notifications. Certification advances exactly one view.
             let mut replayed_certified = false;
-            loop {
+            let mut advanced = false;
+            while !(replayed_certified && advanced) {
                 select! {
                     msg = resolver_receiver.recv() => match msg.unwrap() {
                         MailboxMessage::Certified { round, success, .. } if round.view() == target_view => {
@@ -8479,9 +8598,9 @@ mod tests {
                             current, ..
                         } = msg.unwrap()
                         {
-
-                            if current > target_view {
-                                break;
+                            if current >= target_view.next() {
+                                assert_eq!(current, target_view.next());
+                                advanced = true;
                             }
                         }
                     },
@@ -8491,18 +8610,22 @@ mod tests {
                 }
             }
 
-            assert!(
-                replayed_certified,
-                "resolver should receive Certified during replay for view {target_view}"
-            );
-
             // The voter should NOT have called certify on the automaton for
             // target_view (it was replayed from journal).
-            let certified = certify_calls.lock();
-            assert!(
-                !certified.contains(&target_view),
-                "voter should not re-certify view {target_view} during replay (observed: {certified:?})"
-            );
+            {
+                let certified = certify_calls.lock();
+                assert!(
+                    !certified.contains(&target_view),
+                    "voter should not re-certify view {target_view} during replay (observed: {certified:?})"
+                );
+            }
+
+            let finalizes = replay_reporter.finalizes.lock();
+            let signers = finalizes
+                .get(&target_view)
+                .and_then(|payloads| payloads.get(&proposal.payload))
+                .expect("coalesced finalize should replay after restart");
+            assert!(signers.contains(&me));
         });
     }
 

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -8430,16 +8430,19 @@ mod tests {
             let blocked = deferred.blocked;
             blocked.await.expect("gated section sync was dropped");
 
-            let mut certified = false;
+            let mut certified_before_sync = false;
             while let Some(msg) = resolver_receiver.recv().now_or_never().flatten() {
                 if let MailboxMessage::Certified { round, success, .. } = msg {
                     if round.view() == target_view {
                         assert!(success, "expected successful certification");
-                        certified = true;
+                        certified_before_sync = true;
                     }
                 }
             }
-            assert!(certified, "resolver did not observe successful certification");
+            assert!(
+                !certified_before_sync,
+                "resolver observed certification before the section sync completed"
+            );
 
             let mut finalize_constructed = false;
             while let Some(msg) = batcher_receiver.recv().now_or_never().flatten() {
@@ -8481,6 +8484,26 @@ mod tests {
             }
 
             deferred.release.send(Ok(())).unwrap();
+
+            // The resolver should observe certification only after the section sync completes.
+            let mut certified = false;
+            let deadline = context.current() + Duration::from_secs(5);
+            while !certified {
+                select! {
+                    msg = resolver_receiver.recv() => match msg.unwrap() {
+                        MailboxMessage::Certified { round, success, .. }
+                            if round.view() == target_view =>
+                        {
+                            assert!(success, "expected successful certification");
+                            certified = true;
+                        }
+                        _ => {}
+                    },
+                    _ = context.sleep_until(deadline) => {
+                        panic!("timed out waiting for certification after section sync");
+                    },
+                }
+            }
 
             // The durable finalize should be broadcast, without another section sync.
             let deadline = context.current() + Duration::from_secs(5);

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -8281,7 +8281,7 @@ mod tests {
                 elector: elector.clone(),
             };
             let reporter =
-                mocks::reporter::Reporter::new(context.child("reporter"), reporter_cfg);
+                mocks::reporter::Reporter::new(context.child("reporter"), reporter_cfg.clone());
             let relay = Arc::new(mocks::relay::Relay::new());
             let epoch = Epoch::new(333);
             let target_view = View::new(3);
@@ -8554,14 +8554,9 @@ mod tests {
                 mocks::application::Application::new(context.child("app_restarted"), app_cfg);
             app_actor.start();
 
-            let replay_reporter_cfg = mocks::reporter::Config {
-                participants: participants.clone().try_into().unwrap(),
-                scheme: schemes[0].clone(),
-                elector: elector.clone(),
-            };
             let replay_reporter = mocks::reporter::Reporter::new(
                 context.child("reporter_restarted"),
-                replay_reporter_cfg,
+                reporter_cfg,
             );
 
             let voter_cfg = Config {

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -89,8 +89,9 @@ mod tests {
     use commonware_runtime::{
         deterministic,
         mocks::{next_pending_sync, DelayedSyncContext, PendingSyncs},
-        reschedule, telemetry::traces::collector::TraceStorage, Clock, Metrics as _, Quota, Runner,
-        Supervisor as _,
+        reschedule,
+        telemetry::traces::collector::TraceStorage,
+        Clock, Metrics as _, Quota, Runner, Supervisor as _,
     };
     use commonware_storage::journal::segmented::variable::{Config as JConfig, Journal};
     use commonware_utils::{sync::Mutex, NZUsize, NZU16};

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -312,8 +312,9 @@
 //! on the critical path. To enable recovery, the `Voter` writes valid messages it receives from
 //! consensus and messages it generates to a write-ahead log (WAL) implemented by [commonware_storage::journal::segmented::variable::Journal].
 //! Before sending a message, any pending `Journal` appends are synced to prevent inadvertent Byzantine
-//! behavior on restart (especially in the case of unclean shutdown). Appends made in the same event
-//! loop iteration are coalesced into a single sync.
+//! behavior on restart (especially in the case of unclean shutdown). All appends made in the same event
+//! loop iteration are coalesced into a single sync that runs after messages are constructed and before
+//! any are broadcast (even if there is nothing to broadcast).
 //!
 //! ## Automaton Failure Semantics
 //!

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -311,8 +311,9 @@
 //! The `Voter` caches all data required to participate in consensus to avoid any disk reads on
 //! on the critical path. To enable recovery, the `Voter` writes valid messages it receives from
 //! consensus and messages it generates to a write-ahead log (WAL) implemented by [commonware_storage::journal::segmented::variable::Journal].
-//! Before sending a message, the `Journal` sync is invoked to prevent inadvertent Byzantine behavior
-//! on restart (especially in the case of unclean shutdown).
+//! Before sending a message, any pending `Journal` appends are synced to prevent inadvertent Byzantine
+//! behavior on restart (especially in the case of unclean shutdown). Appends made in the same event
+//! loop iteration are coalesced into a single sync.
 //!
 //! ## Automaton Failure Semantics
 //!

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -333,9 +333,9 @@
 //! Returning `false` from `verify` means the proposal is permanently invalid and causes a local
 //! nullify. Returning `false` from `certify` means the notarized payload is permanently
 //! uncertifiable for that round and also causes a local nullify. Closing `certify` does not provide
-//! a fast-skip signal and can halt progress because certification requests are not retried. The safe
-//! way to stop working on certification is to keep the request pending until Simplex drops it after
-//! finalizing the block or a descendant.
+//! a fast-skip signal and can halt progress because certification requests are not retried during
+//! the same run. The safe way to stop working on certification is to keep the request pending until
+//! Simplex drops it after finalizing the block or a descendant.
 
 pub mod elector;
 pub mod scheme;

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -341,8 +341,9 @@ pub struct PendingSyncs {
 }
 
 /// Forwards [Supervisor], [Clock], [GovernorClock], [ReasonablyRealtime],
-/// [Metrics], and [BufferPooler] to the wrapped context for test context
-/// wrappers with one extra field (named by the second argument).
+/// [Metrics], [BufferPooler], [TryRng], and [TryCryptoRng] to the wrapped
+/// context for test context wrappers with one extra field (named by the
+/// second argument).
 macro_rules! forward_context {
     ($wrapper:ident, $field:ident) => {
         impl<E: Supervisor> Supervisor for $wrapper<E> {
@@ -419,6 +420,24 @@ macro_rules! forward_context {
                 self.inner.storage_buffer_pool()
             }
         }
+
+        impl<E: TryRng> TryRng for $wrapper<E> {
+            type Error = E::Error;
+
+            fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+                self.inner.try_next_u32()
+            }
+
+            fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+                self.inner.try_next_u64()
+            }
+
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+                self.inner.try_fill_bytes(dest)
+            }
+        }
+
+        impl<E: TryCryptoRng> TryCryptoRng for $wrapper<E> {}
     };
 }
 
@@ -460,24 +479,6 @@ impl<E: Spawner> Spawner for DelayedSyncContext<E> {
         self.inner.stopped()
     }
 }
-
-impl<E: TryRng> TryRng for DelayedSyncContext<E> {
-    type Error = E::Error;
-
-    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
-        self.inner.try_next_u32()
-    }
-
-    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
-        self.inner.try_next_u64()
-    }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
-        self.inner.try_fill_bytes(dest)
-    }
-}
-
-impl<E: TryCryptoRng> TryCryptoRng for DelayedSyncContext<E> {}
 
 impl<E: Storage> Storage for DelayedSyncContext<E> {
     type Blob = DelayedSyncBlob<E::Blob>;

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -333,7 +333,13 @@ pub struct DeferredSync {
     pub blocked: oneshot::Receiver<()>,
 }
 
-/// Syncs deferred by a [DelayedSyncContext] or [DelayedSyncBlob], in the order started.
+/// Coordinates durability operations for a [DelayedSyncContext] or [DelayedSyncBlob].
+///
+/// Every started sync parks in a deferred queue (in start order) until a test
+/// releases it. [Self::arm] additionally installs a one-shot gate that blocks
+/// the next durability operation and counts operations from that point on
+/// ([Self::calls]). The gate is pushed onto the deferred queue when [Self::arm]
+/// is called, before any operation reaches it.
 #[derive(Clone, Default)]
 pub struct PendingSyncs {
     syncs: Arc<Mutex<Vec<DeferredSync>>>,

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -1,9 +1,10 @@
 //! Mock implementations of runtime primitives for testing.
 
 use crate::{
+    signal::Signal,
     telemetry::metrics::{Metric, Registered},
     Blob, BufMut, BufferPool, BufferPooler, Clock, Error, Handle, IoBufs, IoBufsMut, Metrics, Name,
-    Storage, Supervisor,
+    Spawner, Storage, Supervisor,
 };
 use bytes::{Bytes, BytesMut};
 use commonware_utils::{
@@ -11,6 +12,7 @@ use commonware_utils::{
     sync::Mutex,
 };
 use governor::clock::{Clock as GovernorClock, ReasonablyRealtime};
+use rand::{TryCryptoRng, TryRng};
 use std::{future::Future, mem, sync::Arc};
 
 /// Default buffer size (64 KB). Controls both how much data the stream
@@ -332,9 +334,13 @@ pub struct DeferredSync {
 }
 
 /// Syncs deferred by a [DelayedSyncContext] or [DelayedSyncBlob], in the order started.
-pub type PendingSyncs = Arc<Mutex<Vec<DeferredSync>>>;
+#[derive(Clone, Default)]
+pub struct PendingSyncs {
+    syncs: Arc<Mutex<Vec<DeferredSync>>>,
+    gate: Arc<Mutex<SyncGateState>>,
+}
 
-/// Context wrapper whose blobs defer [Blob::start_sync] completion until explicitly released.
+/// Context wrapper whose blobs defer [Blob::start_sync] and can gate blocking syncs in tests.
 #[derive(Clone)]
 pub struct DelayedSyncContext<E> {
     pub inner: E,
@@ -361,6 +367,63 @@ impl<E: Supervisor> Supervisor for DelayedSyncContext<E> {
     }
 }
 
+impl<E: Spawner> Spawner for DelayedSyncContext<E> {
+    fn shared(mut self, blocking: bool) -> Self {
+        self.inner = self.inner.shared(blocking);
+        self
+    }
+
+    fn dedicated(mut self) -> Self {
+        self.inner = self.inner.dedicated();
+        self
+    }
+
+    fn spawn<F, Fut, T>(self, f: F) -> Handle<T>
+    where
+        F: FnOnce(Self) -> Fut + Send + 'static,
+        Fut: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let pending = self.pending;
+        self.inner.spawn(move |inner| f(Self { inner, pending }))
+    }
+
+    async fn stop(self, value: i32, timeout: Option<std::time::Duration>) -> Result<(), Error> {
+        self.inner.stop(value, timeout).await
+    }
+
+    fn stopped(&self) -> Signal {
+        self.inner.stopped()
+    }
+}
+
+impl<E: Clock> Clock for DelayedSyncContext<E> {
+    fn current(&self) -> std::time::SystemTime {
+        self.inner.current()
+    }
+
+    fn sleep(&self, duration: std::time::Duration) -> impl Future<Output = ()> + Send + 'static {
+        self.inner.sleep(duration)
+    }
+
+    fn sleep_until(
+        &self,
+        deadline: std::time::SystemTime,
+    ) -> impl Future<Output = ()> + Send + 'static {
+        self.inner.sleep_until(deadline)
+    }
+}
+
+impl<E: Clock> GovernorClock for DelayedSyncContext<E> {
+    type Instant = std::time::SystemTime;
+
+    fn now(&self) -> Self::Instant {
+        self.current()
+    }
+}
+
+impl<E: Clock> ReasonablyRealtime for DelayedSyncContext<E> {}
+
 impl<E: Metrics> Metrics for DelayedSyncContext<E> {
     fn register<N: Into<String>, H: Into<String>, M: Metric>(
         &self,
@@ -385,6 +448,24 @@ impl<E: BufferPooler> BufferPooler for DelayedSyncContext<E> {
         self.inner.storage_buffer_pool()
     }
 }
+
+impl<E: TryRng> TryRng for DelayedSyncContext<E> {
+    type Error = E::Error;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        self.inner.try_next_u32()
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        self.inner.try_next_u64()
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        self.inner.try_fill_bytes(dest)
+    }
+}
+
+impl<E: TryCryptoRng> TryCryptoRng for DelayedSyncContext<E> {}
 
 impl<E: Storage> Storage for DelayedSyncContext<E> {
     type Blob = DelayedSyncBlob<E::Blob>;
@@ -415,7 +496,7 @@ impl<E: Storage> Storage for DelayedSyncContext<E> {
     }
 }
 
-/// Blob wrapper that parks each started sync until it is explicitly completed.
+/// Blob wrapper that parks each started sync and supports one-shot blocking sync tracking.
 #[derive(Clone)]
 pub struct DelayedSyncBlob<B> {
     inner: B,
@@ -459,7 +540,12 @@ impl<B: Blob> Blob for DelayedSyncBlob<B> {
         offset: u64,
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
-        self.inner.write_at_sync(offset, bufs).await
+        if !self.pending.tracking() {
+            return self.inner.write_at_sync(offset, bufs).await;
+        }
+        self.inner.write_at(offset, bufs).await?;
+        self.pending.wait().await?;
+        self.inner.sync().await
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {
@@ -467,17 +553,22 @@ impl<B: Blob> Blob for DelayedSyncBlob<B> {
     }
 
     async fn sync(&self) -> Result<(), Error> {
+        self.pending.wait().await?;
         self.inner.sync().await
     }
 
     async fn start_sync(&self) -> Handle<()> {
-        let (release, receiver) = oneshot::channel();
-        let (notifier, blocked) = oneshot::channel();
-        self.pending.lock().push(DeferredSync { release, blocked });
+        let pending = self.pending.clone();
         let inner = self.inner.clone();
+        if pending.tracking() {
+            return Handle::from_future(async move {
+                pending.wait().await?;
+                inner.sync().await
+            });
+        }
+        let waiter = pending.defer();
         Handle::from_future(async move {
-            let _ = notifier.send(());
-            receiver.await.map_err(|_| Error::Closed)??;
+            waiter.wait().await?;
             inner.sync().await
         })
     }
@@ -518,6 +609,83 @@ pub fn fail_pending_syncs(pending: &PendingSyncs) {
     for sync in mem::take(&mut *pending.lock()) {
         let err = std::io::Error::other("injected sync failure");
         let _ = sync.release.send(Err(Error::Io(err.into())));
+    }
+}
+
+struct SyncWaiter {
+    entered: oneshot::Sender<()>,
+    release: oneshot::Receiver<Result<(), Error>>,
+}
+
+impl SyncWaiter {
+    async fn wait(self) -> Result<(), Error> {
+        self.entered.send_lossy(());
+        self.release.await.map_err(|_| Error::Closed)??;
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct SyncGateState {
+    tracking: bool,
+    calls: usize,
+    waiter: Option<SyncWaiter>,
+}
+
+impl PendingSyncs {
+    /// Locks the deferred sync queue.
+    pub fn lock(&self) -> commonware_utils::sync::MutexGuard<'_, Vec<DeferredSync>> {
+        self.syncs.lock()
+    }
+
+    /// Begins one-shot tracking of durability operations and blocks the first one.
+    pub fn arm(&self) {
+        let (release, release_rx) = oneshot::channel();
+        let (entered, blocked) = oneshot::channel();
+        let mut state = self.gate.lock();
+        assert!(!state.tracking, "sync gate already armed");
+        assert!(state.waiter.is_none(), "sync gate already has a waiter");
+        state.tracking = true;
+        state.calls = 0;
+        state.waiter = Some(SyncWaiter {
+            entered,
+            release: release_rx,
+        });
+        self.syncs.lock().push(DeferredSync { release, blocked });
+    }
+
+    /// Returns the number of durability operations observed since [Self::arm].
+    pub fn calls(&self) -> usize {
+        self.gate.lock().calls
+    }
+
+    fn tracking(&self) -> bool {
+        self.gate.lock().tracking
+    }
+
+    fn defer(&self) -> SyncWaiter {
+        let (release, release_rx) = oneshot::channel();
+        let (entered, blocked) = oneshot::channel();
+        self.syncs.lock().push(DeferredSync { release, blocked });
+        SyncWaiter {
+            entered,
+            release: release_rx,
+        }
+    }
+
+    async fn wait(&self) -> Result<(), Error> {
+        let waiter = {
+            let mut state = self.gate.lock();
+            if !state.tracking {
+                return Ok(());
+            }
+            state.calls += 1;
+            state.waiter.take()
+        };
+        let Some(waiter) = waiter else {
+            return Ok(());
+        };
+        waiter.wait().await
     }
 }
 

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -340,6 +340,88 @@ pub struct PendingSyncs {
     gate: Arc<Mutex<SyncGateState>>,
 }
 
+/// Forwards [Supervisor], [Clock], [GovernorClock], [ReasonablyRealtime],
+/// [Metrics], and [BufferPooler] to the wrapped context for test context
+/// wrappers with one extra field (named by the second argument).
+macro_rules! forward_context {
+    ($wrapper:ident, $field:ident) => {
+        impl<E: Supervisor> Supervisor for $wrapper<E> {
+            fn name(&self) -> Name {
+                self.inner.name()
+            }
+
+            fn child(&self, label: &'static str) -> Self {
+                Self {
+                    inner: self.inner.child(label),
+                    $field: self.$field.clone(),
+                }
+            }
+
+            fn with_attribute(self, key: &'static str, value: impl std::fmt::Display) -> Self {
+                Self {
+                    inner: self.inner.with_attribute(key, value),
+                    $field: self.$field,
+                }
+            }
+        }
+
+        impl<E: Clock> Clock for $wrapper<E> {
+            fn current(&self) -> std::time::SystemTime {
+                self.inner.current()
+            }
+
+            fn sleep(
+                &self,
+                duration: std::time::Duration,
+            ) -> impl Future<Output = ()> + Send + 'static {
+                self.inner.sleep(duration)
+            }
+
+            fn sleep_until(
+                &self,
+                deadline: std::time::SystemTime,
+            ) -> impl Future<Output = ()> + Send + 'static {
+                self.inner.sleep_until(deadline)
+            }
+        }
+
+        impl<E: Clock> GovernorClock for $wrapper<E> {
+            type Instant = std::time::SystemTime;
+
+            fn now(&self) -> Self::Instant {
+                self.current()
+            }
+        }
+
+        impl<E: Clock> ReasonablyRealtime for $wrapper<E> {}
+
+        impl<E: Metrics> Metrics for $wrapper<E> {
+            fn register<N: Into<String>, H: Into<String>, M: Metric>(
+                &self,
+                name: N,
+                help: H,
+                metric: M,
+            ) -> Registered<M> {
+                self.inner.register(name, help, metric)
+            }
+
+            fn encode(&self) -> String {
+                self.inner.encode()
+            }
+        }
+
+        impl<E: BufferPooler> BufferPooler for $wrapper<E> {
+            fn network_buffer_pool(&self) -> &BufferPool {
+                self.inner.network_buffer_pool()
+            }
+
+            fn storage_buffer_pool(&self) -> &BufferPool {
+                self.inner.storage_buffer_pool()
+            }
+        }
+    };
+}
+
 /// Context wrapper whose blobs defer [Blob::start_sync] and can gate blocking syncs in tests.
 #[derive(Clone)]
 pub struct DelayedSyncContext<E> {
@@ -347,25 +429,7 @@ pub struct DelayedSyncContext<E> {
     pub pending: PendingSyncs,
 }
 
-impl<E: Supervisor> Supervisor for DelayedSyncContext<E> {
-    fn name(&self) -> Name {
-        self.inner.name()
-    }
-
-    fn child(&self, label: &'static str) -> Self {
-        Self {
-            inner: self.inner.child(label),
-            pending: self.pending.clone(),
-        }
-    }
-
-    fn with_attribute(self, key: &'static str, value: impl std::fmt::Display) -> Self {
-        Self {
-            inner: self.inner.with_attribute(key, value),
-            pending: self.pending,
-        }
-    }
-}
+forward_context!(DelayedSyncContext, pending);
 
 impl<E: Spawner> Spawner for DelayedSyncContext<E> {
     fn shared(mut self, blocking: bool) -> Self {
@@ -394,58 +458,6 @@ impl<E: Spawner> Spawner for DelayedSyncContext<E> {
 
     fn stopped(&self) -> Signal {
         self.inner.stopped()
-    }
-}
-
-impl<E: Clock> Clock for DelayedSyncContext<E> {
-    fn current(&self) -> std::time::SystemTime {
-        self.inner.current()
-    }
-
-    fn sleep(&self, duration: std::time::Duration) -> impl Future<Output = ()> + Send + 'static {
-        self.inner.sleep(duration)
-    }
-
-    fn sleep_until(
-        &self,
-        deadline: std::time::SystemTime,
-    ) -> impl Future<Output = ()> + Send + 'static {
-        self.inner.sleep_until(deadline)
-    }
-}
-
-impl<E: Clock> GovernorClock for DelayedSyncContext<E> {
-    type Instant = std::time::SystemTime;
-
-    fn now(&self) -> Self::Instant {
-        self.current()
-    }
-}
-
-impl<E: Clock> ReasonablyRealtime for DelayedSyncContext<E> {}
-
-impl<E: Metrics> Metrics for DelayedSyncContext<E> {
-    fn register<N: Into<String>, H: Into<String>, M: Metric>(
-        &self,
-        name: N,
-        help: H,
-        metric: M,
-    ) -> Registered<M> {
-        self.inner.register(name, help, metric)
-    }
-
-    fn encode(&self) -> String {
-        self.inner.encode()
-    }
-}
-
-impl<E: BufferPooler> BufferPooler for DelayedSyncContext<E> {
-    fn network_buffer_pool(&self) -> &BufferPool {
-        self.inner.network_buffer_pool()
-    }
-
-    fn storage_buffer_pool(&self) -> &BufferPool {
-        self.inner.storage_buffer_pool()
     }
 }
 
@@ -558,15 +570,11 @@ impl<B: Blob> Blob for DelayedSyncBlob<B> {
     }
 
     async fn start_sync(&self) -> Handle<()> {
-        let pending = self.pending.clone();
         let inner = self.inner.clone();
-        if pending.tracking() {
-            return Handle::from_future(async move {
-                pending.wait().await?;
-                inner.sync().await
-            });
-        }
-        let waiter = pending.defer();
+        let waiter = self
+            .pending
+            .observe()
+            .unwrap_or_else(|| self.pending.defer());
         Handle::from_future(async move {
             waiter.wait().await?;
             inner.sync().await
@@ -638,20 +646,18 @@ impl PendingSyncs {
         self.syncs.lock()
     }
 
-    /// Begins one-shot tracking of durability operations and blocks the first one.
+    /// Begins counting durability operations and blocks the next one behind a
+    /// one-shot gate (pushed onto the deferred queue so tests can release it).
+    ///
+    /// Once the gate is consumed, started syncs park in the deferred queue as
+    /// usual while [Self::calls] keeps counting.
     pub fn arm(&self) {
-        let (release, release_rx) = oneshot::channel();
-        let (entered, blocked) = oneshot::channel();
         let mut state = self.gate.lock();
         assert!(!state.tracking, "sync gate already armed");
         assert!(state.waiter.is_none(), "sync gate already has a waiter");
         state.tracking = true;
         state.calls = 0;
-        state.waiter = Some(SyncWaiter {
-            entered,
-            release: release_rx,
-        });
-        self.syncs.lock().push(DeferredSync { release, blocked });
+        state.waiter = Some(self.defer());
     }
 
     /// Returns the number of durability operations observed since [Self::arm].
@@ -673,19 +679,22 @@ impl PendingSyncs {
         }
     }
 
+    /// Records a durability operation if the gate is armed, returning the
+    /// one-shot gate waiter if it has not been consumed yet.
+    fn observe(&self) -> Option<SyncWaiter> {
+        let mut state = self.gate.lock();
+        if !state.tracking {
+            return None;
+        }
+        state.calls += 1;
+        state.waiter.take()
+    }
+
     async fn wait(&self) -> Result<(), Error> {
-        let waiter = {
-            let mut state = self.gate.lock();
-            if !state.tracking {
-                return Ok(());
-            }
-            state.calls += 1;
-            state.waiter.take()
-        };
-        let Some(waiter) = waiter else {
-            return Ok(());
-        };
-        waiter.wait().await
+        match self.observe() {
+            Some(waiter) => waiter.wait().await,
+            None => Ok(()),
+        }
     }
 }
 
@@ -696,77 +705,7 @@ pub struct SyncFaultContext<E> {
     pub fail_partition: String,
 }
 
-impl<E: Supervisor> Supervisor for SyncFaultContext<E> {
-    fn name(&self) -> Name {
-        self.inner.name()
-    }
-
-    fn child(&self, label: &'static str) -> Self {
-        Self {
-            inner: self.inner.child(label),
-            fail_partition: self.fail_partition.clone(),
-        }
-    }
-
-    fn with_attribute(self, key: &'static str, value: impl std::fmt::Display) -> Self {
-        Self {
-            inner: self.inner.with_attribute(key, value),
-            fail_partition: self.fail_partition,
-        }
-    }
-}
-
-impl<E: Metrics> Metrics for SyncFaultContext<E> {
-    fn register<N: Into<String>, H: Into<String>, M: Metric>(
-        &self,
-        name: N,
-        help: H,
-        metric: M,
-    ) -> Registered<M> {
-        self.inner.register(name, help, metric)
-    }
-
-    fn encode(&self) -> String {
-        self.inner.encode()
-    }
-}
-
-impl<E: Clock> Clock for SyncFaultContext<E> {
-    fn current(&self) -> std::time::SystemTime {
-        self.inner.current()
-    }
-
-    fn sleep(&self, duration: std::time::Duration) -> impl Future<Output = ()> + Send + 'static {
-        self.inner.sleep(duration)
-    }
-
-    fn sleep_until(
-        &self,
-        deadline: std::time::SystemTime,
-    ) -> impl Future<Output = ()> + Send + 'static {
-        self.inner.sleep_until(deadline)
-    }
-}
-
-impl<E: Clock> GovernorClock for SyncFaultContext<E> {
-    type Instant = std::time::SystemTime;
-
-    fn now(&self) -> Self::Instant {
-        self.current()
-    }
-}
-
-impl<E: Clock> ReasonablyRealtime for SyncFaultContext<E> {}
-
-impl<E: BufferPooler> BufferPooler for SyncFaultContext<E> {
-    fn network_buffer_pool(&self) -> &BufferPool {
-        self.inner.network_buffer_pool()
-    }
-
-    fn storage_buffer_pool(&self) -> &BufferPool {
-        self.inner.storage_buffer_pool()
-    }
-}
+forward_context!(SyncFaultContext, fail_partition);
 
 impl<E: Storage> Storage for SyncFaultContext<E> {
     type Blob = SyncFaultBlob<E::Blob>;

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -226,12 +226,12 @@ mod tests {
         deterministic,
         mocks::{
             fail_pending_syncs, release_next_pending_syncs, release_pending_syncs,
-            DelayedSyncContext,
+            DelayedSyncContext, PendingSyncs,
         },
         telemetry::metrics::has_metric_value,
         BufferPooler, Error as RError, Metrics as _, Runner, Spawner as _, Supervisor as _,
     };
-    use commonware_utils::{sequence::FixedBytes, sync::Mutex, NZUsize, NZU16, NZU64};
+    use commonware_utils::{sequence::FixedBytes, NZUsize, NZU16, NZU64};
     use rand::RngExt as _;
     use std::{
         collections::BTreeMap,
@@ -278,7 +278,7 @@ mod tests {
     fn test_put_after_start_sync_is_accepted_before_handle_completes() {
         let executor = deterministic::Runner::default();
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -339,7 +339,7 @@ mod tests {
     fn test_duplicate_put_start_sync_observes_in_flight_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -400,7 +400,7 @@ mod tests {
     fn test_overlapping_put_start_sync_waits_for_in_flight_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -461,7 +461,7 @@ mod tests {
     fn test_sync_after_put_start_sync_waits_for_in_flight_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -512,7 +512,7 @@ mod tests {
     fn test_destroy_after_put_start_sync_waits_for_in_flight_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -562,7 +562,7 @@ mod tests {
     fn test_prune_after_put_start_sync_waits_for_in_flight_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -616,7 +616,7 @@ mod tests {
     fn test_prune_surfaces_failed_in_flight_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -651,7 +651,7 @@ mod tests {
     fn test_put_start_sync_after_prune_drops_pruned_sync_requests() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -693,7 +693,7 @@ mod tests {
     fn test_overlapping_put_start_sync_restarts_after_all_handles_complete() {
         let executor = deterministic::Runner::default();
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -740,7 +740,7 @@ mod tests {
     fn test_overlapping_put_start_sync_restarts_only_completed_handles() {
         let executor = deterministic::Runner::default();
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -783,7 +783,7 @@ mod tests {
     fn test_failed_start_sync_is_returned_by_next_start_sync_handle() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -436,10 +436,12 @@ mod tests {
     use commonware_runtime::{
         buffer::paged::CacheRef,
         deterministic,
-        mocks::{fail_pending_syncs, release_pending_syncs, DelayedSyncContext},
+        mocks::{
+            fail_pending_syncs, release_pending_syncs, DelayedSyncContext, PendingSyncs,
+        },
         BufferPooler, Error as RError, Runner, Spawner as _, Supervisor as _,
     };
-    use commonware_utils::{sync::Mutex, NZUsize, NZU16};
+    use commonware_utils::{NZUsize, NZU16};
     use core::num::NonZeroU16;
     use futures::{pin_mut, StreamExt};
     use std::sync::{
@@ -1578,7 +1580,7 @@ mod tests {
     fn test_segmented_fixed_prune_waits_for_in_flight_start_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -1632,7 +1634,7 @@ mod tests {
     fn test_segmented_fixed_destroy_waits_for_in_flight_start_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -1684,7 +1686,7 @@ mod tests {
     fn test_segmented_fixed_clear_waits_for_in_flight_start_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -1746,7 +1748,7 @@ mod tests {
     fn test_segmented_fixed_rewind_waits_for_in_flight_start_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),
@@ -1806,7 +1808,7 @@ mod tests {
     fn test_segmented_fixed_prune_surfaces_failed_in_flight_start_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let pending = Arc::new(Mutex::new(Vec::new()));
+            let pending = PendingSyncs::default();
             let context = DelayedSyncContext {
                 inner: context,
                 pending: pending.clone(),

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -436,9 +436,7 @@ mod tests {
     use commonware_runtime::{
         buffer::paged::CacheRef,
         deterministic,
-        mocks::{
-            fail_pending_syncs, release_pending_syncs, DelayedSyncContext, PendingSyncs,
-        },
+        mocks::{fail_pending_syncs, release_pending_syncs, DelayedSyncContext, PendingSyncs},
         BufferPooler, Error as RError, Runner, Spawner as _, Supervisor as _,
     };
     use commonware_utils::{NZUsize, NZU16};


### PR DESCRIPTION
## Summary

The `Voter` previously synced its WAL once per artifact it was about to share: a single event loop iteration could fsync the same section several times (nullify, notarize, notarization, nullification, finalize, finalization), and certification results paid their own sync on arrival. This PR coalesces all appends made in an event loop iteration into a single `Journal::sync`.

## Design

Every iteration now ends with three explicit phases:

```rust
let staged = self.construct(...).await;           // build + record (journal appends)
self.sync_journal(view).await;                    // the only sync call site
self.notify(..., staged, nullify, certification); // broadcast + report to the application
```

- Every append in an iteration targets the view being processed, so `append_journal` just sets a `dirty` flag and `sync_journal(view)` flushes that one section. The sync runs unconditionally, even when nothing will be broadcast (e.g. an iteration that only records a certification result), and `notify` asserts the flag is clear before sending anything. The single-view invariant is documented on `append_journal` and was verified per event loop arm: certificates append at the view they certify (which is the view returned for notification), the timeout arm's nullify appends at the current view (a nullify vote never advances the view), and `construct` appends only at `view`.
- Message-processing arms never send. The timeout arm constructs and records its nullify vote (and fetches the previous view's best certificate on retry), and the certify arm records the certification result. Both are staged as iteration locals and passed to `notify` alongside the `Staged` messages built by `construct`. Nullify construction cannot move into `construct` because `construct_nullify` is gated by the deadline firing, not by state.
- The nullification "floor" broadcast moved from `process_message` into `prepare_nullification`, keyed to the once-per-view `broadcast_nullification` flag. The old floor plumbing through `handle_nullification`'s return value was dead on the prepare path (`broadcast_nullification` only returns certificates already stored by `add_nullification`), so the relocation is behavior-preserving: same certificate, same iteration, emitted once. `process_message` no longer takes a sender at all.

## Contract change

A certification result is now durable at the end of the iteration that recorded it rather than immediately after the automaton resolves, so an unclean shutdown can lose a resolved-but-unsynced result. On restart, replay leaves the round's certification state unset and `certify_candidates` re-requests it. The `CertifiableAutomaton::certify` docs now state this restart exception, and the same caveat was added to `Automaton::verify` (the identical window has always existed for verification verdicts, whose only durable record is the notarize vote they produce).

## Safety argument

A vote must be durable before it reaches the network so a restart cannot cause equivocation. That invariant is preserved and now enforced structurally: all sends happen in `notify`, which runs strictly after the barrier and asserts the journal is clean. An adversarial review (six dimensions, per-finding refutation panels) confirmed:

- Every append is covered by the barrier in the same iteration (no `continue` path appends), and the shutdown path still runs `sync_all`.
- The batcher has no network egress for votes or certificates: a certificate embedding our vote can only return via the voter mailbox in a later iteration, after the barrier that made the vote durable.
- The resolver serves only floor certificates and nullifications to peers, and promotes notarizations to servable only after certification (a strictly later, post-barrier iteration), so pre-barrier `resolver.updated` calls cannot advertise a certificate embedding a non-durable vote.
- A crash mid-barrier loses only artifacts that were never sent.

This also structurally closes the earlier Bugbot finding (certification artifacts left unsynced when nothing was broadcast).

## Notes

- The `simplex.voter.journal.sync` span now fires once per iteration instead of once per artifact.
- Test infrastructure: `runtime::mocks` gains `PendingSyncs`, a deferred-sync parking queue with a one-shot `arm` gate that blocks the next durability operation and counts operations from that point on (once the gate fires, later syncs park as usual). The new certification-replay restart test uses it to hold the section sync open and observe that certification and finalize share one fsync. Shared context-wrapper trait forwarding is generated by a `forward_context!` macro.
- Verified with the full simplex suite (301 tests), the voter actor module (111), and the slow-profile `unclean_shutdown`/`all_recovery` fixtures (28), all passing.
- Follow-up: no deterministic test pins the construct/sync/notify ordering itself (the assert covers the call graph, not a reordering of the phases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
