### PR TITLE
[ci] Check dependency cooldown from merge base

### DIFF
--- a/.github/scripts/check_dependency_cooldown.sh
+++ b/.github/scripts/check_dependency_cooldown.sh
@@ -1,26 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-check_cooldown() {
-  cargo cooldown --workspace --all-features check
-}
-
-check_lockfile() {
-  git diff --exit-code Cargo.lock
-}
-
-if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
-  check_cooldown
-  check_lockfile
-  exit 0
-fi
-
-base_ref="${COOLDOWN_BASE_REF:-}"
-head_sha="${COOLDOWN_HEAD_SHA:-}"
-if [[ -z "${base_ref}" || -z "${head_sha}" ]]; then
-  echo "COOLDOWN_BASE_REF and COOLDOWN_HEAD_SHA are required for pull_request cooldown checks" >&2
-  exit 1
-fi
+base_ref="${COOLDOWN_BASE_REF:-main}"
+head_sha="${COOLDOWN_HEAD_SHA:-HEAD}"
 
 git fetch --no-tags origin "refs/heads/${base_ref}:refs/remotes/origin/${base_ref}"
 base_rev="refs/remotes/origin/${base_ref}"
@@ -33,20 +15,42 @@ fi
 
 tmpdir="$(mktemp -d)"
 cp Cargo.lock "${tmpdir}/pr.Cargo.lock"
+cp cooldown.toml "${tmpdir}/cooldown.toml"
 cleanup() {
   status=$?
   cp "${tmpdir}/pr.Cargo.lock" Cargo.lock
+  cp "${tmpdir}/cooldown.toml" cooldown.toml
   rm -rf "${tmpdir}"
   exit "${status}"
 }
 trap cleanup EXIT
 
-git show "${base_rev}:Cargo.lock" > Cargo.lock
+git show "${merge_base}:Cargo.lock" > "${tmpdir}/base.Cargo.lock"
+# Versions already present at the merge base are allowed regardless of publish age.
+awk '
+  function exempt() {
+    if (source ~ /^registry\+/) {
+      print ""
+      print "[[allow.exact]]"
+      print "crate = \"" name "\""
+      print "version = \"" version "\""
+    }
+  }
 
-check_cooldown
+  /^\[\[package\]\]$/ {
+    exempt()
+    name = version = source = ""
+    next
+  }
+  /^name = "/ { name = substr($0, 9, length($0) - 9) }
+  /^version = "/ { version = substr($0, 12, length($0) - 12) }
+  /^source = "/ { source = substr($0, 11, length($0) - 11) }
+  END { exempt() }
+' "${tmpdir}/base.Cargo.lock" >> cooldown.toml
+
+cargo cooldown metadata --all-features --format-version 1 --no-deps > /dev/null
 
 if ! cmp --silent Cargo.lock "${tmpdir}/pr.Cargo.lock"; then
-  echo "Cargo.lock differs after applying the cooldown baseline." >&2
-  echo "Regenerate Cargo.lock after the upgraded dependencies satisfy cooldown." >&2
+  echo "Cargo.lock contains dependencies that do not pass cooldown." >&2
   exit 1
 fi

--- a/.github/scripts/check_dependency_cooldown.sh
+++ b/.github/scripts/check_dependency_cooldown.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 base_ref="${COOLDOWN_BASE_REF:-main}"
-head_sha="${COOLDOWN_HEAD_SHA:-HEAD}"
 
-git fetch --no-tags origin "refs/heads/${base_ref}:refs/remotes/origin/${base_ref}"
+git fetch --no-tags origin "+refs/heads/${base_ref}:refs/remotes/origin/${base_ref}" ||
+  echo "Failed to fetch origin/${base_ref}; using the local ref." >&2
 base_rev="refs/remotes/origin/${base_ref}"
-merge_base="$(git merge-base "${base_rev}" "${head_sha}")"
+merge_base="$(git merge-base "${base_rev}" HEAD)"
 
-if git diff --quiet "${merge_base}" "${head_sha}" -- Cargo.lock; then
+if git diff --quiet "${merge_base}" -- Cargo.lock; then
   echo "Cargo.lock did not change; skipping cargo-cooldown."
   exit 0
 fi
@@ -27,9 +27,10 @@ trap cleanup EXIT
 
 git show "${merge_base}:Cargo.lock" > "${tmpdir}/base.Cargo.lock"
 # Versions already present at the merge base are allowed regardless of publish age.
+# The generated exemptions match crate and version only (cargo-cooldown ignores source).
 awk '
   function exempt() {
-    if (source ~ /^registry\+/) {
+    if (source ~ /^(registry|sparse)\+/) {
       print ""
       print "[[allow.exact]]"
       print "crate = \"" name "\""
@@ -37,7 +38,7 @@ awk '
     }
   }
 
-  /^\[\[package\]\]$/ {
+  /^\[\[/ {
     exempt()
     name = version = source = ""
     next
@@ -51,6 +52,8 @@ awk '
 cargo cooldown metadata --all-features --format-version 1 --no-deps > /dev/null
 
 if ! cmp --silent Cargo.lock "${tmpdir}/pr.Cargo.lock"; then
-  echo "Cargo.lock contains dependencies that do not pass cooldown." >&2
+  echo "cargo-cooldown rewrote these Cargo.lock entries:" >&2
+  diff "${tmpdir}/pr.Cargo.lock" Cargo.lock >&2 || true
+  echo "Wait for the dependencies above to satisfy cooldown, or regenerate Cargo.lock if it is out of sync with the manifests." >&2
   exit 1
 fi

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -256,7 +256,7 @@ jobs:
       run: just udeps
 
   Cooldown:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -276,7 +276,6 @@ jobs:
     - name: Check dependency cooldown
       env:
         COOLDOWN_BASE_REF: ${{ github.event.pull_request.base.ref }}
-        COOLDOWN_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: just cooldown
 
   Lock:

--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_COOLDOWN_VERSION: 0.3.0
+  CARGO_COOLDOWN_VERSION: 0.3.4
   UDEPS_VERSION: 0.1.57
   NIGHTLY_VERSION: nightly-2026-06-21
   PANDOC_VERSION: 3.8.2.1
@@ -256,12 +256,14 @@ jobs:
       run: just udeps
 
   Cooldown:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
     - name: Checkout repository
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       with:
+        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - name: Run setup
       uses: ./.github/actions/setup

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -1,4 +1,4 @@
 cooldown_minutes = 10080
 enforcement = "strict"
-lockfile_baseline = "floor"
+lockfile_baseline = "ignore"
 cache_dir = "target/cargo-cooldown"

--- a/cooldown.toml
+++ b/cooldown.toml
@@ -1,3 +1,6 @@
+# Exemptions for versions already locked at the merge base are appended by
+# .github/scripts/check_dependency_cooldown.sh (run via `just cooldown`). Invoking
+# `cargo cooldown` directly applies the cooldown window to every locked package.
 cooldown_minutes = 10080
 enforcement = "strict"
 lockfile_baseline = "ignore"


### PR DESCRIPTION
## Overview

Fix a bug where any pull request lockfile change failed the cooldown job. Check dependency cooldown against the pull request merge base so existing dependencies remain blessed while newly introduced dependencies must satisfy the cooldown.