### PR TITLE
[deployer] Bump `tracer`

### DIFF
--- a/deployer/src/aws/services.rs
+++ b/deployer/src/aws/services.rs
@@ -58,7 +58,7 @@ pub const PYROSCOPE_IMAGE: &str = "grafana/pyroscope:1.12.0";
 pub const GRAFANA_IMAGE: &str = "grafana/grafana:11.5.2";
 
 /// Image for Tracer trace viewing
-pub const TRACER_IMAGE: &str = "ghcr.io/clabby/tracer-web:0.1.2";
+pub const TRACER_IMAGE: &str = "ghcr.io/clabby/tracer-web:0.2.1";
 
 #[derive(Clone, Copy)]
 struct ImageService {


### PR DESCRIPTION
## Overview

Bumps the `tracer` image to the latest version, which added a span diff tool and improved the stats/hotpath view for the single trace view.