### PR TITLE
[runtime] Make buffered writers cancellation-safe; make paged appends synchronous

### DIFF
--- a/runtime/fuzz/fuzz_targets/blob_integrity.rs
+++ b/runtime/fuzz/fuzz_targets/blob_integrity.rs
@@ -118,10 +118,7 @@ fn fuzz(input: FuzzInput) {
             .await
             .expect("cannot create append wrapper");
 
-        append
-            .append(&expected_data)
-            .await
-            .expect("cannot append data");
+        append.append(&expected_data);
         append.sync().await.expect("cannot sync");
         drop(append);
 

--- a/runtime/fuzz/fuzz_targets/buffer.rs
+++ b/runtime/fuzz/fuzz_targets/buffer.rs
@@ -255,7 +255,7 @@ fn fuzz(input: FuzzInput) {
                         };
                         let current_size = append.size();
                         if current_size.checked_add(data.len() as u64).is_some() {
-                            let _ = append.append(&data).await;
+                            append.append(&data);
                         }
                     }
                 }

--- a/runtime/src/utils/buffer/benches/append.rs
+++ b/runtime/src/utils/buffer/benches/append.rs
@@ -29,7 +29,7 @@ where
                     for _ in 0..iters {
                         // Write double the bytes that can be held by the cache.
                         for _ in 0..(CACHE_SIZE * PAGE_SIZE.get() as usize / chunk_size) * 2 {
-                            append.append(&data).await.unwrap();
+                            append.append(&data);
                         }
                     }
                     let elapsed = start.elapsed();

--- a/runtime/src/utils/buffer/benches/read.rs
+++ b/runtime/src/utils/buffer/benches/read.rs
@@ -31,7 +31,7 @@ where
                     // Setup: populate the blob
                     let mut append = create_append(&ctx, &name, cache_ref.clone()).await;
                     let data = vec![0xABu8; TOTAL_SIZE];
-                    append.append(&data).await.unwrap();
+                    append.append(&data);
                     append.sync().await.unwrap();
                     drop(append);
 

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -46,22 +46,23 @@ enum State {
     Pending(Completion),
 }
 
-/// Tracks whether blob mutations still need a sync and whether an issued resize is still owed.
+/// Tracks whether blob mutations still need a sync and whether a resize still needs to be
+/// applied.
 ///
 /// Callers rely on four properties:
-/// - Every operation that mutates the blob first waits for an in-flight sync, so a started
-///   sync's coverage is never disturbed by later writes.
-/// - [SyncState::start_sync] while a sync is in flight returns that sync's handle (completed
-///   syncs resolve immediately), so re-requesting a sync is a cheap way to observe outstanding
-///   work.
-/// - A failure is never lost: every handle cloned from the shared completion reports it, and
-///   an unobserved failure surfaces from [SyncState::wait_for_pending] on the next operation,
-///   which also marks the state dirty since the mutations still need durability.
-/// - A dropped [SyncState::resize] is never lost: the intended length is recorded before the
-///   resize is awaited, and every later operation re-issues it (see [SyncState::settle])
-///   before touching the blob. Callers may therefore adopt a resize in memory before awaiting
-///   it. A resize that returns an error keeps the intent recorded, but errors are fatal:
-///   callers must not keep using the writer after one.
+/// 1. Every operation that mutates the blob first waits for an in-flight sync, so a started
+///    sync's coverage is never disturbed by later writes.
+/// 2. [SyncState::start_sync] while a sync is in flight returns that sync's handle (completed
+///    syncs resolve immediately), so re-requesting a sync is a cheap way to observe
+///    outstanding work.
+/// 3. A failure is never lost: every handle cloned from the shared completion reports it, and
+///    an unobserved failure surfaces from [SyncState::wait_for_pending] on the next operation,
+///    which also marks the state dirty since the mutations still need durability.
+/// 4. A dropped [SyncState::resize] is never lost: the intended length is recorded before the
+///    resize is awaited, and every later operation re-issues it (see [SyncState::settle])
+///    before touching the blob. Callers may therefore adopt a resize in memory before awaiting
+///    it. A resize that returns an error keeps the intent recorded, but errors are fatal:
+///    callers must not keep using the writer after one.
 struct SyncState {
     /// Durability of already-issued mutations.
     state: State,

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -176,9 +176,16 @@ impl SyncState {
 
     /// Resize the blob and require a later sync.
     async fn resize(&mut self, blob: &impl crate::Blob, len: u64) -> Result<(), crate::Error> {
+        // A grow must not replace an incomplete shrink. Growing zero-fills the new bytes, so
+        // the bytes the shrink would have removed must not survive it: finish the shrink
+        // first. A resize to an equal or smaller size removes at least as much as the
+        // incomplete one would have, so it can simply take its place.
+        if matches!(self.pending_resize, Some(incomplete) if incomplete < len) {
+            self.settle(blob).await?;
+        }
+
         // Record the intent before any await so a dropped resize is re-issued by the next
-        // operation. A newer resize overwrites an unsettled intent: resizes are absolute, so
-        // the skipped intermediate size was never observable.
+        // operation.
         self.pending_resize = Some(len);
         self.wait_for_pending().await?;
         self.mark_dirty();
@@ -201,7 +208,7 @@ impl SyncState {
 
     /// Start making pending mutations durable and return a handle for completion.
     async fn start_sync(&mut self, blob: &impl crate::Blob) -> crate::Handle<()> {
-        // An owed resize must reach the blob before the sync that covers it starts.
+        // An incomplete resize must reach the blob before the sync that covers it starts.
         if let Err(err) = self.settle(blob).await {
             return crate::Handle::ready(Err(err));
         }
@@ -1381,6 +1388,39 @@ mod tests {
             assert_eq!(size, 5);
             let read = blob.read_at(0, 5).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), b"hello");
+        });
+    }
+
+    // A grow after a canceled shrink must not resurrect the bytes the shrink removed:
+    // everything above the shrunken size reads as zeros.
+    #[test_traced]
+    fn test_write_grow_after_canceled_shrink_zeros() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, gate) = GatedResizeBlob::new(inner.clone(), GatePosition::Before);
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
+
+            writer.write_at(0, b"hello").await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Cancel the shrink before it reaches the blob; the writer claims size 3.
+            gate.cancel(writer.resize(3)).await;
+            assert_eq!(writer.size(), 3);
+            assert_eq!(inner.size(), 5);
+
+            // Grow to 10: bytes [3, 10) must read as zeros per the Blob::resize contract.
+            writer.resize(10).await.unwrap();
+            assert_eq!(writer.size(), 10);
+            let read = writer.read_at(0, 10).await.unwrap().coalesce();
+            assert_eq!(&read.as_ref()[..3], b"hel");
+            assert_eq!(&read.as_ref()[3..], &[0; 7]);
+
+            // The zeroing is durable.
+            writer.sync().await.unwrap();
+            let (durable, _, _, _) = inner.snapshot();
+            assert_eq!(&durable[..3], b"hel");
+            assert_eq!(&durable[3..], &[0; 7]);
         });
     }
 

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -36,18 +36,8 @@ impl From<crate::Handle<()>> for Completion {
     }
 }
 
-/// Tracks whether blob mutations still need a sync.
-///
-/// Callers rely on three properties:
-/// - Every operation that mutates the blob first waits for an in-flight sync, so a started
-///   sync's coverage is never disturbed by later writes.
-/// - [SyncState::start_sync] on a [SyncState::Pending] state returns the in-flight sync's
-///   handle (completed syncs resolve immediately), so re-requesting a sync is a cheap way to
-///   observe outstanding work.
-/// - A failure is never lost: every handle cloned from the shared completion reports it, and
-///   an unobserved failure surfaces from [SyncState::wait_for_pending] on the next operation,
-///   which also marks the state [SyncState::Dirty] since the mutations still need durability.
-enum SyncState {
+/// Durability of already-issued blob mutations.
+enum State {
     // No unsynced mutations.
     Clean,
     // Unsynced mutations need a sync.
@@ -56,32 +46,89 @@ enum SyncState {
     Pending(Completion),
 }
 
+/// Tracks whether blob mutations still need a sync and whether an issued resize is still owed.
+///
+/// Callers rely on four properties:
+/// - Every operation that mutates the blob first waits for an in-flight sync, so a started
+///   sync's coverage is never disturbed by later writes.
+/// - [SyncState::start_sync] while a sync is in flight returns that sync's handle (completed
+///   syncs resolve immediately), so re-requesting a sync is a cheap way to observe outstanding
+///   work.
+/// - A failure is never lost: every handle cloned from the shared completion reports it, and
+///   an unobserved failure surfaces from [SyncState::wait_for_pending] on the next operation,
+///   which also marks the state dirty since the mutations still need durability.
+/// - A dropped [SyncState::resize] is never lost: the intended length is recorded before the
+///   resize is awaited, and every later operation re-issues it (see [SyncState::settle])
+///   before touching the blob. Callers may therefore adopt a resize in memory before awaiting
+///   it. A resize that returns an error keeps the intent recorded, but errors are fatal:
+///   callers must not keep using the writer after one.
+struct SyncState {
+    /// Durability of already-issued mutations.
+    state: State,
+
+    /// A resize issued but not yet known to have completed.
+    pending_resize: Option<u64>,
+}
+
 impl SyncState {
+    /// A state whose blob has mutations needing a sync.
+    const fn dirty() -> Self {
+        Self {
+            state: State::Dirty,
+            pending_resize: None,
+        }
+    }
+
+    /// A state whose blob has no unsynced mutations.
+    const fn clean() -> Self {
+        Self {
+            state: State::Clean,
+            pending_resize: None,
+        }
+    }
+
     /// Mark a new unsynced mutation.
     fn mark_dirty(&mut self) {
         assert!(
-            !matches!(self, Self::Pending(_)),
+            !matches!(self.state, State::Pending(_)),
             "pending sync must be joined before marking dirty"
         );
-        *self = Self::Dirty;
+        self.state = State::Dirty;
     }
 
     /// Wait for an in-flight sync before reusing or mutating the blob.
     async fn wait_for_pending(&mut self) -> Result<(), crate::Error> {
-        let Self::Pending(pending) = self else {
+        let State::Pending(pending) = &self.state else {
             return Ok(());
         };
         match pending.wait().await {
             Ok(()) => {
-                *self = Self::Clean;
+                self.state = State::Clean;
                 Ok(())
             }
             Err(err) => {
                 // The sync failed, so the pending mutations still need durability.
-                *self = Self::Dirty;
+                self.state = State::Dirty;
                 Err(err)
             }
         }
+    }
+
+    /// Re-issue a resize whose completion was never observed.
+    ///
+    /// [crate::Blob::resize] sets an absolute size, so re-issuing is a no-op if the dropped
+    /// resize actually completed.
+    async fn settle(&mut self, blob: &impl crate::Blob) -> Result<(), crate::Error> {
+        let Some(len) = self.pending_resize else {
+            return Ok(());
+        };
+        self.wait_for_pending().await?;
+        // Mark dirty so the re-issued resize is covered by the next sync even if the state
+        // was clean (a resize dropped while waiting on an in-flight sync leaves it clean).
+        self.mark_dirty();
+        blob.resize(len).await?;
+        self.pending_resize = None;
+        Ok(())
     }
 
     /// Write data that will require a later sync.
@@ -92,6 +139,7 @@ impl SyncState {
         bufs: impl Into<crate::IoBufs> + Send,
     ) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
+        self.settle(blob).await?;
         self.mark_dirty();
         blob.write_at(offset, bufs).await?;
         Ok(())
@@ -105,56 +153,67 @@ impl SyncState {
         bufs: impl Into<crate::IoBufs> + Send,
     ) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
-        match self {
-            Self::Dirty => {
+        self.settle(blob).await?;
+        match self.state {
+            State::Dirty => {
                 // Earlier mutations need a full durability barrier too.
                 blob.write_at(offset, bufs).await?;
                 blob.sync().await?;
-                *self = Self::Clean;
+                self.state = State::Clean;
                 Ok(())
             }
-            Self::Clean => {
+            State::Clean => {
                 // If this fails, a later sync must still cover the attempted write.
                 self.mark_dirty();
                 blob.write_at_sync(offset, bufs).await?;
-                *self = Self::Clean;
+                self.state = State::Clean;
                 Ok(())
             }
-            Self::Pending(_) => unreachable!("pending sync waited above"),
+            State::Pending(_) => unreachable!("pending sync waited above"),
         }
     }
 
     /// Resize the blob and require a later sync.
     async fn resize(&mut self, blob: &impl crate::Blob, len: u64) -> Result<(), crate::Error> {
+        // Record the intent before any await so a dropped resize is re-issued by the next
+        // operation. A newer resize overwrites an unsettled intent: resizes are absolute, so
+        // the skipped intermediate size was never observable.
+        self.pending_resize = Some(len);
         self.wait_for_pending().await?;
         self.mark_dirty();
         blob.resize(len).await?;
+        self.pending_resize = None;
         Ok(())
     }
 
     /// Make all pending mutations durable before returning.
     async fn sync(&mut self, blob: &impl crate::Blob) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
-        if matches!(self, Self::Clean) {
+        self.settle(blob).await?;
+        if matches!(self.state, State::Clean) {
             return Ok(());
         }
         blob.sync().await?;
-        *self = Self::Clean;
+        self.state = State::Clean;
         Ok(())
     }
 
     /// Start making pending mutations durable and return a handle for completion.
     async fn start_sync(&mut self, blob: &impl crate::Blob) -> crate::Handle<()> {
-        match self {
-            Self::Clean => crate::Handle::ready(Ok(())),
-            Self::Dirty => {
+        // An owed resize must reach the blob before the sync that covers it starts.
+        if let Err(err) = self.settle(blob).await {
+            return crate::Handle::ready(Err(err));
+        }
+        match &self.state {
+            State::Clean => crate::Handle::ready(Ok(())),
+            State::Dirty => {
                 // Store a shared completion so repeated calls observe the same sync.
                 let pending = Completion::from(blob.start_sync().await);
                 let handle = pending.handle();
-                *self = Self::Pending(pending);
+                self.state = State::Pending(pending);
                 handle
             }
-            Self::Pending(pending) => pending.handle(),
+            State::Pending(pending) => pending.handle(),
         }
     }
 }
@@ -405,21 +464,32 @@ mod tests {
         }
     }
 
-    /// Blob wrapper whose [Gate] parks the next resize after the inner resize completes: a
-    /// canceled caller did the work but never observed it.
+    /// Where [GatedResizeBlob]'s gate sits relative to the inner resize.
+    #[derive(Clone, Copy)]
+    pub enum GatePosition {
+        /// Park before the inner resize runs: a canceled caller never did the work.
+        Before,
+        /// Park after the inner resize completes: a canceled caller did the work but never
+        /// observed it.
+        After,
+    }
+
+    /// Blob wrapper whose [Gate] parks the next resize at the given [GatePosition].
     #[derive(Clone)]
     pub struct GatedResizeBlob<B: crate::Blob> {
         inner: B,
         gate: Gate,
+        position: GatePosition,
     }
 
     impl<B: crate::Blob> GatedResizeBlob<B> {
-        pub fn new(inner: B) -> (Self, Gate) {
+        pub fn new(inner: B, position: GatePosition) -> (Self, Gate) {
             let gate = Gate::default();
             (
                 Self {
                     inner,
                     gate: gate.clone(),
+                    position,
                 },
                 gate,
             )
@@ -453,8 +523,13 @@ mod tests {
         }
 
         async fn resize(&self, len: u64) -> Result<(), Error> {
+            if matches!(self.position, GatePosition::Before) {
+                self.gate.pass_once().await;
+            }
             self.inner.resize(len).await?;
-            self.gate.pass_once().await;
+            if matches!(self.position, GatePosition::After) {
+                self.gate.pass_once().await;
+            }
             Ok(())
         }
 
@@ -1308,14 +1383,14 @@ mod tests {
         });
     }
 
-    // If a resize is canceled during the blob resize itself, the writer keeps its old size and
-    // a retry completes.
+    // If a shrink is canceled after the blob resize landed, the writer already adopted the
+    // shorter size: the claimed range stays readable and a sync makes the shrink durable.
     #[test_traced]
-    fn test_write_resize_cancel_preserves_size() {
+    fn test_write_shrink_cancel_after_resize_stays_consistent() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let inner = SyncTrackingBlob::new();
-            let (blob, gate) = GatedResizeBlob::new(inner.clone());
+            let (blob, gate) = GatedResizeBlob::new(inner.clone(), GatePosition::After);
             let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
 
             writer.write_at(0, b"hello").await.unwrap();
@@ -1324,13 +1399,84 @@ mod tests {
             // Cancel while the completed blob resize is held open.
             gate.cancel(writer.resize(3)).await;
 
-            // The tip was never adjusted, so the writer still claims the old size; the blob
-            // range past the new size is indeterminate until the resize is retried.
-            assert_eq!(writer.size(), 5);
-            writer.resize(3).await.unwrap();
+            // The writer adopted the shorter size before the resize, so it agrees with the
+            // truncated blob and the claimed range stays readable.
             assert_eq!(writer.size(), 3);
+            assert_eq!(inner.size(), 3);
+            let read = writer.read_at(0, 3).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"hel");
+
+            // A later sync covers the landed resize.
+            writer.sync().await.unwrap();
+            let (durable, _, _, _) = inner.snapshot();
+            assert_eq!(durable.as_slice(), b"hel");
+        });
+    }
+
+    // If a shrink is canceled before the blob resize runs, the writer already adopted the
+    // shorter size, and the next blob operation re-issues the resize.
+    #[test_traced]
+    fn test_write_shrink_cancel_before_resize_settles_on_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, gate) = GatedResizeBlob::new(inner.clone(), GatePosition::Before);
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
+
+            writer.write_at(0, b"hello").await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Cancel while the resize is parked before reaching the blob.
+            gate.cancel(writer.resize(3)).await;
+
+            // The writer claims the shorter size, but the blob was never truncated.
+            assert_eq!(writer.size(), 3);
+            assert_eq!(inner.size(), 5);
+
+            // A plain sync re-issues the dropped resize and makes it durable.
             writer.sync().await.unwrap();
             assert_eq!(inner.size(), 3);
+            let (durable, _, _, _) = inner.snapshot();
+            assert_eq!(durable.as_slice(), b"hel");
+        });
+    }
+
+    // If a shrink is canceled while waiting on an in-flight started sync, the recorded resize
+    // survives the wait's clean transition and is re-issued by the next sync.
+    #[test_traced]
+    fn test_write_shrink_cancel_at_pending_sync_settles() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, pending) = DelayedSyncBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
+
+            writer.write_at(0, b"hello").await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Dirty the state, then hold a started sync open.
+            writer.write_at(0, b"h").await.unwrap();
+            let handle = writer.start_sync().await;
+            let deferred = next_pending_sync(&pending);
+
+            // The shrink parks waiting on the started sync. Cancel it there: the blob was
+            // never resized, but the intent is already recorded.
+            {
+                let resize = writer.resize(3);
+                futures::pin_mut!(resize);
+                assert!(resize.as_mut().now_or_never().is_none());
+            }
+            assert_eq!(writer.size(), 3);
+            assert_eq!(inner.size(), 5);
+
+            // Release the started sync; the next sync joins it, re-issues the dropped
+            // resize, and makes it durable.
+            deferred.release.send(Ok(())).unwrap();
+            handle.await.unwrap();
+            writer.sync().await.unwrap();
+            assert_eq!(inner.size(), 3);
+            let (durable, _, _, _) = inner.snapshot();
+            assert_eq!(durable.as_slice(), b"hel");
         });
     }
 

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -365,10 +365,19 @@ mod tests {
         }
     }
 
-    /// One-shot gate a blob wrapper can park on, so tests can cancel an operation mid-flight.
+    /// Parks one blob operation mid-flight so a test can cancel it at a precise point.
     ///
-    /// Starts unarmed, so gated operations pass through until [Self::cancel] arms the gate for
-    /// a single operation.
+    /// Cancellation tests follow the same three steps:
+    ///
+    /// 1. Wrap the blob in [GatedWriteBlob] or [GatedResizeBlob] and hand the wrapper to the
+    ///    writer under test. The gate starts unarmed, so setup traffic passes straight
+    ///    through to the wrapped blob.
+    /// 2. Call [Self::cancel] with the operation to interrupt, e.g.
+    ///    `gate.cancel(writer.resize(3))`. This arms the gate, polls the operation until it
+    ///    parks at the gated blob call, then drops it, exactly as if the caller had dropped
+    ///    the future at that await point.
+    /// 3. Assert on what the canceled operation left behind: the writer's in-memory claims,
+    ///    the wrapped blob's contents, and whether a retry or a later sync recovers.
     #[derive(Clone, Default)]
     pub struct Gate {
         started: Arc<Mutex<Option<oneshot::Sender<()>>>>,
@@ -376,8 +385,11 @@ mod tests {
     }
 
     impl Gate {
-        /// Arm the gate: the next gated operation signals the returned `started` receiver,
-        /// then parks until the returned `release` sender is used or dropped.
+        /// Arm the gate for the next gated operation.
+        ///
+        /// Returns two channel ends for the driver: `started` fires when an operation
+        /// reaches the gate (proof it parked there rather than somewhere earlier), and
+        /// `release` un-parks the operation when used or dropped.
         fn arm(&self) -> (oneshot::Receiver<()>, oneshot::Sender<()>) {
             let (started_tx, started_rx) = oneshot::channel();
             let (release_tx, release_rx) = oneshot::channel();
@@ -386,7 +398,9 @@ mod tests {
             (started_rx, release_tx)
         }
 
-        /// Signal and park on an armed gate, or pass through an unarmed one.
+        /// The gate point. Gated wrappers call this inside the operation they gate: if the
+        /// gate is armed this signals `started` and parks until released; if not, it returns
+        /// immediately. Arming is one-shot, so only the first gated operation parks.
         pub async fn pass_once(&self) {
             let started = self.started.lock().take();
             let release = self.release.lock().take();
@@ -398,11 +412,13 @@ mod tests {
             }
         }
 
-        /// Arm the gate, drive `fut` until it parks at the gate, then drop it to simulate
-        /// cancellation.
+        /// Cancel `fut` at the gate: arm the gate, poll `fut` once so it runs up to the gated
+        /// blob call and parks there, confirm via `started` that it reached the gate, then
+        /// drop it. Dropping the parked future is the cancellation; the writer sees an
+        /// operation abandoned exactly at that blob call.
         ///
-        /// Polls once, so every await before the gate must complete within that poll (true on
-        /// the deterministic runtime).
+        /// Polls only once, so every await before the gate must complete within that poll
+        /// (true on the deterministic runtime).
         pub async fn cancel<F: futures::Future>(&self, fut: F) {
             let (started, _release) = self.arm();
             futures::pin_mut!(fut);
@@ -411,7 +427,10 @@ mod tests {
         }
     }
 
-    /// Blob wrapper whose [Gate] parks the next write before it reaches the blob.
+    /// Blob wrapper that parks the next `write_at`/`write_at_sync` at its [Gate], just before
+    /// the write reaches the wrapped blob. All other operations pass through untouched.
+    ///
+    /// Canceling a future parked here models a write dropped before any bytes hit the blob.
     #[derive(Clone)]
     pub struct GatedWriteBlob<B: crate::Blob> {
         inner: B,
@@ -472,17 +491,21 @@ mod tests {
         }
     }
 
-    /// Where [GatedResizeBlob]'s gate sits relative to the inner resize.
+    /// Which side of the wrapped operation a gated blob parks on. The two positions model
+    /// the two ways a canceled operation can relate to the disk.
     #[derive(Clone, Copy)]
     pub enum GatePosition {
-        /// Park before the inner resize runs: a canceled caller never did the work.
+        /// Park before the inner operation runs. Canceling here models a future dropped
+        /// before its I/O reached the blob: the work never happened.
         Before,
-        /// Park after the inner resize completes: a canceled caller did the work but never
-        /// observed it.
+        /// Park after the inner operation completes. Canceling here models a future dropped
+        /// after its I/O was applied but before the caller could observe the result: the
+        /// work happened, but nothing in memory knows.
         After,
     }
 
-    /// Blob wrapper whose [Gate] parks the next resize at the given [GatePosition].
+    /// Blob wrapper that parks the next `resize` at its [Gate], on the side of the wrapped
+    /// resize chosen by [GatePosition]. All other operations pass through untouched.
     #[derive(Clone)]
     pub struct GatedResizeBlob<B: crate::Blob> {
         inner: B,
@@ -1404,12 +1427,15 @@ mod tests {
             writer.write_at(0, b"hello").await.unwrap();
             writer.sync().await.unwrap();
 
-            // Cancel the shrink before it reaches the blob; the writer claims size 3.
+            // Cancel the shrink before it reaches the blob. The intent was recorded before
+            // the blob call, so the writer claims size 3 while the blob still holds 5 bytes.
             gate.cancel(writer.resize(3)).await;
             assert_eq!(writer.size(), 3);
             assert_eq!(inner.size(), 5);
 
             // Grow to 10: bytes [3, 10) must read as zeros per the Blob::resize contract.
+            // The grow must settle the owed shrink first; resizing the 5-byte blob straight
+            // to 10 would let "lo" survive inside the supposedly zeroed range.
             writer.resize(10).await.unwrap();
             assert_eq!(writer.size(), 10);
             let read = writer.read_at(0, 10).await.unwrap().coalesce();

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -378,10 +378,15 @@ mod tests {
     ///    the future at that await point.
     /// 3. Assert on what the canceled operation left behind: the writer's in-memory claims,
     ///    the wrapped blob's contents, and whether a retry or a later sync recovers.
+    ///
+    /// Two knobs refine where the cancellation lands: [GatePosition] chooses which side of
+    /// the blob call the future parks on (i.e. whether the canceled operation reached the
+    /// disk), and [Self::set_skip] chooses which of several gated calls parks.
     #[derive(Clone, Default)]
     pub struct Gate {
         started: Arc<Mutex<Option<oneshot::Sender<()>>>>,
         release: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
+        skip: Arc<Mutex<usize>>,
     }
 
     impl Gate {
@@ -398,10 +403,26 @@ mod tests {
             (started_rx, release_tx)
         }
 
+        /// Let the next `n` gated operations pass through an armed gate before it parks one.
+        ///
+        /// Used when the operation under test makes several gated blob calls and the test
+        /// wants to cancel at a specific one, e.g. `set_skip(2)` parks the third call.
+        pub fn set_skip(&self, n: usize) {
+            *self.skip.lock() = n;
+        }
+
         /// The gate point. Gated wrappers call this inside the operation they gate: if the
-        /// gate is armed this signals `started` and parks until released; if not, it returns
-        /// immediately. Arming is one-shot, so only the first gated operation parks.
+        /// gate is armed (and the skip budget is spent) this signals `started` and parks
+        /// until released; otherwise it returns immediately. Arming is one-shot, so only
+        /// one gated operation parks.
         pub async fn pass_once(&self) {
+            {
+                let mut skip = self.skip.lock();
+                if *skip > 0 {
+                    *skip -= 1;
+                    return;
+                }
+            }
             let started = self.started.lock().take();
             let release = self.release.lock().take();
             if let Some(started) = started {
@@ -427,23 +448,24 @@ mod tests {
         }
     }
 
-    /// Blob wrapper that parks the next `write_at`/`write_at_sync` at its [Gate], just before
-    /// the write reaches the wrapped blob. All other operations pass through untouched.
-    ///
-    /// Canceling a future parked here models a write dropped before any bytes hit the blob.
+    /// Blob wrapper that parks the next `write_at`/`write_at_sync` at its [Gate], on the side
+    /// of the wrapped write chosen by [GatePosition]. All other operations pass through
+    /// untouched.
     #[derive(Clone)]
     pub struct GatedWriteBlob<B: crate::Blob> {
         inner: B,
         gate: Gate,
+        position: GatePosition,
     }
 
     impl<B: crate::Blob> GatedWriteBlob<B> {
-        pub fn new(inner: B) -> (Self, Gate) {
+        pub fn new(inner: B, position: GatePosition) -> (Self, Gate) {
             let gate = Gate::default();
             (
                 Self {
                     inner,
                     gate: gate.clone(),
+                    position,
                 },
                 gate,
             )
@@ -465,8 +487,14 @@ mod tests {
         }
 
         async fn write_at(&self, offset: u64, buf: impl Into<IoBufs> + Send) -> Result<(), Error> {
-            self.gate.pass_once().await;
-            self.inner.write_at(offset, buf).await
+            if matches!(self.position, GatePosition::Before) {
+                self.gate.pass_once().await;
+            }
+            self.inner.write_at(offset, buf).await?;
+            if matches!(self.position, GatePosition::After) {
+                self.gate.pass_once().await;
+            }
+            Ok(())
         }
 
         async fn write_at_sync(
@@ -474,8 +502,14 @@ mod tests {
             offset: u64,
             buf: impl Into<IoBufs> + Send,
         ) -> Result<(), Error> {
-            self.gate.pass_once().await;
-            self.inner.write_at_sync(offset, buf).await
+            if matches!(self.position, GatePosition::Before) {
+                self.gate.pass_once().await;
+            }
+            self.inner.write_at_sync(offset, buf).await?;
+            if matches!(self.position, GatePosition::After) {
+                self.gate.pass_once().await;
+            }
+            Ok(())
         }
 
         async fn resize(&self, len: u64) -> Result<(), Error> {
@@ -1262,7 +1296,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let inner = SyncTrackingBlob::new();
-            let (blob, gate) = GatedWriteBlob::new(inner.clone());
+            let (blob, gate) = GatedWriteBlob::new(inner.clone(), GatePosition::Before);
             let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(10));
 
             writer.write_at(0, b"abcdefghij").await.unwrap();
@@ -1369,7 +1403,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let inner = SyncTrackingBlob::new();
-            let (blob, gate) = GatedWriteBlob::new(inner.clone());
+            let (blob, gate) = GatedWriteBlob::new(inner.clone(), GatePosition::Before);
             let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
 
             writer.write_at(0, b"hello").await.unwrap();
@@ -1553,7 +1587,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let inner = SyncTrackingBlob::new();
-            let (blob, gate) = GatedWriteBlob::new(inner.clone());
+            let (blob, gate) = GatedWriteBlob::new(inner.clone(), GatePosition::Before);
             let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
 
             writer.write_at(0, b"hello").await.unwrap();
@@ -2218,7 +2252,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let inner = SyncTrackingBlob::new();
-            let (blob, gate) = GatedWriteBlob::new(inner.clone());
+            let (blob, gate) = GatedWriteBlob::new(inner.clone(), GatePosition::Before);
             let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
             // Clear the constructor's dirty state so the canceled sync takes the
             // write-and-sync-in-one path.

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -37,7 +37,7 @@ impl From<crate::Handle<()>> for Completion {
 }
 
 /// Durability of already-issued blob mutations.
-enum State {
+enum Status {
     // No unsynced mutations.
     Clean,
     // Unsynced mutations need a sync.
@@ -65,7 +65,7 @@ enum State {
 ///    callers must not keep using the writer after one.
 struct SyncState {
     /// Durability of already-issued mutations.
-    state: State,
+    status: Status,
 
     /// A resize issued but not yet known to have completed.
     pending_resize: Option<u64>,
@@ -75,7 +75,7 @@ impl SyncState {
     /// A state whose blob has mutations needing a sync.
     const fn dirty() -> Self {
         Self {
-            state: State::Dirty,
+            status: Status::Dirty,
             pending_resize: None,
         }
     }
@@ -83,7 +83,7 @@ impl SyncState {
     /// A state whose blob has no unsynced mutations.
     const fn clean() -> Self {
         Self {
-            state: State::Clean,
+            status: Status::Clean,
             pending_resize: None,
         }
     }
@@ -91,25 +91,25 @@ impl SyncState {
     /// Mark a new unsynced mutation.
     fn mark_dirty(&mut self) {
         assert!(
-            !matches!(self.state, State::Pending(_)),
+            !matches!(self.status, Status::Pending(_)),
             "pending sync must be joined before marking dirty"
         );
-        self.state = State::Dirty;
+        self.status = Status::Dirty;
     }
 
     /// Wait for an in-flight sync before reusing or mutating the blob.
     async fn wait_for_pending(&mut self) -> Result<(), crate::Error> {
-        let State::Pending(pending) = &self.state else {
+        let Status::Pending(pending) = &self.status else {
             return Ok(());
         };
         match pending.wait().await {
             Ok(()) => {
-                self.state = State::Clean;
+                self.status = Status::Clean;
                 Ok(())
             }
             Err(err) => {
                 // The sync failed, so the pending mutations still need durability.
-                self.state = State::Dirty;
+                self.status = Status::Dirty;
                 Err(err)
             }
         }
@@ -155,22 +155,22 @@ impl SyncState {
     ) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
         self.settle(blob).await?;
-        match self.state {
-            State::Dirty => {
+        match self.status {
+            Status::Dirty => {
                 // Earlier mutations need a full durability barrier too.
                 blob.write_at(offset, bufs).await?;
                 blob.sync().await?;
-                self.state = State::Clean;
+                self.status = Status::Clean;
                 Ok(())
             }
-            State::Clean => {
+            Status::Clean => {
                 // If this fails, a later sync must still cover the attempted write.
                 self.mark_dirty();
                 blob.write_at_sync(offset, bufs).await?;
-                self.state = State::Clean;
+                self.status = Status::Clean;
                 Ok(())
             }
-            State::Pending(_) => unreachable!("pending sync waited above"),
+            Status::Pending(_) => unreachable!("pending sync waited above"),
         }
     }
 
@@ -198,11 +198,11 @@ impl SyncState {
     async fn sync(&mut self, blob: &impl crate::Blob) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
         self.settle(blob).await?;
-        if matches!(self.state, State::Clean) {
+        if matches!(self.status, Status::Clean) {
             return Ok(());
         }
         blob.sync().await?;
-        self.state = State::Clean;
+        self.status = Status::Clean;
         Ok(())
     }
 
@@ -212,16 +212,16 @@ impl SyncState {
         if let Err(err) = self.settle(blob).await {
             return crate::Handle::ready(Err(err));
         }
-        match &self.state {
-            State::Clean => crate::Handle::ready(Ok(())),
-            State::Dirty => {
+        match &self.status {
+            Status::Clean => crate::Handle::ready(Ok(())),
+            Status::Dirty => {
                 // Store a shared completion so repeated calls observe the same sync.
                 let pending = Completion::from(blob.start_sync().await);
                 let handle = pending.handle();
-                self.state = State::Pending(pending);
+                self.status = Status::Pending(pending);
                 handle
             }
-            State::Pending(pending) => pending.handle(),
+            Status::Pending(pending) => pending.handle(),
         }
     }
 }

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -92,8 +92,8 @@ impl SyncState {
         bufs: impl Into<crate::IoBufs> + Send,
     ) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
-        blob.write_at(offset, bufs).await?;
         self.mark_dirty();
+        blob.write_at(offset, bufs).await?;
         Ok(())
     }
 
@@ -127,8 +127,8 @@ impl SyncState {
     /// Resize the blob and require a later sync.
     async fn resize(&mut self, blob: &impl crate::Blob, len: u64) -> Result<(), crate::Error> {
         self.wait_for_pending().await?;
-        blob.resize(len).await?;
         self.mark_dirty();
+        blob.resize(len).await?;
         Ok(())
     }
 
@@ -168,7 +168,7 @@ mod tests {
         Blob as _, BufMut, Error, Handle, IoBufMut, IoBufs, IoBufsMut, Runner, Storage,
     };
     use commonware_macros::test_traced;
-    use commonware_utils::{sync::Mutex, NZUsize};
+    use commonware_utils::{channel::oneshot, sync::Mutex, NZUsize};
     use std::sync::Arc;
 
     #[derive(Default)]
@@ -295,6 +295,175 @@ mod tests {
 
         async fn start_sync(&self) -> Handle<()> {
             Handle::ready(self.sync().await)
+        }
+    }
+
+    /// One-shot gate a blob wrapper can park on, so tests can cancel an operation mid-flight.
+    ///
+    /// Starts unarmed, so gated operations pass through until [Self::cancel] arms the gate for
+    /// a single operation.
+    #[derive(Clone, Default)]
+    pub struct Gate {
+        started: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+        release: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
+    }
+
+    impl Gate {
+        /// Arm the gate: the next gated operation signals the returned `started` receiver,
+        /// then parks until the returned `release` sender is used or dropped.
+        fn arm(&self) -> (oneshot::Receiver<()>, oneshot::Sender<()>) {
+            let (started_tx, started_rx) = oneshot::channel();
+            let (release_tx, release_rx) = oneshot::channel();
+            *self.started.lock() = Some(started_tx);
+            *self.release.lock() = Some(release_rx);
+            (started_rx, release_tx)
+        }
+
+        /// Signal and park on an armed gate, or pass through an unarmed one.
+        pub async fn pass_once(&self) {
+            let started = self.started.lock().take();
+            let release = self.release.lock().take();
+            if let Some(started) = started {
+                let _ = started.send(());
+            }
+            if let Some(release) = release {
+                let _ = release.await;
+            }
+        }
+
+        /// Arm the gate, drive `fut` until it parks at the gate, then drop it to simulate
+        /// cancellation.
+        ///
+        /// Polls once, so every await before the gate must complete within that poll (true on
+        /// the deterministic runtime).
+        pub async fn cancel<F: futures::Future>(&self, fut: F) {
+            let (started, _release) = self.arm();
+            futures::pin_mut!(fut);
+            assert!(fut.as_mut().now_or_never().is_none());
+            started.await.unwrap();
+        }
+    }
+
+    /// Blob wrapper whose [Gate] parks the next write before it reaches the blob.
+    #[derive(Clone)]
+    pub struct GatedWriteBlob<B: crate::Blob> {
+        inner: B,
+        gate: Gate,
+    }
+
+    impl<B: crate::Blob> GatedWriteBlob<B> {
+        pub fn new(inner: B) -> (Self, Gate) {
+            let gate = Gate::default();
+            (
+                Self {
+                    inner,
+                    gate: gate.clone(),
+                },
+                gate,
+            )
+        }
+    }
+
+    impl<B: crate::Blob> crate::Blob for GatedWriteBlob<B> {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            buf: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, buf).await
+        }
+
+        async fn write_at(&self, offset: u64, buf: impl Into<IoBufs> + Send) -> Result<(), Error> {
+            self.gate.pass_once().await;
+            self.inner.write_at(offset, buf).await
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            buf: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            self.gate.pass_once().await;
+            self.inner.write_at_sync(offset, buf).await
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            self.inner.sync().await
+        }
+
+        async fn start_sync(&self) -> Handle<()> {
+            self.inner.start_sync().await
+        }
+    }
+
+    /// Blob wrapper whose [Gate] parks the next resize after the inner resize completes: a
+    /// canceled caller did the work but never observed it.
+    #[derive(Clone)]
+    pub struct GatedResizeBlob<B: crate::Blob> {
+        inner: B,
+        gate: Gate,
+    }
+
+    impl<B: crate::Blob> GatedResizeBlob<B> {
+        pub fn new(inner: B) -> (Self, Gate) {
+            let gate = Gate::default();
+            (
+                Self {
+                    inner,
+                    gate: gate.clone(),
+                },
+                gate,
+            )
+        }
+    }
+
+    impl<B: crate::Blob> crate::Blob for GatedResizeBlob<B> {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            buf: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, buf).await
+        }
+
+        async fn write_at(&self, offset: u64, buf: impl Into<IoBufs> + Send) -> Result<(), Error> {
+            self.inner.write_at(offset, buf).await
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            buf: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            self.inner.write_at_sync(offset, buf).await
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await?;
+            self.gate.pass_once().await;
+            Ok(())
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            self.inner.sync().await
+        }
+
+        async fn start_sync(&self) -> Handle<()> {
+            self.inner.start_sync().await
         }
     }
 
@@ -981,6 +1150,38 @@ mod tests {
         });
     }
 
+    // If an overlapping write is canceled while flushing the old tip, keep the old tip.
+    #[test_traced]
+    fn test_write_overlap_flush_cancel_preserves_tip() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, gate) = GatedWriteBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(10));
+
+            writer.write_at(0, b"abcdefghij").await.unwrap();
+            assert_eq!(writer.size(), 10);
+
+            // The overlapping write must flush the old tip before it can continue.
+            // Drop that future while the flush write is blocked.
+            gate.cancel(writer.write_at(5, b"0123456789")).await;
+
+            // The canceled flush must not have drained the tip or touched the blob.
+            assert_eq!(writer.size(), 10);
+            let read = writer.read_at(0, 10).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"abcdefghij");
+            let (durable, writes, _, _) = inner.snapshot();
+            assert!(durable.is_empty());
+            assert_eq!(writes, 0);
+
+            // Retrying the write should flush the same tip bytes and finish normally.
+            writer.write_at(5, b"0123456789").await.unwrap();
+            writer.sync().await.unwrap();
+            let read = writer.read_at(0, 15).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"abcde0123456789");
+        });
+    }
+
     #[test_traced]
     fn test_write_resize() {
         let executor = deterministic::Runner::default();
@@ -1053,6 +1254,111 @@ mod tests {
             // Ensure the blob is empty
             let (_, size_z) = context.open("partition", b"resize_zero").await.unwrap();
             assert_eq!(size_z, 0);
+        });
+    }
+
+    // If a grow resize is canceled while flushing the tip, keep the old size and bytes.
+    #[test_traced]
+    fn test_write_resize_grow_flush_cancel_preserves_tip() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, gate) = GatedWriteBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
+
+            writer.write_at(0, b"hello").await.unwrap();
+            // Growing past buffered data must flush that data first. Cancel during that flush.
+            gate.cancel(writer.resize(10)).await;
+
+            // The resize was canceled, so the writer should still look like it did before.
+            assert_eq!(writer.size(), 5);
+            let read = writer.read_at(0, 5).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"hello");
+            assert_eq!(inner.size(), 0);
+
+            // Retrying the resize should persist the buffered prefix and grow with zeros.
+            writer.resize(10).await.unwrap();
+            assert_eq!(writer.size(), 10);
+            writer.sync().await.unwrap();
+            let read = writer.read_at(0, 10).await.unwrap().coalesce();
+            assert_eq!(&read.as_ref()[..5], b"hello");
+            assert_eq!(&read.as_ref()[5..], &[0; 5]);
+        });
+    }
+
+    // A resize to exactly the current size must flush buffered bytes at their true offset.
+    #[test_traced]
+    fn test_write_resize_to_current_size_flushes_tip() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (blob, size) = context.open("partition", b"resize_equal").await.unwrap();
+            let mut writer = Write::from_pooler(&context, blob, size, NZUsize!(8));
+
+            writer.write_at(0, b"hello").await.unwrap();
+            writer.resize(5).await.unwrap();
+            assert_eq!(writer.size(), 5);
+            let read = writer.read_at(0, 5).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"hello");
+
+            writer.sync().await.unwrap();
+            let (blob, size) = context.open("partition", b"resize_equal").await.unwrap();
+            assert_eq!(size, 5);
+            let read = blob.read_at(0, 5).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"hello");
+        });
+    }
+
+    // If a resize is canceled during the blob resize itself, the writer keeps its old size and
+    // a retry completes.
+    #[test_traced]
+    fn test_write_resize_cancel_preserves_size() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, gate) = GatedResizeBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
+
+            writer.write_at(0, b"hello").await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Cancel while the completed blob resize is held open.
+            gate.cancel(writer.resize(3)).await;
+
+            // The tip was never adjusted, so the writer still claims the old size; the blob
+            // range past the new size is indeterminate until the resize is retried.
+            assert_eq!(writer.size(), 5);
+            writer.resize(3).await.unwrap();
+            assert_eq!(writer.size(), 3);
+            writer.sync().await.unwrap();
+            assert_eq!(inner.size(), 3);
+        });
+    }
+
+    // If an equal-size resize is canceled while flushing the tip, keep the old size and bytes.
+    #[test_traced]
+    fn test_write_resize_to_current_size_cancel_preserves_tip() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, gate) = GatedWriteBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
+
+            writer.write_at(0, b"hello").await.unwrap();
+            // An equal-size resize must flush buffered data first. Cancel during that flush.
+            gate.cancel(writer.resize(5)).await;
+
+            // The resize was canceled, so the writer should still look like it did before.
+            assert_eq!(writer.size(), 5);
+            let read = writer.read_at(0, 5).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"hello");
+            assert_eq!(inner.size(), 0);
+
+            // Retrying the resize should persist the buffered bytes at their true offset.
+            writer.resize(5).await.unwrap();
+            writer.sync().await.unwrap();
+            assert_eq!(writer.size(), 5);
+            let (durable, _, _, _) = inner.snapshot();
+            assert_eq!(durable.as_slice(), b"hello");
         });
     }
 
@@ -1690,6 +1996,42 @@ mod tests {
             assert_eq!(writes, 1);
             assert_eq!(full_syncs, 1);
             assert_eq!(range_syncs, 1);
+        });
+    }
+
+    // If sync is canceled during the tip write, keep the tip for the next sync.
+    #[test_traced]
+    fn test_write_sync_cancel_preserves_tip() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let inner = SyncTrackingBlob::new();
+            let (blob, gate) = GatedWriteBlob::new(inner.clone());
+            let mut writer = Write::from_pooler(&context, blob, 0, NZUsize!(8));
+            // Clear the constructor's dirty state so the canceled sync takes the
+            // write-and-sync-in-one path.
+            writer.sync().await.unwrap();
+
+            writer.write_at(0, b"abc").await.unwrap();
+            // Cancel while sync is trying to write the buffered tip to the blob.
+            gate.cancel(writer.sync()).await;
+
+            // The tip should still be visible, and the blob should not have seen the write.
+            assert_eq!(writer.size(), 3);
+            let read = writer.read_at(0, 3).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"abc");
+            let (durable, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert!(durable.is_empty());
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 1);
+            assert_eq!(range_syncs, 0);
+
+            // A later sync can still persist the buffered bytes.
+            writer.sync().await.unwrap();
+            let (durable, writes, full_syncs, range_syncs) = inner.snapshot();
+            assert_eq!(durable.as_slice(), b"abc");
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 2);
+            assert_eq!(range_syncs, 0);
         });
     }
 

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -154,7 +154,7 @@ impl SyncState {
                 self.status = Status::Clean;
                 Ok(())
             }
-            Status::Pending(_) => unreachable!("pending sync waited above"),
+            Status::Pending(_) => unreachable!("pending sync was waited on first"),
         }
     }
 
@@ -967,7 +967,7 @@ mod tests {
             assert_eq!(reader.position(), 10);
             assert_eq!(reader.buffer_remaining(), 0);
 
-            // Refill should happen only now (at exhaustion), not at seek/read above.
+            // Refill should happen only now (at exhaustion), not at the earlier seek/read.
             let third = reader.read(1).await.unwrap();
             assert_eq!(third.coalesce().as_ref(), b"K");
             assert_eq!(reader.position(), 11);
@@ -1403,7 +1403,7 @@ mod tests {
     }
 
     // A grow after a canceled shrink must not resurrect the bytes the shrink removed:
-    // everything above the shrunken size reads as zeros.
+    // everything after the shrunken size reads as zeros.
     #[test_traced]
     fn test_write_grow_after_canceled_shrink_zeros() {
         let executor = deterministic::Runner::default();

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -46,23 +46,11 @@ enum Status {
     Pending(Completion),
 }
 
-/// Tracks whether blob mutations still need a sync and whether a resize still needs to be
-/// applied.
+/// Tracks durability and a resize that may need retrying.
 ///
-/// Callers rely on four properties:
-/// 1. Every operation that mutates the blob first waits for an in-flight sync, so a started
-///    sync's coverage is never disturbed by later writes.
-/// 2. [SyncState::start_sync] while a sync is in flight returns that sync's handle (completed
-///    syncs resolve immediately), so re-requesting a sync is a cheap way to observe
-///    outstanding work.
-/// 3. A failure is never lost: every handle cloned from the shared completion reports it, and
-///    an unobserved failure surfaces from [SyncState::wait_for_pending] on the next operation,
-///    which also marks the state dirty since the mutations still need durability.
-/// 4. A dropped [SyncState::resize] is never lost: the intended length is recorded before the
-///    resize is awaited, and every later operation re-issues it (see [SyncState::settle])
-///    before touching the blob. Callers may therefore adopt a resize in memory before awaiting
-///    it. A resize that returns an error keeps the intent recorded, but errors are fatal:
-///    callers must not keep using the writer after one.
+/// Blob mutations wait for an in-flight sync. A resize is recorded before awaiting it, so the
+/// next blob operation retries a dropped resize. A later blob operation reports an unobserved
+/// sync failure.
 struct SyncState {
     /// Durability of already-issued mutations.
     status: Status,
@@ -116,16 +104,12 @@ impl SyncState {
     }
 
     /// Re-issue a resize whose completion was never observed.
-    ///
-    /// [crate::Blob::resize] sets an absolute size, so re-issuing is a no-op if the dropped
-    /// resize actually completed.
     async fn settle(&mut self, blob: &impl crate::Blob) -> Result<(), crate::Error> {
         let Some(len) = self.pending_resize else {
             return Ok(());
         };
         self.wait_for_pending().await?;
-        // Mark dirty so the re-issued resize is covered by the next sync even if the state
-        // was clean (a resize dropped while waiting on an in-flight sync leaves it clean).
+        // The retried resize must be covered by the next sync.
         self.mark_dirty();
         blob.resize(len).await?;
         self.pending_resize = None;
@@ -176,10 +160,7 @@ impl SyncState {
 
     /// Resize the blob and require a later sync.
     async fn resize(&mut self, blob: &impl crate::Blob, len: u64) -> Result<(), crate::Error> {
-        // A grow must not replace an incomplete shrink. Growing zero-fills the new bytes, so
-        // the bytes the shrink would have removed must not survive it: finish the shrink
-        // first. A resize to an equal or smaller size removes at least as much as the
-        // incomplete one would have, so it can simply take its place.
+        // Finish a pending shrink before growing, so removed bytes cannot return as zeros.
         if matches!(self.pending_resize, Some(incomplete) if incomplete < len) {
             self.settle(blob).await?;
         }
@@ -365,23 +346,10 @@ mod tests {
         }
     }
 
-    /// Parks one blob operation mid-flight so a test can cancel it at a precise point.
+    /// Parks one blob call so a test can drop a future at that I/O boundary.
     ///
-    /// Cancellation tests follow the same three steps:
-    ///
-    /// 1. Wrap the blob in [GatedWriteBlob] or [GatedResizeBlob] and hand the wrapper to the
-    ///    writer under test. The gate starts unarmed, so setup traffic passes straight
-    ///    through to the wrapped blob.
-    /// 2. Call [Self::cancel] with the operation to interrupt, e.g.
-    ///    `gate.cancel(writer.resize(3))`. This arms the gate, polls the operation until it
-    ///    parks at the gated blob call, then drops it, exactly as if the caller had dropped
-    ///    the future at that await point.
-    /// 3. Assert on what the canceled operation left behind: the writer's in-memory claims,
-    ///    the wrapped blob's contents, and whether a retry or a later sync recovers.
-    ///
-    /// Two knobs refine where the cancellation lands: [GatePosition] chooses which side of
-    /// the blob call the future parks on (i.e. whether the canceled operation reached the
-    /// disk), and [Self::set_skip] chooses which of several gated calls parks.
+    /// Use [Self::cancel] to arm the gate, poll the operation until it parks, and drop it.
+    /// [GatePosition] selects the side of the blob call; [Self::set_skip] selects the call.
     #[derive(Clone, Default)]
     pub struct Gate {
         started: Arc<Mutex<Option<oneshot::Sender<()>>>>,
@@ -392,9 +360,7 @@ mod tests {
     impl Gate {
         /// Arm the gate for the next gated operation.
         ///
-        /// Returns two channel ends for the driver: `started` fires when an operation
-        /// reaches the gate (proof it parked there rather than somewhere earlier), and
-        /// `release` un-parks the operation when used or dropped.
+        /// Returns a signal that fires when the operation parks and a handle that releases it.
         fn arm(&self) -> (oneshot::Receiver<()>, oneshot::Sender<()>) {
             let (started_tx, started_rx) = oneshot::channel();
             let (release_tx, release_rx) = oneshot::channel();
@@ -403,18 +369,12 @@ mod tests {
             (started_rx, release_tx)
         }
 
-        /// Let the next `n` gated operations pass through an armed gate before it parks one.
-        ///
-        /// Used when the operation under test makes several gated blob calls and the test
-        /// wants to cancel at a specific one, e.g. `set_skip(2)` parks the third call.
+        /// Let the next `n` gated calls pass before parking one.
         pub fn set_skip(&self, n: usize) {
             *self.skip.lock() = n;
         }
 
-        /// The gate point. Gated wrappers call this inside the operation they gate: if the
-        /// gate is armed (and the skip budget is spent) this signals `started` and parks
-        /// until released; otherwise it returns immediately. Arming is one-shot, so only
-        /// one gated operation parks.
+        /// Park once when armed, after any configured skipped calls.
         pub async fn pass_once(&self) {
             {
                 let mut skip = self.skip.lock();
@@ -433,13 +393,7 @@ mod tests {
             }
         }
 
-        /// Cancel `fut` at the gate: arm the gate, poll `fut` once so it runs up to the gated
-        /// blob call and parks there, confirm via `started` that it reached the gate, then
-        /// drop it. Dropping the parked future is the cancellation; the writer sees an
-        /// operation abandoned exactly at that blob call.
-        ///
-        /// Polls only once, so every await before the gate must complete within that poll
-        /// (true on the deterministic runtime).
+        /// Cancel `fut` after it reaches the gate.
         pub async fn cancel<F: futures::Future>(&self, fut: F) {
             let (started, _release) = self.arm();
             futures::pin_mut!(fut);

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -106,7 +106,8 @@ impl Drop for PageFetchGuard {
 /// items. Hints are best-effort, never truth: [Clock::get_at] only resolves a slot that still
 /// holds the page's key live, so entries staled by eviction, invalidation, or hint collisions
 /// read as misses and fall back to the [Clock]'s own lookup. Hints need no maintenance on
-/// eviction or invalidation, and their memory is fixed at construction.
+/// eviction or invalidation, and their memory is fixed at construction, so no blob offset can
+/// grow them.
 struct Cache {
     /// Maps each (blob id, page number) to its logical page buffer.
     cache: Clock<(u64, u64), IoBufMut>,
@@ -365,7 +366,7 @@ impl CacheRef {
                         // This shared future still owns `page_fetches[key]`. As long as at least
                         // one waiter remains armed, that entry pins this generation in place, so a
                         // replacement fetch for the same page cannot be inserted before we cache
-                        // the successful result afterward. Only when every waiter cancels can the last
+                        // the successful result below. Only when every waiter cancels can the last
                         // guard remove the entry and let a later reader start a new generation.
                         let mut cache = cache.write();
                         if let Ok(page) = &result {
@@ -932,7 +933,7 @@ mod tests {
             let data = vec![1u8; MIN_PAGE_SIZE as usize * 2];
 
             // Cache pages at a high (but not max) aligned offset so we can verify both pages.
-            // Use an offset a few pages before max to avoid overflow when verifying.
+            // Use an offset that's a few pages below max to avoid overflow when verifying.
             let aligned_max_offset = u64::MAX - (u64::MAX % MIN_PAGE_SIZE);
             let high_offset = aligned_max_offset - (MIN_PAGE_SIZE * 2);
             let remaining = cache_ref.cache(0, &data, high_offset);

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -106,8 +106,7 @@ impl Drop for PageFetchGuard {
 /// items. Hints are best-effort, never truth: [Clock::get_at] only resolves a slot that still
 /// holds the page's key live, so entries staled by eviction, invalidation, or hint collisions
 /// read as misses and fall back to the [Clock]'s own lookup. Hints need no maintenance on
-/// eviction or invalidation, and their memory is fixed at construction, so no blob offset can
-/// grow them.
+/// eviction or invalidation, and their memory is fixed at construction.
 struct Cache {
     /// Maps each (blob id, page number) to its logical page buffer.
     cache: Clock<(u64, u64), IoBufMut>,

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -365,7 +365,7 @@ impl CacheRef {
                         // This shared future still owns `page_fetches[key]`. As long as at least
                         // one waiter remains armed, that entry pins this generation in place, so a
                         // replacement fetch for the same page cannot be inserted before we cache
-                        // the successful result below. Only when every waiter cancels can the last
+                        // the successful result afterward. Only when every waiter cancels can the last
                         // guard remove the entry and let a later reader start a new generation.
                         let mut cache = cache.write();
                         if let Ok(page) = &result {
@@ -932,7 +932,7 @@ mod tests {
             let data = vec![1u8; MIN_PAGE_SIZE as usize * 2];
 
             // Cache pages at a high (but not max) aligned offset so we can verify both pages.
-            // Use an offset that's a few pages below max to avoid overflow when verifying.
+            // Use an offset a few pages before max to avoid overflow when verifying.
             let aligned_max_offset = u64::MAX - (u64::MAX % MIN_PAGE_SIZE);
             let high_offset = aligned_max_offset - (MIN_PAGE_SIZE * 2);
             let remaining = cache_ref.cache(0, &data, high_offset);

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -321,10 +321,9 @@ impl Checksum {
     /// Encode just a slot's leading `len` field (the first [`CHECKSUM_SLOT_LEN_SIZE`] bytes of
     /// [`Self::slot_bytes`]).
     ///
-    /// Because `len` decides which slot is authoritative, rewriting only this field flips a slot's
-    /// authority without disturbing its already-durable CRC: writing a non-zero `len` commits a
-    /// prepared slot, while writing 0 retires one.
     fn slot_len_bytes(len: u16) -> [u8; CHECKSUM_SLOT_LEN_SIZE] {
+        // Recovery chooses the slot with the larger length. A non-zero length makes this slot
+        // eligible; zero retires it without rewriting its CRC.
         let mut bytes = [0; CHECKSUM_SLOT_LEN_SIZE];
         let mut buf = bytes.as_mut_slice();
         len.write(&mut buf);

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -321,9 +321,10 @@ impl Checksum {
     /// Encode just a slot's leading `len` field (the first [`CHECKSUM_SLOT_LEN_SIZE`] bytes of
     /// [`Self::slot_bytes`]).
     ///
+    /// Because `len` decides which slot is authoritative, rewriting only this field flips a slot's
+    /// authority without disturbing its already-durable CRC: writing a non-zero `len` commits a
+    /// previously staged slot, while writing 0 retires one.
     fn slot_len_bytes(len: u16) -> [u8; CHECKSUM_SLOT_LEN_SIZE] {
-        // Recovery chooses the slot with the larger length. A non-zero length makes this slot
-        // eligible; zero retires it without rewriting its CRC.
         let mut bytes = [0; CHECKSUM_SLOT_LEN_SIZE];
         let mut buf = bytes.as_mut_slice();
         len.write(&mut buf);

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -30,6 +30,7 @@ use commonware_cryptography::{crc32, Crc32};
 mod cache;
 mod read;
 mod sealed;
+mod tail;
 mod view;
 mod writer;
 
@@ -80,48 +81,6 @@ fn validate_read_ranges(
         "buf must hold one slot per range totaling its length"
     );
     Ok(())
-}
-
-/// Partition a batch of variable-length range reads into bytes copied from the in-memory tail
-/// and ranges that need cache/blob reads.
-///
-/// `buf` holds one slot per range, back to back (validated by [validate_read_ranges]). `tail`
-/// holds the logical bytes at `[tail_offset, tail_offset + tail.len())`; for [Writer] this is the
-/// tip buffer, for [Sealed] the partial last page. Ranges entirely within `tail` are copied into
-/// place. Ranges fully or partially below `tail_offset` are returned as `(dest_slice, offset)`
-/// pairs for the caller to read from the page cache or blob. `split_at_mut` yields disjoint
-/// per-range slots, so returned slices never alias.
-fn split_read_ranges<'a>(
-    mut buf: &'a mut [u8],
-    ranges: impl ExactSizeIterator<Item = (u64, usize)>,
-    tail_offset: u64,
-    tail: &[u8],
-) -> Vec<(&'a mut [u8], u64)> {
-    let mut cache_ranges = Vec::with_capacity(ranges.len());
-    for (offset, len) in ranges {
-        let (slot, rest) = buf.split_at_mut(len);
-        buf = rest;
-        if len == 0 {
-            continue;
-        }
-        let end = offset + len as u64;
-        if end <= tail_offset {
-            // Entirely below the tail bytes, so this needs a cache/blob read.
-            cache_ranges.push((slot, offset));
-        } else if offset >= tail_offset {
-            // Entirely within the tail bytes.
-            let src = (offset - tail_offset) as usize;
-            slot.copy_from_slice(&tail[src..src + len]);
-        } else {
-            // Straddles the boundary: copy the suffix from the tail bytes, record the prefix
-            // for a cache/blob read.
-            let prefix_len = (tail_offset - offset) as usize;
-            let (prefix, suffix) = slot.split_at_mut(prefix_len);
-            suffix.copy_from_slice(&tail[..len - prefix_len]);
-            cache_ranges.push((prefix, offset));
-        }
-    }
-    cache_ranges
 }
 
 /// Read the designated page from the underlying blob and return its logical bytes as a vector if it
@@ -364,7 +323,7 @@ impl Checksum {
     ///
     /// Because `len` decides which slot is authoritative, rewriting only this field flips a slot's
     /// authority without disturbing its already-durable CRC: writing a non-zero `len` commits a
-    /// previously staged slot, while writing 0 retires one.
+    /// prepared slot, while writing 0 retires one.
     fn slot_len_bytes(len: u16) -> [u8; CHECKSUM_SLOT_LEN_SIZE] {
         let mut bytes = [0; CHECKSUM_SLOT_LEN_SIZE];
         let mut buf = bytes.as_mut_slice();

--- a/runtime/src/utils/buffer/paged/read.rs
+++ b/runtime/src/utils/buffer/paged/read.rs
@@ -405,7 +405,7 @@ mod tests {
 
             // Write data spanning multiple pages
             let data: Vec<u8> = (0u8..=255).cycle().take(300).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             // Create Replay
@@ -443,7 +443,7 @@ mod tests {
 
             // Write data that doesn't fill the last page
             let data: Vec<u8> = (1u8..=(PAGE_SIZE.get() + 10) as u8).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             let mut replay = append.replay(NZUsize!(BUFFER_PAGES)).await.unwrap();
@@ -472,7 +472,7 @@ mod tests {
 
             // Write data spanning 4 pages (4 * 103 = 412 bytes, with last page partial)
             let data: Vec<u8> = (0u8..=255).cycle().take(400).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             // Create Replay with buffer size that results in prefetch_count=1.
@@ -567,7 +567,7 @@ mod tests {
 
             // Write data spanning multiple pages
             let data: Vec<u8> = (0u8..=255).cycle().take(300).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             let mut replay = append.replay(NZUsize!(BUFFER_PAGES)).await.unwrap();

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -247,7 +247,7 @@ mod tests {
 
             // Append some data crossing several pages but don't sync.
             let data: Vec<u8> = (0u8..=255).cycle().take(300).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
 
             let (_durable_before, _writes_before, full_before, range_before) = blob.snapshot();
 
@@ -277,7 +277,7 @@ mod tests {
             let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
                 .await
                 .unwrap();
-            writer.append(b"hello world").await.unwrap();
+            writer.append(b"hello world");
 
             // A snapshot captures the buffered bytes as an owned, frozen read handle.
             let reader = writer.snapshot().await.unwrap();
@@ -315,7 +315,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size * 3 + 7;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
 
             let reader = writer.snapshot().await.unwrap();
             let sealed = writer.seal().await.unwrap();
@@ -354,7 +354,7 @@ mod tests {
 
             // Write data with no fsync.
             let data: Vec<u8> = (0u8..=255).cycle().take(300).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             let (durable_before, _, full_before, _) = blob.snapshot();
@@ -432,7 +432,7 @@ mod tests {
             // Append exactly two pages.
             let page_size = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0u8..=255).cycle().take(page_size * 2).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             assert_eq!(sealed.size(), data.len() as u64);
@@ -458,7 +458,7 @@ mod tests {
 
             // Append fewer than one page of data.
             let data: Vec<u8> = (0u8..=50).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             assert_eq!(sealed.size(), data.len() as u64);
@@ -485,7 +485,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size + 17;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             assert_eq!(sealed.size(), total as u64);
@@ -523,7 +523,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0u8..=255).cycle().take(250).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             let bufs = sealed.read_at(0, data.len()).await.unwrap();
@@ -548,7 +548,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size + 50;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             // 4-byte items at three positions: pure cache, straddling boundary, pure partial.
@@ -587,7 +587,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size * 2 + 50;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             // Items: page 0, page 1, straddling page 1 and the tail, pure tail.
@@ -647,7 +647,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size * 2 + 50;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             // Ranges: page 0, a zero-length range sharing its offset with the page 1 range
@@ -701,7 +701,7 @@ mod tests {
 
             let page_size = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0u8..=255).cycle().take(page_size * 2).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             let offsets = [0u64, page_size as u64];
@@ -732,7 +732,7 @@ mod tests {
             let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
                 .await
                 .unwrap();
-            append.append(&[7; 32]).await.unwrap();
+            append.append(&[7; 32]);
             let sealed = append.seal().await.unwrap();
 
             let mut out = vec![0u8; 8];
@@ -751,7 +751,7 @@ mod tests {
             let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
                 .await
                 .unwrap();
-            append.append(&[7; 32]).await.unwrap();
+            append.append(&[7; 32]);
             let sealed = append.seal().await.unwrap();
 
             let mut out = vec![0u8; 8];
@@ -787,7 +787,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size + 30;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             // Read fully within partial.
@@ -819,7 +819,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size + 30;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             let mut buf = vec![0u8; 12];
@@ -842,7 +842,7 @@ mod tests {
 
             let page_size = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0u8..=255).cycle().take(page_size + 5).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             let sealed = append.seal().await.unwrap();
 
             let mut buf = vec![9u8; 10];
@@ -866,7 +866,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size * 2 + 25;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
             let sealed = append.seal().await.unwrap();
 
@@ -904,7 +904,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let mut original = vec![0xAA; page_size];
             original.extend_from_slice(b"old");
-            writer.append(&original).await.unwrap();
+            writer.append(&original);
             writer.sync().await.unwrap();
 
             let snapshot = writer.snapshot().await.unwrap();
@@ -916,7 +916,7 @@ mod tests {
             let mut replay = snapshot.replay(NZUsize!(BUFFER_SIZE)).unwrap();
             assert_eq!(replay.blob_size(), original.len() as u64);
 
-            writer.append(b"newtail").await.unwrap();
+            writer.append(b"newtail");
             writer.sync().await.unwrap();
 
             let mut out = Vec::new();
@@ -948,7 +948,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size * 2 + 25;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             // Seal without a prior append sync.
             let sealed = append.seal().await.unwrap();
 
@@ -988,7 +988,7 @@ mod tests {
                 let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
                     .await
                     .unwrap();
-                append.append(&data).await.unwrap();
+                append.append(&data);
                 let sealed = append.seal().await.unwrap();
                 sealed.sync().await.unwrap();
             }
@@ -1020,7 +1020,7 @@ mod tests {
                 let mut writer = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref.clone())
                     .await
                     .unwrap();
-                writer.append(&data).await.unwrap();
+                writer.append(&data);
                 writer.sync().await.unwrap();
             }
 

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -46,7 +46,7 @@ struct SealedInner<B: Blob> {
     size: u64,
 
     /// Logical bytes of the partial last page, if the blob ends in one. Bytes at offsets
-    /// `[size - partial_page.len(), size)` come from here; bytes below come from full pages on the
+    /// `[size - partial_page.len(), size)` come from here; earlier bytes come from full pages on the
     /// blob (via the page cache).
     partial_page: Option<IoBuf>,
 

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -15,7 +15,9 @@
 //! any lock; they share the underlying [`Blob`] handle (which provides its own synchronization)
 //! and the page cache.
 
-use super::{read::PageReader, view::View, CacheRef, Replay, CHECKSUM_SIZE};
+use super::{
+    read::PageReader, tail::View as TailView, view::View, CacheRef, Replay, CHECKSUM_SIZE,
+};
 use crate::{Blob, Error, IoBuf, IoBufMut, IoBufs};
 use std::{
     num::{NonZeroU16, NonZeroUsize},
@@ -105,12 +107,16 @@ impl<B: Blob> Sealed<B> {
             cache_ref: &self.inner.cache_ref,
             id: self.inner.id,
             size: self.inner.size,
-            tail_offset: self.partial_offset(),
-            tail: self
-                .inner
-                .partial_page
-                .as_ref()
-                .map_or(&[][..], |p| p.as_ref()),
+            tail: TailView {
+                start: self.partial_offset(),
+                full_pages: &[],
+                tip_offset: self.partial_offset(),
+                tip: self
+                    .inner
+                    .partial_page
+                    .as_ref()
+                    .map_or(&[][..], |p| p.as_ref()),
+            },
         }
     }
 
@@ -179,7 +185,7 @@ impl<B: Blob> Sealed<B> {
 
     /// Returns a [Replay] for sequentially reading all logical bytes of the sealed view.
     ///
-    /// Sealed values have no write buffer to flush, so unlike [`super::Writer::replay`] this method
+    /// Sealed values have no in-memory tail to flush, so unlike [`super::Writer::replay`] this method
     /// is not async.
     pub fn replay(&self, buffer_size: NonZeroUsize) -> Result<Replay<B>, Error> {
         let logical_page_size = self.inner.cache_ref.page_size();
@@ -279,7 +285,7 @@ mod tests {
                 .unwrap();
             writer.append(b"hello world");
 
-            // A snapshot captures the buffered bytes as an owned, frozen read handle.
+            // A snapshot captures the tail bytes as an owned, frozen read handle.
             let reader = writer.snapshot().await.unwrap();
             let reader_clone = reader.clone();
             assert_eq!(reader.size(), 11);

--- a/runtime/src/utils/buffer/paged/tail.rs
+++ b/runtime/src/utils/buffer/paged/tail.rs
@@ -76,7 +76,7 @@ impl Tail {
         self.tip.slice(range)
     }
 
-    /// Append `buf`, returning the logical offset of its first byte.
+    /// Append borrowed bytes and return their first logical offset.
     pub(super) fn append(&mut self, buf: &[u8]) -> u64 {
         let offset = self.tip.size();
         self.tip.append(buf);
@@ -153,10 +153,10 @@ impl Tail {
     }
 }
 
-/// A borrowed, read-only in-memory tail: the authoritative bytes at `[start, size)`.
+/// A borrowed, read-only in-memory tail.
 #[derive(Clone, Copy)]
 pub(super) struct View<'a> {
-    /// First byte served by the tail; bytes below it come from the page cache or blob.
+    /// First byte served by the tail; earlier bytes come from the page cache or blob.
     pub(super) start: u64,
     /// Finished page-aligned bytes.
     pub(super) full_pages: &'a [IoBuf],
@@ -195,8 +195,9 @@ impl View<'_> {
         }
     }
 
-    /// Copy any tail overlap into `buf`, returning the remaining prefix length that must be
-    /// served from the cache or blob.
+    /// Copy the portion of `buf` covered by the tail.
+    ///
+    /// Return the length that still needs a cache or blob read.
     pub(super) fn copy_overlap(&self, buf: &mut [u8], offset: u64) -> usize {
         let tail_start = self.start.max(offset);
         let prefix_len = (tail_start - offset) as usize;

--- a/runtime/src/utils/buffer/paged/tail.rs
+++ b/runtime/src/utils/buffer/paged/tail.rs
@@ -9,8 +9,8 @@ use crate::{buffer::tip::Buffer, BufferPool, IoBuf};
 /// over one slice. Bytes move left to right exactly once:
 ///
 /// ```text
-///   append ──copy──▶ tip ──freeze full pages──▶ full_pages ──flush──▶ blob + page cache
-///   append_owned (whole pages) ──zero-copy────▶ full_pages
+///   append: copy -> tip -> freeze full pages -> full_pages -> flush -> blob + page cache
+///   append_owned (whole pages): retain without copying -> full_pages
 /// ```
 ///
 /// A flush may write tail bytes before it publishes that progress; cancellation leaves the tail
@@ -56,9 +56,17 @@ impl Tail {
         self.tip.size()
     }
 
-    /// The finished page-aligned bytes awaiting their write.
-    pub(super) fn full_pages(&self) -> &[IoBuf] {
+    /// Return the finished pages awaiting their write.
+    ///
+    /// Moves any full pages from the tip first.
+    pub(super) fn full_pages(&mut self) -> &[IoBuf] {
+        self.spill_full_pages();
         &self.full_pages
+    }
+
+    /// True if the tail contains a full page that has not been written.
+    pub(super) const fn has_full_pages(&self) -> bool {
+        !self.full_pages.is_empty() || self.tip.len() >= self.page_size
     }
 
     /// The tip bytes.
@@ -114,7 +122,7 @@ impl Tail {
     }
 
     /// Move the tip's full-page prefix into immutable storage, leaving its partial suffix.
-    pub(super) fn spill_full_pages(&mut self) {
+    fn spill_full_pages(&mut self) {
         let full_bytes = self.tip.len() / self.page_size * self.page_size;
         if full_bytes == 0 {
             return;

--- a/runtime/src/utils/buffer/paged/tail.rs
+++ b/runtime/src/utils/buffer/paged/tail.rs
@@ -86,10 +86,7 @@ impl Tail {
         offset
     }
 
-    /// Append owned bytes, returning the logical offset of the first. Whole pages of `buf` become
-    /// retained without copying; only the bytes topping up the tip's page and the sub-page suffix
-    /// are copied. The copied suffix keeps the tip extendable and releases the caller's allocation
-    /// after the full pages flush.
+    /// Append owned bytes and return their first logical offset.
     pub(super) fn append_owned(&mut self, buf: IoBuf) -> u64 {
         let fill = self.tip.len().next_multiple_of(self.page_size) - self.tip.len();
         if self.tip.len() + buf.len() <= self.tip.capacity || buf.len() < fill + self.page_size {
@@ -103,6 +100,8 @@ impl Tail {
         self.spill_full_pages();
         debug_assert!(self.tip.is_empty());
 
+        // Retain the full-page middle without copying. Copy the suffix into the tip so later
+        // appends can extend it and the caller's allocation is released after flush.
         let full_bytes = (buf.len() - fill) / self.page_size * self.page_size;
         self.tip.offset += full_bytes as u64;
         self.full_pages.push(buf.slice(fill..fill + full_bytes));

--- a/runtime/src/utils/buffer/paged/tail.rs
+++ b/runtime/src/utils/buffer/paged/tail.rs
@@ -1,0 +1,208 @@
+//! The in-memory tail of a paged [`Writer`](super::Writer).
+
+use crate::{buffer::tip::Buffer, BufferPool, IoBuf};
+
+/// The writer's in-memory tail: the logical suffix not yet published as written.
+///
+/// `full_pages` holds finished, page-aligned bytes as immutable, refcounted handles. `tip` is the
+/// growing end: mutable and contiguous, so appends extend it in place and its CRC is computed
+/// over one slice. Bytes move left to right exactly once:
+///
+/// ```text
+///   append ──copy──▶ tip ──freeze full pages──▶ full_pages ──flush──▶ blob + page cache
+///   append_owned (whole pages) ──zero-copy────▶ full_pages
+/// ```
+///
+/// A flush may write tail bytes before it publishes that progress; cancellation leaves the tail
+/// intact until [`Tail::advance_full_pages`] advances the written prefix. The tip may begin with
+/// a committed partial page's bytes, kept in memory because appends extend them in place.
+pub(super) struct Tail {
+    /// Logical offset of the first tail byte; always page-aligned.
+    start: u64,
+    /// Finished page-aligned bytes awaiting their write.
+    full_pages: Vec<IoBuf>,
+    /// The growing final suffix. A flush moves its full-page prefix into `full_pages`.
+    tip: Buffer,
+    /// Logical page size.
+    page_size: usize,
+}
+
+impl Tail {
+    /// Start at page-aligned `start`, seeding the tip with `seed` (a recovered partial page,
+    /// if any).
+    pub(super) fn new(
+        start: u64,
+        seed: IoBuf,
+        capacity: usize,
+        page_size: usize,
+        pool: BufferPool,
+    ) -> Self {
+        debug_assert!(seed.len() < page_size);
+        Self {
+            start,
+            full_pages: Vec::new(),
+            tip: Buffer::from(start, seed, capacity, pool),
+            page_size,
+        }
+    }
+
+    /// Logical offset of the first tail byte.
+    pub(super) const fn start(&self) -> u64 {
+        self.start
+    }
+
+    /// Size of the blob including the tail.
+    pub(super) const fn size(&self) -> u64 {
+        self.tip.size()
+    }
+
+    /// The finished page-aligned bytes awaiting their write.
+    pub(super) fn full_pages(&self) -> &[IoBuf] {
+        &self.full_pages
+    }
+
+    /// The tip bytes.
+    pub(super) fn tip(&self) -> &[u8] {
+        self.tip.as_ref()
+    }
+
+    /// True if the tip is empty.
+    pub(super) const fn tip_is_empty(&self) -> bool {
+        self.tip.is_empty()
+    }
+
+    /// Immutable tip bytes for `range`.
+    pub(super) fn tip_slice(&self, range: impl std::ops::RangeBounds<usize>) -> IoBuf {
+        self.tip.slice(range)
+    }
+
+    /// Append `buf`, returning the logical offset of its first byte.
+    pub(super) fn append(&mut self, buf: &[u8]) -> u64 {
+        let offset = self.tip.size();
+        self.tip.append(buf);
+        if self.tip.len() >= self.tip.capacity {
+            self.spill_full_pages();
+        }
+        offset
+    }
+
+    /// Append owned bytes, returning the logical offset of the first. Whole pages of `buf` become
+    /// retained without copying; only the bytes topping up the tip's page and the sub-page suffix
+    /// are copied. The copied suffix keeps the tip extendable and releases the caller's allocation
+    /// after the full pages flush.
+    pub(super) fn append_owned(&mut self, buf: IoBuf) -> u64 {
+        let fill = self.tip.len().next_multiple_of(self.page_size) - self.tip.len();
+        if self.tip.len() + buf.len() <= self.tip.capacity || buf.len() < fill + self.page_size {
+            return self.append(buf.as_ref());
+        }
+
+        let offset = self.tip.size();
+        if fill > 0 {
+            self.tip.append(&buf.as_ref()[..fill]);
+        }
+        self.spill_full_pages();
+        debug_assert!(self.tip.is_empty());
+
+        let full_bytes = (buf.len() - fill) / self.page_size * self.page_size;
+        self.tip.offset += full_bytes as u64;
+        self.full_pages.push(buf.slice(fill..fill + full_bytes));
+
+        let suffix = &buf.as_ref()[fill + full_bytes..];
+        if !suffix.is_empty() {
+            self.tip.append(suffix);
+        }
+        offset
+    }
+
+    /// Move the tip's full-page prefix into immutable storage, leaving its partial suffix.
+    pub(super) fn spill_full_pages(&mut self) {
+        let full_bytes = self.tip.len() / self.page_size * self.page_size;
+        if full_bytes == 0 {
+            return;
+        }
+        self.full_pages.push(self.tip.slice(..full_bytes));
+        self.tip.advance(full_bytes);
+    }
+
+    /// Record that all full pages were written. The tip's partial page stays in memory.
+    pub(super) fn advance_full_pages(&mut self) {
+        debug_assert!(self.tip.len() < self.page_size);
+        self.full_pages.clear();
+        self.start = self.tip.offset;
+    }
+
+    /// Restart at page-aligned `offset` with the tip seeded from `seed`, discarding all tail
+    /// state. Used by shrinks, which flush first and then re-anchor at the shrunken boundary.
+    pub(super) fn restart_at(&mut self, offset: u64, seed: &[u8]) {
+        self.full_pages.clear();
+        self.start = offset;
+        self.tip.offset = offset;
+        self.tip.clear();
+        if !seed.is_empty() {
+            self.append(seed);
+        }
+    }
+
+    /// A borrowed, read-only view of this tail.
+    pub(super) fn view(&self) -> View<'_> {
+        View {
+            start: self.start,
+            full_pages: &self.full_pages,
+            tip_offset: self.tip.offset,
+            tip: self.tip.as_ref(),
+        }
+    }
+}
+
+/// A borrowed, read-only in-memory tail: the authoritative bytes at `[start, size)`.
+#[derive(Clone, Copy)]
+pub(super) struct View<'a> {
+    /// First byte served by the tail; bytes below it come from the page cache or blob.
+    pub(super) start: u64,
+    /// Finished page-aligned bytes.
+    pub(super) full_pages: &'a [IoBuf],
+    /// Logical offset of the tip bytes.
+    pub(super) tip_offset: u64,
+    /// The tip bytes: the final, incomplete page.
+    pub(super) tip: &'a [u8],
+}
+
+impl View<'_> {
+    /// Copy the tail bytes at `[offset, offset + buf.len())` into `buf`. The range must lie
+    /// entirely within the tail.
+    pub(super) fn copy(&self, buf: &mut [u8], offset: u64) {
+        let mut dst = buf;
+        let mut pos = offset;
+        let mut page_start = self.start;
+        for pages in self.full_pages {
+            let page_end = page_start + pages.len() as u64;
+            if pos < page_end && !dst.is_empty() {
+                let src = (pos - page_start) as usize;
+                let n = dst.len().min((page_end - pos) as usize);
+                let (head, rest) = dst.split_at_mut(n);
+                head.copy_from_slice(&pages.as_ref()[src..src + n]);
+                dst = rest;
+                pos += n as u64;
+            }
+            page_start = page_end;
+            if dst.is_empty() {
+                return;
+            }
+        }
+        if !dst.is_empty() {
+            let src = (pos - self.tip_offset) as usize;
+            let n = dst.len();
+            dst.copy_from_slice(&self.tip[src..src + n]);
+        }
+    }
+
+    /// Copy any tail overlap into `buf`, returning the remaining prefix length that must be
+    /// served from the cache or blob.
+    pub(super) fn copy_overlap(&self, buf: &mut [u8], offset: u64) -> usize {
+        let tail_start = self.start.max(offset);
+        let prefix_len = (tail_start - offset) as usize;
+        let (_, tail_buf) = buf.split_at_mut(prefix_len);
+        self.copy(tail_buf, tail_start);
+        prefix_len
+    }
+}

--- a/runtime/src/utils/buffer/paged/view.rs
+++ b/runtime/src/utils/buffer/paged/view.rs
@@ -2,7 +2,7 @@
 //!
 //! [`Writer`](super::Writer) and [`Sealed`](super::Sealed) read the same way: logical bytes in
 //! `[tail.start, size)` come from an in-memory tail view (the writer's tail, or the sealed
-//! blob's partial last page), and bytes below come from the page cache, falling back to a blob
+//! blob's partial last page), and bytes before the tail come from the page cache, falling back to a blob
 //! read. Each type exposes itself as a borrowed [`View`] so this algorithm lives in exactly
 //! one place.
 
@@ -13,9 +13,9 @@ use std::num::NonZeroUsize;
 
 /// A borrowed view over a paged blob.
 pub struct View<'a, B: Blob> {
-    /// Underlying blob, used for bytes below the tail not resident in the cache.
+    /// Underlying blob, used for bytes before the tail not resident in the cache.
     pub(super) blob: &'a B,
-    /// Page cache used for bytes below the tail.
+    /// Page cache used for bytes before the tail.
     pub(super) cache_ref: &'a CacheRef,
     /// Page-cache id of the originating blob.
     pub(super) id: u64,
@@ -34,12 +34,9 @@ impl<B: Blob> Clone for View<'_, B> {
 impl<B: Blob> Copy for View<'_, B> {}
 
 impl<B: Blob> View<'_, B> {
-    /// Split validated read ranges into tail copies (performed inline) and ranges needing a
-    /// cache or blob read (returned with their slots).
+    /// Copy each range's tail portion into `buf`.
     ///
-    /// `buf` holds one slot per range, back to back. Ranges entirely within the tail are
-    /// copied from memory; a range straddling the boundary is copied above it and returned
-    /// below it.
+    /// Return the earlier portions that need a cache or blob read.
     fn split_read_ranges<'b>(
         &self,
         mut buf: &'b mut [u8],
@@ -54,7 +51,7 @@ impl<B: Blob> View<'_, B> {
             }
             let end = offset + len as u64;
             if end <= self.tail.start {
-                // Entirely below the tail, so this needs a cache/blob read.
+                // Entirely before the tail, so this needs a cache/blob read.
                 cache_ranges.push((slot, offset));
             } else if offset >= self.tail.start {
                 // Entirely within the tail.
@@ -89,7 +86,7 @@ impl<B: Blob> View<'_, B> {
             return self.cache_ref.read_cached(self.id, buf, offset) == buf.len();
         }
 
-        // Copy the suffix overlapping the tail, then serve any prefix below it from the cache.
+        // Copy the suffix overlapping the tail, then serve any earlier prefix from the cache.
         let dst_start = self.tail.copy_overlap(buf, offset);
 
         if dst_start == 0 {
@@ -110,7 +107,7 @@ impl<B: Blob> View<'_, B> {
             return Err(Error::BlobInsufficientLength);
         }
 
-        // Copy any suffix from the tail, leaving the prefix below it to be served from the
+        // Copy any suffix from the tail, leaving the earlier prefix to be served from the
         // page cache or blob.
         let remaining = if end_offset <= self.tail.start {
             buf.len()
@@ -143,7 +140,7 @@ impl<B: Blob> View<'_, B> {
 
     /// Read exactly `len` immutable bytes starting at `offset`.
     pub async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, Error> {
-        // SAFETY: read_into below initializes all `len` bytes.
+        // SAFETY: read_into afterward initializes all `len` bytes.
         let mut buf = unsafe { self.cache_ref.pool().alloc_len(len) };
         self.read_into(buf.as_mut(), offset).await?;
         Ok(buf.into())
@@ -168,7 +165,7 @@ impl<B: Blob> View<'_, B> {
         if available == 0 {
             return Err(Error::BlobInsufficientLength);
         }
-        // SAFETY: read_into below fills all `available` bytes.
+        // SAFETY: read_into afterward fills all `available` bytes.
         unsafe { bufs.set_len(available) };
         self.read_into(bufs.as_mut(), offset).await?;
         Ok((bufs, available))

--- a/runtime/src/utils/buffer/paged/view.rs
+++ b/runtime/src/utils/buffer/paged/view.rs
@@ -1,30 +1,28 @@
 //! Shared view for the paged buffer's read-capable types.
 //!
 //! [`Writer`](super::Writer) and [`Sealed`](super::Sealed) read the same way: logical bytes in
-//! `[tail_offset, size)` come from an in-memory tail slice (the writer's tip buffer or the sealed
-//! blob's partial last page), and bytes in `[0, tail_offset)` come from the page cache, falling back
-//! to a blob read. Each type exposes itself as a borrowed [`View`] so this algorithm lives in
-//! exactly one place.
+//! `[tail.start, size)` come from an in-memory tail view (the writer's tail, or the sealed
+//! blob's partial last page), and bytes below come from the page cache, falling back to a blob
+//! read. Each type exposes itself as a borrowed [`View`] so this algorithm lives in exactly
+//! one place.
 
-use super::CacheRef;
+use super::{tail::View as TailView, CacheRef};
 use crate::{Blob, Error, IoBufMut, IoBufs};
 use futures::stream::{FuturesUnordered, StreamExt};
 use std::num::NonZeroUsize;
 
 /// A borrowed view over a paged blob.
 pub struct View<'a, B: Blob> {
-    /// Underlying blob, used for bytes below `tail_offset` not resident in the cache.
+    /// Underlying blob, used for bytes below the tail not resident in the cache.
     pub(super) blob: &'a B,
-    /// Page cache used for bytes below `tail_offset`.
+    /// Page cache used for bytes below the tail.
     pub(super) cache_ref: &'a CacheRef,
     /// Page-cache id of the originating blob.
     pub(super) id: u64,
     /// Size of the blob, in bytes.
     pub(super) size: u64,
-    /// Offset at which the in-memory `tail` bytes begin.
-    pub(super) tail_offset: u64,
-    /// Logical bytes at `[tail_offset, size)`. May be empty.
-    pub(super) tail: &'a [u8],
+    /// The in-memory tail, serving bytes at `[tail.start, size)`.
+    pub(super) tail: TailView<'a>,
 }
 
 impl<B: Blob> Clone for View<'_, B> {
@@ -36,15 +34,41 @@ impl<B: Blob> Clone for View<'_, B> {
 impl<B: Blob> Copy for View<'_, B> {}
 
 impl<B: Blob> View<'_, B> {
-    /// Copy any in-memory tail overlap into `buf`, returning the remaining prefix length.
-    fn copy_tail_overlap(&self, buf: &mut [u8], offset: u64) -> usize {
-        let tail_start = self.tail_offset.max(offset);
-        let prefix_len = (tail_start - offset) as usize;
-        let tail_offset = (tail_start - self.tail_offset) as usize;
-        let tail_len = buf.len() - prefix_len;
-        let (_, tail_buf) = buf.split_at_mut(prefix_len);
-        tail_buf.copy_from_slice(&self.tail[tail_offset..tail_offset + tail_len]);
-        prefix_len
+    /// Split validated read ranges into tail copies (performed inline) and ranges needing a
+    /// cache or blob read (returned with their slots).
+    ///
+    /// `buf` holds one slot per range, back to back. Ranges entirely within the tail are
+    /// copied from memory; a range straddling the boundary is copied above it and returned
+    /// below it.
+    fn split_read_ranges<'b>(
+        &self,
+        mut buf: &'b mut [u8],
+        ranges: impl ExactSizeIterator<Item = (u64, usize)>,
+    ) -> Vec<(&'b mut [u8], u64)> {
+        let mut cache_ranges = Vec::with_capacity(ranges.len());
+        for (offset, len) in ranges {
+            let (slot, rest) = buf.split_at_mut(len);
+            buf = rest;
+            if len == 0 {
+                continue;
+            }
+            let end = offset + len as u64;
+            if end <= self.tail.start {
+                // Entirely below the tail, so this needs a cache/blob read.
+                cache_ranges.push((slot, offset));
+            } else if offset >= self.tail.start {
+                // Entirely within the tail.
+                self.tail.copy(slot, offset);
+            } else {
+                // Straddles the boundary: copy the suffix from the tail, record the prefix for
+                // a cache/blob read.
+                let prefix_len = (self.tail.start - offset) as usize;
+                let (prefix, suffix) = slot.split_at_mut(prefix_len);
+                self.tail.copy(suffix, self.tail.start);
+                cache_ranges.push((prefix, offset));
+            }
+        }
+        cache_ranges
     }
 
     /// Read into `buf` if it can be done synchronously without I/O. Returns `true` only if all
@@ -61,13 +85,12 @@ impl<B: Blob> View<'_, B> {
             return true;
         }
 
-        if end_offset <= self.tail_offset {
+        if end_offset <= self.tail.start {
             return self.cache_ref.read_cached(self.id, buf, offset) == buf.len();
         }
 
-        // Copy the suffix overlapping the tail, then serve any prefix below `tail_offset` from the
-        // cache.
-        let dst_start = self.copy_tail_overlap(buf, offset);
+        // Copy the suffix overlapping the tail, then serve any prefix below it from the cache.
+        let dst_start = self.tail.copy_overlap(buf, offset);
 
         if dst_start == 0 {
             return true;
@@ -87,12 +110,12 @@ impl<B: Blob> View<'_, B> {
             return Err(Error::BlobInsufficientLength);
         }
 
-        // Copy any suffix from the in-memory tail, leaving the prefix below `tail_offset` to be
-        // served from the page cache or blob.
-        let remaining = if end_offset <= self.tail_offset {
+        // Copy any suffix from the tail, leaving the prefix below it to be served from the
+        // page cache or blob.
+        let remaining = if end_offset <= self.tail.start {
             buf.len()
         } else {
-            self.copy_tail_overlap(buf, offset)
+            self.tail.copy_overlap(buf, offset)
         };
 
         if remaining == 0 {
@@ -170,7 +193,7 @@ impl<B: Blob> View<'_, B> {
             return Ok(0);
         }
 
-        let mut cache_ranges = super::split_read_ranges(buf, ranges(), self.tail_offset, self.tail);
+        let mut cache_ranges = self.split_read_ranges(buf, ranges());
 
         // Fast path: try the page cache for all ranges in a single lock acquisition.
         self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
@@ -210,7 +233,7 @@ impl<B: Blob> View<'_, B> {
             return Vec::new();
         }
 
-        let mut cache_ranges = super::split_read_ranges(buf, ranges(), self.tail_offset, self.tail);
+        let mut cache_ranges = self.split_read_ranges(buf, ranges());
         if cache_ranges.is_empty() {
             return Vec::new();
         }
@@ -230,8 +253,7 @@ impl<B: Blob> View<'_, B> {
             return Vec::new();
         }
 
-        let mut cache_ranges =
-            super::split_read_ranges(buf, ranges.iter().copied(), self.tail_offset, self.tail);
+        let mut cache_ranges = self.split_read_ranges(buf, ranges.iter().copied());
         if cache_ranges.is_empty() {
             return Vec::new();
         }

--- a/runtime/src/utils/buffer/paged/view.rs
+++ b/runtime/src/utils/buffer/paged/view.rs
@@ -291,8 +291,8 @@ mod tests {
 
             // A full page (flushed to the blob) followed by a partial tail kept in the tip buffer.
             let page_size = PAGE_SIZE.get() as usize;
-            writer.append(&vec![0xAA; page_size]).await.unwrap();
-            writer.append(b"TAIL").await.unwrap();
+            writer.append(&vec![0xAA; page_size]);
+            writer.append(b"TAIL");
             writer.sync().await.unwrap();
 
             // Warm the cache for the first page, then read across the page/tail boundary.

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -194,9 +194,9 @@ impl<B: Blob> Writer<B> {
             current_page,
             partial_page_state,
             sync_state: if needs_sync {
-                SyncState::Dirty
+                SyncState::dirty()
             } else {
-                SyncState::Clean
+                SyncState::clean()
             },
             id: cache_ref.next_id(),
             cache_ref,

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1033,10 +1033,15 @@ impl<B: Blob> Writer<B> {
 
         // A logical shrink can leave the physical page count unchanged. Only real physical
         // resizes need to create a pending sync.
+        //
+        // Resize the blob directly, not through [SyncState::resize]: this writer publishes
+        // its state only after the truncate returns, so a recorded resize re-issued by a
+        // later operation (see [SyncState::settle]) would truncate under state that still
+        // claims the old size. A dropped truncate here is simply a no-op.
         if new_physical_size != current_physical_size {
-            self.sync_state
-                .resize(&self.blob, new_physical_size)
-                .await?;
+            self.sync_state.wait_for_pending().await?;
+            self.sync_state.mark_dirty();
+            self.blob.resize(new_physical_size).await?;
         }
 
         // Evict cached pages at or beyond the new full-page boundary. The page at
@@ -1170,6 +1175,59 @@ mod tests {
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(103); // janky size to ensure we test page alignment
     const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;
+
+    // A shrink dropped before its truncate reaches the blob is a no-op: it must not record a
+    // resize that a later operation applies under state still claiming the old size.
+    #[test_traced("DEBUG")]
+    fn test_shrink_cancel_before_truncate_is_noop() {
+        use crate::buffer::tests::{GatePosition, GatedResizeBlob};
+
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_noop")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedResizeBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..3 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Cancel a shrink parked before the truncate reaches the blob: nothing happened.
+            gate.cancel(writer.resize(page as u64 + 30)).await;
+            assert_eq!(writer.size(), data.len() as u64);
+
+            // The writer carries on: appends and syncs land as if the shrink was never asked.
+            writer.append(&data[..10]).await.unwrap();
+            writer.sync().await.unwrap();
+            let expected_size = (data.len() + 10) as u64;
+            assert_eq!(writer.size(), expected_size);
+            drop(writer);
+
+            // The acknowledged state survives a restart.
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_noop")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), expected_size);
+            let read = reopened
+                .read_at(0, expected_size as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(&read.as_ref()[..data.len()], data.as_slice());
+            assert_eq!(&read.as_ref()[data.len()..], &data[..10]);
+        });
+    }
 
     #[test_traced("DEBUG")]
     fn test_read_many_into_empty() {

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -14,10 +14,10 @@
 //! # Paging
 //!
 //! Callers append and read logical bytes; the blob stores physical pages in the format described
-//! in [`super`]. Appends are synchronous: they accumulate in a write buffer and reach the blob
+//! in [`super`]. Appends are synchronous: they extend an in-memory tail and reach the blob
 //! in pages only at flush points (`sync`, `start_sync`, `resize`, `seal`, `snapshot`, `replay`).
-//! Buffered bytes are readable immediately but durable only after `sync`. Full pages read from
-//! the blob are cached in a shared page cache, so reads are served from the write buffer, the
+//! Tail bytes are readable immediately but durable only after `sync`. Full pages read from
+//! the blob are cached in a shared page cache, so reads are served from the tail, the
 //! page cache, or the blob itself.
 //!
 //! # Checksums
@@ -31,18 +31,18 @@
 //!
 //! The [Writer] owns the page layout, page cache entries, and durability bookkeeping of its
 //! [Blob]. Raw handles cloned before the writer existed see physical bytes, including CRC
-//! records, and do not observe buffered bytes until they are flushed. They must not mutate the
-//! blob while a [Writer] exists: such writes bypass the write buffer and page cache and can
+//! records, and do not observe tail bytes until they are flushed. They must not mutate the
+//! blob while a [Writer] exists: such writes bypass the tail and page cache and can
 //! invalidate checksum recovery.
 
 use super::{
     read::{PageReader, Replay},
+    tail::Tail,
     view::View,
 };
 use crate::{
     buffer::{
         paged::{CacheRef, Checksum, Slot, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE},
-        tip::Buffer,
         SyncState,
     },
     Blob, Error, Handle, IoBuf, IoBufMut, IoBufs,
@@ -51,26 +51,6 @@ use bytes::{Buf, BufMut};
 use commonware_cryptography::Crc32;
 use std::num::{NonZeroU16, NonZeroUsize};
 use tracing::warn;
-
-/// Adjusts a requested write-buffer `capacity` upward to the value the buffer actually uses,
-/// applying two upward adjustments:
-///
-/// - Rounds up to a whole multiple of `page_size`, so the buffer always holds an exact number of
-///   pages. Callers can then drain and bulk-cache full pages without re-rounding the capacity.
-/// - Raises the result to a floor of two pages, so the buffer can hold at least one full page of
-///   new data even while caching a nearly-full page of already written data.
-fn adjusted_capacity(capacity: usize, page_size: u64) -> usize {
-    let page_size = page_size as usize;
-    let rounded = capacity.next_multiple_of(page_size);
-    let floor = page_size * 2;
-    if rounded < floor {
-        warn!(
-            floor,
-            "requested buffer capacity is too low, increasing it to floor"
-        );
-    }
-    rounded.max(floor)
-}
 
 /// The state of the tip page's on-disk CRC record.
 enum PartialPage {
@@ -103,7 +83,7 @@ impl PartialPage {
 ///
 /// # Cancellation
 ///
-/// Appends are synchronous: they stage bytes in the write buffer and cannot be cancelled.
+/// Appends are synchronous: they extend the in-memory tail and cannot be cancelled.
 /// The async operations (`sync`, `start_sync`, `resize`, `seal`, `snapshot`, `replay`) are
 /// the only paths that touch the blob; dropping one mid-flight leaves the writer in a
 /// consistent, retryable state. A dropped operation may still have reached the blob (a
@@ -113,9 +93,6 @@ impl PartialPage {
 pub struct Writer<B: Blob> {
     /// The underlying blob being wrapped.
     blob: B,
-
-    /// The page where the next appended byte will be written to.
-    current_page: u64,
 
     /// The state of the tip page's on-disk CRC record.
     partial_page_state: PartialPage,
@@ -129,12 +106,16 @@ pub struct Writer<B: Blob> {
     /// A reference to the page cache that manages read caching for this blob.
     cache_ref: CacheRef,
 
-    /// The write buffer containing any logical bytes following the last full page boundary in the
-    /// underlying blob.
-    buffer: Buffer,
+    /// The in-memory tail: appended bytes not yet published as written. Its start is the
+    /// authority for how many pages the blob holds (see [Self::current_page]).
+    tail: Tail,
 }
 
 impl<B: Blob> Writer<B> {
+    /// The page where the next flushed byte will be written.
+    const fn current_page(&self) -> u64 {
+        self.tail.start() / self.cache_ref.page_size()
+    }
     /// Write bytes to the underlying blob and mark them as needing sync.
     async fn write_at(&mut self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
         self.sync_state.write_at(&self.blob, offset, bufs).await
@@ -169,8 +150,12 @@ impl<B: Blob> Writer<B> {
     }
 
     /// Wrap `blob` in a [Writer]. `blob` must already hold `original_blob_size` physical bytes;
-    /// reads are cached through `cache_ref` and appends stage in a write buffer of capacity
-    /// `capacity`. Rewinds the blob if necessary so it only contains checksum-validated data.
+    /// reads are cached through `cache_ref` and appends stage in the in-memory tail until the
+    /// next flush point. Rewinds the blob if necessary so it only contains checksum-validated
+    /// data.
+    ///
+    /// `capacity` is the preferred allocation size for the mutable tip. Appends may grow it
+    /// temporarily; callers bound pending data by their flush cadence.
     pub async fn new(
         blob: B,
         original_blob_size: u64,
@@ -190,7 +175,6 @@ impl<B: Blob> Writer<B> {
             blob.sync().await?;
         }
 
-        let capacity = adjusted_capacity(capacity, cache_ref.page_size());
         let needs_sync = !invalid_data_found; // ensure pending writes on the wrapped blob are synced
 
         let (current_page, partial_page_state, partial_data) = match partial_page_state {
@@ -202,16 +186,16 @@ impl<B: Blob> Writer<B> {
             None => (pages, PartialPage::None, None),
         };
 
-        let buffer = Buffer::from(
+        let tail = Tail::new(
             current_page * cache_ref.page_size(),
             partial_data.unwrap_or_default(),
             capacity,
+            cache_ref.page_size() as usize,
             cache_ref.pool().clone(),
         );
 
         Ok(Self {
             blob,
-            current_page,
             partial_page_state,
             sync_state: if needs_sync {
                 SyncState::dirty()
@@ -220,7 +204,7 @@ impl<B: Blob> Writer<B> {
             },
             id: cache_ref.next_id(),
             cache_ref,
-            buffer,
+            tail,
         })
     }
 
@@ -294,20 +278,14 @@ impl<B: Blob> Writer<B> {
 
     /// Append all bytes in `buf` to the tip of the blob, returning the logical offset at which
     /// the first byte was written.
-    ///
-    /// Appends stage bytes in the write buffer and perform no I/O; they reach the blob at the
-    /// next flush point (`sync`, `start_sync`, `resize`, `seal`, `snapshot`, or `replay`).
-    /// Callers bound memory by their flush cadence.
     pub fn append(&mut self, buf: &[u8]) -> u64 {
-        let offset = self.buffer.size();
-        self.buffer.append(buf);
-        offset
+        self.tail.append(buf)
     }
 
     /// Append owned bytes to the tip of the blob, returning the logical offset at which the
-    /// first byte was written. See [Self::append].
+    /// first byte was written.
     pub fn append_owned(&mut self, buf: IoBuf) -> u64 {
-        self.append(buf.as_ref())
+        self.tail.append_owned(buf)
     }
 
     /// Resolve an [PartialPage::Unverified] record by reading it back from the blob.
@@ -322,7 +300,7 @@ impl<B: Blob> Writer<B> {
         }
         let (_, record) = super::get_page_with_checksum_from_blob(
             &self.blob,
-            self.current_page,
+            self.current_page(),
             self.cache_ref.page_size(),
         )
         .await?;
@@ -340,7 +318,7 @@ impl<B: Blob> Writer<B> {
         sync: bool,
     ) -> Result<bool, Error> {
         let logical_page_size = self.cache_ref.page_size() as usize;
-        let write_at_offset = self.current_page * (logical_page_size as u64 + CHECKSUM_SIZE);
+        let write_at_offset = self.current_page() * (logical_page_size as u64 + CHECKSUM_SIZE);
 
         // If no CRC slot is protected, everything goes out in one write.
         let Some((prefix_len, slot)) =
@@ -381,11 +359,20 @@ impl<B: Blob> Writer<B> {
         Ok(synced)
     }
 
-    /// Flush all full pages from the buffer to disk, resetting the buffer to contain only the bytes
-    /// in any final partial page.
+    /// Flush the in-memory tail to disk without making it durable.
+    async fn flush(&mut self) -> Result<(), Error> {
+        self.flush_inner(false).await?;
+        Ok(())
+    }
+
+    /// Flush the in-memory tail and make a single write durable when possible.
     ///
-    /// If `write_partial_page` is true, the partial page will be written to the blob as well along
-    /// with a CRC record.
+    /// Returns `true` if the flush already made its writes durable.
+    async fn flush_durable(&mut self) -> Result<bool, Error> {
+        self.flush_inner(true).await
+    }
+
+    /// Flush the in-memory tail to disk.
     ///
     /// If `sync` is true and the flush emits a single write, that write is made durable
     /// immediately: with [`Blob::write_at_sync`] when there are no earlier unsynced mutations, or
@@ -393,7 +380,10 @@ impl<B: Blob> Writer<B> {
     /// plain writes so the caller can make them durable with one sync.
     ///
     /// Returns `true` if the flush made its writes durable, so no additional sync is needed.
-    async fn flush(&mut self, write_partial_page: bool, sync: bool) -> Result<bool, Error> {
+    async fn flush_inner(&mut self, sync: bool) -> Result<bool, Error> {
+        // Keep the tip partial while preparing and publishing this flush.
+        self.tail.spill_full_pages();
+
         // Re-issue any dropped resize before deriving writes from writer state. Writes and
         // syncs settle on their own; this covers paths that may emit no writes at all
         // (sync, seal, snapshot, replay) and would otherwise leave the resize incomplete.
@@ -403,13 +393,10 @@ impl<B: Blob> Writer<B> {
         // re-read it so the writes below go around the true authoritative slot.
         self.verify_partial_page().await?;
 
-        // Prepare the *physical* pages corresponding to the data in the buffer.
-        // Pass the old partial page state so the CRC record is constructed correctly.
-        let (physical_pages, partial_page_state) = self.to_physical_pages(
-            &self.buffer,
-            write_partial_page,
-            self.partial_page_state.record(),
-        );
+        // Prepare physical pages for the tail. The old partial-page record determines how the
+        // first page preserves its committed CRC slot.
+        let (physical_pages, partial_page_state) =
+            self.to_physical_pages(self.partial_page_state.record());
 
         // If there's nothing to write, return early.
         if physical_pages.is_empty() {
@@ -418,35 +405,24 @@ impl<B: Blob> Writer<B> {
 
         let synced = self.write_physical_pages(physical_pages, sync).await?;
 
-        // Update state only after the writes succeed, for cancellation safety.
-        let logical_page_size = self.cache_ref.page_size() as usize;
-        let full_pages = self.buffer.len() / logical_page_size;
-        let full_bytes = full_pages * logical_page_size;
-        if full_bytes > 0 {
-            let remaining = self.cache_ref.cache(
-                self.id,
-                &self.buffer.as_ref()[..full_bytes],
-                self.buffer.offset,
-            );
-            assert_eq!(remaining, 0, "cached full-page prefix must be page-aligned");
+        // Update state only after the writes succeed, for cancellation safety. Populate the
+        // page cache with every written page, then advance the written prefix past them.
+        let mut cache_offset = self.tail.start();
+        for pages in self.tail.full_pages() {
+            let remaining = self.cache_ref.cache(self.id, pages.as_ref(), cache_offset);
+            assert_eq!(remaining, 0, "full pages must be page-aligned");
+            cache_offset += pages.len() as u64;
         }
-        self.buffer.advance(full_bytes);
-        self.current_page += full_pages as u64;
+        self.tail.advance_full_pages();
         self.partial_page_state =
             partial_page_state.map_or(PartialPage::None, PartialPage::Committed);
-
-        // Make sure the buffer offset and underlying blob agree on the state of the tip.
-        assert_eq!(
-            self.current_page * self.cache_ref.page_size(),
-            self.buffer.offset
-        );
 
         Ok(synced)
     }
 
     /// Returns the size of the blob.
     pub const fn size(&self) -> u64 {
-        self.buffer.size()
+        self.tail.size()
     }
 
     /// Returns a borrowed view over this blob.
@@ -455,9 +431,8 @@ impl<B: Blob> Writer<B> {
             blob: &self.blob,
             cache_ref: &self.cache_ref,
             id: self.id,
-            size: self.buffer.size(),
-            tail_offset: self.buffer.offset,
-            tail: self.buffer.as_ref(),
+            size: self.tail.size(),
+            tail: self.tail.view(),
         }
     }
 
@@ -541,51 +516,36 @@ impl<B: Blob> Writer<B> {
         Some((old_len as usize, crc_record.authoritative()))
     }
 
-    /// Prepare physical-page writes from buffered logical bytes.
+    /// Prepare physical-page writes from the in-memory tail.
     ///
-    /// Each physical page contains one logical page plus CRC record. If the last page is not yet
-    /// full, it will be included only if `include_partial_page` is true.
+    /// Each physical page contains one logical page plus a CRC record.
     ///
     /// # Arguments
     ///
-    /// * `buffer` - The buffer containing logical page data
-    /// * `include_partial_page` - Whether to include a partial page if one exists
     /// * `old_crc_record` - The CRC record from a previously committed partial page, if any.
     ///   When present, the first page's CRC record will preserve the old CRC in its original slot
     ///   and place the new CRC in the other slot.
-    fn to_physical_pages(
-        &self,
-        buffer: &Buffer,
-        include_partial_page: bool,
-        old_crc_record: Option<&Checksum>,
-    ) -> (IoBufs, Option<Checksum>) {
+    fn to_physical_pages(&self, old_crc_record: Option<&Checksum>) -> (IoBufs, Option<Checksum>) {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let physical_page_size = logical_page_size + CHECKSUM_SIZE as usize;
-        let pages_to_write = buffer.len() / logical_page_size;
         let mut write_buffer = IoBufs::default();
-        let buffer_data = buffer.as_ref();
 
-        if pages_to_write > 0 {
-            self.append_full_pages(
-                &buffer.slice(..pages_to_write * logical_page_size),
-                old_crc_record,
-                &mut write_buffer,
-            );
+        // Full pages come first. The earliest one may extend a committed partial page, so its
+        // record preserves the old CRC.
+        let mut first_crc = old_crc_record;
+        for pages in self.tail.full_pages() {
+            self.append_full_pages(pages, &mut first_crc, &mut write_buffer);
         }
 
-        if !include_partial_page {
-            return (write_buffer, None);
-        }
-
-        let partial_page = &buffer_data[pages_to_write * logical_page_size..];
+        let partial_page = self.tail.tip();
         if partial_page.is_empty() {
             // No partial page data to write.
             return (write_buffer, None);
         }
 
-        // If there are no full pages and the partial page length matches what was already
+        // If no pages precede the partial page and its length matches what was already
         // written, there's nothing new to write.
-        if pages_to_write == 0 {
+        if write_buffer.is_empty() {
             if let Some(old_crc) = old_crc_record {
                 let (old_len, _) = old_crc.get_crc();
                 if partial_page.len() == old_len as usize {
@@ -596,13 +556,12 @@ impl<B: Blob> Writer<B> {
         let partial_len = partial_page.len();
         let crc = Crc32::checksum(partial_page);
 
-        // For partial pages: if this is the first page and there's an old CRC, preserve it.
-        // Otherwise just use the new CRC in slot 0.
-        let crc_record = if let (0, Some(old_crc)) = (pages_to_write, old_crc_record) {
-            Self::build_crc_record_preserving_old(partial_len as u16, crc, old_crc)
-        } else {
-            Checksum::new(partial_len as u16, crc)
-        };
+        // For partial pages: if this is the first page emitted and there's an old CRC, preserve
+        // it. Otherwise just use the new CRC in slot 0.
+        let crc_record = first_crc.map_or_else(
+            || Checksum::new(partial_len as u16, crc),
+            |old_crc| Self::build_crc_record_preserving_old(partial_len as u16, crc, old_crc),
+        );
 
         // A persisted partial page still occupies one full physical page:
         // [partial logical bytes, zero padding, crc record].
@@ -620,53 +579,40 @@ impl<B: Blob> Writer<B> {
         (write_buffer, Some(crc_record))
     }
 
-    /// Appends each page of `data` to `write_buffer` in on-disk format: its payload (a zero-copy
-    /// slice of `data`) followed by a CRC record.
-    ///
-    /// `data.len()` must be a non-zero multiple of the page size. When `old_crc_record` is present,
-    /// the first page's record preserves the old CRC in its original slot.
+    /// Append full logical pages and their CRC records to `write_buffer` without copying payload
+    /// bytes. The first page preserves an existing partial-page record when needed.
     fn append_full_pages(
         &self,
-        data: &IoBuf,
-        old_crc_record: Option<&Checksum>,
+        pages: &IoBuf,
+        first_crc: &mut Option<&Checksum>,
         write_buffer: &mut IoBufs,
     ) {
         let logical_page_size = self.cache_ref.page_size() as usize;
-        let pages = data.len() / logical_page_size;
-        debug_assert!(pages > 0);
-        debug_assert_eq!(data.len() % logical_page_size, 0);
         let logical_page_size_u16 =
             u16::try_from(logical_page_size).expect("page size must fit in u16 for CRC record");
+        debug_assert!(pages.len().is_multiple_of(logical_page_size));
+        let page_count = pages.len() / logical_page_size;
+        let mut crcs = self
+            .cache_ref
+            .pool()
+            .alloc(CHECKSUM_SIZE as usize * page_count);
 
-        // Build CRC bytes for full pages once. Full-page payload bytes are appended below as
-        // slices from `data`, so we avoid copying logical payload here.
-        let mut crcs = self.cache_ref.pool().alloc(CHECKSUM_SIZE as usize * pages);
-        let data_bytes = data.as_ref();
-        for page in 0..pages {
-            let start_read_idx = page * logical_page_size;
-            let end_read_idx = start_read_idx + logical_page_size;
-            let logical_page = &data_bytes[start_read_idx..end_read_idx];
-            let crc = Crc32::checksum(logical_page);
-
-            // For the first page, if there's an old partial page CRC, construct the record
-            // to preserve the old CRC in its original slot.
-            let crc_record = if let (0, Some(old_crc)) = (page, old_crc_record) {
-                Self::build_crc_record_preserving_old(logical_page_size_u16, crc, old_crc)
-            } else {
-                Checksum::new(logical_page_size_u16, crc)
-            };
+        for page in pages.as_ref().chunks_exact(logical_page_size) {
+            let crc = Crc32::checksum(page);
+            let crc_record = first_crc.take().map_or_else(
+                || Checksum::new(logical_page_size_u16, crc),
+                |old_crc| {
+                    Self::build_crc_record_preserving_old(logical_page_size_u16, crc, old_crc)
+                },
+            );
             crcs.put_slice(&crc_record.to_bytes());
         }
-        let crc_blob = crcs.freeze();
 
-        // Physical full-page layout is [logical_page_bytes, crc_record_bytes].
-        for page in 0..pages {
-            let start_read_idx = page * logical_page_size;
-            let end_read_idx = start_read_idx + logical_page_size;
-            write_buffer.append(data.slice(start_read_idx..end_read_idx));
-
-            let crc_start = page * CHECKSUM_SIZE as usize;
-            write_buffer.append(crc_blob.slice(crc_start..crc_start + CHECKSUM_SIZE as usize));
+        let crcs = crcs.freeze();
+        for start in (0..pages.len()).step_by(logical_page_size) {
+            write_buffer.append(pages.slice(start..start + logical_page_size));
+            let crc_start = (start / logical_page_size) * CHECKSUM_SIZE as usize;
+            write_buffer.append(crcs.slice(crc_start..crc_start + CHECKSUM_SIZE as usize));
         }
     }
 
@@ -721,13 +667,12 @@ impl<B: Blob> Writer<B> {
         let old_slot = old_crc.authoritative();
         let new_slot = old_slot.other();
 
-        // Stage the new slot with a 0 length and the shrunken page CRC. A crash here leaves the
-        // old slot as the only non-zero valid slot.
+        // Write the new slot with length 0. A crash here leaves the old slot authoritative.
         let new_slot_offset = crc_start
             .checked_add(new_slot.offset() as u64)
             .ok_or(Error::OffsetOverflow)?;
-        let staged_slot = Checksum::slot_bytes(0, new_crc);
-        self.write_at_sync(new_slot_offset, staged_slot.to_vec())
+        let prepared_slot = Checksum::slot_bytes(0, new_crc);
+        self.write_at_sync(new_slot_offset, prepared_slot.to_vec())
             .await?;
 
         // Publish the new shrunken length. If a crash happens before the old slot is invalidated,
@@ -748,20 +693,20 @@ impl<B: Blob> Writer<B> {
         Ok(Checksum::in_slot(new_slot, new_len, new_crc))
     }
 
-    /// Flushes any buffered data, then returns a [Replay] for the underlying blob.
+    /// Flushes the in-memory tail, then returns a [Replay] for the underlying blob.
     ///
     /// The returned replay can be used to sequentially read all pages from the blob while ensuring
     /// all data passes integrity verification. CRCs are validated but not included in the output.
     ///
-    /// This is not a durable operation. Buffered data may be plainly written so the replay can
+    /// This is not a durable operation. Tail bytes may be plainly written so the replay can
     /// read it, but callers must still use [`sync`](Self::sync) if that data must survive a crash.
     pub async fn replay(&mut self, buffer_size: NonZeroUsize) -> Result<Replay<B>, Error> {
         let logical_page_size = self.cache_ref.page_size();
         let logical_page_size_nz =
             NonZeroU16::new(logical_page_size as u16).expect("page_size is non-zero");
 
-        // Flush any buffered data (without fsync) so the reader sees all written data.
-        self.flush(true, false).await?;
+        // Flush the tail without fsync so the reader sees all written data.
+        self.flush().await?;
 
         // Convert buffer size (bytes) to page count
         let physical_page_size = logical_page_size + CHECKSUM_SIZE;
@@ -769,11 +714,12 @@ impl<B: Blob> Writer<B> {
         let prefetch_pages = prefetch_pages.max(1); // At least 1 page
 
         // Compute both physical and logical blob sizes.
+        let current_page = self.current_page();
         let (physical_blob_size, logical_blob_size) = self.partial_page_state.record().map_or_else(
             || {
                 // All pages are full.
-                let physical = physical_page_size * self.current_page;
-                let logical = logical_page_size * self.current_page;
+                let physical = physical_page_size * current_page;
+                let logical = logical_page_size * current_page;
                 (physical, logical)
             },
             |crc_record| {
@@ -781,9 +727,9 @@ impl<B: Blob> Writer<B> {
                 let (partial_len, _) = crc_record.get_crc();
                 let partial_len = partial_len as u64;
                 // Physical: all pages including the partial one (which is padded to full size).
-                let physical = physical_page_size * (self.current_page + 1);
+                let physical = physical_page_size * (current_page + 1);
                 // Logical: full pages before this + partial page's actual data length.
-                let logical = logical_page_size * self.current_page + partial_len;
+                let logical = logical_page_size * current_page + partial_len;
                 (physical, logical)
             },
         );
@@ -798,29 +744,28 @@ impl<B: Blob> Writer<B> {
         Ok(Replay::new(reader))
     }
 
-    /// Flush buffered data and capture an immutable [`super::Sealed`] view without consuming the
+    /// Flush the in-memory tail and capture an immutable [`super::Sealed`] view without consuming the
     /// writer.
     ///
-    /// This writes buffered bytes to the blob layout but does not make them durable. Call
+    /// This writes tail bytes to the blob layout but does not make them durable. Call
     /// [`Self::sync`] or [`super::Sealed::sync`] if the returned handle's bytes must survive a
     /// crash.
     ///
     /// If this writer later rewinds or truncates into the returned handle's range, reads from that
     /// handle may observe unspecified contents.
     pub async fn snapshot(&mut self) -> Result<super::Sealed<B>, Error> {
-        self.flush(true, false).await?;
+        self.flush().await?;
         Ok(self.sealed_handle(self.cache_ref.next_id()))
     }
 
-    /// Flushes buffered data and makes all pending mutations durable.
+    /// Flushes the in-memory tail and makes all pending mutations durable.
     ///
     /// A single physical write can be persisted with [`Blob::write_at_sync`]. If there
     /// are earlier unsynced mutations, or if the flush emits multiple physical writes,
     /// durability is completed with [`Blob::sync`].
     pub async fn sync(&mut self) -> Result<(), Error> {
-        // Flush any buffered data, including any partial page.
         // A single emitted write can be made durable directly during the flush.
-        if self.flush(true, true).await? {
+        if self.flush_durable().await? {
             return Ok(());
         }
 
@@ -829,14 +774,14 @@ impl<B: Blob> Writer<B> {
         self.sync_state.sync(&self.blob).await
     }
 
-    /// Flushes buffered data and begins making all pending mutations durable, returning a
+    /// Flushes the in-memory tail and begins making all pending mutations durable, returning a
     /// completion handle.
     ///
     /// Awaiting the returned [`Handle`] waits for the same durability guarantee as [`Self::sync`]
     /// for the state flushed by this call. Later calls to [`Self::sync`] and writer methods that
     /// mutate the blob first wait for any outstanding start_sync handles.
     pub async fn start_sync(&mut self) -> Handle<()> {
-        if let Err(err) = self.flush(true, false).await {
+        if let Err(err) = self.flush().await {
             return Handle::ready(Err(err));
         }
         self.sync_state.start_sync(&self.blob).await
@@ -858,7 +803,7 @@ impl<B: Blob> Writer<B> {
     /// - Concurrent readers which try to read past the new size during the resize may error.
     /// - The resize is not guaranteed durable until the next sync.
     pub async fn resize(&mut self, size: u64) -> Result<(), Error> {
-        let current_size = self.buffer.size();
+        let current_size = self.tail.size();
         if size == current_size {
             return Ok(());
         }
@@ -882,8 +827,12 @@ impl<B: Blob> Writer<B> {
             .checked_add(CHECKSUM_SIZE)
             .ok_or(Error::OffsetOverflow)?;
 
-        // Flush any buffered data first to ensure we have a consistent state on disk.
+        // Flush the tail first to ensure the blob is consistent.
         self.sync().await?;
+        debug_assert!(
+            self.tail.full_pages().is_empty(),
+            "sync must write the tail's full pages"
+        );
 
         // Calculate the physical size needed for the new size.
         let full_pages = target_size / logical_page_size;
@@ -898,12 +847,12 @@ impl<B: Blob> Writer<B> {
             .checked_mul(logical_page_size)
             .ok_or(Error::OffsetOverflow)?;
         let current_physical_size = if self.partial_page_state.record().is_some() {
-            self.current_page
+            self.current_page()
                 .checked_add(1)
                 .and_then(|pages| pages.checked_mul(physical_page_size))
                 .ok_or(Error::OffsetOverflow)?
         } else {
-            self.current_page
+            self.current_page()
                 .checked_mul(physical_page_size)
                 .ok_or(Error::OffsetOverflow)?
         };
@@ -925,9 +874,7 @@ impl<B: Blob> Writer<B> {
         // physical page count and the truncate is never a no-op.
         if partial_bytes == 0 {
             self.partial_page_state = PartialPage::None;
-            self.current_page = full_pages;
-            self.buffer.offset = tail_offset;
-            self.buffer.clear();
+            self.tail.restart_at(tail_offset, &[]);
             return self.sync_state.resize(&self.blob, new_physical_size).await;
         }
 
@@ -950,10 +897,7 @@ impl<B: Blob> Writer<B> {
         // to the page re-reads the record first (see [Self::verify_partial_page]) and writes
         // around whichever slot is actually authoritative.
         self.partial_page_state = PartialPage::Unverified;
-        self.current_page = full_pages;
-        self.buffer.offset = tail_offset;
-        self.buffer.clear();
-        self.buffer.append(page_data.as_ref());
+        self.tail.restart_at(tail_offset, page_data.as_ref());
 
         // If the target stays within the current tip page, the physical page count is
         // unchanged and no truncate is needed. Otherwise truncate every physical page above
@@ -977,10 +921,7 @@ impl<B: Blob> Writer<B> {
             .await?;
 
         // Update state only after the rewrite succeeds, for cancellation safety.
-        self.current_page = full_pages;
-        self.buffer.offset = tail_offset;
-        self.buffer.clear();
-        self.buffer.append(new_data);
+        self.tail.restart_at(tail_offset, new_data);
         self.partial_page_state = PartialPage::Committed(final_record);
 
         Ok(())
@@ -994,21 +935,18 @@ impl<B: Blob> Writer<B> {
 
     /// Construct an immutable read handle for the current blob state.
     fn sealed_handle(&self, id: u64) -> super::Sealed<B> {
-        let logical_page_size = self.cache_ref.page_size();
-        let full_pages = self.current_page;
-        assert_eq!(
-            full_pages.checked_mul(logical_page_size),
-            Some(self.buffer.offset),
-            "flushed page count is inconsistent with the buffer offset"
+        assert!(
+            self.tail.full_pages().is_empty(),
+            "sealing requires a flushed tail"
         );
-        let partial_page = if self.buffer.is_empty() {
+        let partial_page = if self.tail.tip_is_empty() {
             None
         } else {
-            Some(self.buffer.slice(..))
+            Some(self.tail.tip_slice(..))
         };
         super::Sealed::new(
             self.blob.clone(),
-            self.buffer.size(),
+            self.tail.size(),
             partial_page,
             self.cache_ref.clone(),
             id,
@@ -1018,12 +956,12 @@ impl<B: Blob> Writer<B> {
     /// Consume the write handle and return an immutable [`super::Sealed`] handle for the same
     /// blob.
     ///
-    /// Buffered bytes (full and partial pages) are written to the underlying blob, but the blob is
+    /// Tail bytes (full and partial pages) are written to the underlying blob, but the blob is
     /// not fsynced. The returned [`super::Sealed`] handle can be made durable later via
     /// [`super::Sealed::sync`].
     pub async fn seal(mut self) -> Result<super::Sealed<B>, Error> {
         self.sync_state.wait_for_pending().await?;
-        self.flush(true, false).await?;
+        self.flush().await?;
         Ok(self.sealed_handle(self.id))
     }
 }
@@ -1736,8 +1674,8 @@ mod tests {
 
     #[test_traced("DEBUG")]
     fn test_append_large_stages_until_sync() {
-        // A large owned append stages entirely in the tip: no blob or cache activity until the
-        // next flush point.
+        // A large owned append stages its whole pages as zero-copy handles and copies only the
+        // sub-page suffix into the tip: no blob or cache activity until the next flush point.
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context
@@ -1757,13 +1695,22 @@ mod tests {
             append.append_owned(src.clone());
             assert_eq!(append.size(), 500);
 
-            // The staged bytes are a copy, not a view that would pin the input allocation.
-            let tip_ptr = append.buffer.as_ref().as_ptr() as usize;
+            // The whole pages are retained as a view of the input, not copies.
+            assert_eq!(append.tail.full_pages().len(), 1);
+            assert_eq!(
+                append.tail.full_pages()[0].len(),
+                4 * PAGE_SIZE.get() as usize
+            );
+            let pages_ptr = append.tail.full_pages()[0].as_ptr() as usize;
+            assert!(src_range.contains(&pages_ptr));
+
+            // The tip's suffix is a copy, not a view that would pin the input allocation.
+            let tip_ptr = append.tail.tip().as_ptr() as usize;
             assert!(!src_range.contains(&tip_ptr));
 
-            // Everything is staged in the tip: no pages have been written or cached.
-            assert_eq!(append.current_page, 0);
-            assert_eq!(append.buffer.len(), 500);
+            // Nothing has been written or cached.
+            assert_eq!(append.current_page(), 0);
+            assert_eq!(append.tail.tip().len(), 88);
             let mut probe = vec![0u8; PAGE_SIZE.get() as usize];
             assert_eq!(append.cache_ref.read_cached(append.id, &mut probe, 0), 0);
 
@@ -1907,16 +1854,16 @@ mod tests {
             gate.cancel(writer.sync()).await;
 
             // The canceled sync must not publish a partial-page checksum state.
-            assert_eq!(writer.current_page, 0);
+            assert_eq!(writer.current_page(), 0);
             assert!(writer.partial_page_state.is_none());
             assert_eq!(writer.size(), data.len() as u64);
-            assert_eq!(writer.buffer.as_ref(), data.as_slice());
+            assert_eq!(writer.tail.tip(), data.as_slice());
             let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data.as_slice());
 
             // Retrying sync should write the partial page and publish its checksum.
             writer.sync().await.unwrap();
-            assert_eq!(writer.current_page, 0);
+            assert_eq!(writer.current_page(), 0);
             assert!(writer.partial_page_state.is_committed());
             let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data.as_slice());
@@ -2006,9 +1953,9 @@ mod tests {
             gate.cancel(writer.resize(target)).await;
 
             // The writer claims only the target page and below, all of it readable: page 0
-            // from the blob and page 1 from the staged tip.
+            // from the blob and page 1 from the in-memory tip.
             assert!(writer.partial_page_state.is_unverified());
-            assert_eq!(writer.current_page, 1);
+            assert_eq!(writer.current_page(), 1);
             assert_eq!(writer.size(), 2 * page as u64);
             let read = writer.read_at(0, 2 * page).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), &data[..2 * page]);
@@ -2062,7 +2009,7 @@ mod tests {
 
             // The writer claims the shrunken size and the surviving pages remain readable.
             assert_eq!(writer.size(), 2 * page as u64);
-            assert_eq!(writer.current_page, 2);
+            assert_eq!(writer.current_page(), 2);
             assert!(writer.partial_page_state.is_none());
             let read = writer.read_at(0, 2 * page).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), &data[..2 * page]);
@@ -2357,7 +2304,7 @@ mod tests {
             gate.set_skip(2);
             gate.cancel(writer.resize((2 * page + 30) as u64)).await;
 
-            // Memory still claims the old size and can read all of it (staged tip).
+            // Memory still claims the old size and can read all of it from the tip.
             assert!(writer.partial_page_state.is_unverified());
             assert_eq!(writer.size(), data.len() as u64);
             let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
@@ -2901,8 +2848,8 @@ mod tests {
 
     #[test_traced("DEBUG")]
     fn test_sync_drains_full_pages_from_tip() {
-        // A flush drains full pages out of the tip, leaving only the partial-page suffix
-        // buffered.
+        // Growing the tip past its capacity moves its full pages into the tail, leaving only
+        // the partial-page suffix in the tip; a flush writes the full pages.
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context
@@ -2918,18 +2865,24 @@ mod tests {
             let all: Vec<u8> = (0..530).map(|i| (i % 241) as u8).collect();
             append.append(&all[..30]);
 
-            // 500 more bytes stage in the tip, growing it past its 206-byte capacity.
+            // 500 more bytes move five full pages into the tail (530 = 5 full pages + 15
+            // bytes); the sub-page suffix stays in the tip.
             append.append(&all[30..]);
             assert_eq!(append.size(), 530);
-            assert_eq!(append.buffer.len(), 530);
+            assert_eq!(append.tail.full_pages().len(), 1);
+            assert_eq!(
+                append.tail.full_pages()[0].len(),
+                5 * PAGE_SIZE.get() as usize
+            );
+            assert_eq!(append.tail.tip().len(), 15);
 
             let read_buf = append.read_at(0, 530).await.unwrap().coalesce();
             assert_eq!(read_buf, &all[..]);
 
-            // Sync flushes everything; only the partial-page suffix remains buffered
-            // (530 = 5 full pages + 15 bytes).
+            // Sync writes the full pages; the suffix stays in the tip.
             append.sync().await.unwrap();
-            assert_eq!(append.buffer.len(), 15);
+            assert!(append.tail.full_pages().is_empty());
+            assert_eq!(append.tail.tip().len(), 15);
             drop(append);
 
             let (blob, blob_size) = context
@@ -2942,6 +2895,95 @@ mod tests {
             assert_eq!(append.size(), 530);
             let read_buf = append.read_at(0, 530).await.unwrap().coalesce();
             assert_eq!(read_buf, &all[..]);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_tail_serves_reads_across_bands() {
+        // Reads must resolve across all three regions: written pages (cache/blob), full pages
+        // held in the tail, and the tip. Exercise ranges straddling every boundary.
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context.open("test_partition", b"tail_bands").await.unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            let page = PAGE_SIZE.get() as usize;
+
+            // Write one page durably so the lowest band has content.
+            let all: Vec<u8> = (0..8 * page + 20).map(|i| (i % 239) as u8).collect();
+            append.append(&all[..page]);
+            append.sync().await.unwrap();
+            assert_eq!(append.current_page(), 1);
+
+            // Two large owned appends retain seven full pages in two tail entries; a small
+            // append fills the tip.
+            append.append_owned(IoBuf::from(all[page..4 * page].to_vec()));
+            append.append_owned(IoBuf::from(all[4 * page..8 * page].to_vec()));
+            append.append(&all[8 * page..]);
+            assert_eq!(append.tail.full_pages().len(), 2);
+            assert_eq!(append.size(), all.len() as u64);
+
+            // A whole-range read crosses written pages -> tail pages -> tip.
+            let read = append.read_at(0, all.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &all[..]);
+
+            // Synchronous reads straddling each seam.
+            for start in [page - 3, 4 * page - 3, 8 * page - 3] {
+                let mut buf = [0u8; 6];
+                assert!(append.try_read_sync_into(&mut buf, start as u64));
+                assert_eq!(&buf, &all[start..start + 6]);
+            }
+
+            // Everything survives a sync and reopen.
+            append.sync().await.unwrap();
+            drop(append);
+            let (blob, blob_size) = context.open("test_partition", b"tail_bands").await.unwrap();
+            let append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let read = append.read_at(0, all.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &all[..]);
+        });
+    }
+
+    // If sync is canceled while writing full tail pages, the tail stays intact and a retry
+    // completes without losing bytes.
+    #[test_traced("DEBUG")]
+    fn test_sync_cancel_preserves_tail_pages() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"tail_cancel")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let page = PAGE_SIZE.get() as usize;
+
+            let all: Vec<u8> = (0..4 * page + 20).map(|i| (i % 251) as u8).collect();
+            writer.append_owned(IoBuf::from(all[..4 * page].to_vec()));
+            writer.append(&all[4 * page..]);
+            assert_eq!(writer.tail.full_pages().len(), 1);
+
+            // Cancel the sync during its physical write: nothing may be published.
+            gate.cancel(writer.sync()).await;
+            assert_eq!(writer.current_page(), 0);
+            assert_eq!(writer.tail.full_pages().len(), 1);
+            assert_eq!(writer.size(), all.len() as u64);
+            let read = writer.read_at(0, all.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &all[..]);
+
+            // Retrying completes durability without losing bytes.
+            writer.sync().await.unwrap();
+            assert!(writer.tail.full_pages().is_empty());
+            assert_eq!(writer.current_page(), 4);
+            let read = writer.read_at(0, all.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &all[..]);
         });
     }
 
@@ -3171,7 +3213,7 @@ mod tests {
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
-            // Release the started sync; the next sync flushes the staged bytes durably.
+            // Release the started sync; the next sync makes the tail durable.
             deferred.release.send(Ok(())).unwrap();
             handle.await.unwrap();
             writer.sync().await.unwrap();
@@ -3408,7 +3450,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Keep the write buffered so sync attempts the clean `write_at_sync` path.
+            // Keep the write in the tail so sync attempts the clean `write_at_sync` path.
             append.append(b"abc");
 
             // Removing the blob makes the range-sync flush fail.
@@ -3434,7 +3476,7 @@ mod tests {
             // Keep data buffered so replay has to flush it without syncing.
             append.append(b"replayed");
 
-            // Replay flushes buffered data for reading, but does not make that write durable.
+            // Replay flushes the tail for reading, but does not make that write durable.
             let mut replay = append.replay(NZUsize!(1024)).await.unwrap();
             assert!(replay.ensure(b"replayed".len()).await.unwrap());
             assert_eq!(replay.remaining(), b"replayed".len());
@@ -3912,7 +3954,7 @@ mod tests {
             let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
 
             // Create a Writer.
-            let append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
 
@@ -3924,13 +3966,12 @@ mod tests {
                 .map(|i| (i % 251) as u8)
                 .collect();
 
-            // Seed a tip buffer with the logical bytes exactly as flush would see them.
-            let mut buffer = Buffer::new(0, data.len(), cache_ref.pool().clone());
-            buffer.append(&data);
+            // Normalize the tail as flush does before encoding it.
+            append.append(&data);
+            append.tail.spill_full_pages();
 
-            // Convert buffered logical bytes into physical-page writes.
-            let (physical_pages, partial_page_state) =
-                append.to_physical_pages(&buffer, true, None);
+            // Convert the in-memory tail into physical-page writes.
+            let (physical_pages, partial_page_state) = append.to_physical_pages(None);
 
             // Two full pages should each contribute a logical slice and a CRC slice, and the
             // trailing partial page should contribute one materialized padded physical page.

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -52,29 +52,29 @@ use commonware_cryptography::Crc32;
 use std::num::{NonZeroU16, NonZeroUsize};
 use tracing::warn;
 
-/// The state of the tip page's on-disk CRC record.
-enum PartialPage {
-    /// No committed partial page exists; the tip page's record can be written whole.
+/// CRC record for a partial final page already stored in the blob.
+///
+/// This is disk metadata, separate from the writer's in-memory tail.
+enum PartialRecord {
+    /// The blob has no partial final page.
     None,
-    /// The on-disk record is known; flushes write around its authoritative slot.
-    Committed(Checksum),
-    /// A canceled shrink left the on-disk record in an unknown slot state. It must be re-read
-    /// (see [Writer::verify_partial_page]) before any write to the page: writing a whole
-    /// record over an unknown one could tear the disk's authoritative slot.
-    Unverified,
+    /// The record is known; flush preserves its authoritative slot.
+    Known(Checksum),
+    /// Re-read the record before writing this page again.
+    NeedsVerification,
 }
 
-impl PartialPage {
-    /// The committed record, if any.
+impl PartialRecord {
+    /// The known record, if any.
     ///
     /// # Panics
     ///
-    /// Panics on [PartialPage::Unverified]: the record must be verified before use.
+    /// Panics when the record needs verification.
     fn record(&self) -> Option<&Checksum> {
         match self {
             Self::None => None,
-            Self::Committed(record) => Some(record),
-            Self::Unverified => panic!("partial page record must be verified before use"),
+            Self::Known(record) => Some(record),
+            Self::NeedsVerification => panic!("partial record must be verified before use"),
         }
     }
 }
@@ -89,8 +89,8 @@ pub struct Writer<B: Blob> {
     /// The underlying blob being wrapped.
     blob: B,
 
-    /// The state of the tip page's on-disk CRC record.
-    partial_page_state: PartialPage,
+    /// CRC record for the blob's partial final page.
+    partial_record: PartialRecord,
 
     /// Durability state for plain writes, resizes, and range-sync writes.
     sync_state: SyncState,
@@ -110,6 +110,7 @@ impl<B: Blob> Writer<B> {
     const fn current_page(&self) -> u64 {
         self.tail.start() / self.cache_ref.page_size()
     }
+
     /// Write bytes to the underlying blob and mark them as needing sync.
     async fn write_at(&mut self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
         self.sync_state.write_at(&self.blob, offset, bufs).await
@@ -156,7 +157,7 @@ impl<B: Blob> Writer<B> {
         capacity: usize,
         cache_ref: CacheRef,
     ) -> Result<Self, Error> {
-        let (partial_page_state, pages, invalid_data_found) =
+        let (partial_record, pages, invalid_data_found) =
             Self::read_last_valid_page(&blob, original_blob_size, cache_ref.page_size()).await?;
         if invalid_data_found {
             // Invalid data was detected, trim it from the blob.
@@ -171,13 +172,13 @@ impl<B: Blob> Writer<B> {
 
         let needs_sync = !invalid_data_found; // ensure pending writes on the wrapped blob are synced
 
-        let (current_page, partial_page_state, partial_data) = match partial_page_state {
+        let (current_page, partial_record, partial_data) = match partial_record {
             Some((partial_page, crc_record)) => (
                 pages - 1,
-                PartialPage::Committed(crc_record),
+                PartialRecord::Known(crc_record),
                 Some(partial_page),
             ),
-            None => (pages, PartialPage::None, None),
+            None => (pages, PartialRecord::None, None),
         };
 
         let tail = Tail::new(
@@ -190,7 +191,7 @@ impl<B: Blob> Writer<B> {
 
         Ok(Self {
             blob,
-            partial_page_state,
+            partial_record,
             sync_state: if needs_sync {
                 SyncState::dirty()
             } else {
@@ -281,8 +282,8 @@ impl<B: Blob> Writer<B> {
     }
 
     /// Resolve an unknown partial-page record.
-    async fn verify_partial_page(&mut self) -> Result<(), Error> {
-        if !matches!(self.partial_page_state, PartialPage::Unverified) {
+    async fn verify_partial_record(&mut self) -> Result<(), Error> {
+        if !matches!(self.partial_record, PartialRecord::NeedsVerification) {
             return Ok(());
         }
         // A canceled shrink can leave either CRC slot authoritative. Read it before writing the
@@ -293,7 +294,7 @@ impl<B: Blob> Writer<B> {
             self.cache_ref.page_size(),
         )
         .await?;
-        self.partial_page_state = PartialPage::Committed(record);
+        self.partial_record = PartialRecord::Known(record);
         Ok(())
     }
 
@@ -308,7 +309,7 @@ impl<B: Blob> Writer<B> {
 
         // If no CRC slot is protected, everything goes out in one write.
         let Some((prefix_len, slot)) =
-            Self::identify_protected_regions(self.partial_page_state.record())
+            Self::identify_protected_regions(self.partial_record.record())
         else {
             self.write_at_maybe_sync(write_at_offset, physical_pages, sync)
                 .await?;
@@ -351,13 +352,6 @@ impl<B: Blob> Writer<B> {
         Ok(())
     }
 
-    /// Flush the in-memory tail and make a single write durable when possible.
-    ///
-    /// Returns `true` if the flush already made its writes durable.
-    async fn flush_durable(&mut self) -> Result<bool, Error> {
-        self.flush_inner(true).await
-    }
-
     /// Flush the in-memory tail to disk.
     ///
     /// If `sync` is true and the flush emits a single write, that write is made durable
@@ -367,22 +361,19 @@ impl<B: Blob> Writer<B> {
     ///
     /// Returns `true` if the flush made its writes durable, so no additional sync is needed.
     async fn flush_inner(&mut self, sync: bool) -> Result<bool, Error> {
-        // Keep the tip partial while preparing and publishing this flush.
-        self.tail.spill_full_pages();
-
         // Re-issue any dropped resize before deriving writes from writer state. Writes and
         // syncs settle on their own; this covers paths that may emit no writes at all
         // (sync, seal, snapshot, replay) and would otherwise leave the resize incomplete.
         self.sync_state.settle(&self.blob).await?;
 
-        // A canceled shrink leaves the tip page's on-disk record in an unknown slot state;
-        // re-read it so following writes avoid the true authoritative slot.
-        self.verify_partial_page().await?;
+        // A canceled shrink can leave the CRC record for the blob's partial final page
+        // uncertain. Re-read it so following writes preserve the authoritative slot.
+        self.verify_partial_record().await?;
 
         // Prepare physical pages for the tail. The old partial-page record determines how the
         // first page preserves its committed CRC slot.
-        let (physical_pages, partial_page_state) =
-            self.to_physical_pages(self.partial_page_state.record());
+        let old_record = self.partial_record.record().cloned();
+        let (physical_pages, partial_record) = self.prepare_physical_pages(old_record.as_ref());
 
         // If there's nothing to write, return early.
         if physical_pages.is_empty() {
@@ -393,15 +384,16 @@ impl<B: Blob> Writer<B> {
 
         // Update state only after the writes succeed, for cancellation safety. Populate the
         // page cache with every written page, then advance the written prefix past them.
+        let cache_ref = &self.cache_ref;
+        let id = self.id;
         let mut cache_offset = self.tail.start();
         for pages in self.tail.full_pages() {
-            let remaining = self.cache_ref.cache(self.id, pages.as_ref(), cache_offset);
+            let remaining = cache_ref.cache(id, pages.as_ref(), cache_offset);
             assert_eq!(remaining, 0, "full pages must be page-aligned");
             cache_offset += pages.len() as u64;
         }
         self.tail.advance_full_pages();
-        self.partial_page_state =
-            partial_page_state.map_or(PartialPage::None, PartialPage::Committed);
+        self.partial_record = partial_record.map_or(PartialRecord::None, PartialRecord::Known);
 
         Ok(synced)
     }
@@ -495,15 +487,18 @@ impl<B: Blob> Writer<B> {
     /// - `prefix_len`: bytes `[0, prefix_len)` are committed logical data already covered by the
     ///   protected CRC and do not need to be rewritten
     /// - `protected_crc`: which CRC slot must not be overwritten by the next flush
-    fn identify_protected_regions(partial_page_state: Option<&Checksum>) -> Option<(usize, Slot)> {
-        let crc_record = partial_page_state?;
+    fn identify_protected_regions(partial_record: Option<&Checksum>) -> Option<(usize, Slot)> {
+        let crc_record = partial_record?;
         let (old_len, _) = crc_record.get_crc();
         // The protected CRC is the authoritative (longer) slot.
         Some((old_len as usize, crc_record.authoritative()))
     }
 
     /// Prepare physical-page writes from the in-memory tail.
-    fn to_physical_pages(&self, old_crc_record: Option<&Checksum>) -> (IoBufs, Option<Checksum>) {
+    fn prepare_physical_pages(
+        &mut self,
+        old_crc_record: Option<&Checksum>,
+    ) -> (IoBufs, Option<Checksum>) {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let physical_page_size = logical_page_size + CHECKSUM_SIZE as usize;
         let mut write_buffer = IoBufs::default();
@@ -511,8 +506,9 @@ impl<B: Blob> Writer<B> {
         // Full pages come first. The earliest one may extend a committed partial page, so its
         // record preserves the old CRC.
         let mut first_crc = old_crc_record;
+        let cache_ref = &self.cache_ref;
         for pages in self.tail.full_pages() {
-            self.append_full_pages(pages, &mut first_crc, &mut write_buffer);
+            Self::append_full_pages(cache_ref, pages, &mut first_crc, &mut write_buffer);
         }
 
         let partial_page = self.tail.tip();
@@ -557,22 +553,19 @@ impl<B: Blob> Writer<B> {
         (write_buffer, Some(crc_record))
     }
 
-    /// Append full logical pages and CRC records without copying payload bytes.
+    /// Append full logical pages, along with a CRC record for each.
     fn append_full_pages(
-        &self,
+        cache_ref: &CacheRef,
         pages: &IoBuf,
         first_crc: &mut Option<&Checksum>,
         write_buffer: &mut IoBufs,
     ) {
-        let logical_page_size = self.cache_ref.page_size() as usize;
+        let logical_page_size = cache_ref.page_size() as usize;
         let logical_page_size_u16 =
             u16::try_from(logical_page_size).expect("page size must fit in u16 for CRC record");
         debug_assert!(pages.len().is_multiple_of(logical_page_size));
         let page_count = pages.len() / logical_page_size;
-        let mut crcs = self
-            .cache_ref
-            .pool()
-            .alloc(CHECKSUM_SIZE as usize * page_count);
+        let mut crcs = cache_ref.pool().alloc(CHECKSUM_SIZE as usize * page_count);
 
         for page in pages.as_ref().chunks_exact(logical_page_size) {
             let crc = Crc32::checksum(page);
@@ -692,7 +685,7 @@ impl<B: Blob> Writer<B> {
 
         // Compute both physical and logical blob sizes.
         let current_page = self.current_page();
-        let (physical_blob_size, logical_blob_size) = self.partial_page_state.record().map_or_else(
+        let (physical_blob_size, logical_blob_size) = self.partial_record.record().map_or_else(
             || {
                 // All pages are full.
                 let physical = physical_page_size * current_page;
@@ -742,7 +735,7 @@ impl<B: Blob> Writer<B> {
     /// durability is completed with [`Blob::sync`].
     pub async fn sync(&mut self) -> Result<(), Error> {
         // A single emitted write can be made durable directly during the flush.
-        if self.flush_durable().await? {
+        if self.flush_inner(true).await? {
             return Ok(());
         }
 
@@ -823,7 +816,7 @@ impl<B: Blob> Writer<B> {
         let tail_offset = full_pages
             .checked_mul(logical_page_size)
             .ok_or(Error::OffsetOverflow)?;
-        let current_physical_size = if self.partial_page_state.record().is_some() {
+        let current_physical_size = if self.partial_record.record().is_some() {
             self.current_page()
                 .checked_add(1)
                 .and_then(|pages| pages.checked_mul(physical_page_size))
@@ -850,7 +843,7 @@ impl<B: Blob> Writer<B> {
         // The earlier sync wrote out any partial tip, so a boundary shrink always reduces the
         // physical page count and the truncate is never a no-op.
         if partial_bytes == 0 {
-            self.partial_page_state = PartialPage::None;
+            self.partial_record = PartialRecord::None;
             self.tail.restart_at(tail_offset, &[]);
             return self.sync_state.resize(&self.blob, new_physical_size).await;
         }
@@ -871,9 +864,9 @@ impl<B: Blob> Writer<B> {
         // claims nothing after it. If the following truncate is dropped, the writer
         // under-claims and never claims deleted pages. If a following CRC slot write is dropped,
         // the record's on-disk slot state is unknown, so mark it unverified: the next write
-        // to the page re-reads the record first (see [Self::verify_partial_page]) and writes
+        // to the page re-reads the record first (see [Self::verify_partial_record]) and writes
         // around whichever slot is actually authoritative.
-        self.partial_page_state = PartialPage::Unverified;
+        self.partial_record = PartialRecord::NeedsVerification;
         self.tail.restart_at(tail_offset, page_data.as_ref());
 
         // If the target stays within the current tip page, the physical page count is
@@ -899,7 +892,7 @@ impl<B: Blob> Writer<B> {
 
         // Update state only after the rewrite succeeds, for cancellation safety.
         self.tail.restart_at(tail_offset, new_data);
-        self.partial_page_state = PartialPage::Committed(final_record);
+        self.partial_record = PartialRecord::Known(final_record);
 
         Ok(())
     }
@@ -913,7 +906,7 @@ impl<B: Blob> Writer<B> {
     /// Construct an immutable read handle for the current blob state.
     fn sealed_handle(&self, id: u64) -> super::Sealed<B> {
         assert!(
-            self.tail.full_pages().is_empty(),
+            !self.tail.has_full_pages(),
             "sealing requires a flushed tail"
         );
         let partial_page = if self.tail.tip_is_empty() {
@@ -972,20 +965,20 @@ mod tests {
     const PAGE_SIZE: NonZeroU16 = NZU16!(103); // janky size to ensure we test page alignment
     const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;
 
-    impl PartialPage {
-        /// True if no committed partial page exists.
+    impl PartialRecord {
+        /// True if no partial page record exists.
         const fn is_none(&self) -> bool {
             matches!(self, Self::None)
         }
 
-        /// True if the on-disk record is known.
-        const fn is_committed(&self) -> bool {
-            matches!(self, Self::Committed(_))
+        /// True if the record is known.
+        const fn is_known(&self) -> bool {
+            matches!(self, Self::Known(_))
         }
 
-        /// True if the on-disk record must be re-read before the next write.
-        const fn is_unverified(&self) -> bool {
-            matches!(self, Self::Unverified)
+        /// True if the record must be re-read before the next write.
+        const fn needs_verification(&self) -> bool {
+            matches!(self, Self::NeedsVerification)
         }
     }
 
@@ -1832,7 +1825,7 @@ mod tests {
 
             // The canceled sync must not publish a partial-page checksum state.
             assert_eq!(writer.current_page(), 0);
-            assert!(writer.partial_page_state.is_none());
+            assert!(writer.partial_record.is_none());
             assert_eq!(writer.size(), data.len() as u64);
             assert_eq!(writer.tail.tip(), data.as_slice());
             let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
@@ -1841,7 +1834,7 @@ mod tests {
             // Retrying sync should write the partial page and publish its checksum.
             writer.sync().await.unwrap();
             assert_eq!(writer.current_page(), 0);
-            assert!(writer.partial_page_state.is_committed());
+            assert!(writer.partial_record.is_known());
             let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data.as_slice());
         });
@@ -1875,7 +1868,7 @@ mod tests {
 
             // The canceled shrink published its reduced claim before the truncate: the writer
             // claims exactly the pages the blob still holds and can read all of them.
-            assert!(writer.partial_page_state.is_unverified());
+            assert!(writer.partial_record.needs_verification());
             assert_eq!(writer.size(), 2 * page as u64);
             let read = writer.read_at(0, 2 * page).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), &data[..2 * page]);
@@ -1931,7 +1924,7 @@ mod tests {
 
             // The writer claims only the target page and earlier pages, all readable: page 0
             // from the blob and page 1 from the in-memory tip.
-            assert!(writer.partial_page_state.is_unverified());
+            assert!(writer.partial_record.needs_verification());
             assert_eq!(writer.current_page(), 1);
             assert_eq!(writer.size(), 2 * page as u64);
             let read = writer.read_at(0, 2 * page).await.unwrap().coalesce();
@@ -1987,7 +1980,7 @@ mod tests {
             // The writer claims the shrunken size and the surviving pages remain readable.
             assert_eq!(writer.size(), 2 * page as u64);
             assert_eq!(writer.current_page(), 2);
-            assert!(writer.partial_page_state.is_none());
+            assert!(writer.partial_record.is_none());
             let read = writer.read_at(0, 2 * page).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), &data[..2 * page]);
 
@@ -2223,7 +2216,7 @@ mod tests {
 
             // The canceled rewrite leaves the old tip bytes staged with the record cleared,
             // so the next flush rewrites the whole record instead of trusting a stale one.
-            assert!(writer.partial_page_state.is_unverified());
+            assert!(writer.partial_record.needs_verification());
             assert_eq!(writer.size(), data.len() as u64);
             let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data.as_slice());
@@ -2282,7 +2275,7 @@ mod tests {
             gate.cancel(writer.resize((2 * page + 30) as u64)).await;
 
             // Memory still claims the old size and can read all of it from the tip.
-            assert!(writer.partial_page_state.is_unverified());
+            assert!(writer.partial_record.needs_verification());
             assert_eq!(writer.size(), data.len() as u64);
             let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data.as_slice());
@@ -2333,7 +2326,7 @@ mod tests {
 
             // The whole claimed range stays readable: the last page is served from the tip
             // even though its on-disk record now validates to the shorter length.
-            assert!(writer.partial_page_state.is_unverified());
+            assert!(writer.partial_record.needs_verification());
             assert_eq!(writer.size(), data.len() as u64);
             let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data.as_slice());
@@ -2541,13 +2534,13 @@ mod tests {
 
             // Cancel the shrink parked before its first slot write: disk is untouched.
             gate.cancel(writer.resize((2 * page + 30) as u64)).await;
-            assert!(writer.partial_page_state.is_unverified());
+            assert!(writer.partial_record.needs_verification());
 
             // Arm a tear for the next write: the healing sync must not issue one.
             tear.arm(3);
             writer.sync().await.unwrap();
             assert_eq!(tear.fired(), 0, "no-op heal must not write");
-            assert!(writer.partial_page_state.is_committed());
+            assert!(writer.partial_record.is_known());
 
             // The old size remains durable.
             drop(writer);
@@ -2593,7 +2586,7 @@ mod tests {
             let target = (2 * page + 30) as u64;
             gate.set_skip(2);
             gate.cancel(writer.resize(target)).await;
-            assert!(writer.partial_page_state.is_unverified());
+            assert!(writer.partial_record.needs_verification());
 
             // Tear the healing write so none of the free slot's bytes land (its stale
             // contents remain invalid); the authoritative slot is never touched.
@@ -2703,7 +2696,7 @@ mod tests {
 
             // Cancel the shrink parked before its first slot write.
             gate.cancel(writer.resize((2 * page + 30) as u64)).await;
-            assert!(writer.partial_page_state.is_unverified());
+            assert!(writer.partial_record.needs_verification());
 
             // The next sync's flush completes the tip page in place.
             let big: Vec<u8> = (0..500).map(|i| (i % 241) as u8).collect();
@@ -3908,12 +3901,12 @@ mod tests {
         );
     }
 
-    /// Test that `to_physical_pages` emits full pages zero-copy while still materializing the
+    /// Test that `prepare_physical_pages` emits full pages zero-copy while still materializing the
     /// trailing partial page into one padded physical page.
     #[test_traced("DEBUG")]
-    fn test_to_physical_pages_zero_copy_full_pages_and_materialized_partial() {
+    fn test_prepare_physical_pages_zero_copy_full_pages_and_materialized_partial() {
         // Build a tip buffer containing two full logical pages plus a trailing partial
-        // page, convert it with `to_physical_pages`, then verify:
+        // page, prepare physical pages, then verify:
         // - the result is chunked rather than one contiguous buffer for the full-page portion
         // - the logical payload bytes for the first two pages are preserved in order
         // - the partial page is padded with zeros up to one full logical page
@@ -3922,7 +3915,7 @@ mod tests {
         executor.start(|context: deterministic::Context| async move {
             // Open a new blob.
             let (blob, blob_size) = context
-                .open("test_partition", b"to_physical_pages_zero_copy")
+                .open("test_partition", b"prepare_physical_pages_zero_copy")
                 .await
                 .unwrap();
             assert_eq!(blob_size, 0);
@@ -3943,19 +3936,17 @@ mod tests {
                 .map(|i| (i % 251) as u8)
                 .collect();
 
-            // Normalize the tail as flush does before encoding it.
             append.append(&data);
-            append.tail.spill_full_pages();
 
             // Convert the in-memory tail into physical-page writes.
-            let (physical_pages, partial_page_state) = append.to_physical_pages(None);
+            let (physical_pages, partial_record) = append.prepare_physical_pages(None);
 
             // Two full pages should each contribute a logical slice and a CRC slice, and the
             // trailing partial page should contribute one materialized padded physical page.
             assert_eq!(physical_pages.chunk_count(), 5);
 
             // The returned partial-page CRC state must describe the exact trailing logical length.
-            let crc_record = partial_page_state.expect("partial page state must be returned");
+            let crc_record = partial_record.expect("partial record must be returned");
             let (len, _) = crc_record.get_crc();
             assert_eq!(len as usize, partial_len);
 

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -97,7 +97,6 @@ impl PartialPage {
             Self::Unverified => panic!("partial page record must be verified before use"),
         }
     }
-
 }
 
 /// Unique writer to a cache-wrapped [Blob].
@@ -1810,8 +1809,7 @@ mod tests {
             append.sync().await.unwrap();
 
             // 450 more bytes stage on top of the synced 50-byte partial page (protected CRC).
-            append
-                .append_owned(IoBuf::from(all[50..].to_vec()));
+            append.append_owned(IoBuf::from(all[50..].to_vec()));
             assert_eq!(append.size(), 500);
             let read_buf = append.read_at(0, 500).await.unwrap().coalesce();
             assert_eq!(read_buf, &all[..]);
@@ -1832,8 +1830,7 @@ mod tests {
 
             // Repeating the owned append after recovery and syncing makes everything durable,
             // exercising the protected-CRC handling for the recovered partial page.
-            append
-                .append_owned(IoBuf::from(all[50..].to_vec()));
+            append.append_owned(IoBuf::from(all[50..].to_vec()));
             append.sync().await.unwrap();
             drop(append);
 
@@ -1867,8 +1864,7 @@ mod tests {
 
             let all: Vec<u8> = (0..430).map(|i| (i % 239) as u8).collect();
             append.append(&all[..30]);
-            append
-                .append_owned(IoBuf::from(all[30..].to_vec()));
+            append.append_owned(IoBuf::from(all[30..].to_vec()));
             assert_eq!(append.size(), 430);
             let read_buf = append.read_at(0, 430).await.unwrap().coalesce();
             assert_eq!(read_buf, &all[..]);
@@ -2826,14 +2822,12 @@ mod tests {
 
             // Exactly 4 pages: no remainder.
             let bulk: Vec<u8> = (0..412).map(|i| (i % 233) as u8).collect();
-            append
-                .append_owned(IoBuf::from(bulk.clone()));
+            append.append_owned(IoBuf::from(bulk.clone()));
             assert_eq!(append.size(), 412);
 
             // A small owned append takes the buffered path.
             let small: Vec<u8> = (0..10).map(|i| (i % 229) as u8).collect();
-            append
-                .append_owned(IoBuf::from(small.clone()));
+            append.append_owned(IoBuf::from(small.clone()));
             assert_eq!(append.size(), 422);
 
             let read_buf = append.read_at(0, 422).await.unwrap().coalesce();
@@ -2872,8 +2866,7 @@ mod tests {
             let mut direct = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            direct
-                .append_owned(IoBuf::from(data.clone()));
+            direct.append_owned(IoBuf::from(data.clone()));
             direct.sync().await.unwrap();
             drop(direct);
 
@@ -2975,8 +2968,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            append
-                .append(&vec![7; PAGE_SIZE.get() as usize]);
+            append.append(&vec![7; PAGE_SIZE.get() as usize]);
 
             // One pooled slot backs the page cache and one backs the mutable tip.
             assert!(
@@ -4018,8 +4010,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append
-                .append(&(11..=30).collect::<Vec<u8>>());
+            append.append(&(11..=30).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4067,8 +4058,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append
-                .append(&(31..=50).collect::<Vec<u8>>());
+            append.append(&(31..=50).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4140,8 +4130,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append
-                .append(&(11..=30).collect::<Vec<u8>>());
+            append.append(&(11..=30).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4150,8 +4139,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append
-                .append(&(31..=50).collect::<Vec<u8>>());
+            append.append(&(31..=50).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4199,8 +4187,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append
-                .append(&(51..=70).collect::<Vec<u8>>());
+            append.append(&(51..=70).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4292,8 +4279,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append
-                .append(&(21..=40).collect::<Vec<u8>>());
+            append.append(&(21..=40).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4357,8 +4343,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append
-                .append(&(51..=80).collect::<Vec<u8>>());
+            append.append(&(51..=80).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4391,8 +4376,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append
-                .append(&(81..=120).collect::<Vec<u8>>());
+            append.append(&(81..=120).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4488,8 +4472,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append
-                .append(&(11..=30).collect::<Vec<u8>>());
+            append.append(&(11..=30).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4608,8 +4591,7 @@ mod tests {
                 .await
                 .unwrap();
             // Add bytes 11 through 103 (93 more bytes)
-            append
-                .append(&(11..=PAGE_SIZE.get() as u8).collect::<Vec<u8>>());
+            append.append(&(11..=PAGE_SIZE.get() as u8).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4637,8 +4619,7 @@ mod tests {
                 .await
                 .unwrap();
             // Add bytes 104 through 113 (10 more bytes, now on page 1)
-            append
-                .append(&(104..=113).collect::<Vec<u8>>());
+            append.append(&(104..=113).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -14,11 +14,11 @@
 //! # Paging
 //!
 //! Callers append and read logical bytes; the blob stores physical pages in the format described
-//! in [`super`]. Appends accumulate in a write buffer and reach the blob in pages. Buffered bytes
-//! are readable immediately but durable only after `sync`. Full pages read from the blob are
-//! cached in a shared page cache, so reads are served from the write buffer, the page cache, or
-//! the blob itself. Large appends bypass the write buffer and write whole pages directly to the
-//! blob; these are called direct appends throughout this module.
+//! in [`super`]. Appends are synchronous: they accumulate in a write buffer and reach the blob
+//! in pages only at flush points (`sync`, `start_sync`, `resize`, `seal`, `snapshot`, `replay`).
+//! Buffered bytes are readable immediately but durable only after `sync`. Full pages read from
+//! the blob are cached in a shared page cache, so reads are served from the write buffer, the
+//! page cache, or the blob itself.
 //!
 //! # Checksums
 //!
@@ -98,34 +98,19 @@ impl PartialPage {
         }
     }
 
-    /// True if no committed partial page exists.
-    const fn is_none(&self) -> bool {
-        matches!(self, Self::None)
-    }
-}
-
-/// A direct append staged into the blob whose publication was never observed.
-///
-/// Set before the append's blob writes are awaited and cleared only after the writer's state
-/// updates publish the written bytes. A record still present when a later operation runs
-/// means the append's future was dropped mid-write, and the blob must be reconciled back to
-/// the writer's claim (see [Writer::reconcile_publication]) before it is touched again.
-struct PendingPublication {
-    /// The physical size implied by the writer's claim; reconciliation truncates back to it.
-    physical_end: u64,
-    /// The tip page and the free CRC slot the append staged a full-page record into.
-    /// Present only when the append completed a committed partial tip page.
-    staged_slot: Option<(u64, Slot)>,
 }
 
 /// Unique writer to a cache-wrapped [Blob].
 ///
 /// # Cancellation
 ///
-/// Dropping an in-flight operation leaves the writer in a consistent, retryable state. A
-/// dropped operation may still have reached the blob (a direct append's bytes, a shrink's
-/// truncate); the writer records such intents before awaiting them, and every later
-/// mutation or sync first settles them so the blob agrees with the writer's claim.
+/// Appends are synchronous: they stage bytes in the write buffer and cannot be cancelled.
+/// The async operations (`sync`, `start_sync`, `resize`, `seal`, `snapshot`, `replay`) are
+/// the only paths that touch the blob; dropping one mid-flight leaves the writer in a
+/// consistent, retryable state. A dropped operation may still have reached the blob (a
+/// flush's bytes, a shrink's truncate); the writer records such intents before awaiting
+/// them, and every later operation first settles them so the blob agrees with the writer's
+/// claim.
 pub struct Writer<B: Blob> {
     /// The underlying blob being wrapped.
     blob: B,
@@ -135,9 +120,6 @@ pub struct Writer<B: Blob> {
 
     /// The state of the tip page's on-disk CRC record.
     partial_page_state: PartialPage,
-
-    /// A direct append whose publication was never observed, if any.
-    pending_publication: Option<PendingPublication>,
 
     /// Durability state for plain writes, resizes, and range-sync writes.
     sync_state: SyncState,
@@ -232,7 +214,6 @@ impl<B: Blob> Writer<B> {
             blob,
             current_page,
             partial_page_state,
-            pending_publication: None,
             sync_state: if needs_sync {
                 SyncState::dirty()
             } else {
@@ -312,213 +293,22 @@ impl<B: Blob> Writer<B> {
         Ok((None, 0, invalid_data_found))
     }
 
-    /// Returns whether appending `n` bytes should bypass the write buffer and write whole pages
-    /// directly to the blob.
-    const fn too_big_for_buffer(&self, n: usize) -> bool {
-        let page_size = self.cache_ref.page_size() as usize;
-        let len = self.buffer.len();
-
-        // Bypass only when the append would overflow capacity AND at least one whole page
-        // remains after topping the current partial page up to a boundary. Appends below that
-        // threshold are buffered, so the buffer's peak size stays under capacity plus one page
-        // (capacity is a whole number of pages; see [adjusted_capacity]).
-        let fill = len.next_multiple_of(page_size) - len;
-        let overflows_capacity = len + n > self.buffer.capacity;
-        let has_full_page_after_fill = n >= fill + page_size;
-
-        overflows_capacity && has_full_page_after_fill
-    }
-
     /// Append all bytes in `buf` to the tip of the blob, returning the logical offset at which
     /// the first byte was written.
-    pub async fn append(&mut self, buf: &[u8]) -> Result<u64, Error> {
-        // Bypass the write buffer and write whole pages directly when `buf` is large.
-        if self.too_big_for_buffer(buf.len()) {
-            return self.append_owned(IoBuf::copy_from_slice(buf)).await;
-        }
-
+    ///
+    /// Appends stage bytes in the write buffer and perform no I/O; they reach the blob at the
+    /// next flush point (`sync`, `start_sync`, `resize`, `seal`, `snapshot`, or `replay`).
+    /// Callers bound memory by their flush cadence.
+    pub fn append(&mut self, buf: &[u8]) -> u64 {
         let offset = self.buffer.size();
-        if self.buffer.append(buf) {
-            self.flush(false, false).await?;
-        }
-        Ok(offset)
+        self.buffer.append(buf);
+        offset
     }
 
     /// Append owned bytes to the tip of the blob, returning the logical offset at which the
-    /// first byte was written.
-    pub async fn append_owned(&mut self, buf: IoBuf) -> Result<u64, Error> {
-        let logical_page_size = self.cache_ref.page_size() as usize;
-        let offset = self.buffer.size();
-
-        // Buffer the append unless `buf` is too big for the buffer.
-        if !self.too_big_for_buffer(buf.len()) {
-            if self.buffer.append(buf.as_ref()) {
-                self.flush(false, false).await?;
-            }
-            return Ok(offset);
-        }
-
-        // `buf` is too big to buffer, so write its full pages directly to the blob. `buf` is
-        // split into three parts:
-        // - `fill`: the first bytes, which complete the tip's partial page (if any)
-        // - `bulk`: the whole pages after `fill`
-        // - `suffix`: the remainder (less than one page), which becomes the new tip
-        // All three are staged in local variables; the writer's state is updated only after the
-        // blob write succeeds, so a dropped append publishes nothing.
-
-        // Undo any earlier direct append that was dropped mid-write, so the blob matches the
-        // writer's claim before new bytes are staged beyond it.
-        self.reconcile_publication().await?;
-
-        // First, flush any full pages already in the tip, so it holds at most a partial page.
-        if self.buffer.len() >= logical_page_size {
-            self.flush(false, false).await?;
-        }
-
-        // The completed page below writes around the tip page's committed record, so the
-        // record must be known (a canceled shrink leaves it unverified).
-        self.verify_partial_page().await?;
-
-        // Complete the tip's partial page (if any) into one full page, copying the tip's bytes
-        // and the first `fill` bytes of `buf`.
-        let tip_len = self.buffer.len();
-        if tip_len == 0 {
-            // The bulk pages below are built without a prior CRC record, which is only correct
-            // when no committed partial page exists.
-            assert!(
-                self.partial_page_state.is_none(),
-                "an empty tip implies no partial page state"
-            );
-        }
-        // Bytes needed to fill the current page to a page boundary (0 if already aligned).
-        let fill = tip_len.next_multiple_of(logical_page_size) - tip_len;
-        let mut physical_pages = IoBufs::default();
-        let mut completed_page = None;
-        if fill > 0 {
-            let mut page = self.cache_ref.pool().alloc(logical_page_size);
-            page.put_slice(self.buffer.as_ref());
-            page.put_slice(&buf.as_ref()[..fill]);
-            let page = page.freeze();
-            self.append_full_pages(&page, self.partial_page_state.record(), &mut physical_pages);
-            completed_page = Some(page);
-        }
-
-        // Prepare the `bulk` pages as views of `buf`, copying no payload bytes.
-        let bulk_len = (buf.len() - fill) / logical_page_size * logical_page_size;
-        let bulk = buf.slice(fill..fill + bulk_len);
-        self.append_full_pages(&bulk, None, &mut physical_pages);
-
-        // Copy the `suffix` for the new tip. A view of `buf` would work, but a sub-page tip is
-        // never drained by flush, so the view would pin `buf`'s entire backing allocation until
-        // the next append (or forever, if there is none).
-        let suffix = buf.slice(fill + bulk_len..);
-        let suffix = if suffix.is_empty() {
-            suffix
-        } else {
-            let mut copied = self.cache_ref.pool().alloc(suffix.len());
-            copied.put_slice(suffix.as_ref());
-            copied.freeze()
-        };
-
-        // Record the staged append before its writes are awaited: if the future is dropped
-        // mid-write, bytes may land on disk without ever being published into writer state,
-        // and the next operation must undo them (see [Self::reconcile_publication]). The
-        // completed page's record is staged into the free slot of the tip page's committed
-        // record.
-        let physical_page_size = self.cache_ref.page_size() + CHECKSUM_SIZE;
-        let staged_slot = self
-            .partial_page_state
-            .record()
-            .map(|old| (self.current_page, old.authoritative().other()));
-        let claimed_pages = self
-            .current_page
-            .checked_add(u64::from(staged_slot.is_some()))
-            .ok_or(Error::OffsetOverflow)?;
-        self.pending_publication = Some(PendingPublication {
-            physical_end: claimed_pages
-                .checked_mul(physical_page_size)
-                .ok_or(Error::OffsetOverflow)?,
-            staged_slot,
-        });
-
-        self.write_physical_pages(physical_pages, false).await?;
-
-        // Update state only after the write succeeds, for cancellation safety. Cache chunks
-        // of `capacity` are page-aligned because the capacity is a whole number of pages
-        // (see [adjusted_capacity]).
-        let mut cache_offset = self.buffer.offset;
-        if let Some(completed_page) = completed_page {
-            let remaining = self
-                .cache_ref
-                .cache(self.id, completed_page.as_ref(), cache_offset);
-            assert_eq!(remaining, 0, "cached completed page must be page-aligned");
-            cache_offset += logical_page_size as u64;
-            self.current_page += 1;
-            self.partial_page_state = PartialPage::None;
-        }
-        for chunk in bulk.as_ref().chunks(self.buffer.capacity) {
-            let remaining = self.cache_ref.cache(self.id, chunk, cache_offset);
-            assert_eq!(remaining, 0, "cached bulk pages must be page-aligned");
-            cache_offset += chunk.len() as u64;
-        }
-        self.current_page += (bulk_len / logical_page_size) as u64;
-
-        // The `suffix` becomes the new tip, starting after the last written page.
-        self.buffer.replace(cache_offset, suffix);
-
-        // The written bytes are now published: the claim covers them.
-        self.pending_publication = None;
-
-        // Make sure the buffer offset and underlying blob agree on the state of the tip.
-        assert_eq!(
-            self.current_page * self.cache_ref.page_size(),
-            self.buffer.offset
-        );
-
-        Ok(offset)
-    }
-
-    /// Undo a direct append whose future was dropped after its writes may have reached the
-    /// blob.
-    ///
-    /// Such an append leaves bytes the writer never published: bulk pages past the claimed
-    /// physical end, and possibly a full-page record staged in the tip page's free CRC
-    /// slot. Recovery would prefer both over the claim. Truncating back to the claimed
-    /// physical end removes the bulk pages, and zeroing the staged slot's length bytes
-    /// retires it (length 0 is never authoritative; the committed slot is untouched).
-    ///
-    /// The truncate must land first: recovery accepts a partial page only in the last
-    /// position, so the orphan pages must already be gone when retiring the slot demotes
-    /// the staged page back to partial.
-    ///
-    /// Both steps are idempotent and the record is cleared only after they complete, so a
-    /// dropped reconciliation re-runs on the next operation. Ordering against the orphan's
-    /// own writes comes from the [Blob] contract: mutations execute in submission order, so
-    /// these mutations land after the orphan's.
-    async fn reconcile_publication(&mut self) -> Result<(), Error> {
-        let Some(PendingPublication {
-            physical_end,
-            staged_slot,
-        }) = self.pending_publication
-        else {
-            return Ok(());
-        };
-
-        self.sync_state.resize(&self.blob, physical_end).await?;
-
-        if let Some((page, slot)) = staged_slot {
-            let physical_page_size = self.cache_ref.page_size() + CHECKSUM_SIZE;
-            let slot_offset = page
-                .checked_mul(physical_page_size)
-                .and_then(|start| start.checked_add(self.cache_ref.page_size()))
-                .and_then(|crc| crc.checked_add(slot.offset() as u64))
-                .ok_or(Error::OffsetOverflow)?;
-            self.write_at(slot_offset, Checksum::slot_len_bytes(0).to_vec())
-                .await?;
-        }
-
-        self.pending_publication = None;
-        Ok(())
+    /// first byte was written. See [Self::append].
+    pub fn append_owned(&mut self, buf: IoBuf) -> u64 {
+        self.append(buf.as_ref())
     }
 
     /// Resolve an [PartialPage::Unverified] record by reading it back from the blob.
@@ -605,10 +395,6 @@ impl<B: Blob> Writer<B> {
     ///
     /// Returns `true` if the flush made its writes durable, so no additional sync is needed.
     async fn flush(&mut self, write_partial_page: bool, sync: bool) -> Result<bool, Error> {
-        // Undo any direct append dropped mid-write, so the writes below (and the sync that
-        // may follow) act on a blob that matches the writer's claim.
-        self.reconcile_publication().await?;
-
         // Re-issue any dropped resize before deriving writes from writer state. Writes and
         // syncs settle on their own; this covers paths that may emit no writes at all
         // (sync, seal, snapshot, replay) and would otherwise leave the resize incomplete.
@@ -1083,7 +869,7 @@ impl<B: Blob> Writer<B> {
             let zeros_needed = (size - current_size) as usize;
             let mut zeros = self.cache_ref.pool().alloc(zeros_needed);
             zeros.put_bytes(0, zeros_needed);
-            self.append_owned(zeros.freeze()).await?;
+            self.append_owned(zeros.freeze());
             return Ok(());
         }
 
@@ -1168,8 +954,7 @@ impl<B: Blob> Writer<B> {
         self.current_page = full_pages;
         self.buffer.offset = tail_offset;
         self.buffer.clear();
-        let over_capacity = self.buffer.append(page_data.as_ref());
-        assert!(!over_capacity);
+        self.buffer.append(page_data.as_ref());
 
         // If the target stays within the current tip page, the physical page count is
         // unchanged and no truncate is needed. Otherwise truncate every physical page above
@@ -1196,8 +981,7 @@ impl<B: Blob> Writer<B> {
         self.current_page = full_pages;
         self.buffer.offset = tail_offset;
         self.buffer.clear();
-        let over_capacity = self.buffer.append(new_data);
-        assert!(!over_capacity);
+        self.buffer.append(new_data);
         self.partial_page_state = PartialPage::Committed(final_record);
 
         Ok(())
@@ -1275,6 +1059,11 @@ mod tests {
     const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;
 
     impl PartialPage {
+        /// True if no committed partial page exists.
+        const fn is_none(&self) -> bool {
+            matches!(self, Self::None)
+        }
+
         /// True if the on-disk record is known.
         const fn is_committed(&self) -> bool {
             matches!(self, Self::Committed(_))
@@ -1304,7 +1093,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..3 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Cancel a shrink parked before the truncate reaches the blob. The writer
@@ -1313,7 +1102,7 @@ mod tests {
             assert_eq!(writer.size(), 2 * page as u64);
 
             // Appends continue from the claim; the sync settles the truncate, then flushes.
-            writer.append(&data[..10]).await.unwrap();
+            writer.append(&data[..10]);
             writer.sync().await.unwrap();
             let expected_size = (2 * page + 10) as u64;
             assert_eq!(writer.size(), expected_size);
@@ -1348,7 +1137,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            append.append(&[0u8; 8]).await.unwrap();
+            append.append(&[0u8; 8]);
             assert_eq!(append.size(), 8);
 
             // Empty offsets should succeed immediately.
@@ -1372,7 +1161,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0..20).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             assert_eq!(append.size(), 20);
 
             // Read 4-byte items at offsets 0, 4, 8, 12, 16.
@@ -1406,7 +1195,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0..20).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
 
             let mut buf = vec![0u8; data.len()];
             assert!(append.try_read_sync_into(&mut buf, 0));
@@ -1430,7 +1219,7 @@ mod tests {
 
             let page_size = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0u8..=255).cycle().take(page_size * 2).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             let _ = append.read_at(0, page_size).await.unwrap();
@@ -1453,7 +1242,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0..20).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
             assert_eq!(append.size(), 20);
 
@@ -1485,11 +1274,11 @@ mod tests {
                 .unwrap();
 
             let first: Vec<u8> = (0..16).collect();
-            append.append(&first).await.unwrap();
+            append.append(&first);
             append.sync().await.unwrap();
 
             let second: Vec<u8> = (16..32).collect();
-            append.append(&second).await.unwrap();
+            append.append(&second);
             assert_eq!(append.size(), 32);
 
             // Offsets span both synced and unsynced regions.
@@ -1520,7 +1309,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            append.append(&[0u8; 8]).await.unwrap();
+            append.append(&[0u8; 8]);
             assert_eq!(append.size(), 8);
 
             // Last offset's end (8 + 4 = 12) exceeds size (8).
@@ -1544,7 +1333,7 @@ mod tests {
                 .unwrap();
 
             let data = vec![0xAA; 8];
-            append.append(&data).await.unwrap();
+            append.append(&data);
             assert_eq!(append.size(), 8);
 
             let mut buf = vec![0u8; 8];
@@ -1568,7 +1357,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0..16).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
 
             let offsets = [0u64, 4];
             let mut buf = vec![0u8; 7];
@@ -1588,7 +1377,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0..16).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
 
             let mut buf = vec![0u8; 8];
             let _ = append.read_many_into(&mut buf, &[8, 4], NZUsize!(4)).await;
@@ -1607,7 +1396,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0..16).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
 
             let mut buf = vec![0u8; 8];
             let _ = append.read_many_into(&mut buf, &[2, 4], NZUsize!(4)).await;
@@ -1625,7 +1414,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0..16).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
 
             let mut buf = vec![0u8; 8];
             let err = append
@@ -1649,11 +1438,11 @@ mod tests {
 
             // Write enough data to span multiple pages (PAGE_SIZE=103).
             let data: Vec<u8> = (0u8..=255).cycle().take(300).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
             // Add more in tip buffer.
             let more: Vec<u8> = (0u8..50).collect();
-            append.append(&more).await.unwrap();
+            append.append(&more);
             assert_eq!(append.size(), 350);
 
             let item_size = 10;
@@ -1695,7 +1484,7 @@ mod tests {
                 .cycle()
                 .take(PAGE_SIZE.get() as usize * 3)
                 .collect();
-            append.append(&synced).await.unwrap();
+            append.append(&synced);
             append.sync().await.unwrap();
 
             // Write a partial page that stays in the tip buffer. The item_size
@@ -1703,7 +1492,7 @@ mod tests {
             let item_size = 10;
             let tip_len = PAGE_SIZE.get() as usize / 2;
             let tip: Vec<u8> = (100u8..=255).cycle().take(tip_len).collect();
-            append.append(&tip).await.unwrap();
+            append.append(&tip);
 
             // Prime pages 0 and 2 into cache, leaving page 1 uncached.
             let _ = append.read_at(0, item_size).await.unwrap();
@@ -1761,14 +1550,14 @@ mod tests {
                 .cycle()
                 .take(PAGE_SIZE.get() as usize * 3)
                 .collect();
-            append.append(&synced).await.unwrap();
+            append.append(&synced);
             append.sync().await.unwrap();
             let item_size = 10;
             let tip: Vec<u8> = (100u8..=255)
                 .cycle()
                 .take(PAGE_SIZE.get() as usize / 2)
                 .collect();
-            append.append(&tip).await.unwrap();
+            append.append(&tip);
 
             // Fault page 0 in, evicting whatever sync left resident, so the straddle
             // prefix page (page 2) is guaranteed not cached.
@@ -1850,14 +1639,14 @@ mod tests {
 
             // Append some bytes.
             let data = vec![1, 2, 3, 4, 5];
-            append.append(&data).await.unwrap();
+            append.append(&data);
 
             // Verify size reflects appended data.
             assert_eq!(append.size(), 5);
 
             // Append more bytes.
             let more_data = vec![6, 7, 8, 9, 10];
-            append.append(&more_data).await.unwrap();
+            append.append(&more_data);
 
             // Verify size is cumulative.
             assert_eq!(append.size(), 10);
@@ -1891,7 +1680,7 @@ mod tests {
             // PAGE_SIZE=103 is the logical page size. We have 10 bytes, so writing
             // 100 more bytes (total 110) will cross the page boundary at byte 103.
             let spanning_data: Vec<u8> = (11..=110).collect();
-            append.append(&spanning_data).await.unwrap();
+            append.append(&spanning_data);
             assert_eq!(append.size(), 110);
 
             // Read back data that spans the page boundary.
@@ -1920,7 +1709,7 @@ mod tests {
             // So we need 96 more bytes.
             let boundary_data: Vec<u8> = (111..=206).collect();
             assert_eq!(boundary_data.len(), 96);
-            append.append(&boundary_data).await.unwrap();
+            append.append(&boundary_data);
             assert_eq!(append.size(), 206);
 
             // Verify we can read it back.
@@ -1947,9 +1736,9 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
-    fn test_append_owned_bypass_from_empty_tip() {
-        // A large owned append from an empty, page-aligned tip writes whole pages directly to the
-        // blob and leaves the partial-page suffix buffered.
+    fn test_append_large_stages_until_sync() {
+        // A large owned append stages entirely in the tip: no blob or cache activity until the
+        // next flush point.
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context
@@ -1966,23 +1755,20 @@ mod tests {
             let src = IoBuf::from(data.clone());
             let src_start = src.as_ptr() as usize;
             let src_range = src_start..src_start + src.len();
-            append.append_owned(src.clone()).await.unwrap();
+            append.append_owned(src.clone());
             assert_eq!(append.size(), 500);
 
-            // The buffered suffix is a copy, not a view that would pin the input allocation.
+            // The staged bytes are a copy, not a view that would pin the input allocation.
             let tip_ptr = append.buffer.as_ref().as_ptr() as usize;
             assert!(!src_range.contains(&tip_ptr));
 
-            // The directly written pages populate the page cache, exactly as a buffered flush
-            // would.
+            // Everything is staged in the tip: no pages have been written or cached.
+            assert_eq!(append.current_page, 0);
+            assert_eq!(append.buffer.len(), 500);
             let mut probe = vec![0u8; PAGE_SIZE.get() as usize];
-            assert_eq!(
-                append.cache_ref.read_cached(append.id, &mut probe, 0),
-                PAGE_SIZE.get() as usize
-            );
-            assert_eq!(probe, &data[..PAGE_SIZE.get() as usize]);
+            assert_eq!(append.cache_ref.read_cached(append.id, &mut probe, 0), 0);
 
-            // All bytes are readable before any sync (bulk from the cache, suffix from tip).
+            // All bytes are readable before any sync, straight from the tip.
             let read_buf = append.read_at(0, 500).await.unwrap().coalesce();
             assert_eq!(read_buf, &data[..]);
 
@@ -2004,7 +1790,7 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
-    fn test_append_owned_bypass_with_synced_partial_page() {
+    fn test_append_large_after_synced_partial_page() {
         // A large owned append on top of a synced partial page must run the protected-CRC
         // handling for the first page before writing the bulk directly.
         let executor = deterministic::Runner::default();
@@ -2020,20 +1806,17 @@ mod tests {
 
             // Durably write a 50-byte partial page.
             let all: Vec<u8> = (0..500).map(|i| (i % 247) as u8).collect();
-            append.append(&all[..50]).await.unwrap();
+            append.append(&all[..50]);
             append.sync().await.unwrap();
 
-            // 450 more bytes: 53 fill the first page (protected CRC), 3 whole pages (309 bytes)
-            // bypass the buffer, 88 remain in the tip.
+            // 450 more bytes stage on top of the synced 50-byte partial page (protected CRC).
             append
-                .append_owned(IoBuf::from(all[50..].to_vec()))
-                .await
-                .unwrap();
+                .append_owned(IoBuf::from(all[50..].to_vec()));
             assert_eq!(append.size(), 500);
             let read_buf = append.read_at(0, 500).await.unwrap().coalesce();
             assert_eq!(read_buf, &all[..]);
 
-            // The direct write is not durable until sync: dropping without one preserves only the
+            // Staged bytes are not durable until sync: dropping without one preserves only the
             // synced 50-byte prefix.
             drop(append);
             let (blob, blob_size) = context
@@ -2050,9 +1833,7 @@ mod tests {
             // Repeating the owned append after recovery and syncing makes everything durable,
             // exercising the protected-CRC handling for the recovered partial page.
             append
-                .append_owned(IoBuf::from(all[50..].to_vec()))
-                .await
-                .unwrap();
+                .append_owned(IoBuf::from(all[50..].to_vec()));
             append.sync().await.unwrap();
             drop(append);
 
@@ -2070,9 +1851,9 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
-    fn test_append_owned_bypass_with_buffered_tip() {
-        // A large owned append merges with unsynced buffered bytes: the fill completes the
-        // current page, the bulk bypasses the buffer, and everything is readable.
+    fn test_append_large_merges_with_buffered_tip() {
+        // A large owned append stages after unsynced buffered bytes, and everything is
+        // readable.
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context
@@ -2085,11 +1866,9 @@ mod tests {
                 .unwrap();
 
             let all: Vec<u8> = (0..430).map(|i| (i % 239) as u8).collect();
-            append.append(&all[..30]).await.unwrap();
+            append.append(&all[..30]);
             append
-                .append_owned(IoBuf::from(all[30..].to_vec()))
-                .await
-                .unwrap();
+                .append_owned(IoBuf::from(all[30..].to_vec()));
             assert_eq!(append.size(), 430);
             let read_buf = append.read_at(0, 430).await.unwrap().coalesce();
             assert_eq!(read_buf, &all[..]);
@@ -2107,512 +1886,6 @@ mod tests {
             assert_eq!(append.size(), 430);
             let read_buf = append.read_at(0, 430).await.unwrap().coalesce();
             assert_eq!(read_buf, &all[..]);
-        });
-    }
-
-    // If a page flush is canceled during the blob write, keep the data in the tip.
-    #[test_traced("DEBUG")]
-    fn test_flush_cancel_preserves_paged_tip() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"flush_cancel")
-                .await
-                .unwrap();
-            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-
-            let mut expected = vec![7u8; BUFFER_SIZE];
-            writer.append(&expected).await.unwrap();
-            expected.push(9);
-
-            // This append overflows the buffer and starts a full-page flush. Cancel during it.
-            gate.cancel(writer.append(&[9])).await;
-
-            // Nothing should have moved from the tip into page/cache state yet.
-            assert_eq!(writer.current_page, 0);
-            assert!(writer.partial_page_state.is_none());
-            assert_eq!(writer.size(), expected.len() as u64);
-            assert_eq!(writer.buffer.as_ref(), expected.as_slice());
-            let read = writer.read_at(0, expected.len()).await.unwrap().coalesce();
-            assert_eq!(read.as_ref(), expected.as_slice());
-
-            // Retrying sync should flush the same bytes and publish the page state.
-            writer.sync().await.unwrap();
-            assert_eq!(writer.current_page, 2);
-            assert!(writer.partial_page_state.is_committed());
-            let read = writer.read_at(0, expected.len()).await.unwrap().coalesce();
-            assert_eq!(read.as_ref(), expected.as_slice());
-        });
-    }
-
-    // If a large direct append is canceled during the blob write, publish nothing.
-    #[test_traced("DEBUG")]
-    fn test_append_owned_cancel_preserves_state() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"append_owned_cancel")
-                .await
-                .unwrap();
-            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            // This takes the direct path: full pages go straight to the blob.
-            // Cancel before those pages are allowed to publish into writer state.
-            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
-                .await;
-
-            // The direct append was canceled, so it should not change size, cache, or page count.
-            assert_eq!(writer.current_page, 0);
-            assert!(writer.partial_page_state.is_none());
-            assert_eq!(writer.size(), 0);
-
-            let mut probe = vec![0u8; PAGE_SIZE.get() as usize];
-            assert_eq!(writer.cache_ref.read_cached(writer.id, &mut probe, 0), 0);
-
-            // Retrying should write and publish the full append normally.
-            writer
-                .append_owned(IoBuf::from(data.clone()))
-                .await
-                .unwrap();
-            assert_eq!(writer.size(), data.len() as u64);
-            let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
-            assert_eq!(read.as_ref(), data.as_slice());
-
-            writer.sync().await.unwrap();
-            drop(writer);
-
-            // The retried append must survive reopening.
-            let (blob, blob_size) = context
-                .open("test_partition", b"append_owned_cancel")
-                .await
-                .unwrap();
-            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(reopened.size(), data.len() as u64);
-            let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
-            assert_eq!(read.as_ref(), data.as_slice());
-        });
-    }
-
-    // If a large direct append from a non-aligned tip is canceled during the blob write, the
-    // tip keeps only the pre-append bytes: not even a page-completing prefix is published.
-    #[test_traced("DEBUG")]
-    fn test_append_owned_fill_cancel_publishes_nothing() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"append_owned_fill_cancel")
-                .await
-                .unwrap();
-            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            // Leave a committed partial page in the tip so the direct path must complete it.
-            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
-            writer.append(&pre).await.unwrap();
-            writer.sync().await.unwrap();
-
-            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
-                .await;
-
-            // The canceled append published nothing: the tip holds only the pre-append bytes.
-            assert_eq!(writer.current_page, 0);
-            assert!(writer.partial_page_state.is_committed());
-            assert_eq!(writer.size(), pre.len() as u64);
-            assert_eq!(writer.buffer.as_ref(), pre.as_slice());
-
-            // Retrying appends the full input exactly once.
-            writer
-                .append_owned(IoBuf::from(data.clone()))
-                .await
-                .unwrap();
-            let total = pre.len() + data.len();
-            assert_eq!(writer.size(), total as u64);
-            writer.sync().await.unwrap();
-            drop(writer);
-
-            let (blob, blob_size) = context
-                .open("test_partition", b"append_owned_fill_cancel")
-                .await
-                .unwrap();
-            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(reopened.size(), total as u64);
-            let read = reopened.read_at(0, total).await.unwrap().coalesce();
-            assert_eq!(&read.as_ref()[..pre.len()], pre.as_slice());
-            assert_eq!(&read.as_ref()[pre.len()..], data.as_slice());
-        });
-    }
-
-    // A direct append dropped after its blob writes landed leaves durable bytes the writer
-    // does not claim, including a full-page CRC record in the tip page's free slot that
-    // recovery would prefer over the committed one. A later sync must reconcile the blob
-    // back to the writer's claim before acknowledging durability, so a reopen recovers
-    // exactly the claimed bytes.
-    #[test_traced("DEBUG")]
-    fn test_append_owned_cancel_after_write_publishes_nothing() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"append_cancel_after")
-                .await
-                .unwrap();
-            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            // Leave a committed partial page in the tip so the direct path completes it.
-            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
-            writer.append(&pre).await.unwrap();
-            writer.sync().await.unwrap();
-
-            // The direct write is split around the committed CRC slot into two blob writes.
-            // Let the payload write pass and park after the second (free-slot record plus
-            // bulk pages), so the whole orphan is on disk when the future is dropped.
-            gate.set_skip(1);
-            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
-                .await;
-
-            // The canceled append published nothing.
-            assert_eq!(writer.size(), pre.len() as u64);
-
-            writer.sync().await.unwrap();
-            drop(writer);
-
-            // The reopened writer must recover the claim, not the orphan.
-            let (blob, blob_size) = context
-                .open("test_partition", b"append_cancel_after")
-                .await
-                .unwrap();
-            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(
-                reopened.size(),
-                pre.len() as u64,
-                "orphan bytes must not be recovered"
-            );
-            let read = reopened.read_at(0, pre.len()).await.unwrap().coalesce();
-            assert_eq!(read.as_ref(), pre.as_slice());
-        });
-    }
-
-    // A direct append from an empty tip is a single write with no CRC slot to protect.
-    // Dropped after it lands, the orphan is bulk pages only; reconciliation truncates the
-    // blob back to empty.
-    #[test_traced("DEBUG")]
-    fn test_append_owned_cancel_after_write_empty_tip_publishes_nothing() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"append_cancel_after_empty")
-                .await
-                .unwrap();
-            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
-                .await;
-
-            // The canceled append published nothing.
-            assert_eq!(writer.size(), 0);
-
-            writer.sync().await.unwrap();
-            drop(writer);
-
-            let (blob, blob_size) = context
-                .open("test_partition", b"append_cancel_after_empty")
-                .await
-                .unwrap();
-            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(reopened.size(), 0, "orphan bytes must not be recovered");
-        });
-    }
-
-    // A retried direct append reconciles the dropped one before staging its own bytes, so
-    // the data lands exactly once. Returns the auditor state so the caller can assert
-    // determinism across runs of the same seed.
-    fn dropped_append_retry_scenario(seed: u64) -> String {
-        let executor = deterministic::Runner::seeded(seed);
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"append_cancel_retry")
-                .await
-                .unwrap();
-            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
-            writer.append(&pre).await.unwrap();
-            writer.sync().await.unwrap();
-
-            // Drop the append after both of its split writes landed.
-            gate.set_skip(1);
-            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
-                .await;
-
-            // The retry appends the full input exactly once.
-            writer
-                .append_owned(IoBuf::from(data.clone()))
-                .await
-                .unwrap();
-            let total = pre.len() + data.len();
-            assert_eq!(writer.size(), total as u64);
-            writer.sync().await.unwrap();
-            drop(writer);
-
-            let (blob, blob_size) = context
-                .open("test_partition", b"append_cancel_retry")
-                .await
-                .unwrap();
-            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(reopened.size(), total as u64);
-            let read = reopened.read_at(0, total).await.unwrap().coalesce();
-            assert_eq!(&read.as_ref()[..pre.len()], pre.as_slice());
-            assert_eq!(&read.as_ref()[pre.len()..], data.as_slice());
-
-            context.auditor().state()
-        })
-    }
-
-    #[test_traced("DEBUG")]
-    fn test_append_owned_cancel_after_write_retry_appends_once() {
-        let state = dropped_append_retry_scenario(42);
-        assert_eq!(
-            state,
-            dropped_append_retry_scenario(42),
-            "scenario must be deterministic"
-        );
-    }
-
-    // start_sync reconciles a dropped direct append the same way sync does.
-    #[test_traced("DEBUG")]
-    fn test_append_owned_cancel_after_write_start_sync_reconciles() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"append_cancel_start_sync")
-                .await
-                .unwrap();
-            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
-            writer.append(&pre).await.unwrap();
-            writer.sync().await.unwrap();
-
-            // Drop the append after both of its split writes landed.
-            gate.set_skip(1);
-            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
-                .await;
-
-            writer.start_sync().await.await.unwrap();
-            drop(writer);
-
-            let (blob, blob_size) = context
-                .open("test_partition", b"append_cancel_start_sync")
-                .await
-                .unwrap();
-            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(
-                reopened.size(),
-                pre.len() as u64,
-                "orphan bytes must not be recovered"
-            );
-        });
-    }
-
-    // A repairing sync dropped at its staged-slot retire write must not demote the staged
-    // page while orphan pages remain after it: recovery trusts the last valid page it
-    // finds. Reopening must recover exactly the claimed bytes.
-    #[test_traced("DEBUG")]
-    fn test_reconcile_cancel_at_slot_retire_reopen_recovers_claim() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"reconcile_cancel_retire")
-                .await
-                .unwrap();
-            let (blob, gate) = GatedWriteBlob::new(inner.clone(), GatePosition::After);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            // Leave a committed partial page in the tip so the direct path completes it.
-            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
-            writer.append(&pre).await.unwrap();
-            writer.sync().await.unwrap();
-
-            // Drop the append after both of its split writes landed.
-            gate.set_skip(1);
-            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            gate.cancel(writer.append_owned(IoBuf::from(data))).await;
-
-            // Drop the repairing sync after its staged-slot retire write landed.
-            gate.cancel(writer.sync()).await;
-            drop(writer);
-
-            // Model a crash that loses no applied writes: persist them all, then reopen.
-            inner.sync().await.unwrap();
-            let (blob, blob_size) = context
-                .open("test_partition", b"reconcile_cancel_retire")
-                .await
-                .unwrap();
-            let mut reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(
-                reopened.size(),
-                pre.len() as u64,
-                "orphan bytes must not be recovered"
-            );
-            let read = reopened.read_at(0, pre.len()).await.unwrap().coalesce();
-            assert_eq!(read.as_ref(), pre.as_slice());
-            let mut replay = reopened.replay(NZUsize!(BUFFER_SIZE)).await.unwrap();
-            assert!(replay.ensure(pre.len()).await.unwrap());
-            assert_eq!(replay.copy_to_bytes(pre.len()).as_ref(), pre.as_slice());
-        });
-    }
-
-    // A repair dropped between its truncate and its staged-slot retire leaves the staged
-    // page as the last page, where either slot state is a valid tail. Reopening recovers
-    // the completed page.
-    #[test_traced("DEBUG")]
-    fn test_reconcile_cancel_after_truncate_reopen_is_consistent() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"reconcile_cancel_truncate")
-                .await
-                .unwrap();
-            let (blob, write_gate) = GatedWriteBlob::new(inner.clone(), GatePosition::After);
-            let (blob, resize_gate) = GatedResizeBlob::new(blob, GatePosition::After);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
-            writer.append(&pre).await.unwrap();
-            writer.sync().await.unwrap();
-
-            // Drop the append after both of its split writes landed.
-            write_gate.set_skip(1);
-            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            write_gate
-                .cancel(writer.append_owned(IoBuf::from(data.clone())))
-                .await;
-
-            // Drop the repairing sync after its truncate removed the orphan pages.
-            resize_gate.cancel(writer.sync()).await;
-            drop(writer);
-
-            // Model a crash that loses no applied writes: persist them all, then reopen.
-            inner.sync().await.unwrap();
-            let page = PAGE_SIZE.get() as usize;
-            let (blob, blob_size) = context
-                .open("test_partition", b"reconcile_cancel_truncate")
-                .await
-                .unwrap();
-            let mut reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(reopened.size(), page as u64);
-            let read = reopened.read_at(0, page).await.unwrap().coalesce();
-            assert_eq!(&read.as_ref()[..pre.len()], pre.as_slice());
-            assert_eq!(&read.as_ref()[pre.len()..], &data[..page - pre.len()]);
-            let mut replay = reopened.replay(NZUsize!(BUFFER_SIZE)).await.unwrap();
-            assert!(replay.ensure(page).await.unwrap());
-        });
-    }
-
-    // A repair dropped between its two steps re-runs on the next operation: the truncate
-    // repeats harmlessly and the staged slot is retired, restoring the claim.
-    #[test_traced("DEBUG")]
-    fn test_reconcile_cancel_after_truncate_retry_reconciles() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let (inner, blob_size) = context
-                .open("test_partition", b"reconcile_cancel_retry")
-                .await
-                .unwrap();
-            let (blob, write_gate) = GatedWriteBlob::new(inner, GatePosition::After);
-            let (blob, resize_gate) = GatedResizeBlob::new(blob, GatePosition::After);
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
-                .await
-                .unwrap();
-
-            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
-            writer.append(&pre).await.unwrap();
-            writer.sync().await.unwrap();
-
-            // Drop the append after both of its split writes landed.
-            write_gate.set_skip(1);
-            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
-            write_gate
-                .cancel(writer.append_owned(IoBuf::from(data)))
-                .await;
-
-            // Drop the repairing sync after its truncate removed the orphan pages.
-            resize_gate.cancel(writer.sync()).await;
-
-            // The claim is unchanged and a retried sync completes the repair.
-            assert_eq!(writer.size(), pre.len() as u64);
-            writer.sync().await.unwrap();
-            drop(writer);
-
-            let (blob, blob_size) = context
-                .open("test_partition", b"reconcile_cancel_retry")
-                .await
-                .unwrap();
-            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            assert_eq!(
-                reopened.size(),
-                pre.len() as u64,
-                "orphan bytes must not be recovered"
-            );
-            let read = reopened.read_at(0, pre.len()).await.unwrap().coalesce();
-            assert_eq!(read.as_ref(), pre.as_slice());
         });
     }
 
@@ -2632,7 +1905,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0..50).map(|i| i as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
 
             // Sync writes the partial page and its checksum. Cancel during that write.
             gate.cancel(writer.sync()).await;
@@ -2672,7 +1945,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Shrinking into page 1 truncates the blob to two physical pages, deleting the tip
@@ -2728,7 +2001,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..4 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Shrinking into page 1 truncates full pages 2-3 and the partial page. Cancel
@@ -2784,7 +2057,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..3 * page).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // A boundary shrink publishes the shrunken size before truncating. Cancel while
@@ -2799,7 +2072,7 @@ mod tests {
             assert_eq!(read.as_ref(), &data[..2 * page]);
 
             // Appends and sync continue normally from the new size.
-            writer.append(&data[..10]).await.unwrap();
+            writer.append(&data[..10]);
             writer.sync().await.unwrap();
             drop(writer);
             let (blob, blob_size) = context
@@ -2834,7 +2107,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..3 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Cancel while the truncate is parked before reaching the blob.
@@ -2883,7 +2156,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..4 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Cancel while the truncate is parked before reaching the blob.
@@ -2931,7 +2204,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..3 * page).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             let target = 2 * page as u64;
@@ -2975,7 +2248,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..3 * page).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             let target = 2 * page as u64;
@@ -3020,7 +2293,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Shrinking within the tip page rewrites only its CRC record. Cancel during the
@@ -3079,7 +2352,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // The shrink issues three slot writes; skipping two parks the gate at the third
@@ -3130,7 +2403,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..3 * page).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Shrink into the last full page. As above, skip two slot writes so the gate
@@ -3343,7 +2616,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Cancel the shrink parked before its first slot write: disk is untouched.
@@ -3391,7 +2664,7 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Skip two slot writes so the gate parks at the third (the commit point) after
@@ -3451,7 +2724,7 @@ mod tests {
             let data: Vec<u8> = (0..2 * page as usize + 50)
                 .map(|i| (i % 251) as u8)
                 .collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Skip two slot writes so the gate parks at the applied commit point, then
@@ -3505,16 +2778,16 @@ mod tests {
 
             let page = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
 
             // Cancel the shrink parked before its first slot write.
             gate.cancel(writer.resize((2 * page + 30) as u64)).await;
             assert!(writer.partial_page_state.is_unverified());
 
-            // A large append takes the direct path, which completes the tip page in place.
+            // The next sync's flush completes the tip page in place.
             let big: Vec<u8> = (0..500).map(|i| (i % 241) as u8).collect();
-            writer.append_owned(IoBuf::from(big.clone())).await.unwrap();
+            writer.append_owned(IoBuf::from(big.clone()));
             writer.sync().await.unwrap();
 
             let expected: Vec<u8> = data.iter().chain(big.iter()).copied().collect();
@@ -3554,17 +2827,13 @@ mod tests {
             // Exactly 4 pages: no remainder.
             let bulk: Vec<u8> = (0..412).map(|i| (i % 233) as u8).collect();
             append
-                .append_owned(IoBuf::from(bulk.clone()))
-                .await
-                .unwrap();
+                .append_owned(IoBuf::from(bulk.clone()));
             assert_eq!(append.size(), 412);
 
             // A small owned append takes the buffered path.
             let small: Vec<u8> = (0..10).map(|i| (i % 229) as u8).collect();
             append
-                .append_owned(IoBuf::from(small.clone()))
-                .await
-                .unwrap();
+                .append_owned(IoBuf::from(small.clone()));
             assert_eq!(append.size(), 422);
 
             let read_buf = append.read_at(0, 422).await.unwrap().coalesce();
@@ -3586,9 +2855,11 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
-    fn test_append_owned_physical_bytes_match_buffered() {
-        // The direct path must produce byte-identical physical output (page layout, CRC slot
-        // placement, zero padding) to the buffered path for the same logical content.
+    fn test_flush_boundaries_do_not_affect_physical_bytes() {
+        // One big flush must produce byte-identical physical output (page layout, CRC slot
+        // placement, zero padding) to page-aligned flush cycles of the same logical content.
+        // (Only page-aligned boundaries qualify: re-syncing a partial page rewrites its
+        // dual-slot CRC record, which legitimately differs by history.)
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
@@ -3602,13 +2873,11 @@ mod tests {
                 .await
                 .unwrap();
             direct
-                .append_owned(IoBuf::from(data.clone()))
-                .await
-                .unwrap();
+                .append_owned(IoBuf::from(data.clone()));
             direct.sync().await.unwrap();
             drop(direct);
 
-            // Small appends always stay on the buffered path and force intermediate flushes.
+            // Sync after every page-aligned append to force one flush cycle per page.
             let (blob, size) = context
                 .open("test_partition", b"phys_buffered")
                 .await
@@ -3616,10 +2885,10 @@ mod tests {
             let mut buffered = Writer::new(blob, size, BUFFER_SIZE, cache_ref)
                 .await
                 .unwrap();
-            for chunk in data.chunks(10) {
-                buffered.append(chunk).await.unwrap();
+            for chunk in data.chunks(PAGE_SIZE.get() as usize) {
+                buffered.append(chunk);
+                buffered.sync().await.unwrap();
             }
-            buffered.sync().await.unwrap();
             drop(buffered);
 
             let (blob_a, size_a) = context
@@ -3638,9 +2907,9 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
-    fn test_append_borrowed_large_takes_direct_path() {
-        // A plain `append` larger than the write buffer is routed through the direct path, so the
-        // write buffer holds only the partial-page suffix afterwards instead of the whole input.
+    fn test_sync_drains_full_pages_from_tip() {
+        // A flush drains full pages out of the tip, leaving only the partial-page suffix
+        // buffered.
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (blob, blob_size) = context
@@ -3654,19 +2923,20 @@ mod tests {
 
             // Start misaligned with a small buffered prefix.
             let all: Vec<u8> = (0..530).map(|i| (i % 241) as u8).collect();
-            append.append(&all[..30]).await.unwrap();
+            append.append(&all[..30]);
 
-            // 500 more bytes exceed the 206-byte write buffer and take the direct path.
-            append.append(&all[30..]).await.unwrap();
+            // 500 more bytes stage in the tip, growing it past its 206-byte capacity.
+            append.append(&all[30..]);
             assert_eq!(append.size(), 530);
-
-            // Only the partial-page suffix remains buffered (530 = 5 full pages + 15 bytes).
-            assert_eq!(append.buffer.len(), 15);
+            assert_eq!(append.buffer.len(), 530);
 
             let read_buf = append.read_at(0, 530).await.unwrap().coalesce();
             assert_eq!(read_buf, &all[..]);
 
+            // Sync flushes everything; only the partial-page suffix remains buffered
+            // (530 = 5 full pages + 15 bytes).
             append.sync().await.unwrap();
+            assert_eq!(append.buffer.len(), 15);
             drop(append);
 
             let (blob, blob_size) = context
@@ -3706,9 +2976,7 @@ mod tests {
                 .unwrap();
 
             append
-                .append(&vec![7; PAGE_SIZE.get() as usize])
-                .await
-                .unwrap();
+                .append(&vec![7; PAGE_SIZE.get() as usize]);
 
             // One pooled slot backs the page cache and one backs the mutable tip.
             assert!(
@@ -3748,7 +3016,7 @@ mod tests {
 
             // A single buffered write with no remaining dirty state can be made durable directly.
             let data = b"hello world";
-            append.append(data).await.unwrap();
+            append.append(data);
             append.sync().await.unwrap();
 
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
@@ -3794,7 +3062,7 @@ mod tests {
 
             // Now clean, so the next write syncs just its range instead of the whole blob.
             let data = b"hello world";
-            writer.append(data).await.unwrap();
+            writer.append(data);
             writer.sync().await.unwrap();
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
             assert_eq!(writes, 1);
@@ -3864,7 +3132,7 @@ mod tests {
 
             let handle = writer.start_sync().await;
             let deferred = next_pending_sync(&pending);
-            writer.append(b"hello world").await.unwrap();
+            writer.append(b"hello world");
 
             // Sync must wait before flushing the buffered write.
             let mut sync = Box::pin(writer.sync());
@@ -3890,8 +3158,8 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
-    // Verifies a large append cannot flush before pending start_sync finishes.
-    fn test_write_flush_waits_for_outstanding_start_sync() {
+    // Verifies a large append stages without blob activity while a start_sync is pending.
+    fn test_append_stages_while_start_sync_pending() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let inner = SyncTrackingBlob::new();
@@ -3902,24 +3170,17 @@ mod tests {
             let handle = writer.start_sync().await;
             let deferred = next_pending_sync(&pending);
 
+            // Appending while the started sync is in flight stages in the tip: no write can
+            // sneak past the pending durability barrier.
             let data = vec![7; BUFFER_SIZE + PAGE_SIZE.get() as usize];
-            let append = context.child("append").spawn(move |_| async move {
-                writer.append(&data).await.unwrap();
-                writer
-            });
-            // The append has reached the pending sync wait.
-            deferred
-                .blocked
-                .await
-                .expect("append never waited on start_sync");
+            writer.append(&data);
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(writes, 0);
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
-            // Release the started sync so the append can flush.
+            // Release the started sync; the next sync flushes the staged bytes durably.
             deferred.release.send(Ok(())).unwrap();
-            let mut writer = append.await.unwrap();
             handle.await.unwrap();
             writer.sync().await.unwrap();
             let (_, writes, full_syncs, _) = inner.snapshot();
@@ -3940,7 +3201,7 @@ mod tests {
 
             let prior = writer.start_sync().await;
             let deferred = next_pending_sync(&pending);
-            writer.append(b"hello world").await.unwrap();
+            writer.append(b"hello world");
 
             let seal = context
                 .child("seal")
@@ -3985,7 +3246,7 @@ mod tests {
             // Start a sync, then buffer newer bytes not covered by it.
             let prior = writer.start_sync().await;
             let deferred = next_pending_sync(&pending);
-            writer.append(b"hello world").await.unwrap();
+            writer.append(b"hello world");
 
             let snapshot = context.child("snapshot").spawn(move |_| async move {
                 let snapshot = writer.snapshot().await.unwrap();
@@ -4032,7 +3293,7 @@ mod tests {
             // Start a sync, then buffer newer bytes not covered by it.
             let prior = writer.start_sync().await;
             let deferred = next_pending_sync(&pending);
-            writer.append(b"hello world").await.unwrap();
+            writer.append(b"hello world");
 
             let replay = context.child("replay").spawn(move |_| async move {
                 {
@@ -4065,8 +3326,9 @@ mod tests {
     }
 
     #[test_traced("DEBUG")]
-    // Verifies resize growth cannot write zeros before pending start_sync finishes.
-    fn test_resize_grow_waits_for_outstanding_start_sync_before_writing() {
+    // Verifies resize growth stages zeros without blob activity, even while a start_sync is
+    // pending; the zeros reach the blob at the next sync, which waits for the pending one.
+    fn test_resize_grow_stages_without_writes() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let inner = SyncTrackingBlob::new();
@@ -4074,32 +3336,25 @@ mod tests {
             let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
             let mut writer = Writer::new(blob, 0, BUFFER_SIZE, cache_ref).await.unwrap();
 
-            // Start a sync before growing into the direct-write path.
+            // Start a sync, then grow past the buffer capacity while it is still pending.
             let prior = writer.start_sync().await;
             let deferred = next_pending_sync(&pending);
 
             let target_size = (BUFFER_SIZE + PAGE_SIZE.get() as usize) as u64;
-            let resize = context.child("resize_grow").spawn(move |_| async move {
-                writer.resize(target_size).await.unwrap();
-                writer
-            });
+            writer.resize(target_size).await.unwrap();
+            assert_eq!(writer.size(), target_size);
 
-            // Growth must wait before writing zero-filled pages.
-            deferred
-                .blocked
-                .await
-                .expect("resize grow never waited on start_sync");
+            // The growth staged in the tip: nothing reached the blob.
             let (_, writes, full_syncs, range_syncs) = inner.snapshot();
             assert_eq!(writes, 0);
             assert_eq!(full_syncs, 0);
             assert_eq!(range_syncs, 0);
 
-            // Releasing the sync lets the resize complete.
+            // Releasing the pending sync lets the next sync flush the zeros durably.
             deferred.release.send(Ok(())).unwrap();
-            let mut writer = resize.await.unwrap();
             prior.await.unwrap();
-            assert_eq!(writer.size(), target_size);
             writer.sync().await.unwrap();
+            assert_eq!(writer.size(), target_size);
             let (_, writes, full_syncs, _) = inner.snapshot();
             assert!(writes > 0);
             assert!(full_syncs > 0);
@@ -4118,9 +3373,9 @@ mod tests {
 
             // Build durable pages, then start a sync for a newer partial page.
             let data = vec![3; PAGE_SIZE.get() as usize * 2];
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
-            writer.append(b"x").await.unwrap();
+            writer.append(b"x");
             let prior = writer.start_sync().await;
             let deferred = next_pending_sync(&pending);
             let physical_size = inner.size();
@@ -4162,7 +3417,7 @@ mod tests {
                 .unwrap();
 
             // Keep the write buffered so sync attempts the clean `write_at_sync` path.
-            append.append(b"abc").await.unwrap();
+            append.append(b"abc");
 
             // Removing the blob makes the range-sync flush fail.
             context.remove("test_partition", Some(name)).await.unwrap();
@@ -4171,59 +3426,6 @@ mod tests {
             // The failed `write_at_sync` must leave a pending full-sync barrier, so a
             // later sync cannot report success.
             assert!(append.sync().await.is_err());
-        });
-    }
-
-    #[test_traced("DEBUG")]
-    fn test_sync_uses_full_sync_after_prior_plain_flush() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let blob = SyncTrackingBlob::new();
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let mut append = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-
-            // This append overflows the buffer, so a plain flush happens before sync writes the
-            // remaining tip.
-            let data = vec![7u8; BUFFER_SIZE + 1];
-            append.append(&data).await.unwrap();
-            append.sync().await.unwrap();
-
-            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
-            assert_eq!(writes, 2);
-            assert_eq!(full_syncs, 1);
-            assert_eq!(range_syncs, 0);
-
-            // With no new work, sync should not issue another durability operation.
-            append.sync().await.unwrap();
-            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
-            assert_eq!(writes, 2);
-            assert_eq!(full_syncs, 1);
-            assert_eq!(range_syncs, 0);
-
-            // The next sync still needs a full barrier because the append path flushed the full
-            // page before the final partial tip.
-            append.append(b"tip").await.unwrap();
-            append.sync().await.unwrap();
-
-            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
-            assert_eq!(writes, 4);
-            assert_eq!(full_syncs, 2);
-            assert_eq!(range_syncs, 0);
-
-            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let reopened = Writer::new(blob.clone(), blob.size(), BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-            let mut expected = data;
-            expected.extend_from_slice(b"tip");
-            let read = reopened
-                .read_at(0, expected.len())
-                .await
-                .unwrap()
-                .coalesce();
-            assert_eq!(read.as_ref(), expected.as_slice());
         });
     }
 
@@ -4238,7 +3440,7 @@ mod tests {
                 .unwrap();
 
             // Keep data buffered so replay has to flush it without syncing.
-            append.append(b"replayed").await.unwrap();
+            append.append(b"replayed");
 
             // Replay flushes buffered data for reading, but does not make that write durable.
             let mut replay = append.replay(NZUsize!(1024)).await.unwrap();
@@ -4270,7 +3472,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            append.append(b"replayed").await.unwrap();
+            append.append(b"replayed");
             let mut replay = append.replay(NZUsize!(1024)).await.unwrap();
             assert!(replay.ensure(b"replayed".len()).await.unwrap());
             assert_eq!(replay.remaining(), b"replayed".len());
@@ -4309,7 +3511,7 @@ mod tests {
                 .await
                 .unwrap();
             append.sync().await.unwrap();
-            append.append(b"valid").await.unwrap();
+            append.append(b"valid");
             append.sync().await.unwrap();
             drop(append);
 
@@ -4347,12 +3549,12 @@ mod tests {
             append.sync().await.unwrap();
 
             // Establish a persisted partial page with one authoritative CRC slot.
-            append.append(b"abc").await.unwrap();
+            append.append(b"abc");
             append.sync().await.unwrap();
 
             // Extending that partial page must write around the protected slot, so the two emitted
             // writes are batched behind one full sync.
-            append.append(b"de").await.unwrap();
+            append.append(b"de");
             append.sync().await.unwrap();
 
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
@@ -4362,7 +3564,7 @@ mod tests {
 
             // On the next extension, the protected slot is the second CRC, so only the prefix
             // write is needed.
-            append.append(b"fg").await.unwrap();
+            append.append(b"fg");
             append.sync().await.unwrap();
 
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
@@ -4397,7 +3599,7 @@ mod tests {
             let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
                 .await
                 .unwrap();
-            append.append(&[1, 2, 3, 4]).await.unwrap();
+            append.append(&[1, 2, 3, 4]);
 
             // Request a zero-length read with a reused, non-empty buffer.
             let stale = vec![9, 8, 7, 6];
@@ -4732,8 +3934,7 @@ mod tests {
 
             // Seed a tip buffer with the logical bytes exactly as flush would see them.
             let mut buffer = Buffer::new(0, data.len(), cache_ref.pool().clone());
-            let over_capacity = buffer.append(&data);
-            assert!(!over_capacity);
+            buffer.append(&data);
 
             // Convert buffered logical bytes into physical-page writes.
             let (physical_pages, partial_page_state) =
@@ -4808,7 +4009,7 @@ mod tests {
             let mut append = Writer::new(blob, 0, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append.append(&(1..=10).collect::<Vec<u8>>()).await.unwrap();
+            append.append(&(1..=10).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4818,9 +4019,7 @@ mod tests {
                 .await
                 .unwrap();
             append
-                .append(&(11..=30).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(11..=30).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4869,9 +4068,7 @@ mod tests {
                 .await
                 .unwrap();
             append
-                .append(&(31..=50).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(31..=50).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4934,7 +4131,7 @@ mod tests {
             let mut append = Writer::new(blob, 0, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append.append(&(1..=10).collect::<Vec<u8>>()).await.unwrap();
+            append.append(&(1..=10).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4944,9 +4141,7 @@ mod tests {
                 .await
                 .unwrap();
             append
-                .append(&(11..=30).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(11..=30).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -4956,9 +4151,7 @@ mod tests {
                 .await
                 .unwrap();
             append
-                .append(&(31..=50).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(31..=50).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5007,9 +4200,7 @@ mod tests {
                 .await
                 .unwrap();
             append
-                .append(&(51..=70).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(51..=70).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5074,7 +4265,7 @@ mod tests {
                 .await
                 .unwrap();
             let data1: Vec<u8> = (1..=20).collect();
-            append.append(&data1).await.unwrap();
+            append.append(&data1);
             append.sync().await.unwrap();
             drop(append);
 
@@ -5102,9 +4293,7 @@ mod tests {
                 .await
                 .unwrap();
             append
-                .append(&(21..=40).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(21..=40).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5159,7 +4348,7 @@ mod tests {
             let mut append = Writer::new(blob, 0, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append.append(&(1..=50).collect::<Vec<u8>>()).await.unwrap();
+            append.append(&(1..=50).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5169,9 +4358,7 @@ mod tests {
                 .await
                 .unwrap();
             append
-                .append(&(51..=80).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(51..=80).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5205,9 +4392,7 @@ mod tests {
                 .await
                 .unwrap();
             append
-                .append(&(81..=120).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(81..=120).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5291,7 +4476,7 @@ mod tests {
                 .await
                 .unwrap();
             let data1: Vec<u8> = (1..=10).collect();
-            append.append(&data1).await.unwrap();
+            append.append(&data1);
             append.sync().await.unwrap();
             drop(append);
 
@@ -5304,9 +4489,7 @@ mod tests {
                 .await
                 .unwrap();
             append
-                .append(&(11..=30).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(11..=30).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5412,7 +4595,7 @@ mod tests {
             let mut append = Writer::new(blob, 0, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append.append(&(1..=10).collect::<Vec<u8>>()).await.unwrap();
+            append.append(&(1..=10).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5426,9 +4609,7 @@ mod tests {
                 .unwrap();
             // Add bytes 11 through 103 (93 more bytes)
             append
-                .append(&(11..=PAGE_SIZE.get() as u8).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(11..=PAGE_SIZE.get() as u8).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5457,9 +4638,7 @@ mod tests {
                 .unwrap();
             // Add bytes 104 through 113 (10 more bytes, now on page 1)
             append
-                .append(&(104..=113).collect::<Vec<u8>>())
-                .await
-                .unwrap();
+                .append(&(104..=113).collect::<Vec<u8>>());
             append.sync().await.unwrap();
             drop(append);
 
@@ -5567,7 +4746,7 @@ mod tests {
             // Write data across 3 pages: page 0 (full), page 1 (full), page 2 (partial).
             // PAGE_SIZE = 103, so 250 bytes = 103 + 103 + 44.
             let data: Vec<u8> = (0..=249).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
             assert_eq!(append.size(), 250);
             drop(append);
@@ -5626,7 +4805,7 @@ mod tests {
             // pattern so a stale cache read would be obvious.
             let page_size = PAGE_SIZE.get() as usize;
             let old_bytes = vec![0xAAu8; page_size];
-            append.append(&old_bytes).await.unwrap();
+            append.append(&old_bytes);
             append.sync().await.unwrap();
 
             // Confirm page 0 is reachable via the cache-only fast path.
@@ -5637,7 +4816,7 @@ mod tests {
             // Rewind to 0 (crossing the page boundary) and append a new, distinct pattern.
             append.resize(0).await.unwrap();
             let new_bytes = vec![0xBBu8; 16];
-            append.append(&new_bytes).await.unwrap();
+            append.append(&new_bytes);
 
             // The cache must not serve pre-resize bytes. Either try_read_sync_into misses (cache
             // was invalidated) or it returns the new pattern; it must never return 0xAA.
@@ -5676,8 +4855,8 @@ mod tests {
 
             let old_page0 = vec![0x11u8; page_size];
             let old_page1 = vec![0x22u8; page_size];
-            writer.append(&old_page0).await.unwrap();
-            writer.append(&old_page1).await.unwrap();
+            writer.append(&old_page0);
+            writer.append(&old_page1);
             writer.sync().await.unwrap();
 
             writer.cache_ref.invalidate_from(writer.id, 1);
@@ -5690,7 +4869,7 @@ mod tests {
 
             writer.resize(page_size as u64).await.unwrap();
             let new_page1 = vec![0x33u8; page_size];
-            writer.append(&new_page1).await.unwrap();
+            writer.append(&new_page1);
             writer.sync().await.unwrap();
 
             let _ = release_tx.send(());
@@ -5722,7 +4901,7 @@ mod tests {
 
             let page_size = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0u8..=255).cycle().take(page_size * 2 + 7).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             let snapshot = append.snapshot().await.unwrap();
@@ -5761,7 +4940,7 @@ mod tests {
             let page_size = PAGE_SIZE.get() as usize;
             let total = page_size * 3 + 13;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             let snapshot = append.snapshot().await.unwrap();
@@ -5804,11 +4983,11 @@ mod tests {
                 .unwrap();
 
             let page_size = PAGE_SIZE.get() as usize;
-            append.append(&vec![0xAA; page_size]).await.unwrap();
+            append.append(&vec![0xAA; page_size]);
             append.sync().await.unwrap();
 
             let tail = b"oldtail";
-            append.append(tail).await.unwrap();
+            append.append(tail);
             let snapshot = append.snapshot().await.unwrap();
 
             let poison = vec![0xBB; page_size];
@@ -5837,7 +5016,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            append.append(b"hello world").await.unwrap();
+            append.append(b"hello world");
             assert_eq!(append.size(), 11);
 
             // Resize to same size. Should succeed.
@@ -5868,7 +5047,7 @@ mod tests {
 
             // Create a partial page whose authoritative CRC is in the first slot. The interrupted
             // tests below exercise the opposite slot orientation.
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             append.resize(45).await.unwrap();
@@ -5902,9 +5081,9 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append.append(&data[..40]).await.unwrap();
+            append.append(&data[..40]);
             append.sync().await.unwrap();
-            append.append(&data[40..]).await.unwrap();
+            append.append(&data[40..]);
             append.sync().await.unwrap();
             drop(append);
 
@@ -5959,9 +5138,9 @@ mod tests {
             let mut append = Writer::new(blob, size, LARGE_BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append.append(&data[..255]).await.unwrap();
+            append.append(&data[..255]);
             append.sync().await.unwrap();
-            append.append(&data[255..]).await.unwrap();
+            append.append(&data[255..]);
             append.sync().await.unwrap();
             drop(append);
 
@@ -6015,15 +5194,15 @@ mod tests {
             let mut append = Writer::new(faulty_blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append.append(&data[..48]).await.unwrap();
+            append.append(&data[..48]);
             append.sync().await.unwrap();
             assert_eq!(write_count.load(Ordering::SeqCst), 1);
 
-            append.append(&data[48..50]).await.unwrap();
+            append.append(&data[48..50]);
             append.sync().await.unwrap();
             assert_eq!(write_count.load(Ordering::SeqCst), 3);
 
-            append.append(&data[50..]).await.unwrap();
+            append.append(&data[50..]);
             append.sync().await.unwrap();
             assert_eq!(write_count.load(Ordering::SeqCst), 4);
 
@@ -6075,7 +5254,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             append.resize(target).await.unwrap();
@@ -6111,7 +5290,7 @@ mod tests {
             let mut append = Writer::new(blob, size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
             drop(append);
 
@@ -6175,9 +5354,9 @@ mod tests {
                 .unwrap();
             // Put the old authoritative CRC in slot 1, so the shorter CRC will be staged in slot
             // 0. The old length is above 255, so a one-byte tear changes the decoded length.
-            append.append(&data[..255]).await.unwrap();
+            append.append(&data[..255]);
             append.sync().await.unwrap();
-            append.append(&data[255..]).await.unwrap();
+            append.append(&data[255..]);
             append.sync().await.unwrap();
             drop(append);
 
@@ -6234,7 +5413,7 @@ mod tests {
             append.sync().await.unwrap();
 
             let data = vec![5u8; PAGE_SIZE.get() as usize];
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             // Shrinking within the same physical page only rewrites CRC metadata.
@@ -6260,7 +5439,7 @@ mod tests {
             append.sync().await.unwrap();
 
             let data = vec![9u8; PAGE_SIZE.get() as usize * 2];
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             // Shrinking from two physical pages to one partial page must also make the resize
@@ -6274,7 +5453,7 @@ mod tests {
             assert_eq!(range_syncs, 3);
 
             // Once the resize barrier is cleared, the next single flush can use range sync again.
-            append.append(b"x").await.unwrap();
+            append.append(b"x");
             append.sync().await.unwrap();
 
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
@@ -6304,7 +5483,7 @@ mod tests {
             // can persist them with one range-sync write.
             let page_size = PAGE_SIZE.get() as usize;
             let data = vec![11u8; page_size * 2];
-            append.append(&data).await.unwrap();
+            append.append(&data);
             append.sync().await.unwrap();
 
             // Shrinking to a page boundary resizes the blob but does not rewrite CRC metadata.
@@ -6347,7 +5526,7 @@ mod tests {
                 .unwrap();
 
             // Write some initial data.
-            append.append(&[1, 2, 3, 4, 5]).await.unwrap();
+            append.append(&[1, 2, 3, 4, 5]);
             append.sync().await.unwrap();
             assert_eq!(append.size(), 5);
             drop(append);
@@ -6362,7 +5541,7 @@ mod tests {
                 .unwrap();
             assert_eq!(append.size(), 5);
 
-            append.append(&[6, 7, 8]).await.unwrap();
+            append.append(&[6, 7, 8]);
             append.resize(6).await.unwrap();
             append.sync().await.unwrap();
 
@@ -6389,7 +5568,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            append.append(&[0x42; 50]).await.unwrap();
+            append.append(&[0x42; 50]);
             append.sync().await.unwrap();
             drop(append);
 
@@ -6459,7 +5638,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            append.append(&[0x42; 50]).await.unwrap();
+            append.append(&[0x42; 50]);
             append.sync().await.unwrap();
             drop(append);
 
@@ -6514,7 +5693,7 @@ mod tests {
                 .unwrap();
 
             let data: Vec<u8> = (0u8..50).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
 
             // No flush or sync has happened; reads must still see the buffered bytes.
             assert_eq!(writer.size(), 50);
@@ -6541,7 +5720,7 @@ mod tests {
 
             let page_size = PAGE_SIZE.get() as usize;
             let data: Vec<u8> = (0u8..=255).cycle().take(page_size * 2).collect();
-            writer.append(&data).await.unwrap();
+            writer.append(&data);
             writer.sync().await.unwrap();
             assert_eq!(writer.size(), (page_size * 2) as u64);
 

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1154,7 +1154,10 @@ impl<B: Blob> Writer<B> {
 mod tests {
     use super::*;
     use crate::{
-        buffer::{paged::CHECKSUM_SLOT_LEN_SIZE, tests::SyncTrackingBlob},
+        buffer::{
+            paged::CHECKSUM_SLOT_LEN_SIZE,
+            tests::{GatePosition, GatedResizeBlob, SyncTrackingBlob},
+        },
         deterministic,
         mocks::{next_pending_sync, DelayedSyncBlob},
         telemetry::metrics::Registry,
@@ -1180,8 +1183,6 @@ mod tests {
     // resize that a later operation applies under state still claiming the old size.
     #[test_traced("DEBUG")]
     fn test_shrink_cancel_before_truncate_is_noop() {
-        use crate::buffer::tests::{GatePosition, GatedResizeBlob};
-
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (inner, blob_size) = context

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -324,7 +324,7 @@ impl<B: Blob> Writer<B> {
         let protected_end = protected_start + CHECKSUM_SLOT_SIZE;
 
         // Split the prepared bytes into the two segments that may need writing: `before` is
-        // the first page's new bytes ([prefix_len, protected_start): everything below
+        // the first page's new bytes ([prefix_len, protected_start): everything before
         // `prefix_len` is already committed), and `after` is everything past the slot.
         let mut before = physical_pages.split_to(protected_start);
         before.advance(prefix_len);
@@ -376,7 +376,7 @@ impl<B: Blob> Writer<B> {
         self.sync_state.settle(&self.blob).await?;
 
         // A canceled shrink leaves the tip page's on-disk record in an unknown slot state;
-        // re-read it so the writes below go around the true authoritative slot.
+        // re-read it so following writes avoid the true authoritative slot.
         self.verify_partial_page().await?;
 
         // Prepare physical pages for the tail. The old partial-page record determines how the
@@ -632,7 +632,7 @@ impl<B: Blob> Writer<B> {
     ) -> Result<Checksum, Error> {
         // Recovery chooses the valid slot with the larger length. While shrinking, the new
         // checksum must be made durable without becoming authoritative until the old longer slot
-        // can be disabled. The sequence below therefore lets recovery observe either the old page
+        // can be disabled. The following sequence lets recovery observe either the old page
         // or the new shorter page, but not a footer where both slots were damaged by one torn write.
         let physical_page_size = logical_page_size
             .checked_add(CHECKSUM_SIZE)
@@ -835,9 +835,9 @@ impl<B: Blob> Writer<B> {
         };
 
         // Evict cached pages at or beyond the new full-page boundary. The page at
-        // `full_pages` (if partial) is now owned by the tip buffer, and anything above is
+        // `full_pages` (if partial) is now owned by the tip buffer, and anything after it is
         // beyond the new size. Leaving their pre-resize contents in the cache
-        // lets `try_read_sync_into` (whose reads below the tip boundary come straight from
+        // lets `try_read_sync_into` (whose reads before the tip boundary come straight from
         // the page cache) observe stale bytes once
         // the tip is repopulated.
         self.cache_ref.invalidate_from(self.id, full_pages);
@@ -847,7 +847,7 @@ impl<B: Blob> Writer<B> {
         // updating after would leave the writer claiming pages the blob no longer holds if the
         // truncate is dropped. Updating first is safe: a dropped truncate then leaves the
         // writer claiming less than the blob holds, and later appends overwrite the excess.
-        // The sync above wrote out any partial tip, so a boundary shrink always reduces the
+        // The earlier sync wrote out any partial tip, so a boundary shrink always reduces the
         // physical page count and the truncate is never a no-op.
         if partial_bytes == 0 {
             self.partial_page_state = PartialPage::None;
@@ -856,7 +856,7 @@ impl<B: Blob> Writer<B> {
         }
 
         // Shrink into a partial page. Read the target page now: its retained prefix becomes
-        // the new tip, and its CRC record seeds the rewrite below.
+        // the new tip, and its CRC record seeds the following rewrite.
         let (page_data, old_crc) =
             super::get_page_with_checksum_from_blob(&self.blob, full_pages, logical_page_size)
                 .await?;
@@ -868,8 +868,8 @@ impl<B: Blob> Writer<B> {
 
         // Publish a reduced claim before any destructive step: the target page's full
         // contents become the tip (so reads of it are served from memory) and the writer
-        // claims nothing above it. If the truncate below is dropped, the writer
-        // under-claims and never claims deleted pages. If a CRC slot write below is dropped,
+        // claims nothing after it. If the following truncate is dropped, the writer
+        // under-claims and never claims deleted pages. If a following CRC slot write is dropped,
         // the record's on-disk slot state is unknown, so mark it unverified: the next write
         // to the page re-reads the record first (see [Self::verify_partial_page]) and writes
         // around whichever slot is actually authoritative.
@@ -877,7 +877,7 @@ impl<B: Blob> Writer<B> {
         self.tail.restart_at(tail_offset, page_data.as_ref());
 
         // If the target stays within the current tip page, the physical page count is
-        // unchanged and no truncate is needed. Otherwise truncate every physical page above
+        // unchanged and no truncate is needed. Otherwise truncate every physical page after
         // the target page.
         if new_physical_size != current_physical_size {
             self.sync_state
@@ -1011,7 +1011,7 @@ mod tests {
             writer.sync().await.unwrap();
 
             // Cancel a shrink parked before the truncate reaches the blob. The writer
-            // published the reduced claim: the target page and below.
+            // published the reduced claim: the target page and earlier pages.
             gate.cancel(writer.resize(page as u64 + 30)).await;
             assert_eq!(writer.size(), 2 * page as u64);
 
@@ -1929,7 +1929,7 @@ mod tests {
             let target = page as u64 + 30;
             gate.cancel(writer.resize(target)).await;
 
-            // The writer claims only the target page and below, all of it readable: page 0
+            // The writer claims only the target page and earlier pages, all readable: page 0
             // from the blob and page 1 from the in-memory tip.
             assert!(writer.partial_page_state.is_unverified());
             assert_eq!(writer.current_page(), 1);
@@ -2326,7 +2326,7 @@ mod tests {
             writer.append(&data);
             writer.sync().await.unwrap();
 
-            // Shrink into the last full page. As above, skip two slot writes so the gate
+            // Shrink into the last full page. As before, skip two slot writes so the gate
             // parks at the applied commit point, then cancel.
             gate.set_skip(2);
             gate.cancel(writer.resize((2 * page + 30) as u64)).await;
@@ -2604,7 +2604,7 @@ mod tests {
             drop(writer);
 
             // The page still validates via the surviving slot: size is the transferred
-            // target, never a truncation below the committed pages.
+            // target, never a truncation inside the committed pages.
             let (blob, blob_size) = context
                 .open("test_partition", b"shrink_heal_torn")
                 .await
@@ -4786,7 +4786,7 @@ mod tests {
     #[test]
     fn test_resize_invalidates_cache() {
         // Regression: shrinking a blob across a page boundary must drop cached pages for the
-        // truncated region. Before the fix, `try_read_sync_into` (whose reads below the tip
+        // truncated region. Before the fix, `try_read_sync_into` (whose reads before the tip
         // boundary come straight from the page cache)
         // would observe pre-resize bytes at offsets later reclaimed by new appends.
         let executor = deterministic::Runner::default();
@@ -5045,7 +5045,7 @@ mod tests {
                 .unwrap();
 
             // Create a partial page whose authoritative CRC is in the first slot. The interrupted
-            // tests below exercise the opposite slot orientation.
+            // later tests exercise the opposite slot orientation.
             append.append(&data);
             append.sync().await.unwrap();
 
@@ -5352,7 +5352,7 @@ mod tests {
                 .await
                 .unwrap();
             // Put the old authoritative CRC in slot 1, so the shorter CRC will be staged in slot
-            // 0. The old length is above 255, so a one-byte tear changes the decoded length.
+            // 0. The old length exceeds 255, so a one-byte tear changes the decoded length.
             append.append(&data[..255]);
             append.sync().await.unwrap();
             append.append(&data[255..]);
@@ -5723,7 +5723,7 @@ mod tests {
             writer.sync().await.unwrap();
             assert_eq!(writer.size(), (page_size * 2) as u64);
 
-            // Shrink below the last observed size.
+            // Shrink to a smaller size.
             let new_size = (page_size / 2) as u64;
             writer.resize(new_size).await.unwrap();
 

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -18,7 +18,7 @@
 //! are readable immediately but durable only after `sync`. Full pages read from the blob are
 //! cached in a shared page cache, so reads are served from the write buffer, the page cache, or
 //! the blob itself. Large appends bypass the write buffer and write whole pages directly to the
-//! blob.
+//! blob; these are called direct appends throughout this module.
 //!
 //! # Checksums
 //!
@@ -47,7 +47,7 @@ use crate::{
     },
     Blob, Error, Handle, IoBuf, IoBufMut, IoBufs,
 };
-use bytes::BufMut;
+use bytes::{Buf, BufMut};
 use commonware_cryptography::Crc32;
 use std::num::{NonZeroU16, NonZeroUsize};
 use tracing::warn;
@@ -72,27 +72,60 @@ fn adjusted_capacity(capacity: usize, page_size: u64) -> usize {
     rounded.max(floor)
 }
 
-/// Returns whether appending `append_len` bytes should bypass the write buffer and write whole
-/// pages directly: the append would overflow capacity, and at least one whole page remains to
-/// write after filling the current page up to a boundary.
-///
-/// Larger appends bypass the buffer, so a buffered append exceeds `capacity` by less than one
-/// page (given `capacity` is a whole number of pages; see [adjusted_capacity]). The write
-/// buffer's peak size therefore stays under `capacity + logical_page_size`.
-const fn too_big_for_buffer(
-    buffer_len: usize,
-    buffer_capacity: usize,
-    append_len: usize,
-    logical_page_size: usize,
-) -> bool {
-    let fill = buffer_len.next_multiple_of(logical_page_size) - buffer_len;
-    let overflows_capacity = buffer_len + append_len > buffer_capacity;
-    let has_full_page_after_fill = append_len >= fill + logical_page_size;
+/// The state of the tip page's on-disk CRC record.
+enum PartialPage {
+    /// No committed partial page exists; the tip page's record can be written whole.
+    None,
+    /// The on-disk record is known; flushes write around its authoritative slot.
+    Committed(Checksum),
+    /// A canceled shrink left the on-disk record in an unknown slot state. It must be re-read
+    /// (see [Writer::verify_partial_page]) before any write to the page: writing a whole
+    /// record over an unknown one could tear the disk's authoritative slot.
+    Unverified,
+}
 
-    overflows_capacity && has_full_page_after_fill
+impl PartialPage {
+    /// The committed record, if any.
+    ///
+    /// # Panics
+    ///
+    /// Panics on [PartialPage::Unverified]: the record must be verified before use.
+    fn record(&self) -> Option<&Checksum> {
+        match self {
+            Self::None => None,
+            Self::Committed(record) => Some(record),
+            Self::Unverified => panic!("partial page record must be verified before use"),
+        }
+    }
+
+    /// True if no committed partial page exists.
+    const fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+/// A direct append staged into the blob whose publication was never observed.
+///
+/// Set before the append's blob writes are awaited and cleared only after the writer's state
+/// updates publish the written bytes. A record still present when a later operation runs
+/// means the append's future was dropped mid-write, and the blob must be reconciled back to
+/// the writer's claim (see [Writer::reconcile_publication]) before it is touched again.
+struct PendingPublication {
+    /// The physical size implied by the writer's claim; reconciliation truncates back to it.
+    physical_end: u64,
+    /// The tip page and the free CRC slot the append staged a full-page record into.
+    /// Present only when the append completed a committed partial tip page.
+    staged_slot: Option<(u64, Slot)>,
 }
 
 /// Unique writer to a cache-wrapped [Blob].
+///
+/// # Cancellation
+///
+/// Dropping an in-flight operation leaves the writer in a consistent, retryable state. A
+/// dropped operation may still have reached the blob (a direct append's bytes, a shrink's
+/// truncate); the writer records such intents before awaiting them, and every later
+/// mutation or sync first settles them so the blob agrees with the writer's claim.
 pub struct Writer<B: Blob> {
     /// The underlying blob being wrapped.
     blob: B,
@@ -100,9 +133,11 @@ pub struct Writer<B: Blob> {
     /// The page where the next appended byte will be written to.
     current_page: u64,
 
-    /// The state of the partial page in the blob. If it was written due to a sync call, then this
-    /// will contain its CRC record.
-    partial_page_state: Option<Checksum>,
+    /// The state of the tip page's on-disk CRC record.
+    partial_page_state: PartialPage,
+
+    /// A direct append whose publication was never observed, if any.
+    pending_publication: Option<PendingPublication>,
 
     /// Durability state for plain writes, resizes, and range-sync writes.
     sync_state: SyncState,
@@ -178,8 +213,12 @@ impl<B: Blob> Writer<B> {
         let needs_sync = !invalid_data_found; // ensure pending writes on the wrapped blob are synced
 
         let (current_page, partial_page_state, partial_data) = match partial_page_state {
-            Some((partial_page, crc_record)) => (pages - 1, Some(crc_record), Some(partial_page)),
-            None => (pages, None, None),
+            Some((partial_page, crc_record)) => (
+                pages - 1,
+                PartialPage::Committed(crc_record),
+                Some(partial_page),
+            ),
+            None => (pages, PartialPage::None, None),
         };
 
         let buffer = Buffer::from(
@@ -193,6 +232,7 @@ impl<B: Blob> Writer<B> {
             blob,
             current_page,
             partial_page_state,
+            pending_publication: None,
             sync_state: if needs_sync {
                 SyncState::dirty()
             } else {
@@ -272,99 +312,105 @@ impl<B: Blob> Writer<B> {
         Ok((None, 0, invalid_data_found))
     }
 
+    /// Returns whether appending `n` bytes should bypass the write buffer and write whole pages
+    /// directly to the blob.
+    const fn too_big_for_buffer(&self, n: usize) -> bool {
+        let page_size = self.cache_ref.page_size() as usize;
+        let len = self.buffer.len();
+
+        // Bypass only when the append would overflow capacity AND at least one whole page
+        // remains after topping the current partial page up to a boundary. Appends below that
+        // threshold are buffered, so the buffer's peak size stays under capacity plus one page
+        // (capacity is a whole number of pages; see [adjusted_capacity]).
+        let fill = len.next_multiple_of(page_size) - len;
+        let overflows_capacity = len + n > self.buffer.capacity;
+        let has_full_page_after_fill = n >= fill + page_size;
+
+        overflows_capacity && has_full_page_after_fill
+    }
+
     /// Append all bytes in `buf` to the tip of the blob, returning the logical offset at which
     /// the first byte was written.
     pub async fn append(&mut self, buf: &[u8]) -> Result<u64, Error> {
-        let logical_page_size = self.cache_ref.page_size() as usize;
-
         // Bypass the write buffer and write whole pages directly when `buf` is large.
-        if too_big_for_buffer(
-            self.buffer.len(),
-            self.buffer.capacity,
-            buf.len(),
-            logical_page_size,
-        ) {
+        if self.too_big_for_buffer(buf.len()) {
             return self.append_owned(IoBuf::copy_from_slice(buf)).await;
         }
 
         let offset = self.buffer.size();
         if self.buffer.append(buf) {
-            self.flush_internal(false, false).await?;
+            self.flush(false, false).await?;
         }
         Ok(offset)
     }
 
-    /// Append owned bytes to the tip of the blob.
-    ///
-    /// Large appends fill the current tip to a page boundary, write complete pages directly to the
-    /// blob, and leave only a sub-page suffix in the write buffer. This avoids copying full-page
-    /// payloads while preserving the invariant that the buffer starts at `current_page`.
+    /// Append owned bytes to the tip of the blob, returning the logical offset at which the
+    /// first byte was written.
     pub async fn append_owned(&mut self, buf: IoBuf) -> Result<u64, Error> {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let offset = self.buffer.size();
 
         // Buffer the append unless `buf` is too big for the buffer.
-        if !too_big_for_buffer(
-            self.buffer.len(),
-            self.buffer.capacity,
-            buf.len(),
-            logical_page_size,
-        ) {
+        if !self.too_big_for_buffer(buf.len()) {
             if self.buffer.append(buf.as_ref()) {
-                self.flush_internal(false, false).await?;
+                self.flush(false, false).await?;
             }
             return Ok(offset);
         }
 
-        // Bytes needed to fill current page to a page boundary (0 if already aligned).
-        let fill = self.buffer.len().next_multiple_of(logical_page_size) - self.buffer.len();
+        // `buf` is too big to buffer, so write its full pages directly to the blob. `buf` is
+        // split into three parts:
+        // - `fill`: the first bytes, which complete the tip's partial page (if any)
+        // - `bulk`: the whole pages after `fill`
+        // - `suffix`: the remainder (less than one page), which becomes the new tip
+        // All three are staged in local variables; the writer's state is updated only after the
+        // blob write succeeds, so a dropped append publishes nothing.
 
-        // Top up the tip to a page boundary so its contents flush as full pages, leaving any
-        // partial-page CRC handling to the regular flush path.
-        if fill > 0 {
-            self.buffer.append(&buf.as_ref()[..fill]);
+        // Undo any earlier direct append that was dropped mid-write, so the blob matches the
+        // writer's claim before new bytes are staged beyond it.
+        self.reconcile_publication().await?;
+
+        // First, flush any full pages already in the tip, so it holds at most a partial page.
+        if self.buffer.len() >= logical_page_size {
+            self.flush(false, false).await?;
         }
-        let boundary = self.buffer.size();
-        if !self.buffer.is_empty() {
-            self.flush_internal(false, false).await?;
+
+        // The completed page below writes around the tip page's committed record, so the
+        // record must be known (a canceled shrink leaves it unverified).
+        self.verify_partial_page().await?;
+
+        // Complete the tip's partial page (if any) into one full page, copying the tip's bytes
+        // and the first `fill` bytes of `buf`.
+        let tip_len = self.buffer.len();
+        if tip_len == 0 {
+            // The bulk pages below are built without a prior CRC record, which is only correct
+            // when no committed partial page exists.
             assert!(
-                self.buffer.size() == boundary && self.buffer.is_empty(),
-                "flush left unexpected buffered bytes before a direct-path append"
+                self.partial_page_state.is_none(),
+                "an empty tip implies no partial page state"
             );
         }
-
-        // Prepare physical pages for the whole pages remaining in `buf` without copying logical
-        // payload bytes.
-        let bulk_len = (buf.len() - fill) / logical_page_size * logical_page_size;
-        let bulk = buf.slice(fill..fill + bulk_len);
+        // Bytes needed to fill the current page to a page boundary (0 if already aligned).
+        let fill = tip_len.next_multiple_of(logical_page_size) - tip_len;
         let mut physical_pages = IoBufs::default();
-        self.append_full_pages(&bulk, None, &mut physical_pages);
-
-        assert!(
-            self.partial_page_state.is_none(),
-            "an empty tip implies no partial page state"
-        );
-
-        // Direct blob writes must not overtake an earlier started sync barrier.
-        self.sync_state.wait_for_pending().await?;
-
-        // Cache the pages before `replace` publishes the new size, so reads of the bulk range are
-        // served from the cache while the blob write is still in flight. Insert in
-        // write-buffer-sized chunks. The capacity is a whole number of pages (see
-        // [adjusted_capacity]), so each chunk is page-aligned.
-        let chunk_len = self.buffer.capacity;
-        let mut cache_offset = boundary;
-        for chunk in bulk.as_ref().chunks(chunk_len) {
-            let remaining = self.cache_ref.cache(self.id, chunk, cache_offset);
-            assert_eq!(remaining, 0, "cached bulk pages must be page-aligned");
-            cache_offset += chunk.len() as u64;
+        let mut completed_page = None;
+        if fill > 0 {
+            let mut page = self.cache_ref.pool().alloc(logical_page_size);
+            page.put_slice(self.buffer.as_ref());
+            page.put_slice(&buf.as_ref()[..fill]);
+            let page = page.freeze();
+            self.append_full_pages(&page, self.partial_page_state.record(), &mut physical_pages);
+            completed_page = Some(page);
         }
 
-        // Update state before writing, seeding the tip with the partial-page suffix of `buf`.
-        // The suffix (less than one page) is copied: a sub-page tip is never drained by flush,
-        // so seeding it with a view of `buf` would pin the entire backing allocation until the
-        // next append to this blob (or forever, if there is none).
-        self.current_page += (bulk_len / logical_page_size) as u64;
+        // Prepare the `bulk` pages as views of `buf`, copying no payload bytes.
+        let bulk_len = (buf.len() - fill) / logical_page_size * logical_page_size;
+        let bulk = buf.slice(fill..fill + bulk_len);
+        self.append_full_pages(&bulk, None, &mut physical_pages);
+
+        // Copy the `suffix` for the new tip. A view of `buf` would work, but a sub-page tip is
+        // never drained by flush, so the view would pin `buf`'s entire backing allocation until
+        // the next append (or forever, if there is none).
         let suffix = buf.slice(fill + bulk_len..);
         let suffix = if suffix.is_empty() {
             suffix
@@ -373,7 +419,55 @@ impl<B: Blob> Writer<B> {
             copied.put_slice(suffix.as_ref());
             copied.freeze()
         };
-        self.buffer.replace(boundary + bulk_len as u64, suffix);
+
+        // Record the staged append before its writes are awaited: if the future is dropped
+        // mid-write, bytes may land on disk without ever being published into writer state,
+        // and the next operation must undo them (see [Self::reconcile_publication]). The
+        // completed page's record is staged into the free slot of the tip page's committed
+        // record.
+        let physical_page_size = self.cache_ref.page_size() + CHECKSUM_SIZE;
+        let staged_slot = self
+            .partial_page_state
+            .record()
+            .map(|old| (self.current_page, old.authoritative().other()));
+        let claimed_pages = self
+            .current_page
+            .checked_add(u64::from(staged_slot.is_some()))
+            .ok_or(Error::OffsetOverflow)?;
+        self.pending_publication = Some(PendingPublication {
+            physical_end: claimed_pages
+                .checked_mul(physical_page_size)
+                .ok_or(Error::OffsetOverflow)?,
+            staged_slot,
+        });
+
+        self.write_physical_pages(physical_pages, false).await?;
+
+        // Update state only after the write succeeds, for cancellation safety. Cache chunks
+        // of `capacity` are page-aligned because the capacity is a whole number of pages
+        // (see [adjusted_capacity]).
+        let mut cache_offset = self.buffer.offset;
+        if let Some(completed_page) = completed_page {
+            let remaining = self
+                .cache_ref
+                .cache(self.id, completed_page.as_ref(), cache_offset);
+            assert_eq!(remaining, 0, "cached completed page must be page-aligned");
+            cache_offset += logical_page_size as u64;
+            self.current_page += 1;
+            self.partial_page_state = PartialPage::None;
+        }
+        for chunk in bulk.as_ref().chunks(self.buffer.capacity) {
+            let remaining = self.cache_ref.cache(self.id, chunk, cache_offset);
+            assert_eq!(remaining, 0, "cached bulk pages must be page-aligned");
+            cache_offset += chunk.len() as u64;
+        }
+        self.current_page += (bulk_len / logical_page_size) as u64;
+
+        // The `suffix` becomes the new tip, starting after the last written page.
+        self.buffer.replace(cache_offset, suffix);
+
+        // The written bytes are now published: the claim covers them.
+        self.pending_publication = None;
 
         // Make sure the buffer offset and underlying blob agree on the state of the tip.
         assert_eq!(
@@ -381,11 +475,116 @@ impl<B: Blob> Writer<B> {
             self.buffer.offset
         );
 
-        let physical_page_size = logical_page_size as u64 + CHECKSUM_SIZE;
-        let write_at_offset = boundary / logical_page_size as u64 * physical_page_size;
-        self.write_at(write_at_offset, physical_pages).await?;
-
         Ok(offset)
+    }
+
+    /// Undo a direct append whose future was dropped after its writes may have reached the
+    /// blob.
+    ///
+    /// Such an append leaves bytes the writer never published: bulk pages past the claimed
+    /// physical end, and possibly a full-page record staged in the tip page's free CRC
+    /// slot. Recovery would prefer both over the claim. Zeroing the staged slot's length
+    /// bytes retires it (length 0 is never authoritative; the committed slot is untouched),
+    /// and truncating back to the claimed physical end removes the bulk pages.
+    ///
+    /// Both steps are idempotent and the record is cleared only after they complete, so a
+    /// dropped reconciliation re-runs on the next operation. Ordering against the orphan's
+    /// own writes comes from the [Blob] contract: mutations execute in submission order, so
+    /// these writes land after the orphan's.
+    async fn reconcile_publication(&mut self) -> Result<(), Error> {
+        let Some(PendingPublication {
+            physical_end,
+            staged_slot,
+        }) = self.pending_publication
+        else {
+            return Ok(());
+        };
+
+        if let Some((page, slot)) = staged_slot {
+            let physical_page_size = self.cache_ref.page_size() + CHECKSUM_SIZE;
+            let slot_offset = page
+                .checked_mul(physical_page_size)
+                .and_then(|start| start.checked_add(self.cache_ref.page_size()))
+                .and_then(|crc| crc.checked_add(slot.offset() as u64))
+                .ok_or(Error::OffsetOverflow)?;
+            self.write_at(slot_offset, Checksum::slot_len_bytes(0).to_vec())
+                .await?;
+        }
+
+        self.sync_state.resize(&self.blob, physical_end).await?;
+        self.pending_publication = None;
+        Ok(())
+    }
+
+    /// Resolve an [PartialPage::Unverified] record by reading it back from the blob.
+    ///
+    /// A canceled shrink may have left either CRC slot authoritative on disk. Re-reading the
+    /// record lets later flushes write around the true authoritative slot, preserving the
+    /// dual-slot guarantee that a torn write never damages both slots of a committed page.
+    /// The state is updated only after the read returns, so a dropped verify changes nothing.
+    async fn verify_partial_page(&mut self) -> Result<(), Error> {
+        if !matches!(self.partial_page_state, PartialPage::Unverified) {
+            return Ok(());
+        }
+        let (_, record) = super::get_page_with_checksum_from_blob(
+            &self.blob,
+            self.current_page,
+            self.cache_ref.page_size(),
+        )
+        .await?;
+        self.partial_page_state = PartialPage::Committed(record);
+        Ok(())
+    }
+
+    /// Writes prepared physical pages to the blob at the position described by `current_page`
+    /// and `partial_page_state`.
+    ///
+    /// Returns `true` if the writes were made durable, so no later sync is needed.
+    async fn write_physical_pages(
+        &mut self,
+        mut physical_pages: IoBufs,
+        sync: bool,
+    ) -> Result<bool, Error> {
+        let logical_page_size = self.cache_ref.page_size() as usize;
+        let write_at_offset = self.current_page * (logical_page_size as u64 + CHECKSUM_SIZE);
+
+        // If no CRC slot is protected, everything goes out in one write.
+        let Some((prefix_len, slot)) =
+            Self::identify_protected_regions(self.partial_page_state.record())
+        else {
+            self.write_at_maybe_sync(write_at_offset, physical_pages, sync)
+                .await?;
+            return Ok(sync);
+        };
+
+        // The protected slot occupies [protected_start, protected_end) of the first physical
+        // page and must not be overwritten.
+        let protected_start = match slot {
+            Slot::First => logical_page_size,
+            Slot::Second => logical_page_size + CHECKSUM_SLOT_SIZE,
+        };
+        let protected_end = protected_start + CHECKSUM_SLOT_SIZE;
+
+        // Split the prepared bytes into the two segments that may need writing: `before` is
+        // the first page's new bytes ([prefix_len, protected_start): everything below
+        // `prefix_len` is already committed), and `after` is everything past the slot.
+        let mut before = physical_pages.split_to(protected_start);
+        before.advance(prefix_len);
+        physical_pages.advance(protected_end - protected_start);
+        let after = physical_pages;
+
+        // A lone segment can be made durable by its own write; when both are present, keep
+        // them plain so one later sync covers both.
+        let synced = sync && (before.is_empty() != after.is_empty());
+        if !before.is_empty() {
+            self.write_at_maybe_sync(write_at_offset + prefix_len as u64, before, synced)
+                .await?;
+        }
+        if !after.is_empty() {
+            self.write_at_maybe_sync(write_at_offset + protected_end as u64, after, synced)
+                .await?;
+        }
+        Ok(synced)
     }
 
     /// Flush all full pages from the buffer to disk, resetting the buffer to contain only the bytes
@@ -400,17 +599,26 @@ impl<B: Blob> Writer<B> {
     /// plain writes so the caller can make them durable with one sync.
     ///
     /// Returns `true` if the flush made its writes durable, so no additional sync is needed.
-    async fn flush_internal(
-        &mut self,
-        write_partial_page: bool,
-        sync: bool,
-    ) -> Result<bool, Error> {
+    async fn flush(&mut self, write_partial_page: bool, sync: bool) -> Result<bool, Error> {
+        // Undo any direct append dropped mid-write, so the writes below (and the sync that
+        // may follow) act on a blob that matches the writer's claim.
+        self.reconcile_publication().await?;
+
+        // Re-issue any dropped resize before deriving writes from writer state. Writes and
+        // syncs settle on their own; this covers paths that may emit no writes at all
+        // (sync, seal, snapshot, replay) and would otherwise leave the resize incomplete.
+        self.sync_state.settle(&self.blob).await?;
+
+        // A canceled shrink leaves the tip page's on-disk record in an unknown slot state;
+        // re-read it so the writes below go around the true authoritative slot.
+        self.verify_partial_page().await?;
+
         // Prepare the *physical* pages corresponding to the data in the buffer.
         // Pass the old partial page state so the CRC record is constructed correctly.
-        let (mut physical_pages, partial_page_state) = self.to_physical_pages(
+        let (physical_pages, partial_page_state) = self.to_physical_pages(
             &self.buffer,
             write_partial_page,
-            self.partial_page_state.as_ref(),
+            self.partial_page_state.record(),
         );
 
         // If there's nothing to write, return early.
@@ -418,153 +626,32 @@ impl<B: Blob> Writer<B> {
             return Ok(false);
         }
 
-        // A flush mutates the blob, so first resolve any outstanding start_sync barrier.
-        self.sync_state.wait_for_pending().await?;
+        let synced = self.write_physical_pages(physical_pages, sync).await?;
 
-        // Split buffered bytes into full logical pages to hand off now, leaving any trailing
-        // partial page in tip for continued buffering.
+        // Update state only after the writes succeed, for cancellation safety.
         let logical_page_size = self.cache_ref.page_size() as usize;
-        let pages_to_cache = self.buffer.len() / logical_page_size;
-        let bytes_to_drain = pages_to_cache * logical_page_size;
-
-        // Remember the logical start offset and page bytes for caching of flushed full pages.
-        let cache_pages = if pages_to_cache > 0 {
-            Some((self.buffer.offset, self.buffer.slice(..bytes_to_drain)))
-        } else {
-            None
-        };
-
-        // Drain full pages from the buffered logical data. If the tip is fully drained, detach its
-        // backing so empty append buffers don't retain pooled storage.
-        if bytes_to_drain == self.buffer.len() && bytes_to_drain != 0 {
-            let _ = self
-                .buffer
-                .take()
-                .expect("take must succeed when flush drains all buffered bytes");
-        } else if bytes_to_drain != 0 {
-            self.buffer.drop_prefix(bytes_to_drain);
-            self.buffer.offset += bytes_to_drain as u64;
-        }
-        let new_offset = self.buffer.offset;
-
-        // Cache full pages before publishing the new blob state so reads don't observe stale
-        // persisted bytes during the handoff from tip to cache.
-        if let Some((cache_offset, pages)) = cache_pages {
-            let remaining = self.cache_ref.cache(self.id, pages.as_ref(), cache_offset);
+        let full_pages = self.buffer.len() / logical_page_size;
+        let full_bytes = full_pages * logical_page_size;
+        if full_bytes > 0 {
+            let remaining = self.cache_ref.cache(
+                self.id,
+                &self.buffer.as_ref()[..full_bytes],
+                self.buffer.offset,
+            );
             assert_eq!(remaining, 0, "cached full-page prefix must be page-aligned");
         }
-
-        let physical_page_size = logical_page_size + CHECKSUM_SIZE as usize;
-        let write_at_offset = self.current_page * physical_page_size as u64;
-
-        // Identify protected regions based on the OLD partial page state.
-        let protected_regions = Self::identify_protected_regions(self.partial_page_state.as_ref());
-
-        // Update state before writing. This may appear to risk data loss if writes fail,
-        // but write failures are fatal per this codebase's design: callers must not use
-        // the blob after any mutable method returns an error.
-        self.current_page += pages_to_cache as u64;
-        self.partial_page_state = partial_page_state;
+        self.buffer.advance(full_bytes);
+        self.current_page += full_pages as u64;
+        self.partial_page_state =
+            partial_page_state.map_or(PartialPage::None, PartialPage::Committed);
 
         // Make sure the buffer offset and underlying blob agree on the state of the tip.
-        assert_eq!(self.current_page * self.cache_ref.page_size(), new_offset);
+        assert_eq!(
+            self.current_page * self.cache_ref.page_size(),
+            self.buffer.offset
+        );
 
-        // Write the physical pages to the blob.
-        // If there are protected regions in the first page, we need to write around them.
-        match protected_regions {
-            Some((prefix_len, Slot::First)) => {
-                // Protected CRC is first: [page_size..page_size+6].
-                //
-                // If only one of these writes is emitted, it can be made durable here. If
-                // both are emitted, keep them plain so one later sync covers both.
-                //
-                // Write 1: new data in first page [prefix_len..page_size].
-                let has_first_write = prefix_len < logical_page_size;
-                if has_first_write {
-                    let _ = physical_pages.split_to(prefix_len);
-                    let first_payload = physical_pages.split_to(logical_page_size - prefix_len);
-                    let has_second_write = physical_pages.len() > CHECKSUM_SLOT_SIZE;
-                    self.write_at_maybe_sync(
-                        write_at_offset + prefix_len as u64,
-                        first_payload,
-                        sync && !has_second_write,
-                    )
-                    .await?;
-                    if !has_second_write {
-                        return Ok(sync);
-                    }
-                } else {
-                    // Skip the protected first page bytes when they are fully covered.
-                    let _ = physical_pages.split_to(logical_page_size);
-                }
-
-                // Write 2: second CRC of first page + all remaining pages [page_size+6..end].
-                if physical_pages.len() > CHECKSUM_SLOT_SIZE {
-                    let _ = physical_pages.split_to(CHECKSUM_SLOT_SIZE);
-                    self.write_at_maybe_sync(
-                        write_at_offset + (logical_page_size + CHECKSUM_SLOT_SIZE) as u64,
-                        physical_pages,
-                        sync && !has_first_write,
-                    )
-                    .await?;
-                    if !has_first_write {
-                        return Ok(sync);
-                    }
-                }
-
-                Ok(false)
-            }
-            Some((prefix_len, Slot::Second)) => {
-                // Protected CRC is second: [page_size+6..page_size+12].
-                //
-                // If only one of these writes is emitted, it can be made durable here. If
-                // both are emitted, keep them plain so one later sync covers both.
-                //
-                // Write 1: new data + first CRC of first page [prefix_len..page_size+6].
-                let first_crc_end = logical_page_size + CHECKSUM_SLOT_SIZE;
-                let skip = physical_page_size - first_crc_end;
-                let has_first_write = prefix_len < first_crc_end;
-                if has_first_write {
-                    let _ = physical_pages.split_to(prefix_len);
-                    let first_payload = physical_pages.split_to(first_crc_end - prefix_len);
-                    let has_second_write = physical_pages.len() > skip;
-                    self.write_at_maybe_sync(
-                        write_at_offset + prefix_len as u64,
-                        first_payload,
-                        sync && !has_second_write,
-                    )
-                    .await?;
-                    if !has_second_write {
-                        return Ok(sync);
-                    }
-                } else {
-                    // Skip the fully protected first segment when no bytes from it need update.
-                    let _ = physical_pages.split_to(first_crc_end);
-                }
-
-                // Write 2: all remaining pages (if any) [physical_page_size..end].
-                if physical_pages.len() > skip {
-                    let _ = physical_pages.split_to(skip);
-                    self.write_at_maybe_sync(
-                        write_at_offset + physical_page_size as u64,
-                        physical_pages,
-                        sync && !has_first_write,
-                    )
-                    .await?;
-                    if !has_first_write {
-                        return Ok(sync);
-                    }
-                }
-
-                Ok(false)
-            }
-            None => {
-                // No protected regions, write everything in one operation
-                self.write_at_maybe_sync(write_at_offset, physical_pages, sync)
-                    .await?;
-                Ok(sync)
-            }
-        }
+        Ok(synced)
     }
 
     /// Returns the size of the blob.
@@ -738,8 +825,8 @@ impl<B: Blob> Writer<B> {
         padded.put_slice(&crc_record.to_bytes());
         write_buffer.append(padded.freeze());
 
-        // Return the CRC record that matches what we wrote to disk, so that future flushes
-        // correctly identify which slot is protected.
+        // Return the CRC record matching the prepared partial page, so a later flush
+        // identifies the protected slot.
         (write_buffer, Some(crc_record))
     }
 
@@ -884,7 +971,7 @@ impl<B: Blob> Writer<B> {
             NonZeroU16::new(logical_page_size as u16).expect("page_size is non-zero");
 
         // Flush any buffered data (without fsync) so the reader sees all written data.
-        self.flush_internal(true, false).await?;
+        self.flush(true, false).await?;
 
         // Convert buffer size (bytes) to page count
         let physical_page_size = logical_page_size + CHECKSUM_SIZE;
@@ -892,7 +979,7 @@ impl<B: Blob> Writer<B> {
         let prefetch_pages = prefetch_pages.max(1); // At least 1 page
 
         // Compute both physical and logical blob sizes.
-        let (physical_blob_size, logical_blob_size) = self.partial_page_state.as_ref().map_or_else(
+        let (physical_blob_size, logical_blob_size) = self.partial_page_state.record().map_or_else(
             || {
                 // All pages are full.
                 let physical = physical_page_size * self.current_page;
@@ -931,7 +1018,7 @@ impl<B: Blob> Writer<B> {
     /// If this writer later rewinds or truncates into the returned handle's range, reads from that
     /// handle may observe unspecified contents.
     pub async fn snapshot(&mut self) -> Result<super::Sealed<B>, Error> {
-        self.flush_internal(true, false).await?;
+        self.flush(true, false).await?;
         Ok(self.sealed_handle(self.cache_ref.next_id()))
     }
 
@@ -943,7 +1030,7 @@ impl<B: Blob> Writer<B> {
     pub async fn sync(&mut self) -> Result<(), Error> {
         // Flush any buffered data, including any partial page.
         // A single emitted write can be made durable directly during the flush.
-        if self.flush_internal(true, true).await? {
+        if self.flush(true, true).await? {
             return Ok(());
         }
 
@@ -959,7 +1046,7 @@ impl<B: Blob> Writer<B> {
     /// for the state flushed by this call. Later calls to [`Self::sync`] and writer methods that
     /// mutate the blob first wait for any outstanding start_sync handles.
     pub async fn start_sync(&mut self) -> Handle<()> {
-        if let Err(err) = self.flush_internal(true, false).await {
+        if let Err(err) = self.flush(true, false).await {
             return Handle::ready(Err(err));
         }
         self.sync_state.start_sync(&self.blob).await
@@ -1020,7 +1107,7 @@ impl<B: Blob> Writer<B> {
         let tail_offset = full_pages
             .checked_mul(logical_page_size)
             .ok_or(Error::OffsetOverflow)?;
-        let current_physical_size = if self.partial_page_state.is_some() {
+        let current_physical_size = if self.partial_page_state.record().is_some() {
             self.current_page
                 .checked_add(1)
                 .and_then(|pages| pages.checked_mul(physical_page_size))
@@ -1031,19 +1118,6 @@ impl<B: Blob> Writer<B> {
                 .ok_or(Error::OffsetOverflow)?
         };
 
-        // A logical shrink can leave the physical page count unchanged. Only real physical
-        // resizes need to create a pending sync.
-        //
-        // Resize the blob directly, not through [SyncState::resize]: this writer publishes
-        // its state only after the truncate returns, so a recorded resize re-issued by a
-        // later operation (see [SyncState::settle]) would truncate under state that still
-        // claims the old size. A dropped truncate here is simply a no-op.
-        if new_physical_size != current_physical_size {
-            self.sync_state.wait_for_pending().await?;
-            self.sync_state.mark_dirty();
-            self.blob.resize(new_physical_size).await?;
-        }
-
         // Evict cached pages at or beyond the new full-page boundary. The page at
         // `full_pages` (if partial) is now owned by the tip buffer, and anything above is
         // beyond the new size. Leaving their pre-resize contents in the cache
@@ -1052,34 +1126,23 @@ impl<B: Blob> Writer<B> {
         // the tip is repopulated.
         self.cache_ref.invalidate_from(self.id, full_pages);
 
-        if partial_bytes > 0 {
-            return self
-                .shrink_to_partial(full_pages, partial_bytes, logical_page_size, tail_offset)
-                .await;
+        // Shrink to a page boundary, which requires no CRC-slot rewrite. The state update must
+        // come before the truncate: truncated full pages cannot be rebuilt from the tip, so
+        // updating after would leave the writer claiming pages the blob no longer holds if the
+        // truncate is dropped. Updating first is safe: a dropped truncate then leaves the
+        // writer claiming less than the blob holds, and later appends overwrite the excess.
+        // The sync above wrote out any partial tip, so a boundary shrink always reduces the
+        // physical page count and the truncate is never a no-op.
+        if partial_bytes == 0 {
+            self.partial_page_state = PartialPage::None;
+            self.current_page = full_pages;
+            self.buffer.offset = tail_offset;
+            self.buffer.clear();
+            return self.sync_state.resize(&self.blob, new_physical_size).await;
         }
 
-        // Shrink the blob to a page boundary, which requires no CRC-slot rewrite.
-        self.partial_page_state = None;
-        self.current_page = full_pages;
-        self.buffer.offset = tail_offset;
-        self.buffer.clear();
-
-        Ok(())
-    }
-
-    /// Perform a shrink to a partial page tip and make the shorter CRC slot authoritative.
-    async fn shrink_to_partial(
-        &mut self,
-        full_pages: u64,
-        partial_bytes: u64,
-        logical_page_size: u64,
-        tail_offset: u64,
-    ) -> Result<(), Error> {
-        // Update blob state and buffer based on the desired size. The page data is
-        // read with CRC validation, then durably rewritten below with a shorter CRC.
-        self.current_page = full_pages;
-        self.buffer.offset = tail_offset;
-
+        // Shrink into a partial page. Read the target page now: its retained prefix becomes
+        // the new tip, and its CRC record seeds the rewrite below.
         let (page_data, old_crc) =
             super::get_page_with_checksum_from_blob(&self.blob, full_pages, logical_page_size)
                 .await?;
@@ -1089,11 +1152,31 @@ impl<B: Blob> Writer<B> {
             return Err(Error::InvalidChecksum);
         }
 
+        // Publish a reduced claim before any destructive step: the target page's full
+        // contents become the tip (so reads of it are served from memory) and the writer
+        // claims nothing above it. If the truncate below is dropped, the writer
+        // under-claims and never claims deleted pages. If a CRC slot write below is dropped,
+        // the record's on-disk slot state is unknown, so mark it unverified: the next write
+        // to the page re-reads the record first (see [Self::verify_partial_page]) and writes
+        // around whichever slot is actually authoritative.
+        self.partial_page_state = PartialPage::Unverified;
+        self.current_page = full_pages;
+        self.buffer.offset = tail_offset;
         self.buffer.clear();
-        let new_data = &page_data.as_ref()[..partial_bytes as usize];
-        let over_capacity = self.buffer.append(new_data);
+        let over_capacity = self.buffer.append(page_data.as_ref());
         assert!(!over_capacity);
 
+        // If the target stays within the current tip page, the physical page count is
+        // unchanged and no truncate is needed. Otherwise truncate every physical page above
+        // the target page.
+        if new_physical_size != current_physical_size {
+            self.sync_state
+                .resize(&self.blob, new_physical_size)
+                .await?;
+        }
+
+        // Durably rewrite the target page's CRC record to the shorter length.
+        let new_data = &page_data.as_ref()[..partial_bytes as usize];
         let final_record = self
             .sync_partial_page_shrink(
                 full_pages,
@@ -1103,7 +1186,14 @@ impl<B: Blob> Writer<B> {
                 &old_crc,
             )
             .await?;
-        self.partial_page_state = Some(final_record);
+
+        // Update state only after the rewrite succeeds, for cancellation safety.
+        self.current_page = full_pages;
+        self.buffer.offset = tail_offset;
+        self.buffer.clear();
+        let over_capacity = self.buffer.append(new_data);
+        assert!(!over_capacity);
+        self.partial_page_state = PartialPage::Committed(final_record);
 
         Ok(())
     }
@@ -1145,7 +1235,7 @@ impl<B: Blob> Writer<B> {
     /// [`super::Sealed::sync`].
     pub async fn seal(mut self) -> Result<super::Sealed<B>, Error> {
         self.sync_state.wait_for_pending().await?;
-        self.flush_internal(true, false).await?;
+        self.flush(true, false).await?;
         Ok(self.sealed_handle(self.id))
     }
 }
@@ -1156,7 +1246,7 @@ mod tests {
     use crate::{
         buffer::{
             paged::CHECKSUM_SLOT_LEN_SIZE,
-            tests::{GatePosition, GatedResizeBlob, SyncTrackingBlob},
+            tests::{GatePosition, GatedResizeBlob, GatedWriteBlob, SyncTrackingBlob},
         },
         deterministic,
         mocks::{next_pending_sync, DelayedSyncBlob},
@@ -1179,14 +1269,26 @@ mod tests {
     const PAGE_SIZE: NonZeroU16 = NZU16!(103); // janky size to ensure we test page alignment
     const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;
 
-    // A shrink dropped before its truncate reaches the blob is a no-op: it must not record a
-    // resize that a later operation applies under state still claiming the old size.
+    impl PartialPage {
+        /// True if the on-disk record is known.
+        const fn is_committed(&self) -> bool {
+            matches!(self, Self::Committed(_))
+        }
+
+        /// True if the on-disk record must be re-read before the next write.
+        const fn is_unverified(&self) -> bool {
+            matches!(self, Self::Unverified)
+        }
+    }
+
+    // Appends after a canceled shrink continue from the published reduced claim, and the
+    // next sync settles the dropped truncate before flushing them.
     #[test_traced("DEBUG")]
-    fn test_shrink_cancel_before_truncate_is_noop() {
+    fn test_shrink_cancel_before_truncate_appends_continue() {
         let executor = deterministic::Runner::default();
         executor.start(|context: deterministic::Context| async move {
             let (inner, blob_size) = context
-                .open("test_partition", b"shrink_noop")
+                .open("test_partition", b"shrink_append")
                 .await
                 .unwrap();
             let (blob, gate) = GatedResizeBlob::new(inner, GatePosition::Before);
@@ -1200,20 +1302,21 @@ mod tests {
             writer.append(&data).await.unwrap();
             writer.sync().await.unwrap();
 
-            // Cancel a shrink parked before the truncate reaches the blob: nothing happened.
+            // Cancel a shrink parked before the truncate reaches the blob. The writer
+            // published the reduced claim: the target page and below.
             gate.cancel(writer.resize(page as u64 + 30)).await;
-            assert_eq!(writer.size(), data.len() as u64);
+            assert_eq!(writer.size(), 2 * page as u64);
 
-            // The writer carries on: appends and syncs land as if the shrink was never asked.
+            // Appends continue from the claim; the sync settles the truncate, then flushes.
             writer.append(&data[..10]).await.unwrap();
             writer.sync().await.unwrap();
-            let expected_size = (data.len() + 10) as u64;
+            let expected_size = (2 * page + 10) as u64;
             assert_eq!(writer.size(), expected_size);
             drop(writer);
 
             // The acknowledged state survives a restart.
             let (blob, blob_size) = context
-                .open("test_partition", b"shrink_noop")
+                .open("test_partition", b"shrink_append")
                 .await
                 .unwrap();
             let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
@@ -1225,8 +1328,8 @@ mod tests {
                 .await
                 .unwrap()
                 .coalesce();
-            assert_eq!(&read.as_ref()[..data.len()], data.as_slice());
-            assert_eq!(&read.as_ref()[data.len()..], &data[..10]);
+            assert_eq!(&read.as_ref()[..2 * page], &data[..2 * page]);
+            assert_eq!(&read.as_ref()[2 * page..], &data[..10]);
         });
     }
 
@@ -1999,6 +2102,1274 @@ mod tests {
             assert_eq!(append.size(), 430);
             let read_buf = append.read_at(0, 430).await.unwrap().coalesce();
             assert_eq!(read_buf, &all[..]);
+        });
+    }
+
+    // If a page flush is canceled during the blob write, keep the data in the tip.
+    #[test_traced("DEBUG")]
+    fn test_flush_cancel_preserves_paged_tip() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"flush_cancel")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            let mut expected = vec![7u8; BUFFER_SIZE];
+            writer.append(&expected).await.unwrap();
+            expected.push(9);
+
+            // This append overflows the buffer and starts a full-page flush. Cancel during it.
+            gate.cancel(writer.append(&[9])).await;
+
+            // Nothing should have moved from the tip into page/cache state yet.
+            assert_eq!(writer.current_page, 0);
+            assert!(writer.partial_page_state.is_none());
+            assert_eq!(writer.size(), expected.len() as u64);
+            assert_eq!(writer.buffer.as_ref(), expected.as_slice());
+            let read = writer.read_at(0, expected.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), expected.as_slice());
+
+            // Retrying sync should flush the same bytes and publish the page state.
+            writer.sync().await.unwrap();
+            assert_eq!(writer.current_page, 2);
+            assert!(writer.partial_page_state.is_committed());
+            let read = writer.read_at(0, expected.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), expected.as_slice());
+        });
+    }
+
+    // If a large direct append is canceled during the blob write, publish nothing.
+    #[test_traced("DEBUG")]
+    fn test_append_owned_cancel_preserves_state() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"append_owned_cancel")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            // This takes the direct path: full pages go straight to the blob.
+            // Cancel before those pages are allowed to publish into writer state.
+            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
+                .await;
+
+            // The direct append was canceled, so it should not change size, cache, or page count.
+            assert_eq!(writer.current_page, 0);
+            assert!(writer.partial_page_state.is_none());
+            assert_eq!(writer.size(), 0);
+
+            let mut probe = vec![0u8; PAGE_SIZE.get() as usize];
+            assert_eq!(writer.cache_ref.read_cached(writer.id, &mut probe, 0), 0);
+
+            // Retrying should write and publish the full append normally.
+            writer
+                .append_owned(IoBuf::from(data.clone()))
+                .await
+                .unwrap();
+            assert_eq!(writer.size(), data.len() as u64);
+            let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+
+            writer.sync().await.unwrap();
+            drop(writer);
+
+            // The retried append must survive reopening.
+            let (blob, blob_size) = context
+                .open("test_partition", b"append_owned_cancel")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), data.len() as u64);
+            let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+        });
+    }
+
+    // If a large direct append from a non-aligned tip is canceled during the blob write, the
+    // tip keeps only the pre-append bytes: not even a page-completing prefix is published.
+    #[test_traced("DEBUG")]
+    fn test_append_owned_fill_cancel_publishes_nothing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"append_owned_fill_cancel")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Leave a committed partial page in the tip so the direct path must complete it.
+            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
+            writer.append(&pre).await.unwrap();
+            writer.sync().await.unwrap();
+
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
+                .await;
+
+            // The canceled append published nothing: the tip holds only the pre-append bytes.
+            assert_eq!(writer.current_page, 0);
+            assert!(writer.partial_page_state.is_committed());
+            assert_eq!(writer.size(), pre.len() as u64);
+            assert_eq!(writer.buffer.as_ref(), pre.as_slice());
+
+            // Retrying appends the full input exactly once.
+            writer
+                .append_owned(IoBuf::from(data.clone()))
+                .await
+                .unwrap();
+            let total = pre.len() + data.len();
+            assert_eq!(writer.size(), total as u64);
+            writer.sync().await.unwrap();
+            drop(writer);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"append_owned_fill_cancel")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), total as u64);
+            let read = reopened.read_at(0, total).await.unwrap().coalesce();
+            assert_eq!(&read.as_ref()[..pre.len()], pre.as_slice());
+            assert_eq!(&read.as_ref()[pre.len()..], data.as_slice());
+        });
+    }
+
+    // A direct append dropped after its blob writes landed leaves durable bytes the writer
+    // does not claim, including a full-page CRC record in the tip page's free slot that
+    // recovery would prefer over the committed one. A later sync must reconcile the blob
+    // back to the writer's claim before acknowledging durability, so a reopen recovers
+    // exactly the claimed bytes.
+    #[test_traced("DEBUG")]
+    fn test_append_owned_cancel_after_write_publishes_nothing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"append_cancel_after")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Leave a committed partial page in the tip so the direct path completes it.
+            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
+            writer.append(&pre).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // The direct write is split around the committed CRC slot into two blob writes.
+            // Let the payload write pass and park after the second (free-slot record plus
+            // bulk pages), so the whole orphan is on disk when the future is dropped.
+            gate.set_skip(1);
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
+                .await;
+
+            // The canceled append published nothing.
+            assert_eq!(writer.size(), pre.len() as u64);
+
+            writer.sync().await.unwrap();
+            drop(writer);
+
+            // The reopened writer must recover the claim, not the orphan.
+            let (blob, blob_size) = context
+                .open("test_partition", b"append_cancel_after")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(
+                reopened.size(),
+                pre.len() as u64,
+                "orphan bytes must not be recovered"
+            );
+            let read = reopened.read_at(0, pre.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), pre.as_slice());
+        });
+    }
+
+    // A direct append from an empty tip is a single write with no CRC slot to protect.
+    // Dropped after it lands, the orphan is bulk pages only; reconciliation truncates the
+    // blob back to empty.
+    #[test_traced("DEBUG")]
+    fn test_append_owned_cancel_after_write_empty_tip_publishes_nothing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"append_cancel_after_empty")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
+                .await;
+
+            // The canceled append published nothing.
+            assert_eq!(writer.size(), 0);
+
+            writer.sync().await.unwrap();
+            drop(writer);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"append_cancel_after_empty")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), 0, "orphan bytes must not be recovered");
+        });
+    }
+
+    // A retried direct append reconciles the dropped one before staging its own bytes, so
+    // the data lands exactly once. Returns the auditor state so the caller can assert
+    // determinism across runs of the same seed.
+    fn dropped_append_retry_scenario(seed: u64) -> String {
+        let executor = deterministic::Runner::seeded(seed);
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"append_cancel_retry")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
+            writer.append(&pre).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Drop the append after both of its split writes landed.
+            gate.set_skip(1);
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
+                .await;
+
+            // The retry appends the full input exactly once.
+            writer
+                .append_owned(IoBuf::from(data.clone()))
+                .await
+                .unwrap();
+            let total = pre.len() + data.len();
+            assert_eq!(writer.size(), total as u64);
+            writer.sync().await.unwrap();
+            drop(writer);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"append_cancel_retry")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), total as u64);
+            let read = reopened.read_at(0, total).await.unwrap().coalesce();
+            assert_eq!(&read.as_ref()[..pre.len()], pre.as_slice());
+            assert_eq!(&read.as_ref()[pre.len()..], data.as_slice());
+
+            context.auditor().state()
+        })
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_append_owned_cancel_after_write_retry_appends_once() {
+        let state = dropped_append_retry_scenario(42);
+        assert_eq!(
+            state,
+            dropped_append_retry_scenario(42),
+            "scenario must be deterministic"
+        );
+    }
+
+    // start_sync reconciles a dropped direct append the same way sync does.
+    #[test_traced("DEBUG")]
+    fn test_append_owned_cancel_after_write_start_sync_reconciles() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"append_cancel_start_sync")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
+            writer.append(&pre).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Drop the append after both of its split writes landed.
+            gate.set_skip(1);
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            gate.cancel(writer.append_owned(IoBuf::from(data.clone())))
+                .await;
+
+            writer.start_sync().await.await.unwrap();
+            drop(writer);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"append_cancel_start_sync")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(
+                reopened.size(),
+                pre.len() as u64,
+                "orphan bytes must not be recovered"
+            );
+        });
+    }
+
+    // If sync is canceled during a partial-page write, keep that partial page in the tip.
+    #[test_traced("DEBUG")]
+    fn test_sync_cancel_preserves_paged_tip() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"sync_cancel")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            let data: Vec<u8> = (0..50).map(|i| i as u8).collect();
+            writer.append(&data).await.unwrap();
+
+            // Sync writes the partial page and its checksum. Cancel during that write.
+            gate.cancel(writer.sync()).await;
+
+            // The canceled sync must not publish a partial-page checksum state.
+            assert_eq!(writer.current_page, 0);
+            assert!(writer.partial_page_state.is_none());
+            assert_eq!(writer.size(), data.len() as u64);
+            assert_eq!(writer.buffer.as_ref(), data.as_slice());
+            let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+
+            // Retrying sync should write the partial page and publish its checksum.
+            writer.sync().await.unwrap();
+            assert_eq!(writer.current_page, 0);
+            assert!(writer.partial_page_state.is_committed());
+            let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+        });
+    }
+
+    // If a shrink is canceled after the physical truncate completes, a later sync restores the
+    // tip page the truncate deleted instead of silently forgetting it.
+    #[test_traced("DEBUG")]
+    fn test_shrink_cancel_after_truncate_underclaims_consistently() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_cancel")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedResizeBlob::new(inner, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Shrinking into page 1 truncates the blob to two physical pages, deleting the tip
+            // page. Cancel while that completed truncate is held open.
+            let target = page as u64 + 30;
+            gate.cancel(writer.resize(target)).await;
+
+            // The canceled shrink published its reduced claim before the truncate: the writer
+            // claims exactly the pages the blob still holds and can read all of them.
+            assert!(writer.partial_page_state.is_unverified());
+            assert_eq!(writer.size(), 2 * page as u64);
+            let read = writer.read_at(0, 2 * page).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data[..2 * page]);
+
+            // Retrying the shrink completes it.
+            writer.resize(target).await.unwrap();
+            assert_eq!(writer.size(), target);
+            writer.sync().await.unwrap();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_cancel")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), target);
+            let read = reopened
+                .read_at(0, target as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..target as usize]);
+        });
+    }
+
+    // Regression: a multi-page partial shrink deletes full pages that nothing in memory can
+    // rebuild. A canceled truncate must not leave the writer claiming them (over-claiming
+    // previously made reads of the claimed range fail).
+    #[test_traced("DEBUG")]
+    fn test_shrink_cancel_multi_page_never_overclaims() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_cancel_multi")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedResizeBlob::new(inner, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..4 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Shrinking into page 1 truncates full pages 2-3 and the partial page. Cancel
+            // while the completed truncate is held open.
+            let target = page as u64 + 30;
+            gate.cancel(writer.resize(target)).await;
+
+            // The writer claims only the target page and below, all of it readable: page 0
+            // from the blob and page 1 from the staged tip.
+            assert!(writer.partial_page_state.is_unverified());
+            assert_eq!(writer.current_page, 1);
+            assert_eq!(writer.size(), 2 * page as u64);
+            let read = writer.read_at(0, 2 * page).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data[..2 * page]);
+
+            // Retrying the shrink completes it, and the result survives a restart.
+            writer.resize(target).await.unwrap();
+            assert_eq!(writer.size(), target);
+            writer.sync().await.unwrap();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_cancel_multi")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), target);
+            let read = reopened
+                .read_at(0, target as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..target as usize]);
+        });
+    }
+
+    // If a page-boundary shrink is canceled after the truncate completes, the writer already
+    // published the shrunken size and remains consistent.
+    #[test_traced("DEBUG")]
+    fn test_shrink_to_boundary_cancel_publishes_shrunken_size() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_boundary_cancel")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedResizeBlob::new(inner, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..3 * page).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // A boundary shrink publishes the shrunken size before truncating. Cancel while
+            // the completed truncate is held open.
+            gate.cancel(writer.resize(2 * page as u64)).await;
+
+            // The writer claims the shrunken size and the surviving pages remain readable.
+            assert_eq!(writer.size(), 2 * page as u64);
+            assert_eq!(writer.current_page, 2);
+            assert!(writer.partial_page_state.is_none());
+            let read = writer.read_at(0, 2 * page).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data[..2 * page]);
+
+            // Appends and sync continue normally from the new size.
+            writer.append(&data[..10]).await.unwrap();
+            writer.sync().await.unwrap();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_boundary_cancel")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), (2 * page + 10) as u64);
+            let read = reopened.read_at(0, 2 * page + 10).await.unwrap().coalesce();
+            assert_eq!(&read.as_ref()[..2 * page], &data[..2 * page]);
+            assert_eq!(&read.as_ref()[2 * page..], &data[..10]);
+        });
+    }
+
+    // If a boundary shrink is canceled before the truncate reaches the blob, the recorded
+    // resize is re-issued by the next sync even though the retried resize is a no-op.
+    #[test_traced("DEBUG")]
+    fn test_shrink_to_boundary_cancel_before_truncate_settles_on_retry() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_boundary_settle_retry")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedResizeBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..3 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Cancel while the truncate is parked before reaching the blob.
+            let target = 2 * page as u64;
+            gate.cancel(writer.resize(target)).await;
+            assert_eq!(writer.size(), target);
+
+            // The retry observes the already-published size and does nothing; the sync
+            // re-issues the dropped truncate and makes it durable.
+            writer.resize(target).await.unwrap();
+            writer.sync().await.unwrap();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_boundary_settle_retry")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), target);
+            let read = reopened
+                .read_at(0, target as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..target as usize]);
+        });
+    }
+
+    // If a multi-page partial shrink is canceled before the truncate reaches the blob, the
+    // retried shrink settles the truncate before rewriting the CRC record: the durable result
+    // is the shrunken blob, not a resurrected old size with an unreadable page.
+    #[test_traced("DEBUG")]
+    fn test_shrink_partial_cancel_before_truncate_settles_on_retry() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_partial_settle_retry")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedResizeBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..4 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Cancel while the truncate is parked before reaching the blob.
+            let target = page as u64 + 30;
+            gate.cancel(writer.resize(target)).await;
+            assert_eq!(writer.size(), 2 * page as u64);
+
+            // Retrying the shrink completes it, and the result survives a restart.
+            writer.resize(target).await.unwrap();
+            assert_eq!(writer.size(), target);
+            writer.sync().await.unwrap();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_partial_settle_retry")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), target);
+            let read = reopened
+                .read_at(0, target as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..target as usize]);
+        });
+    }
+
+    // A shrink canceled before the truncate reaches the blob is settled by a plain sync, with
+    // no retry of the resize itself.
+    #[test_traced("DEBUG")]
+    fn test_shrink_cancel_before_truncate_settles_on_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_settle_sync")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedResizeBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..3 * page).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            let target = 2 * page as u64;
+            gate.cancel(writer.resize(target)).await;
+            assert_eq!(writer.size(), target);
+
+            writer.sync().await.unwrap();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_settle_sync")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), target);
+            let read = reopened
+                .read_at(0, target as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..target as usize]);
+        });
+    }
+
+    // Sealing after a canceled shrink settles the dropped truncate before the writer (and its
+    // recorded resize) is consumed, so the sealed handle's durability claim is honest.
+    #[test_traced("DEBUG")]
+    fn test_shrink_cancel_before_truncate_settles_on_seal() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_settle_seal")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedResizeBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..3 * page).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            let target = 2 * page as u64;
+            gate.cancel(writer.resize(target)).await;
+            assert_eq!(writer.size(), target);
+
+            let sealed = writer.seal().await.unwrap();
+            sealed.sync().await.unwrap();
+            drop(sealed);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_settle_seal")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), target);
+            let read = reopened
+                .read_at(0, target as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..target as usize]);
+        });
+    }
+
+    // If a shrink is canceled during the CRC slot rewrite, the writer keeps the old size and a
+    // retried shrink completes.
+    #[test_traced("DEBUG")]
+    fn test_shrink_cancel_during_crc_rewrite_keeps_old_size() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_crc_cancel")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Shrinking within the tip page rewrites only its CRC record. Cancel during the
+            // first rewrite write.
+            let target = (2 * page + 30) as u64;
+            gate.cancel(writer.resize(target)).await;
+
+            // The canceled rewrite leaves the old tip bytes staged with the record cleared,
+            // so the next flush rewrites the whole record instead of trusting a stale one.
+            assert!(writer.partial_page_state.is_unverified());
+            assert_eq!(writer.size(), data.len() as u64);
+            let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+            writer.sync().await.unwrap();
+
+            // Retrying the shrink completes normally.
+            writer.resize(target).await.unwrap();
+            assert_eq!(writer.size(), target);
+            writer.sync().await.unwrap();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_crc_cancel")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), target);
+            let read = reopened
+                .read_at(0, target as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..target as usize]);
+        });
+    }
+
+    // A same-page shrink transfers CRC authority with three slot writes; the third (zeroing
+    // the old slot's length) is the commit point. If it lands but the future is dropped, the
+    // disk says the shorter length while memory claims the old one. The unverified record
+    // makes the next sync re-read it from disk and rewrite it slot-safely, instead of
+    // skipping as a false no-op.
+    #[test_traced("DEBUG")]
+    fn test_shrink_cancel_after_authority_transfer_heals_on_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_authority_cancel")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // The shrink issues three slot writes; skipping two parks the gate at the third
+            // (the commit point), after it applied. Canceling there leaves the disk
+            // committed to the shorter length while memory never saw the shrink finish.
+            gate.set_skip(2);
+            gate.cancel(writer.resize((2 * page + 30) as u64)).await;
+
+            // Memory still claims the old size and can read all of it (staged tip).
+            assert!(writer.partial_page_state.is_unverified());
+            assert_eq!(writer.size(), data.len() as u64);
+            let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+
+            // The sync must rewrite the record the transfer half-committed, so the size it
+            // acknowledges is the size a restart recovers.
+            writer.sync().await.unwrap();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_authority_cancel")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), data.len() as u64);
+            let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+        });
+    }
+
+    // Same drop point, but shrinking an aligned blob into its last full page: the target page
+    // is staged as the tip before the transfer, so live reads of the claimed range survive
+    // the on-disk record temporarily validating to the shorter length.
+    #[test_traced("DEBUG")]
+    fn test_shrink_cancel_after_authority_transfer_aligned_keeps_reads() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_authority_aligned")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..3 * page).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Shrink into the last full page. As above, skip two slot writes so the gate
+            // parks at the applied commit point, then cancel.
+            gate.set_skip(2);
+            gate.cancel(writer.resize((2 * page + 30) as u64)).await;
+
+            // The whole claimed range stays readable: the last page is served from the tip
+            // even though its on-disk record now validates to the shorter length.
+            assert!(writer.partial_page_state.is_unverified());
+            assert_eq!(writer.size(), data.len() as u64);
+            let read = writer.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+
+            // The sync rewrites the page's record; a restart recovers the acknowledged size.
+            writer.sync().await.unwrap();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_authority_aligned")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), data.len() as u64);
+            let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+        });
+    }
+
+    /// Blob wrapper that, once armed, turns the next write into a durable partial write
+    /// (cut `shortfall` bytes early) followed by an error, simulating a torn write.
+    ///
+    /// Tests use it to model power loss during a specific write: the truncated bytes are
+    /// what made it to disk, and everything after (including the writer observing success)
+    /// never happened. This proves the heal path never has both CRC slots at risk in a
+    /// single write.
+    #[derive(Clone)]
+    struct ArmedTearBlob<B: Blob> {
+        inner: B,
+        armed: Arc<Mutex<Option<usize>>>,
+        fired: Arc<AtomicUsize>,
+    }
+
+    impl<B: Blob> ArmedTearBlob<B> {
+        fn new(inner: B) -> Self {
+            Self {
+                inner,
+                armed: Arc::new(Mutex::new(None)),
+                fired: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        /// Tear the next write `shortfall` bytes before its end.
+        fn arm(&self, shortfall: usize) {
+            *self.armed.lock() = Some(shortfall);
+        }
+
+        fn fired(&self) -> usize {
+            self.fired.load(Ordering::SeqCst)
+        }
+
+        async fn tear(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+            shortfall: usize,
+        ) -> Result<(), Error> {
+            self.fired.fetch_add(1, Ordering::SeqCst);
+            let bytes = bufs.into().coalesce();
+            let partial_len = bytes.len().saturating_sub(shortfall);
+            self.inner
+                .write_at(offset, bytes.slice(..partial_len))
+                .await?;
+            self.inner.sync().await?;
+            Err(Error::Io(
+                std::io::Error::other("injected torn write").into(),
+            ))
+        }
+    }
+
+    impl<B: Blob> crate::Blob for ArmedTearBlob<B> {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            bufs: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, bufs).await
+        }
+
+        async fn write_at(&self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
+            let armed = self.armed.lock().take();
+            match armed {
+                Some(shortfall) => self.tear(offset, bufs, shortfall).await,
+                None => self.inner.write_at(offset, bufs).await,
+            }
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            let armed = self.armed.lock().take();
+            match armed {
+                Some(shortfall) => self.tear(offset, bufs, shortfall).await,
+                None => self.inner.write_at_sync(offset, bufs).await,
+            }
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            self.inner.sync().await
+        }
+
+        async fn start_sync(&self) -> Handle<()> {
+            self.inner.start_sync().await
+        }
+    }
+
+    /// Blob wrapper recording the byte range of every write, so tests can assert which
+    /// on-disk regions an operation did (or did not) touch.
+    #[derive(Clone)]
+    struct RecordingBlob<B: Blob> {
+        inner: B,
+        writes: Arc<Mutex<Vec<(u64, usize)>>>,
+    }
+
+    impl<B: Blob> RecordingBlob<B> {
+        fn new(inner: B) -> Self {
+            Self {
+                inner,
+                writes: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn writes(&self) -> Arc<Mutex<Vec<(u64, usize)>>> {
+            self.writes.clone()
+        }
+    }
+
+    impl<B: Blob> crate::Blob for RecordingBlob<B> {
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            bufs: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, bufs).await
+        }
+
+        async fn write_at(&self, offset: u64, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
+            let bufs = bufs.into();
+            self.writes.lock().push((offset, bufs.len()));
+            self.inner.write_at(offset, bufs).await
+        }
+
+        async fn write_at_sync(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+        ) -> Result<(), Error> {
+            let bufs = bufs.into();
+            self.writes.lock().push((offset, bufs.len()));
+            self.inner.write_at_sync(offset, bufs).await
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            self.inner.sync().await
+        }
+
+        async fn start_sync(&self) -> Handle<()> {
+            self.inner.start_sync().await
+        }
+    }
+
+    // A shrink canceled before any slot write reached the blob leaves the disk record exactly
+    // as committed, so the heal must be a true no-op: no write at all, and in particular no
+    // unprotected rewrite of the record that a torn write could destroy.
+    #[test_traced("DEBUG")]
+    fn test_shrink_cancel_untouched_record_heals_without_writes() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_heal_noop")
+                .await
+                .unwrap();
+            let tear = ArmedTearBlob::new(inner);
+            let (blob, gate) = GatedWriteBlob::new(tear.clone(), GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Cancel the shrink parked before its first slot write: disk is untouched.
+            gate.cancel(writer.resize((2 * page + 30) as u64)).await;
+            assert!(writer.partial_page_state.is_unverified());
+
+            // Arm a tear for the next write: the healing sync must not issue one.
+            tear.arm(3);
+            writer.sync().await.unwrap();
+            assert_eq!(tear.fired(), 0, "no-op heal must not write");
+            assert!(writer.partial_page_state.is_committed());
+
+            // The old size remains durable.
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_heal_noop")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), data.len() as u64);
+            let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data.as_slice());
+        });
+    }
+
+    // If the heal write itself tears (power loss mid-write), the page must still validate via
+    // one slot: the heal writes around the disk-authoritative slot, so a tear can only damage
+    // the free slot.
+    #[test_traced("DEBUG")]
+    fn test_torn_heal_write_preserves_one_slot() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_heal_torn")
+                .await
+                .unwrap();
+            let tear = ArmedTearBlob::new(inner);
+            let (blob, gate) = GatedWriteBlob::new(tear.clone(), GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Skip two slot writes so the gate parks at the third (the commit point) after
+            // it applied: the shorter slot is now the disk-authoritative one, but memory
+            // never saw the shrink finish.
+            let target = (2 * page + 30) as u64;
+            gate.set_skip(2);
+            gate.cancel(writer.resize(target)).await;
+            assert!(writer.partial_page_state.is_unverified());
+
+            // Tear the healing write so none of the free slot's bytes land (its stale
+            // contents remain invalid); the authoritative slot is never touched.
+            tear.arm(CHECKSUM_SLOT_SIZE);
+            let result = writer.sync().await;
+            assert!(result.is_err(), "torn write must surface an error");
+            assert_eq!(tear.fired(), 1);
+            drop(writer);
+
+            // The page still validates via the surviving slot: size is the transferred
+            // target, never a truncation below the committed pages.
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_heal_torn")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), target);
+            let read = reopened
+                .read_at(0, target as usize)
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), &data[..target as usize]);
+        });
+    }
+
+    // The healing write must go around the disk-authoritative slot and the committed payload
+    // prefix: neither may be rewritten in place.
+    #[test_traced("DEBUG")]
+    fn test_heal_write_avoids_authoritative_slot_and_committed_prefix() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_heal_ranges")
+                .await
+                .unwrap();
+            let recorder = RecordingBlob::new(inner);
+            let (blob, gate) = GatedWriteBlob::new(recorder.clone(), GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as u64;
+            let pps = page + CHECKSUM_SIZE;
+            let data: Vec<u8> = (0..2 * page as usize + 50)
+                .map(|i| (i % 251) as u8)
+                .collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Skip two slot writes so the gate parks at the applied commit point, then
+            // cancel: on disk, the shorter length in the second slot is now authoritative
+            // (the record was born slot-1-authoritative).
+            gate.set_skip(2);
+            gate.cancel(writer.resize(2 * page + 30)).await;
+
+            // Record the healing sync's writes.
+            let writes = recorder.writes();
+            writes.lock().clear();
+            writer.sync().await.unwrap();
+
+            // No write may touch the committed payload prefix [0, 30) of the tip page or the
+            // disk-authoritative second slot of its record.
+            let page_start = 2 * pps;
+            let committed_payload = (page_start, page_start + 30);
+            let authoritative_slot = (
+                page_start + page + CHECKSUM_SLOT_SIZE as u64,
+                page_start + page + CHECKSUM_SIZE,
+            );
+            let writes = writes.lock();
+            assert!(!writes.is_empty(), "the heal must rewrite the free slot");
+            for &(offset, len) in writes.iter() {
+                let end = offset + len as u64;
+                for (lo, hi) in [committed_payload, authoritative_slot] {
+                    assert!(
+                        end <= lo || offset >= hi,
+                        "write [{offset}, {end}) overlaps protected range [{lo}, {hi})"
+                    );
+                }
+            }
+        });
+    }
+
+    // A large owned append directly after a canceled shrink must verify the record before
+    // building the page that completes the tip.
+    #[test_traced("DEBUG")]
+    fn test_append_owned_after_canceled_shrink_verifies_record() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"shrink_heal_append")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner, GatePosition::Before);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0..2 * page + 50).map(|i| (i % 251) as u8).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Cancel the shrink parked before its first slot write.
+            gate.cancel(writer.resize((2 * page + 30) as u64)).await;
+            assert!(writer.partial_page_state.is_unverified());
+
+            // A large append takes the direct path, which completes the tip page in place.
+            let big: Vec<u8> = (0..500).map(|i| (i % 241) as u8).collect();
+            writer.append_owned(IoBuf::from(big.clone())).await.unwrap();
+            writer.sync().await.unwrap();
+
+            let expected: Vec<u8> = data.iter().chain(big.iter()).copied().collect();
+            drop(writer);
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_heal_append")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), expected.len() as u64);
+            let read = reopened
+                .read_at(0, expected.len())
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(read.as_ref(), expected.as_slice());
         });
     }
 
@@ -3196,7 +4567,7 @@ mod tests {
                 .map(|i| (i % 251) as u8)
                 .collect();
 
-            // Seed a tip buffer with the logical bytes exactly as flush_internal would see them.
+            // Seed a tip buffer with the logical bytes exactly as flush would see them.
             let mut buffer = Buffer::new(0, data.len(), cache_ref.pool().clone());
             let over_capacity = buffer.append(&data);
             assert!(!over_capacity);

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -83,13 +83,8 @@ impl PartialPage {
 ///
 /// # Cancellation
 ///
-/// Appends are synchronous: they extend the in-memory tail and cannot be cancelled.
-/// The async operations (`sync`, `start_sync`, `resize`, `seal`, `snapshot`, `replay`) are
-/// the only paths that touch the blob; dropping one mid-flight leaves the writer in a
-/// consistent, retryable state. A dropped operation may still have reached the blob (a
-/// flush's bytes, a shrink's truncate); the writer records such intents before awaiting
-/// them, and every later operation first settles them so the blob agrees with the writer's
-/// claim.
+/// Appends are synchronous and cannot be cancelled. Dropping an async operation leaves the
+/// writer usable; a later operation or reopen finishes incomplete work.
 pub struct Writer<B: Blob> {
     /// The underlying blob being wrapped.
     blob: B,
@@ -106,8 +101,7 @@ pub struct Writer<B: Blob> {
     /// A reference to the page cache that manages read caching for this blob.
     cache_ref: CacheRef,
 
-    /// The in-memory tail: appended bytes not yet published as written. Its start is the
-    /// authority for how many pages the blob holds (see [Self::current_page]).
+    /// The in-memory tail. Its start is where the writer begins serving bytes from memory.
     tail: Tail,
 }
 
@@ -154,8 +148,8 @@ impl<B: Blob> Writer<B> {
     /// next flush point. Rewinds the blob if necessary so it only contains checksum-validated
     /// data.
     ///
-    /// `capacity` is the preferred allocation size for the mutable tip. Appends may grow it
-    /// temporarily; callers bound pending data by their flush cadence.
+    /// `capacity` is the preferred allocation size for the mutable tip. It controls when full
+    /// pages leave the tip, but callers bound pending data by their flush cadence.
     pub async fn new(
         blob: B,
         original_blob_size: u64,
@@ -276,28 +270,23 @@ impl<B: Blob> Writer<B> {
         Ok((None, 0, invalid_data_found))
     }
 
-    /// Append all bytes in `buf` to the tip of the blob, returning the logical offset at which
-    /// the first byte was written.
+    /// Append bytes and return their first logical offset.
     pub fn append(&mut self, buf: &[u8]) -> u64 {
         self.tail.append(buf)
     }
 
-    /// Append owned bytes to the tip of the blob, returning the logical offset at which the
-    /// first byte was written.
+    /// Append owned bytes and return their first logical offset.
     pub fn append_owned(&mut self, buf: IoBuf) -> u64 {
         self.tail.append_owned(buf)
     }
 
-    /// Resolve an [PartialPage::Unverified] record by reading it back from the blob.
-    ///
-    /// A canceled shrink may have left either CRC slot authoritative on disk. Re-reading the
-    /// record lets later flushes write around the true authoritative slot, preserving the
-    /// dual-slot guarantee that a torn write never damages both slots of a committed page.
-    /// The state is updated only after the read returns, so a dropped verify changes nothing.
+    /// Resolve an unknown partial-page record.
     async fn verify_partial_page(&mut self) -> Result<(), Error> {
         if !matches!(self.partial_page_state, PartialPage::Unverified) {
             return Ok(());
         }
+        // A canceled shrink can leave either CRC slot authoritative. Read it before writing the
+        // page again so the next flush preserves that slot.
         let (_, record) = super::get_page_with_checksum_from_blob(
             &self.blob,
             self.current_page(),
@@ -308,10 +297,7 @@ impl<B: Blob> Writer<B> {
         Ok(())
     }
 
-    /// Writes prepared physical pages to the blob at the position described by `current_page`
-    /// and `partial_page_state`.
-    ///
-    /// Returns `true` if the writes were made durable, so no later sync is needed.
+    /// Write prepared physical pages and return whether they are durable.
     async fn write_physical_pages(
         &mut self,
         mut physical_pages: IoBufs,
@@ -517,14 +503,6 @@ impl<B: Blob> Writer<B> {
     }
 
     /// Prepare physical-page writes from the in-memory tail.
-    ///
-    /// Each physical page contains one logical page plus a CRC record.
-    ///
-    /// # Arguments
-    ///
-    /// * `old_crc_record` - The CRC record from a previously committed partial page, if any.
-    ///   When present, the first page's CRC record will preserve the old CRC in its original slot
-    ///   and place the new CRC in the other slot.
     fn to_physical_pages(&self, old_crc_record: Option<&Checksum>) -> (IoBufs, Option<Checksum>) {
         let logical_page_size = self.cache_ref.page_size() as usize;
         let physical_page_size = logical_page_size + CHECKSUM_SIZE as usize;
@@ -579,8 +557,7 @@ impl<B: Blob> Writer<B> {
         (write_buffer, Some(crc_record))
     }
 
-    /// Append full logical pages and their CRC records to `write_buffer` without copying payload
-    /// bytes. The first page preserves an existing partial-page record when needed.
+    /// Append full logical pages and CRC records without copying payload bytes.
     fn append_full_pages(
         &self,
         pages: &IoBuf,

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -483,14 +483,18 @@ impl<B: Blob> Writer<B> {
     ///
     /// Such an append leaves bytes the writer never published: bulk pages past the claimed
     /// physical end, and possibly a full-page record staged in the tip page's free CRC
-    /// slot. Recovery would prefer both over the claim. Zeroing the staged slot's length
-    /// bytes retires it (length 0 is never authoritative; the committed slot is untouched),
-    /// and truncating back to the claimed physical end removes the bulk pages.
+    /// slot. Recovery would prefer both over the claim. Truncating back to the claimed
+    /// physical end removes the bulk pages, and zeroing the staged slot's length bytes
+    /// retires it (length 0 is never authoritative; the committed slot is untouched).
+    ///
+    /// The truncate must land first: recovery accepts a partial page only in the last
+    /// position, so the orphan pages must already be gone when retiring the slot demotes
+    /// the staged page back to partial.
     ///
     /// Both steps are idempotent and the record is cleared only after they complete, so a
     /// dropped reconciliation re-runs on the next operation. Ordering against the orphan's
     /// own writes comes from the [Blob] contract: mutations execute in submission order, so
-    /// these writes land after the orphan's.
+    /// these mutations land after the orphan's.
     async fn reconcile_publication(&mut self) -> Result<(), Error> {
         let Some(PendingPublication {
             physical_end,
@@ -499,6 +503,8 @@ impl<B: Blob> Writer<B> {
         else {
             return Ok(());
         };
+
+        self.sync_state.resize(&self.blob, physical_end).await?;
 
         if let Some((page, slot)) = staged_slot {
             let physical_page_size = self.cache_ref.page_size() + CHECKSUM_SIZE;
@@ -511,7 +517,6 @@ impl<B: Blob> Writer<B> {
                 .await?;
         }
 
-        self.sync_state.resize(&self.blob, physical_end).await?;
         self.pending_publication = None;
         Ok(())
     }
@@ -2450,6 +2455,164 @@ mod tests {
                 pre.len() as u64,
                 "orphan bytes must not be recovered"
             );
+        });
+    }
+
+    // A repairing sync dropped at its staged-slot retire write must not demote the staged
+    // page while orphan pages remain after it: recovery trusts the last valid page it
+    // finds. Reopening must recover exactly the claimed bytes.
+    #[test_traced("DEBUG")]
+    fn test_reconcile_cancel_at_slot_retire_reopen_recovers_claim() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"reconcile_cancel_retire")
+                .await
+                .unwrap();
+            let (blob, gate) = GatedWriteBlob::new(inner.clone(), GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Leave a committed partial page in the tip so the direct path completes it.
+            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
+            writer.append(&pre).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Drop the append after both of its split writes landed.
+            gate.set_skip(1);
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            gate.cancel(writer.append_owned(IoBuf::from(data))).await;
+
+            // Drop the repairing sync after its staged-slot retire write landed.
+            gate.cancel(writer.sync()).await;
+            drop(writer);
+
+            // Model a crash that loses no applied writes: persist them all, then reopen.
+            inner.sync().await.unwrap();
+            let (blob, blob_size) = context
+                .open("test_partition", b"reconcile_cancel_retire")
+                .await
+                .unwrap();
+            let mut reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(
+                reopened.size(),
+                pre.len() as u64,
+                "orphan bytes must not be recovered"
+            );
+            let read = reopened.read_at(0, pre.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), pre.as_slice());
+            let mut replay = reopened.replay(NZUsize!(BUFFER_SIZE)).await.unwrap();
+            assert!(replay.ensure(pre.len()).await.unwrap());
+            assert_eq!(replay.copy_to_bytes(pre.len()).as_ref(), pre.as_slice());
+        });
+    }
+
+    // A repair dropped between its truncate and its staged-slot retire leaves the staged
+    // page as the last page, where either slot state is a valid tail. Reopening recovers
+    // the completed page.
+    #[test_traced("DEBUG")]
+    fn test_reconcile_cancel_after_truncate_reopen_is_consistent() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"reconcile_cancel_truncate")
+                .await
+                .unwrap();
+            let (blob, write_gate) = GatedWriteBlob::new(inner.clone(), GatePosition::After);
+            let (blob, resize_gate) = GatedResizeBlob::new(blob, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
+            writer.append(&pre).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Drop the append after both of its split writes landed.
+            write_gate.set_skip(1);
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            write_gate
+                .cancel(writer.append_owned(IoBuf::from(data.clone())))
+                .await;
+
+            // Drop the repairing sync after its truncate removed the orphan pages.
+            resize_gate.cancel(writer.sync()).await;
+            drop(writer);
+
+            // Model a crash that loses no applied writes: persist them all, then reopen.
+            inner.sync().await.unwrap();
+            let page = PAGE_SIZE.get() as usize;
+            let (blob, blob_size) = context
+                .open("test_partition", b"reconcile_cancel_truncate")
+                .await
+                .unwrap();
+            let mut reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(reopened.size(), page as u64);
+            let read = reopened.read_at(0, page).await.unwrap().coalesce();
+            assert_eq!(&read.as_ref()[..pre.len()], pre.as_slice());
+            assert_eq!(&read.as_ref()[pre.len()..], &data[..page - pre.len()]);
+            let mut replay = reopened.replay(NZUsize!(BUFFER_SIZE)).await.unwrap();
+            assert!(replay.ensure(page).await.unwrap());
+        });
+    }
+
+    // A repair dropped between its two steps re-runs on the next operation: the truncate
+    // repeats harmlessly and the staged slot is retired, restoring the claim.
+    #[test_traced("DEBUG")]
+    fn test_reconcile_cancel_after_truncate_retry_reconciles() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (inner, blob_size) = context
+                .open("test_partition", b"reconcile_cancel_retry")
+                .await
+                .unwrap();
+            let (blob, write_gate) = GatedWriteBlob::new(inner, GatePosition::After);
+            let (blob, resize_gate) = GatedResizeBlob::new(blob, GatePosition::After);
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let pre: Vec<u8> = (0..50).map(|i| i as u8).collect();
+            writer.append(&pre).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Drop the append after both of its split writes landed.
+            write_gate.set_skip(1);
+            let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+            write_gate
+                .cancel(writer.append_owned(IoBuf::from(data)))
+                .await;
+
+            // Drop the repairing sync after its truncate removed the orphan pages.
+            resize_gate.cancel(writer.sync()).await;
+
+            // The claim is unchanged and a retried sync completes the repair.
+            assert_eq!(writer.size(), pre.len() as u64);
+            writer.sync().await.unwrap();
+            drop(writer);
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"reconcile_cancel_retry")
+                .await
+                .unwrap();
+            let reopened = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(
+                reopened.size(),
+                pre.len() as u64,
+                "orphan bytes must not be recovered"
+            );
+            let read = reopened.read_at(0, pre.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), pre.as_slice());
         });
     }
 

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -97,10 +97,6 @@ impl Buffer {
 
     /// Discards the first `n` bytes of the buffer and advances the offset by `n`.
     ///
-    /// To flush, callers write a [Self::slice] view of the buffered bytes to the blob and call
-    /// this only after the write succeeds. The buffer keeps the bytes until then, so a dropped
-    /// or failed write loses nothing and a retry re-flushes them.
-    ///
     /// # Panics
     ///
     /// Panics if `n` is greater than the length of the buffer.

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -11,12 +11,11 @@ use std::ops::{Bound, RangeBounds};
 ///
 /// - Backing storage starts detached in [Self::new] and is allocated on first write.
 /// - Logical data length is tracked separately from backing view length.
-/// - Draining paths ([Self::take]) hand buffered bytes to the caller and reset the tip to a
-///   detached empty state.
+/// - To flush, callers write a [Self::slice] view of the buffered bytes to the blob and call
+///   [Self::advance] only after the write succeeds. The buffer keeps the bytes until then, so
+///   a dropped or failed write loses nothing and a retry re-flushes them.
 /// - Subsequent writes are copy-on-write: [Self::writable] recovers mutable ownership when
 ///   backing is unique, otherwise allocates from the pool and copies existing bytes.
-/// - Prefix drains in [Self::drop_prefix] update the logical view and preserve backing whenever
-///   possible.
 pub(super) struct Buffer {
     /// The data to be written to the blob.
     ///
@@ -135,28 +134,6 @@ impl Buffer {
         }
     }
 
-    /// Returns the buffered data and its blob offset, or returns `None` if the buffer is already
-    /// empty.
-    ///
-    /// This hands ownership of the buffered bytes to the caller, resets the tip to empty, and
-    /// advances offset to the end of the drained range.
-    pub(super) fn take(&mut self) -> Option<(IoBuf, u64)> {
-        if self.is_empty() {
-            return None;
-        }
-
-        // Clear the logical length up front so the tip is empty even if the returned buffer
-        // still aliases the old backing.
-        let len = std::mem::take(&mut self.len);
-        let offset = self.offset;
-        self.offset += len as u64;
-
-        // Hand the buffered prefix to the caller without copying. If `data` retained extra
-        // capacity or trailing bytes, `split_to` leaves them behind in the discarded remainder.
-        let mut data = std::mem::take(&mut self.data);
-        Some((data.split_to(len), offset))
-    }
-
     /// Returns a mutable tip buffer with capacity for at least `needed` bytes.
     ///
     /// This consumes current backing and preserves existing contents.
@@ -229,8 +206,8 @@ impl Buffer {
     /// Appends the provided `data` to the buffer, and returns `true` if the buffer is over capacity
     /// after the append.
     ///
-    /// If the buffer is above capacity, the caller is responsible for using `take` to bring it back
-    /// under. Further appends are safe, but will continue growing the buffer beyond its capacity.
+    /// If the buffer is above capacity, the caller is responsible for flushing. Further appends
+    /// are safe, but will continue growing the buffer beyond its capacity.
     pub(super) fn append(&mut self, data: &[u8]) -> bool {
         let end = self.len + data.len();
         let mut writable = self.writable(end);
@@ -239,27 +216,6 @@ impl Buffer {
         self.len = writable.len();
         self.data = writable.freeze();
         over_capacity
-    }
-
-    /// Removes `len` leading bytes from the buffered data while preserving the remaining suffix.
-    ///
-    /// The remaining suffix stays as a logical prefix in the updated view.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `len` exceeds current buffer length.
-    pub(super) fn drop_prefix(&mut self, len: usize) {
-        assert!(len <= self.len);
-        if len == 0 {
-            return;
-        }
-        let current_len = self.len;
-        if len == current_len {
-            self.len = 0;
-            return;
-        }
-        self.data = self.data.slice(len..current_len);
-        self.len = current_len - len;
     }
 
     /// Clears buffered data while preserving offset.
@@ -292,19 +248,18 @@ mod tests {
         let mut buffer = Buffer::new(50, 100, pool);
         assert_eq!(buffer.size(), 50);
         assert!(buffer.is_empty());
-        assert!(buffer.take().is_none());
 
         // Add some data to the buffer.
         assert!(!buffer.append(&[1, 2, 3]));
         assert_eq!(buffer.size(), 53);
         assert!(!buffer.is_empty());
 
-        // Confirm `take()` works as intended.
-        let taken = buffer.take().unwrap();
-        assert_eq!(taken.0.as_ref(), &[1, 2, 3]);
-        assert_eq!(taken.1, 50);
+        // Confirm advancing past flushed bytes empties the buffer.
+        let flushed = buffer.slice(..);
+        assert_eq!(flushed.as_ref(), &[1, 2, 3]);
+        buffer.advance(3);
         assert_eq!(buffer.size(), 53);
-        assert!(buffer.take().is_none());
+        assert!(buffer.is_empty());
 
         // Fill the buffer to capacity.
         let mut buf = vec![42; 100];
@@ -315,9 +270,11 @@ mod tests {
         assert!(buffer.append(&[43]));
         assert_eq!(buffer.size(), 154);
         buf.push(43);
-        let taken = buffer.take().unwrap();
-        assert_eq!(taken.0.as_ref(), buf.as_slice());
-        assert_eq!(taken.1, 53);
+        let flushed = buffer.slice(..);
+        assert_eq!(flushed.as_ref(), buf.as_slice());
+        buffer.advance(buf.len());
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.size(), 154);
     }
 
     #[test]
@@ -330,9 +287,8 @@ mod tests {
         // Truncate into the buffered bytes: the prefix below the new size survives.
         buffer.truncate(61);
         assert_eq!(buffer.size(), 61);
-        let taken = buffer.take().unwrap();
-        assert_eq!(taken.0.as_ref(), &[4]);
-        assert_eq!(taken.1, 60);
+        assert_eq!(buffer.as_ref(), &[4]);
+        buffer.advance(1);
         assert_eq!(buffer.size(), 61);
 
         buffer.append(&[7, 8, 9]);
@@ -341,8 +297,7 @@ mod tests {
         // empty buffer restarts at the new size.
         buffer.truncate(59);
         assert_eq!(buffer.size(), 59);
-        assert!(buffer.take().is_none());
-        assert_eq!(buffer.size(), 59);
+        assert!(buffer.is_empty());
     }
 
     #[test]
@@ -370,7 +325,9 @@ mod tests {
         let mut buffer = Buffer::new(0, 16, pool);
 
         buffer.append(b"stale");
-        let _ = buffer.take().expect("buffer should contain data");
+        // `clear` empties the buffer logically but leaves the old bytes in the backing
+        // allocation. A slice must see the empty buffer, not the leftover bytes.
+        buffer.clear();
 
         assert!(buffer.slice(..).is_empty());
         assert!(buffer.slice(0..).is_empty());

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -95,6 +95,31 @@ impl Buffer {
         self.data.slice(start..end)
     }
 
+    /// Discards the first `n` bytes of the buffer and advances the offset by `n`.
+    ///
+    /// To flush, callers write a [Self::slice] view of the buffered bytes to the blob and call
+    /// this only after the write succeeds. The buffer keeps the bytes until then, so a dropped
+    /// or failed write loses nothing and a retry re-flushes them.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is greater than the length of the buffer.
+    pub(super) fn advance(&mut self, n: usize) {
+        assert!(n <= self.len);
+        match n {
+            0 => {}
+            n if n == self.len => {
+                self.data = IoBuf::default();
+                self.len = 0;
+            }
+            n => {
+                self.data = self.data.slice(n..self.len);
+                self.len -= n;
+            }
+        }
+        self.offset += n as u64;
+    }
+
     /// Adjust the buffer to correspond to resizing the logical blob to size `len`.
     ///
     /// If the new size is greater than the current size, the existing buffered bytes are returned

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -11,8 +11,8 @@ use std::ops::{Bound, RangeBounds};
 ///
 /// - Backing storage starts detached in [Self::new] and is allocated on first write.
 /// - Logical data length is tracked separately from backing view length.
-/// - Draining paths ([Self::take] and grow-resize in [Self::resize]) hand buffered bytes to the
-///   caller and reset the tip to a detached empty state.
+/// - Draining paths ([Self::take]) hand buffered bytes to the caller and reset the tip to a
+///   detached empty state.
 /// - Subsequent writes are copy-on-write: [Self::writable] recovers mutable ownership when
 ///   backing is unique, otherwise allocates from the pool and copies existing bytes.
 /// - Prefix drains in [Self::drop_prefix] update the logical view and preserve backing whenever

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -116,38 +116,22 @@ impl Buffer {
         self.offset += n as u64;
     }
 
-    /// Adjust the buffer to correspond to resizing the logical blob to size `len`.
+    /// Shrinks the logical blob size ([Self::size]) to `len`. Buffered bytes below `len` are
+    /// kept; the rest are discarded.
     ///
-    /// If the new size is greater than the current size, the existing buffered bytes are returned
-    /// (to be flushed to the underlying blob), and the tip is reset to empty. (The returned data
-    /// is what would be returned by a call to [Self::take].)
+    /// # Panics
     ///
-    /// If the new size is less than the current size (but still greater than current offset), the
-    /// buffer is truncated to the new size.
-    ///
-    /// If the new size is less than the current offset, the buffer is reset to the empty state with
-    /// an updated offset positioned at the end of the logical blob.
-    pub(super) fn resize(&mut self, len: u64) -> Option<(IoBuf, u64)> {
-        // Handle case where the buffer is empty.
-        if self.is_empty() {
-            self.offset = len;
-            return None;
-        }
+    /// Panics if `len` does not shrink the blob.
+    pub(super) fn truncate(&mut self, len: u64) {
+        assert!(len < self.size(), "truncate must shrink the blob");
 
-        // Handle case where there is some data in the buffer.
-        if len >= self.size() {
-            let previous = self
-                .take()
-                .expect("take must succeed when resize observes buffered data");
-            self.offset = len;
-            Some(previous)
-        } else if len >= self.offset {
-            self.len = (len - self.offset) as usize;
-            None
-        } else {
+        if len <= self.offset {
+            // All buffered bytes are at or beyond `len`: drop them and restart at the new end.
             self.len = 0;
             self.offset = len;
-            None
+        } else {
+            // Keep only the buffered bytes below `len`.
+            self.len = (len - self.offset) as usize;
         }
     }
 
@@ -337,26 +321,14 @@ mod tests {
     }
 
     #[test]
-    fn test_tip_resize() {
+    fn test_tip_truncate() {
         let pool = test_pool();
-        let mut buffer = Buffer::new(50, 100, pool);
-        buffer.append(&[1, 2, 3]);
-        assert_eq!(buffer.size(), 53);
-
-        // Resize the buffer to correspond to a blob resized to size 60. The returned buffer should
-        // match exactly what we'd expect to be returned by `take` since 60 is greater than the
-        // current size of 53.
-        let resized = buffer.resize(60).unwrap();
-        assert_eq!(resized.0.as_ref(), &[1, 2, 3]);
-        assert_eq!(resized.1, 50);
-        assert_eq!(buffer.size(), 60);
-        assert!(buffer.take().is_none());
-
+        let mut buffer = Buffer::new(60, 100, pool);
         buffer.append(&[4, 5, 6]);
         assert_eq!(buffer.size(), 63);
 
-        // Resize the buffer down to size 61.
-        assert!(buffer.resize(61).is_none());
+        // Truncate into the buffered bytes: the prefix below the new size survives.
+        buffer.truncate(61);
         assert_eq!(buffer.size(), 61);
         let taken = buffer.take().unwrap();
         assert_eq!(taken.0.as_ref(), &[4]);
@@ -365,12 +337,21 @@ mod tests {
 
         buffer.append(&[7, 8, 9]);
 
-        // Resize the buffer prior to the current offset of 61. This should simply reset the buffer
-        // at the new size.
-        assert!(buffer.resize(59).is_none());
+        // Truncate below the buffer's offset of 61: all buffered bytes are dropped and the
+        // empty buffer restarts at the new size.
+        buffer.truncate(59);
         assert_eq!(buffer.size(), 59);
         assert!(buffer.take().is_none());
         assert_eq!(buffer.size(), 59);
+    }
+
+    #[test]
+    #[should_panic(expected = "truncate must shrink the blob")]
+    fn test_tip_truncate_rejects_grow() {
+        let pool = test_pool();
+        let mut buffer = Buffer::new(50, 100, pool);
+        buffer.append(&[1, 2, 3]);
+        buffer.truncate(60);
     }
 
     #[test]

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -109,7 +109,7 @@ impl Buffer {
         self.offset += n as u64;
     }
 
-    /// Shrinks the logical blob size ([Self::size]) to `len`. Buffered bytes below `len` are
+    /// Shrinks the logical blob size ([Self::size]) to `len`. Buffered bytes before `len` are
     /// kept; the rest are discarded.
     ///
     /// # Panics
@@ -123,7 +123,7 @@ impl Buffer {
             self.len = 0;
             self.offset = len;
         } else {
-            // Keep only the buffered bytes below `len`.
+            // Keep only the buffered bytes before `len`.
             self.len = (len - self.offset) as usize;
         }
     }
@@ -266,7 +266,7 @@ mod tests {
         buffer.append(&[4, 5, 6]);
         assert_eq!(buffer.size(), 63);
 
-        // Truncate into the buffered bytes: the prefix below the new size survives.
+        // Truncate into the buffered bytes: the prefix before the new size survives.
         buffer.truncate(61);
         assert_eq!(buffer.size(), 61);
         assert_eq!(buffer.as_ref(), &[4]);
@@ -275,7 +275,7 @@ mod tests {
 
         buffer.append(&[7, 8, 9]);
 
-        // Truncate below the buffer's offset of 61: all buffered bytes are dropped and the
+        // Truncate before the buffer's offset of 61: all buffered bytes are dropped and the
         // empty buffer restarts at the new size.
         buffer.truncate(59);
         assert_eq!(buffer.size(), 59);

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -194,28 +194,16 @@ impl Buffer {
         true
     }
 
-    /// Replaces the buffered contents with `data` positioned at blob offset `offset`, without
-    /// copying. The capacity and pool are preserved; a later mutation recovers or reallocates
-    /// backing via [Self::writable].
-    pub(super) fn replace(&mut self, offset: u64, data: IoBuf) {
-        self.len = data.len();
-        self.data = data;
-        self.offset = offset;
-    }
-
-    /// Appends the provided `data` to the buffer, and returns `true` if the buffer is over capacity
-    /// after the append.
+    /// Appends the provided `data` to the buffer.
     ///
-    /// If the buffer is above capacity, the caller is responsible for flushing. Further appends
-    /// are safe, but will continue growing the buffer beyond its capacity.
-    pub(super) fn append(&mut self, data: &[u8]) -> bool {
+    /// The buffer grows beyond `capacity` as needed; callers bound growth by draining full
+    /// pages at flush points.
+    pub(super) fn append(&mut self, data: &[u8]) {
         let end = self.len + data.len();
         let mut writable = self.writable(end);
         writable.put_slice(data);
-        let over_capacity = writable.len() > self.capacity;
         self.len = writable.len();
         self.data = writable.freeze();
-        over_capacity
     }
 
     /// Clears buffered data while preserving offset.
@@ -250,7 +238,7 @@ mod tests {
         assert!(buffer.is_empty());
 
         // Add some data to the buffer.
-        assert!(!buffer.append(&[1, 2, 3]));
+        buffer.append(&[1, 2, 3]);
         assert_eq!(buffer.size(), 53);
         assert!(!buffer.is_empty());
 
@@ -263,11 +251,11 @@ mod tests {
 
         // Fill the buffer to capacity.
         let mut buf = vec![42; 100];
-        assert!(!buffer.append(&buf));
+        buffer.append(&buf);
         assert_eq!(buffer.size(), 153);
 
-        // Add one more byte, which should push it over capacity. The byte should still be appended.
-        assert!(buffer.append(&[43]));
+        // Add one more byte, growing the buffer past capacity.
+        buffer.append(&[43]);
         assert_eq!(buffer.size(), 154);
         buf.push(43);
         let flushed = buffer.slice(..);
@@ -338,7 +326,7 @@ mod tests {
         let pool = test_pool();
         let mut buffer = Buffer::new(0, 16, pool);
 
-        assert!(!buffer.append(b"abc"));
+        buffer.append(b"abc");
         let snapshot = buffer.slice(..);
 
         let mut writable = buffer.writable(6);
@@ -361,7 +349,7 @@ mod tests {
         assert_eq!(buffer.len(), 3);
         assert_eq!(buffer.as_ref(), b"abc");
 
-        assert!(!buffer.append(b"def"));
+        buffer.append(b"def");
         assert_eq!(buffer.as_ref(), b"abcdef");
     }
 }

--- a/runtime/src/utils/buffer/tip.rs
+++ b/runtime/src/utils/buffer/tip.rs
@@ -7,15 +7,9 @@ use std::ops::{Bound, RangeBounds};
 /// The buffer always represents data at the "tip" of the logical blob, starting at `offset` and
 /// extending for `len` bytes.
 ///
-/// # Allocation Semantics
-///
-/// - Backing storage starts detached in [Self::new] and is allocated on first write.
-/// - Logical data length is tracked separately from backing view length.
-/// - To flush, callers write a [Self::slice] view of the buffered bytes to the blob and call
-///   [Self::advance] only after the write succeeds. The buffer keeps the bytes until then, so
-///   a dropped or failed write loses nothing and a retry re-flushes them.
-/// - Subsequent writes are copy-on-write: [Self::writable] recovers mutable ownership when
-///   backing is unique, otherwise allocates from the pool and copies existing bytes.
+/// Callers write a [Self::slice] and call [Self::advance] only after it succeeds. A dropped
+/// write therefore leaves the bytes available for retry. Later writes reuse unique backing or
+/// copy into a pooled allocation when a slice is shared.
 pub(super) struct Buffer {
     /// The data to be written to the blob.
     ///
@@ -25,7 +19,7 @@ pub(super) struct Buffer {
     /// Number of logical buffered bytes in `data`.
     len: usize,
 
-    /// The offset in the blob where the buffered data starts.
+    /// The offset where the buffered data starts.
     ///
     /// This represents the logical position in the blob where `data[0]` would be written. The
     /// buffer is maintained at the "tip" to support efficient size calculation and appends.

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -224,12 +224,12 @@ impl<B: Blob> Write<B> {
             // now-empty tip to the new end.
             self.flush(NonDurable).await?;
             self.sync_state.resize(&self.blob, len).await?;
-            let _ = self.buffer.resize(len);
+            self.buffer.offset = len;
         } else {
             // Shrink: adopt the shorter size first, so a dropped resize never leaves the
             // buffer claiming more than the blob holds. If the blob resize is dropped
             // mid-flight, the next blob operation re-issues it (see [SyncState::settle]).
-            let _ = self.buffer.resize(len);
+            self.buffer.truncate(len);
             self.sync_state.resize(&self.blob, len).await?;
         }
 

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -4,6 +4,13 @@ use crate::{
 };
 use std::num::NonZeroUsize;
 
+/// Whether a flush must make its bytes durable before returning.
+enum Durability {
+    NonDurable,
+    Durable,
+}
+use Durability::{Durable, NonDurable};
+
 /// A writer that buffers the raw content of a [Blob] to optimize the performance of appending or
 /// updating data.
 ///
@@ -13,8 +20,10 @@ use std::num::NonZeroUsize;
 /// - Subsequent writes reuse that backing, copy-on-write allocation only occurs when buffered data
 ///   is shared (for example, after handing out immutable views) or a merge needs more capacity.
 /// - Sparse writes merged into tip extend logical length and zero-fill any gap in-buffer.
-/// - Flush paths ([Self::sync], [Self::resize], overlap flushes in [Self::write_at]) hand drained
-///   bytes to the blob and leave the tip detached until the next buffered write.
+///
+/// # Cancellation
+///
+/// Dropping an in-flight operation leaves the writer in a consistent, retryable state.
 ///
 /// # Access
 ///
@@ -176,15 +185,11 @@ impl<B: Blob> Write<B> {
             // if merge is possible after.
             let chunk_end = current_offset + chunk_len as u64;
             if self.buffer.offset < chunk_end {
-                if let Some((old_buf, old_offset)) = self.buffer.take() {
-                    self.sync_state
-                        .write_at(&self.blob, old_offset, old_buf)
-                        .await?;
-                    if self.buffer.merge(chunk, current_offset) {
-                        bufs.advance(chunk_len);
-                        current_offset += chunk_len as u64;
-                        continue;
-                    }
+                self.flush(NonDurable).await?;
+                if self.buffer.merge(chunk, current_offset) {
+                    bufs.advance(chunk_len);
+                    current_offset += chunk_len as u64;
+                    continue;
                 }
             }
 
@@ -208,28 +213,22 @@ impl<B: Blob> Write<B> {
 
     /// Resize the logical blob to `len`.
     ///
-    /// If buffered data exists and the resize extends beyond current size, buffered data is flushed
+    /// If buffered data exists and the resize does not shrink below it, buffered data is flushed
     /// before resizing the underlying blob.
     pub async fn resize(&mut self, len: u64) -> Result<(), Error> {
-        // Flush buffered data to the underlying blob.
-        //
-        // This can only happen if the new size is greater than the current size.
-        if let Some((buf, offset)) = self.buffer.resize(len) {
-            self.sync_state.write_at(&self.blob, offset, buf).await?;
+        if len >= self.buffer.size() {
+            self.flush(NonDurable).await?;
         }
 
         self.sync_state.resize(&self.blob, len).await?;
+        let _ = self.buffer.resize(len);
 
         Ok(())
     }
 
     /// Flush buffered bytes and durably sync mutations tracked by this writer.
     pub async fn sync(&mut self) -> Result<(), Error> {
-        if let Some((buf, offset)) = self.buffer.take() {
-            return self.write_blob_sync(offset, buf).await;
-        }
-
-        self.sync_blob().await
+        self.flush(Durable).await
     }
 
     /// Flush buffered bytes and begin durably syncing mutations tracked by this writer.
@@ -238,10 +237,8 @@ impl<B: Blob> Write<B> {
     /// for the state flushed by this call. Later calls to [`Self::sync`] and writer methods that
     /// mutate the blob wait before issuing blob operations.
     pub async fn start_sync(&mut self) -> Handle<()> {
-        if let Some((buf, offset)) = self.buffer.take() {
-            if let Err(err) = self.sync_state.write_at(&self.blob, offset, buf).await {
-                return Handle::ready(Err(err));
-            }
+        if let Err(err) = self.flush(NonDurable).await {
+            return Handle::ready(Err(err));
         }
 
         self.sync_state.start_sync(&self.blob).await
@@ -252,22 +249,31 @@ impl<B: Blob> Write<B> {
         self.sync_state.wait_for_pending().await
     }
 
-    /// Write bytes to the underlying blob and make them durable.
+    /// Flush all buffered bytes to the blob. Internal state is only modified on success, so
+    /// retry after cancellation or failure is possible.
     ///
-    /// Uses [`Blob::write_at_sync`] when there are no earlier unsynced mutations. Otherwise, writes
-    /// the bytes and then syncs the blob.
-    async fn write_blob_sync(
-        &mut self,
-        offset: u64,
-        bufs: impl Into<IoBufs> + Send,
-    ) -> Result<(), Error> {
-        self.sync_state
-            .write_at_sync(&self.blob, offset, bufs)
-            .await
-    }
+    /// When `durability` is [Durable], [Write] is guaranteed to be durable when this returns.
+    async fn flush(&mut self, durability: Durability) -> Result<(), Error> {
+        if self.buffer.is_empty() {
+            return match durability {
+                Durable => self.sync_state.sync(&self.blob).await,
+                NonDurable => Ok(()),
+            };
+        }
 
-    /// Sync the underlying blob if there are unsynced mutations.
-    async fn sync_blob(&mut self) -> Result<(), Error> {
-        self.sync_state.sync(&self.blob).await
+        let offset = self.buffer.offset;
+        let buffered = self.buffer.len();
+        let buf = self.buffer.slice(..);
+        match durability {
+            Durable => {
+                self.sync_state
+                    .write_at_sync(&self.blob, offset, buf)
+                    .await?
+            }
+            NonDurable => self.sync_state.write_at(&self.blob, offset, buf).await?,
+        }
+        self.buffer.advance(buffered);
+
+        Ok(())
     }
 }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -83,7 +83,7 @@ impl<B: Blob> Write<B> {
             blob,
             buffer: Buffer::new(size, capacity.get(), pool),
             // Existing blob contents may not be durable yet.
-            sync_state: SyncState::Dirty,
+            sync_state: SyncState::dirty(),
         }
     }
 
@@ -217,11 +217,18 @@ impl<B: Blob> Write<B> {
     /// before resizing the underlying blob.
     pub async fn resize(&mut self, len: u64) -> Result<(), Error> {
         if len >= self.buffer.size() {
+            // Grow (or keep the size): flush buffered bytes, resize the blob, and move the
+            // now-empty tip to the new end.
             self.flush(NonDurable).await?;
+            self.sync_state.resize(&self.blob, len).await?;
+            let _ = self.buffer.resize(len);
+        } else {
+            // Shrink: adopt the shorter size first, so a dropped resize never leaves the
+            // buffer claiming more than the blob holds. If the blob resize is dropped
+            // mid-flight, the next blob operation re-issues it (see [SyncState::settle]).
+            let _ = self.buffer.resize(len);
+            self.sync_state.resize(&self.blob, len).await?;
         }
-
-        self.sync_state.resize(&self.blob, len).await?;
-        let _ = self.buffer.resize(len);
 
         Ok(())
     }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -215,6 +215,9 @@ impl<B: Blob> Write<B> {
     ///
     /// If buffered data exists and the resize does not shrink below it, buffered data is flushed
     /// before resizing the underlying blob.
+    ///
+    /// A dropped resize may still be applied to the blob by a later operation. [Self::size]
+    /// reflects a grow only once it returns `Ok`, and a shrink as soon as it is issued.
     pub async fn resize(&mut self, len: u64) -> Result<(), Error> {
         if len >= self.buffer.size() {
             // Grow (or keep the size): flush buffered bytes, resize the blob, and move the

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -14,12 +14,8 @@ use Durability::{Durable, NonDurable};
 /// A writer that buffers the raw content of a [Blob] to optimize the performance of appending or
 /// updating data.
 ///
-/// # Allocation Semantics
-///
-/// - [Self::new] starts with a detached tip buffer and allocates backing on first buffered write.
-/// - Subsequent writes reuse that backing, copy-on-write allocation only occurs when buffered data
-///   is shared (for example, after handing out immutable views) or a merge needs more capacity.
-/// - Sparse writes merged into tip extend logical length and zero-fill any gap in-buffer.
+/// Writes reuse their tip allocation. A shared view or a larger merge copies into a pooled
+/// allocation; sparse writes zero-fill gaps.
 ///
 /// # Cancellation
 ///
@@ -27,13 +23,8 @@ use Durability::{Durable, NonDurable};
 ///
 /// # Access
 ///
-/// [Write] is a single-owner buffered handle that owns mutation ordering and durability
-/// bookkeeping for the wrapped [Blob]. Raw [Blob] handles cloned before wrapping observe only
-/// flushed data and may not see the latest buffered writes until [Self::sync], [Self::resize], or
-/// an overlapping [Self::write_at] flushes them. Those raw handles must not be used to write,
-/// resize, or otherwise mutate the blob while a [Write] exists. External mutations bypass the
-/// buffer state and [Self::sync] may use [Blob::write_at_sync], which is not a durability barrier
-/// for those external mutations.
+/// Raw [Blob] handles see only flushed bytes. They must not mutate the blob while [Write] exists:
+/// external mutations bypass its buffer and durability tracking.
 ///
 /// # Example
 ///

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -186,8 +186,8 @@ impl<B: Blob> Write<B> {
 
             // Chunk could not be merged (exceeds buffer capacity or outside its range), so
             // write directly. Note that we may end up writing an intersecting range twice:
-            // once when the buffer is flushed above, then again when we write the chunk
-            // below. Removing this inefficiency may not be worth the additional complexity.
+            // once when the buffer is flushed first, then again when we write the chunk.
+            // Removing this inefficiency may not be worth the additional complexity.
             let direct = bufs.split_to(chunk_len);
             self.sync_state
                 .write_at(&self.blob, current_offset, direct)
@@ -204,8 +204,8 @@ impl<B: Blob> Write<B> {
 
     /// Resize the logical blob to `len`.
     ///
-    /// If buffered data exists and the resize does not shrink below it, buffered data is flushed
-    /// before resizing the underlying blob.
+    /// If a resize retains buffered data, it flushes that data before resizing the underlying
+    /// blob.
     ///
     /// A dropped resize may still be applied to the blob by a later operation. [Self::size]
     /// reflects a grow only once it returns `Ok`, and a shrink as soon as it is issued.

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -826,7 +826,7 @@ mod tests {
                 .await
                 .unwrap();
             let mut writer = Writer::new(blob, size, 128, cache_ref).await.unwrap();
-            writer.append(b"abc").await.unwrap();
+            writer.append(b"abc");
 
             let size = writer.size();
             let tail = Blob::Writer(&writer);

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -957,9 +957,7 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
 
             self.blobs
                 .tail_writer()
-                .append_owned(items_buf.slice(start..end))
-                .await
-                .map_err(Error::Runtime)?;
+                .append_owned(items_buf.slice(start..end));
             self.bounds.end = new_size;
             written += batch_count;
 
@@ -2304,7 +2302,7 @@ mod tests {
                 .unwrap();
             let mut append = Writer::new(blob, blob_size, 2048, cache_ref).await.unwrap();
             let extra = test_digest(999);
-            append.append(extra.as_ref()).await.unwrap();
+            append.append(extra.as_ref());
             append.sync().await.unwrap();
             drop(append);
 
@@ -2759,10 +2757,7 @@ mod tests {
                 let mut append = Writer::new(blob, blob_size, 2048, cache_ref)
                     .await
                     .expect("failed to wrap blob 0");
-                append
-                    .append(extra.as_ref())
-                    .await
-                    .expect("failed to append extra item");
+                append.append(extra.as_ref());
                 append.sync().await.expect("failed to sync corrupted blob");
             }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1463,14 +1463,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
                 .unwrap_or(encoded.len());
 
             // Append pre-encoded data to the tail, then convert relative item starts into
-            // absolute offsets. A large batch is written whole-page-direct to the blob; the
-            // returned offset is where this batch's first byte was written.
+            // absolute offsets. The returned offset is where this batch's first byte was
+            // staged.
             let base_offset = self
                 .blobs
                 .tail_writer()
-                .append_owned(encoded.slice(batch_start..batch_end))
-                .await
-                .map_err(Error::Runtime)?;
+                .append_owned(encoded.slice(batch_start..batch_end));
 
             let absolute_offsets = item_starts[written..written + batch_count]
                 .iter()
@@ -2260,13 +2258,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         if blob == tail_blob {
             let writer = self.blobs.tail_writer();
             let offset = writer.size();
-            writer.append(&encoded).await.map_err(Error::Runtime)?;
+            writer.append(&encoded);
             return Ok((offset, item_len));
         }
         assert!(blob > tail_blob, "cannot append to a sealed blob");
         let mut writer = self.blobs.open_blob(blob).await?;
         let offset = writer.size();
-        writer.append(&encoded).await.map_err(Error::Runtime)?;
+        writer.append(&encoded);
         writer.sync().await.map_err(Error::Runtime)?;
         Ok((offset, item_len))
     }
@@ -4334,7 +4332,7 @@ mod tests {
 
             let mut encoded = Vec::new();
             encode_frame_into(None, &100u64, &mut encoded).unwrap();
-            pending.get_mut(&0).unwrap().append(&encoded).await.unwrap();
+            pending.get_mut(&0).unwrap().append(&encoded);
             offsets.append(&0).await.unwrap();
 
             let result = Journal::<_, u64>::rebuild_offsets_from_anchor(
@@ -4725,7 +4723,7 @@ mod tests {
                 .await
                 .unwrap();
                 let expected_size = append.size();
-                append.append(&[0xFF, 0xFF]).await.unwrap();
+                append.append(&[0xFF, 0xFF]);
                 append.sync().await.unwrap();
                 drop(append);
 

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -126,7 +126,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
 
         // Encode the item
         let buf = item.encode_mut();
-        let offset = blob.append(&buf).await?;
+        let offset = blob.append(&buf);
         if !offset.is_multiple_of(Self::CHUNK_SIZE_U64) {
             return Err(Error::InvalidBlobSize(section, offset));
         }

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -431,7 +431,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// The buffer must be in the on-disk format produced by [Self::encode_item].
     async fn append_raw(&mut self, section: u64, buf: IoBuf) -> Result<u64, Error> {
         let blob = self.manager.get_or_create(section).await?;
-        let offset = blob.append_owned(buf).await?;
+        let offset = blob.append_owned(buf);
         trace!(blob = section, offset, "appended item");
         Ok(offset)
     }


### PR DESCRIPTION
Dropping a storage future at an `.await` (via `select!`, timeouts, or shutdown) could leave the buffer layer's in-memory state disagreeing with the blob: lost buffered data, forgotten resizes, and partially published pages. This PR makes the two buffered writers safe under cancellation and removes the largest class of cancellation points entirely by making appends synchronous.

## What changed

### 1. `buffer::Write` is cancellation-safe

`SyncState` becomes a struct: the old `Clean`/`Dirty`/`Pending` enum (now `Status`) plus a `pending_resize: Option<u64>` intent.

- A cancelled flush no longer discards the tip; the next operation retries the write.
- A cancelled `resize` is recorded before I/O. Later blob operations finish that resize before doing new work.
- Shrinks adopt the shorter size in memory first, so a dropped shrink never leaves the writer claiming bytes the blob no longer holds.
- A later blob operation reports an unobserved started-sync failure.

### 2. `paged::Writer::append` / `append_owned` are synchronous

```rust
// before
pub async fn append(&mut self, buf: &[u8]) -> Result<u64, Error>
// after
pub fn append(&mut self, buf: &[u8]) -> u64
```

Appends extend the writer's in-memory tail and cannot fail or be cancelled. Disk I/O moves to `sync()`, `start_sync()`, `resize()`, `seal()`, `snapshot()`, and `replay()`. This removes every mid-append cancellation window and lets callers batch appends before paying for I/O.

The tail has two parts:

- Full pages are held as immutable, refcounted slices until flush. Large `append_owned` calls retain their complete pages without copying.
- The mutable tip holds the final partial page. Only bytes needed to complete that page and its final suffix are copied.

Before writing, a flush moves every complete page out of the tip. It then writes the full pages and partial tip in order, updates the page cache, and advances the writer only after the writes succeed. A cancelled flush therefore leaves the tail intact for retry.

`capacity` is the preferred allocation size for the mutable tip, not a bound on all pending data. Callers bound pending data through their flush cadence. The old large-append path instead issued I/O during append; the new path defers it to the caller's existing barrier.

The paged writer also repairs cancellation during page publication and shrinking: later operations clean up uncommitted page bytes before changing their CRC record, and re-read an uncertain partial-page record after a cancelled shrink.

### 3. Supporting changes

- `tip::Buffer` is now the small copy-on-write byte window shared by raw and paged writers. It keeps bytes until the caller advances it after a successful write.
- New `paged::tail` code owns page splitting, zero-copy full-page retention, and tail reads. The shared read path sees one in-memory tail rather than separately reasoning about page slices and a tip.
- Callers in contiguous and segmented journals, fuzz targets, and benches drop `.await` on appends. Appends now remain in memory until their existing barrier; durability points are unchanged.

## Testing

- Gated blob helpers (`Gate`, `GatedWriteBlob`, `GatedResizeBlob`) stop a specific write or resize so tests can drop a future at an exact await.
- Cancel-then-retry coverage includes flushes, grows, resizes, page publication, partial-page shrink, and full-page tail writes.
- Tests verify that full pages from large owned appends remain zero-copy, reads work across the persisted prefix, full tail pages, and the tip, and a cancelled flush preserves the full tail.
- Buffer fuzz targets (`buffer`, `blob_integrity`) were adapted. The append benchmark flushes each iteration, measuring staged append plus sync.

## Cancellation contract

Dropping any `buffer::Write` or `paged::Writer` future leaves the writer usable. Its tip, full tail pages, and resize intent remain available to the next operation or reopen. Appends have no cancellation points.
