### PR TITLE
[runtime] Defer blob-creation durability to the first sync

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -629,9 +629,20 @@ stability_scope!(BETA {
         /// Multiple instances of the same blob can be opened concurrently, however,
         /// writing to the same blob concurrently may lead to undefined behavior.
         ///
-        /// An Ok result indicates the blob is durably created (or already exists). On
-        /// platforms without directory sync (e.g. Windows), the durability of the blob's
-        /// name is best-effort.
+        /// # Durability
+        ///
+        /// An already-existing blob is returned durable. A newly created blob is not: its
+        /// existence (and its name) become durable only once its first durability request
+        /// completes — [`Blob::sync`], a non-empty [`Blob::write_at_sync`], or the handle
+        /// returned by [`Blob::start_sync`]. A blob created and then dropped without such a
+        /// request may not survive a crash. On platforms without directory sync (e.g.
+        /// Windows), name durability is best-effort even after the first sync.
+        ///
+        /// An uncommitted creation is indistinguishable on disk from one interrupted by a
+        /// crash, so opening such a blob recreates it, resetting it to empty. Opening a name
+        /// while another live handle holds an unsynced creation of it is therefore undefined
+        /// behavior: the recreate discards the earlier handle's writes, and syncing that handle
+        /// afterward may certify data the recreate has already discarded.
         ///
         /// # Versions
         ///
@@ -743,6 +754,10 @@ stability_scope!(BETA {
         /// only the bytes submitted to this call are guaranteed durable. Earlier unsynced
         /// [`Blob::write_at`] or [`Blob::resize`] calls require [`Blob::sync`] to become
         /// durable.
+        ///
+        /// The one exception is the first non-empty request on a newly created blob: it also
+        /// commits the deferred creation, which as a side effect makes the blob's prior
+        /// writes, length, and name durable. An empty request is a no-op and never commits.
         fn write_at_sync(
             &self,
             offset: u64,
@@ -756,6 +771,9 @@ stability_scope!(BETA {
         fn resize(&self, len: u64) -> impl Future<Output = Result<(), Error>> + Send;
 
         /// Ensure all pending data is durably persisted.
+        ///
+        /// On a newly created blob, this also commits the deferred creation, making the
+        /// blob's existence and name durable.
         fn sync(&self) -> impl Future<Output = Result<(), Error>> + Send;
 
         /// Request that all pending data is durably persisted.

--- a/runtime/src/storage/header.rs
+++ b/runtime/src/storage/header.rs
@@ -34,24 +34,6 @@ stability_scope!(BETA {
     }
 
     impl HeaderError {
-        /// Returns true if this parse failure could be the signature of a creation interrupted
-        /// before the header became durable, making the blob a candidate for
-        /// [Layout::interrupted_creation] classification.
-        ///
-        /// [HeaderError::VersionMismatch] is excluded: for V1 it fires only once the CRC has
-        /// validated and the full header region is present, so the header was completely
-        /// written and the failure is a genuine version disagreement. (A V0 version mismatch
-        /// is checked without a CRC, but V0 recovery is out of scope.)
-        pub(crate) const fn may_be_torn_creation(&self) -> bool {
-            matches!(
-                self,
-                Self::InvalidMagic { .. }
-                    | Self::UnsupportedRuntimeVersion { .. }
-                    | Self::InvalidChecksum
-                    | Self::Truncated { .. }
-            )
-        }
-
         /// Converts this error into an [`Error`](enum@crate::Error) with partition and name context.
         pub(crate) fn into_error(self, partition: &str, name: &[u8]) -> crate::Error {
             match self {
@@ -190,67 +172,32 @@ stability_scope!(BETA {
             }
         }
 
-        /// Returns true if a blob's raw contents are consistent with the creation of a
-        /// blob with this layout that was interrupted before its header became durable.
-        ///
-        /// This runtime never creates [Layout::V0] blobs, so no contents qualify for V0 (a
-        /// pre-V1 writer's torn creation is a sub-prelude file, healed as new before any
-        /// parsing).
-        ///
-        /// [Layout::V1] creation writes the region with set_len(0) -> write -> sync, and
-        /// this classifier models the states it recovers as a prefix of the canonical
-        /// region, possibly followed by zeros (a persisted length without persisted bytes
-        /// reads as zeros). A file is accepted iff it fits within the region and equals a
-        /// canonical prefix followed by zeros: the magic and runtime version are fixed;
-        /// the blob version bytes continue the prefix with whatever value the writer
-        /// chose; the CRC bytes must be a prefix of the CRC over the preceding prelude,
-        /// which can only have begun persisting once the full prelude did; and everything
-        /// past the prefix must be zero.
-        ///
-        /// The prefix shape is a model, not a filesystem guarantee: device writeback before
-        /// the sync completes may persist bytes out of order. A file that is not a canonical
-        /// prefix (a lost byte followed by persisted ones, or a CRC that does not match its
-        /// own prelude) stays loudly corrupt rather than healing, trading recovery
-        /// coverage for avoiding broader acceptance that might erase nonzero data.
-        pub(crate) fn interrupted_creation(self, raw: &[u8]) -> bool {
-            match self {
-                Self::V0 => false,
-                Self::V1 => {
-                    // The file cannot extend past the region creation writes, and
-                    // everything past the parseable header must be zero padding.
-                    if raw.len() > self.data_offset() as usize {
-                        return false;
-                    }
-                    let head = &raw[..raw.len().min(Header::PARSE_LEN)];
-                    if raw[head.len()..].iter().any(|&byte| byte != 0) {
-                        return false;
-                    }
+    }
 
-                    // The written prefix ends after the last nonzero byte (trailing zeros
-                    // are indistinguishable from unwritten bytes).
-                    let written = head.iter().rposition(|&byte| byte != 0).map_or(0, |i| i + 1);
+    /// Bytes withheld until a new V1 blob's first durability request commits its header.
+    ///
+    /// Deferred creation reserves a zero header page and writes nothing durable. The first
+    /// durability request writes the prelude and makes the file and its directory entries
+    /// durable, then writes this CRC as the commit record: a complete valid CRC can only exist
+    /// after that barrier, so it proves the whole file is durable.
+    #[derive(Clone)]
+    pub(crate) struct PendingHeader {
+        prelude: [u8; Header::PRELUDE_SIZE],
+        checksum: [u8; Header::EXTENSION_SIZE],
+    }
 
-                    let mut canonical = [0u8; Header::PARSE_LEN];
-                    canonical[..4].copy_from_slice(&self.magic());
-                    canonical[4..6].copy_from_slice(&self.runtime_version().to_be_bytes());
-                    if written <= Header::PRELUDE_SIZE {
-                        // Torn at or before the CRC: the fixed bytes of the prefix must
-                        // match; the blob version bytes (6-7) are the writer's choice.
-                        head[..written.min(6)] == canonical[..written.min(6)]
-                    } else {
-                        // CRC bytes persisted, so the full prelude did too: it must be
-                        // canonical (with the writer's version), and the CRC bytes must be
-                        // a prefix of the CRC over it.
-                        if head[..6] != canonical[..6] {
-                            return false;
-                        }
-                        canonical[6..8].copy_from_slice(&head[6..8]);
-                        let crc = Crc32::checksum(&canonical[..Header::PRELUDE_SIZE]);
-                        canonical[8..12].copy_from_slice(&crc.to_be_bytes());
-                        head[8..written] == canonical[8..written]
-                    }
-                }
-            }
+    impl PendingHeader {
+        /// Offset of the commit CRC within the header region (immediately after the prelude).
+        pub(crate) const CHECKSUM_OFFSET: u64 = Header::PRELUDE_SIZE as u64;
+
+        /// The 8-byte prelude written in phase one of the commit.
+        pub(crate) const fn prelude(&self) -> &[u8; Header::PRELUDE_SIZE] {
+            &self.prelude
+        }
+
+        /// The 4-byte CRC written last, as the commit record.
+        pub(crate) const fn checksum(&self) -> &[u8; Header::EXTENSION_SIZE] {
+            &self.checksum
         }
     }
 
@@ -310,15 +257,10 @@ stability_scope!(BETA {
             }
         }
 
-        /// Creates the header region for a new blob using the latest version from the range and
-        /// the latest header layout. Returns (encoded header region, blob version); the data
-        /// offset is the region's length.
-        ///
-        /// Callers writing this region over an existing blob must truncate it to zero first, so
-        /// a torn write cannot splice old bytes into a fully valid header with a wrong version:
-        /// every partial state in the canonical-prefix model then remains classifiable as an
-        /// interrupted creation.
-        pub(crate) fn create(versions: &RangeInclusive<u16>) -> (Vec<u8>, u16) {
+        /// Prepares the V1 prelude and its commit CRC for a new blob, without writing either to
+        /// storage. Returns the withheld bytes and the blob version stamped (the newest in the
+        /// range); the data offset is [Layout::V1]'s `data_offset`.
+        pub(crate) fn prepare(versions: &RangeInclusive<u16>) -> (PendingHeader, u16) {
             let layout = Layout::V1;
             let blob_version = *versions.end();
             let header = Self {
@@ -326,12 +268,86 @@ stability_scope!(BETA {
                 runtime_version: layout.runtime_version(),
                 blob_version,
             };
+            let encoded = header.encode();
+            let mut prelude = [0u8; Self::PRELUDE_SIZE];
+            prelude.copy_from_slice(encoded.as_ref());
+            let checksum = Crc32::checksum(&prelude).to_be_bytes();
+            assert_ne!(
+                checksum,
+                [0u8; Self::EXTENSION_SIZE],
+                "a zero V1 CRC is reserved for the uncommitted state"
+            );
+            (PendingHeader { prelude, checksum }, blob_version)
+        }
+
+        /// Constructs a committed V1 header region (prelude + CRC + zero padding) as it appears
+        /// on disk after a successful commit. Test-only: production creation reserves a zero
+        /// region via [Self::prepare] and commits it on the first durability request.
+        #[cfg(test)]
+        pub(crate) fn create(versions: &RangeInclusive<u16>) -> (Vec<u8>, u16) {
+            let (pending, blob_version) = Self::prepare(versions);
             let mut region = Vec::with_capacity(Layout::V1.data_offset() as usize);
-            region.extend_from_slice(&header.encode());
-            let crc = Crc32::checksum(&region);
-            region.extend_from_slice(&crc.to_be_bytes());
-            region.resize(layout.data_offset() as usize, 0);
+            region.extend_from_slice(pending.prelude());
+            region.extend_from_slice(pending.checksum());
+            region.resize(Layout::V1.data_offset() as usize, 0);
             (region, blob_version)
+        }
+
+        /// Returns true if `raw` matches an uncommitted V1 creation: the header region is not yet
+        /// a complete valid CRC over a canonical prelude, so no first-durability commit has
+        /// certified it. Bytes past the header region are uncommitted user data (a crash after
+        /// data pages flushed but before the header committed) and are ignored.
+        ///
+        /// Before the commit the header region is zero. The commit writes the prelude, makes the
+        /// file durable, then writes the CRC last, so recovery accepts a zero-or-canonical
+        /// prelude while the CRC is absent, or a complete prelude followed by an incomplete
+        /// zero-or-canonical CRC. A complete valid CRC is committed (it could only follow the
+        /// durability barrier). Padding within the region must be zero.
+        fn uncommitted_v1(raw: &[u8]) -> bool {
+            let head = &raw[..raw.len().min(Self::PARSE_LEN)];
+            let padding_end = raw.len().min(Layout::V1.data_offset() as usize);
+            if raw[head.len()..padding_end].iter().any(|&byte| byte != 0) {
+                return false;
+            }
+
+            let mut canonical = [0u8; Self::PARSE_LEN];
+            canonical[..4].copy_from_slice(&Layout::V1.magic());
+            canonical[4..6].copy_from_slice(&Layout::V1.runtime_version().to_be_bytes());
+
+            let mut found_checksum = [0u8; Self::EXTENSION_SIZE];
+            if let Some(checksum) = head.get(Self::PRELUDE_SIZE..) {
+                found_checksum[..checksum.len()].copy_from_slice(checksum);
+            }
+            if found_checksum.iter().all(|&byte| byte == 0) {
+                // The CRC is not issued until the prelude and user bytes are durable. Before
+                // then each fixed prelude byte is either its new value or the original zero; the
+                // blob-version bytes are whatever value the creating caller selected.
+                return head[..head.len().min(6)]
+                    .iter()
+                    .zip(&canonical)
+                    .all(|(&found, &expected)| found == 0 || found == expected);
+            }
+
+            // A nonzero CRC byte is only issued after the reserved header page's length and the
+            // prelude are durable, so a shorter file carrying one cannot be an uncommitted
+            // creation.
+            if (raw.len() as u64) < Layout::V1.data_offset()
+                || head.len() < Self::PRELUDE_SIZE
+                || head[..6] != canonical[..6]
+            {
+                return false;
+            }
+            canonical[6..8].copy_from_slice(&head[6..8]);
+            let checksum = Crc32::checksum(&canonical[..Self::PRELUDE_SIZE]).to_be_bytes();
+            if found_checksum == checksum {
+                // A complete valid CRC is a commit record, not an uncommitted creation.
+                return false;
+            }
+            canonical[8..12].copy_from_slice(&checksum);
+            found_checksum
+                .iter()
+                .zip(&canonical[8..12])
+                .all(|(&found, &expected)| found == 0 || found == expected)
         }
 
         /// Parses and validates a blob's header from its leading bytes, returning the blob's
@@ -414,16 +430,20 @@ stability_scope!(BETA {
         }
     }
 
-    /// Resolves a blob's header from its leading bytes.
+    /// Classifies a blob's on-disk header region from its leading bytes, performing no I/O.
     ///
-    /// Returns `Some((logical_size, blob_version, data_offset))` for a valid header and
-    /// `None` when the caller should (re)create the blob: the file is too short to hold a
-    /// header, or its contents are those of a [Layout::V1] creation interrupted
-    /// before its header became durable. Anything else fails as corrupt or unacceptable.
+    /// Returns `Some((logical_size, blob_version, data_offset))` for a committed header (a
+    /// complete valid CRC over a canonical prelude), `None` when the caller should reset and
+    /// recreate the blob (too short to hold a header, or an uncommitted V1 creation whose first
+    /// durability request never committed the CRC), and an error otherwise. A committed-looking
+    /// header whose CRC does not match is loud corruption the blob layer cannot adjudicate; the
+    /// contiguous journal recreates such a tail using its recovery watermark.
     ///
-    /// `raw` must hold the blob's first [Header::resolve_len] bytes, where `raw_len` is
-    /// the blob's raw on-disk length.
-    pub(crate) fn resolve(
+    /// `raw` must hold the blob's first [Header::resolve_len] bytes, where `raw_len` is the
+    /// blob's raw on-disk length. The full header region is required (not just the parse head):
+    /// uncommitted classification must observe any nonzero reserved-padding byte to reject a
+    /// foreign state, and cannot see bytes the caller did not read.
+    pub(crate) fn classify_header(
         raw: &[u8],
         raw_len: u64,
         versions: &RangeInclusive<u16>,
@@ -432,10 +452,10 @@ stability_scope!(BETA {
     ) -> Result<Option<(u64, u16, u64)>, crate::Error> {
         assert!(
             raw.len() >= Header::resolve_len(raw_len),
-            "caller must provide enough bytes to resolve the header region"
+            "caller must provide enough bytes to classify the header region"
         );
 
-        // Too short to hold any header: treat as new.
+        // Too short to hold any header: an uncommitted creation, recreate.
         if Header::missing(raw_len) {
             return Ok(None);
         }
@@ -445,17 +465,14 @@ stability_scope!(BETA {
             Err(err) => err,
         };
 
-        // Heal a V1 creation interrupted before its header became durable: the failure
-        // must be one a torn write can produce, and the contents must match the canonical
-        // creation prefix. Files longer than the creation region hold data and never heal.
-        if raw_len <= Layout::V1.data_offset()
-            && err.may_be_torn_creation()
-            && Layout::V1.interrupted_creation(raw)
-        {
+        // An uncommitted V1 creation (no complete valid CRC over a canonical prelude) recreates
+        // in place; anything else is loud corruption. `uncommitted_v1` clamps `raw` to the
+        // header region itself, ignoring any uncommitted user data past it.
+        if Header::uncommitted_v1(raw) {
             warn!(
                 partition,
                 name = %hex(name),
-                "recreating blob left torn by an interrupted creation"
+                "recreating uncommitted V1 blob"
             );
             return Ok(None);
         }
@@ -657,36 +674,6 @@ pub(crate) mod tests {
         ));
     }
 
-    /// Classification only triggers for parse failures a torn write can produce. A version
-    /// mismatch requires a validated CRC over a complete header region and stays loud.
-    #[test]
-    fn test_header_error_torn_creation_candidates() {
-        assert!(HeaderError::InvalidMagic { found: [0; 4] }.may_be_torn_creation());
-        assert!(
-            HeaderError::UnsupportedRuntimeVersion {
-                expected: 1,
-                found: 0
-            }
-            .may_be_torn_creation()
-        );
-        assert!(HeaderError::InvalidChecksum.may_be_torn_creation());
-        assert!(
-            HeaderError::Truncated {
-                required_len: Layout::V1.data_offset(),
-                raw_len: 100
-            }
-            .may_be_torn_creation()
-        );
-        assert!(!HeaderError::InvalidPadding.may_be_torn_creation());
-        assert!(
-            !HeaderError::VersionMismatch {
-                expected: 0..=0,
-                found: 1
-            }
-            .may_be_torn_creation()
-        );
-    }
-
     /// A magic with any byte zeroed by a torn write must be invalid, never another layout's
     /// magic: this is what lets an unparseable header safely identify a torn creation.
     #[test]
@@ -751,79 +738,94 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_header_interrupted_v1_creation_accepts_torn_states() {
+    fn test_header_uncommitted_v1_accepts_interrupted_commit_states() {
         let region = v1_blob_bytes(5, b"");
         let cases: &[(&str, Vec<u8>)] = &[
-            ("only sizes flushed", vec![0u8; region.len()]),
-            ("sub-prelude fragment", vec![0u8; 3]),
-            ("prefix of the magic", region[..2].to_vec()),
-            ("prefix ending in the version bytes", region[..8].to_vec()),
-            ("prefix ending mid-CRC", region[..10].to_vec()),
-            ("full region", region.clone()),
-            ("torn after the prelude, CRC unwritten", {
+            ("reserved header page", vec![0u8; region.len()]),
+            ("short zero region", vec![0u8; 3]),
+            ("arbitrary prelude subset", {
+                let mut raw = vec![0u8; region.len()];
+                for index in [0, 2, 5, 7] {
+                    raw[index] = region[index];
+                }
+                raw
+            }),
+            ("prelude durable, CRC unwritten", {
                 let mut raw = region.clone();
                 raw[8..12].fill(0);
                 raw
             }),
-            ("prefix with a persisted length", {
-                let mut raw = vec![0u8; region.len()];
-                raw[..10].copy_from_slice(&region[..10]);
+            ("arbitrary CRC subset", {
+                let mut raw = region.clone();
+                raw[8] = 0;
+                raw[10] = 0;
                 raw
             }),
-            (
-                "documented residual: V0 blob rotted into a canonical prefix",
-                {
-                    // The magics share the `CWI` brand, so a V0 blob whose surviving bytes
-                    // form a canonical V1 prefix (a default version stamp of 0, an all-zero
-                    // payload, and the tag byte lost) is byte-identical to a V1 creation
-                    // torn inside the magic, and heals. Its logical length is lost, but
-                    // every erased payload byte is zero. Any nonzero stamp, payload, or
-                    // non-prefix survivor stays loud (see the reject table).
-                    let mut raw = v0_blob_bytes(0, &[0u8; 100]);
-                    raw[3] = 0;
-                    raw
-                },
-            ),
+            ("uncommitted header with user data", {
+                let mut raw = vec![0u8; region.len()];
+                raw.extend_from_slice(b"unsynced data");
+                raw
+            }),
+            ("partial CRC with user data", {
+                let mut raw = region;
+                raw[9..12].fill(0);
+                raw.extend_from_slice(b"unsynced data");
+                raw
+            }),
+            ("documented residual: committed V1 with erased CRC", {
+                // Once all CRC bytes are lost, a committed V1 blob is byte-identical to an
+                // uncommitted one. This narrow corruption pattern is the cost of using zero
+                // as the precommit state without another on-disk marker.
+                let mut raw = v1_blob_bytes(5, b"durable data");
+                raw[8..12].fill(0);
+                raw
+            }),
+            ("deliberate no-guarantee: V0 with erased layout tag", {
+                // V0 recovery and corruption detection are best-effort. New blobs are always V1,
+                // but V0 remains readable; with its layout tag erased and an all-zero payload, a
+                // V0 blob can be byte-identical to an interrupted V1 prelude regardless of its
+                // opaque blob version, so it is recreated as an uncommitted V1 blob.
+                let mut raw = v0_blob_bytes(5, &[0u8; 100]);
+                raw[3] = 0;
+                raw
+            }),
         ];
         for (label, raw) in cases {
             assert!(
-                Layout::V1.interrupted_creation(raw),
-                "{label} should classify as an interrupted creation"
+                Header::uncommitted_v1(raw),
+                "{label} should classify as an uncommitted V1 blob"
             );
         }
     }
 
-    /// This runtime never creates V0 blobs, so no contents qualify as an interrupted V0
-    /// creation, including ones that heal under V1.
     #[test]
-    fn test_layout_v0_interrupted_creation_rejects_all() {
-        let (region, _) = Header::create(&(0..=0));
-        assert!(Layout::V1.interrupted_creation(&region[..10]));
-        assert!(!Layout::V0.interrupted_creation(&region[..10]));
-        assert!(!Layout::V0.interrupted_creation(&[]));
+    fn test_header_complete_v1_crc_is_committed() {
+        let raw = v1_blob_bytes(5, b"");
+        assert!(!Header::uncommitted_v1(&raw));
+        assert!(Header::parse(&raw, raw.len() as u64, &(5..=5)).is_ok());
     }
 
     #[test]
-    fn test_header_interrupted_v1_creation_rejects_foreign_bytes() {
+    fn test_header_uncommitted_v1_rejects_foreign_bytes() {
         let region = v1_blob_bytes(5, b"");
         let cases: &[(&str, Vec<u8>)] = &[
             ("non-canonical magic byte", {
-                let mut raw = region.clone();
+                let mut raw = vec![0u8; region.len()];
                 raw[0] = b'X';
                 raw
             }),
             ("non-canonical runtime version", {
-                let mut raw = region.clone();
+                let mut raw = vec![0u8; region.len()];
                 raw[4] = 0x02;
                 raw
             }),
-            ("magic byte lost with later bytes persisted", {
-                // Not a prefix: a write cannot persist byte 5 without byte 3.
+            ("short foreign bytes", vec![b'X', 0]),
+            ("CRC issued before the complete magic", {
                 let mut raw = region.clone();
                 raw[3] = 0;
                 raw
             }),
-            ("runtime version byte lost with later bytes persisted", {
+            ("CRC issued before the complete runtime version", {
                 let mut raw = region.clone();
                 raw[5] = 0;
                 raw
@@ -836,23 +838,9 @@ pub(crate) mod tests {
                 raw
             }),
             ("nonzero padding", {
-                let mut raw = region.clone();
-                raw[100] = 0xFF;
-                raw
-            }),
-            ("data past the header region", {
                 let mut raw = region;
-                raw.push(1);
-                raw
-            }),
-            ("rotted-magic V0 blob with its version stamp", {
-                // The nonzero version stamp makes byte 3 part of the written prefix, so
-                // the zeroed magic byte is non-canonical, not unwritten. Only a V0 blob
-                // whose surviving bytes form a canonical V1 prefix heals (see the accepts
-                // table).
-                let mut raw = v0_header(5).encode().to_vec();
-                raw[3] = 0;
-                raw.extend_from_slice(&[0u8; 100]);
+                raw[8..12].fill(0);
+                raw[100] = 0xFF;
                 raw
             }),
             ("rotted-magic V0 blob with payload", {
@@ -861,24 +849,32 @@ pub(crate) mod tests {
                 raw.extend_from_slice(&[0xAA, 0xBB]);
                 raw
             }),
-            (
-                "all zeros, one byte longer than the creation region",
-                vec![0u8; Layout::V1.data_offset() as usize + 1],
-            ),
-            ("zero payload past the header region, CRC lost", {
-                // A synced V1 blob whose payload is all zeros, with the CRC bytes rotted
-                // away: the file extends past the header region, so healing it would
-                // erase the payload.
-                let mut raw = v1_blob_bytes(5, &[0u8; 100]);
-                raw[8..12].fill(0);
+            ("committed blob truncated below the reserved page", {
+                // A nonzero CRC is only issued after the 4096-byte page length is durable,
+                // so a shorter file carrying one was truncated, not left uncommitted.
+                let mut raw = v1_blob_bytes(5, b"");
+                raw.truncate(100);
+                raw
+            }),
+            ("committed blob truncated to exactly the header region", {
+                let mut raw = v1_blob_bytes(5, b"");
+                raw.truncate(Header::PARSE_LEN);
                 raw
             }),
         ];
         for (label, raw) in cases {
             assert!(
-                !Layout::V1.interrupted_creation(raw),
+                !Header::uncommitted_v1(raw),
                 "{label} must stay a loud corruption error"
             );
+        }
+    }
+
+    #[test]
+    fn test_v1_crc_never_uses_uncommitted_value() {
+        for version in u16::MIN..=u16::MAX {
+            let (pending, _) = Header::prepare(&(version..=version));
+            assert_ne!(pending.checksum(), &[0; Header::EXTENSION_SIZE]);
         }
     }
 

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -20,7 +20,7 @@
 //! This implementation is only available on Linux systems that support io_uring.
 //! It requires Linux kernel 6.1 or newer. See [crate::iouring] for details.
 
-use super::Header;
+use super::{Header, PendingHeader};
 use crate::{
     Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut,
     iouring::{self},
@@ -31,14 +31,14 @@ use commonware_formatting::{from_hex, hex};
 use commonware_utils::sync::Mutex;
 use std::{
     fs::{self, File},
-    io::{Error as IoError, Read, Seek, SeekFrom, Write},
+    io::{Error as IoError, Read, Seek, SeekFrom},
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
-/// Reads a blob's leading bytes and resolves its header (see [super::header::resolve]).
-fn resolve_header(
+/// Reads a blob's leading bytes and classifies its header (see [super::header::classify_header]).
+fn classify_header(
     file: &mut File,
     raw_len: u64,
     versions: &RangeInclusive<u16>,
@@ -49,7 +49,7 @@ fn resolve_header(
     file.seek(SeekFrom::Start(0))
         .map_err(|_| Error::ReadFailed)?;
     file.read_exact(&mut raw).map_err(|_| Error::ReadFailed)?;
-    super::header::resolve(&raw, raw_len, versions, partition, name)
+    super::header::classify_header(&raw, raw_len, versions, partition, name)
 }
 
 /// Syncs a directory to ensure directory entry changes are durable.
@@ -130,8 +130,8 @@ impl crate::Storage for Storage {
     ) -> Result<(Blob, u64, u16), Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock
-        let _guard = self.lock.lock();
+        // Serialize opens against each other and against removal for the duration of this open.
+        let _namespace = self.lock.lock();
 
         // Construct the full path
         let path = self.storage_directory.join(partition).join(hex(name));
@@ -153,32 +153,29 @@ impl crate::Storage for Storage {
 
         let raw_len = file.metadata().map_err(|_| Error::ReadFailed)?.len();
 
-        // Handle header: existing blobs have their header read; new blobs and blobs left torn
-        // by an interrupted creation get a fresh header written.
-        let existing = resolve_header(&mut file, raw_len, &versions, partition, name)?;
-        let (logical_len, blob_version, data_offset) = match existing {
-            Some(resolved) => resolved,
+        // Existing blobs have their committed header read. New and uncommitted blobs reserve the
+        // V1 header region; its prelude, directory entries, and CRC are committed by the first
+        // durability request, not at open (creation performs no fsync).
+        let existing = classify_header(&mut file, raw_len, &versions, partition, name)?;
+        let (logical_len, blob_version, data_offset, pending_header) = match existing {
+            Some((size, version, data_offset)) => (size, version, data_offset, None),
             None => {
-                // Sync the directories before writing the header so a parseable header
-                // always implies durable directory entries (an open that parses a header
-                // never re-runs these). The storage directory is synced unconditionally:
-                // the partition directory existing in the namespace does not imply its
-                // entry is durable.
-                sync_dir(parent)?;
-                sync_dir(&self.storage_directory)?;
+                let (header, blob_version) = Header::prepare(&versions);
+                let data_offset = super::Layout::V1.data_offset();
 
-                // Truncate to zero before writing, per the [Header::create] contract.
-                let (region, blob_version) = Header::create(&versions);
-                let data_offset = region.len() as u64;
+                // Reserve the header region without writing or syncing it. Opening a blob
+                // another handle's uncommitted creation still holds is undefined behavior.
                 file.set_len(0)
                     .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
-                file.seek(SeekFrom::Start(0))
-                    .map_err(|_| Error::WriteFailed)?;
-                file.write_all(&region).map_err(|_| Error::WriteFailed)?;
-                file.sync_all()
-                    .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
+                file.set_len(data_offset)
+                    .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
 
-                (0, blob_version, data_offset)
+                (
+                    0,
+                    blob_version,
+                    data_offset,
+                    Some((header, parent.to_path_buf(), self.storage_directory.clone())),
+                )
             }
         };
 
@@ -189,6 +186,7 @@ impl crate::Storage for Storage {
             self.io_handle.clone(),
             self.pool.clone(),
             data_offset,
+            pending_header,
         );
         Ok((blob, logical_len, blob_version))
     }
@@ -266,6 +264,18 @@ pub struct Blob {
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// First-durability header commit, shared by cloned handles.
+    pending_commit: Arc<tokio::sync::Mutex<Option<Arc<PendingCommit>>>>,
+}
+
+/// A new blob's uncommitted creation: everything the first durability request needs to run the
+/// deferred two-phase commit (the withheld header bytes and the directories whose entries it
+/// must make durable). Held by the blob until that commit completes; while present, every
+/// durability request routes through the commit path.
+struct PendingCommit {
+    header: PendingHeader,
+    partition_directory: PathBuf,
+    storage_directory: PathBuf,
 }
 
 impl Clone for Blob {
@@ -277,6 +287,7 @@ impl Clone for Blob {
             io_handle: self.io_handle.clone(),
             pool: self.pool.clone(),
             data_offset: self.data_offset,
+            pending_commit: self.pending_commit.clone(),
         }
     }
 }
@@ -290,6 +301,7 @@ impl Blob {
         io_handle: iouring::Handle,
         pool: BufferPool,
         data_offset: u64,
+        pending: Option<(PendingHeader, PathBuf, PathBuf)>,
     ) -> Self {
         Self {
             partition,
@@ -298,7 +310,74 @@ impl Blob {
             io_handle,
             pool,
             data_offset,
+            pending_commit: Arc::new(tokio::sync::Mutex::new(pending.map(
+                |(header, partition_directory, storage_directory)| {
+                    Arc::new(PendingCommit {
+                        header,
+                        partition_directory,
+                        storage_directory,
+                    })
+                },
+            ))),
         }
+    }
+
+    fn sync_error(&self, error: Error) -> Error {
+        match error {
+            Error::Io(error) => {
+                Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), error)
+            }
+            error => error,
+        }
+    }
+
+    /// Completes this blob's pending first commit, if any, returning whether one was performed.
+    /// The commit runs on a detached task so a dropped caller cannot split its two-phase I/O;
+    /// concurrent clones serialize on the pending lock, and the loser sees no pending commit.
+    async fn commit_pending(&self) -> Result<bool, Error> {
+        let blob = self.clone();
+        tokio::spawn(async move { blob.commit_pending_inner().await })
+            .await
+            .map_err(|_| Error::WriteFailed)?
+    }
+
+    async fn commit_pending_inner(&self) -> Result<bool, Error> {
+        let mut pending = self.pending_commit.lock().await;
+        let Some(commit) = pending.as_ref().cloned() else {
+            return Ok(false);
+        };
+
+        // Phase 1: publish the prelude and make it, all prior user writes, and both directory
+        // entries durable before the CRC can be issued.
+        self.io_handle
+            .write_at(
+                self.file.clone(),
+                0,
+                commit.header.prelude().to_vec().into(),
+            )
+            .await?;
+        self.io_handle
+            .sync(self.file.clone())
+            .await
+            .map_err(|error| self.sync_error(error))?;
+        sync_dir(&commit.partition_directory)?;
+        sync_dir(&commit.storage_directory)?;
+
+        // Phase 2: the CRC is the commit record. Once it is durable, the preceding barriers are
+        // known to have completed.
+        self.io_handle
+            .write_at(
+                self.file.clone(),
+                PendingHeader::CHECKSUM_OFFSET,
+                commit.header.checksum().to_vec().into(),
+            )
+            .await?;
+        self.io_handle
+            .sync(self.file.clone())
+            .await
+            .map_err(|error| self.sync_error(error))?;
+        *pending = None;
+        Ok(true)
     }
 }
 
@@ -372,6 +451,16 @@ impl crate::Blob for Blob {
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
         let bufs = bufs.into();
+        // While a first commit is pending, a non-empty write_at_sync serves as that commit:
+        // route through write_at + sync so the two-phase commit runs (the fused write_at_sync
+        // fast path syncs only the file, not the header commit or directory entries).
+        if self.pending_commit.lock().await.is_some() {
+            if !bufs.has_remaining() {
+                return Ok(());
+            }
+            crate::Blob::write_at(self, offset, bufs).await?;
+            return crate::Blob::sync(self).await;
+        }
         let offset = offset
             .checked_add(self.data_offset)
             .ok_or(Error::OffsetOverflow)?;
@@ -400,16 +489,22 @@ impl crate::Blob for Blob {
     }
 
     async fn sync(&self) -> Result<(), Error> {
+        if self.commit_pending().await? {
+            return Ok(());
+        }
         self.io_handle
             .sync(self.file.clone())
             .await
-            .map_err(|err| match err {
-                Error::Io(e) => Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), e),
-                err => err,
-            })
+            .map_err(|err| self.sync_error(err))
     }
 
     async fn start_sync(&self) -> Handle<()> {
+        match self.commit_pending().await {
+            Ok(true) => return Handle::ready(Ok(())),
+            Err(error) => return Handle::ready(Err(error)),
+            Ok(false) => {}
+        }
+
         let partition = self.partition.clone();
         let name = self.name.clone();
         let receiver = self.io_handle.start_sync(self.file.clone()).await;
@@ -692,14 +787,19 @@ mod tests {
             assert_eq!(size, 0, "recovered blob should be empty");
             drop(blob);
 
-            // The recovered blob is a valid header-only file and reopens cleanly.
+            // The recovered blob reserves an uncommitted header region (all zeros): under
+            // deferred creation the prelude and CRC are written only by the first durability
+            // request, so the magic is absent until then. It still reopens cleanly.
             let raw = std::fs::read(&path).unwrap();
             assert_eq!(
                 raw.len(),
                 Layout::V1.data_offset() as usize,
-                "recovered blob should be header-only"
+                "recovered blob should reserve the header region"
             );
-            assert_eq!(&raw[..Header::MAGIC_LENGTH], &Layout::V1.magic());
+            assert!(
+                raw.iter().all(|&byte| byte == 0),
+                "reserved region is uncommitted until the first durability request"
+            );
             storage
                 .open("partition", name.as_bytes())
                 .await
@@ -1021,6 +1121,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
+            None,
         );
 
         // Read and write should fail through their wrapper-specific error enums
@@ -1080,6 +1181,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
+            None,
         );
         // Sync should fail through the blob-specific wrapper before any kernel work is attempted.
         let err = blob
@@ -1119,6 +1221,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
+            None,
         );
         let err = blob
             .start_sync()
@@ -1162,6 +1265,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
+            None,
         );
         let err = blob
             .resize(0)
@@ -1200,6 +1304,7 @@ mod tests {
             submitter.clone(),
             pool,
             Layout::V0.data_offset(),
+            None,
         );
         // The request should reach the kernel and come back as a wrapped sync failure.
         let err = blob
@@ -1238,19 +1343,25 @@ mod tests {
         let path = storage_directory.join("partition").join(hex(b"torn"));
         let region = std::fs::read(&path).unwrap();
 
-        // Simulate a torn creation: a prefix of the canonical header region (the full
-        // state enumeration lives in the Layout::interrupted_creation unit tables).
-        let states = [region[..10].to_vec()];
+        // Simulate deferred-creation torn states (the full enumeration lives in the
+        // Header::uncommitted_v1 unit tables): a reserved zero region, and a durable prelude
+        // whose CRC commit record was never written.
+        let mut prelude_only = region.clone();
+        prelude_only[8..12].fill(0);
+        let states = [vec![0u8; region.len()], prelude_only];
         for state in states {
             std::fs::write(&path, &state).unwrap();
             let (blob, size) = storage.open("partition", b"torn").await.unwrap();
             assert_eq!(size, 0);
+            blob.write_at(0, b"data".to_vec()).await.unwrap();
             blob.sync().await.unwrap();
             drop(blob);
 
-            // The healed blob round-trips through a reopen.
+            // The healed blob round-trips through a reopen with its data intact.
             let (blob, size) = storage.open("partition", b"torn").await.unwrap();
-            assert_eq!(size, 0);
+            assert_eq!(size, 4);
+            let read = blob.read_at(0, 4).await.unwrap();
+            assert_eq!(read.coalesce(), b"data");
             drop(blob);
         }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,18 +1,18 @@
-use super::Header;
+use super::{Header, PendingHeader};
 use crate::{Buf, BufferPool, Handle, IoBufs, IoBufsMut, deterministic::AuditHasher};
 use commonware_formatting::hex;
 use commonware_utils::sync::{Mutex, RwLock};
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 
-/// Resolves a blob's header from its full contents (see [super::header::resolve]).
-fn resolve_header(
+/// Classifies a blob's header from its full contents (see [super::header::classify_header]).
+fn classify_header(
     content: &[u8],
     versions: &RangeInclusive<u16>,
     partition: &str,
     name: &[u8],
 ) -> Result<Option<(u64, u16, u64)>, crate::Error> {
     let raw = &content[..Header::resolve_len(content.len() as u64)];
-    super::header::resolve(raw, content.len() as u64, versions, partition, name)
+    super::header::classify_header(raw, content.len() as u64, versions, partition, name)
 }
 
 /// In-memory storage implementation for the commonware runtime.
@@ -68,25 +68,38 @@ impl crate::Storage for Storage {
         let partition_entry = partitions.entry(partition.into()).or_default();
         let content = partition_entry.entry(name.into()).or_default();
 
-        // Handle header: existing blobs have their header read; new blobs and blobs left torn
-        // by an interrupted creation get a fresh header written.
-        let existing = resolve_header(content, &versions, partition, name)?;
-        let (logical_size, blob_version, data_offset) = existing.unwrap_or_else(|| {
-            let (region, blob_version) = Header::create(&versions);
-            let data_offset = region.len() as u64;
-            content.clear();
-            content.extend_from_slice(&region);
-            (0, blob_version, data_offset)
-        });
+        // Existing blobs have their committed header read. New and uncommitted blobs reserve the
+        // V1 header region; the first durability request publishes and commits it. Opening an
+        // uncommitted blob another handle still holds is undefined behavior (see
+        // [crate::Storage::open_versioned]), so no cross-open coordination is performed here.
+        let existing = classify_header(content, &versions, partition, name)?;
+        let (logical_size, blob_version, data_offset, pending_header) = match existing {
+            Some((size, version, data_offset)) => (size, version, data_offset, None),
+            None => {
+                let (header, blob_version) = Header::prepare(&versions);
+                let data_offset = super::Layout::V1.data_offset();
+                content.clear();
+                content.resize(data_offset as usize, 0);
+                (
+                    0,
+                    blob_version,
+                    data_offset,
+                    Some(Arc::new(PendingCreation { header })),
+                )
+            }
+        };
+        let content = content.clone();
+        drop(partitions);
 
         Ok((
             Blob::new(
                 self.partitions.clone(),
                 partition.into(),
                 name,
-                content.clone(),
+                content,
                 self.pool.clone(),
                 data_offset,
+                pending_header,
             ),
             logical_size,
             blob_version,
@@ -132,6 +145,13 @@ impl crate::Storage for Storage {
 
 type Partition = BTreeMap<Vec<u8>, Vec<u8>>;
 
+/// A new blob's uncommitted creation: the withheld header bytes the first durability request
+/// must publish. Held by the blob until that commit completes; while present, every durability
+/// request routes through the commit path.
+struct PendingCreation {
+    header: PendingHeader,
+}
+
 #[derive(Clone)]
 pub struct Blob {
     partitions: Arc<Mutex<BTreeMap<String, Partition>>>,
@@ -141,6 +161,8 @@ pub struct Blob {
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// The uncommitted creation, published by the first durability request; shared by clones.
+    pending_header: Arc<Mutex<Option<Arc<PendingCreation>>>>,
 }
 
 impl Blob {
@@ -151,6 +173,7 @@ impl Blob {
         content: Vec<u8>,
         pool: BufferPool,
         data_offset: u64,
+        pending_header: Option<Arc<PendingCreation>>,
     ) -> Self {
         Self {
             partitions,
@@ -159,7 +182,29 @@ impl Blob {
             content: Arc::new(RwLock::new(content)),
             pool,
             data_offset,
+            pending_header: Arc::new(Mutex::new(pending_header)),
         }
+    }
+
+    /// Runs the deferred header commit if this blob is still uncommitted, returning whether it
+    /// committed (in which case the contents are already published).
+    /// Runs the deferred header commit if this blob is still uncommitted, returning whether it
+    /// committed. The pending lock is held throughout so concurrent clones serialize: the loser
+    /// observes `None` and falls through to a plain sync.
+    fn commit_header(&self) -> Result<bool, crate::Error> {
+        let mut pending = self.pending_header.lock();
+        let Some(creation) = pending.clone() else {
+            return Ok(false);
+        };
+        {
+            let mut content = self.content.write();
+            let checksum_offset = PendingHeader::CHECKSUM_OFFSET as usize;
+            content[..Header::PRELUDE_SIZE].copy_from_slice(creation.header.prelude());
+            content[checksum_offset..Header::PARSE_LEN].copy_from_slice(creation.header.checksum());
+        }
+        self.sync_inner()?;
+        *pending = None;
+        Ok(true)
     }
 
     fn sync_inner(&self) -> Result<(), crate::Error> {
@@ -257,6 +302,9 @@ impl crate::Blob for Blob {
     }
 
     async fn sync(&self) -> Result<(), crate::Error> {
+        if self.commit_header()? {
+            return Ok(());
+        }
         self.sync_inner()
     }
 
@@ -413,11 +461,13 @@ mod tests {
     async fn test_blob_torn_creation_recovers() {
         let storage = Storage::new(test_pool());
 
-        // Manually insert a torn-creation leftover: a prefix of a canonical V1 header
-        // region (the full state enumeration lives in the Layout::interrupted_creation
-        // unit tables)
-        let (region, _) = Header::create(&(0..=0));
-        let states = [region[..10].to_vec()];
+        // Manually insert deferred-creation torn states: creation reserves a zero region and
+        // commits the prelude and CRC only on the first durability request, so a torn creation
+        // is a zero-or-partial region (the full enumeration is in the Header::uncommitted_v1
+        // unit tables).
+        let (mut prelude_only, _) = Header::create(&(0..=0));
+        prelude_only[8..12].fill(0); // prelude durable, CRC unwritten
+        let states = [vec![0u8; Layout::V1.data_offset() as usize], prelude_only];
         for (i, state) in states.into_iter().enumerate() {
             let name = format!("torn_{i}").into_bytes();
             {
@@ -464,24 +514,5 @@ mod tests {
         assert!(
             matches!(result, Err(crate::Error::BlobCorrupt(_, _, reason)) if reason.contains("header padding"))
         );
-    }
-
-    #[tokio::test]
-    async fn test_blob_zero_payload_with_lost_crc_stays_corrupt() {
-        let storage = Storage::new(test_pool());
-
-        // A synced V1 blob whose payload is all zeros, with the header's CRC bytes
-        // rotted away: the file extends past the header region, so healing it would
-        // erase the payload.
-        let mut raw = crate::storage::header::tests::v1_blob_bytes(0, &[0u8; 100]);
-        raw[8..12].fill(0);
-        {
-            let mut partitions = storage.partitions.lock();
-            let partition = partitions.entry("partition".into()).or_default();
-            partition.insert(b"rotted".to_vec(), raw);
-        }
-
-        let result = storage.open("partition", b"rotted").await;
-        assert!(matches!(result, Err(crate::Error::BlobCorrupt(_, _, _))));
     }
 }

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -106,7 +106,7 @@ stability_scope!(BETA {
     pub mod metered;
 
     mod header;
-    pub(crate) use header::{Header, Layout};
+    pub(crate) use header::{Header, Layout, PendingHeader};
 
     /// Validate that a partition name contains only allowed characters.
     ///

--- a/runtime/src/storage/tokio/fallback.rs
+++ b/runtime/src/storage/tokio/fallback.rs
@@ -1,3 +1,4 @@
+use super::super::PendingHeader;
 use crate::{Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut};
 use commonware_formatting::hex;
 use commonware_utils::channel::oneshot;
@@ -19,6 +20,14 @@ pub struct Blob {
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// First-durability header commit, shared by cloned handles.
+    pending_commit: Arc<Mutex<Option<Arc<PendingCommit>>>>,
+}
+
+/// A new blob's uncommitted creation: the withheld header bytes the first durability request
+/// must publish. Windows has no directory-sync notion, so name durability is best-effort.
+struct PendingCommit {
+    header: PendingHeader,
 }
 
 impl Blob {
@@ -28,6 +37,7 @@ impl Blob {
         file: fs::File,
         pool: BufferPool,
         data_offset: u64,
+        pending: Option<PendingHeader>,
     ) -> Self {
         Self {
             partition,
@@ -35,7 +45,65 @@ impl Blob {
             file: Arc::new(Mutex::new(file)),
             pool,
             data_offset,
+            pending_commit: Arc::new(Mutex::new(
+                pending.map(|header| Arc::new(PendingCommit { header })),
+            )),
         }
+    }
+
+    /// Publishes a pending first commit's two-phase I/O: write the prelude and make it (and all
+    /// prior user writes) durable, then issue the CRC commit record and make it durable in turn.
+    async fn commit_inner(
+        file: &mut fs::File,
+        partition: &str,
+        name: &[u8],
+        pending: &PendingCommit,
+    ) -> Result<(), Error> {
+        // Phase 1: publish the prelude and make it, and all prior user writes, durable before
+        // the CRC can be issued.
+        Self::write_physical_at(file, 0, pending.header.prelude()).await?;
+        Self::sync_inner(file, partition, name).await?;
+
+        // Phase 2: the CRC is the commit record. Once it is durable, the preceding barrier is
+        // known to have completed.
+        Self::write_physical_at(
+            file,
+            PendingHeader::CHECKSUM_OFFSET,
+            pending.header.checksum(),
+        )
+        .await?;
+        Self::sync_inner(file, partition, name).await
+    }
+
+    /// Completes this blob's pending first commit, if any, returning whether one was performed.
+    /// The commit runs on a detached task so a dropped caller cannot split its two-phase I/O;
+    /// concurrent clones serialize on the pending lock, and the loser sees no pending commit.
+    async fn commit_pending(&self) -> Result<bool, Error> {
+        let blob = self.clone();
+        tokio::spawn(async move { blob.commit_pending_inner().await })
+            .await
+            .map_err(|_| Error::WriteFailed)?
+    }
+
+    async fn commit_pending_inner(&self) -> Result<bool, Error> {
+        let mut pending = self.pending_commit.lock().await;
+        let Some(commit) = pending.as_ref().cloned() else {
+            return Ok(false);
+        };
+
+        {
+            let mut file = self.file.lock().await;
+            Self::commit_inner(&mut file, &self.partition, &self.name, &commit).await?;
+        }
+        *pending = None;
+        Ok(true)
+    }
+
+    async fn write_physical_at(file: &mut fs::File, offset: u64, buf: &[u8]) -> Result<(), Error> {
+        file.seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|_| Error::WriteFailed)?;
+        file.write_all(buf).await.map_err(|_| Error::WriteFailed)
     }
 
     async fn write_at_inner(
@@ -121,6 +189,15 @@ impl crate::Blob for Blob {
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
         let mut bufs = bufs.into();
+        // While a first commit is pending, a non-empty write_at_sync serves as that commit:
+        // route through write_at + sync so the two-phase commit runs.
+        if self.pending_commit.lock().await.is_some() {
+            if !bufs.has_remaining() {
+                return Ok(());
+            }
+            crate::Blob::write_at(self, offset, bufs).await?;
+            return crate::Blob::sync(self).await;
+        }
         if !bufs.has_remaining() {
             return Ok(());
         }
@@ -142,18 +219,18 @@ impl crate::Blob for Blob {
     }
 
     async fn sync(&self) -> Result<(), Error> {
+        if self.commit_pending().await? {
+            return Ok(());
+        }
         let file = self.file.lock().await;
         Self::sync_inner(&file, &self.partition, &self.name).await
     }
 
     async fn start_sync(&self) -> Handle<()> {
         let (tx, rx) = oneshot::channel();
-        let file = self.file.clone();
-        let partition = self.partition.clone();
-        let name = self.name.clone();
+        let blob = self.clone();
         tokio::spawn(async move {
-            let file = file.lock().await;
-            let result = Self::sync_inner(&file, &partition, &name).await;
+            let result = crate::Blob::sync(&blob).await;
             let _ = tx.send(result);
         });
         Handle::from_receiver(rx)

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -4,11 +4,7 @@ use commonware_formatting::{from_hex, hex};
 #[cfg(unix)]
 use std::path::Path;
 use std::{ops::RangeInclusive, path::PathBuf, sync::Arc};
-use tokio::{
-    fs,
-    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
-    sync::Mutex,
-};
+use tokio::{fs, io::AsyncReadExt, sync::Mutex};
 
 #[cfg(not(unix))]
 mod fallback;
@@ -58,8 +54,8 @@ pub struct Storage {
     pool: BufferPool,
 }
 
-/// Reads a blob's leading bytes and resolves its header (see [super::header::resolve]).
-async fn resolve_header(
+/// Reads a blob's leading bytes and classifies its header (see [super::header::classify_header]).
+async fn classify_header(
     file: &mut fs::File,
     raw_len: u64,
     versions: &RangeInclusive<u16>,
@@ -70,7 +66,7 @@ async fn resolve_header(
     file.read_exact(&mut raw)
         .await
         .map_err(|_| Error::ReadFailed)?;
-    super::header::resolve(&raw, raw_len, versions, partition, name)
+    super::header::classify_header(&raw, raw_len, versions, partition, name)
 }
 
 impl Storage {
@@ -97,8 +93,8 @@ impl crate::Storage for Storage {
     ) -> Result<(Self::Blob, u64, u16), Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock. The guard is owned so the creation path can move it
-        // into a task that outlives a dropped open future.
+        // Acquire the filesystem lock. The guard is owned so the creation path can move it into
+        // a task that outlives a dropped open future (see the creation arm).
         let guard = self.lock.clone().lock_owned().await;
 
         // Construct the full path
@@ -128,70 +124,79 @@ impl crate::Storage for Storage {
         // Set the maximum buffer size
         file.set_max_buf_size(self.cfg.maximum_buffer_size);
 
-        // Handle header: existing blobs have their header read; new blobs and blobs left torn
-        // by an interrupted creation get a fresh header written.
-        let existing = resolve_header(&mut file, raw_len, &versions, partition, name).await?;
-        let (file, guard, (logical_size, blob_version, data_offset)) = match existing {
-            Some(resolved) => (file, guard, resolved),
+        // Existing blobs have their committed header read. New and uncommitted blobs reserve the
+        // V1 header region; its prelude, directory entries, and CRC are committed by the first
+        // durability request, not at open (creation performs no fsync).
+        let existing = classify_header(&mut file, raw_len, &versions, partition, name).await?;
+        let (file, guard, logical_size, blob_version, data_offset, pending_header) = match existing
+        {
+            Some((size, version, data_offset)) => (file, guard, size, version, data_offset, None),
             None => {
-                // Run creation to completion on a task that owns the filesystem lock:
-                // dropping the open future must not abandon the sequence half-done (a
-                // straggling truncate could clobber a successor's blob) or leave a later
-                // open trusting a header whose syncs never ran. The task hands the lock
-                // back so the open holds it until the blob is returned, like the reopen
-                // path.
-                let parent = parent.to_path_buf();
-                let storage_directory = self.cfg.storage_directory.clone();
+                let (header, blob_version) = Header::prepare(&versions);
+                let data_offset = super::Layout::V1.data_offset();
+
+                // Reserve the header region on a task that owns the filesystem lock: set_len is
+                // backed by spawn_blocking and outlives a dropped open future, so a cancelled
+                // open must not release the lock while a straggling truncate could still clobber
+                // a successor's blob. The task hands the lock back so the open holds it until the
+                // blob is returned. Nothing durable is written; the header commits on first sync.
                 let err_partition = partition.to_string();
                 let err_name = hex(name);
                 let creation = tokio::task::spawn(async move {
-                    // Sync the directories before writing the header so a parseable
-                    // header always implies durable directory entries (an open that
-                    // parses a header never re-runs these). The storage directory is
-                    // synced unconditionally: the partition directory existing in the
-                    // namespace does not imply its entry is durable. (Windows has no
-                    // notion of syncing a directory entry; see
-                    // https://github.com/commonwarexyz/monorepo/issues/2026.)
-                    #[cfg(unix)]
-                    {
-                        sync_dir(&parent).await?;
-                        sync_dir(&storage_directory).await?;
-                    }
-                    #[cfg(not(unix))]
-                    let _ = (parent, storage_directory);
-
-                    // Truncate to zero before writing, per the [Header::create] contract.
-                    let (region, blob_version) = Header::create(&versions);
-                    let data_offset = region.len() as u64;
                     file.set_len(0).await.map_err(|e| {
                         Error::BlobResizeFailed(err_partition.clone(), err_name.clone(), e.into())
                     })?;
-                    file.rewind().await.map_err(|_| Error::WriteFailed)?;
-                    file.write_all(&region)
+                    file.set_len(data_offset)
                         .await
-                        .map_err(|_| Error::WriteFailed)?;
-                    file.sync_all()
-                        .await
-                        .map_err(|e| Error::BlobSyncFailed(err_partition, err_name, e.into()))?;
-
-                    Ok::<_, Error>((file, guard, (0, blob_version, data_offset)))
+                        .map_err(|e| Error::BlobResizeFailed(err_partition, err_name, e.into()))?;
+                    Ok::<_, Error>((file, guard))
                 });
-                match creation.await {
+                let (file, guard) = match creation.await {
                     Ok(result) => result?,
                     Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
                     Err(_) => return Err(Error::Closed),
-                }
+                };
+
+                (file, guard, 0, blob_version, data_offset, Some(header))
             }
         };
 
-        // Convert to a blocking std::fs::File
+        // Construct the blob while still holding the filesystem lock. On Unix the pending
+        // creation carries the directories the first commit must make durable; Windows has
+        // no directory-sync notion (https://github.com/commonwarexyz/monorepo/issues/2026).
         #[cfg(unix)]
-        let file = file.into_std().await;
-
-        // Construct the blob while still holding the filesystem lock.
-        let blob = Self::Blob::new(partition.into(), name, file, self.pool.clone(), data_offset);
-        drop(guard);
-        Ok((blob, logical_size, blob_version))
+        {
+            let file = file.into_std().await;
+            let blob = Self::Blob::new(
+                partition.into(),
+                name,
+                file,
+                self.pool.clone(),
+                data_offset,
+                pending_header.map(|header| {
+                    (
+                        header,
+                        parent.to_path_buf(),
+                        self.cfg.storage_directory.clone(),
+                    )
+                }),
+            );
+            drop(guard);
+            Ok((blob, logical_size, blob_version))
+        }
+        #[cfg(not(unix))]
+        {
+            let blob = Self::Blob::new(
+                partition.into(),
+                name,
+                file,
+                self.pool.clone(),
+                data_offset,
+                pending_header,
+            );
+            drop(guard);
+            Ok((blob, logical_size, blob_version))
+        }
     }
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
@@ -492,12 +497,12 @@ mod tests {
         let path = storage_directory.join("partition").join(hex(b"torn"));
         let region = std::fs::read(&path).unwrap();
 
-        // Simulate torn creations (the full state enumeration lives in the
-        // Layout::interrupted_creation unit tables): a file truncated mid-CRC and the same
-        // prefix at a persisted full length.
-        let mut torn_content = vec![0u8; region.len()];
-        torn_content[..10].copy_from_slice(&region[..10]);
-        let states = [region[..10].to_vec(), torn_content];
+        // Simulate deferred-creation torn states (the full enumeration lives in the
+        // Header::uncommitted_v1 unit tables): a reserved zero region, and a durable prelude
+        // whose CRC commit record was never written.
+        let mut prelude_only = region.clone();
+        prelude_only[8..12].fill(0);
+        let states = [vec![0u8; region.len()], prelude_only];
         for state in states {
             std::fs::write(&path, &state).unwrap();
             let (blob, size) = storage.open("partition", b"torn").await.unwrap();
@@ -731,14 +736,19 @@ mod tests {
             assert_eq!(size, 0, "recovered blob should be empty");
             drop(blob);
 
-            // The recovered blob is a valid header-only file and reopens cleanly.
+            // The recovered blob reserves an uncommitted header region (all zeros): under
+            // deferred creation the prelude and CRC are written only by the first durability
+            // request, so the magic is absent until then. It still reopens cleanly.
             let raw = std::fs::read(&path).unwrap();
             assert_eq!(
                 raw.len(),
                 Layout::V1.data_offset() as usize,
-                "recovered blob should be header-only"
+                "recovered blob should reserve the header region"
             );
-            assert_eq!(&raw[..Header::MAGIC_LENGTH], &Layout::V1.magic());
+            assert!(
+                raw.iter().all(|&byte| byte == 0),
+                "reserved region is uncommitted until the first durability request"
+            );
             storage
                 .open("partition", name.as_bytes())
                 .await

--- a/runtime/src/storage/tokio/unix.rs
+++ b/runtime/src/storage/tokio/unix.rs
@@ -1,3 +1,4 @@
+use super::super::PendingHeader;
 use crate::{Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut};
 use cfg_if::cfg_if;
 use commonware_formatting::hex;
@@ -6,13 +7,24 @@ use std::{
     fs::File,
     io::IoSlice,
     os::{fd::AsRawFd, unix::fs::FileExt},
+    path::{Path, PathBuf},
     sync::Arc,
 };
-use tokio::task;
+use tokio::{sync::Mutex, task};
 
 // Cap iovec batch size: larger iovecs reduce syscall count but increase
 // per-write kernel setup overhead.
 const IOVEC_BATCH_SIZE: usize = 32;
+
+/// A new blob's uncommitted creation: everything the first durability request needs to run the
+/// deferred two-phase commit (the withheld header bytes and the directories whose entries it
+/// must make durable). Held by the blob until that commit completes; while present, every
+/// durability request routes through the commit path.
+struct PendingCommit {
+    header: PendingHeader,
+    partition_directory: PathBuf,
+    storage_directory: PathBuf,
+}
 
 #[derive(Clone)]
 pub struct Blob {
@@ -22,15 +34,18 @@ pub struct Blob {
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// First-durability header commit, shared by cloned handles.
+    pending_commit: Arc<Mutex<Option<Arc<PendingCommit>>>>,
 }
 
 impl Blob {
-    pub fn new(
+    pub(super) fn new(
         partition: String,
         name: &[u8],
         file: File,
         pool: BufferPool,
         data_offset: u64,
+        pending: Option<(PendingHeader, PathBuf, PathBuf)>,
     ) -> Self {
         Self {
             partition,
@@ -38,7 +53,85 @@ impl Blob {
             file: Arc::new(file),
             pool,
             data_offset,
+            pending_commit: Arc::new(Mutex::new(pending.map(
+                |(header, partition_directory, storage_directory)| {
+                    Arc::new(PendingCommit {
+                        header,
+                        partition_directory,
+                        storage_directory,
+                    })
+                },
+            ))),
         }
+    }
+
+    fn sync_dir(path: &Path) -> Result<(), Error> {
+        let dir = File::open(path).map_err(|e| {
+            Error::BlobOpenFailed(
+                path.to_string_lossy().into_owned(),
+                "directory".into(),
+                e.into(),
+            )
+        })?;
+        dir.sync_all().map_err(|e| {
+            Error::BlobSyncFailed(
+                path.to_string_lossy().into_owned(),
+                "directory".into(),
+                e.into(),
+            )
+        })
+    }
+
+    /// Runs a pending first commit's two-phase I/O: publishes the prelude and makes it, all
+    /// prior user writes, the file length, and both directory entries durable, then issues the
+    /// CRC commit record and makes it durable in turn. Must run under the creation gate.
+    fn commit_inner(
+        file: &File,
+        partition: &str,
+        name: &[u8],
+        pending: &PendingCommit,
+    ) -> Result<(), Error> {
+        // Phase 1: publish the prelude and make it, all prior user writes, and both directory
+        // entries durable before the CRC can be issued.
+        Self::write_single_at(file, 0, pending.header.prelude())?;
+        Self::sync_inner(file, partition, name)?;
+        Self::sync_dir(&pending.partition_directory)?;
+        Self::sync_dir(&pending.storage_directory)?;
+
+        // Phase 2: the CRC is the commit record. Once it is durable, the preceding barriers are
+        // known to have completed.
+        Self::write_single_at(
+            file,
+            PendingHeader::CHECKSUM_OFFSET,
+            pending.header.checksum(),
+        )?;
+        Self::sync_inner(file, partition, name)
+    }
+
+    /// Completes this blob's pending first commit, if any, returning whether one was performed.
+    /// The commit runs on a detached task so a dropped caller cannot split its two-phase I/O;
+    /// concurrent clones serialize on the pending lock, and the loser sees no pending commit.
+    async fn commit_pending(&self) -> Result<bool, Error> {
+        let blob = self.clone();
+        task::spawn(async move { blob.commit_pending_inner().await })
+            .await
+            .map_err(|_| Error::WriteFailed)?
+    }
+
+    async fn commit_pending_inner(&self) -> Result<bool, Error> {
+        let mut pending = self.pending_commit.lock().await;
+        let Some(commit) = pending.as_ref().cloned() else {
+            return Ok(false);
+        };
+
+        let file = self.file.clone();
+        let partition = self.partition.clone();
+        let name = self.name.clone();
+        task::spawn_blocking(move || Self::commit_inner(&file, &partition, &name, &commit))
+            .await
+            .map_err(|_| Error::WriteFailed)??;
+        *pending = None;
+        Ok(true)
     }
 
     fn sync_inner(file: &File, partition: &str, name: &[u8]) -> Result<(), Error> {
@@ -172,6 +265,16 @@ impl crate::Blob for Blob {
         bufs: impl Into<IoBufs> + Send,
     ) -> Result<(), Error> {
         let bufs = bufs.into();
+        // While a first commit is pending, a non-empty write_at_sync serves as that commit:
+        // route through write_at + sync so the two-phase commit runs (the RWF_SYNC fast path
+        // syncs only the file, not the header commit or directory entries).
+        if self.pending_commit.lock().await.is_some() {
+            if !bufs.has_remaining() {
+                return Ok(());
+            }
+            crate::Blob::write_at(self, offset, bufs).await?;
+            return crate::Blob::sync(self).await;
+        }
         let file = self.file.clone();
         let offset = offset
             .checked_add(self.data_offset)
@@ -217,6 +320,9 @@ impl crate::Blob for Blob {
     }
 
     async fn sync(&self) -> Result<(), Error> {
+        if self.commit_pending().await? {
+            return Ok(());
+        }
         let file = self.file.clone();
         let partition = self.partition.clone();
         let name = self.name.clone();
@@ -230,11 +336,9 @@ impl crate::Blob for Blob {
 
     async fn start_sync(&self) -> Handle<()> {
         let (tx, rx) = oneshot::channel();
-        let file = self.file.clone();
-        let partition = self.partition.clone();
-        let name = self.name.clone();
-        task::spawn_blocking(move || {
-            let result = Self::sync_inner(&file, &partition, &name);
+        let blob = self.clone();
+        tokio::spawn(async move {
+            let result = crate::Blob::sync(&blob).await;
             let _ = tx.send(result);
         });
         Handle::from_receiver(rx)

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -52,19 +52,19 @@ hash = "13b3e99a8c74b50dc18150194a92306de670b94e6642758feb6d9b6e9881f827"
 
 ["commonware_storage::journal::conformance::StorageConformance<AuthenticatedMmbWorkload>"]
 n_cases = 256
-hash = "74d03c4e36ba59834df32aa131bc6ad659dc55b1dab5e5926b9aa033d0ed821f"
+hash = "09ef68a7c611fdddd3f50a652a50f5f2285df1cb4d013758244b1d5208200f48"
 
 ["commonware_storage::journal::conformance::StorageConformance<AuthenticatedMmrWorkload>"]
 n_cases = 256
-hash = "9eec5df6e9016f6d3fb2317bc0d1e0a969ee3ef6efa4ee6a04770a1e533116b8"
+hash = "957528c511c98526b446682f08b02ce2584fe5cd8ae28a3c7bbef4df51451643"
 
 ["commonware_storage::journal::conformance::StorageConformance<ContiguousFixedWorkload>"]
 n_cases = 512
-hash = "627ba252d6f69ef04e74cc493024712e8701ffc3fc27576858eb67995532e5a9"
+hash = "6447f8cef7cf37a8630fda92d20ba3699af77836232116b49c682e1195d6f8ad"
 
 ["commonware_storage::journal::conformance::StorageConformance<ContiguousVariableWorkload>"]
 n_cases = 512
-hash = "595d3b70ca5c4482669d6d1356b63870f319a78b9365211517b03b526eb25f64"
+hash = "5b2544c90344ef545d934294a9e3ac15209b0562bc419bf2de1493e81d263ac0"
 
 ["commonware_storage::journal::conformance::StorageConformance<SegmentedFixedWorkload>"]
 n_cases = 512
@@ -92,11 +92,11 @@ hash = "4078ce1f5e242f8edb1d41575d51e166af620404036124f8094fc74d4b401047"
 
 ["commonware_storage::merkle::conformance::tests::StorageConformance<MmbFullWorkload>"]
 n_cases = 256
-hash = "e1bb3e91b15311352a0696ab40600747292876fcaf3f8e1188d071d603761b7d"
+hash = "e70b383bae642ebce9ab36851e671b90a7e3f4fb08f7985c037ce63dfbe60281"
 
 ["commonware_storage::merkle::conformance::tests::StorageConformance<MmrFullWorkload>"]
 n_cases = 256
-hash = "a6e586229899a2361b90cb2a208953ecaec6b23c98ec356d4a50c57be5eeb645"
+hash = "82de36ff726be9938d37eec0da7462f40767c1c0b0d50581b8063b73cf9cb384"
 
 ["commonware_storage::merkle::mmr::proof::tests::conformance::CodecConformance<Proof<Family,Sha256Digest>>"]
 n_cases = 65536
@@ -300,131 +300,131 @@ hash = "d6b0f89534be60d85f5754c16574536d84899fce930dfc182ef973475d3078e4"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbOrderedFixedStorage>"]
 n_cases = 64
-hash = "8865dbff79b343e15be6248f7c9b9ecbcee4ce62fc6ce6ad74a10aeba0b037ca"
+hash = "4455e1c211dee60b7747f5e9feda5097bb02706a77b8d514cf3b92b06e2c884c"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbOrderedVariableStorage>"]
 n_cases = 64
-hash = "08fa4a62f53a26a2bdebd93302dcf961aab3f50b11a576239b9e65cfb135a7e0"
+hash = "fd4bea9f5e075b3df215fde79feb5afcba3b7a204bcaea2d94615a88e6d5c124"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbUnorderedFixedStorage>"]
 n_cases = 64
-hash = "e27ea4efaa3ca3fb1a9bda6e1e4989f6636f9b064aabbbca70dbaab906f0bc01"
+hash = "94da5e3acc8c6e95e034d2d0dc8aa53f7a0fae25ac0b953ff0f0bd85617b60f2"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbUnorderedVariableStorage>"]
 n_cases = 64
-hash = "4bcfc84a06a52c0a27de3d1bf87ffce490a0fe2150bd5350908c49020c5e820d"
+hash = "bbd2626b2b30816704b4f630e190fcc2812200774e68aff2561e38ebfccacd26"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrOrderedFixedStorage>"]
 n_cases = 64
-hash = "2c31e793a22f349c713cbe43fae4494ee39b9eb91e7085ee1ba9add1509c1b6b"
+hash = "d08fee3fdd7c0a28b671ea9a31fd0d9a1db0c300535213c448531f51d57929ea"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrOrderedVariableStorage>"]
 n_cases = 64
-hash = "45cb75ee32c6455b2cbefbc9e6c791f782f1992e39713b548c7d61894597a4d8"
+hash = "7873145822ead2aee2bae9a23fb21e147cfc5fcf14ca82d8180a4aea84994751"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrUnorderedFixedStorage>"]
 n_cases = 64
-hash = "6ec3a1e38743976cf2132583e80dce3429ea8cc59b8a765a7eb293eaeddb3055"
+hash = "ac92cf0083384b995d5494c7ed755da15c096b7237d982f9e4784ca40e4ad0ab"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrUnorderedVariableStorage>"]
 n_cases = 64
-hash = "3025d50d87c472227cc38a59c939454f2c9ca07d5c4b8fe614a9a54d961c3f45"
+hash = "424a41e4c83824c1d96955b2c17c39cb3093fa606624bb711725e6771d72f252"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbOrderedFixedStorage>"]
 n_cases = 64
-hash = "52203c4160810631e6f8f02697970ed2db6a15be433be848eeb3de311a5ca1ac"
+hash = "d16ae606c70b0ebee4de825c8bbdab1ff39388a3c477d21828667593719a2578"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbOrderedVariableStorage>"]
 n_cases = 64
-hash = "9b859e3d42869a0305e538584d914b691fc7a236de01ce3da68093eb26111aba"
+hash = "daec073ff1ed335711bcea47f2b09d6460479ffe844b573b521cb70bac0dc46f"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbUnorderedFixedStorage>"]
 n_cases = 64
-hash = "a33d79be75ae3db4f7c8f706cbb9707326adf070cb67ddf673fabcd17afab6eb"
+hash = "1dc7af1e6d8a8c3f5e98418f2fa71376a1257cb95623bfac8aad27d2d0169637"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbUnorderedVariableStorage>"]
 n_cases = 64
-hash = "244811c362aa673e3f573f233b58c379671c64c26784acbb49343a3144fb90b0"
+hash = "94cc4d90b01a77e578e10a9366bb40546062e309371fb9ff1fd945a8dfab9821"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrOrderedFixedStorage>"]
 n_cases = 64
-hash = "abb6e4b1281d59e7fb5a223bc906c1989b3fd652533c2f94bea14c1b8cf4de08"
+hash = "e30d27b12ee37b7de6f9ae35773b7069a34626bd69527a88654a87a34c3213ec"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrOrderedVariableStorage>"]
 n_cases = 64
-hash = "f2f7bd0129408519e54778487759de2e8ea7dedc239229cf389529f5e1621179"
+hash = "a47c0234abcb0e61c5915695223ea2666c459c79da4b776b541e85313d6831be"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrUnorderedFixedStorage>"]
 n_cases = 64
-hash = "7bf844eb896054ec13e2912e53c26f464fa56ac7431e1f7200cd6a8a4dcec944"
+hash = "d68a86a8601da83bb60b0b04f7b50df5881ace0b82c3acefe17524b66c4e26f7"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrUnorderedVariableStorage>"]
 n_cases = 64
-hash = "02d3fa9305fed943c9ade46fe6c6e9eba9c06621aa120f02bbd79b3f81589540"
+hash = "2ca587ce1475a18cc4298ba86ec04c9aa876ca55eeaf2a00edd4825c888ea2ac"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbCompactFixedStorage>"]
 n_cases = 64
-hash = "a0c9acaef2b9fada1d623fb9bae7f7835539aebe408fdd0d801986c86eddd125"
+hash = "eba62ddd620593b21554b278b2b7a25e8b71a0ac083c270a7a9cf7afe759fe08"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbCompactVariableStorage>"]
 n_cases = 64
-hash = "15bb7b90c800f1c8d27f9bec2ca765c9f14782a341bdcb9144e09d836c7cc8ca"
+hash = "230ba2bde654e75ed3b03c869be9452614a8847bad6b7edc9077493c78213328"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbFixedStorage>"]
 n_cases = 64
-hash = "312105a085f950c933da73418c5bb1e7595247d27e52a2c3c7589ac4db75cdeb"
+hash = "e26ab335232e91eea4b7b2ec4693e1557459a3ff4d23581970edc31cdefd5b71"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbVariableStorage>"]
 n_cases = 64
-hash = "83a12aee531340131135b182651b53de86325e71122796be29b6b9708acfdaa9"
+hash = "10e883cf5aff7d01207b1e41d7214787f58214daf69f8038fe053d0e3c206d6e"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrCompactFixedStorage>"]
 n_cases = 64
-hash = "767a38711571e2893ff641f8ffce454b3dc890c4c848e711902b4c90a320646b"
+hash = "9a0375c4d7459bc885a95d408b340c2fd21a19a88f8dc1cc64ca47080cb74541"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrCompactVariableStorage>"]
 n_cases = 64
-hash = "5d82b14cbc49e2cd878d0c683ea88219b04c20d90d76ddeae8793b6bae797f7a"
+hash = "bbb9b2029f22ad1a8ebcf7d56b629d69f87a6336a17e0a0e825cd7f91a95ce95"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrFixedStorage>"]
 n_cases = 64
-hash = "3cf7ae2e5798fc7c78699f59c835552b49ee8b4355f4e8d49cd9659ba20bfd21"
+hash = "17e7189063aefb1d7fba70f19e56f8056c878b6c477eaf297f5295114eae23d4"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrVariableStorage>"]
 n_cases = 64
-hash = "9f48c1fa5f420774726c6271f3f1180ab293c5fdb39cfd3e7e1c3be3551d57fe"
+hash = "15031032405fea2371556f10914178d2f86ffed85d1829819ac390e1d4196e25"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbCompactFixedStorage>"]
 n_cases = 64
-hash = "6a0b77ab225335c548d5c8e49cf41361c8900a116ddb5a2e68f581bd13cdf1cd"
+hash = "37d36d7f19f6f7c7e7d86ec9380666a278a67112e3c7209a72d8af2183ec2a60"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbCompactVariableStorage>"]
 n_cases = 64
-hash = "418eec9ff6e231951bc5c9f0e6021f5af643bfed7859eb4695af403344eb6fcb"
+hash = "24ea97fda72e95b7a7e864bec96787af6508dd6071a0a7245504d34879df200a"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbFixedStorage>"]
 n_cases = 64
-hash = "46bb0f05abd856a34be672ee5ef1a319a1fc4bc724d9f45439b4490d43e071b8"
+hash = "467f6b37ce6910d15fdedcbeb5a37adbe9455ac86f07cdd6f8ee267aecd54f9e"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbVariableStorage>"]
 n_cases = 64
-hash = "98f24f75150d38e7c7151887dc0deb4ad5eb1190d1790ba304aaf78141e970f8"
+hash = "825010594b4aeea14b1b450d174fea61cca0f34191af8edef96cf3b90ff3b1d2"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrCompactFixedStorage>"]
 n_cases = 64
-hash = "ee43661be83069608fe7b4c9956480efb6925ea1b51af1c2b1e71bbabfb0a9c1"
+hash = "08b18b45b2806a820993f86470b28dbca6f2e8880c46538e9bf67b81438b2229"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrCompactVariableStorage>"]
 n_cases = 64
-hash = "3945b645594d6f803b7dc4279b8bb17e92ce23bbb30dae2e98646ceaa0f6425d"
+hash = "606895a36b4b451b35d6626994da3da4a1eac09e48bbe84993bb1dd8a4e6d05d"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrFixedStorage>"]
 n_cases = 64
-hash = "182b01f2749b189e6a4c14c3a5c10e1c06600c6aedf01496c119cd01fbd5ba0e"
+hash = "4eed2162666a7165e36c60ee51ee1a5823f3133927bd8a4308e5a7fe81289f27"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrVariableStorage>"]
 n_cases = 64
-hash = "a023b1399b8656e8e113787f935d10013606440d43c8cb7c818749f6f09fc2fd"
+hash = "e8fff8f1e79298a97f7b3cb3d6fb1ed23d53f0fdab05903211ce3cf875733f6e"
 
 ["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmb::Family,U64,FixedEncoding<U64>\n,Sha256Digest,32>>"]
 n_cases = 65536
@@ -508,4 +508,4 @@ hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
 
 ["commonware_storage::queue::conformance::StorageConformance<QueueWorkload>"]
 n_cases = 512
-hash = "af39c4e1fccf63cac68a7866703d7764c3baf3be3e3906460dc4fab9c7ffd19d"
+hash = "5b80dfb32dfa15c6f79442989f356c3798f25c423a486f660a83f8d814b1d258"

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -155,6 +155,16 @@ pub(super) struct Writable<E: Context> {
 
     /// Sync of the live tail. Kept on failure so later operations keep failing.
     tail_sync: Option<SyncCompletion>,
+
+    /// Test-only: park [Self::seal_tail] at entry so tests can drop an append future at the
+    /// roll-over await, leaving the logical end ahead of the physical tail.
+    #[cfg(test)]
+    pub(super) halt_seal_tail: bool,
+
+    /// Test-only: park [Self::prune] after tracking advances but before any unlink, so tests
+    /// can drop a prune future that leaves every condemned file behind, untracked.
+    #[cfg(test)]
+    pub(super) halt_prune_unlinks: bool,
 }
 
 impl<E: Context> Writable<E> {
@@ -224,6 +234,10 @@ impl<E: Context> Writable<E> {
             sealed_snapshot: None,
             tail_predecessor_sync: None,
             tail_sync: None,
+            #[cfg(test)]
+            halt_seal_tail: false,
+            #[cfg(test)]
+            halt_prune_unlinks: false,
         })
     }
 
@@ -270,6 +284,11 @@ impl<E: Context> Writable<E> {
 
     /// Seal the tail, start syncing it, and open the next blob as the new tail.
     pub(super) async fn seal_tail(&mut self) -> Result<(), Error> {
+        #[cfg(test)]
+        if self.halt_seal_tail {
+            std::future::pending::<()>().await;
+        }
+
         self.drain_tail_predecessor_sync().await?;
         // seal() waits only for syncs the writer started: a commit whose flush failed before its
         // sync began is retained solely in the tail sync slot, so it must be drained here too.
@@ -293,9 +312,10 @@ impl<E: Context> Writable<E> {
         Ok(())
     }
 
-    /// Drop every blob below `min_blob` and remove its file, oldest-first. Safe with live readers:
-    /// snapshot readers keep their own handles, which the runtime's read-after-remove contract keeps
-    /// valid.
+    /// Drop and remove every blob below `min_blob`.
+    ///
+    /// Safe with live readers: snapshot readers keep their own handles, which the runtime's
+    /// read-after-remove contract keeps valid.
     ///
     /// # Invariants
     ///
@@ -311,11 +331,18 @@ impl<E: Context> Writable<E> {
         self.sealed_snapshot = None;
         self.oldest_blob_index = min_blob;
 
-        for blob in prev_oldest_blob_index..min_blob {
-            self.partition.remove(blob).await?;
-            self.metrics.tracked.dec();
-            self.metrics.pruned.inc();
+        #[cfg(test)]
+        if self.halt_prune_unlinks {
+            std::future::pending::<()>().await;
         }
+
+        // Remove blobs concurrently. (Some backends serialize removals internally, so concurrency
+        // is an upper bound, not a guarantee.)
+        let partition = &self.partition;
+        try_join_all((prev_oldest_blob_index..min_blob).map(|blob| partition.remove(blob))).await?;
+
+        self.metrics.tracked.dec_by(drop_count as i64);
+        self.metrics.pruned.inc_by(drop_count as u64);
         Ok(())
     }
 
@@ -391,9 +418,9 @@ impl<E: Context> Writable<E> {
         self.drain_tail_predecessor_sync().await?;
         self.drain_tail_sync().await?;
 
-        for blob in self.oldest_blob_index..=self.tail_blob_index() {
-            self.partition.remove(blob).await?;
-        }
+        // Remove the whole partition: a cancelled prune may leave untracked blob files
+        // whose contents would become visible again after resetting the boundary.
+        Partition::remove_all(&self.partition.context, &self.partition.name).await?;
         let _ = self.metrics.tracked.try_set(0);
         self.tail = self.partition.open(tail_blob).await?;
         self.metrics.tracked.inc();

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -68,7 +68,7 @@ impl<E: Context> Partition<E> {
     }
 
     /// Scan a partition's blob names, treating a missing partition as empty.
-    async fn scan_names(context: &E, name: &str) -> Result<Vec<Vec<u8>>, Error> {
+    pub(super) async fn scan_names(context: &E, name: &str) -> Result<Vec<Vec<u8>>, Error> {
         match context.scan(name).await {
             Ok(names) => Ok(names),
             Err(RError::PartitionMissing(_)) => Ok(Vec::new()),

--- a/storage/src/journal/contiguous/checkpoint.rs
+++ b/storage/src/journal/contiguous/checkpoint.rs
@@ -5,9 +5,8 @@
 //! the first one that is missing or too short, since everything after a gap is unreachable.
 //! The [Checkpoint] records the three facts that blob state alone cannot provide:
 //!
-//! - The pruning boundary, when it falls mid-blob (from
-//!   [Journal::init_at_size](super::fixed::Journal::init_at_size)): recovery needs the exact
-//!   position where the oldest blob's items begin.
+//! - The pruning boundary: recovery needs the intended first retained position so it can
+//!   complete an interrupted prune instead of inferring intent from which blobs survive.
 //! - The recovery watermark: a floor on the journal size that has been durably recorded. Items
 //!   below the watermark must survive a crash; items above it may be replayed, discarded, or (after
 //!   an in-place rewind followed by new appends) decode to a value from neither the pre- nor
@@ -20,11 +19,13 @@
 //!
 //! [Checkpoint] is a passive store; the journal upholds these by ordering its calls:
 //!
-//! - An entry advances only after the blob state it describes is durable.
+//! - The pruning boundary advances before blobs are removed, committing the prune so recovery can
+//!   finish it after a crash.
+//! - The recovery watermark advances only after the blob state it describes is durable.
 //! - An entry is lowered before blob state moves backward (rewind, clear).
 //!
-//! Together they keep the checkpoint a safe under-estimate of what is on disk: recovery may find
-//! more durable data than the checkpoint claims, never less.
+//! Together they make backward operations recoverable without requiring blob presence alone to
+//! prove what the journal intended.
 
 use crate::{
     Context,
@@ -33,8 +34,8 @@ use crate::{
 };
 use commonware_utils::sequence::VecU64;
 
-/// Key for the mid-blob pruning boundary. Absent when the boundary is blob-aligned (it is then
-/// derived from the oldest blob).
+/// Key for the pruning boundary. Legacy checkpoints may omit blob-aligned boundaries, in which
+/// case recovery derives the boundary from the oldest blob once and persists it explicitly.
 const PRUNING_BOUNDARY_KEY: u64 = 1;
 
 /// Key for the target of an in-progress clear.
@@ -46,6 +47,11 @@ const RECOVERY_WATERMARK_KEY: u64 = 3;
 /// The journal's durable recovery checkpoint.
 pub(super) struct Checkpoint<E: Context> {
     metadata: Metadata<E, u64, VecU64>,
+
+    /// Test-only: park [Self::persist] after its durable sync so tests can drop a pending
+    /// prune future at the point where the boundary is durable but the call never returns.
+    #[cfg(test)]
+    pub(super) halt_after_persist_sync: bool,
 }
 
 impl<E: Context> Checkpoint<E> {
@@ -59,7 +65,11 @@ impl<E: Context> Checkpoint<E> {
             },
         )
         .await?;
-        Ok(Self { metadata })
+        Ok(Self {
+            metadata,
+            #[cfg(test)]
+            halt_after_persist_sync: false,
+        })
     }
 
     /// Read a `u64`-valued entry, if present.
@@ -72,7 +82,7 @@ impl<E: Context> Checkpoint<E> {
         self.get(RECOVERY_WATERMARK_KEY)
     }
 
-    /// The recorded mid-blob pruning boundary, if any.
+    /// The recorded pruning boundary, if any.
     pub(super) fn boundary_hint(&self) -> Option<u64> {
         self.get(PRUNING_BOUNDARY_KEY)
     }
@@ -83,19 +93,8 @@ impl<E: Context> Checkpoint<E> {
     }
 
     /// Durably record the boundary and watermark, writing only entries that changed.
-    pub(super) async fn persist(
-        &mut self,
-        items_per_blob: u64,
-        boundary: u64,
-        watermark: u64,
-    ) -> Result<(), Error> {
-        // A blob-aligned boundary is derived from the oldest blob, so the entry is only kept
-        // while the boundary is mid-blob.
-        if boundary.is_multiple_of(items_per_blob) {
-            if self.boundary_hint().is_some() {
-                self.metadata.remove(&PRUNING_BOUNDARY_KEY);
-            }
-        } else if self.boundary_hint() != Some(boundary) {
+    pub(super) async fn persist(&mut self, boundary: u64, watermark: u64) -> Result<(), Error> {
+        if self.boundary_hint() != Some(boundary) {
             self.metadata.put(PRUNING_BOUNDARY_KEY, boundary.into());
         }
         if self.watermark() != Some(watermark) {
@@ -103,7 +102,14 @@ impl<E: Context> Checkpoint<E> {
         }
         // Always sync, even if this call staged nothing: `lower_watermark` stages without syncing,
         // so skipping the sync when our own entries are unchanged could drop that pending change.
-        self.sync().await
+        self.sync().await?;
+
+        #[cfg(test)]
+        if self.halt_after_persist_sync {
+            std::future::pending::<()>().await;
+        }
+
+        Ok(())
     }
 
     /// Lower the watermark to at most `limit`, returning whether it changed. Called before
@@ -128,13 +134,9 @@ impl<E: Context> Checkpoint<E> {
 
     /// Durably complete a clear to `target`: drop the intent and record `target` as both the
     /// boundary and the watermark.
-    pub(super) async fn finish_clear(
-        &mut self,
-        items_per_blob: u64,
-        target: u64,
-    ) -> Result<(), Error> {
+    pub(super) async fn finish_clear(&mut self, target: u64) -> Result<(), Error> {
         self.metadata.remove(&CLEAR_TARGET_KEY);
-        self.persist(items_per_blob, target, target).await
+        self.persist(target, target).await
     }
 
     /// Make staged entries durable.
@@ -172,7 +174,7 @@ mod tests {
             }
         }
 
-        /// Set the mid-blob pruning boundary directly.
+        /// Set the pruning boundary directly.
         pub(crate) fn set_boundary_hint(&mut self, boundary: u64) {
             self.metadata.put(PRUNING_BOUNDARY_KEY, boundary.into());
         }
@@ -198,7 +200,7 @@ mod tests {
             assert!(!checkpoint.lower_watermark(5));
             assert_eq!(checkpoint.watermark(), None);
 
-            checkpoint.persist(10, 0, 8).await.unwrap();
+            checkpoint.persist(0, 8).await.unwrap();
             // Equal and higher limits are not lowerings.
             assert!(!checkpoint.lower_watermark(8));
             assert!(!checkpoint.lower_watermark(12));
@@ -215,8 +217,8 @@ mod tests {
         executor.start(|context| async move {
             {
                 let mut checkpoint = Checkpoint::open(context.child("a"), "rt").await.unwrap();
-                // A mid-blob boundary is kept; the watermark is recorded.
-                checkpoint.persist(10, 13, 25).await.unwrap();
+                // The boundary and watermark are recorded.
+                checkpoint.persist(13, 25).await.unwrap();
             }
             let checkpoint = Checkpoint::open(context.child("b"), "rt").await.unwrap();
             assert_eq!(checkpoint.boundary_hint(), Some(13));
@@ -226,19 +228,19 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_persist_boundary_hint_tracks_alignment() {
+    fn test_persist_boundary_hint_records_aligned_boundaries() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut checkpoint = Checkpoint::open(context, "align").await.unwrap();
 
-            // A mid-blob boundary is recorded as a hint.
-            checkpoint.persist(10, 13, 0).await.unwrap();
+            // A mid-blob boundary is recorded.
+            checkpoint.persist(13, 0).await.unwrap();
             assert_eq!(checkpoint.boundary_hint(), Some(13));
 
-            // A later blob-aligned boundary drops the stale hint (it is derived from the
-            // oldest blob).
-            checkpoint.persist(10, 20, 0).await.unwrap();
-            assert_eq!(checkpoint.boundary_hint(), None);
+            // Blob-aligned boundaries are also recorded so recovery need not infer pruning from
+            // the oldest surviving blob.
+            checkpoint.persist(20, 0).await.unwrap();
+            assert_eq!(checkpoint.boundary_hint(), Some(20));
         });
     }
 
@@ -248,7 +250,7 @@ mod tests {
         executor.start(|context| async move {
             {
                 let mut checkpoint = Checkpoint::open(context.child("a"), "clear").await.unwrap();
-                checkpoint.persist(10, 0, 30).await.unwrap();
+                checkpoint.persist(0, 30).await.unwrap();
                 // Staging records the intent and lowers the watermark to the target.
                 checkpoint.stage_clear(20).await.unwrap();
                 assert_eq!(checkpoint.clear_target(), Some(20));
@@ -259,13 +261,12 @@ mod tests {
                 let mut checkpoint = Checkpoint::open(context.child("b"), "clear").await.unwrap();
                 assert_eq!(checkpoint.clear_target(), Some(20));
                 // Completing drops the intent and records the target as boundary and watermark.
-                checkpoint.finish_clear(10, 20).await.unwrap();
+                checkpoint.finish_clear(20).await.unwrap();
             }
             let checkpoint = Checkpoint::open(context.child("c"), "clear").await.unwrap();
             assert_eq!(checkpoint.clear_target(), None);
             assert_eq!(checkpoint.watermark(), Some(20));
-            // 20 is blob-aligned, so no hint is retained.
-            assert_eq!(checkpoint.boundary_hint(), None);
+            assert_eq!(checkpoint.boundary_hint(), Some(20));
         });
     }
 
@@ -274,7 +275,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut checkpoint = Checkpoint::open(context, "sc").await.unwrap();
-            checkpoint.persist(10, 0, 5).await.unwrap();
+            checkpoint.persist(0, 5).await.unwrap();
 
             // Target above the current watermark: the intent is recorded but the watermark holds.
             checkpoint.stage_clear(9).await.unwrap();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -491,6 +491,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             &mut pending,
             cfg.items_per_blob.get(),
             checkpoint.boundary_hint(),
+            checkpoint.watermark(),
         )
         .await?;
 
@@ -583,8 +584,8 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
     /// Recover the journal bounds and any tail repair from the checkpoint and blob state.
     ///
     /// The pruning boundary has already been reconciled with physical blob state: an ahead
-    /// boundary completed an interrupted prune, while a lagging boundary adopted the oldest
-    /// surviving blob. A watermark beyond the recovered size is corruption. The caller
+    /// boundary completed an interrupted prune, while a missing unsynced prefix discarded
+    /// unreachable survivors. A watermark beyond the recovered size is corruption. The caller
     /// persists the checkpoint before applying the returned repair (see comment at the call site).
     fn recover_bounds(
         pending: &BTreeMap<u64, Writer<E::Blob>>,
@@ -632,16 +633,20 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
     /// Reconcile blobs against the recorded pruning boundary before recovering lengths.
     ///
     /// New checkpoints always record the boundary. If it is ahead of physical storage, a prune
-    /// was interrupted after committing its boundary and recovery finishes the removals. A
-    /// lagging mid-blob boundary is a legacy checkpoint that predates a completed prune, so the
-    /// oldest surviving blob is authoritative; a lagging blob-aligned boundary is corruption,
-    /// since aligned boundaries are only ever recorded before removals. Legacy checkpoints
-    /// without a boundary derive it from the oldest blob.
+    /// was interrupted after committing its boundary and recovery finishes the removals. If the
+    /// first expected blob is missing while the watermark has not advanced beyond the boundary,
+    /// its never-synced directory entry may have vanished; surviving newer blobs are discarded.
+    /// When the watermark proves the missing blob was durable, a lagging mid-blob boundary is a
+    /// legacy checkpoint that predates a completed prune (the oldest surviving blob is
+    /// authoritative), while a lagging blob-aligned boundary is corruption, since aligned
+    /// boundaries are only ever recorded before removals. Legacy checkpoints without a boundary
+    /// derive it from the oldest blob.
     async fn reconcile_pruning_boundary(
         partition: &Partition<E>,
         pending: &mut BTreeMap<u64, Writer<E::Blob>>,
         items_per_blob: u64,
         boundary_hint: Option<u64>,
+        watermark_hint: Option<u64>,
     ) -> Result<u64, Error> {
         let Some(boundary) = boundary_hint else {
             return pending.keys().next().copied().map_or(Ok(0), |oldest| {
@@ -651,12 +656,17 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         let boundary_blob = super::position_to_blob(boundary, items_per_blob);
 
         // Blob-aligned boundaries are recorded only by code that persists them before removing
-        // any blob, and removals never touch the boundary blob itself, so an aligned boundary
-        // can never lag physical state: its missing blob was lost, not pruned. Classify before
-        // removing the stale prefix below the boundary, so a failed init leaves every surviving
-        // blob untouched.
+        // any blob, and removals never touch the boundary blob itself, so once the watermark
+        // proves the boundary blob was synced (or the journal is legacy, with every blob
+        // eagerly durable), an aligned boundary can never lag physical state: its missing blob
+        // was lost, not pruned. Classify before removing the stale prefix below the boundary,
+        // so a failed init leaves every surviving blob untouched. With the watermark at or
+        // below the boundary, the missing blob may instead be a never-synced creation whose
+        // directory entry vanished; the repair below handles it after the stale prefix is
+        // removed.
         if boundary.is_multiple_of(items_per_blob)
             && !pending.contains_key(&boundary_blob)
+            && watermark_hint.is_none_or(|watermark| watermark > boundary)
             && let Some((&survivor, _)) = pending.first_key_value()
         {
             return Err(Error::Corruption(format!(
@@ -690,17 +700,36 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             return Ok(boundary);
         }
 
-        // Only a mid-blob boundary reaches this point: a missing aligned boundary blob was
-        // classified above whenever any blob survived, and with none pending recovery already
-        // returned the boundary. A mid-blob boundary may predate boundary recording (from a
-        // legacy `init_at_size`) and lag a prune completed by code that did not record
-        // boundaries; the oldest surviving blob is authoritative.
-        let recovered = super::blob_first_position(oldest, items_per_blob)?;
+        // A retained item below the watermark implies the missing boundary blob was synced;
+        // a watermark absent entirely marks a legacy journal whose blobs were all eagerly
+        // durable. Positions below the boundary prove nothing: they are pruned, so a mid-blob
+        // boundary's blob may still be a never-synced creation.
+        if watermark_hint.is_none_or(|watermark| watermark > boundary) {
+            // Only a mid-blob boundary reaches this point when the watermark proves the
+            // boundary blob was synced: a missing aligned boundary blob was classified before
+            // the removals above whenever any blob survived, and with none pending recovery
+            // already returned the boundary. A mid-blob boundary may predate boundary recording
+            // (from a legacy `init_at_size`) and lag a prune completed by code that did not
+            // record boundaries; the oldest surviving blob is authoritative.
+            let recovered = super::blob_first_position(oldest, items_per_blob)?;
+            warn!(
+                boundary,
+                recovered, "crash repair: pruning boundary checkpoint lagged physical storage"
+            );
+            return Ok(recovered);
+        }
+
+        // Otherwise the expected blob may simply have been a never-synced creation whose
+        // directory entry vanished. Everything after that gap is unreachable.
         warn!(
             boundary,
-            recovered, "crash repair: pruning boundary checkpoint lagged physical storage"
+            oldest, "crash repair: discarding blobs after vanished unsynced prefix"
         );
-        Ok(recovered)
+        while let Some((&newest, _)) = pending.last_key_value() {
+            drop(pending.remove(&newest));
+            partition.remove(newest).await?;
+        }
+        Ok(boundary)
     }
 
     /// Classify a blob's untrusted on-disk length against its capacity. A missing blob counts
@@ -1114,8 +1143,8 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         on_commit();
 
         // Commit the boundary before removing blobs. Recovery treats an ahead boundary as an
-        // interrupted prune and completes it, so blob removal never has to finish atomically
-        // or in order.
+        // interrupted prune and completes it, so physical absence alone never has to prove that
+        // pruning (rather than selective loss of an unsynced creation) occurred.
         let recovery_watermark = self.recovery_watermark();
         self.checkpoint
             .persist(new_boundary, recovery_watermark)
@@ -4184,10 +4213,55 @@ mod tests {
         });
     }
 
-    /// A checkpoint written by pre-boundary-recording code can lag a completed prune. The
-    /// oldest surviving blob is authoritative, regardless of the watermark.
+    /// A legacy checkpoint can lag a completed prune with a watermark past the boundary. That
+    /// watermark proves a retained item in the missing boundary blob was durable, so recovery
+    /// adopts the physical boundary.
     #[test_traced]
     fn test_fixed_recovery_lagged_legacy_boundary_adopts_physical() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+
+            {
+                let mut checkpoint = Checkpoint::open(context.child("meta"), &cfg.partition)
+                    .await
+                    .unwrap();
+                checkpoint.set_boundary_hint(7);
+                checkpoint.set_watermark(Some(8));
+                checkpoint.sync().await.unwrap();
+            }
+            for blob in 0u64..2 {
+                context
+                    .remove(&blob_partition(&cfg), Some(&blob.to_be_bytes()))
+                    .await
+                    .unwrap();
+            }
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 10..15);
+            for position in 10..15 {
+                assert_eq!(journal.read(position).await.unwrap(), test_digest(position));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A watermark equal to a mid-blob boundary proves nothing about the boundary blob:
+    /// positions below the boundary are pruned, so the blob may be a never-synced creation
+    /// (e.g. the fresh tail of `init_at_size`) whose directory entry vanished. Recovery must
+    /// resume at the boundary rather than fabricating a prune from the surviving suffix.
+    #[test_traced]
+    fn test_fixed_recovery_mid_blob_boundary_does_not_fabricate_prune() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(5));
@@ -4218,10 +4292,45 @@ mod tests {
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(journal.bounds(), 10..15);
-            for position in 10..15 {
-                assert_eq!(journal.read(position).await.unwrap(), test_digest(position));
+            assert_eq!(journal.bounds(), 7..7);
+            let (journal, pos) = journal.append(&test_digest(7)).await.unwrap();
+            assert_eq!(pos, 7);
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(journal.read(7).await.unwrap(), test_digest(7));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A surviving later unsynced directory entry must not be mistaken for a completed prune.
+    #[test_traced]
+    fn test_fixed_recovery_does_not_fabricate_prune_from_surviving_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(10));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
+            drop(journal);
+
+            let partition = blob_partition(&cfg);
+            for blob in 0u64..2 {
+                context
+                    .remove(&partition, Some(&blob.to_be_bytes()))
+                    .await
+                    .unwrap();
+            }
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..0);
+            let (journal, pos) = journal.append(&test_digest(42)).await.unwrap();
+            assert_eq!(pos, 0);
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(journal.read(0).await.unwrap(), test_digest(42));
             journal.destroy().await.unwrap();
         });
     }
@@ -5450,6 +5559,35 @@ mod tests {
             let pos;
             (journal, pos) = journal.append(&test_digest(100)).await.unwrap();
             assert_eq!(pos, 100);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// The checkpoint, rather than the fresh tail's directory entry, makes a completed clear
+    /// recoverable. If that uncommitted entry vanishes, init recreates the empty tail at the
+    /// recorded boundary without requiring clear to sync it.
+    #[test_traced]
+    fn test_fixed_journal_clear_recovers_without_fresh_tail_entry() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            journal.clear_to_size(12).await.unwrap();
+            drop(journal);
+
+            context
+                .remove(&blob_partition(&cfg), Some(&2u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 12..12);
+            let (journal, pos) = journal.append(&test_digest(12)).await.unwrap();
+            assert_eq!(pos, 12);
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -346,6 +346,11 @@ pub(super) struct Inner<E: Context, A> {
     /// Shared with [Reader]s.
     metrics: Arc<Metrics<E>>,
 
+    /// Test-only: park [Self::prune_with] after the boundary commit, before any removal, so
+    /// tests can drop the pending future at that exact point.
+    #[cfg(test)]
+    pub(in crate::journal::contiguous) halt_prune_removals: bool,
+
     _phantom: PhantomData<A>,
 }
 
@@ -381,6 +386,8 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             bounds,
             items_per_blob,
             metrics: Arc::new(metrics),
+            #[cfg(test)]
+            halt_prune_removals: false,
             _phantom: PhantomData,
         }
     }
@@ -477,6 +484,16 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             writer.sync().await?;
         }
 
+        // Complete any interrupted prune (a committed boundary ahead of physical storage) and
+        // reconcile the pruning boundary before walking blob lengths.
+        let pruning_boundary = Self::reconcile_pruning_boundary(
+            &partition,
+            &mut pending,
+            cfg.items_per_blob.get(),
+            checkpoint.boundary_hint(),
+        )
+        .await?;
+
         let RecoveredBounds {
             pruning_boundary,
             size,
@@ -485,18 +502,14 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         } = Self::recover_bounds(
             &pending,
             cfg.items_per_blob.get(),
-            checkpoint.boundary_hint(),
+            pruning_boundary,
             checkpoint.watermark(),
         )?;
 
         // Persist any lowered checkpoint before applying blob repairs that move recovered state
         // backward.
         checkpoint
-            .persist(
-                cfg.items_per_blob.get(),
-                pruning_boundary,
-                recovery_watermark,
-            )
+            .persist(pruning_boundary, recovery_watermark)
             .await?;
 
         // Apply repair (if any). The short blob becomes the new tail; blobs strictly newer
@@ -554,9 +567,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         );
         let tail_blob = super::position_to_blob(clear_target, cfg.items_per_blob.get());
         let blobs = Writable::recover(partition, BTreeMap::new(), tail_blob).await?;
-        checkpoint
-            .finish_clear(cfg.items_per_blob.get(), clear_target)
-            .await?;
+        checkpoint.finish_clear(clear_target).await?;
 
         let metrics = Metrics::new(context);
         metrics.update(clear_target, clear_target, cfg.items_per_blob.get());
@@ -571,21 +582,16 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
 
     /// Recover the journal bounds and any tail repair from the checkpoint and blob state.
     ///
-    /// A boundary hint that lags blob state is repaired from the blob boundary; a hint ahead of
-    /// blob state or a watermark beyond the recovered size is corruption. The caller persists the
-    /// checkpoint before applying the returned repair (see comment at the call site).
+    /// The pruning boundary has already been reconciled with physical blob state: an ahead
+    /// boundary completed an interrupted prune, while a lagging boundary adopted the oldest
+    /// surviving blob. A watermark beyond the recovered size is corruption. The caller
+    /// persists the checkpoint before applying the returned repair (see comment at the call site).
     fn recover_bounds(
         pending: &BTreeMap<u64, Writer<E::Blob>>,
         items_per_blob: u64,
-        boundary_hint: Option<u64>,
+        pruning_boundary: u64,
         watermark_hint: Option<u64>,
     ) -> Result<RecoveredBounds, Error> {
-        let pruning_boundary = Self::recover_pruning_boundary(
-            boundary_hint,
-            pending.keys().next().copied(),
-            items_per_blob,
-        )?;
-
         let (size, repair) =
             Self::recover_by_walking_lengths(pending, items_per_blob, pruning_boundary)?;
 
@@ -623,55 +629,78 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         })
     }
 
-    /// Recover the pruning boundary from the checkpoint hint if it still matches the oldest
-    /// retained blob.
+    /// Reconcile blobs against the recorded pruning boundary before recovering lengths.
     ///
-    /// A missing or blob-aligned hint means the blob boundary is authoritative. A mid-blob hint
-    /// is trusted only when it belongs to the current oldest blob.
-    fn recover_pruning_boundary(
-        boundary_hint: Option<u64>,
-        oldest_blob: Option<u64>,
+    /// New checkpoints always record the boundary. If it is ahead of physical storage, a prune
+    /// was interrupted after committing its boundary and recovery finishes the removals. A
+    /// lagging mid-blob boundary is a legacy checkpoint that predates a completed prune, so the
+    /// oldest surviving blob is authoritative; a lagging blob-aligned boundary is corruption,
+    /// since aligned boundaries are only ever recorded before removals. Legacy checkpoints
+    /// without a boundary derive it from the oldest blob.
+    async fn reconcile_pruning_boundary(
+        partition: &Partition<E>,
+        pending: &mut BTreeMap<u64, Writer<E::Blob>>,
         items_per_blob: u64,
+        boundary_hint: Option<u64>,
     ) -> Result<u64, Error> {
-        let blob_boundary = match oldest_blob {
-            Some(oldest) => super::blob_first_position(oldest, items_per_blob)?,
-            None => 0,
+        let Some(boundary) = boundary_hint else {
+            return pending.keys().next().copied().map_or(Ok(0), |oldest| {
+                super::blob_first_position(oldest, items_per_blob)
+            });
         };
+        let boundary_blob = super::position_to_blob(boundary, items_per_blob);
 
-        let Some(boundary_hint) = boundary_hint else {
-            return Ok(blob_boundary);
-        };
-        if boundary_hint.is_multiple_of(items_per_blob) {
-            return Ok(blob_boundary);
+        // Blob-aligned boundaries are recorded only by code that persists them before removing
+        // any blob, and removals never touch the boundary blob itself, so an aligned boundary
+        // can never lag physical state: its missing blob was lost, not pruned. Classify before
+        // removing the stale prefix below the boundary, so a failed init leaves every surviving
+        // blob untouched.
+        if boundary.is_multiple_of(items_per_blob)
+            && !pending.contains_key(&boundary_blob)
+            && let Some((&survivor, _)) = pending.first_key_value()
+        {
+            return Err(Error::Corruption(format!(
+                "blob at pruning boundary {boundary} is missing \
+                 (oldest surviving blob is {survivor})"
+            )));
         }
 
-        let hint_blob = super::position_to_blob(boundary_hint, items_per_blob);
-        match oldest_blob {
-            Some(oldest_blob) if hint_blob == oldest_blob => Ok(boundary_hint),
-            Some(oldest_blob) if hint_blob < oldest_blob => {
-                warn!(
-                    hint_blob,
-                    oldest_blob, "crash repair: boundary hint stale, computing from blobs"
-                );
-                Ok(blob_boundary)
+        // A recorded boundary ahead of the oldest blob is a committed prune that crashed before
+        // finishing its removals. Remove the files concurrently; the durable boundary makes
+        // removal order irrelevant to recovery.
+        let stale: Vec<u64> = pending
+            .range(..boundary_blob)
+            .map(|(&blob, _)| blob)
+            .collect();
+        if !stale.is_empty() {
+            warn!(
+                count = stale.len(),
+                boundary, "crash repair: completing interrupted prune"
+            );
+            for blob in &stale {
+                drop(pending.remove(blob));
             }
-            Some(oldest_blob) => {
-                // A hint ahead of blob state should never arise: prune removes blobs before
-                // sync persists the checkpoint, and clear_to_size stages a clear intent.
-                Err(Error::Corruption(format!(
-                    "boundary hint references blob {hint_blob} \
-                     but oldest blob is blob {oldest_blob}"
-                )))
-            }
-            None => {
-                // A mid-blob hint with no blobs should never arise: a staged clear is completed
-                // before we get here, and no other operation removes all blobs without updating
-                // the checkpoint.
-                Err(Error::Corruption(format!(
-                    "boundary hint references blob {hint_blob} but no blobs exist"
-                )))
-            }
+            try_join_all(stale.into_iter().map(|blob| partition.remove(blob))).await?;
         }
+
+        let Some(&oldest) = pending.keys().next() else {
+            return Ok(boundary);
+        };
+        if oldest == boundary_blob {
+            return Ok(boundary);
+        }
+
+        // Only a mid-blob boundary reaches this point: a missing aligned boundary blob was
+        // classified above whenever any blob survived, and with none pending recovery already
+        // returned the boundary. A mid-blob boundary may predate boundary recording (from a
+        // legacy `init_at_size`) and lag a prune completed by code that did not record
+        // boundaries; the oldest surviving blob is authoritative.
+        let recovered = super::blob_first_position(oldest, items_per_blob)?;
+        warn!(
+            boundary,
+            recovered, "crash repair: pruning boundary checkpoint lagged physical storage"
+        );
+        Ok(recovered)
     }
 
     /// Classify a blob's untrusted on-disk length against its capacity. A missing blob counts
@@ -700,7 +729,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
     /// Recover size by walking blob lengths from oldest to newest, truncating at the
     /// first short or missing non-tail blob.
     ///
-    /// `pruning_boundary` is trusted (already reconciled by `recover_pruning_boundary`); blob
+    /// `pruning_boundary` is trusted (already reconciled by `reconcile_pruning_boundary`); blob
     /// lengths are untrusted disk state. The returned size is chunk-exact and the retained
     /// prefix is contiguous.
     fn recover_by_walking_lengths(
@@ -827,11 +856,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         let handle = self.blobs.start_sync().await;
         handle.await?;
         self.checkpoint
-            .persist(
-                self.items_per_blob.get(),
-                self.bounds.start,
-                self.bounds.end,
-            )
+            .persist(self.bounds.start, self.bounds.end)
             .await
     }
 
@@ -1019,30 +1044,27 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
 
     /// In-place [Journal::prune].
     pub(crate) async fn prune(&mut self, min_item_pos: u64) -> Result<bool, Error> {
-        // Calculate the blob that would contain min_item_pos, capped to the tail (which is
-        // guaranteed to exist by our invariant).
-        let target_blob = super::position_to_blob(min_item_pos, self.items_per_blob.get());
-        let tail_blob = super::position_to_blob(self.bounds.end, self.items_per_blob.get());
-        let min_blob = std::cmp::min(target_blob, tail_blob);
+        self.prune_with(min_item_pos, || {}).await
+    }
 
-        if min_blob <= self.blobs.oldest_blob_index() {
+    /// Like [Self::prune], but invokes `on_commit` when the new boundary has been adopted,
+    /// before it is persisted and before any blob removal. Callers that mirror the boundary use
+    /// this to keep their copy consistent even if the returned future is dropped mid-removal.
+    pub(in crate::journal::contiguous) async fn prune_with(
+        &mut self,
+        min_item_pos: u64,
+        on_commit: impl FnOnce(),
+    ) -> Result<bool, Error> {
+        let Some(min_blob) = self.commit_prune(min_item_pos, on_commit).await? else {
             return Ok(false);
+        };
+
+        #[cfg(test)]
+        if self.halt_prune_removals {
+            std::future::pending::<()>().await;
         }
 
-        // Make all data durable before removing any: the prune target may be justified by an
-        // appended-but-unflushed item (e.g. a consumer's commit record), and removals are
-        // durable, so pruning without this barrier could leave a recovered journal whose
-        // surviving items no longer justify its boundary. The barrier also covers unsynced
-        // survivors above the boundary: removal may be interrupted, and recovery truncates at
-        // the first torn item, so an unsynced survivor could discard every synced blob
-        // behind it.
-        let sync = self.blobs.start_sync().await;
-        sync.await?;
-
-        let new_boundary = super::blob_first_position(min_blob, self.items_per_blob.get())?;
         self.blobs.prune(min_blob).await?;
-        self.bounds.start = new_boundary;
-
         self.metrics.update(
             self.bounds.end,
             self.bounds.start,
@@ -1050,6 +1072,56 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         );
 
         Ok(true)
+    }
+
+    /// Durably commit and adopt the prune boundary without removing any blob, returning the
+    /// first retained blob when the prune is effective.
+    async fn commit_prune(
+        &mut self,
+        min_item_pos: u64,
+        on_commit: impl FnOnce(),
+    ) -> Result<Option<u64>, Error> {
+        // Cap the target at the physical tail, but never below the adopted
+        // boundary's blob. This handles cancelled rollovers and prune cleanup.
+        let target_blob = super::position_to_blob(min_item_pos, self.items_per_blob.get());
+        let min_blob = target_blob
+            .min(self.blobs.tail_blob_index())
+            .max(super::position_to_blob(
+                self.bounds.start,
+                self.items_per_blob.get(),
+            ));
+
+        if min_blob <= self.blobs.oldest_blob_index() {
+            return Ok(None);
+        }
+
+        // Make all data durable before persisting a boundary that authorizes removal: the target
+        // may be justified by an appended-but-unflushed item, and a committed boundary lets
+        // recovery complete removals, so an unsynced survivor above the boundary could otherwise be
+        // lost. `start_sync` joins the tail and its predecessor (the only blobs that can be
+        // unsynced), so awaiting it is a full barrier.
+        let sync = self.blobs.start_sync().await;
+        sync.await?;
+
+        // The max keeps a mid-blob adopted boundary from regressing to its blob's start.
+        let new_boundary =
+            super::blob_first_position(min_blob, self.items_per_blob.get())?.max(self.bounds.start);
+
+        // Adopt the boundary, including any mirrored copy, before persisting it.
+        // Cancellation may leave memory ahead of disk (conservative), but never behind
+        // a boundary that may already be durable. A later sync completes the prune.
+        self.bounds.start = new_boundary;
+        on_commit();
+
+        // Commit the boundary before removing blobs. Recovery treats an ahead boundary as an
+        // interrupted prune and completes it, so blob removal never has to finish atomically
+        // or in order.
+        let recovery_watermark = self.recovery_watermark();
+        self.checkpoint
+            .persist(new_boundary, recovery_watermark)
+            .await?;
+
+        Ok(Some(min_blob))
     }
 
     /// See [Journal::destroy].
@@ -1084,9 +1156,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         self.bounds = new_size..new_size;
 
         // Complete the clear in the checkpoint.
-        self.checkpoint
-            .finish_clear(self.items_per_blob.get(), new_size)
-            .await?;
+        self.checkpoint.finish_clear(new_size).await?;
 
         self.metrics.update(
             self.bounds.end,
@@ -1282,8 +1352,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Readers holding earlier snapshots keep reading pruned blobs through their own handles;
     /// later snapshots observe [Error::ItemPruned].
     ///
-    /// Note that this operation may NOT be atomic, however it's guaranteed not to leave gaps in the
-    /// event of failure as items are always pruned in order from oldest to newest.
+    /// Note that this operation is NOT atomic and does not remove blobs in order: a failure or
+    /// crash can leave gaps below the committed pruning boundary. Recovery tolerates this because
+    /// the boundary is durably recorded before any removal, so reopening discards everything below
+    /// it regardless of which blobs survive. A binary built before two-phase pruning must not open
+    /// a journal left in that state; it infers the boundary from the oldest surviving blob and
+    /// would misread a gap as retained history.
     pub async fn prune(mut self, min_item_pos: u64) -> Result<(Self, bool), Error> {
         let pruned = self.0.prune(min_item_pos).await?;
         Ok((self, pruned))
@@ -1660,6 +1734,18 @@ impl<E: Context, A: CodecFixedShared> authenticated::Backing<E> for Journal<E, A
 }
 
 #[cfg(test)]
+impl<E: Context, A: CodecFixedShared> Journal<E, A> {
+    /// Test helper: commit and adopt the prune boundary without removing any blob, the state
+    /// a prune future dropped at the removal await leaves behind.
+    pub(crate) async fn test_prune_commit_only(
+        &mut self,
+        min_item_pos: u64,
+    ) -> Result<bool, Error> {
+        Ok(self.0.commit_prune(min_item_pos, || {}).await?.is_some())
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::journal::contiguous::{Contiguous as _, tests::corrupt_page};
@@ -1798,6 +1884,12 @@ mod tests {
         /// Test helper: Get the oldest blob from the blob store.
         pub(crate) const fn test_oldest_blob(&self) -> Option<u64> {
             Some(self.blobs.oldest_blob_index())
+        }
+
+        /// Test helper: park [Checkpoint::persist] after its durable sync so a pending prune
+        /// future can be dropped with the boundary durable but the call unreturned.
+        pub(in crate::journal::contiguous) fn test_halt_checkpoint_persist(&mut self, halt: bool) {
+            self.checkpoint.halt_after_persist_sync = halt;
         }
 
         /// Test helper: Get the newest blob from the blob store.
@@ -2484,12 +2576,7 @@ mod tests {
             // Persist the recovered metadata (watermark=9) as init_with_checkpoint does before
             // applying the rewind repair. This simulates a crash after metadata sync but before
             // the repair removes stale blobs.
-            journal
-                .0
-                .checkpoint
-                .persist(cfg.items_per_blob.get(), 0, 9)
-                .await
-                .unwrap();
+            journal.0.checkpoint.persist(0, 9).await.unwrap();
             drop(journal);
 
             // Shorten blob 1 to simulate a short non-tail blob. Recovery will compute
@@ -2806,11 +2893,10 @@ mod tests {
         });
     }
 
-    /// A boundary hint ahead of the oldest blob is not a reachable crash state: prune removes
-    /// blobs before sync persists the checkpoint, and clear_to_size stages a clear intent for
-    /// atomicity. Verify it is rejected as corruption.
+    /// Prune commits its boundary before removing blobs. Recovery completes the removals when a
+    /// crash leaves that boundary ahead of physical storage.
     #[test_traced]
-    fn test_fixed_journal_boundary_hint_ahead_of_blobs_is_corruption() {
+    fn test_fixed_journal_completes_prune_from_ahead_boundary() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(5));
@@ -2826,24 +2912,25 @@ mod tests {
             let mut journal = journal.sync().await.unwrap();
             assert_eq!(journal.bounds(), 3..15);
 
-            // Set the boundary hint to 8 (blob 1) and lower the watermark so it won't
-            // independently trigger the watermark > size corruption check. Then remove blob 1's
-            // blob so blob 0 is the oldest. The boundary hint now references a blob ahead
-            // of the oldest blob, which is the corruption we're testing.
+            // Persist the boundary that prune records before deleting blobs, then simulate a
+            // crash before the first deletion.
             {
-                journal.0.checkpoint.set_boundary_hint(8);
-                journal.0.checkpoint.set_watermark(Some(3));
+                journal.0.checkpoint.set_boundary_hint(10);
                 journal.0.checkpoint.sync().await.unwrap();
             }
             drop(journal);
 
-            context
-                .remove(&blob_partition(&cfg), Some(&1u64.to_be_bytes()))
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
                 .unwrap();
-
-            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
-            assert!(matches!(result, Err(Error::Corruption(_))));
+            assert_eq!(journal.bounds(), 10..15);
+            for position in 10..15 {
+                assert_eq!(
+                    journal.read(position).await.unwrap(),
+                    test_digest(position - 3)
+                );
+            }
+            journal.destroy().await.unwrap();
         });
     }
 
@@ -2997,7 +3084,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_fixed_journal_prune_to_blob_boundary_removes_pruning_metadata() {
+    fn test_fixed_journal_prune_to_blob_boundary_persists_pruning_metadata() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(5));
@@ -3023,7 +3110,7 @@ mod tests {
             let checkpoint = Checkpoint::open(context.child("metadata"), &cfg.partition)
                 .await
                 .expect("failed to reopen checkpoint");
-            assert!(checkpoint.boundary_hint().is_none());
+            assert_eq!(checkpoint.boundary_hint(), Some(10));
             drop(checkpoint);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -3031,6 +3118,53 @@ mod tests {
                 .expect("failed to reopen journal");
             assert_eq!(journal.bounds(), 10..15);
             assert_eq!(journal.read(10).await.unwrap(), test_digest(3));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A prune future dropped at the removal await leaves the boundary durably committed
+    /// while the caller sees no error and may legally keep using the journal. The in-memory
+    /// boundary must already match the committed one at that point: a later sync must not
+    /// re-persist a stale boundary below partially removed blobs.
+    #[test_traced]
+    fn test_fixed_journal_prune_interrupted_removal_keeps_committed_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Commit the prune boundary without running any removal, the state a prune
+            // future dropped at the removal await leaves behind. A cancelled future
+            // surfaces no error, so the continued use below is legal.
+            assert!(journal.test_prune_commit_only(10).await.unwrap());
+
+            // The committed boundary must already be adopted in memory.
+            assert_eq!(journal.pruning_boundary(), 10);
+
+            // Simulate one concurrent unlink having completed before the drop: blob 1 is
+            // removed while blob 0 survives.
+            context
+                .remove(&blob_partition(&cfg), Some(&1u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            // Continued use persists the committed boundary, not a stale one below the gap.
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
             journal.destroy().await.unwrap();
         });
     }
@@ -3054,7 +3188,7 @@ mod tests {
             drop(journal);
 
             // Inject an extra item into blob 0 at the blob level so its length exceeds
-            // items_per_blob -- this is what `recover_bounds` validates and rejects as Corruption.
+            // items_per_blob; this is what `recover_bounds` validates and rejects as Corruption.
             {
                 let extra = test_digest(99);
                 let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
@@ -3799,6 +3933,218 @@ mod tests {
         });
     }
 
+    /// After a cancelled prune adopted (and possibly persisted) a boundary the physical
+    /// state has not caught up to, a smaller prune request must not move the boundary
+    /// backward. Its physical cleanup still catches up to the adopted boundary.
+    #[test_traced]
+    fn test_fixed_prune_boundary_is_monotonic() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Adopt and persist boundary 10, then drop the prune before any removal. The
+            // in-place future borrows the journal, so the handle survives the drop with the
+            // adopted boundary live.
+            journal.0.halt_prune_removals = true;
+            {
+                let fut = journal.0.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park before the removals"
+                );
+            }
+            journal.0.halt_prune_removals = false;
+            assert_eq!(journal.pruning_boundary(), 10);
+
+            // A smaller request must not lower the boundary, and still completes the
+            // outstanding physical cleanup below it.
+            let (journal, pruned) = journal.prune(5).await.unwrap();
+            assert!(pruned);
+            assert_eq!(journal.pruning_boundary(), 10);
+            assert!(matches!(journal.read(7).await, Err(Error::ItemPruned(7))));
+            let mut journal = journal;
+            assert!(matches!(
+                journal.0.rewind(7).await,
+                Err(Error::ItemPruned(7))
+            ));
+
+            // Physical cleanup caught up to the adopted boundary, not the smaller request:
+            // both condemned blobs are gone.
+            let names = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert!(!names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(!names.contains(&1u64.to_be_bytes().to_vec()));
+
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen with the monotonic boundary");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A prune future dropped mid-unlink leaves condemned files the journal no longer
+    /// tracks. A later clear_to_size must not adopt one as its fresh tail, which would
+    /// resurrect the condemned items.
+    #[test_traced]
+    fn test_fixed_clear_after_prune_dropped_mid_unlink() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop the prune after tracking advanced but before any condemned file was
+            // unlinked: blobs 0 and 1 survive on disk, untracked. The in-place future borrows
+            // the journal, so the handle survives the drop.
+            journal.0.blobs.halt_prune_unlinks = true;
+            {
+                let fut = journal.0.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park before the unlinks"
+                );
+            }
+            journal.0.blobs.halt_prune_unlinks = false;
+
+            // Clear to a size whose tail blob index collides with leftover blob 1. The
+            // fresh tail must be genuinely empty.
+            journal.0.clear_to_size(5).await.unwrap();
+            assert_eq!(journal.bounds(), 5..5);
+            let pos;
+            (journal, pos) = journal.append(&test_digest(100)).await.unwrap();
+            assert_eq!(pos, 5);
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(journal.read(5).await.unwrap(), test_digest(100));
+
+            drop(journal);
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen after the clear");
+            assert_eq!(journal.bounds(), 5..6);
+            assert_eq!(journal.read(5).await.unwrap(), test_digest(100));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A prune future dropped inside the checkpoint persist can leave the new boundary
+    /// durable while the call never returns. The boundary must already be adopted in memory
+    /// so a later rewind cannot slide below the durable boundary, which recovery would then
+    /// complete as a prune over the rewound data.
+    #[test_traced]
+    fn test_fixed_prune_dropped_during_persist_adopts_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..12u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop the prune while parked inside the persist, after its durable sync. The
+            // in-place future borrows the journal, so the handle survives the drop.
+            journal.0.checkpoint.halt_after_persist_sync = true;
+            {
+                let fut = journal.0.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park inside the checkpoint persist"
+                );
+            }
+            journal.0.checkpoint.halt_after_persist_sync = false;
+
+            // The possibly-durable boundary is already adopted: rewinding below it is
+            // rejected rather than sliding under the durable boundary.
+            assert_eq!(journal.pruning_boundary(), 10);
+            assert!(matches!(
+                journal.0.rewind(7).await,
+                Err(Error::ItemPruned(7))
+            ));
+
+            // Continued use persists the adopted boundary; recovery completes the prune.
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen after the dropped prune");
+            assert_eq!(journal.bounds(), 10..12);
+            for i in 10..12u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A prune issued after an append future was dropped at the tail roll-over must cap its
+    /// boundary at the physical tail rather than panicking on the missing next blob.
+    #[test_traced]
+    fn test_fixed_prune_after_cancelled_seal_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..9u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop the append that fills blob 1 while it is parked at the tail roll-over. The
+            // in-place future borrows the journal, so the handle survives the drop with the
+            // interrupted roll-over state live.
+            journal.0.blobs.halt_seal_tail = true;
+            let item = test_digest(9);
+            {
+                let fut = journal.0.append(&item);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "append must park at the tail roll-over"
+                );
+            }
+            journal.0.blobs.halt_seal_tail = false;
+            assert_eq!(journal.size(), 10);
+
+            // Prune to the logical end: capped at the physical tail, pruning only blob 0.
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            assert_eq!(journal.bounds(), 5..10);
+            for i in 5..10u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+
+            drop(journal);
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen after a capped prune");
+            assert_eq!(journal.bounds(), 5..10);
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// A crash right after pruning must not lose retained items that were appended but never
     /// synced. Blob removal is durable, so prune makes all data durable first: otherwise the
     /// unsynced tail would vanish with the crash and recovery would truncate the journal to
@@ -3835,6 +4181,181 @@ mod tests {
                 assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
             }
             journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A checkpoint written by pre-boundary-recording code can lag a completed prune. The
+    /// oldest surviving blob is authoritative, regardless of the watermark.
+    #[test_traced]
+    fn test_fixed_recovery_lagged_legacy_boundary_adopts_physical() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+
+            {
+                let mut checkpoint = Checkpoint::open(context.child("meta"), &cfg.partition)
+                    .await
+                    .unwrap();
+                checkpoint.set_boundary_hint(7);
+                checkpoint.set_watermark(Some(7));
+                checkpoint.sync().await.unwrap();
+            }
+            for blob in 0u64..2 {
+                context
+                    .remove(&blob_partition(&cfg), Some(&blob.to_be_bytes()))
+                    .await
+                    .unwrap();
+            }
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 10..15);
+            for position in 10..15 {
+                assert_eq!(journal.read(position).await.unwrap(), test_digest(position));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A blob-aligned boundary is recorded before any removal, so it can never lag physical
+    /// state. If its blob is missing while later blobs survive, recovery must report
+    /// corruption rather than silently reclassifying the retained items as pruned.
+    #[test_traced]
+    fn test_fixed_recovery_rejects_missing_aligned_boundary_blob() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose the blob at the recorded boundary while later blobs survive.
+            context
+                .remove(&blob_partition(&cfg), Some(&2u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The surviving suffix is left intact for diagnosis.
+            assert!(
+                context
+                    .open(&blob_partition(&cfg), &3u64.to_be_bytes())
+                    .await
+                    .is_ok()
+            );
+        });
+    }
+
+    /// A failed init must not mutate the blob set: when a committed prune's removals were
+    /// interrupted and the aligned boundary blob is then lost, the missing-boundary corruption
+    /// verdict must be reached before the stale prefix below the boundary is unlinked, and the
+    /// verdict must be stable across retries.
+    #[test_traced]
+    fn test_fixed_recovery_missing_boundary_preserves_stale_prefix() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(5));
+            cfg.partition = "missing-boundary-preserves-prefix".into();
+
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Commit the boundary without removing any blob, as a prune interrupted after its
+            // checkpoint persist would.
+            assert!(journal.test_prune_commit_only(10).await.unwrap());
+            drop(journal);
+
+            // Lose the blob at the committed boundary while a later blob survives.
+            context
+                .remove(&blob_partition(&cfg), Some(&2u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // Every surviving blob is untouched, including the stale prefix below the boundary.
+            let names = context.scan(&blob_partition(&cfg)).await.unwrap();
+            assert!(names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(names.contains(&1u64.to_be_bytes().to_vec()));
+            assert!(names.contains(&3u64.to_be_bytes().to_vec()));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, Digest>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// A missing aligned boundary blob is corruption even when nothing survives past it: an
+    /// interrupted prune never removes its boundary blob, so a surviving stale prefix alone
+    /// proves the retained blobs were lost. The verdict must be reached before the prefix is
+    /// unlinked and must be stable across retries.
+    #[test_traced]
+    fn test_fixed_recovery_missing_boundary_with_only_stale_prefix() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(5));
+            cfg.partition = "missing-boundary-only-prefix".into();
+
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Commit the boundary without removing any blob, as a prune interrupted after its
+            // checkpoint persist would.
+            assert!(journal.test_prune_commit_only(10).await.unwrap());
+            drop(journal);
+
+            // Lose every blob at and after the committed boundary, leaving only the stale
+            // prefix below it.
+            for name in context.scan(&blob_partition(&cfg)).await.unwrap() {
+                let blob = u64::from_be_bytes(name.as_slice().try_into().unwrap());
+                if blob >= 2 {
+                    context
+                        .remove(&blob_partition(&cfg), Some(&name))
+                        .await
+                        .unwrap();
+                }
+            }
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The failed init left the stale prefix untouched.
+            let names = context.scan(&blob_partition(&cfg)).await.unwrap();
+            assert!(names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(names.contains(&1u64.to_be_bytes().to_vec()));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, Digest>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
         });
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1032,6 +1032,37 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         let items_per_blob = cfg.items_per_section.get();
         let data_partition = cfg.data_partition();
         let data_context = context.child("data");
+        let offsets_partition = cfg.offsets_partition();
+
+        // A valid variable journal initializes and durably checkpoints its offsets journal before
+        // opening data blobs. Complete external loss of both offsets data and metadata must not
+        // be mistaken for selective loss of unsynced data blob entries, and must be classified
+        // before the offsets journal is recovered: recovery is mutating (it recreates checkpoint
+        // metadata and an empty tail), which would flip a retried init into the vanished-prefix
+        // repair and erase the surviving data.
+        let mut offsets_state_present = false;
+        for partition in [
+            offsets_partition.clone(),
+            format!("{offsets_partition}-blobs"),
+            format!("{offsets_partition}-metadata"),
+        ] {
+            offsets_state_present |= !Partition::<E>::scan_names(&context, &partition)
+                .await?
+                .is_empty();
+        }
+        if !offsets_state_present {
+            let oldest = Partition::<E>::scan_names(&context, &data_partition)
+                .await?
+                .iter()
+                .filter_map(|name| <[u8; 8]>::try_from(name.as_slice()).ok())
+                .map(u64::from_be_bytes)
+                .min();
+            if oldest.is_some_and(|oldest| oldest > 0) {
+                return Err(Error::Corruption(
+                    "data blobs exist but all offsets state is missing".into(),
+                ));
+            }
+        }
 
         // If a prior `init_at_size`/`clear_to_size` crashed mid-reset, the offsets journal
         // carries a staged clear. `init_cleared` discards the data partition before finishing
@@ -1039,7 +1070,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         let mut offsets = fixed::Inner::<E, u64>::init_cleared(
             context.child("offsets"),
             fixed::Config {
-                partition: cfg.offsets_partition(),
+                partition: offsets_partition,
                 items_per_blob: cfg.items_per_section,
                 page_cache: cfg.page_cache.clone(),
                 write_buffer: cfg.write_buffer,
@@ -1312,7 +1343,9 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         // watermark before any state moves backward, so a crash anywhere in this sequence leaves
         // offsets at or behind the data, a shape init repairs by rebuilding offsets from the
         // data. Truncating data first would leave a window where a crash strands a short blob
-        // below a watermark that recovery trusts, permanently hiding the missing items.
+        // below a watermark that recovery trusts, permanently hiding the missing items. The
+        // offsets-side rewind may sync entries that reference never-synced data; if those data
+        // entries vanish, recovery bounds the adopted size by the watermark.
         self.offsets.rewind(size).await?;
 
         if discard_blob == self.blobs.tail_blob_index() {
@@ -1556,8 +1589,9 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         let data_sync = self.blobs.start_sync().await;
         data_sync.await?;
 
-        // The offsets journal is the durable prune record. Mirror its adopted
-        // boundary so cancellation cannot leave the outer bounds behind it.
+        // The offsets journal is the durable prune record, distinguishing a deliberate prune
+        // from selective loss of never-synced data blob entries. Mirror its adopted boundary
+        // so cancellation cannot leave the outer bounds behind it.
         let bounds = &mut self.bounds;
         self.offsets
             .prune_with(new_boundary, || {
@@ -1665,6 +1699,24 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             };
             let data_oldest_pos = blob_first_position(oldest_blob, items_per_blob)?;
 
+            // With no durable data beyond the pruning boundary, an older unsynced blob may have
+            // vanished while a newer one survived. Discard the unreachable suffix rather than
+            // turning its physical index into a fabricated prune boundary.
+            if offsets_start_blob < oldest_blob
+                && offsets.recovery_watermark() <= offsets_bounds.start
+            {
+                warn!(
+                    oldest_blob,
+                    boundary = offsets_bounds.start,
+                    "crash repair: discarding data after vanished unsynced prefix"
+                );
+                while let Some((&newest, _)) = pending.last_key_value() {
+                    drop(pending.remove(&newest));
+                    partition.remove(newest).await?;
+                }
+                return Self::align_empty(partition, pending, offsets, items_per_blob).await;
+            }
+
             // The offsets journal ending before the oldest retained data blob represents an
             // impossible state under normal crash/prune sequences, indicating external corruption.
             if offsets_bounds.end < data_oldest_pos {
@@ -1688,9 +1740,24 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
                     // An interrupted prune preserves its boundary blob. Check before deleting
                     // the stale prefix so corruption remains detectable on retry.
                     if !pending.contains_key(&offsets_start_blob) {
-                        return Err(Error::Corruption(format!(
-                            "data blob {offsets_start_blob} at the pruning boundary is missing"
-                        )));
+                        if offsets.recovery_watermark() > offsets_bounds.start {
+                            return Err(Error::Corruption(format!(
+                                "data blob {offsets_start_blob} at the pruning boundary is missing"
+                            )));
+                        }
+                        // No retained item was ever durable, so the missing blobs were
+                        // never-synced creations whose directory entries vanished; the
+                        // survivors are unreachable. Discard them and resume at the boundary.
+                        warn!(
+                            boundary = offsets_bounds.start,
+                            "crash repair: discarding data after vanished retained blobs"
+                        );
+                        while let Some((&newest, _)) = pending.last_key_value() {
+                            drop(pending.remove(&newest));
+                            partition.remove(newest).await?;
+                        }
+                        return Self::align_empty(partition, pending, offsets, items_per_blob)
+                            .await;
                     }
 
                     // The offsets boundary commits a prune before data blobs are removed. Finish
@@ -1842,11 +1909,12 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         items_per_blob: u64,
     ) -> Result<Range<u64>, Error> {
         let offsets_bounds = offsets.pruning_boundary()..offsets.size();
+        let watermark = offsets.recovery_watermark();
 
         // A watermark past the pruning boundary proves retained items were durable, so their
         // data blobs were lost, not pruned; a surviving empty tail cannot vouch for them.
         // Check before any branch or repair so the result is stable across retries.
-        if offsets.recovery_watermark() > offsets_bounds.start {
+        if watermark > offsets_bounds.start {
             return Err(Error::Corruption(format!(
                 "no item-bearing data blobs survive the committed pruning boundary {}",
                 offsets_bounds.start
@@ -1854,12 +1922,16 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         }
 
         let Some(&blob) = pending.keys().next() else {
-            // No data blobs at all: a fresh partition or a journal with no retained durable
-            // items. Clear (rather than prune) the offsets so bounds collapse even when the
-            // size is mid-blob.
-            let size = offsets_bounds.end;
-            if !offsets_bounds.is_empty() {
-                warn!("crash repair: clearing offsets to {size} (no data blobs)");
+            // No data blobs at all: a fresh partition, a reset that had not yet created its
+            // data tail, or never-synced creations whose directory entries vanished. Never
+            // adopt a size beyond the durable watermark. Clear (rather than prune) the offsets
+            // so bounds collapse even when the size is mid-blob.
+            let size = offsets_bounds.end.min(watermark).max(offsets_bounds.start);
+            if offsets_bounds != (size..size) {
+                warn!(
+                    watermark,
+                    "crash repair: clearing offsets to {size} (no data blobs)"
+                );
                 offsets.clear_to_size(size).await?;
             }
             return Ok(size..size);
@@ -1868,6 +1940,23 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         // The journal restarts at the empty blob's first position, or at the offsets journal's
         // mid-blob boundary within it.
         let blob_start = blob_first_position(blob, items_per_blob)?;
+
+        // A later, never-synced empty tail cannot by itself prove the missing prefix was pruned
+        // (the guard above already established the watermark is at or below the boundary).
+        if blob_start > offsets_bounds.start {
+            warn!(
+                blob,
+                "crash repair: removing empty tail after vanished prefix"
+            );
+            pending.remove(&blob);
+            partition.remove(blob).await?;
+            let size = offsets_bounds.start;
+            if offsets_bounds != (size..size) {
+                offsets.clear_to_size(size).await?;
+            }
+            return Ok(size..size);
+        }
+
         let target = blob_start.max(offsets_bounds.start);
 
         // Nothing to repair when the blob is the tail of an already-aligned empty journal.
@@ -3261,6 +3350,60 @@ mod tests {
         });
     }
 
+    /// Total offsets loss must be classified without mutating storage: consecutive reopens all
+    /// report corruption, no offsets state is recreated behind the verdict, and the surviving
+    /// retained data blobs stay untouched for diagnosis.
+    #[test_traced]
+    fn test_variable_offsets_partition_loss_verdict_is_stable_and_non_mutating() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "offsets-loss-stable-verdict".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let (journal, _) = journal.prune(20).await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+
+            // Lose every offsets partition while the retained data survives.
+            let offsets_blobs = format!("{}-blobs", cfg.offsets_partition());
+            let offsets_meta = format!("{}-metadata", cfg.offsets_partition());
+            context.remove(&offsets_blobs, None).await.unwrap();
+            context.remove(&offsets_meta, None).await.unwrap();
+
+            let first = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(first, Err(Error::Corruption(_))));
+
+            // The failed init recreated nothing: no offsets state exists.
+            assert!(
+                context.scan(&offsets_blobs).await.is_err()
+                    || context.scan(&offsets_blobs).await.unwrap().is_empty()
+            );
+            assert!(
+                context.scan(&offsets_meta).await.is_err()
+                    || context.scan(&offsets_meta).await.unwrap().is_empty()
+            );
+
+            // The verdict is stable across retries and the retained data survives them.
+            let second = Journal::<_, u64>::init(context.child("third"), cfg.clone()).await;
+            assert!(matches!(second, Err(Error::Corruption(_))));
+            let data_names = context.scan(&cfg.data_partition()).await.unwrap();
+            assert!(data_names.contains(&2u64.to_be_bytes().to_vec()));
+            assert!(data_names.contains(&3u64.to_be_bytes().to_vec()));
+        });
+    }
+
     /// Test that complete offsets partition loss after pruning is detected as unrecoverable.
     ///
     /// When the offsets partition is completely lost and the data has been pruned, we cannot
@@ -4164,10 +4307,11 @@ mod tests {
         });
     }
 
-    /// If the data blob at the committed pruning boundary is missing, recovery must report
-    /// corruption rather than deleting the surviving suffix and treating its items as pruned.
+    /// If the boundary blob itself is missing despite a watermark beyond the boundary, recovery
+    /// must report corruption rather than deleting the surviving suffix and treating durable
+    /// items as pruned.
     #[test_traced]
-    fn test_variable_recovery_rejects_missing_boundary_blob() {
+    fn test_variable_recovery_rejects_missing_durable_boundary_blob() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = Config {
@@ -4386,10 +4530,12 @@ mod tests {
         });
     }
 
-    /// Offsets journal is empty but in a different blob than data. This is an impossible state:
-    /// both journals are always created in the same blob by init or init_at_size.
+    /// Offsets journal is empty in a later blob than the surviving data, with no durable item
+    /// past its boundary. Under deferred creation this is the shape left when a committed
+    /// prune's never-synced boundary blob vanishes, so recovery discards the condemned data
+    /// and resumes empty at the boundary.
     #[test_traced]
-    fn test_variable_recovery_offsets_empty_different_blob_is_corruption() {
+    fn test_variable_recovery_offsets_empty_different_blob_repairs_to_boundary() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = Config {
@@ -4410,13 +4556,27 @@ mod tests {
             }
             let mut journal = journal.sync().await.unwrap();
 
-            // Clear offsets to blob 2 (position 20) while data starts at blob 0.
-            // This puts them in different blobs with offsets empty (bounds 20..20).
+            // Clear offsets to blob 2 (position 20) while data starts at blob 0, leaving the
+            // journals in different blobs with offsets empty (bounds 20..20).
             journal.0.offsets.clear_to_size(20).await.unwrap();
             drop(journal);
 
-            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
-            assert!(matches!(result, Err(Error::Corruption(_))));
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 20..20);
+
+            // The unreachable data blobs below the boundary were discarded.
+            let names = context.scan(&cfg.data_partition()).await.unwrap();
+            assert!(!names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(!names.contains(&1u64.to_be_bytes().to_vec()));
+
+            // The repaired journal resumes appending at the boundary.
+            let (journal, pos) = journal.append(&999).await.unwrap();
+            assert_eq!(pos, 20);
+            assert_eq!(journal.read(20).await.unwrap(), 999);
+
+            journal.destroy().await.unwrap();
         });
     }
 
@@ -8213,6 +8373,131 @@ mod tests {
                 assert_eq!(journal.read(i).await.unwrap(), i * 100);
             }
 
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Surviving offsets content cannot prove never-synced data existed; the watermark bounds the
+    /// recovered size when all data directory entries vanish.
+    #[test_traced]
+    fn test_variable_vanished_unsynced_data_does_not_fabricate_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "vanished-unsynced-data".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..25u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.test_rewind_offsets(5).await.unwrap();
+            drop(journal);
+
+            for blob in 0u64..3 {
+                context
+                    .remove(&cfg.data_partition(), Some(&blob.to_be_bytes()))
+                    .await
+                    .unwrap();
+            }
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..0);
+            let (journal, pos) = journal.append(&42).await.unwrap();
+            assert_eq!(pos, 0);
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(journal.read(0).await.unwrap(), 42);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A populated later blob without its unsynced prefix is unreachable, not evidence of prune.
+    #[test_traced]
+    fn test_variable_vanished_unsynced_prefix_does_not_fabricate_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "vanished-unsynced-prefix".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..25u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.test_rewind_offsets(5).await.unwrap();
+            drop(journal);
+
+            for blob in 0u64..2 {
+                context
+                    .remove(&cfg.data_partition(), Some(&blob.to_be_bytes()))
+                    .await
+                    .unwrap();
+            }
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..0);
+            let (journal, pos) = journal.append(&42).await.unwrap();
+            assert_eq!(pos, 0);
+            let journal = journal.sync().await.unwrap();
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A surviving never-synced empty tail also cannot prove the missing prefix was pruned.
+    #[test_traced]
+    fn test_variable_surviving_unsynced_empty_tail_does_not_fabricate_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "surviving-unsynced-empty-tail".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.test_rewind_offsets(5).await.unwrap();
+            drop(journal);
+
+            for blob in 0u64..2 {
+                context
+                    .remove(&cfg.data_partition(), Some(&blob.to_be_bytes()))
+                    .await
+                    .unwrap();
+            }
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..0);
+            let (journal, pos) = journal.append(&42).await.unwrap();
+            assert_eq!(pos, 0);
+            let journal = journal.sync().await.unwrap();
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -386,11 +386,6 @@ struct Inner<E: Context, V: Codec> {
     /// The readable positions; `bounds.end` is the next append position.
     bounds: Range<u64>,
 
-    /// Test-only: park [Self::prune] after the data-blob removal, before the offsets prune,
-    /// so tests can drop the pending future at that exact point.
-    #[cfg(test)]
-    halt_before_offsets_prune: bool,
-
     /// The number of items per blob.
     ///
     /// # Invariant
@@ -1158,8 +1153,6 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             blobs,
             offsets,
             bounds,
-            #[cfg(test)]
-            halt_before_offsets_prune: false,
             items_per_blob: cfg.items_per_section,
             compression: cfg.compression,
             codec_config: cfg.codec_config,
@@ -1219,8 +1212,6 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             blobs,
             offsets,
             bounds: size..size,
-            #[cfg(test)]
-            halt_before_offsets_prune: false,
             items_per_blob: cfg.items_per_section,
             compression: cfg.compression,
             codec_config: cfg.codec_config,
@@ -1517,46 +1508,11 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 
     /// In-place [Journal::prune].
     pub(crate) async fn prune(&mut self, min_position: u64) -> Result<bool, Error> {
-        let items_per_blob = self.items_per_blob.get();
-
-        // Calculate the blob that would contain min_position, capped to the tail (which is
-        // guaranteed to exist by our invariant).
-        let target_blob = position_to_blob(min_position, items_per_blob);
-        let tail_blob = position_to_blob(self.bounds.end, items_per_blob);
-        let min_blob = target_blob.min(tail_blob);
-
-        if min_blob <= self.blobs.oldest_blob_index() {
+        let Some(min_blob) = self.commit_prune(min_position).await? else {
             return Ok(false);
-        }
-
-        let new_boundary = blob_first_position(min_blob, items_per_blob)?;
-
-        // Make all data durable before removing any: the prune target may be justified by an
-        // appended-but-unflushed item (e.g. a consumer's commit record), and removals are
-        // durable, so pruning without this barrier could leave a recovered journal whose
-        // surviving items no longer justify its boundary. The barrier also covers unsynced
-        // survivors above the boundary: removal may be interrupted, and recovery truncates at
-        // the first torn item, so an unsynced survivor could discard every synced blob behind
-        // it. Offsets entries for retained items must survive the same crash: recovery rebuilds
-        // offsets that end behind the surviving data's end by replaying data, but offsets that
-        // end behind its start are unrecoverable because the data needed to rebuild the missing
-        // entries is about to be removed. Data is flushed first, matching the ordering every
-        // other durability path maintains.
-        let data_sync = self.blobs.start_sync().await;
-        data_sync.await?;
-        self.offsets.commit().await?;
+        };
 
         self.blobs.prune(min_blob).await?;
-        self.bounds.start = new_boundary;
-
-        #[cfg(test)]
-        if self.halt_before_offsets_prune {
-            std::future::pending::<()>().await;
-        }
-
-        // Prune data before offsets so a crash leaves offsets behind, which init repairs by
-        // pruning offsets to match.
-        self.offsets.prune(new_boundary).await?;
         self.metrics.update(
             self.bounds.end,
             self.bounds.start,
@@ -1570,6 +1526,46 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
     pub(crate) async fn start_commit(&mut self) -> Handle<()> {
         self.metrics.start_commit_calls.inc();
         self.blobs.start_sync().await
+    }
+
+    /// Prune the offsets journal and adopt the committed boundary without touching data
+    /// blobs, returning the first retained blob when the prune is effective.
+    async fn commit_prune(&mut self, min_position: u64) -> Result<Option<u64>, Error> {
+        let items_per_blob = self.items_per_blob.get();
+
+        // Cap the target at the physical tail, but never below the adopted
+        // boundary's blob. This handles cancelled rollovers and prune cleanup.
+        let target_blob = position_to_blob(min_position, items_per_blob);
+        let min_blob = target_blob
+            .min(self.blobs.tail_blob_index())
+            .max(position_to_blob(self.bounds.start, items_per_blob));
+
+        if min_blob <= self.blobs.oldest_blob_index() {
+            return Ok(None);
+        }
+
+        // The max keeps a mid-blob adopted boundary from regressing to its blob's start.
+        let new_boundary = blob_first_position(min_blob, items_per_blob)?.max(self.bounds.start);
+
+        // Make all data durable before the offsets journal commits the boundary that authorizes
+        // removal: the target may be justified by an appended-but-unflushed item, and offsets
+        // entries for retained items must survive the same crash (recovery rebuilds offsets that
+        // end behind the surviving data's end by replaying data, but not offsets that end behind
+        // its start, since that data is about to be removed). `start_sync` joins the tail and its
+        // predecessor (the only blobs that can be unsynced), so awaiting it is a full barrier.
+        let data_sync = self.blobs.start_sync().await;
+        data_sync.await?;
+
+        // The offsets journal is the durable prune record. Mirror its adopted
+        // boundary so cancellation cannot leave the outer bounds behind it.
+        let bounds = &mut self.bounds;
+        self.offsets
+            .prune_with(new_boundary, || {
+                bounds.start = new_boundary;
+            })
+            .await?;
+
+        Ok(Some(min_blob))
     }
 
     /// In-place [Journal::commit].
@@ -1659,8 +1655,67 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         codec_config: &V::Cfg,
         compressed: bool,
     ) -> Result<Range<u64>, Error> {
-        // Find the newest item-bearing blob, truncating torn trailing bytes along the way (the
-        // first invalid frame is the end of the journal).
+        // Reconcile pruning before inspecting data: stale prefix blobs are outside
+        // the retained range. A mid-blob boundary is valid within the same blob.
+        let offsets_bounds = offsets.pruning_boundary()..offsets.size();
+        let offsets_start_blob = position_to_blob(offsets_bounds.start, items_per_blob);
+        {
+            let Some(&oldest_blob) = pending.keys().next() else {
+                return Self::align_empty(partition, pending, offsets, items_per_blob).await;
+            };
+            let data_oldest_pos = blob_first_position(oldest_blob, items_per_blob)?;
+
+            // The offsets journal ending before the oldest retained data blob represents an
+            // impossible state under normal crash/prune sequences, indicating external corruption.
+            if offsets_bounds.end < data_oldest_pos {
+                return Err(Error::Corruption(format!(
+                    "offsets journal size {} is behind data oldest position {data_oldest_pos}",
+                    offsets_bounds.end
+                )));
+            }
+            match offsets_start_blob.cmp(&oldest_blob) {
+                std::cmp::Ordering::Less => {
+                    // Pruning removes data blobs only after the offsets boundary is durably
+                    // committed, so data ahead of the boundary means the blobs at and after
+                    // it were lost, not pruned.
+                    return Err(Error::Corruption(format!(
+                        "data blob {offsets_start_blob} at the pruning boundary is missing \
+                         (oldest surviving blob is {oldest_blob})"
+                    )));
+                }
+                std::cmp::Ordering::Equal => {}
+                std::cmp::Ordering::Greater => {
+                    // An interrupted prune preserves its boundary blob. Check before deleting
+                    // the stale prefix so corruption remains detectable on retry.
+                    if !pending.contains_key(&offsets_start_blob) {
+                        return Err(Error::Corruption(format!(
+                            "data blob {offsets_start_blob} at the pruning boundary is missing"
+                        )));
+                    }
+
+                    // The offsets boundary commits a prune before data blobs are removed. Finish
+                    // an interrupted prune by deleting data below it, removing the files
+                    // concurrently; the durable boundary makes removal order irrelevant.
+                    let stale: Vec<u64> = pending
+                        .range(..offsets_start_blob)
+                        .map(|(&blob, _)| blob)
+                        .collect();
+                    if !stale.is_empty() {
+                        warn!(
+                            count = stale.len(),
+                            "crash repair: completing interrupted data prune"
+                        );
+                        for blob in &stale {
+                            drop(pending.remove(blob));
+                        }
+                        try_join_all(stale.into_iter().map(|blob| partition.remove(blob))).await?;
+                    }
+                }
+            }
+        }
+
+        // Find the newest item-bearing retained blob, truncating torn trailing bytes along the
+        // way (the first invalid frame is the end of the journal).
         let scanned: Vec<u64> = pending.keys().rev().copied().collect();
         let mut items_in_newest = 0;
         let mut newest_blob = None;
@@ -1690,11 +1745,19 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         }
 
         // The tail blob (where the next append lands) is one past the newest full blob, the
-        // newest partial blob, or the oldest blob when empty (resolved by `align_empty`). Any
-        // blob above it is an empty crash artifact; the loop below removes them.
+        // newest partial blob, or the oldest blob when empty (resolved by `align_empty`). A
+        // blob the pruning boundary starts within is full at correspondingly fewer items. Any
+        // blob above the tail is an empty crash artifact; the loop below removes them.
         let tail_blob = match newest_blob {
-            Some(blob) if items_in_newest == items_per_blob => blob.saturating_add(1),
-            Some(blob) => blob,
+            Some(blob) => {
+                let newest_start = blob_first_position(blob, items_per_blob)?;
+                let capacity = items_per_blob - offsets_bounds.start.saturating_sub(newest_start);
+                if items_in_newest == capacity {
+                    blob.saturating_add(1)
+                } else {
+                    blob
+                }
+            }
             None => pending.keys().next().copied().unwrap_or(0),
         };
         for &blob in &scanned {
@@ -1709,43 +1772,6 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         let Some(newest_blob) = newest_blob else {
             return Self::align_empty(partition, pending, offsets, items_per_blob).await;
         };
-
-        // Align pruning state at the blob level. After alignment, the offsets journal starts in
-        // the oldest data blob; a mid-blob offsets start (from `init_at_size`) is valid within
-        // the same blob.
-        let oldest_blob = *pending.keys().next().expect("pending is non-empty");
-        let data_oldest_pos = blob_first_position(oldest_blob, items_per_blob)?;
-        {
-            let offsets_bounds = offsets.pruning_boundary()..offsets.size();
-
-            // The offsets journal ending before the oldest retained data blob represents an
-            // impossible state under normal crash/prune sequences, indicating external corruption.
-            if offsets_bounds.end < data_oldest_pos {
-                return Err(Error::Corruption(format!(
-                    "offsets journal size {} is behind data oldest position {data_oldest_pos}",
-                    offsets_bounds.end
-                )));
-            }
-            let offsets_start_blob = position_to_blob(offsets_bounds.start, items_per_blob);
-            match offsets_start_blob.cmp(&oldest_blob) {
-                std::cmp::Ordering::Less => {
-                    warn!("crash repair: pruning offsets journal to {data_oldest_pos}");
-                    offsets.prune(data_oldest_pos).await?;
-                }
-                std::cmp::Ordering::Equal => {}
-                std::cmp::Ordering::Greater => {
-                    // Prune always removes data before offsets, so offsets should never be
-                    // ahead by a blob.
-                    return Err(Error::Corruption(format!(
-                        "offsets start blob {offsets_start_blob} ahead of \
-                         oldest data blob {oldest_blob}"
-                    )));
-                }
-            }
-        }
-
-        // Re-fetch bounds since prune may have been called above.
-        let offsets_bounds = offsets.pruning_boundary()..offsets.size();
 
         // The newest item-bearing blob bounds how far recovery can possibly go. If it is also
         // the oldest retained blob, its logical start may be a mid-blob pruning boundary.
@@ -1783,13 +1809,14 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             // the only populated blob, so no contiguous data-backed prefix exists). In that case
             // there is no oldest blob to anchor against; otherwise offsets and data must start in
             // the same blob.
-            if !offsets_bounds.is_empty()
-                && position_to_blob(offsets_bounds.start, items_per_blob) != oldest_blob
-            {
-                return Err(Error::Corruption(format!(
-                    "recovered offsets and data start in different blobs: {} != {oldest_blob}",
-                    position_to_blob(offsets_bounds.start, items_per_blob)
-                )));
+            if !offsets_bounds.is_empty() {
+                let oldest_blob = *pending.keys().next().expect("pending is non-empty");
+                if position_to_blob(offsets_bounds.start, items_per_blob) != oldest_blob {
+                    return Err(Error::Corruption(format!(
+                        "recovered offsets and data start in different blobs: {} != {oldest_blob}",
+                        position_to_blob(offsets_bounds.start, items_per_blob)
+                    )));
+                }
             }
 
             // Return bounds.start from offsets as the true boundary.
@@ -1816,13 +1843,23 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
     ) -> Result<Range<u64>, Error> {
         let offsets_bounds = offsets.pruning_boundary()..offsets.size();
 
+        // A watermark past the pruning boundary proves retained items were durable, so their
+        // data blobs were lost, not pruned; a surviving empty tail cannot vouch for them.
+        // Check before any branch or repair so the result is stable across retries.
+        if offsets.recovery_watermark() > offsets_bounds.start {
+            return Err(Error::Corruption(format!(
+                "no item-bearing data blobs survive the committed pruning boundary {}",
+                offsets_bounds.start
+            )));
+        }
+
         let Some(&blob) = pending.keys().next() else {
-            // No data blobs at all: a fresh partition, or a crash after pruning the data blobs
-            // but before pruning the offsets journal. Clear (rather than prune) the offsets so
-            // bounds collapse even when the size is mid-blob.
+            // No data blobs at all: a fresh partition or a journal with no retained durable
+            // items. Clear (rather than prune) the offsets so bounds collapse even when the
+            // size is mid-blob.
             let size = offsets_bounds.end;
             if !offsets_bounds.is_empty() {
-                warn!("crash repair: clearing offsets to {size} (prune-all crash)");
+                warn!("crash repair: clearing offsets to {size} (no data blobs)");
                 offsets.clear_to_size(size).await?;
             }
             return Ok(size..size);
@@ -2076,19 +2113,21 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 ///
 /// ## 1. Data Blobs are the Source of Truth
 ///
-/// The data blobs are always the source of truth. The offsets journal is an index that may
-/// temporarily diverge during crashes. Divergences are automatically aligned during init():
+/// The data blobs are always the source of truth for item contents. The offsets journal is an
+/// index that may temporarily diverge during crashes. Divergences are automatically aligned
+/// during init():
 /// * If offsets are behind data after the recovery watermark: rebuild missing offsets by replaying
 ///   data from the recovery anchor.
 /// * If offsets are ahead of the retained data prefix but the data still reaches the recovery
 ///   watermark: rewind offsets to match the data-backed size. Retained data ending before the
 ///   watermark is corruption because acknowledged data is missing.
-/// * If offsets.bounds().start < the oldest data blob's start: prune offsets to match (this can
-///   happen if we crash after pruning the data blobs but before pruning the offsets journal).
 ///
-/// Offsets may start after the data's blob-aligned start when both are in the same blob, as in a
-/// mid-blob `init_at_size`. Offsets starting in a later blob imply corruption because we
-/// always prune the data blobs before the offsets journal.
+/// The offsets journal's pruning boundary is the committed prune record: it is durably advanced
+/// before any data blob is removed. Offsets starting in a later blob than the oldest data blob
+/// therefore mark an interrupted prune, which init completes by removing the stale data prefix.
+/// Data starting in a later blob than the offsets boundary means retained blobs were lost, not
+/// pruned, and init reports corruption. Offsets may start after the data's blob-aligned start
+/// when both are in the same blob, as in a mid-blob `init_at_size`.
 ///
 /// ## 2. Offsets Recovery Watermark
 ///
@@ -2424,6 +2463,21 @@ impl<E: Context, V: CodecShared> authenticated::Backing<E> for Journal<E, V> {
 
 #[cfg(test)]
 impl<E: Context, V: CodecShared> Journal<E, V> {
+    /// Test helper: run prune through the offsets commit, skipping data-blob removal; this is the
+    /// state a prune future dropped at the data-removal await leaves behind.
+    pub(crate) async fn test_prune_before_data_removal(
+        &mut self,
+        min_position: u64,
+    ) -> Result<bool, Error> {
+        Ok(self.0.commit_prune(min_position).await?.is_some())
+    }
+
+    /// Test helper: park the production prune after the offsets journal's boundary commit,
+    /// before any blob removal, so a test can drop the pending prune future at that point.
+    pub(crate) fn test_halt_offsets_prune_removals(&mut self, halt: bool) {
+        self.0.offsets.halt_prune_removals = halt;
+    }
+
     /// Test helper: Prune the data blobs directly (simulates crash scenario).
     pub(crate) async fn test_prune_data(&mut self, min_blob: u64) -> Result<bool, Error> {
         let min_blob = min_blob.min(self.0.blobs.tail_blob_index());
@@ -3261,15 +3315,10 @@ mod tests {
         });
     }
 
-    /// Test that init aligns state when data is pruned/lost but offsets survives.
-    ///
-    /// This handles both:
-    /// 1. Crash during prune-all (data pruned, offsets not yet)
-    /// 2. External data partition loss
-    ///
-    /// In both cases, we align by pruning offsets to match.
+    /// Losing the data partition while the watermark proves durable retained items is
+    /// corruption that is stable across retries, not a completed prune-all to accept silently.
     #[test_traced]
-    fn test_variable_align_data_offsets_mismatch() {
+    fn test_variable_recovery_rejects_data_partition_loss() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = Config {
@@ -3281,12 +3330,9 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            // === Setup: Create journal with data ===
             let mut variable = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-
-            // Append 20 items across 2 blobs
             for i in 0..20u64 {
                 (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
@@ -3294,38 +3340,17 @@ mod tests {
             let variable = variable.sync().await.unwrap();
             drop(variable);
 
-            // === Simulate data loss: Delete data partition but keep offsets ===
             context
                 .remove(&cfg.data_partition(), None)
                 .await
                 .expect("Failed to remove data partition");
 
-            // === Verify init aligns the mismatch ===
-            let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
-                .await
-                .expect("Should align offsets to match empty data");
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
 
-            // Size should be preserved
-            assert_eq!(journal.size(), 20);
-
-            // But no items remain (both journals pruned)
-            assert!(journal.bounds().is_empty());
-
-            // All reads should fail with ItemPruned
-            for i in 0..20 {
-                assert!(matches!(
-                    journal.read(i).await,
-                    Err(crate::journal::Error::ItemPruned(_))
-                ));
-            }
-
-            // Can append new data starting at position 20
-            let pos;
-            (journal, pos) = journal.append(&999).await.unwrap();
-            assert_eq!(pos, 20);
-            assert_eq!(journal.read(20).await.unwrap(), 999);
-
-            journal.destroy().await.unwrap();
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
         });
     }
 
@@ -3725,12 +3750,13 @@ mod tests {
         });
     }
 
-    /// Test recovery from crash after data blobs pruned but before offsets journal.
+    /// Data pruned ahead of the committed boundary (the pre-two-phase prune ordering) is
+    /// intentionally unsupported: recovery reports corruption, stable across retries, rather
+    /// than inferring the prune from blob absence.
     #[test_traced]
-    fn test_variable_recovery_prune_crash_offsets_behind() {
+    fn test_variable_recovery_rejects_data_pruned_ahead_of_boundary() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // === Setup: Create Variable wrapper with data ===
             let cfg = Config {
                 partition: "recovery-prune-crash".into(),
                 items_per_section: NZU64!(10),
@@ -3743,8 +3769,6 @@ mod tests {
             let mut variable = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-
-            // Append 40 items across 4 blobs to both journals
             for i in 0..40u64 {
                 (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
@@ -3753,46 +3777,29 @@ mod tests {
             let (mut variable, _) = variable.prune(10).await.unwrap();
             assert_eq!(variable.bounds().start, 10);
 
-            // === Simulate crash: Prune data blobs but not offsets journal ===
-            // Manually prune data blobs to blob 2 (position 20)
+            // Remove data blobs past the committed boundary, as a crash under the
+            // pre-two-phase prune ordering could.
             variable.test_prune_data(2).await.unwrap();
-            // Offsets journal still has data from position 10-19
-
             variable.sync().await.unwrap();
 
-            // === Verify recovery ===
-            let variable = Journal::<_, u64>::init(context.child("second"), cfg.clone())
-                .await
-                .unwrap();
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
 
-            // Init should auto-repair: offsets journal pruned to match data blobs
-            let bounds = variable.bounds();
-            assert_eq!(bounds.start, 20);
-            assert_eq!(bounds.end, 40);
-
-            // Reads before position 20 should fail (pruned from both journals)
-            assert!(matches!(
-                variable.read(10).await,
-                Err(crate::journal::Error::ItemPruned(_))
-            ));
-
-            // Reads at position 20+ should succeed
-            assert_eq!(variable.read(20).await.unwrap(), 2000);
-            assert_eq!(variable.read(39).await.unwrap(), 3900);
-
-            variable.destroy().await.unwrap();
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
         });
     }
 
-    /// A crash after data pruning but before offsets pruning must remain recoverable even when
-    /// the last durable offsets end is below the new data boundary.
+    /// After a cancelled prune adopted a boundary the physical state has not caught up to,
+    /// a smaller prune request must not move the boundary backward.
     #[test_traced]
-    fn test_variable_recovery_prune_crash_offsets_end_behind() {
+    fn test_variable_prune_boundary_is_monotonic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = Config {
-                partition: "recovery-prune-offsets-end-behind".into(),
-                items_per_section: NZU64!(10),
+                partition: "prune-boundary-monotonic".into(),
+                items_per_section: NZU64!(5),
                 compression: None,
                 codec_config: (),
                 page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
@@ -3802,33 +3809,95 @@ mod tests {
             let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-
-            // Persist offsets only through position 7, then append enough unsynced items for a
-            // prune to advance the data boundary beyond that durable offsets end.
-            for i in 0..7u64 {
+            for i in 0..15u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             let mut journal = journal.sync().await.unwrap();
-            for i in 7..12u64 {
-                (journal, _) = journal.append(&(i * 100)).await.unwrap();
-            }
 
-            // Drop the production prune future while it is parked after the data-blob
-            // removal, before offsets.prune has made the appended offsets durable: a
-            // genuine cancellation at that await.
-            journal.0.halt_before_offsets_prune = true;
+            // Adopt and persist boundary 10, then drop the prune inside the offsets prune
+            // before any removal anywhere. The in-place future borrows the journal, so the
+            // handle survives the drop with the adopted boundary live.
+            journal.0.offsets.halt_prune_removals = true;
             {
-                let fut = journal.prune(10);
+                let fut = journal.0.prune(10);
                 futures::pin_mut!(fut);
                 assert!(
                     futures::poll!(fut.as_mut()).is_pending(),
-                    "prune must park before offsets.prune"
+                    "prune must park before the offsets removals"
                 );
             }
+            journal.0.offsets.halt_prune_removals = false;
+            assert_eq!(journal.bounds().start, 10);
 
+            // A smaller request must not lower the boundary.
+            let (journal, pruned) = journal.prune(5).await.unwrap();
+            assert!(pruned);
+            assert_eq!(journal.bounds().start, 10);
+            assert!(matches!(journal.read(7).await, Err(Error::ItemPruned(7))));
+
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
-                .expect("prune crash must leave a recoverable journal");
+                .expect("journal must reopen with the monotonic boundary");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A prune future dropped inside the offsets checkpoint persist can leave the boundary
+    /// durable while the call never returns. The outer bounds must already be adopted so a
+    /// later rewind cannot slide below the durable boundary.
+    #[test_traced]
+    fn test_variable_prune_dropped_during_persist_adopts_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-dropped-during-persist".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..12u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop the prune while parked inside the offsets checkpoint persist. The
+            // in-place future borrows the journal, so the handle survives the drop.
+            journal.0.offsets.test_halt_checkpoint_persist(true);
+            {
+                let fut = journal.0.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park inside the offsets checkpoint persist"
+                );
+            }
+            journal.0.offsets.test_halt_checkpoint_persist(false);
+
+            // The possibly-durable boundary is already adopted in the outer bounds.
+            assert_eq!(journal.bounds().start, 10);
+            assert!(matches!(
+                journal.0.rewind(7).await,
+                Err(Error::ItemPruned(7))
+            ));
+
+            // Continued use persists the adopted boundary; recovery completes the prune.
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen after the dropped prune");
             assert_eq!(journal.bounds(), 10..12);
             for i in 10..12u64 {
                 assert_eq!(journal.read(i).await.unwrap(), i * 100);
@@ -3837,12 +3906,69 @@ mod tests {
         });
     }
 
-    /// Test recovery detects corruption when offsets journal pruned ahead of data blobs.
-    ///
-    /// Simulates an impossible state (offsets journal pruned more than data blobs) which
-    /// should never happen due to write ordering. Verifies that init() returns corruption error.
+    /// A prune issued after an append future was dropped at the tail roll-over must not
+    /// commit a boundary into the never-created next blob. The prune caps at the physical
+    /// tail, pruning less than requested, and the journal stays live and recoverable.
     #[test_traced]
-    fn test_variable_recovery_offsets_ahead_corruption() {
+    fn test_variable_prune_after_cancelled_seal_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-after-cancelled-seal".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..9u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop the append that fills blob 1 while it is parked at the tail roll-over:
+            // the logical end advances to 10 but data blob 2 is never created. The in-place
+            // future borrows the journal, so the handle survives the drop with the
+            // interrupted roll-over state live.
+            journal.0.blobs.halt_seal_tail = true;
+            {
+                let fut = journal.0.append(&900);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "append must park at the tail roll-over"
+                );
+            }
+            journal.0.blobs.halt_seal_tail = false;
+            assert_eq!(journal.size(), 10);
+
+            // Prune to the logical end: the boundary caps at the physical tail, pruning
+            // only blob 0 rather than committing a boundary into the missing blob 2.
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            assert_eq!(journal.bounds(), 5..10);
+            for i in 5..10u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+
+            // The journal remains recoverable.
+            drop(journal);
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen after a capped prune");
+            assert_eq!(journal.bounds(), 5..10);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// The offsets boundary commits a prune before data removal. Recovery completes the data
+    /// removal when a crash leaves offsets ahead.
+    #[test_traced]
+    fn test_variable_recovery_completes_offsets_ahead_prune() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // === Setup: Create Variable wrapper with data ===
@@ -3864,16 +3990,399 @@ mod tests {
                 (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
 
-            // Prune offsets journal ahead of data blobs (impossible state)
+            // Persist the offsets prune, then remove only part of the data prefix.
             variable.test_prune_offsets(20).await.unwrap(); // Prune to position 20
             variable.test_prune_data(1).await.unwrap(); // Only prune data blobs to blob 1 (position 10)
 
             let variable = variable.sync().await.unwrap();
             drop(variable);
 
-            // === Verify corruption detected ===
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 20..40);
+            for i in 20..40u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A mid-blob journal pruned exactly to the next blob boundary must recover from a crash
+    /// between the offsets prune and the data prune: the stale mid-blob data blob is removed
+    /// and the journal resumes empty at the committed boundary.
+    #[test_traced]
+    fn test_variable_recovery_completes_mid_blob_interrupted_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "mid-blob-interrupted-prune".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            // A mid-blob journal: blob 1 holds positions 7..10, blob 2 is the empty tail.
+            let mut journal =
+                Journal::<_, u64>::init_at_size(context.child("first"), cfg.clone(), 7)
+                    .await
+                    .unwrap();
+            for i in 7..10u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Commit the offsets boundary without removing any data blob, simulating a prune
+            // that crashed between the offsets prune and the data prune.
+            journal.test_prune_offsets(10).await.unwrap();
+            drop(journal);
+
+            let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 10..10);
+
+            // The interrupted prune completed: the stale mid-blob data blob is gone.
+            let names = context.scan(&cfg.data_partition()).await.unwrap();
+            assert!(!names.contains(&1u64.to_be_bytes().to_vec()));
+
+            // The journal resumes normally at the boundary.
+            let pos;
+            (journal, pos) = journal.append(&1000).await.unwrap();
+            assert_eq!(pos, 10);
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(journal.read(10).await.unwrap(), 1000);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A variable prune future dropped during the offsets prune has already committed the
+    /// boundary. The outer bounds must be adopted at the same transition: a live journal must
+    /// never report bounds whose offsets are pruned, and continued use must persist the
+    /// committed boundary, not a stale one.
+    #[test_traced]
+    fn test_variable_prune_interrupted_removal_keeps_committed_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-interrupted-keeps-boundary".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Run prune through the offsets commit but drop it before data removal. A
+            // cancelled future surfaces no error, so the continued use below is legal.
+            assert!(journal.test_prune_before_data_removal(10).await.unwrap());
+
+            // The bounds must agree with the offsets journal: retained items readable,
+            // pruned positions reported as pruned rather than sitting inside bounds().
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            assert!(matches!(journal.read(5).await, Err(Error::ItemPruned(5))));
+
+            // Continued use persists the committed boundary, not a stale one.
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A variable prune future dropped during the offsets-blob removal has already committed
+    /// the boundary but removed no blob anywhere. Dropping the future discards the journal
+    /// (mutating methods consume it), and recovery must complete both removal layers of the
+    /// interrupted prune.
+    #[test_traced]
+    fn test_variable_prune_dropped_during_offsets_removal() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-dropped-during-offsets-removal".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop the production prune future while it is parked after the offsets
+            // journal's boundary commit, before any blob removal: a genuine cancellation
+            // at the removal await. The journal is consumed with the dropped future; its
+            // durable state holds the committed boundary with every blob still present.
+            journal.test_halt_offsets_prune_removals(true);
+            {
+                let fut = journal.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park at the halt before offsets-blob removal"
+                );
+            }
+
+            // Recovery completes both removal layers of the interrupted prune.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            let names = context.scan(&cfg.data_partition()).await.unwrap();
+            assert!(!names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(!names.contains(&1u64.to_be_bytes().to_vec()));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// If the data blob at the committed pruning boundary is missing, recovery must report
+    /// corruption rather than deleting the surviving suffix and treating its items as pruned.
+    #[test_traced]
+    fn test_variable_recovery_rejects_missing_boundary_blob() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "missing-durable-boundary".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+            journal.test_prune_offsets(20).await.unwrap();
+            drop(journal);
+
+            let data_partition = cfg.data_partition();
+            context
+                .remove(&data_partition, Some(&2u64.to_be_bytes()))
+                .await
+                .unwrap();
+
             let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
             assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The surviving blobs are left intact for diagnosis or external recovery.
+            let names = context.scan(&data_partition).await.unwrap();
+            assert!(names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(names.contains(&3u64.to_be_bytes().to_vec()));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// If every data blob at or above the committed pruning boundary is missing while stale
+    /// prefix blobs survive an interrupted prune, recovery must report corruption rather than
+    /// collapsing the retained range to a completed prune-all.
+    #[test_traced]
+    fn test_variable_recovery_rejects_lost_retained_range() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "lost-retained-range".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Commit the offsets boundary without removing any data blob, simulating a prune
+            // that crashed before its first data removal.
+            journal.test_prune_offsets(20).await.unwrap();
+            drop(journal);
+
+            // Lose every data blob at or above the boundary; the stale prefix survives.
+            let data_partition = cfg.data_partition();
+            for blob in 2u64..5 {
+                let _ = context
+                    .remove(&data_partition, Some(&blob.to_be_bytes()))
+                    .await;
+            }
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// Losing the boundary blob after a fully completed prune is corruption, stable across
+    /// retries: with no stale prefix left, the loss surfaces as data ahead of the committed
+    /// boundary rather than as an interrupted prune.
+    #[test_traced]
+    fn test_variable_recovery_rejects_boundary_loss_after_completed_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "completed-prune-boundary-loss".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let (journal, pruned) = journal.prune(20).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose the blob at the committed boundary; later blobs survive.
+            let data_partition = cfg.data_partition();
+            context
+                .remove(&data_partition, Some(&2u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The surviving suffix is left intact, and the result is stable across retries.
+            let names = context.scan(&data_partition).await.unwrap();
+            assert!(names.contains(&3u64.to_be_bytes().to_vec()));
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// Losing every retained blob after a fully completed prune is corruption, stable across
+    /// retries: the watermark proves acknowledged items were lost, not pruned.
+    #[test_traced]
+    fn test_variable_recovery_rejects_retained_loss_after_completed_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "completed-prune-retained-loss".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let (journal, pruned) = journal.prune(20).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose every retained blob at or above the boundary.
+            let data_partition = cfg.data_partition();
+            for blob in 2u64..5 {
+                let _ = context
+                    .remove(&data_partition, Some(&blob.to_be_bytes()))
+                    .await;
+            }
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// A surviving empty tail cannot vouch for lost acknowledged blobs: recovery must report
+    /// corruption, stable across retries, rather than adopting the tail's position as the
+    /// pruning boundary.
+    #[test_traced]
+    fn test_variable_recovery_rejects_item_blob_loss_with_surviving_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "item-loss-surviving-tail".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose the only item-bearing retained blob; the empty tail survives.
+            let data_partition = cfg.data_partition();
+            context
+                .remove(&data_partition, Some(&1u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
         });
     }
 
@@ -4861,69 +5370,6 @@ mod tests {
             assert_eq!(journal.read(20).await.unwrap(), 2000);
 
             journal.destroy().await.unwrap();
-        });
-    }
-
-    /// Test recovery from multiple prune operations with crash.
-    #[test_traced]
-    fn test_variable_recovery_multiple_prunes_crash() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            // === Setup: Create Variable wrapper with data ===
-            let cfg = Config {
-                partition: "recovery-multiple-prunes".into(),
-                items_per_section: NZU64!(10),
-                compression: None,
-                codec_config: (),
-                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
-                write_buffer: NZUsize!(1024),
-            };
-
-            let mut variable = Journal::<_, u64>::init(context.child("first"), cfg.clone())
-                .await
-                .unwrap();
-
-            // Append 50 items across 5 blobs to both journals
-            for i in 0..50u64 {
-                (variable, _) = variable.append(&(i * 100)).await.unwrap();
-            }
-
-            // Prune to position 10 normally (both data and offsets journals pruned)
-            let (mut variable, _) = variable.prune(10).await.unwrap();
-            assert_eq!(variable.bounds().start, 10);
-
-            // === Simulate crash: Multiple prunes on data blobs, not on offsets journal ===
-            // Manually prune data blobs to blob 3 (position 30)
-            variable.test_prune_data(3).await.unwrap();
-            // Offsets journal still thinks oldest is position 10
-
-            variable.sync().await.unwrap();
-
-            // === Verify recovery ===
-            let variable = Journal::<_, u64>::init(context.child("second"), cfg.clone())
-                .await
-                .unwrap();
-
-            // Init should auto-repair: offsets journal pruned to match data blobs
-            let bounds = variable.bounds();
-            assert_eq!(bounds.start, 30);
-            assert_eq!(bounds.end, 50);
-
-            // Reads before position 30 should fail (pruned from both journals)
-            assert!(matches!(
-                variable.read(10).await,
-                Err(crate::journal::Error::ItemPruned(_))
-            ));
-            assert!(matches!(
-                variable.read(20).await,
-                Err(crate::journal::Error::ItemPruned(_))
-            ));
-
-            // Reads at position 30+ should succeed
-            assert_eq!(variable.read(30).await.unwrap(), 3000);
-            assert_eq!(variable.read(49).await.unwrap(), 4900);
-
-            variable.destroy().await.unwrap();
         });
     }
 
@@ -6356,67 +6802,6 @@ mod tests {
             for i in 0..8u64 {
                 assert_eq!(journal.read(7 + i).await.unwrap(), 700 + i);
             }
-
-            journal.destroy().await.unwrap();
-        });
-    }
-
-    /// Regression test: data-empty crash repair must preserve mid-blob pruning boundary.
-    #[test_traced]
-    fn test_align_journals_data_empty_mid_blob_pruning_boundary() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            let cfg = Config {
-                partition: "align-journals-mid-blob-pruning-boundary".into(),
-                items_per_section: NZU64!(5),
-                compression: None,
-                codec_config: (),
-                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
-                write_buffer: NZUsize!(1024),
-            };
-
-            // Phase 1: Create data and offsets, then simulate data-only pruning crash.
-            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
-                .await
-                .unwrap();
-            for i in 0..7u64 {
-                (journal, _) = journal.append(&(100 + i)).await.unwrap();
-            }
-            journal = journal.sync().await.unwrap();
-
-            // Simulate crash after data was cleared but before offsets were pruned.
-            drop(journal);
-            Partition::<deterministic::Context>::remove_all(&context, &cfg.data_partition())
-                .await
-                .unwrap();
-
-            // Phase 2: Init triggers data-empty repair and should treat journal as fully pruned at size 7.
-            let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
-                .await
-                .unwrap();
-            let bounds = journal.bounds();
-            assert_eq!(bounds.end, 7);
-            assert!(bounds.is_empty());
-
-            // Append one item at position 7.
-            let pos;
-            (journal, pos) = journal.append(&777).await.unwrap();
-            assert_eq!(pos, 7);
-            assert_eq!(journal.size(), 8);
-            assert_eq!(journal.read(7).await.unwrap(), 777);
-
-            // Sync only the data blobs to simulate a crash before offsets are synced.
-            journal.0.blobs.start_sync().await.await.unwrap();
-            drop(journal);
-
-            // Phase 3: Reopen and verify we did not lose the appended item.
-            let journal = Journal::<_, u64>::init(context.child("third"), cfg.clone())
-                .await
-                .unwrap();
-            let bounds = journal.bounds();
-            assert_eq!(bounds.end, 8);
-            assert_eq!(bounds.start, 7);
-            assert_eq!(journal.read(7).await.unwrap(), 777);
 
             journal.destroy().await.unwrap();
         });


### PR DESCRIPTION
Defers blob-creation durability to the first durability request, removing the fsyncs that
creation currently pays up front. This is Step 2 of #4190.

## Motivation

Creating a blob on the filesystem backends currently fsyncs before `open_versioned` returns
(tokio: fsync parent dir → fsync storage-root dir → write the header page → fsync file), and
the contract promises the blob is "durably created." That work sits directly on the journal
rollover path — `seal_tail` pre-creates the next blob once per `items_per_blob` appends — so
every rollover pays three fsyncs for a blob that may never be synced.

## What changes

Creation now **reserves** a zero header page and writes nothing durable. The first durability
request — `Blob::sync`, a non-empty `Blob::write_at_sync`, or the `Blob::start_sync` handle —
runs a two-phase commit:

1. write the 8-byte prelude, fsync the file, fsync the parent and storage-root directories;
2. write the 4-byte CRC **last**, then fsync.

The CRC is the commit record: a complete, valid CRC can only exist after the phase-1 barrier,
so its presence proves the whole file (prelude, prior writes, directory entries) is durable.
A blob that is created and never synced costs zero fsyncs.

**Committed on-disk bytes are byte-identical to the eager layout (#4184)** — magic + version +
CRC + zero padding + data — so this is a recovery-model and creation-timing change, not a
format change. Conformance hashes are unchanged.

### Recovery

Two layers cooperate, because an uncommitted header on disk is indistinguishable from one left
by a crash:

- **Blob layer** — `open_versioned` classifies a header with no complete valid CRC as
  uncommitted and recreates the blob in place (resets it to an empty reserved region).
- **Contiguous journal** — a never-synced creation whose directory entry vanished after a crash
  leaves a blob missing where recovery expects one. The journal uses its recovery watermark to
  adjudicate: at or below the watermark the missing/short blob was a vanished unsynced creation
  and recovery discards the unreachable suffix and resumes; above it the loss is genuine
  corruption and recovery fails loudly. This applies to both the fixed and variable journals
  (boundary reconciliation, offsets-state classification, and empty-tail alignment).

## Contract change

The `Storage` contract already declared that writing to two separate handles of the same blob
name concurrently is undefined behavior. Deferred creation extends that: because opening an
uncommitted blob **recreates** it, opening a name while another live handle holds an unsynced
creation of it is now undefined behavior — the recreate discards the earlier handle's writes,
and syncing that handle afterward may certify data the recreate has already discarded. Under
the previous eager model a second open simply re-read the already-committed header, so this
case was benign; it is not under deferral.

`open_versioned`, `write_at_sync`, and `sync` doc comments are updated accordingly. In-tree
consumers (the journals) open each blob once and are unaffected.

## Notes

- Stacks on #4235 (two-phase prune); the diff shows #4235's commit until it merges.
- No new coordination types: creation reserves and the first durability request commits;
  cloned handles serialize their commit on the blob's own lock.
